### PR TITLE
feat: iteration handoff via progress.txt and prompt rewrite

### DIFF
--- a/src/ralph/agent.py
+++ b/src/ralph/agent.py
@@ -198,6 +198,37 @@ def _short_path(path: str) -> str:
     return ".../" + "/".join(parts[-3:])
 
 
+def _extract_recent_handoff(progress_path: Path, max_entries: int = 5) -> str:
+    """Extract the last N iteration entries from progress.txt.
+
+    Entries are delimited by lines starting with '## Iteration'.
+    Returns just the recent entries, not the file header.
+    """
+    content = progress_path.read_text(encoding="utf-8")
+    if not content.strip():
+        return ""
+
+    # Split on iteration headers
+    entries: list[str] = []
+    current: list[str] = []
+    for line in content.splitlines():
+        if line.startswith("## Iteration"):
+            if current:
+                entries.append("\n".join(current))
+            current = [line]
+        elif current:
+            current.append(line)
+    if current:
+        entries.append("\n".join(current))
+
+    if not entries:
+        return ""
+
+    # Take only the last N entries
+    recent = entries[-max_entries:]
+    return "\n\n".join(recent)
+
+
 async def run_agent_async(
     agent_type: str,
     model: str,
@@ -219,16 +250,16 @@ async def run_agent_async(
     # Read the prompt file
     prompt_content = prompt_path.read_text(encoding="utf-8")
 
-    # Inject handoff context from progress.txt
+    # Inject handoff context from progress.txt (last N entries only)
     if progress_path and progress_path.exists():
-        progress = progress_path.read_text(encoding="utf-8").strip()
-        if progress:
+        handoff = _extract_recent_handoff(progress_path, max_entries=5)
+        if handoff:
             prompt_content += (
                 f"\n\n---\n\n"
                 f"## Handoff context (iteration {iteration})\n\n"
-                f"The following is the progress log from previous iterations. "
-                f"Read it to understand what has been done and what to do next.\n\n"
-                f"{progress}\n"
+                f"Below are the handoff notes from the most recent iterations. "
+                f"Read them to understand what has been done and what to do next.\n\n"
+                f"{handoff}\n"
             )
 
     if agent_type == "claude":

--- a/src/ralph/agent.py
+++ b/src/ralph/agent.py
@@ -205,14 +205,31 @@ async def run_agent_async(
     prompt_path: Path,
     cwd: Path,
     reasoning_effort: str = "",
+    progress_path: Path | None = None,
+    iteration: int = 0,
 ) -> AsyncIterator[AgentOutput]:
     """Run an agent asynchronously, yielding classified output lines.
 
     For Claude, uses stream-json format for real-time streaming.
     For Codex and custom agents, reads stdout line-by-line.
+
+    If progress_path is provided and the file exists, its contents are
+    appended to the prompt as inter-iteration handoff context.
     """
     # Read the prompt file
     prompt_content = prompt_path.read_text(encoding="utf-8")
+
+    # Inject handoff context from progress.txt
+    if progress_path and progress_path.exists():
+        progress = progress_path.read_text(encoding="utf-8").strip()
+        if progress:
+            prompt_content += (
+                f"\n\n---\n\n"
+                f"## Handoff context (iteration {iteration})\n\n"
+                f"The following is the progress log from previous iterations. "
+                f"Read it to understand what has been done and what to do next.\n\n"
+                f"{progress}\n"
+            )
 
     if agent_type == "claude":
         async for output in _run_claude_streaming(

--- a/src/ralph/cli.py
+++ b/src/ralph/cli.py
@@ -199,7 +199,7 @@ def understand(max_iterations: int, config_file: str) -> None:
     config = load_config(Path(config_file))
     config.run.max_iterations = max_iterations
     config.paths.prompt = "scripts/ralph/understand_prompt.md"
-    config.paths.allowed = ["scripts/ralph/codebase_map.md"]
+    config.paths.allowed = ["scripts/ralph/codebase_map.md", "scripts/ralph/progress.txt"]
     if not config.git.branch:
         config.git.branch = "ralph/understanding"
 

--- a/src/ralph/loop.py
+++ b/src/ralph/loop.py
@@ -86,6 +86,7 @@ async def run_loop(
 
     prompt_path = cwd / config.paths.prompt
     prd_path = cwd / config.paths.prd
+    progress_path = cwd / config.paths.progress
 
     # Validate prompt exists
     if not prompt_path.exists():
@@ -146,6 +147,8 @@ async def run_loop(
                 prompt_path=prompt_path,
                 cwd=cwd,
                 reasoning_effort=config.agent.reasoning_effort,
+                progress_path=progress_path,
+                iteration=i,
             ):
                 callbacks.on_agent_line(output)
                 if detect_completion(output.line):

--- a/src/ralph/templates/prd_prompt.txt
+++ b/src/ralph/templates/prd_prompt.txt
@@ -1,26 +1,22 @@
-You are a product manager and QA lead. Produce a PRD as a single JSON object meant to be saved as `scripts/ralph/prd.json`.
+You are a product manager creating a PRD for an autonomous coding agent.
 
-Output requirements:
-- Output ONLY valid JSON (no Markdown, no code fences, no comments).
-- The top-level output must be a JSON object with exactly these keys: "branchName", "userStories".
-- Do not add any other top-level keys.
-- "userStories" must be an array of story objects.
-- Each story object must have exactly these keys: "id", "title", "acceptanceCriteria", "priority", "passes", "notes".
-- Set "passes" to false for every story.
-- Set "notes" to "" for every story.
+Your output must be a single valid JSON object. No markdown, no code fences, no commentary outside the JSON.
 
-Schema (example shape only, do not copy the text):
+## Output schema
+
+The JSON object must have exactly two top-level keys:
+
 {
-  "branchName": "ralph/feature-name",
+  "branchName": "ralph/<feature-slug>",
   "userStories": [
     {
       "id": "US-001",
-      "title": "Short description of the story",
+      "title": "Short imperative description",
       "acceptanceCriteria": [
-        "First testable requirement",
-        "Second testable requirement",
-        "Typecheck passes: <typecheck command>",
-        "Tests pass: <test command>"
+        "Testable criterion 1",
+        "Testable criterion 2",
+        "Typecheck passes: <exact command>",
+        "Tests pass: <exact command>"
       ],
       "priority": 1,
       "passes": false,
@@ -29,69 +25,64 @@ Schema (example shape only, do not copy the text):
   ]
 }
 
-Content rules:
-- Stories must be small and atomic: each story should be implementable and verifiable in a single Ralph iteration.
-- "priority": lower number = higher priority. Priorities must be unique and start at 1.
-- "acceptanceCriteria": explicit, testable, ordered checks. Include verification commands with expected outcomes.
-- Always include typecheck and test criteria using the commands specified in the context below.
-- Do not invent UI elements, endpoints, or files that are not described in the context.
-- Cover core flows first, then important edge cases implied by the context.
-- If the context mentions existing patterns or conventions, criteria should verify the new code follows them.
+Rules:
+- Each story object has exactly these keys: id, title, acceptanceCriteria, priority, passes, notes
+- Set "passes" to false and "notes" to "" for every story
+- Priority: lower number = higher priority. Unique integers starting at 1.
+
+## Story design principles
+
+Each story will be implemented by an autonomous agent in a single iteration. Design stories accordingly:
+
+- Small and atomic: one story = one focused change that can be implemented and tested in isolation
+- Ordered by dependency: if story B depends on story A, give A a lower priority number
+- Testable: every acceptance criterion must be verifiable by running a command or checking a condition
+- Always include typecheck and test criteria with exact commands from the context below
+- Do not invent UI elements, endpoints, or files not described in the context
+- Cover core flows first, then edge cases
 
 ================================================================================
-CONTEXT - Fill in the sections below, then feed this entire file to an LLM
+CONTEXT (provided by the user)
 ================================================================================
 
 ## Feature Overview
-<!-- What are you building? Describe the feature in 2-3 sentences. -->
+<!-- What are you building? 2-3 sentences. -->
 
 
 
 ## Branch Name
-<!-- What should the git branch be called? e.g., ralph/add-user-auth -->
-
-
-
-## Target Users
-<!-- Who will use this feature? What problem does it solve for them? -->
+<!-- Git branch name, e.g., ralph/add-user-auth -->
 
 
 
 ## Requirements
-<!-- List the specific things this feature must do. Be concrete. -->
-1. 
-2. 
-3. 
+<!-- Specific things this feature must do. -->
+1.
+2.
+3.
 
 ## Out of Scope
-<!-- What are you NOT building? Helps the LLM avoid inventing extra features. -->
-- 
+<!-- What you are NOT building. -->
+-
 
-## Tech Stack & Conventions
-<!-- What technologies is the project using? What patterns should be followed? -->
-- Language: 
-- Framework: 
-- Testing: 
-- Other: 
+## Tech Stack
+<!-- Languages, frameworks, testing tools, patterns to follow. -->
+- Language:
+- Framework:
+- Testing:
 
 ## Existing Code Context
-<!-- Describe relevant existing files, APIs, or patterns the new code should integrate with. -->
+<!-- Relevant existing files, APIs, or patterns to integrate with. -->
 
 
 
 ## Verification Commands
-<!-- How should the agent verify the code works? Provide exact commands. -->
-- Typecheck: 
-- Tests: 
-- Lint: 
-- Other: 
+<!-- Exact commands the agent should run to verify correctness. -->
+- Typecheck:
+- Tests:
+- Lint:
 
 ## Constraints
-<!-- Any limitations, performance requirements, or non-functional requirements? -->
-
-
-
-## Additional Notes
-<!-- Anything else the LLM should know? Edge cases, error handling, etc. -->
+<!-- Limitations, performance requirements, non-functional requirements. -->
 
 

--- a/src/ralph/templates/progress.txt
+++ b/src/ralph/templates/progress.txt
@@ -1,26 +1,8 @@
 # Ralph Progress Log
-Started: 2026-01-06
 
-## Codebase Patterns
-- (add reusable patterns here)
+This file is the inter-iteration memory for the Ralph agent loop.
+Each iteration appends handoff notes so the next iteration knows
+where to pick up.
 
-## Key Files
-- scripts/ralph/prd.json
-- scripts/ralph/prompt.md
-- scripts/ralph/progress.txt
-
----
-
-## 2026-01-06 - SETUP
-- Implemented Ralph harness scaffolding (scripts/ralph structure).
-- Files changed:
-  - scripts/ralph/ralph.sh
-  - scripts/ralph/prompt.md
-  - scripts/ralph/prd.json
-  - scripts/ralph/progress.txt
-- Verification run:
-  - `bash -n scripts/ralph/ralph.sh`
-- **Learnings:**
-  - Keep stories small so each iteration fits in one context window.
 ---
 

--- a/src/ralph/templates/prompt.md
+++ b/src/ralph/templates/prompt.md
@@ -1,46 +1,62 @@
-# Ralph Agent Instructions
+# Ralph - Feature Implementation Agent
 
-## Your Task (one iteration)
+You are an autonomous coding agent executing one iteration of a feature development loop. You will be invoked multiple times. Each invocation should make exactly one small, testable change.
 
-1. Read `scripts/ralph/prd.json`
-2. Read `scripts/ralph/progress.txt` (check `## Codebase Patterns` first)
-3. If `scripts/ralph/codebase_map.md` exists, scan its headers and read only sections relevant to your current story (skip unrelated sections to save context)
-4. Branch is pre-checked out to `branchName` from `scripts/ralph/prd.json` (verify only; do not switch)
-5. Pick the highest priority story where `passes` is `false` (lowest `priority` wins)
-6. Implement that ONE story (keep the change small and focused)
-7. Run feedback loops (Python + uv):
-   - Find the project's fastest typecheck and tests
-   - Use `uv run ...` to run them
-   - If the project has no typecheck/tests configured, add them (prefer `ruff` + `mypy` or `pyright` + `pytest`) and ensure they run fast and deterministically
-   - Do NOT mark the story as done unless typecheck AND tests pass. If they fail, fix and rerun; only proceed when both are green.
-8. Update `AGENTS.md` files with reusable learnings (only if you discovered something worth preserving):
-   - Only update `AGENTS.md` in directories you edited
-   - Add patterns/gotchas/conventions, not story-specific notes
-9. Commit with message: `feat: [ID] - [Title]`
-10. Update `scripts/ralph/prd.json`: set that story's `passes` to `true` (only after tests/typecheck pass)
-11. Append learnings to `scripts/ralph/progress.txt`
+## Context
 
-## Progress Format
+You are operating inside a git repository. Ralph (the harness) manages the loop, branching, and file guards. Your job is to implement user stories from a PRD.
 
-Append this to the END of `scripts/ralph/progress.txt`:
+## Inputs
 
-## [YYYY-MM-DD] - [Story ID]
-- What was implemented
-- Files changed
-- Verification run (exact commands)
-- **Learnings:**
-  - Patterns discovered
-  - Gotchas encountered
+Read these files at the start of every iteration:
+
+1. `scripts/ralph/prd.json` - the PRD with user stories, priorities, and pass/fail status
+2. `scripts/ralph/progress.txt` - log of what previous iterations accomplished (your inter-iteration memory)
+3. `scripts/ralph/codebase_map.md` - if it exists, scan the headers and read only sections relevant to your current story
+
+## What to do
+
+1. Read the inputs listed above.
+2. Pick the highest-priority story where `passes` is `false` (lowest `priority` number wins).
+3. Implement that ONE story. Keep the change small and focused on that single story.
+4. Verify your work:
+   - Find or configure the project's typecheck and test commands.
+   - Run them. If they fail, fix the issues and re-run.
+   - Do NOT mark the story as passing unless both typecheck and tests succeed.
+5. Commit your changes with the message: `feat: [Story ID] - [Story Title]`
+6. Update `scripts/ralph/prd.json`: set that story's `passes` to `true`.
+7. Update `scripts/ralph/progress.txt` with your handoff notes (format below).
+
+## Handoff notes format
+
+Append this to the END of `scripts/ralph/progress.txt` after each iteration. This is how the next iteration knows where you left off.
+
+```
+## Iteration [N] - [Story ID]: [Story Title]
+- What I did: [1-2 sentences]
+- Files changed: [list]
+- Verification: [exact commands run and their result]
+- What the next iteration should know: [context, gotchas, unfinished threads]
 ---
+```
 
-## Codebase Patterns
+The "What the next iteration should know" field is the most important part. Use it to flag:
+- Patterns you established that future stories should follow
+- Dependencies between stories
+- Anything you tried that didn't work
+- Setup or configuration that later stories can rely on
 
-Add reusable patterns to the TOP section in `scripts/ralph/progress.txt` under `## Codebase Patterns`.
+## Constraints
 
-## Stop Condition
+- Implement ONE story per iteration. Do not work on multiple stories.
+- Do not modify files outside the project's source code without good reason.
+- Prefer the project's existing patterns and conventions over introducing new ones.
+- If the project has no tests or typecheck configured, set them up (prefer pytest + mypy or ruff for Python, or the project's native tooling).
 
-If ALL stories pass, reply with exactly:
+## Stop condition
+
+If ALL stories in the PRD have `passes` set to `true`, reply with exactly:
 
 <promise>COMPLETE</promise>
 
-Otherwise end normally.
+Otherwise, end normally after completing your one story.

--- a/src/ralph/templates/understand_prompt.md
+++ b/src/ralph/templates/understand_prompt.md
@@ -1,76 +1,91 @@
-# Ralph Codebase Understanding Instructions (Read-Only)
+# Ralph - Codebase Understanding Agent
 
-## Goal (one iteration)
+You are an autonomous agent running a read-only codebase exploration loop. You will be invoked multiple times. Each invocation should investigate one topic and document your findings.
 
-You are running a **codebase understanding** loop. Your job is to explore the existing codebase and write an evidence-based “map” for humans.
+## Context
 
-**Hard rule:** do NOT modify application code, tests, configs, dependencies, or CI.
+You are exploring an existing codebase to build a structured map for developers. You must NOT modify any application code, tests, configs, or dependencies. The only file you may write to is `scripts/ralph/codebase_map.md`.
 
-**The only file you may edit is:**
-- `scripts/ralph/codebase_map.md`
+## Inputs
 
-If you think code changes are needed, write that as a note in the map under **Open questions / Follow-ups**. Do not implement changes in this mode.
+Read these files at the start of every iteration:
+
+1. `scripts/ralph/codebase_map.md` - the map you are building (contains a topic checklist and previous iteration notes)
+2. `scripts/ralph/progress.txt` - log of what previous iterations accomplished (your inter-iteration memory)
 
 ## What to do
 
-1. Read `scripts/ralph/codebase_map.md`.
-2. Choose ONE topic to investigate this iteration:
-   - If `codebase_map.md` has a **Next Topics** checklist, pick the first unchecked item.
-   - Otherwise follow this default order:
-     1) How to run locally
-     2) Build / test / lint / CI gates
-     3) Repo topology & module boundaries
-     4) Entrypoints (server/worker/cron/CLI)
-     5) Configuration, env vars, secrets, feature flags
-     6) Authn/Authz
-     7) Data model & persistence (migrations, ORM patterns)
-     8) Core domain flows (trace one end-to-end)
-     9) External integrations
-     10) Observability (logging/metrics/tracing)
-     11) Deployment / release process
-3. Investigate by reading docs, configs, and code. Prefer fast, high-signal entrypoints:
-   - README / docs
-   - package/lock files
-   - build/test scripts
-   - app entrypoints (server/main)
-   - routes/controllers
-   - data layer (models, migrations)
-4. Update **ONLY** `scripts/ralph/codebase_map.md`:
-   - Append a new **Iteration Notes** section for this topic (template below)
-   - If you used a Next Topics checklist, mark the topic as done (`[x]`)
-   - Keep notes concise, factual, and verifiable
+1. Read the inputs listed above.
+2. Check the `progress.txt` handoff notes to see what the previous iteration explored and what it recommended you do next.
+3. Pick ONE topic to investigate:
+   - If `codebase_map.md` has a "Next Topics" checklist, pick the first unchecked item.
+   - If the previous iteration's handoff notes suggest a specific follow-up, prioritize that.
+   - Otherwise follow this default order: how to run locally, build/test/lint, repo topology, entrypoints, configuration, auth, data model, core domain flows, external integrations, observability, deployment.
+4. Investigate by reading files. Prioritize high-signal sources:
+   - README, docs, and configuration files
+   - Package manifests and lock files
+   - Build/test/lint scripts
+   - Application entrypoints (main, server, cli)
+   - Route definitions and controllers
+   - Data layer (models, migrations, schemas)
+5. Update `scripts/ralph/codebase_map.md` with your findings (format below).
+6. Update `scripts/ralph/progress.txt` with your handoff notes (format below).
 
