### PR TITLE
feat: pre-run config screen for iterations and model selection

### DIFF
--- a/src/ralph/tui/app.py
+++ b/src/ralph/tui/app.py
@@ -11,7 +11,7 @@ from ralph.tui.screens.init_wizard import InitWizardScreen
 from ralph.tui.screens.main_menu import MainMenuScreen
 from ralph.tui.screens.new_project_wizard import NewProjectWizardScreen
 from ralph.tui.screens.prd_wizard import PRDWizardScreen
-from ralph.tui.screens.run_dashboard import RunDashboardScreen
+from ralph.tui.screens.run_config import RunConfigScreen
 from ralph.tui.screens.status_screen import StatusScreen
 
 CSS_PATH = Path(__file__).parent / "styles" / "app.tcss"
@@ -29,8 +29,8 @@ class RalphApp(App):
         "main_menu": MainMenuScreen,
         "init_wizard": InitWizardScreen,
         "new_project_wizard": NewProjectWizardScreen,
-        "run_dashboard": lambda: RunDashboardScreen(understand_mode=False),
-        "run_dashboard_understand": lambda: RunDashboardScreen(understand_mode=True),
+        "run_config": lambda: RunConfigScreen(understand_mode=False),
+        "run_config_understand": lambda: RunConfigScreen(understand_mode=True),
         "prd_wizard": PRDWizardScreen,
         "config": ConfigScreen,
         "status": StatusScreen,

--- a/src/ralph/tui/screens/main_menu.py
+++ b/src/ralph/tui/screens/main_menu.py
@@ -109,10 +109,10 @@ class MainMenuScreen(Screen):
         self.app.push_screen("init_wizard")
 
     def action_select_run(self) -> None:
-        self.app.push_screen("run_dashboard")
+        self.app.push_screen("run_config")
 
     def action_select_understand(self) -> None:
-        self.app.push_screen("run_dashboard_understand")
+        self.app.push_screen("run_config_understand")
 
     def action_select_prd(self) -> None:
         self.app.push_screen("prd_wizard")

