### PR TITLE
fix: deduplicate streamed thinking, bold iteration separators

### DIFF
--- a/src/ralph/agent.py
+++ b/src/ralph/agent.py
@@ -81,6 +81,13 @@ def detect_completion(line: str) -> bool:
     return COMPLETION_MARKER in line
 
 
+# Track last emitted thinking/text to deduplicate accumulated content.
+# Claude's stream-json sends the full accumulated content on each event,
+# so the same thinking block appears repeatedly as it grows.
+_last_thinking: str = ""
+_last_ai_text: str = ""
+
+
 def _parse_stream_json_line(raw: str) -> list[AgentOutput]:
     """Parse a single stream-json line from Claude into AgentOutput(s).
 
@@ -122,7 +129,14 @@ def _parse_stream_json_line(raw: str) -> list[AgentOutput]:
 
 
 def _parse_assistant_event(data: dict) -> list[AgentOutput]:
-    """Parse an assistant event into one output per content block."""
+    """Parse an assistant event into one output per content block.
+
+    Deduplicates thinking and AI text blocks since Claude's stream-json
+    sends accumulated content on each event (the same block appears
+    repeatedly as it grows).
+    """
+    global _last_thinking, _last_ai_text  # noqa: PLW0603
+
     message = data.get("message", {})
     content_blocks = message.get("content", [])
     outputs: list[AgentOutput] = []
@@ -132,21 +146,36 @@ def _parse_assistant_event(data: dict) -> list[AgentOutput]:
 
         if block_type == "text":
             text = block.get("text", "").strip()
-            if text:
-                outputs.append(AgentOutput(line=text, role=LineRole.AI))
+            if text and text != _last_ai_text:
+                # Only emit the new portion
+                if _last_ai_text and text.startswith(_last_ai_text):
+                    new_part = text[len(_last_ai_text):].strip()
+                    if new_part:
+                        outputs.append(AgentOutput(
+                            line=new_part, role=LineRole.AI,
+                        ))
+                else:
+                    outputs.append(AgentOutput(line=text, role=LineRole.AI))
+                _last_ai_text = text
 
         elif block_type == "thinking":
             thinking = block.get("thinking", "").strip()
-            if thinking:
-                # Show first two meaningful lines of thinking
-                lines = [
-                    ln.strip() for ln in thinking.split("\n")
-                    if ln.strip()
-                ]
-                for ln in lines[:2]:
+            if thinking and thinking != _last_thinking:
+                # Only emit the new portion of thinking
+                if _last_thinking and thinking.startswith(_last_thinking):
+                    new_part = thinking[len(_last_thinking):].strip()
+                    if new_part:
+                        first_line = new_part.split("\n")[0][:200]
+                        outputs.append(AgentOutput(
+                            line=first_line, role=LineRole.THINK,
+                        ))
+                else:
+                    # First thinking block or completely new
+                    first_line = thinking.split("\n")[0][:200]
                     outputs.append(AgentOutput(
-                        line=ln[:200], role=LineRole.THINK,
+                        line=first_line, role=LineRole.THINK,
                     ))
+                _last_thinking = thinking
 
         elif block_type == "tool_use":
             tool_name = block.get("name", "unknown")
@@ -162,6 +191,13 @@ def _parse_assistant_event(data: dict) -> list[AgentOutput]:
                 ))
 
     return outputs
+
+
+def reset_stream_state() -> None:
+    """Reset dedup state between iterations."""
+    global _last_thinking, _last_ai_text  # noqa: PLW0603
+    _last_thinking = ""
+    _last_ai_text = ""
 
 
 def _format_tool_call(name: str, inputs: dict) -> str:

--- a/src/ralph/tui/screens/run_dashboard.py
+++ b/src/ralph/tui/screens/run_dashboard.py
@@ -10,7 +10,7 @@ from textual.screen import Screen
 from textual.widgets import Footer, Header
 from textual.worker import Worker
 
-from ralph.agent import AgentOutput
+from ralph.agent import AgentOutput, reset_stream_state
 from ralph.config import RalphConfig, load_config
 from ralph.loop import LoopControl, LoopResult, run_loop
 from ralph.prd import PRD, load_prd
@@ -177,11 +177,14 @@ class RunDashboardScreen(Screen):
         log.write_info(f"Starting {mode} loop")
 
     def _on_iteration_start(self, iteration: int, max_iterations: int) -> None:
+        # Reset stream dedup state so new iteration starts clean
+        reset_stream_state()
+
         header = self.query_one("#run-header", RunHeader)
         header.set_iteration(iteration, max_iterations)
 
         log = self.query_one("#agent-log", AgentLogWidget)
-        log.write_info(f"--- Iteration {iteration} / {max_iterations} ---")
+        log.write_separator(f"Iteration {iteration} / {max_iterations}")
 
         # Refresh PRD to get current story (not in understanding mode)
         if self._config and not self.understand_mode:

--- a/src/ralph/tui/widgets/agent_log.py
+++ b/src/ralph/tui/widgets/agent_log.py
@@ -108,6 +108,19 @@ class AgentLogWidget(RichLog):
         text.append(line, style="dim")
         self.write(text)
 
+    def write_separator(self, label: str) -> None:
+        """Write a prominent separator line between iterations."""
+        self.write(Text(""))
+        line = Text()
+        width = 60
+        pad = max(0, width - len(label) - 4)
+        line.append("-- ", style="bold")
+        line.append(label, style="bold")
+        line.append(" " + "-" * pad, style="bold")
+        self.write(line)
+        self.write(Text(""))
+        self._last_role = None
+
     def write_info(self, message: str) -> None:
         """Informational message."""
         text = Text()


### PR DESCRIPTION
## Summary

Two display fixes:

**1. Thinking/text deduplication**

Claude's stream-json sends the full accumulated content on each event. So as a thinking block grows from "Let me analyze..." to "Let me analyze the project structure...", we'd see both lines displayed. Now we track the last emitted content and only display the new portion, eliminating duplicate lines.

`reset_stream_state()` is called at each iteration boundary so the dedup starts fresh.

**2. Bold iteration separators**

Iteration transitions were rendered with `write_info` (dim text) making them invisible among tool calls. Now uses `write_separator()` which renders:

```
-- Iteration 1 / 10 -----------------------------------------------
```

Bold, with blank lines above and below. Iterations are now visually distinct.

## Test plan

- [ ] Run understanding mode for 2+ iterations - thinking should not repeat
- [ ] Iteration boundaries should be bold separator lines, clearly visible
- [ ] `uv run pytest` passes (257 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)