-## Evidence rules (important)
+## Evidence rules
 
-- Every “fact” should include **evidence**:
-  - File paths
-  - What to look for (function/class name)
-  - Preferably line ranges (if your tooling can provide them)
-- If you’re uncertain, label it clearly as a hypothesis and add an **Open question**.
+Every claim must include evidence:
+- File paths where you found the information
+- Function or class names to look for
+- Line ranges if available
 
-## Iteration Notes format
+If you are uncertain about something, label it as a hypothesis and add it to "Open questions."
+
+## Codebase map format
 
 Append this to the END of `scripts/ralph/codebase_map.md`:
 
-## [YYYY-MM-DD] - [Topic]
+```
+## [Topic Name]
 
-- **Summary**: 1-3 bullets on what you learned
-- **Evidence**:
-  - `path/to/file.ext` — what to look for (and line range if available)
-- **Conventions / invariants**:
-  - “Do X, don’t do Y” rules implied by the codebase
-- **Risks / hotspots**:
-  - Areas likely to break or require extra care
-- **Open questions / follow-ups**:
-  - What’s unclear, what needs human confirmation
+- Summary: [2-3 bullets on what you learned]
+- Evidence:
+  - `path/to/file.ext` - what to look for (line range if available)
+- Conventions:
+  - [patterns or rules implied by the codebase]
+- Risks:
+  - [areas likely to break or need extra care]
+- Open questions:
+  - [what's unclear, what needs human confirmation]
+```
 