--- a/src/ralph/tui/screens/run_config.py
+++ b/src/ralph/tui/screens/run_config.py
@@ -1,0 +1,197 @@
+"""Pre-run configuration screen.
+
+Shown before launching the run dashboard so the user can review and
+adjust iterations, model, and mode before committing to a run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from textual.app import ComposeResult
+from textual.containers import Center, Horizontal, Vertical
+from textual.screen import Screen
+from textual.widgets import (
+    Button,
+    Footer,
+    Header,
+    Input,
+    Label,
+    Static,
+)
+
+from ralph.config import load_config
+from ralph.models import agent_display_name
+from ralph.prd import load_prd
+from ralph.tui.widgets.model_selector import ModelSelector
+
+
+class RunConfigScreen(Screen):
+    """Pre-run configuration: iterations, model, and summary before starting."""
+
+    BINDINGS = [
+        ("escape", "back", "Back"),
+    ]
+
+    def __init__(
+        self,
+        understand_mode: bool = False,
+        name: str | None = None,
+        id: str | None = None,
+    ) -> None:
+        super().__init__(name=name, id=id)
+        self.understand_mode = understand_mode
+        self._error = ""
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        mode_label = "Codebase Understanding" if self.understand_mode else "Feature Loop"
+        with Center(classes="wizard-outer"):
+            with Vertical(id="new-project-container"):
+                yield Static(f"Run {mode_label}", classes="title")
+                yield Vertical(id="run-config-body")
+                with Horizontal(id="new-project-nav"):
+                    yield Button("Back", id="rc-back", variant="default")
+                    yield Button(
+                        "Start", id="rc-start", variant="primary",
+                    )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._render_form()
+
+    def _render_form(self) -> None:
+        body = self.query_one("#run-config-body", Vertical)
+        body.remove_children()
+
+        cwd = Path.cwd()
+        toml_exists = (cwd / "ralph.toml").exists()
+
+        if not toml_exists:
+            body.mount(
+                Static(
+                    "[red]No ralph.toml found.[/red] "
+                    "Run project setup first.",
+                )
+            )
+            self.query_one("#rc-start", Button).disabled = True
+            return
+
+        config = load_config()
+
+        # Current agent/model display
+        agent_desc = agent_display_name(config.agent.type, config.agent.model)
+        body.mount(Static(f"  Agent: [bold]{agent_desc}[/bold]"))
+        body.mount(Static(""))
+
+        # Model selector
+        body.mount(Label("Agent and model"))
+        body.mount(
+            Static(
+                "[dim]Change the agent or model for this run only. "
+                "This does not modify ralph.toml.[/dim]",
+                classes="help-text",
+            )
+        )
+        body.mount(ModelSelector(id="rc-model-selector"))
+
+        # Iterations
+        body.mount(Label("Max iterations"))
+        body.mount(
+            Input(
+                value=str(config.run.max_iterations),
+                id="rc-iterations",
+                type="integer",
+                placeholder="e.g. 10",
+            )
+        )
+
+        # Context summary
+        body.mount(Static(""))
+        if self.understand_mode:
+            prompt_path = cwd / "scripts/ralph/understand_prompt.md"
+            body.mount(
+                Static(
+                    f"  Prompt: {prompt_path.name}  "
+                    f"{'[green]exists[/green]' if prompt_path.exists() else '[red]missing[/red]'}"
+                )
+            )
+            map_path = cwd / "scripts/ralph/codebase_map.md"
+            map_status = (
+                "[green]exists[/green]" if map_path.exists()
+                else "[dim]will be created[/dim]"
+            )
+            body.mount(
+                Static(f"  Map:    {map_path.name}  {map_status}")
+            )
+        else:
+            prompt_path = cwd / config.paths.prompt
+            body.mount(
+                Static(
+                    f"  Prompt: {prompt_path.name}  "
+                    f"{'[green]exists[/green]' if prompt_path.exists() else '[red]missing[/red]'}"
+                )
+            )
+            prd_path = cwd / config.paths.prd
+            try:
+                prd = load_prd(prd_path)
+                body.mount(
+                    Static(
+                        f"  PRD:    {prd.total_stories} stories  "
+                        f"[green]{prd.passing_stories} pass[/green]  "
+                        f"[red]{prd.failing_stories} fail[/red]"
+                    )
+                )
+            except Exception:
+                body.mount(
+                    Static("  PRD:    [red]not found or invalid[/red]")
+                )
+
+        if self._error:
+            body.mount(Static(""))
+            body.mount(Static(f"[red]{self._error}[/red]"))
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "rc-back":
+            self.app.pop_screen()
+        elif event.button.id == "rc-start":
+            self._start_run()
+
+    def _start_run(self) -> None:
+        # Validate iterations
+        try:
+            iterations = int(
+                self.query_one("#rc-iterations", Input).value
+            )
+            if iterations < 1:
+                self._error = "Iterations must be at least 1"
+                self._render_form()
+                return
+        except ValueError:
+            self._error = "Invalid iteration count"
+            self._render_form()
+            return
+
+        # Get selected model
+        try:
+            selector = self.query_one("#rc-model-selector", ModelSelector)
+            agent_type = selector.agent_type
+            model = selector.model
+        except Exception:
+            agent_type = ""
+            model = ""
+
+        # Pop this screen and push the dashboard with config overrides
+        from ralph.tui.screens.run_dashboard import RunDashboardScreen
+
+        self.app.pop_screen()
+        dashboard = RunDashboardScreen(
+            understand_mode=self.understand_mode,
+            max_iterations_override=iterations,
+            agent_type_override=agent_type or None,
+            model_override=model or None,
+        )
+        self.app.push_screen(dashboard)
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/src/ralph/tui/screens/run_dashboard.py
+++ b/src/ralph/tui/screens/run_dashboard.py
@@ -69,11 +69,17 @@ class RunDashboardScreen(Screen):
     def __init__(
         self,
         understand_mode: bool = False,
+        max_iterations_override: int | None = None,
+        agent_type_override: str | None = None,
+        model_override: str | None = None,
         name: str | None = None,
         id: str | None = None,
     ) -> None:
         super().__init__(name=name, id=id)
         self.understand_mode = understand_mode
+        self._max_iterations_override = max_iterations_override
+        self._agent_type_override = agent_type_override
+        self._model_override = model_override
         self.control = LoopControl()
         self._prd: PRD | None = None
         self._config: RalphConfig | None = None
@@ -111,6 +117,14 @@ class RunDashboardScreen(Screen):
             return
 
         config = load_config()
+
+        # Apply overrides from pre-run config screen
+        if self._max_iterations_override is not None:
+            config.run.max_iterations = self._max_iterations_override
+        if self._agent_type_override:
+            config.agent.type = self._agent_type_override
+        if self._model_override:
+            config.agent.model = self._model_override
 
         if self.understand_mode:
             config.paths.prompt = "scripts/ralph/understand_prompt.md"

--- a/src/ralph/tui/styles/app.tcss
+++ b/src/ralph/tui/styles/app.tcss
@@ -284,6 +284,13 @@ Screen {
     margin-left: 1;
 }
 
+/* ── Run Config ──────────────────────────────────────── */
+
+#run-config-body {
+    min-height: 10;
+    padding: 1 0;
+}
+
 /* ── Widget Overrides ───────────────────────────────── */
 
 AgentLogWidget {


### PR DESCRIPTION
## Summary

Adds a configuration screen between the main menu and the run dashboard. Previously, clicking "Run Feature Loop" or "Run Codebase Understanding" immediately started the loop with whatever defaults were in ralph.toml. Now you get a screen to review and adjust before committing.

The pre-run screen shows:
- Current agent and model (from ralph.toml)
- Model selector to change agent/model for this run only
- Max iterations input
- Context summary: prompt file status, PRD story counts (feature mode) or codebase map status (understanding mode)

Settings are applied as overrides - they don't modify ralph.toml.

## Test plan

- [ ] Main menu -> "Run Feature Loop" -> pre-run screen appears with settings
- [ ] Main menu -> "Run Codebase Understanding" -> pre-run screen appears
- [ ] Change iterations to 5, click Start -> dashboard runs with 5 iterations
- [ ] Change model, click Start -> dashboard uses selected model
- [ ] Click Back -> returns to main menu
- [ ] Invalid iterations (0, negative, text) -> shows validation error
- [ ] No ralph.toml -> shows error, Start button disabled
- [ ] `uv run pytest` passes (257 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)