### PR TITLE
fix: wizard end-states - Done buttons and clear exit paths

### DIFF
--- a/src/ralph/tui/screens/init_wizard.py
+++ b/src/ralph/tui/screens/init_wizard.py
@@ -34,6 +34,7 @@ class InitWizardScreen(Screen):
         self._step = 0
         self._target_dir = str(Path.cwd())
         self._error = ""
+        self._done = False
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -118,6 +119,10 @@ class InitWizardScreen(Screen):
                 )
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "init-done":
+            self.app.pop_screen()
+            return
+
         if event.button.id == "init-back":
             if self._step > 0:
                 self._step -= 1
@@ -130,7 +135,6 @@ class InitWizardScreen(Screen):
                 except Exception:
                     pass
 
-                # Validate directory exists
                 target = Path(self._target_dir).resolve()
                 if not target.exists():
                     self._error = f"Directory does not exist: {target}"
@@ -148,7 +152,6 @@ class InitWizardScreen(Screen):
                 self._run_init()
 
     def _run_init(self) -> None:
-        # Disable button immediately to prevent double-clicks
         next_btn = self.query_one("#init-next", Button)
         next_btn.disabled = True
 
@@ -157,16 +160,15 @@ class InitWizardScreen(Screen):
         step_container.remove_children()
 
         step_container.mount(Static(f"Initializing {target}..."))
+        step_container.mount(Static(""))
 
-        # Scaffold files
         messages = scaffold_project(target)
         for msg in messages:
             if msg.startswith("Created"):
-                step_container.mount(Static(f"[green]{msg}[/green]"))
+                step_container.mount(Static(f"  [green]{msg}[/green]"))
             else:
-                step_container.mount(Static(f"[dim]{msg}[/dim]"))
+                step_container.mount(Static(f"  [dim]{msg}[/dim]"))
 
-        # Create ralph.toml
         config = RalphConfig()
         try:
             selector = self.query_one("#init-model-selector", ModelSelector)
@@ -177,31 +179,38 @@ class InitWizardScreen(Screen):
             if "claude" in installed:
                 config.agent.type = "claude"
                 step_container.mount(
-                    Static("[dim]Auto-detected agent: claude[/dim]")
+                    Static("  [dim]Auto-detected agent: claude[/dim]")
                 )
             elif "codex" in installed:
                 config.agent.type = "codex"
                 step_container.mount(
-                    Static("[dim]Auto-detected agent: codex[/dim]")
+                    Static("  [dim]Auto-detected agent: codex[/dim]")
                 )
 
         toml_path = target / "ralph.toml"
         if not toml_path.exists():
             save_config(config, toml_path)
-            step_container.mount(Static("[green]Created: ralph.toml[/green]"))
+            step_container.mount(Static("  [green]Created: ralph.toml[/green]"))
         else:
-            step_container.mount(Static("[dim]Exists: ralph.toml[/dim]"))
+            step_container.mount(Static("  [dim]Exists: ralph.toml[/dim]"))
 
         step_container.mount(Static(""))
         step_container.mount(Static("[bold green]Setup complete[/bold green]"))
-        step_container.mount(Static(
-            "\nRecommended next steps:\n"
-            "  1. ralph understand 10   - Map your codebase\n"
-            "  2. ralph prd create      - Create your PRD\n"
-            "  3. ralph run 25          - Run the feature loop"
-        ))
+        step_container.mount(Static(""))
+        step_container.mount(Static("Next steps:"))
+        step_container.mount(Static("  1. ralph understand 10   Map your codebase"))
+        step_container.mount(Static("  2. ralph prd create      Create your PRD"))
+        step_container.mount(Static("  3. ralph run 25          Run the feature loop"))
 
-        self.query_one("#init-step-label", Static).update("Setup Complete")
+        self._done = True
+        self.query_one("#init-step-label", Static).update(
+            "[green]o[/green]  [green]o[/green]    Complete"
+        )
+
+        # Replace nav buttons with Done
+        nav = self.query_one("#new-project-nav", Horizontal)
+        nav.remove_children()
+        nav.mount(Button("Done", id="init-done", variant="primary"))
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/ralph/tui/screens/new_project_wizard.py
+++ b/src/ralph/tui/screens/new_project_wizard.py
@@ -296,6 +296,10 @@ class NewProjectWizardScreen(Screen):
     # -- Button handling --
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "np-done":
+            self.app.pop_screen()
+            return
+
         if event.button.id == "np-next":
             self._save_current_step()
 
@@ -319,7 +323,6 @@ class NewProjectWizardScreen(Screen):
                 self._error = ""
 
             if self._step == TOTAL_STEPS - 1:
