### PR TITLE
fix: claude permission mode - auto doesn't work in print mode

### DIFF
--- a/src/ralph/agent.py
+++ b/src/ralph/agent.py
@@ -329,7 +329,7 @@ async def _run_claude_streaming(
     cmd = (
         f"claude --print --model {effective_model} "
         f"--output-format stream-json --verbose "
-        f"--permission-mode auto"
+        f"--permission-mode acceptEdits"
     )
 
     # Stream-json lines can be very large (tool results with full file

--- a/src/ralph/models.py
+++ b/src/ralph/models.py
@@ -53,7 +53,7 @@ KNOWN_AGENTS: dict[str, AgentInfo] = {
         id="claude",
         name="Claude Code",
         detect_command="claude",
-        command_template="claude --print --model {model} --permission-mode auto",
+        command_template="claude --print --model {model} --permission-mode acceptEdits",
         models=CLAUDE_MODELS,
         default_model="sonnet",
     ),


### PR DESCRIPTION
## Summary

This is why codebase_map.md and progress.txt were never updated across iterations.

**Root cause**: `--permission-mode auto` does NOT auto-approve tool calls when combined with `--print` mode. The agent asks for permission but there's no interactive session to grant it, so file writes silently fail. The agent appears to work (thinking, tool calls visible in output) but nothing is written to disk.

**Fix**: Change from `auto` to `acceptEdits`, which auto-approves file edits and bash commands without requiring an interactive session.

**Verification**:
```
# auto mode - file NOT written:
echo 'Write "WRITTEN" to test.md' | claude --print --model haiku --permission-mode auto
cat test.md  # unchanged

# acceptEdits mode - file written:
echo 'Write "WRITTEN" to test.md' | claude --print --model haiku --permission-mode acceptEdits
cat test.md  # contains "WRITTEN"
```

## Test plan

- [ ] Run understanding mode for 2 iterations - codebase_map.md should have new content
- [ ] Check progress.txt - should have handoff notes
- [ ] `uv run pytest` passes (257 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)