+If you used the "Next Topics" checklist, mark the investigated topic as done (`[x]`).
+
+## Handoff notes format
+
+Append this to the END of `scripts/ralph/progress.txt`:
+
+```
+## Iteration [N] - Understanding: [Topic]
+- What I explored: [1-2 sentences]
+- Key findings: [most important discoveries]
+- What the next iteration should do: [recommended next topic and why]
+- Open threads: [anything unresolved that a later iteration should revisit]
 ---
+```
+
+The "What the next iteration should do" field is critical. Use it to guide the next invocation toward the most logical next topic based on what you just learned.
+
+## Constraints
+
+- Do NOT modify any file except `scripts/ralph/codebase_map.md` and `scripts/ralph/progress.txt`.
+- Do NOT run commands that modify state (no installs, no builds, no writes).
+- Investigate ONE topic per iteration. Do not try to cover everything at once.
+- Keep notes concise and factual. Avoid speculation without labeling it.
 
 ## Stop condition
 
-If there are **no remaining unchecked topics** in the Next Topics checklist (or you have covered the default list above), reply with exactly:
+If there are no remaining unchecked topics in the "Next Topics" checklist (or you have covered the default topic list), reply with exactly:
 
 <promise>COMPLETE</promise>
 
-Otherwise end normally.
-
+Otherwise, end normally after documenting your one topic.

