### PR TITLE
Fix interactive feature mode crashes and redesign conversation UI

### DIFF
--- a/src/ralph/agent.py
+++ b/src/ralph/agent.py
@@ -330,7 +330,7 @@ async def run_conversation_agent(
     """
     async for output in _run_claude_streaming(
         model=model, prompt=prompt, cwd=cwd,
-        verbose=False, permission_mode="",
+        verbose=True, permission_mode="",
     ):
         yield output
 

--- a/src/ralph/tui/screens/feature_config.py
+++ b/src/ralph/tui/screens/feature_config.py
@@ -33,7 +33,6 @@ class FeatureConfigScreen(Screen):
 
     def __init__(self, name: str | None = None, id: str | None = None) -> None:
         super().__init__(name=name, id=id)
-        self._error = ""
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -46,7 +45,28 @@ class FeatureConfigScreen(Screen):
                     "generating a PRD.[/dim]",
                     classes="help-text",
                 )
-                yield Vertical(id="fc-body")
+                with Vertical(id="fc-body"):
+                    yield Label("Agent and model")
+                    yield ModelSelector(id="fc-model-selector")
+                    yield Label("Describe your feature (optional)")
+                    yield Static(
+                        "[dim]A few sentences about what you want to build. "
+                        "You can also provide this interactively in the "
+                        "conversation.[/dim]",
+                        classes="help-text",
+                    )
+                    yield TextArea("", id="fc-prompt", tab_behavior="indent")
+                    yield Label("Markdown spec file (optional)")
+                    yield Static(
+                        "[dim]Path to an existing spec or requirements "
+                        "document. Leave empty to skip.[/dim]",
+                        classes="help-text",
+                    )
+                    yield Input(
+                        value="",
+                        id="fc-file",
+                        placeholder="/path/to/spec.md",
+                    )
                 with Horizontal(id="new-project-nav"):
                     yield Button("Back", id="fc-back", variant="default")
                     yield Button(
@@ -56,47 +76,13 @@ class FeatureConfigScreen(Screen):
                     )
         yield Footer()
 
-    def on_mount(self) -> None:
-        self._render_form()
-
-    def _render_form(self) -> None:
-        body = self.query_one("#fc-body", Vertical)
-        body.remove_children()
-
-        body.mount(Label("Agent and model"))
-        body.mount(ModelSelector(id="fc-model-selector"))
-
-        body.mount(Label("Describe your feature (optional)"))
-        body.mount(
-            Static(
-                "[dim]A few sentences about what you want to build. "
-                "You can also provide this interactively in the "
-                "conversation.[/dim]",
-                classes="help-text",
-            )
-        )
-        body.mount(
-            TextArea("", id="fc-prompt", tab_behavior="indent")
-        )
-
-        body.mount(Label("Markdown spec file (optional)"))
-        body.mount(
-            Static(
-                "[dim]Path to an existing spec or requirements "
-                "document. Leave empty to skip.[/dim]",
-                classes="help-text",
-            )
-        )
-        body.mount(
-            Input(
-                value="",
-                id="fc-file",
-                placeholder="/path/to/spec.md",
-            )
-        )
-
-        if self._error:
-            body.mount(Static(f"[red]{self._error}[/red]"))
+    def _show_error(self, message: str) -> None:
+        self.notify(message, severity="error")
+        try:
+            error_widget = self.query_one("#fc-error", Static)
+            error_widget.update(f"[red]{message}[/red]" if message else "")
+        except Exception:
+            pass
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "fc-back":
@@ -105,37 +91,24 @@ class FeatureConfigScreen(Screen):
             self._start_conversation()
 
     def _start_conversation(self) -> None:
-        prompt = ""
-        file_path = ""
-
-        try:
-            prompt = self.query_one("#fc-prompt", TextArea).text.strip()
-        except Exception:
-            pass
-
-        try:
-            file_path = self.query_one("#fc-file", Input).value.strip()
-        except Exception:
-            pass
+        prompt = self.query_one("#fc-prompt", TextArea).text.strip()
+        file_path = self.query_one("#fc-file", Input).value.strip()
 
         # Validate file exists if provided
         if file_path:
             p = Path(file_path).expanduser().resolve()
             if not p.exists():
-                self._error = f"File not found: {p}"
-                self._render_form()
+                self._show_error(f"File not found: {p}")
                 return
             if not p.is_file():
-                self._error = f"Not a file: {p}"
-                self._render_form()
+                self._show_error(f"Not a file: {p}")
                 return
 
         # At least one input required
         if not prompt and not file_path:
-            self._error = (
+            self._show_error(
                 "Provide a feature description, a spec file, or both."
             )
-            self._render_form()
             return
 
         # Get model selection

--- a/src/ralph/tui/screens/feature_conversation.py
+++ b/src/ralph/tui/screens/feature_conversation.py
@@ -1,18 +1,17 @@
-"""Interactive feature planning conversation screen.
+"""Interactive feature planning conversation.
 
-Chat-like interface where a PM agent reviews the user's feature spec,
-asks probing questions, and eventually generates a PRD.
+Near-monochrome terminal interface. The green prompt '>' is the only
+strong visual element. Everything else is just text.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from rich.text import Text
 from textual.app import ComposeResult
-from textual.containers import Horizontal
+from textual.containers import VerticalScroll
 from textual.screen import Screen
-from textual.widgets import Button, Footer, Header, Input
+from textual.widgets import Input, Static
 
 from ralph.agent import (
     AgentOutput,
@@ -29,15 +28,12 @@ from ralph.conversation import (
     parse_prd_from_json_output,
     response_has_ready_marker,
 )
-from ralph.tui.widgets.agent_log import AgentLogWidget
+from ralph.tui.widgets.chat_log import ChatLogWidget
 
 
 class FeatureConversationScreen(Screen):
-    """Chat-like screen for interactive feature planning."""
 
-    BINDINGS = [
-        ("escape", "back", "Back"),
-    ]
+    BINDINGS = [("escape", "back", "Back")]
 
     def __init__(
         self,
@@ -56,224 +52,217 @@ class FeatureConversationScreen(Screen):
         self._messages: list[ConversationMessage] = []
         self._agent_busy = False
         self._accumulated_response = ""
+        self._activity_lines: list[tuple[str, LineRole]] = []
 
     def compose(self) -> ComposeResult:
-        yield Header(show_clock=True)
-        yield AgentLogWidget(
-            id="conv-log", wrap=True, highlight=True, markup=True,
-        )
-        with Horizontal(id="conv-input-bar"):
-            yield Input(
-                placeholder="Type your response...",
-                id="conv-input",
+        with VerticalScroll(id="chat-scroll"):
+            yield ChatLogWidget(
+                id="chat-log", wrap=True, highlight=False, markup=False,
             )
-            yield Button("Send", id="conv-send", variant="primary")
-        yield Footer()
+            yield Static("", id="streaming-display")
+        yield Input(placeholder="Type your response...", id="chat-input")
 
     def on_mount(self) -> None:
-        log = self.query_one("#conv-log", AgentLogWidget)
-        log.write_info("Starting interactive feature planning session")
-        log.write_info(f"Agent: {self._agent_type} ({self._model})")
-        log.write(Text(""))
-
+        self.query_one("#streaming-display").display = False
+        log = self.query_one("#chat-log", ChatLogWidget)
+        log.write_system(
+            f"feature planning / {self._agent_type} / {self._model}"
+        )
         self._build_initial_context()
         self._send_to_agent()
 
+    # -- Context -----------------------------------------------------------
+
     def _build_initial_context(self) -> None:
-        """Build the first user message from prompt and/or file."""
         parts: list[str] = []
-
         if self._initial_file:
-            file_path = Path(self._initial_file).expanduser().resolve()
-            if file_path.exists():
-                content = file_path.read_text(encoding="utf-8")
+            p = Path(self._initial_file).expanduser().resolve()
+            if p.exists():
                 parts.append(
-                    f"Here is my feature specification:\n\n{content}"
+                    f"Here is my feature specification:\n\n"
+                    f"{p.read_text(encoding='utf-8')}"
                 )
-
         if self._initial_prompt:
             parts.append(self._initial_prompt)
 
-        first_message = "\n\n".join(parts) if parts else (
-            "I want to build a new feature. Let me describe it."
-        )
+        msg = "\n\n".join(parts) or "I want to build a new feature."
+        self.query_one("#chat-log", ChatLogWidget).write_user_message(msg)
+        self._messages.append(ConversationMessage(role="user", content=msg))
 
-        # Display what we're sending
-        log = self.query_one("#conv-log", AgentLogWidget)
-        log.write_separator("You")
-        for line in first_message.split("\n")[:10]:
-            log.write(Text(f"  {line}", style="bold green"))
-        if first_message.count("\n") > 10:
-            log.write(Text(
-                f"  ... ({first_message.count(chr(10)) - 10} more lines)",
-                style="dim green",
-            ))
-
-        self._messages.append(
-            ConversationMessage(role="user", content=first_message)
-        )
+    # -- Agent -------------------------------------------------------------
 
     def _send_to_agent(self) -> None:
-        """Send the full conversation to Claude and stream the response."""
         self._agent_busy = True
         self._accumulated_response = ""
+        self._activity_lines = []
         self._disable_input()
+        self._show_streaming()
 
         reset_stream_state()
-
-        log = self.query_one("#conv-log", AgentLogWidget)
-        log.write(Text(""))
-        log.write_separator("PM")
-
-        prompt = build_conversation_prompt(self._messages)
         self.run_worker(
-            self._agent_worker(prompt),
-            name="conv-agent",
-            thread=True,
-            exclusive=True,
+            self._agent_worker(
+                build_conversation_prompt(self._messages)
+            ),
+            name="conv-agent", thread=True, exclusive=True,
         )
 
     async def _agent_worker(self, prompt: str) -> None:
-        """Worker: stream Claude response and post to UI."""
         try:
             async for output in run_conversation_agent(
-                model=self._model,
-                prompt=prompt,
-                cwd=Path.cwd(),
+                model=self._model, prompt=prompt, cwd=Path.cwd(),
             ):
                 self.app.call_from_thread(self._on_agent_line, output)
         except Exception as e:
             self.app.call_from_thread(self._on_agent_error, str(e))
-
         self.app.call_from_thread(self._on_agent_done)
 
     def _on_agent_line(self, output: AgentOutput) -> None:
-        """Handle a single streamed line from the agent."""
-        log = self.query_one("#conv-log", AgentLogWidget)
-        log.write_agent_line(output)
-
         if output.role == LineRole.AI:
             self._accumulated_response += output.line + "\n"
+            self._update_streaming()
+        elif output.role in (
+            LineRole.THINK, LineRole.TOOL, LineRole.GIT, LineRole.SYS,
+        ):
+            self._activity_lines.append((output.line, output.role))
+            self._update_streaming()
 
     def _on_agent_error(self, error: str) -> None:
-        log = self.query_one("#conv-log", AgentLogWidget)
-        log.write_error(f"Agent error: {error}")
+        self.query_one("#chat-log", ChatLogWidget).write_system(
+            f"error: {error}"
+        )
+        self._hide_streaming()
+        self._enable_input()
 
     def _on_agent_done(self) -> None:
-        """Agent finished responding. Check for ready marker or re-enable input."""
         self._agent_busy = False
         response = self._accumulated_response.strip()
+        log = self.query_one("#chat-log", ChatLogWidget)
+
+        if response or self._activity_lines:
+            log.write_activity_summary(self._activity_lines)
+            if response:
+                log.write_pm_response(response)
+
+        self._hide_streaming()
 
         if response:
             self._messages.append(
                 ConversationMessage(role="assistant", content=response)
             )
 
-        # Check if the PM agent signaled it's ready to generate
         if response_has_ready_marker(response):
-            log = self.query_one("#conv-log", AgentLogWidget)
-            log.write(Text(""))
-            log.write_info(
-                "PM is satisfied. Generating PRD with structured output..."
-            )
+            log.write_system("generating PRD...")
             self._generate_prd()
         else:
             self._enable_input()
 
+    # -- Streaming ---------------------------------------------------------
+
+    def _show_streaming(self) -> None:
+        d = self.query_one("#streaming-display", Static)
+        d.display = True
+        d.update("")
+
+    def _hide_streaming(self) -> None:
+        d = self.query_one("#streaming-display", Static)
+        d.update("")
+        d.display = False
+
+    def _update_streaming(self) -> None:
+        parts: list[str] = []
+
+        # Activity: last 4 lines
+        recent = self._activity_lines[-4:]
+        if recent:
+            from ralph.tui.widgets.chat_log import _shorten_activity
+            for raw, _ in recent:
+                s = _shorten_activity(raw)
+                if s:
+                    parts.append(f"    [dim]{s}[/dim]")
+
+        # AI text
+        ai = self._accumulated_response.strip()
+        if ai:
+            if parts:
+                parts.append("")
+            for line in ai.split("\n"):
+                parts.append(f"  {line}")
+
+        self.query_one("#streaming-display", Static).update(
+            "\n".join(parts)
+        )
+        try:
+            self.query_one("#chat-scroll", VerticalScroll).scroll_end(
+                animate=False
+            )
+        except Exception:
+            pass
+
+    # -- PRD ---------------------------------------------------------------
+
     def _generate_prd(self) -> None:
-        """Launch the structured PRD generation call."""
         self._agent_busy = True
         self._disable_input()
         self.run_worker(
-            self._prd_generation_worker(),
-            name="prd-gen",
-            thread=True,
-            exclusive=True,
+            self._prd_worker(), name="prd-gen", thread=True, exclusive=True,
         )
 
-    async def _prd_generation_worker(self) -> None:
-        """Worker: call Claude with --json-schema to generate PRD."""
+    async def _prd_worker(self) -> None:
         try:
-            prompt = build_generation_prompt(self._messages)
             raw = await run_prd_generation(
                 model=self._model,
-                prompt=prompt,
+                prompt=build_generation_prompt(self._messages),
                 json_schema=PRD_JSON_SCHEMA,
                 cwd=Path.cwd(),
             )
             self.app.call_from_thread(self._on_prd_generated, raw)
         except Exception as e:
             self.app.call_from_thread(self._on_agent_error, str(e))
-            self.app.call_from_thread(self._enable_input)
 
-    def _on_prd_generated(self, raw_output: str) -> None:
-        """Handle the structured PRD generation result."""
+    def _on_prd_generated(self, raw: str) -> None:
         self._agent_busy = False
-        log = self.query_one("#conv-log", AgentLogWidget)
-
-        prd = parse_prd_from_json_output(raw_output)
+        log = self.query_one("#chat-log", ChatLogWidget)
+        prd = parse_prd_from_json_output(raw)
         if prd is not None:
-            log.write(Text(""))
-            log.write_success(
-                f"PRD generated: {prd.total_stories} stories, "
-                f"branch: {prd.branch_name}"
+            log.write_system(
+                f"PRD: {prd.total_stories} stories, branch {prd.branch_name}"
             )
-            log.write_info("Opening review screen...")
-
             from ralph.tui.screens.prd_review import PRDReviewScreen
             self.app.push_screen(PRDReviewScreen(prd=prd))
         else:
-            log.write_error("Failed to generate valid PRD. Try again.")
-            log.write_info(
-                "Type 'generate' to retry, or continue the conversation."
-            )
+            log.write_system("PRD generation failed. type 'generate' to retry")
             self._enable_input()
 
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "conv-send":
-            self._submit_user_input()
+    # -- Input -------------------------------------------------------------
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        if event.input.id == "conv-input":
-            self._submit_user_input()
+        if event.input.id == "chat-input":
+            self._submit()
 
-    def _submit_user_input(self) -> None:
-        """Handle user pressing Send or Enter."""
+    def _submit(self) -> None:
         if self._agent_busy:
             return
-
-        inp = self.query_one("#conv-input", Input)
-        user_text = inp.value.strip()
-        if not user_text:
+        inp = self.query_one("#chat-input", Input)
+        text = inp.value.strip()
+        if not text:
             return
-
         inp.value = ""
-
-        # Display user message
-        log = self.query_one("#conv-log", AgentLogWidget)
-        log.write(Text(""))
-        log.write_separator("You")
-        log.write(Text(f"  {user_text}", style="bold green"))
-
-        self._messages.append(
-            ConversationMessage(role="user", content=user_text)
-        )
-
+        log = self.query_one("#chat-log", ChatLogWidget)
+        log.write_user_message(text)
+        self._messages.append(ConversationMessage(role="user", content=text))
         self._send_to_agent()
 
     def _disable_input(self) -> None:
         try:
-            self.query_one("#conv-input", Input).disabled = True
-            self.query_one("#conv-send", Button).disabled = True
+            self.query_one("#chat-input", Input).disabled = True
         except Exception:
             pass
 
     def _enable_input(self) -> None:
         try:
-            inp = self.query_one("#conv-input", Input)
+            inp = self.query_one("#chat-input", Input)
             inp.disabled = False
             inp.focus()
-            self.query_one("#conv-send", Button).disabled = False
         except Exception:
             pass
 

--- a/src/ralph/tui/styles/app.tcss
+++ b/src/ralph/tui/styles/app.tcss
@@ -293,23 +293,36 @@ Screen {
 
 /* ── Feature Conversation ───────────────────────────── */
 
-#conv-log {
+#chat-scroll {
     height: 1fr;
+    scrollbar-size: 1 1;
 }
 
-#conv-input-bar {
+#chat-log {
+    height: auto;
+    min-height: 1;
+}
+
+#streaming-display {
+    height: auto;
+}
+
+#chat-input {
     dock: bottom;
     height: 3;
-    padding: 0 1;
+    border: none;
+    border-top: solid $surface-lighten-1;
+    background: $surface;
+    padding: 1 2;
 }
 
-#conv-input-bar Input {
-    width: 1fr;
+#chat-input:disabled {
+    opacity: 0.4;
 }
 
-#conv-input-bar Button {
-    width: 10;
-    margin-left: 1;
+#chat-input:focus {
+    border: none;
+    border-top: solid $surface-lighten-1;
 }
 
 /* ── PRD Review ─────────────────────────────────────── */

--- a/src/ralph/tui/widgets/chat_log.py
+++ b/src/ralph/tui/widgets/chat_log.py
@@ -1,0 +1,79 @@
+"""Chat log widget.
+
+Minimal but with clear information hierarchy:
+- User turns marked with green '>'
+- PM turns use rendered markdown
+- Activity is a single dim summary line
+- System messages are dim
+"""
+
+from __future__ import annotations
+
+from rich.markdown import Markdown as RichMarkdown
+from rich.text import Text
+from textual.widgets import RichLog
+
+from ralph.agent import LineRole
+
+
+class ChatLogWidget(RichLog):
+    """Conversation log with markdown rendering."""
+
+    def _separator(self) -> None:
+        self.write(Text(""))
+        self.write(Text("  -------", style="dim"))
+        self.write(Text(""))
+
+    def write_user_message(self, content: str) -> None:
+        self._separator()
+        lines = content.split("\n")
+        first = Text()
+        first.append("  > ", style="bold green")
+        first.append(lines[0])
+        self.write(first)
+        for line in lines[1:]:
+            self.write(Text(f"    {line}"))
+
+    def write_pm_response(self, content: str) -> None:
+        self.write(Text(""))
+        if content.strip():
+            try:
+                self.write(RichMarkdown(content, code_theme="monokai"))
+            except Exception:
+                for line in content.split("\n"):
+                    self.write(Text(f"  {line}"))
+
+    def write_activity_summary(
+        self, lines: list[tuple[str, LineRole]],
+    ) -> None:
+        if not lines:
+            return
+        seen: list[str] = []
+        for raw, _ in lines:
+            short = _shorten_activity(raw)
+            if short and short not in seen:
+                seen.append(short)
+        if not seen:
+            return
+        summary = ", ".join(seen[-8:])
+        self.write(Text(f"    {summary}", style="dim"))
+
+    def write_system(self, content: str) -> None:
+        self.write(Text(f"  {content}", style="dim"))
+
+
+def _shorten_activity(line: str) -> str:
+    line = line.strip()
+    if not line or line in ("Agent",):
+        return ""
+    for prefix in ("Read ", "Glob ", "Grep "):
+        if line.startswith(prefix):
+            rest = line[len(prefix):]
+            if "/" in rest:
+                return rest.rsplit("/", 1)[-1][:40]
+            return rest[:40]
+    if line.startswith("$ "):
+        parts = line[2:].split()
+        if parts:
+            return parts[0][:20]
+    return line[:30]

--- a/src/ralph/tui/widgets/model_selector.py
+++ b/src/ralph/tui/widgets/model_selector.py
@@ -19,7 +19,17 @@ from ralph.models import (
 class ModelSelector(Widget):
     """Compound widget for selecting agent type and model."""
 
-    DEFAULT_CSS = ""
+    DEFAULT_CSS = """
+    ModelSelector {
+        height: auto;
+    }
+    ModelSelector Vertical {
+        height: auto;
+    }
+    ModelSelector Horizontal {
+        height: auto;
+    }
+    """
 
     class Changed(Message):
         """Emitted when the agent or model selection changes."""


### PR DESCRIPTION
## Summary

- **Fix DuplicateIds crash** in feature config screen: form widgets moved into `compose()` instead of dynamic `mount()` which caused duplicate ID errors on validation re-renders
- **Fix ModelSelector layout bug**: added `height: auto` CSS to prevent ModelSelector from consuming all vertical space and hiding form fields below it
- **Fix `--verbose` bug**: conversation agent passed `verbose=False` to `_run_claude_streaming`, but Claude CLI requires `--verbose` with `--output-format stream-json`
- **Redesign conversation UI**: replaced the bordered-widget-per-message approach with a terminal-native two-widget architecture (ChatLogWidget + streaming Static), markdown rendering for PM responses, compressed activity summaries, and near-monochrome palette

## Test plan

- [ ] Open `ralph` and navigate to Interactive Feature mode
- [ ] Verify form fields (TextArea, Input) are visible below ModelSelector
- [ ] Click Start Conversation with empty fields - should show error notification
- [ ] Fill in a feature description and click Start Conversation
- [ ] Verify no `--verbose` error, agent streams response
- [ ] Verify user messages marked with green `>`, PM responses render markdown
- [ ] Verify activity shows as compressed file summaries
- [ ] Verify multi-turn conversation works (type response, press Enter)
- [ ] Press Escape to go back

🤖 Generated with [Claude Code](https://claude.com/claude-code)