### PR TITLE
feat: TUI overhaul - settings fix, markdown import, greenfield wizard, visual refresh

### DIFF
--- a/src/ralph/prd.py
+++ b/src/ralph/prd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -169,4 +170,171 @@ def create_story(
         priority=priority,
         passes=False,
         notes="",
+    )
+
+
+# -- Section names that should be treated as metadata, not stories --
+_META_SECTIONS = {
+    "overview",
+    "background",
+    "context",
+    "introduction",
+    "intro",
+    "summary",
+    "tech stack",
+    "technology",
+    "technologies",
+    "stack",
+    "architecture",
+    "design",
+    "notes",
+    "references",
+    "appendix",
+    "glossary",
+    "verification",
+    "testing",
+    "test plan",
+    "non-functional requirements",
+    "constraints",
+    "assumptions",
+    "dependencies",
+}
+
+
+@dataclass
+class ParsedMarkdown:
+    """Result of parsing a free-form markdown document into PRD components."""
+
+    feature_overview: str
+    stories: list[dict[str, str]]  # [{"title": ..., "criteria": ...}]
+    tech_stack: str
+    verification_commands: str
+
+
+def parse_markdown_to_stories(content: str) -> ParsedMarkdown:
+    """Parse a free-form markdown document into story components.
+
+    Parsing strategy:
+    - ## or ### headings become story titles (unless they match meta-section names)
+    - Bullet items (- or * or 1.) under a heading become acceptance criteria
+    - Meta-sections (Overview, Background, Tech Stack, etc.) are extracted as metadata
+    - If no headings exist, paragraphs separated by blank lines become stories
+    """
+    lines = content.splitlines()
+    feature_overview = ""
+    tech_stack = ""
+    verification_commands = ""
+    stories: list[dict[str, str]] = []
+
+    current_heading: str | None = None
+    current_bullets: list[str] = []
+    current_text: list[str] = []
+
+    def _flush_section() -> None:
+        nonlocal feature_overview, tech_stack, verification_commands
+        if current_heading is None:
+            return
+
+        heading_lower = current_heading.lower().strip()
+
+        if heading_lower in _META_SECTIONS or any(
+            heading_lower.startswith(m) for m in _META_SECTIONS
+        ):
+            text_block = "\n".join(current_text).strip()
+            bullets_block = "\n".join(current_bullets).strip()
+            combined = (text_block + "\n" + bullets_block).strip()
+
+            overview_keys = {
+                "overview", "background", "context", "introduction", "intro", "summary",
+            }
+            tech_keys = {
+                "tech stack", "technology", "technologies", "stack", "architecture",
+            }
+            verify_keys = {"verification", "testing", "test plan"}
+
+            if heading_lower in overview_keys:
+                feature_overview = (feature_overview + "\n" + combined).strip()
+            elif heading_lower in tech_keys:
+                tech_stack = (tech_stack + "\n" + combined).strip()
+            elif heading_lower in verify_keys:
+                verification_commands = (verification_commands + "\n" + combined).strip()
+        else:
+            criteria_text = (
+                "\n".join(current_bullets) if current_bullets
+                else "\n".join(current_text)
+            )
+            stories.append({
+                "title": current_heading.strip(),
+                "criteria": criteria_text.strip(),
+            })
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Detect headings (## or ###, skip # which is usually document title)
+        if stripped.startswith("## ") or stripped.startswith("### "):
+            _flush_section()
+            current_heading = stripped.lstrip("#").strip()
+            current_bullets = []
+            current_text = []
+            continue
+
+        # Detect # heading as document title -> feature overview
+        if stripped.startswith("# ") and not stripped.startswith("## "):
+            _flush_section()
+            # Use the title text as part of feature overview if we have no heading yet
+            title_text = stripped.lstrip("#").strip()
+            if not feature_overview:
+                feature_overview = title_text
+            current_heading = None
+            current_bullets = []
+            current_text = []
+            continue
+
+        # Detect bullet items
+        if stripped.startswith("- ") or stripped.startswith("* "):
+            current_bullets.append(stripped[2:].strip())
+            continue
+
+        # Detect numbered items
+        numbered = re.match(r"^\d+[\.\)]\s+(.+)", stripped)
+        if numbered:
+            current_bullets.append(numbered.group(1).strip())
+            continue
+
+        # Regular text
+        if stripped:
+            current_text.append(stripped)
+
+    # Flush last section
+    _flush_section()
+
+    # Fallback: if no stories were found from headings, split by paragraphs
+    if not stories:
+        paragraphs: list[str] = []
+        current_para: list[str] = []
+        for line in lines:
+            if line.strip():
+                current_para.append(line.strip())
+            elif current_para:
+                paragraphs.append("\n".join(current_para))
+                current_para = []
+        if current_para:
+            paragraphs.append("\n".join(current_para))
+
+        for para in paragraphs:
+            # Skip very short paragraphs (likely titles or separators)
+            if len(para) < 10:
+                continue
+            # Use first line as title, rest as criteria
+            para_lines = para.splitlines()
+            title = para_lines[0][:80]
+            criteria = "\n".join(para_lines[1:]) if len(para_lines) > 1 else ""
+            stories.append({"title": title, "criteria": criteria})
+
+    return ParsedMarkdown(
+        feature_overview=feature_overview,
+        stories=stories,
+        tech_stack=tech_stack,
+        verification_commands=verification_commands,
     )

--- a/src/ralph/tui/app.py
+++ b/src/ralph/tui/app.py
@@ -9,6 +9,7 @@ from textual.app import App
 from ralph.tui.screens.config_screen import ConfigScreen
 from ralph.tui.screens.init_wizard import InitWizardScreen
 from ralph.tui.screens.main_menu import MainMenuScreen
+from ralph.tui.screens.new_project_wizard import NewProjectWizardScreen
 from ralph.tui.screens.prd_wizard import PRDWizardScreen
 from ralph.tui.screens.run_dashboard import RunDashboardScreen
 from ralph.tui.screens.status_screen import StatusScreen
@@ -27,6 +28,7 @@ class RalphApp(App):
     SCREENS = {
         "main_menu": MainMenuScreen,
         "init_wizard": InitWizardScreen,
+        "new_project_wizard": NewProjectWizardScreen,
         "run_dashboard": lambda: RunDashboardScreen(understand_mode=False),
         "run_dashboard_understand": lambda: RunDashboardScreen(understand_mode=True),
         "prd_wizard": PRDWizardScreen,

--- a/src/ralph/tui/screens/config_screen.py
+++ b/src/ralph/tui/screens/config_screen.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Vertical, VerticalScroll
 from textual.screen import Screen
 from textual.widgets import (
     Button,
@@ -32,43 +32,66 @@ class ConfigScreen(Screen):
     def __init__(self, name: str | None = None, id: str | None = None) -> None:
         super().__init__(name=name, id=id)
         self._config = load_config()
+        self._toml_exists = Path("ralph.toml").exists()
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
-        with Vertical(id="config-container"):
+        with VerticalScroll(id="config-container"):
             yield Static("Settings", classes="title")
-            yield Static("")
+
+            if not self._toml_exists:
+                yield Static(
+                    "[yellow]No ralph.toml found.[/yellow] "
+                    "Showing defaults. Save to create the file.",
+                    classes="help-text",
+                )
 
             # Agent section
             with Vertical(classes="config-section"):
                 yield Static("Agent", classes="config-section-title")
+                yield Static(
+                    "Select which AI agent and model to use.",
+                    classes="config-help",
+                )
                 yield ModelSelector(id="model-selector")
 
             # Run section
             with Vertical(classes="config-section"):
                 yield Static("Run", classes="config-section-title")
-                yield Label("Max iterations:")
+                yield Static(
+                    "Control loop execution behavior.",
+                    classes="config-help",
+                )
+                yield Label("Max iterations")
                 yield Input(
                     value=str(self._config.run.max_iterations),
                     id="max-iterations",
                     type="integer",
                 )
-                yield Label("Sleep seconds:")
+                yield Label("Sleep between iterations (seconds)")
                 yield Input(
                     value=str(self._config.run.sleep_seconds),
                     id="sleep-seconds",
                     type="integer",
                 )
-                yield Checkbox("Interactive mode", self._config.run.interactive, id="interactive")
+                yield Checkbox(
+                    "Interactive mode (pause after each iteration)",
+                    self._config.run.interactive,
+                    id="interactive",
+                )
 
             # Paths section
             with Vertical(classes="config-section"):
                 yield Static("Paths", classes="config-section-title")
-                yield Label("Prompt file:")
+                yield Static(
+                    "File locations for prompts, PRD, and path restrictions.",
+                    classes="config-help",
+                )
+                yield Label("Prompt file")
                 yield Input(value=self._config.paths.prompt, id="prompt-path")
-                yield Label("PRD file:")
+                yield Label("PRD file")
                 yield Input(value=self._config.paths.prd, id="prd-path")
-                yield Label("Allowed paths (comma-separated):")
+                yield Label("Allowed paths (comma-separated, empty = unrestricted)")
                 yield Input(
                     value=", ".join(self._config.paths.allowed),
                     id="allowed-paths",
@@ -77,12 +100,19 @@ class ConfigScreen(Screen):
             # Git section
             with Vertical(classes="config-section"):
                 yield Static("Git", classes="config-section-title")
-                yield Label("Branch override (empty = from PRD):")
+                yield Static(
+                    "Branch management and checkout behavior.",
+                    classes="config-help",
+                )
+                yield Label("Branch override (empty = use PRD branch name)")
                 yield Input(value=self._config.git.branch, id="git-branch")
-                yield Checkbox("Auto checkout", self._config.git.auto_checkout, id="auto-checkout")
+                yield Checkbox(
+                    "Auto-checkout branch before running",
+                    self._config.git.auto_checkout,
+                    id="auto-checkout",
+                )
 
             # Actions
-            yield Static("")
             yield Button("Save", id="save-btn", variant="primary")
             yield Static("", id="save-status")
 
@@ -95,11 +125,15 @@ class ConfigScreen(Screen):
     def _collect_form_data(self) -> None:
         """Collect all form values into config."""
         try:
-            self._config.run.max_iterations = int(self.query_one("#max-iterations", Input).value)
+            self._config.run.max_iterations = int(
+                self.query_one("#max-iterations", Input).value
+            )
         except ValueError:
             pass
         try:
-            self._config.run.sleep_seconds = int(self.query_one("#sleep-seconds", Input).value)
+            self._config.run.sleep_seconds = int(
+                self.query_one("#sleep-seconds", Input).value
+            )
         except ValueError:
             pass
         self._config.run.interactive = self.query_one("#interactive", Checkbox).value
@@ -122,6 +156,7 @@ class ConfigScreen(Screen):
         self._collect_form_data()
         toml_path = Path.cwd() / "ralph.toml"
         save_config(self._config, toml_path)
+        self._toml_exists = True
         status = self.query_one("#save-status", Static)
         status.update(f"[green]Saved to {toml_path}[/green]")
 

--- a/src/ralph/tui/screens/init_wizard.py
+++ b/src/ralph/tui/screens/init_wizard.py
@@ -1,11 +1,11 @@
-"""Init wizard screen - guided project setup."""
+"""Init wizard screen - guided setup for existing (brownfield) projects."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 from textual.app import ComposeResult
-from textual.containers import Center, Vertical
+from textual.containers import Center, Horizontal, Vertical
 from textual.screen import Screen
 from textual.widgets import (
     Button,
@@ -13,8 +13,6 @@ from textual.widgets import (
     Header,
     Input,
     Label,
-    RadioButton,
-    RadioSet,
     Static,
 )
 
@@ -25,7 +23,7 @@ from ralph.tui.widgets.model_selector import ModelSelector
 
 
 class InitWizardScreen(Screen):
-    """Guided project initialization wizard."""
+    """Guided project initialization wizard for existing codebases."""
 
     BINDINGS = [
         ("escape", "back", "Back"),
@@ -35,87 +33,100 @@ class InitWizardScreen(Screen):
         super().__init__(name=name, id=id)
         self._step = 0
         self._target_dir = str(Path.cwd())
-        self._project_type = "greenfield"
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
-        with Center():
+        with Center(classes="wizard-outer"):
             with Vertical(id="init-container"):
-                yield Static("Project Setup", classes="title")
-                yield Static("Step 1 of 3: Target Directory", id="init-step-label")
+                yield Static("Add Ralph to Existing Project", classes="title")
+                yield Static(
+                    self._progress_dots(),
+                    id="init-step-label",
+                )
                 yield Vertical(id="init-step")
-                yield Button("Next", id="init-next", variant="primary")
+                with Horizontal(id="new-project-nav"):
+                    yield Button("Back", id="init-back", variant="default", disabled=True)
+                    yield Button("Next", id="init-next", variant="primary")
         yield Footer()
 
     def on_mount(self) -> None:
         self._render_step()
 
+    def _progress_dots(self) -> str:
+        """Render step progress as dots."""
+        total = 2
+        parts: list[str] = []
+        for i in range(total):
+            if i == self._step:
+                parts.append("[bold]()[/bold]")
+            else:
+                parts.append("[dim]o[/dim]")
+        return "  ".join(parts) + f"    Step {self._step + 1} of {total}"
+
     def _render_step(self) -> None:
         step_container = self.query_one("#init-step", Vertical)
         step_label = self.query_one("#init-step-label", Static)
         next_btn = self.query_one("#init-next", Button)
+        back_btn = self.query_one("#init-back", Button)
 
         step_container.remove_children()
+        step_label.update(self._progress_dots())
 
-        step_titles = [
-            "Step 1 of 3: Target Directory",
-            "Step 2 of 3: Project Type",
-            "Step 3 of 3: Agent Selection",
-        ]
-        step_label.update(step_titles[self._step])
-        next_btn.label = "Initialize" if self._step == 2 else "Next"
+        back_btn.disabled = self._step == 0
+        next_btn.label = "Initialize" if self._step == 1 else "Next"
 
         if self._step == 0:
-            step_container.mount(Label("Target directory:"))
+            step_container.mount(Label("Target directory"))
             step_container.mount(
-                Input(value=self._target_dir, id="target-dir", placeholder="/path/to/project")
-            )
-        elif self._step == 1:
-            step_container.mount(Label("Is this an existing codebase?"))
-            step_container.mount(
-                RadioSet(
-                    RadioButton(
-                        "Greenfield (new project)",
-                        value=self._project_type == "greenfield",
-                    ),
-                    RadioButton(
-                        "Brownfield (existing code)",
-                        value=self._project_type == "brownfield",
-                    ),
-                    id="project-type",
+                Input(
+                    value=self._target_dir,
+                    id="target-dir",
+                    placeholder="/path/to/project",
                 )
             )
-        elif self._step == 2:
-            step_container.mount(Label("Select your AI agent:"))
+            step_container.mount(
+                Static(
+                    "[dim]The directory containing your existing codebase. "
+                    "Ralph will create a scripts/ralph/ directory here.[/dim]",
+                    classes="help-text",
+                )
+            )
+        elif self._step == 1:
+            step_container.mount(Label("Select your AI agent"))
             step_container.mount(ModelSelector(id="init-model-selector"))
 
             installed = detect_installed_agents()
             if not installed:
                 step_container.mount(
-                    Static("[yellow]No agents detected. Install claude or codex first.[/yellow]")
+                    Static(
+                        "[yellow]No agents detected. "
+                        "Install claude or codex first.[/yellow]"
+                    )
+                )
+            else:
+                step_container.mount(
+                    Static(
+                        "[dim]Tip: after setup, run 'ralph understand 10' "
+                        "to map your codebase before writing a PRD.[/dim]",
+                        classes="help-text",
+                    )
                 )
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id != "init-next":
-            return
-
-        if self._step == 0:
-            try:
-                self._target_dir = self.query_one("#target-dir", Input).value
-            except Exception:
-                pass
-            self._step = 1
-            self._render_step()
-        elif self._step == 1:
-            radio_set = self.query_one("#project-type", RadioSet)
-            if radio_set.pressed_index == 1:
-                self._project_type = "brownfield"
-            else:
-                self._project_type = "greenfield"
-            self._step = 2
-            self._render_step()
-        elif self._step == 2:
-            self._run_init()
+        if event.button.id == "init-back":
+            if self._step > 0:
+                self._step -= 1
+                self._render_step()
+        elif event.button.id == "init-next":
+            if self._step == 0:
+                try:
+                    self._target_dir = self.query_one("#target-dir", Input).value
+                except Exception:
+                    pass
+                self._step = 1
+                self._render_step()
+            elif self._step == 1:
+                self._run_init()
 
     def _run_init(self) -> None:
         target = Path(self._target_dir).resolve()
@@ -151,19 +162,13 @@ class InitWizardScreen(Screen):
             step_container.mount(Static("[green]Created: ralph.toml[/green]"))
 
         step_container.mount(Static(""))
-        step_container.mount(Static("[bold green]Setup complete![/bold green]"))
-
-        if self._project_type == "brownfield":
-            step_container.mount(Static(
-                "\nRecommended next step: run codebase understanding first.\n"
-                "  ralph understand 10"
-            ))
-        else:
-            step_container.mount(Static(
-                "\nNext steps:\n"
-                "  ralph prd create    # Create your PRD\n"
-                "  ralph run 25        # Run the feature loop"
-            ))
+        step_container.mount(Static("[bold green]Setup complete[/bold green]"))
+        step_container.mount(Static(
+            "\nRecommended next steps:\n"
+            "  1. ralph understand 10   - Map your codebase\n"
+            "  2. ralph prd create      - Create your PRD\n"
+            "  3. ralph run 25          - Run the feature loop"
+        ))
 
         self.query_one("#init-next", Button).disabled = True
         self.query_one("#init-step-label", Static).update("Setup Complete")

--- a/src/ralph/tui/screens/main_menu.py
+++ b/src/ralph/tui/screens/main_menu.py
@@ -13,34 +13,44 @@ from ralph.config import load_config
 from ralph.models import agent_display_name, detect_installed_agents
 from ralph.prd import load_prd
 
+LOGO = """\
+ ____       _       _
+|  _ \\ __ _| |_ __ | |__
+| |_) / _` | | '_ \\| '_ \\
+|  _ < (_| | | |_) | | | |
+|_| \\_\\__,_|_| .__/|_| |_|
+             |_|"""
+
 
 class MainMenuScreen(Screen):
     """Landing screen with mode selection and project overview."""
 
     BINDINGS = [
         ("q", "quit", "Quit"),
-        ("1", "select_init", "Init"),
-        ("2", "select_run", "Run"),
-        ("3", "select_understand", "Understand"),
-        ("4", "select_prd", "PRD"),
-        ("5", "select_status", "Status"),
-        ("6", "select_config", "Settings"),
+        ("1", "select_new_project", "New Project"),
+        ("2", "select_existing_project", "Existing Project"),
+        ("3", "select_run", "Run"),
+        ("4", "select_understand", "Understand"),
+        ("5", "select_prd", "PRD"),
+        ("6", "select_status", "Status"),
+        ("7", "select_config", "Settings"),
     ]
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
         with Center():
             with Vertical(id="main-menu"):
-                yield Static("Ralph", id="main-menu-title")
+                yield Static(LOGO, id="main-menu-logo")
                 yield Static("Agentic Loop Harness", id="main-menu-subtitle")
 
                 yield ListView(
-                    ListItem(Label("[1] New Project Setup"), id="menu-init"),
-                    ListItem(Label("[2] Run Feature Loop"), id="menu-run"),
-                    ListItem(Label("[3] Run Codebase Understanding"), id="menu-understand"),
-                    ListItem(Label("[4] Create / Edit PRD"), id="menu-prd"),
-                    ListItem(Label("[5] View Status"), id="menu-status"),
-                    ListItem(Label("[6] Settings"), id="menu-config"),
+                    ListItem(Label("[1]  New Project"), id="menu-new-project"),
+                    ListItem(Label("[2]  Add to Existing Project"), id="menu-existing-project"),
+                    ListItem(Label("[3]  Run Feature Loop"), id="menu-run"),
+                    ListItem(Label("[4]  Run Codebase Understanding"), id="menu-understand"),
+                    ListItem(Label("[5]  Create / Edit PRD"), id="menu-prd"),
+                    ListItem(Label("[6]  View Status"), id="menu-status"),
+                    ListItem(Label("[7]  Settings"), id="menu-config"),
                     id="main-menu-list",
                 )
 
@@ -54,45 +64,48 @@ class MainMenuScreen(Screen):
     def _refresh_project_info(self) -> None:
         info = self.query_one("#project-info", Static)
         cwd = Path.cwd()
-        lines = [f"Project: {cwd}"]
+        lines: list[str] = [f"[bold]Project[/bold]  {cwd.name}"]
 
         try:
             config = load_config()
             agent_desc = agent_display_name(config.agent.type, config.agent.model)
-            lines.append(f"Agent: {agent_desc}")
+            lines.append(f"[bold]Agent[/bold]    {agent_desc}")
         except Exception:
             installed = detect_installed_agents()
-            lines.append(
-                f"Agents: {', '.join(installed) if installed else 'none detected'}"
-            )
+            agents = ", ".join(installed) if installed else "none detected"
+            lines.append(f"[bold]Agents[/bold]   {agents}")
 
         try:
             prd = load_prd(cwd / "scripts" / "ralph" / "prd.json")
             lines.append(
-                f"PRD: {prd.total_stories} stories "
-                f"({prd.passing_stories} passing, {prd.failing_stories} failing)"
+                f"[bold]PRD[/bold]      {prd.total_stories} stories  "
+                f"[green]{prd.passing_stories} pass[/green]  "
+                f"[red]{prd.failing_stories} fail[/red]"
             )
         except Exception:
-            lines.append("PRD: not found")
+            lines.append("[bold]PRD[/bold]      [dim]not found[/dim]")
 
         info.update("\n".join(lines))
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
-        item_id = event.item.id
-        if item_id == "menu-init":
-            self.action_select_init()
-        elif item_id == "menu-run":
-            self.action_select_run()
-        elif item_id == "menu-understand":
-            self.action_select_understand()
-        elif item_id == "menu-prd":
-            self.action_select_prd()
-        elif item_id == "menu-status":
-            self.action_select_status()
-        elif item_id == "menu-config":
-            self.action_select_config()
+        item_id = event.item.id or ""
+        actions = {
+            "menu-new-project": self.action_select_new_project,
+            "menu-existing-project": self.action_select_existing_project,
+            "menu-run": self.action_select_run,
+            "menu-understand": self.action_select_understand,
+            "menu-prd": self.action_select_prd,
+            "menu-status": self.action_select_status,
+            "menu-config": self.action_select_config,
+        }
+        action = actions.get(item_id)
+        if action:
+            action()
 
-    def action_select_init(self) -> None:
+    def action_select_new_project(self) -> None:
+        self.app.push_screen("new_project_wizard")
+
+    def action_select_existing_project(self) -> None:
         self.app.push_screen("init_wizard")
 
     def action_select_run(self) -> None:

--- a/src/ralph/tui/screens/new_project_wizard.py
+++ b/src/ralph/tui/screens/new_project_wizard.py
@@ -1,0 +1,368 @@
+"""New project wizard - guided setup for greenfield projects.
+
+Combines project initialization and PRD creation into a single flow.
+Branch name is auto-derived from the project name.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from textual.app import ComposeResult
+from textual.containers import Center, Horizontal, Vertical
+from textual.screen import Screen
+from textual.widgets import (
+    Button,
+    Footer,
+    Header,
+    Input,
+    Label,
+    Static,
+    TextArea,
+)
+
+from ralph.config import RalphConfig, save_config
+from ralph.models import detect_installed_agents
+from ralph.prd import PRD, create_empty_prd, create_story, save_prd
+from ralph.prompt import scaffold_project
+from ralph.tui.widgets.model_selector import ModelSelector
+
+TOTAL_STEPS = 4
+
+
+def _slugify(name: str) -> str:
+    """Convert a project name to a branch-safe slug."""
+    slug = name.lower().strip()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    slug = slug.strip("-")
+    return slug or "project"
+
+
+class NewProjectWizardScreen(Screen):
+    """Guided wizard for creating brand-new projects from scratch.
+
+    Steps:
+        1. Project name and directory
+        2. Agent selection
+        3. Feature description and user stories (quick PRD)
+        4. Scaffold and finish
+    """
+
+    BINDINGS = [
+        ("escape", "back", "Back"),
+    ]
+
+    def __init__(self, name: str | None = None, id: str | None = None) -> None:
+        super().__init__(name=name, id=id)
+        self._step = 0
+        self._project_name = ""
+        self._target_dir = str(Path.cwd())
+        self._feature_overview = ""
+        self._stories: list[dict[str, str]] = []
+        self._tech_stack = ""
+        self._verification_commands = ""
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Center(classes="wizard-outer"):
+            with Vertical(id="new-project-container"):
+                yield Static("New Project", classes="title")
+                yield Static(
+                    self._progress_dots(),
+                    id="new-project-step-label",
+                )
+                yield Vertical(id="new-project-step")
+                with Horizontal(id="new-project-nav"):
+                    yield Button("Back", id="np-back", variant="default", disabled=True)
+                    yield Button("Next", id="np-next", variant="primary")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._render_step()
+
+    def _progress_dots(self) -> str:
+        parts: list[str] = []
+        for i in range(TOTAL_STEPS):
+            if i == self._step:
+                parts.append("[bold]()[/bold]")
+            elif i < self._step:
+                parts.append("[green]o[/green]")
+            else:
+                parts.append("[dim]o[/dim]")
+        return "  ".join(parts) + f"    Step {self._step + 1} of {TOTAL_STEPS}"
+
+    def _render_step(self) -> None:
+        container = self.query_one("#new-project-step", Vertical)
+        label = self.query_one("#new-project-step-label", Static)
+        back_btn = self.query_one("#np-back", Button)
+        next_btn = self.query_one("#np-next", Button)
+
+        container.remove_children()
+        label.update(self._progress_dots())
+
+        back_btn.disabled = self._step == 0
+
+        if self._step == 0:
+            next_btn.label = "Next"
+            self._render_name_step(container)
+        elif self._step == 1:
+            next_btn.label = "Next"
+            self._render_agent_step(container)
+        elif self._step == 2:
+            next_btn.label = "Next"
+            self._render_prd_step(container)
+        elif self._step == 3:
+            next_btn.label = "Create Project"
+            self._render_review_step(container)
+
+    # -- Step renderers --
+
+    def _render_name_step(self, container: Vertical) -> None:
+        container.mount(Label("Project name"))
+        container.mount(
+            Input(
+                value=self._project_name,
+                id="project-name",
+                placeholder="my-awesome-project",
+            )
+        )
+        container.mount(Label("Target directory"))
+        container.mount(
+            Input(
+                value=self._target_dir,
+                id="target-dir",
+                placeholder="/path/to/project",
+            )
+        )
+        container.mount(
+            Static(
+                "[dim]Ralph will scaffold files in this directory. "
+                "The branch name will be auto-generated from the project name.[/dim]",
+                classes="help-text",
+            )
+        )
+
+    def _render_agent_step(self, container: Vertical) -> None:
+        container.mount(Label("Select your AI agent"))
+        container.mount(ModelSelector(id="np-model-selector"))
+
+        installed = detect_installed_agents()
+        if not installed:
+            container.mount(
+                Static(
+                    "[yellow]No agents detected. "
+                    "Install claude or codex first.[/yellow]"
+                )
+            )
+
+    def _render_prd_step(self, container: Vertical) -> None:
+        container.mount(Label("What are you building?"))
+        container.mount(
+            TextArea(
+                self._feature_overview,
+                id="np-feature-overview",
+            )
+        )
+        container.mount(Static(""))
+        container.mount(Label("User stories"))
+        container.mount(
+            Static(
+                "[dim]Add at least one story with acceptance criteria. "
+                "One criterion per line.[/dim]",
+                classes="help-text",
+            )
+        )
+
+        if not self._stories:
+            self._stories.append({"title": "", "criteria": ""})
+
+        for i, story in enumerate(self._stories):
+            container.mount(Label(f"Story {i + 1}"))
+            container.mount(
+                Input(
+                    value=story["title"],
+                    id=f"np-story-title-{i}",
+                    placeholder="Story title",
+                )
+            )
+            container.mount(
+                TextArea(
+                    story["criteria"],
+                    id=f"np-story-criteria-{i}",
+                )
+            )
+
+        container.mount(Button("+ Add Story", id="np-add-story", variant="success"))
+        container.mount(Static(""))
+        container.mount(Label("Tech stack"))
+        container.mount(
+            TextArea(self._tech_stack, id="np-tech-stack")
+        )
+        container.mount(Label("Verification commands"))
+        container.mount(
+            Static(
+                "[dim]Commands to verify correctness (e.g., pytest, mypy, npm test). "
+                "Added as acceptance criteria to every story.[/dim]",
+                classes="help-text",
+            )
+        )
+        container.mount(
+            TextArea(self._verification_commands, id="np-verification")
+        )
+
+    def _render_review_step(self, container: Vertical) -> None:
+        slug = _slugify(self._project_name)
+        branch = f"ralph/{slug}"
+        prd = self._build_prd(branch)
+        preview = json.dumps(prd.to_dict(), indent=2)
+
+        container.mount(Label("Review"))
+        container.mount(Static(f"  Project:   {self._project_name}"))
+        container.mount(Static(f"  Directory: {self._target_dir}"))
+        container.mount(Static(f"  Branch:    {branch}"))
+        container.mount(Static(f"  Stories:   {prd.total_stories}"))
+        container.mount(Static(""))
+        container.mount(
+            TextArea(preview, id="np-preview", read_only=True)
+        )
+
+    # -- Data collection --
+
+    def _save_current_step(self) -> None:
+        if self._step == 0:
+            try:
+                self._project_name = self.query_one("#project-name", Input).value
+                self._target_dir = self.query_one("#target-dir", Input).value
+            except Exception:
+                pass
+        elif self._step == 2:
+            try:
+                self._feature_overview = self.query_one(
+                    "#np-feature-overview", TextArea
+                ).text
+            except Exception:
+                pass
+            for i in range(len(self._stories)):
+                try:
+                    self._stories[i]["title"] = self.query_one(
+                        f"#np-story-title-{i}", Input
+                    ).value
+                    self._stories[i]["criteria"] = self.query_one(
+                        f"#np-story-criteria-{i}", TextArea
+                    ).text
+                except Exception:
+                    pass
+            try:
+                self._tech_stack = self.query_one("#np-tech-stack", TextArea).text
+                self._verification_commands = self.query_one(
+                    "#np-verification", TextArea
+                ).text
+            except Exception:
+                pass
+
+    def _build_prd(self, branch_name: str) -> PRD:
+        prd = create_empty_prd(branch_name)
+        for i, story_data in enumerate(self._stories):
+            title = story_data["title"].strip()
+            if not title:
+                continue
+            criteria_lines = [
+                line.strip()
+                for line in story_data["criteria"].splitlines()
+                if line.strip()
+            ]
+            if self._verification_commands.strip():
+                for cmd_line in self._verification_commands.strip().splitlines():
+                    cmd_line = cmd_line.strip()
+                    if cmd_line and cmd_line not in criteria_lines:
+                        criteria_lines.append(cmd_line)
+
+            story = create_story(
+                story_id=f"US-{i + 1:03d}",
+                title=title,
+                acceptance_criteria=criteria_lines or ["Typecheck passes", "Tests pass"],
+                priority=i + 1,
+            )
+            prd.user_stories.append(story)
+        return prd
+
+    # -- Button handling --
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "np-next":
+            self._save_current_step()
+            if self._step == TOTAL_STEPS - 1:
+                self._create_project()
+            else:
+                self._step += 1
+                self._render_step()
+        elif event.button.id == "np-back":
+            self._save_current_step()
+            if self._step > 0:
+                self._step -= 1
+                self._render_step()
+        elif event.button.id == "np-add-story":
+            self._save_current_step()
+            self._stories.append({"title": "", "criteria": ""})
+            self._render_step()
+
+    def _create_project(self) -> None:
+        target = Path(self._target_dir).resolve()
+        slug = _slugify(self._project_name)
+        branch = f"ralph/{slug}"
+
+        container = self.query_one("#new-project-step", Vertical)
+        container.remove_children()
+
+        container.mount(Static(f"Creating project at {target}..."))
+
+        # Scaffold files
+        messages = scaffold_project(target)
+        for msg in messages:
+            if msg.startswith("Created"):
+                container.mount(Static(f"[green]{msg}[/green]"))
+            else:
+                container.mount(Static(f"[dim]{msg}[/dim]"))
+
+        # Create ralph.toml
+        config = RalphConfig()
+        try:
+            selector = self.query_one("#np-model-selector", ModelSelector)
+            config.agent.type = selector.agent_type
+            config.agent.model = selector.model
+        except Exception:
+            installed = detect_installed_agents()
+            if "claude" in installed:
+                config.agent.type = "claude"
+            elif "codex" in installed:
+                config.agent.type = "codex"
+
+        toml_path = target / "ralph.toml"
+        if not toml_path.exists():
+            save_config(config, toml_path)
+            container.mount(Static("[green]Created: ralph.toml[/green]"))
+
+        # Save PRD
+        prd = self._build_prd(branch)
+        prd_path = target / "scripts" / "ralph" / "prd.json"
+        prd_path.parent.mkdir(parents=True, exist_ok=True)
+        save_prd(prd, prd_path)
+        container.mount(
+            Static(f"[green]Created: PRD with {prd.total_stories} stories[/green]")
+        )
+
+        container.mount(Static(""))
+        container.mount(Static("[bold green]Project created[/bold green]"))
+        container.mount(Static(
+            "\nNext steps:\n"
+            f"  cd {target}\n"
+            f"  ralph run 25    - Run the feature loop"
+        ))
+
+        self.query_one("#np-next", Button).disabled = True
+        self.query_one("#new-project-step-label", Static).update("Done")
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/ralph/tui/screens/prd_wizard.py
+++ b/src/ralph/tui/screens/prd_wizard.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 
 from textual.app import ComposeResult
-from textual.containers import Center, Horizontal, Vertical
+from textual.containers import Center, Horizontal, Vertical, VerticalScroll
 from textual.screen import Screen
 from textual.widgets import (
     Button,
@@ -14,15 +14,26 @@ from textual.widgets import (
     Header,
     Input,
     Label,
+    RadioButton,
+    RadioSet,
     Static,
     TextArea,
 )
 
-from ralph.prd import PRD, create_empty_prd, create_story, save_prd
+from ralph.prd import PRD, create_empty_prd, create_story, parse_markdown_to_stories, save_prd
+
+# Step indices after the mode-selection step
+_STEP_MODE = 0
+_STEP_FEATURE = 1
+_STEP_BRANCH = 2
+_STEP_STORIES = 3
+_STEP_TECH = 4
+_STEP_REVIEW = 5
+_TOTAL_STEPS = 6
 
 
 class PRDWizardScreen(Screen):
-    """Multi-step PRD creation wizard."""
+    """Multi-step PRD creation wizard with markdown import support."""
 
     BINDINGS = [
         ("escape", "back", "Back"),
@@ -30,7 +41,10 @@ class PRDWizardScreen(Screen):
 
     def __init__(self, name: str | None = None, id: str | None = None) -> None:
         super().__init__(name=name, id=id)
-        self._step = 0
+        self._step = _STEP_MODE
+        self._mode = "scratch"  # "scratch" or "import"
+        self._import_path = ""
+        self._import_error = ""
         self._branch_name = "ralph/feature"
         self._feature_overview = ""
         self._stories: list[dict[str, str]] = []
@@ -39,11 +53,14 @@ class PRDWizardScreen(Screen):
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
-        with Center():
+        with Center(classes="wizard-outer"):
             with Vertical(id="wizard-container"):
                 yield Static("PRD Wizard", classes="title")
-                yield Static("Step 1 of 5: Feature Overview", id="wizard-step-label")
-                yield Vertical(id="wizard-step")
+                yield Static(
+                    self._progress_dots(),
+                    id="wizard-step-label",
+                )
+                yield VerticalScroll(id="wizard-step")
                 with Horizontal(id="wizard-nav"):
                     yield Button("Back", id="wizard-back", variant="default")
                     yield Button("Next", id="wizard-next", variant="primary")
@@ -52,40 +69,92 @@ class PRDWizardScreen(Screen):
     def on_mount(self) -> None:
         self._render_step()
 
+    def _progress_dots(self) -> str:
+        total = _TOTAL_STEPS
+        parts: list[str] = []
+        for i in range(total):
+            if i == self._step:
+                parts.append("[bold]()[/bold]")
+            elif i < self._step:
+                parts.append("[green]o[/green]")
+            else:
+                parts.append("[dim]o[/dim]")
+        return "  ".join(parts)
+
     def _render_step(self) -> None:
-        step_container = self.query_one("#wizard-step", Vertical)
+        step_container = self.query_one("#wizard-step", VerticalScroll)
         step_label = self.query_one("#wizard-step-label", Static)
         back_btn = self.query_one("#wizard-back", Button)
         next_btn = self.query_one("#wizard-next", Button)
 
-        # Clear previous content
         step_container.remove_children()
+        step_label.update(self._progress_dots())
 
-        back_btn.disabled = self._step == 0
-        next_btn.label = "Save" if self._step == 4 else "Next"
+        back_btn.disabled = self._step == _STEP_MODE
 
-        step_titles = [
-            "Step 1 of 5: Feature Overview",
-            "Step 2 of 5: Branch Name",
-            "Step 3 of 5: User Stories",
-            "Step 4 of 5: Tech Stack & Verification",
-            "Step 5 of 5: Review & Save",
-        ]
-        step_label.update(step_titles[self._step])
-
-        if self._step == 0:
+        if self._step == _STEP_MODE:
+            next_btn.label = "Next"
+            self._render_mode_step(step_container)
+        elif self._step == _STEP_FEATURE:
+            next_btn.label = "Next"
             self._render_feature_step(step_container)
-        elif self._step == 1:
+        elif self._step == _STEP_BRANCH:
+            next_btn.label = "Next"
             self._render_branch_step(step_container)
-        elif self._step == 2:
+        elif self._step == _STEP_STORIES:
+            next_btn.label = "Next"
             self._render_stories_step(step_container)
-        elif self._step == 3:
+        elif self._step == _STEP_TECH:
+            next_btn.label = "Next"
             self._render_tech_step(step_container)
-        elif self._step == 4:
+        elif self._step == _STEP_REVIEW:
+            next_btn.label = "Save"
             self._render_review_step(step_container)
 
-    def _render_feature_step(self, container: Vertical) -> None:
-        container.mount(Label("Describe the feature you're building:"))
+    # -- Step renderers --
+
+    def _render_mode_step(self, container: VerticalScroll) -> None:
+        container.mount(Label("How would you like to create your PRD?"))
+        container.mount(Static(""))
+        container.mount(
+            RadioSet(
+                RadioButton(
+                    "Start from scratch",
+                    value=self._mode == "scratch",
+                ),
+                RadioButton(
+                    "Import from a markdown file",
+                    value=self._mode == "import",
+                ),
+                id="prd-mode",
+            )
+        )
+
+        if self._mode == "import":
+            container.mount(Static(""))
+            container.mount(Label("Path to markdown file"))
+            container.mount(
+                Input(
+                    value=self._import_path,
+                    id="import-path",
+                    placeholder="/path/to/spec.md",
+                )
+            )
+            container.mount(
+                Static(
+                    "[dim]The file will be parsed into user stories. "
+                    "Headings become story titles, bullets become acceptance criteria. "
+                    "You can review and edit everything before saving.[/dim]",
+                    classes="help-text",
+                )
+            )
+            if self._import_error:
+                container.mount(
+                    Static(f"[red]{self._import_error}[/red]")
+                )
+
+    def _render_feature_step(self, container: VerticalScroll) -> None:
+        container.mount(Label("Describe the feature you're building"))
         container.mount(
             TextArea(
                 self._feature_overview,
@@ -93,25 +162,35 @@ class PRDWizardScreen(Screen):
             )
         )
 
-    def _render_branch_step(self, container: Vertical) -> None:
-        container.mount(Label("Git branch name for this work:"))
+    def _render_branch_step(self, container: VerticalScroll) -> None:
+        container.mount(Label("Git branch name for this work"))
         container.mount(Input(
             value=self._branch_name,
             id="branch-name",
             placeholder="ralph/my-feature",
         ))
+        container.mount(
+            Static(
+                "[dim]The agent will check out this branch before starting work.[/dim]",
+                classes="help-text",
+            )
+        )
 
-    def _render_stories_step(self, container: Vertical) -> None:
-        container.mount(Label("User stories (one per section):"))
-        container.mount(Static("Add stories with a title and acceptance criteria."))
-        container.mount(Static("Criteria: one per line, should be testable."))
-        container.mount(Static(""))
+    def _render_stories_step(self, container: VerticalScroll) -> None:
+        container.mount(Label("User stories"))
+        container.mount(
+            Static(
+                "[dim]Each story needs a title and testable acceptance criteria, "
+                "one per line.[/dim]",
+                classes="help-text",
+            )
+        )
 
         if not self._stories:
             self._stories.append({"title": "", "criteria": ""})
 
         for i, story in enumerate(self._stories):
-            container.mount(Label(f"Story {i + 1}:"))
+            container.mount(Label(f"Story {i + 1}"))
             container.mount(Input(
                 value=story["title"],
                 id=f"story-title-{i}",
@@ -126,43 +205,70 @@ class PRDWizardScreen(Screen):
 
         container.mount(Button("+ Add Story", id="add-story", variant="success"))
 
-    def _render_tech_step(self, container: Vertical) -> None:
-        container.mount(Label("Tech stack (language, framework, testing tools):"))
+    def _render_tech_step(self, container: VerticalScroll) -> None:
+        container.mount(Label("Tech stack"))
+        container.mount(
+            Static(
+                "[dim]Language, framework, testing tools, etc.[/dim]",
+                classes="help-text",
+            )
+        )
         container.mount(
             TextArea(self._tech_stack, id="tech-stack")
         )
-        container.mount(Label("Verification commands (typecheck, test, lint):"))
+        container.mount(Label("Verification commands"))
+        container.mount(
+            Static(
+                "[dim]Commands to verify correctness (e.g., pytest, mypy, npm test). "
+                "These are added as acceptance criteria to every story.[/dim]",
+                classes="help-text",
+            )
+        )
         container.mount(
             TextArea(self._verification_commands, id="verification-commands")
         )
 
-    def _render_review_step(self, container: Vertical) -> None:
+    def _render_review_step(self, container: VerticalScroll) -> None:
         prd = self._build_prd()
         preview = json.dumps(prd.to_dict(), indent=2)
-        container.mount(Label("Review your PRD:"))
+        container.mount(Label("Review your PRD"))
+        container.mount(Static(
+            f"  Branch:  {prd.branch_name}\n"
+            f"  Stories: {prd.total_stories}"
+        ))
+        container.mount(Static(""))
         container.mount(
             TextArea(preview, id="prd-preview", read_only=True)
         )
-        container.mount(Static(
-            f"Branch: {prd.branch_name}  |  "
-            f"Stories: {prd.total_stories}"
-        ))
+
+    # -- Data collection --
 
     def _save_current_step(self) -> None:
         """Save form data from the current step before navigating."""
-        if self._step == 0:
+        if self._step == _STEP_MODE:
+            try:
+                radio_set = self.query_one("#prd-mode", RadioSet)
+                self._mode = "import" if radio_set.pressed_index == 1 else "scratch"
+            except Exception:
+                pass
+            if self._mode == "import":
+                try:
+                    self._import_path = self.query_one("#import-path", Input).value
+                except Exception:
+                    pass
+        elif self._step == _STEP_FEATURE:
             try:
                 ta = self.query_one("#feature-overview", TextArea)
                 self._feature_overview = ta.text
             except Exception:
                 pass
-        elif self._step == 1:
+        elif self._step == _STEP_BRANCH:
             try:
                 inp = self.query_one("#branch-name", Input)
                 self._branch_name = inp.value
             except Exception:
                 pass
-        elif self._step == 2:
+        elif self._step == _STEP_STORIES:
             for i in range(len(self._stories)):
                 try:
                     title_inp = self.query_one(f"#story-title-{i}", Input)
@@ -171,13 +277,41 @@ class PRDWizardScreen(Screen):
                     self._stories[i]["criteria"] = criteria_ta.text
                 except Exception:
                     pass
-        elif self._step == 3:
+        elif self._step == _STEP_TECH:
             try:
                 self._tech_stack = self.query_one("#tech-stack", TextArea).text
                 ta = self.query_one("#verification-commands", TextArea)
                 self._verification_commands = ta.text
             except Exception:
                 pass
+
+    def _try_import_markdown(self) -> bool:
+        """Attempt to import a markdown file. Returns True on success."""
+        path = Path(self._import_path).expanduser().resolve()
+        if not path.exists():
+            self._import_error = f"File not found: {path}"
+            return False
+        if not path.is_file():
+            self._import_error = f"Not a file: {path}"
+            return False
+
+        try:
+            content = path.read_text(encoding="utf-8")
+        except Exception as e:
+            self._import_error = f"Could not read file: {e}"
+            return False
+
+        if not content.strip():
+            self._import_error = "File is empty"
+            return False
+
+        parsed = parse_markdown_to_stories(content)
+        self._feature_overview = parsed.feature_overview
+        self._stories = parsed.stories if parsed.stories else [{"title": "", "criteria": ""}]
+        self._tech_stack = parsed.tech_stack
+        self._verification_commands = parsed.verification_commands
+        self._import_error = ""
+        return True
 
     def _build_prd(self) -> PRD:
         """Build a PRD from the wizard data."""
@@ -191,7 +325,6 @@ class PRDWizardScreen(Screen):
                 for line in story_data["criteria"].splitlines()
                 if line.strip()
             ]
-            # Add typecheck/test criteria from verification commands if present
             if self._verification_commands.strip():
                 for cmd_line in self._verification_commands.strip().splitlines():
                     cmd_line = cmd_line.strip()
@@ -207,22 +340,41 @@ class PRDWizardScreen(Screen):
             prd.user_stories.append(story)
         return prd
 
+    # -- Navigation --
+
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "wizard-next":
             self._save_current_step()
-            if self._step == 4:
+
+            # Handle import on mode step
+            if self._step == _STEP_MODE and self._mode == "import":
+                if not self._try_import_markdown():
+                    self._render_step()  # Re-render to show error
+                    return
+                # Skip feature overview step (already populated from file)
+                self._step = _STEP_BRANCH
+                self._render_step()
+                return
+
+            if self._step == _STEP_REVIEW:
                 self._save_prd()
             else:
                 self._step += 1
                 self._render_step()
         elif event.button.id == "wizard-back":
             self._save_current_step()
-            if self._step > 0:
+            if self._step > _STEP_MODE:
                 self._step -= 1
                 self._render_step()
         elif event.button.id == "add-story":
             self._save_current_step()
             self._stories.append({"title": "", "criteria": ""})
+            self._render_step()
+
+    def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
+        """Show/hide import fields when mode changes."""
+        if event.radio_set.id == "prd-mode":
+            self._mode = "import" if event.index == 1 else "scratch"
             self._render_step()
 
     def _save_prd(self) -> None:
@@ -231,11 +383,12 @@ class PRDWizardScreen(Screen):
         output_path.parent.mkdir(parents=True, exist_ok=True)
         save_prd(prd, output_path)
 
-        step_container = self.query_one("#wizard-step", Vertical)
+        step_container = self.query_one("#wizard-step", VerticalScroll)
         step_container.remove_children()
         step_container.mount(Static(f"[green]PRD saved to {output_path}[/green]"))
         step_container.mount(Static(
-            f"Branch: {prd.branch_name}  |  Stories: {prd.total_stories}"
+            f"  Branch:  {prd.branch_name}\n"
+            f"  Stories: {prd.total_stories}"
         ))
         step_container.mount(Static("\nYou can now run: ralph run"))
         self.query_one("#wizard-next", Button).disabled = True

--- a/src/ralph/tui/screens/status_screen.py
+++ b/src/ralph/tui/screens/status_screen.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Vertical, VerticalScroll
 from textual.screen import Screen
 from textual.widgets import Footer, Header, Static
 
@@ -26,12 +26,25 @@ class StatusScreen(Screen):
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
-        with Vertical(id="status-container"):
+        with VerticalScroll(id="status-container"):
             yield Static("Project Status", classes="title")
-            yield Static("", id="config-summary")
-            yield Static("", id="git-summary")
-            yield Static("", id="agent-summary")
-            yield Static("", id="prd-summary")
+
+            with Vertical(classes="status-card"):
+                yield Static("Configuration", classes="status-card-title")
+                yield Static("", id="config-summary")
+
+            with Vertical(classes="status-card"):
+                yield Static("Git", classes="status-card-title")
+                yield Static("", id="git-summary")
+
+            with Vertical(classes="status-card"):
+                yield Static("Agents", classes="status-card-title")
+                yield Static("", id="agent-summary")
+
+            with Vertical(classes="status-card"):
+                yield Static("PRD", classes="status-card-title")
+                yield Static("", id="prd-summary")
+
             yield StoryTableWidget(id="story-table")
         yield Footer()
 
@@ -46,53 +59,41 @@ class StatusScreen(Screen):
             config = load_config()
             display = config_to_display(config)
             config_lines = "\n".join(f"  {k}: {v}" for k, v in display.items())
-            self.query_one("#config-summary", Static).update(
-                f"[bold]Configuration[/bold]\n{config_lines}"
-            )
+            self.query_one("#config-summary", Static).update(config_lines)
         except Exception as e:
             self.query_one("#config-summary", Static).update(
-                f"[yellow]Config: {e}[/yellow]"
+                f"[yellow]{e}[/yellow]"
             )
 
         # Git summary
         if is_git_repo(cwd):
             branch = current_branch(cwd)
-            self.query_one("#git-summary", Static).update(
-                f"\n[bold]Git[/bold]\n  Branch: {branch}"
-            )
+            self.query_one("#git-summary", Static).update(f"  Branch: {branch}")
         else:
             self.query_one("#git-summary", Static).update(
-                "\n[dim]Not a git repository[/dim]"
+                "  [dim]Not a git repository[/dim]"
             )
 
         # Agent summary
         installed = detect_installed_agents()
         agent_str = ", ".join(installed) if installed else "[yellow]none found[/yellow]"
-        self.query_one("#agent-summary", Static).update(
-            f"\n[bold]Installed Agents[/bold]\n  {agent_str}"
-        )
+        self.query_one("#agent-summary", Static).update(f"  {agent_str}")
 
         # PRD summary
         try:
             config = load_config()
             prd = load_prd(cwd / config.paths.prd)
             self.query_one("#prd-summary", Static).update(
-                f"\n[bold]PRD[/bold]\n"
                 f"  Branch: {prd.branch_name}\n"
                 f"  Stories: {prd.total_stories} total, "
                 f"{prd.passing_stories} passing, {prd.failing_stories} failing"
             )
-            next_story = prd.next_story()
-            if next_story:
-                self.query_one("#prd-summary", Static).update(
-                    self.query_one("#prd-summary", Static).renderable  # type: ignore[arg-type]
-                )
 
             story_table = self.query_one("#story-table", StoryTableWidget)
             story_table.update_stories(prd)
         except Exception as e:
             self.query_one("#prd-summary", Static).update(
-                f"\n[dim]PRD: {e}[/dim]"
+                f"  [dim]{e}[/dim]"
             )
 
     def action_refresh(self) -> None:

--- a/src/ralph/tui/styles/app.tcss
+++ b/src/ralph/tui/styles/app.tcss
@@ -1,135 +1,30 @@
-/* Ralph TUI Theme */
+/* Ralph TUI - Clean & Professional Theme */
+
+/* ── Global ─────────────────────────────────────────── */
 
 Screen {
     background: $surface;
 }
 
-/* Main menu */
-#main-menu {
-    align: center middle;
-}
-
-#main-menu-title {
-    text-align: center;
-    color: $accent;
-    text-style: bold;
-    margin-bottom: 1;
-}
-
-#main-menu-subtitle {
-    text-align: center;
-    color: $text-muted;
-    margin-bottom: 2;
-}
-
-#main-menu-list {
-    width: 60;
-    height: auto;
-    max-height: 20;
-}
-
-#project-info {
-    margin-top: 1;
-    padding: 1 2;
-    border: solid $primary-background;
-    width: 60;
-}
-
-/* Run dashboard */
-#run-header {
-    dock: top;
-    height: 3;
-    background: $primary-background;
-    color: $text;
-    padding: 0 2;
-}
-
-#run-body {
-    height: 1fr;
-}
-
-#agent-log {
-    width: 3fr;
-    border-right: solid $primary-background;
-}
-
-#story-panel {
-    width: 2fr;
-    padding: 0 1;
-}
-
-#run-footer {
-    dock: bottom;
-    height: 1;
-    background: $primary-background;
-}
-
-/* PRD wizard */
-#wizard-container {
-    align: center middle;
-    padding: 2;
-}
-
-#wizard-step {
-    width: 80;
-    max-height: 30;
-    border: solid $primary-background;
-    padding: 1 2;
-}
-
-#wizard-nav {
-    dock: bottom;
-    height: 3;
-    align: center middle;
-}
-
-/* Config screen */
-#config-container {
-    padding: 1 2;
-}
-
-.config-section {
-    margin-bottom: 1;
-    padding: 1;
-    border: solid $primary-background;
-}
-
-.config-section-title {
-    text-style: bold;
-    color: $accent;
-    margin-bottom: 1;
-}
-
-/* Status screen */
-#status-container {
-    padding: 1 2;
-}
-
-#status-summary {
-    margin-bottom: 1;
-    padding: 1;
-    border: solid $primary-background;
-}
-
-/* Init wizard */
-#init-container {
-    align: center middle;
-    padding: 2;
-}
-
-#init-step {
-    width: 70;
-    border: solid $primary-background;
-    padding: 1 2;
-}
-
-/* Common styles */
 .title {
     text-style: bold;
-    color: $accent;
+    color: $text;
+    margin-bottom: 1;
 }
 
-.subtitle {
+.section-heading {
+    text-style: bold;
+    color: $text-muted;
+    text-transform: uppercase;
+    margin-bottom: 1;
+}
+
+.help-text {
+    color: $text-muted;
+    margin-bottom: 1;
+}
+
+.muted {
     color: $text-muted;
 }
 
@@ -145,6 +40,289 @@ Screen {
     color: $warning;
 }
 
-.muted {
+/* ── Main Menu ──────────────────────────────────────── */
+
+#main-menu {
+    align: center middle;
+    width: 64;
+}
+
+#main-menu-logo {
+    text-align: center;
+    color: $text;
+    text-style: bold;
+    margin-bottom: 0;
+}
+
+#main-menu-subtitle {
+    text-align: center;
     color: $text-muted;
+    margin-bottom: 2;
+}
+
+#main-menu-list {
+    width: 100%;
+    height: auto;
+    max-height: 24;
+    margin-bottom: 1;
+}
+
+#main-menu-list > ListItem {
+    padding: 0 2;
+    height: 3;
+}
+
+#main-menu-list > ListItem > Label {
+    padding: 1 0;
+}
+
+#project-info {
+    padding: 1 2;
+    background: $panel;
+    width: 100%;
+    margin-top: 1;
+}
+
+/* ── Run Dashboard ──────────────────────────────────── */
+
+#run-header {
+    dock: top;
+    height: 3;
+    background: $panel;
+    color: $text;
+    padding: 0 2;
+}
+
+#run-body {
+    height: 1fr;
+}
+
+#agent-log {
+    width: 3fr;
+    border-right: solid $surface-darken-2;
+}
+
+#story-panel {
+    width: 2fr;
+    padding: 0 1;
+}
+
+#run-footer {
+    dock: bottom;
+    height: 1;
+    background: $panel;
+}
+
+/* ── Wizard Shared ──────────────────────────────────── */
+
+.wizard-outer {
+    align: center middle;
+    width: 100%;
+    height: 100%;
+}
+
+.wizard-box {
+    width: 90;
+    max-width: 90;
+    padding: 2 3;
+}
+
+.wizard-progress {
+    text-align: center;
+    color: $text-muted;
+    margin-bottom: 2;
+}
+
+.wizard-step-content {
+    min-height: 8;
+    max-height: 32;
+    padding: 1 0;
+}
+
+.wizard-nav {
+    height: 3;
+    align: right middle;
+    margin-top: 1;
+}
+
+.wizard-nav Button {
+    margin-left: 1;
+}
+
+/* ── PRD Wizard (legacy IDs kept for compat) ────────── */
+
+#wizard-container {
+    width: 90;
+    max-width: 90;
+    padding: 2 3;
+}
+
+#wizard-step-label {
+    text-align: center;
+    color: $text-muted;
+    margin-bottom: 1;
+}
+
+#wizard-step {
+    min-height: 8;
+    max-height: 32;
+    padding: 1 0;
+}
+
+#wizard-nav {
+    height: 3;
+    align: right middle;
+    margin-top: 1;
+}
+
+#wizard-nav Button {
+    margin-left: 1;
+}
+
+/* ── Config Screen ──────────────────────────────────── */
+
+#config-container {
+    padding: 2 4;
+}
+
+.config-section {
+    margin-bottom: 2;
+    padding: 1 2;
+    background: $panel;
+}
+
+.config-section-title {
+    text-style: bold;
+    color: $text-muted;
+    text-transform: uppercase;
+    margin-bottom: 1;
+}
+
+.config-help {
+    color: $text-muted;
+    margin-bottom: 1;
+}
+
+#save-btn {
+    margin-top: 1;
+}
+
+#save-status {
+    margin-top: 1;
+}
+
+/* ── Status Screen ──────────────────────────────────── */
+
+#status-container {
+    padding: 2 4;
+}
+
+.status-card {
+    margin-bottom: 1;
+    padding: 1 2;
+    background: $panel;
+}
+
+.status-card-title {
+    text-style: bold;
+    color: $text-muted;
+    text-transform: uppercase;
+    margin-bottom: 1;
+}
+
+/* ── Init Wizard ────────────────────────────────────── */
+
+#init-container {
+    width: 90;
+    max-width: 90;
+    padding: 2 3;
+}
+
+#init-step-label {
+    text-align: center;
+    color: $text-muted;
+    margin-bottom: 1;
+}
+
+#init-step {
+    min-height: 6;
+    padding: 1 0;
+}
+
+#init-next {
+    margin-top: 1;
+    dock: bottom;
+}
+
+/* ── New Project Wizard ─────────────────────────────── */
+
+#new-project-container {
+    width: 90;
+    max-width: 90;
+    padding: 2 3;
+}
+
+#new-project-step-label {
+    text-align: center;
+    color: $text-muted;
+    margin-bottom: 1;
+}
+
+#new-project-step {
+    min-height: 8;
+    max-height: 32;
+    padding: 1 0;
+}
+
+#new-project-nav {
+    height: 3;
+    align: right middle;
+    margin-top: 1;
+}
+
+#new-project-nav Button {
+    margin-left: 1;
+}
+
+/* ── Widget Overrides ───────────────────────────────── */
+
+AgentLogWidget {
+    scrollbar-size: 1;
+}
+
+StoryTableWidget {
+    height: 1fr;
+}
+
+RunHeader {
+    height: 3;
+    background: $panel;
+    padding: 1 2;
+    text-style: bold;
+}
+
+ModelSelector {
+    height: auto;
+    padding: 1;
+}
+
+ModelSelector Horizontal {
+    height: auto;
+}
+
+ModelSelector .selector-label {
+    width: 12;
+    padding: 1 1 0 0;
+}
+
+ModelSelector Select {
+    width: 30;
+}
+
+Input {
+    margin-bottom: 1;
+}
+
+TextArea {
+    margin-bottom: 1;
 }

--- a/src/ralph/tui/widgets/agent_log.py
+++ b/src/ralph/tui/widgets/agent_log.py
@@ -25,11 +25,7 @@ ROLE_STYLES: dict[LineRole, tuple[str, str]] = {
 class AgentLogWidget(RichLog):
     """RichLog-based agent output display with role-classified coloring."""
 
-    DEFAULT_CSS = """
-    AgentLogWidget {
-        scrollbar-size: 1;
-    }
-    """
+    DEFAULT_CSS = ""
 
     def write_agent_line(self, output: AgentOutput) -> None:
         """Write a classified agent output line to the log."""

--- a/src/ralph/tui/widgets/header.py
+++ b/src/ralph/tui/widgets/header.py
@@ -17,14 +17,7 @@ class RunHeader(Static):
     elapsed = reactive(0.0)
     _start_time: float = 0.0
 
-    DEFAULT_CSS = """
-    RunHeader {
-        height: 3;
-        background: $primary-background;
-        padding: 1 2;
-        text-style: bold;
-    }
-    """
+    DEFAULT_CSS = ""
 
     def on_mount(self) -> None:
         self._start_time = time.monotonic()
@@ -38,10 +31,10 @@ class RunHeader(Static):
         seconds = int(self.elapsed) % 60
         time_str = f"{minutes:02d}:{seconds:02d}"
 
-        iter_str = f"Iteration {self.iteration} / {self.max_iterations}"
-        story_str = self.current_story or "..."
+        iter_str = f"Iteration {self.iteration}/{self.max_iterations}"
+        story_str = self.current_story or "-"
 
-        return f"  {iter_str}        {story_str}        {time_str}"
+        return f"  {iter_str}   |   Story: {story_str}   |   {time_str}"
 
     def set_iteration(self, iteration: int, max_iterations: int) -> None:
         self.iteration = iteration

--- a/src/ralph/tui/widgets/model_selector.py
+++ b/src/ralph/tui/widgets/model_selector.py
@@ -19,33 +19,7 @@ from ralph.models import (
 class ModelSelector(Widget):
     """Compound widget for selecting agent type and model."""
 
-    DEFAULT_CSS = """
-    ModelSelector {
-        height: auto;
-        padding: 1;
-    }
-
-    ModelSelector Horizontal {
-        height: auto;
-    }
-
-    ModelSelector .selector-label {
-        width: 12;
-        padding: 1 1 0 0;
-    }
-
-    ModelSelector Select {
-        width: 30;
-    }
-
-    ModelSelector #custom-command-label {
-        display: none;
-    }
-
-    ModelSelector #custom-command-display {
-        display: none;
-    }
-    """
+    DEFAULT_CSS = ""
 
     class Changed(Message):
         """Emitted when the agent or model selection changes."""

--- a/src/ralph/tui/widgets/story_table.py
+++ b/src/ralph/tui/widgets/story_table.py
@@ -10,11 +10,7 @@ from ralph.prd import PRD
 class StoryTableWidget(DataTable):
     """DataTable showing user story status with pass/fail indicators."""
 
-    DEFAULT_CSS = """
-    StoryTableWidget {
-        height: 1fr;
-    }
-    """
+    DEFAULT_CSS = ""
 
     def on_mount(self) -> None:
         self.add_column("ID", key="id", width=8)

--- a/tests/test_prd.py
+++ b/tests/test_prd.py
@@ -11,6 +11,7 @@ from ralph.prd import (
     create_empty_prd,
     create_story,
     load_prd,
+    parse_markdown_to_stories,
     save_prd,
     validate_prd,
 )
@@ -155,3 +156,95 @@ def test_create_story() -> None:
     assert story.id == "US-001"
     assert story.passes is False
     assert story.notes == ""
+
+
+# -- parse_markdown_to_stories tests --
+
+
+def test_parse_markdown_headings_to_stories() -> None:
+    md = """\
+# My Feature
+
+## User login
+- Username and password required
+- Session token returned on success
+
+## Password reset
+- Email sent with reset link
+- Link expires after 24h
+"""
+    result = parse_markdown_to_stories(md)
+    assert result.feature_overview == "My Feature"
+    assert len(result.stories) == 2
+    assert result.stories[0]["title"] == "User login"
+    assert "Username and password required" in result.stories[0]["criteria"]
+    assert result.stories[1]["title"] == "Password reset"
+
+
+def test_parse_markdown_meta_sections() -> None:
+    md = """\
+## Overview
+This is the project overview.
+
+## Tech Stack
+Python, FastAPI, PostgreSQL
+
+## User registration
+- Form validation works
+- Confirmation email sent
+"""
+    result = parse_markdown_to_stories(md)
+    assert "project overview" in result.feature_overview
+    assert "Python" in result.tech_stack
+    assert len(result.stories) == 1
+    assert result.stories[0]["title"] == "User registration"
+
+
+def test_parse_markdown_numbered_lists() -> None:
+    md = """\
+## Data export
+1. CSV format supported
+2. JSON format supported
+3. Download link generated
+"""
+    result = parse_markdown_to_stories(md)
+    assert len(result.stories) == 1
+    assert "CSV format supported" in result.stories[0]["criteria"]
+    assert "JSON format supported" in result.stories[0]["criteria"]
+
+
+def test_parse_markdown_no_headings_fallback() -> None:
+    md = """\
+This is the first feature. It should handle user authentication
+with OAuth support and session management.
+
+This is the second feature. It should provide an API
+for fetching user profiles with pagination.
+"""
+    result = parse_markdown_to_stories(md)
+    assert len(result.stories) >= 1
+
+
+def test_parse_markdown_empty() -> None:
+    result = parse_markdown_to_stories("")
+    assert result.stories == []
+    assert result.feature_overview == ""
+
+
+def test_parse_markdown_h3_headings() -> None:
+    md = """\
+## Features
+
+### Search
+- Full-text search
+- Filters by date
+
+### Sort
+- Sort by name
+- Sort by date
+"""
+    result = parse_markdown_to_stories(md)
+    # "Features" might be treated as a story or skipped
+    story_titles = [s["title"] for s in result.stories]
+    assert "Search" in story_titles
+    assert "Sort" in story_titles


### PR DESCRIPTION
## Summary

- **Fix settings screen**: wrapped in `VerticalScroll` to prevent content overflow, added empty-state banner when `ralph.toml` is missing, added help text for each config section
- **PRD markdown import**: new step 0 in PRD wizard lets users import a free-form `.md` file - headings become story titles, bullets become acceptance criteria, meta-sections (Overview, Tech Stack) populate the corresponding fields
- **Separate greenfield wizard**: new "New Project" flow with auto-derived branch name from project name, combined init + PRD creation in one pass - no more asking for a feature branch on brand-new projects
- **UI overhaul**: clean & professional theme with panel backgrounds instead of borders, ASCII logo, progress dot indicators, wider wizard containers, card-based status screen, centralized TCSS

## Test plan

- [ ] Run `ralph` and navigate every screen (main menu, new project, existing project, PRD wizard, config, status)
- [ ] Test PRD import: create a markdown file with headings/bullets, import via PRD wizard, verify stories are parsed correctly
- [ ] Test greenfield flow end-to-end: new project -> name -> agent -> stories -> scaffold
- [ ] Test settings screen renders correctly both with and without `ralph.toml`
- [ ] `uv run pytest` passes (254 tests)
- [ ] `uv run ruff check src/ tests/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)