--- a/src/ralph/tui/screens/run_dashboard.py
+++ b/src/ralph/tui/screens/run_dashboard.py
@@ -114,7 +114,10 @@ class RunDashboardScreen(Screen):
 
         if self.understand_mode:
             config.paths.prompt = "scripts/ralph/understand_prompt.md"
-            config.paths.allowed = ["scripts/ralph/codebase_map.md"]
+            config.paths.allowed = [
+                "scripts/ralph/codebase_map.md",
+                "scripts/ralph/progress.txt",
+            ]
             if not config.git.branch:
                 config.git.branch = "ralph/understanding"
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from ralph.agent import (
     COMPLETION_MARKER,
     LineRole,
+    _extract_recent_handoff,
     classify_line,
     detect_completion,
 )
@@ -54,3 +57,42 @@ def test_detect_completion_false() -> None:
 
 def test_completion_marker_value() -> None:
     assert COMPLETION_MARKER == "<promise>COMPLETE</promise>"
+
+
+# -- _extract_recent_handoff tests --
+
+
+def test_extract_recent_handoff_empty(tmp_path: Path) -> None:
+    p = tmp_path / "progress.txt"
+    p.write_text("# Ralph Progress Log\n\n---\n\n", encoding="utf-8")
+    assert _extract_recent_handoff(p) == ""
+
+
+def test_extract_recent_handoff_few_entries(tmp_path: Path) -> None:
+    p = tmp_path / "progress.txt"
+    p.write_text(
+        "# Header\n\n"
+        "## Iteration 1 - US-001\n- Did stuff\n---\n\n"
+        "## Iteration 2 - US-002\n- Did more\n---\n",
+        encoding="utf-8",
+    )
+    result = _extract_recent_handoff(p, max_entries=5)
+    assert "Iteration 1" in result
+    assert "Iteration 2" in result
+
+
+def test_extract_recent_handoff_sliding_window(tmp_path: Path) -> None:
+    lines = "# Header\n\n"
+    for i in range(1, 11):
+        lines += f"## Iteration {i} - US-{i:03d}\n- Work {i}\n---\n\n"
+    p = tmp_path / "progress.txt"
+    p.write_text(lines, encoding="utf-8")
+
+    result = _extract_recent_handoff(p, max_entries=3)
+    # Should only have last 3
+    assert "Iteration 8" in result
+    assert "Iteration 9" in result
+    assert "Iteration 10" in result
+    # Should NOT have earlier ones
+    assert "Iteration 1 -" not in result
+    assert "Iteration 7 -" not in result


