### PR TITLE
fix: remove invalid TCSS properties

### DIFF
--- a/src/ralph/tui/styles/app.tcss
+++ b/src/ralph/tui/styles/app.tcss
@@ -15,7 +15,7 @@ Screen {
 .section-heading {
     text-style: bold;
     color: $text-muted;
-    text-transform: uppercase;
+
     margin-bottom: 1;
 }
 
@@ -194,7 +194,7 @@ Screen {
 .config-section-title {
     text-style: bold;
     color: $text-muted;
-    text-transform: uppercase;
+
     margin-bottom: 1;
 }
 
@@ -226,7 +226,7 @@ Screen {
 .status-card-title {
     text-style: bold;
     color: $text-muted;
-    text-transform: uppercase;
+
     margin-bottom: 1;
 }
 
@@ -287,7 +287,7 @@ Screen {
 /* ── Widget Overrides ───────────────────────────────── */
 
 AgentLogWidget {
-    scrollbar-size: 1;
+    scrollbar-size: 1 1;
 }
 
 StoryTableWidget {


### PR DESCRIPTION
## Summary

- Remove `text-transform: uppercase` from 3 selectors - not a valid Textual CSS property
- Fix `scrollbar-size: 1` to `scrollbar-size: 1 1` - requires two values (horizontal vertical)

These were lost during the squash merge of #4.

## Test plan

- [ ] Run `ralph` - no CSS parsing errors on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)