-                # Disable button to prevent double-click
                 self.query_one("#np-next", Button).disabled = True
                 self._create_project()
             else:
@@ -383,14 +386,19 @@ class NewProjectWizardScreen(Screen):
 
         container.mount(Static(""))
         container.mount(Static("[bold green]Project created[/bold green]"))
-        container.mount(Static(
-            "\nNext steps:\n"
-            f"  cd {target}\n"
-            f"  ralph run 25    - Run the feature loop"
-        ))
+        container.mount(Static(""))
+        container.mount(Static("Next steps:"))
+        container.mount(Static(f"  cd {target}"))
+        container.mount(Static("  ralph run 25    Run the feature loop"))
 
-        self.query_one("#np-next", Button).disabled = True
-        self.query_one("#new-project-step-label", Static).update("Done")
+        # Replace nav buttons with Done
+        self.query_one("#new-project-step-label", Static).update(
+            "  ".join("[green]o[/green]" for _ in range(TOTAL_STEPS))
+            + "    Complete"
+        )
+        nav = self.query_one("#new-project-nav", Horizontal)
+        nav.remove_children()
+        nav.mount(Button("Done", id="np-done", variant="primary"))
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/ralph/tui/screens/prd_wizard.py
+++ b/src/ralph/tui/screens/prd_wizard.py
@@ -343,6 +343,10 @@ class PRDWizardScreen(Screen):
     # -- Navigation --
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "wizard-done":
+            self.app.pop_screen()
+            return
+
         if event.button.id == "wizard-next":
             self._save_current_step()
 
@@ -388,12 +392,22 @@ class PRDWizardScreen(Screen):
         step_container = self.query_one("#wizard-step", VerticalScroll)
         step_container.remove_children()
         step_container.mount(Static(f"[green]PRD saved to {output_path}[/green]"))
+        step_container.mount(Static(""))
         step_container.mount(Static(
             f"  Branch:  {prd.branch_name}\n"
             f"  Stories: {prd.total_stories}"
         ))
-        step_container.mount(Static("\nYou can now run: ralph run"))
-        self.query_one("#wizard-next", Button).disabled = True
+        step_container.mount(Static(""))
+        step_container.mount(Static("You can now run: [bold]ralph run[/bold]"))
+
+        # Replace nav buttons with Done
+        self.query_one("#wizard-step-label", Static).update(
+            "  ".join("[green]o[/green]" for _ in range(_TOTAL_STEPS))
+            + "    Complete"
+        )
+        nav = self.query_one("#wizard-nav", Horizontal)
+        nav.remove_children()
+        nav.mount(Button("Done", id="wizard-done", variant="primary"))
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/src/ralph/tui/screens/run_dashboard.py
+++ b/src/ralph/tui/screens/run_dashboard.py
@@ -201,6 +201,9 @@ class RunDashboardScreen(Screen):
         else:
             log.write_error(f"Max iterations reached ({iterations_used})")
 
+        log.write_info("")
+        log.write_info("Press Escape to return to the menu.")
+
         # Final story table refresh
         if self._config:
             try:
@@ -209,6 +212,10 @@ class RunDashboardScreen(Screen):
                 story_table.update_stories(self._prd)
             except Exception:
                 pass
+
+        # Update header to show completion
+        header = self.query_one("#run-header", RunHeader)
+        header.set_story("done" if success else "stopped")
 
     def _on_info(self, message: str) -> None:
         log = self.query_one("#agent-log", AgentLogWidget)


### PR DESCRIPTION
## Summary

Every wizard flow now ends with a clear, unambiguous terminal state instead of leaving users staring at disabled buttons.

**Before**: After completing a wizard, the action button (Initialize/Create/Save) was disabled and the Back button was still visible. No clear "what now?" signal.

**After**: On completion, nav buttons are replaced with a single **Done** button that returns to the main menu. Progress dots turn green and show "Complete".

### Changes by screen

| Screen | Before | After |
|--------|--------|-------|
| Init wizard | Initialize (disabled) + Back | "Done" button, returns to menu |
| New project wizard | Create Project (disabled) + Back | "Done" button, returns to menu |
| PRD wizard | Save (disabled) + Back | "Done" button, returns to menu |
| Run dashboard | No completion signal | "Press Escape to return to the menu" + header shows "done"/"stopped" |

## Test plan

- [ ] Init wizard: complete init flow, verify "Done" button appears, click returns to menu
- [ ] New project wizard: complete flow, verify "Done" appears
- [ ] PRD wizard: save a PRD, verify "Done" appears
- [ ] Run dashboard: start a run, wait for completion or press S to stop, verify exit instructions appear
- [ ] `uv run pytest` passes (254 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)