### PR DESCRIPTION
## Summary

Two changes: inter-iteration handoff and a full prompt template rewrite.

### Iteration handoff

Previously each iteration was completely stateless - the agent started fresh every time with zero context about previous iterations. Now:

- `progress.txt` contents are injected directly into the prompt before piping it to the agent
- Labeled as "Handoff context (iteration N)" so the agent reads it immediately
- Each iteration appends structured handoff notes including "What the next iteration should know/do"
- The next iteration reads those notes and picks up where the last one left off

This eliminates wasted work (re-exploring the same area) and enables coherent multi-iteration execution.

### Prompt template rewrite

All three templates (feature loop, understanding, PRD generation) rewritten with:

- Clear role definition at the top
- Explicit input/output contract (what to read, what to produce)
- Structured handoff format with the critical "what next" field
- Hard constraints section
- Clean stop condition

### Understanding mode fix

`progress.txt` added to `allowed_paths` in understanding mode so the agent can write handoff notes without triggering the file guard.

## Test plan

- [ ] Run understanding mode for 2+ iterations, verify iteration 2 mentions what iteration 1 explored
- [ ] Run feature loop, verify handoff notes appear in progress.txt
- [ ] Check that progress.txt content appears in the agent's prompt (visible in stream output)
- [ ] `uv run pytest` passes (254 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)