### PR TITLE
Overhaul README with clear structure and complete reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,48 @@
 # Ralph
 
-Ralph is an agentic loop harness for autonomous AI-driven development. It runs an AI coding agent in a loop against a set of user stories, iterating until every acceptance criterion passes or a maximum iteration count is reached.
+Ralph lets you hand a feature spec to an AI coding agent and walk away. It runs the agent in a loop - writing code, running tests, checking results - and keeps going until every requirement passes or it hits a retry limit.
 
-You define what to build. Ralph drives the agent until it's done.
+The problem it solves: AI coding agents like Claude Code and Codex are powerful, but they work on a single prompt at a time. If the agent doesn't finish in one shot, you're back to manually re-prompting, checking progress, and deciding what to try next. Ralph automates that outer loop. You define the requirements up front as testable acceptance criteria, and Ralph handles the iteration, progress tracking, and guardrails.
 
-## Features
+## What a session looks like
 
-- **Autonomous iteration loop** - runs an AI coding agent repeatedly against a PRD until all acceptance criteria pass, with automatic progress tracking between iterations
-- **Multi-agent support** - works with Claude Code, OpenAI Codex, or any custom command that reads stdin and writes stdout
-- **Interactive feature planning** - conversation with an AI PM agent that reviews your spec from product, engineering, and reliability perspectives before generating a structured PRD
-- **Codebase understanding mode** - read-only mapping pass that produces an evidence-based architecture document before you start building
-- **Guard rails** - path restrictions that automatically revert changes outside allowed directories, with infrastructure file protection
-- **Git integration** - automatic branch creation/checkout from PRD, change tracking, and disallowed file reversion per iteration
-- **Real-time streaming** - classified output display (AI text, thinking, tool calls, git operations) with role-based visual hierarchy
-- **Terminal UI and CLI** - full interactive TUI with live dashboard, PRD wizard, config editor, and status views, plus headless CLI for scripting and CI
-- **PRD-driven workflow** - three paths to create a PRD: step-by-step wizard, import from markdown spec, or AI-assisted interactive planning
-- **Configuration layering** - settings resolved from CLI flags, environment variables, and ralph.toml with clear precedence
+You start with an idea. Ralph helps you turn it into a structured spec, then drives an agent to implement it:
 
-## How it works
+```
+$ ralph init .                         # scaffold ralph config in your project
+$ ralph prd create                     # define what you want to build
+$ ralph run 25 --agent claude          # let the agent work for up to 25 iterations
+```
+
+Behind the scenes, each iteration:
+
+1. Ralph reads your requirements (a JSON file of user stories with acceptance criteria)
+2. It builds a prompt that includes the requirements, the agent's instructions, and a log of what happened in previous iterations
+3. It sends the prompt to the agent, which writes code, runs tests, and reports back
+4. Ralph checks whether the agent signaled completion and whether any file changes violated path restrictions
+5. If stories remain incomplete, it loops back to step 2 with updated context
+
+The loop exits when the agent marks all stories as passing, or when the iteration limit is reached.
 
 ```mermaid
 flowchart TD
-    PRD[prd.json\nUser stories + acceptance criteria] --> Prompt[prompt.md\nInstructions + progress context]
-    Prompt --> Agent[AI Agent\nClaude / Codex / Custom]
-    Agent --> Code[Code changes + test results]
-    Code --> Guard[Guard rails\nPath enforcement + completion check]
-    Guard -->|Stories incomplete| Prompt
-    Guard -->|All stories pass\nor max iterations| Done[Loop exits]
+    PRD["Requirements\n(user stories + acceptance criteria)"] --> Prompt["Build prompt\n(instructions + progress from prior iterations)"]
+    Prompt --> Agent["AI agent writes code and runs tests\n(Claude Code, Codex, or custom)"]
+    Agent --> Check{"All stories\npassing?"}
+    Check -->|No| Prompt
+    Check -->|Yes| Done["Done"]
+    Check -->|Max iterations| Done
 ```
 
-Each iteration: Ralph builds a prompt from the PRD and progress log, sends it to the agent, streams the output, checks for the completion marker (`<promise>COMPLETE</promise>`), enforces path restrictions, and logs results.
+## Why not just use Claude Code directly?
+
+You can, and for small tasks you should. Ralph is for when you want to:
+
+- **Define success criteria before starting** - "tests pass, types check, login form works" - and have the agent keep trying until they're met
+- **Walk away** - Ralph runs unattended. You come back to a branch with the work done (or a progress log showing what was attempted)
+- **Constrain the agent** - restrict which files it can touch, automatically revert out-of-scope changes
+- **Track progress across iterations** - each run builds on the last, with full context injection so the agent knows what it already tried
+- **Plan before building** - Ralph's interactive mode lets you have a conversation with an AI PM that stress-tests your spec before any code is written
 
 ## Installation
 
@@ -39,182 +52,152 @@ Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/).
 uv tool install ralph-cli
 ```
 
-For development:
+You also need at least one AI coding agent CLI:
 
-```bash
-git clone https://github.com/0xfauzi/ralph-loop.git
-cd ralph-loop
-uv sync
-uv tool install -e .
-```
-
-Verify the install:
-
-```bash
-ralph --help
-```
-
-## Prerequisites
-
-Ralph needs an AI coding agent CLI installed:
-
-| Agent | Command | Models |
+| Agent | Install | Models |
 |-------|---------|--------|
-| Claude Code (recommended) | `claude` | sonnet, opus, haiku |
-| OpenAI Codex | `codex` | o3, o4-mini, codex-mini-latest |
+| Claude Code (recommended) | [claude.ai/code](https://claude.ai/code) | sonnet, opus, haiku |
+| OpenAI Codex | [github.com/openai/codex](https://github.com/openai/codex) | o3, o4-mini |
 | Custom | Any command that reads stdin | - |
-
-Git is optional but recommended for branch management and path enforcement.
 
 ## Quick start
 
-### 1. Initialize a project
+### 1. Set up
 
 ```bash
-ralph init /path/to/your/project
+cd your-project
+ralph init .
 ```
 
-This scaffolds `scripts/ralph/` with template files and creates `ralph.toml` with auto-detected agent settings.
+This creates `ralph.toml` (configuration) and `scripts/ralph/` (prompt templates, progress log). Ralph auto-detects which agent CLIs you have installed.
 
-### 2. Create a PRD
+### 2. Define what to build
 
-Three ways to create a PRD:
+Three options depending on how fleshed out your idea is:
 
-**Interactive wizard** - step-by-step form:
+**You have a rough idea** - talk it through with an AI PM first:
+```bash
+ralph                    # launch TUI, select "Interactive Feature"
+```
+Ralph starts a conversation where an AI reviewer asks probing questions from product, engineering, and reliability perspectives. When the spec is tight enough, it generates a structured PRD automatically.
+
+**You have a spec document** - import and convert it:
+```bash
+ralph prd import spec.md --agent claude
+```
+
+**You want to define stories manually** - use the step-by-step wizard:
 ```bash
 ralph prd create
 ```
 
-**Import from spec** - generate from an existing markdown spec:
-```bash
-ralph prd import my-spec.md --agent claude
-```
+All three produce the same output: a `prd.json` file with user stories, acceptance criteria, priorities, and a branch name.
 
-**Interactive planning** - conversation with an AI PM that asks probing questions, then generates a PRD:
-```bash
-ralph
-# Select "Interactive Feature" from the menu
-```
-
-### 3. Run the loop
+### 3. Run
 
 ```bash
-ralph run 25 --agent claude --model sonnet
+ralph run 25
 ```
 
-Ralph creates or checks out the branch from the PRD, builds the prompt, and starts iterating. The agent writes code, runs tests, and Ralph tracks progress.
+Ralph checks out (or creates) the branch from the PRD, then starts iterating. You'll see the agent reading files, writing code, running tests. Progress is logged between iterations so each run builds on the last.
 
 ```bash
-ralph run              # Default: 10 iterations
-ralph run 50           # 50 iterations
-ralph run --interactive  # Pause after each iteration
+ralph run                  # 10 iterations (default)
+ralph run 50 --model opus  # 50 iterations with a specific model
+ralph run --interactive    # pause after each iteration for review
 ```
 
-### 4. Understand a codebase
+### 4. (Optional) Understand an unfamiliar codebase first
 
-Before implementing features on an unfamiliar codebase, run a read-only mapping pass:
+Before building features on a codebase you don't know well:
 
 ```bash
 ralph understand 10
 ```
 
-This produces `scripts/ralph/codebase_map.md` with evidence-based findings about the architecture, patterns, and conventions. The agent reads but does not modify source files.
+This runs the agent in read-only mode for 10 iterations, producing `scripts/ralph/codebase_map.md` - an evidence-based document about the architecture, patterns, and conventions. The agent reads but does not modify source files.
+
+## Features
+
+- **Autonomous iteration** - runs the agent in a loop until acceptance criteria pass, with progress context injected between iterations
+- **Interactive feature planning** - AI PM conversation that stress-tests your spec before generating a PRD
+- **Codebase understanding** - read-only mode that maps architecture before you start building
+- **Guard rails** - path restrictions auto-revert out-of-scope changes; infrastructure files are protected; 3 consecutive errors trigger bail-out
+- **Git integration** - auto branch creation/checkout, change tracking, per-iteration reversion of disallowed files
+- **Multi-agent** - Claude Code (streaming with classified output), OpenAI Codex, or any stdin/stdout command
+- **Terminal UI** - live dashboard with agent output and story progress, PRD wizard, config editor, status view
+- **Headless CLI** - every TUI feature available as a command for scripting and CI
 
 ## Terminal UI
 
-Running `ralph` with no arguments launches the interactive TUI:
-
 ```bash
-ralph
+ralph                    # launch TUI
 ```
 
-| Screen | Purpose |
-|--------|---------|
-| Main menu | Mode selection and project status |
-| Run dashboard | Live agent output with story progress table. `p` to pause, `s` to stop |
-| Interactive feature | Conversation with an AI PM that reviews your spec and generates a PRD |
-| PRD wizard | Step-by-step PRD creation form |
-| Config | Visual editor for ralph.toml settings |
-| Status | Read-only project overview with story table |
-| Init wizard | Guided project setup |
+| Screen | What it does |
+|--------|-------------|
+| Run dashboard | Live agent output alongside story progress table. `p` pause, `s` stop |
+| Interactive feature | Chat with an AI PM to refine your spec and generate a PRD |
+| PRD wizard | Step-by-step story creation form |
+| Config | Visual editor for ralph.toml |
+| Status | Project overview with story table |
 
 ## CLI reference
 
 ```
-ralph                     Launch interactive TUI
-ralph init [DIR]          Initialize project scaffolding
-ralph run [N]             Run feature loop (N = max iterations)
-ralph understand [N]      Run codebase understanding loop (read-only)
-ralph prd create          Interactive PRD creation wizard
-ralph prd import FILE     Generate PRD from spec via LLM
-ralph prd validate        Validate prd.json schema
-ralph prd status          Show story summary table
-ralph config show         Show current configuration
+ralph                     Launch TUI
+ralph init [DIR]          Set up Ralph in a project
+ralph run [N]             Run the agent loop (N = max iterations, default 10)
+ralph understand [N]      Run read-only codebase mapping
+ralph prd create          PRD creation wizard
+ralph prd import FILE     Generate PRD from a spec document
+ralph prd validate        Check prd.json schema
+ralph prd status          Story summary table
+ralph config show         Print current config
 ralph config init         Create ralph.toml with defaults
-ralph status              Project status overview
+ralph status              Project overview
 ```
 
 ## Configuration
 
-Ralph uses `ralph.toml` at the project root. Create one with defaults:
-
-```bash
-ralph config init
-```
-
-### Settings
+Ralph uses `ralph.toml` at the project root:
 
 ```toml
 [agent]
 type = "claude"           # "claude", "codex", or "custom"
-model = ""                # Model override (empty = agent default)
-command = ""              # Custom shell command (type = "custom" only)
+model = ""                # model override (empty = agent default)
+command = ""              # shell command for custom agents
 
 [run]
 max_iterations = 10
 sleep_seconds = 2
-interactive = false       # Pause after each iteration
+interactive = false
 
 [paths]
-prompt = "scripts/ralph/prompt.md"
-prd = "scripts/ralph/prd.json"
-progress = "scripts/ralph/progress.txt"
-codebase_map = "scripts/ralph/codebase_map.md"
-allowed = []              # Guard rail: restrict which files agent can change
+allowed = []              # restrict which files the agent can change
 
 [git]
-branch = ""               # Override branch (empty = use PRD branchName)
+branch = ""               # override branch (empty = use PRD branch name)
 auto_checkout = true
 ```
 
-### Environment variable overrides
+Environment variables override ralph.toml: `AGENT_CMD`, `MODEL`, `INTERACTIVE`, `SLEEP_SECONDS`, `ALLOWED_PATHS`, `RALPH_BRANCH`.
 
-Environment variables take precedence over ralph.toml:
+## How the PRD works
 
-| Variable | Setting |
-|----------|---------|
-| `AGENT_CMD` | `agent.command` (also sets type = custom) |
-| `MODEL` | `agent.model` |
-| `INTERACTIVE` | `run.interactive` |
-| `SLEEP_SECONDS` | `run.sleep_seconds` |
-| `ALLOWED_PATHS` | `paths.allowed` (comma-separated) |
-| `RALPH_BRANCH` | `git.branch` |
-
-## PRD format
-
-The PRD is a JSON file defining user stories with testable acceptance criteria:
+The PRD (`prd.json`) is a list of user stories with testable acceptance criteria:
 
 ```json
 {
-  "branchName": "ralph/my-feature",
+  "branchName": "ralph/login-feature",
   "userStories": [
     {
       "id": "US-001",
       "title": "User can log in with email",
       "acceptanceCriteria": [
         "Login form accepts email and password",
-        "Typecheck passes: uv run mypy src/",
-        "Tests pass: uv run pytest"
+        "Invalid credentials show error message",
+        "Tests pass: uv run pytest tests/test_auth.py"
       ],
       "priority": 1,
       "passes": false,
@@ -224,83 +207,33 @@ The PRD is a JSON file defining user stories with testable acceptance criteria:
 }
 ```
 
-The agent updates `passes` to `true` and writes `notes` as it completes each story. Ralph tracks progress across iterations.
-
-## Guard rails
-
-Ralph enforces boundaries on what the agent can modify:
-
-- **Allowed paths** - if `paths.allowed` is set, the agent can only modify files matching those paths. Changes outside are automatically reverted after each iteration.
-- **Infrastructure protection** - Ralph's own files (ralph.toml, prompts, PRD) are never reverted, even if not in the allowed list.
-- **Consecutive error bail-out** - if the agent fails 3 iterations in a row, the loop stops.
+The agent updates `passes` and `notes` as it works. Ralph reads these between iterations to decide whether to continue or stop. Acceptance criteria should be concrete and testable - commands the agent can run, behavior it can verify.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
-    CLI[cli.py\nClick commands] --> Loop[loop.py\nCore loop]
-    TUI[tui/\nTextual app] --> Loop
-    Loop --> Agent[agent.py\nAgent abstraction]
-    Loop --> PRD[prd.py\nSchema + validation]
-    Loop --> Git[git_ops.py\nBranch + path enforcement]
-    Agent --> Models[models.py\nAgent registry]
-    TUI --> Conv[conversation.py\nInteractive planning]
-    Conv --> Agent
+    CLI["CLI\n(headless)"] --> Loop["Core loop\n(loop.py)"]
+    TUI["TUI\n(interactive)"] --> Loop
+    Loop --> Agent["Agent\nabstraction"]
+    Loop --> Guard["Guard rails\n+ git ops"]
+    Agent --> Claude["Claude Code"]
+    Agent --> Codex["Codex"]
+    Agent --> Custom["Custom cmd"]
+    TUI --> Planning["Interactive\nplanning"]
+    Planning --> Agent
 ```
 
-The loop logic (`loop.py`) is decoupled from presentation via a `LoopCallbacks` protocol. Both the CLI and TUI implement this protocol, so the same loop drives both interfaces.
-
-### Source layout
-
-```
-src/ralph/
-  cli.py               CLI entry point (Click)
-  loop.py              Core agentic loop
-  agent.py             Agent abstraction + output streaming
-  models.py            Agent/model registry + auto-detection
-  config.py            Configuration loading (toml + env vars)
-  prd.py               PRD schema, validation, markdown parsing
-  conversation.py      Interactive PM conversation + PRD generation
-  git_ops.py           Branch management + path enforcement
-  templates/           Bundled prompt templates
-  tui/
-    app.py             Textual TUI application
-    screens/           Screen implementations
-    widgets/           Reusable UI components
-    styles/            Textual CSS
-```
-
-## Supported agents
-
-**Claude Code** (`claude`) - recommended. Uses `--output-format stream-json` for real-time streaming with thinking, tool calls, and git operations classified and displayed separately.
-
-**OpenAI Codex** (`codex`) - supported. Output parsed line-by-line from stdout with role detection via transcript markers.
-
-**Custom** - any command that reads a prompt from stdin and writes output to stdout. Set `agent.type = "custom"` and `agent.command` to your command.
-
-## Project scaffolding
-
-After `ralph init`, your project gets:
-
-```
-your-project/
-  ralph.toml                          # Configuration
-  scripts/ralph/
-    prompt.md                         # Agent instructions template
-    prd.json                          # User stories (after PRD creation)
-    progress.txt                      # Running iteration log
-    codebase_map.md                   # Understanding mode output
-    understand_prompt.md              # Understanding mode prompt
-    prd_prompt.txt                    # PRD generation template
-```
+The core loop is decoupled from the interface via a callback protocol. Both CLI and TUI implement the same protocol, so the loop works identically in both modes.
 
 ## Development
 
 ```bash
-uv sync                  # Install with dev dependencies
-uv run pytest            # Run tests
-uv run ruff check src/   # Lint
-uv run mypy src/         # Type check
+git clone https://github.com/0xfauzi/ralph-loop.git
+cd ralph-loop
+uv sync
+uv tool install -e .
+uv run pytest
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,134 +1,228 @@
 # Ralph
 
-**Ralph** is a lightweight agentic loop harness for autonomous AI-driven development. It iteratively runs an AI agent against a set of user stories until all acceptance criteria pass - or a maximum iteration count is reached.
+Ralph is an agentic loop harness for autonomous AI-driven development. It runs an AI coding agent in a loop against a set of user stories, iterating until every acceptance criterion passes or a maximum iteration count is reached.
 
-## Overview
+You define what to build. Ralph drives the agent until it's done.
 
-Ralph operates on a simple loop:
+## How it works
+
+Ralph's core is a feedback loop between a PRD (product requirements document) and an AI coding agent:
 
 ```
-prompt.md --> AI Agent --> Code Changes
-     ^                        |
-     |                        v
-     +------ prd.json <-- Tests/Validation
-
-Repeat until: <promise>COMPLETE</promise>
-              or max iterations reached
+                    +------------------+
+                    |    prd.json      |
+                    | (user stories +  |
+                    |  acceptance      |
+                    |  criteria)       |
+                    +--------+---------+
+                             |
+                             v
+                    +------------------+
+              +---->|   prompt.md      |
+              |     | (instructions +  |
+              |     |  progress        |
+              |     |  context)        |
+              |     +--------+---------+
+              |              |
+              |              v
+              |     +------------------+
+              |     |   AI Agent       |
+              |     | (Claude, Codex,  |
+              |     |  or custom)      |
+              |     +--------+---------+
+              |              |
+              |              v
+              |     +------------------+
+              |     |  Code changes    |
+              |     |  + test results  |
+              |     +--------+---------+
+              |              |
+              |              v
+              |     +------------------+
+              +-----| Guard rails +    |
+                    | completion       |
+                    | check            |
+                    +------------------+
 ```
+
+Each iteration: Ralph builds a prompt from the PRD and progress log, sends it to the agent, streams the output, checks for the completion marker (`<promise>COMPLETE</promise>`), enforces path restrictions, and logs results. The loop exits when all stories pass or the iteration limit is hit.
 
 ## Installation
 
 Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/).
 
 ```bash
-# Install from source
-uv pip install -e .
+uv tool install ralph-cli
+```
 
-# Verify
+For development:
+
+```bash
+git clone https://github.com/0xfauzi/ralph-loop.git
+cd ralph-loop
+uv sync
+uv tool install -e .
+```
+
+Verify the install:
+
+```bash
 ralph --help
 ```
 
-## Quick Start
+## Prerequisites
+
+Ralph needs an AI coding agent CLI installed:
+
+| Agent | Command | Models |
+|-------|---------|--------|
+| Claude Code (recommended) | `claude` | sonnet, opus, haiku |
+| OpenAI Codex | `codex` | o3, o4-mini, codex-mini-latest |
+| Custom | Any command that reads stdin | - |
+
+Git is optional but recommended for branch management and path enforcement.
+
+## Quick start
 
 ### 1. Initialize a project
 
 ```bash
-# Interactive TUI wizard
-ralph init
-
-# Or headless
-ralph init /path/to/project
+ralph init /path/to/your/project
 ```
 
-This scaffolds `scripts/ralph/` with template files and creates `ralph.toml` with auto-detected agent settings.
+This scaffolds `scripts/ralph/` with template files and creates `ralph.toml` with auto-detected agent settings. Ralph auto-detects which agent CLIs are installed.
 
 ### 2. Create a PRD
 
-```bash
-# Interactive wizard
-ralph prd create
+Three ways to create a PRD:
 
-# Or generate from a spec file
+**Interactive wizard** - step-by-step form:
+```bash
+ralph prd create
+```
+
+**Import from spec** - generate from an existing markdown spec:
+```bash
 ralph prd import my-spec.md --agent claude
 ```
 
-The PRD wizard walks you through: feature overview, branch name, user stories with acceptance criteria, tech stack, and verification commands.
+**Interactive planning** - conversation with an AI PM that asks probing questions, then generates a PRD:
+```bash
+ralph
+# Select "Interactive Feature" from the menu
+```
 
 ### 3. Run the loop
 
 ```bash
-# Default: 10 iterations
-ralph run
-
-# Specify iterations, agent, and model
 ralph run 25 --agent claude --model sonnet
-
-# Interactive mode (pause after each iteration)
-ralph run 25 --interactive
 ```
 
-### 4. Launch the full TUI
+Ralph creates or checks out the branch from the PRD, builds the prompt, and starts iterating. The agent writes code, runs tests, and Ralph tracks progress.
+
+Options:
 
 ```bash
-# Opens the interactive terminal UI
+ralph run              # Default: 10 iterations
+ralph run 50           # 50 iterations
+ralph run --interactive  # Pause after each iteration
+```
+
+### 4. Understand a codebase
+
+Before implementing features on an unfamiliar codebase, run a read-only mapping pass:
+
+```bash
+ralph understand 10
+```
+
+This produces `scripts/ralph/codebase_map.md` with evidence-based findings about the architecture, patterns, and conventions. The agent reads but does not modify source files.
+
+## Terminal UI
+
+Running `ralph` with no arguments launches the interactive TUI:
+
+```bash
 ralph
 ```
 
-The TUI provides: main menu, live run dashboard with agent output + story progress, PRD wizard, settings editor, and status overview.
+### Screens
 
-## Commands
+| Screen | Purpose |
+|--------|---------|
+| Main menu | Mode selection and project status |
+| Run dashboard | Live agent output with story progress table. `p` to pause, `s` to stop |
+| Interactive feature | Conversation with an AI PM that reviews your spec and generates a PRD |
+| PRD wizard | Step-by-step PRD creation form |
+| Config | Visual editor for ralph.toml settings |
+| Status | Read-only project overview with story table |
+| Init wizard | Guided project setup |
+
+## CLI reference
 
 ```
-ralph                    Launch interactive TUI
-ralph init [DIR]         Initialize project scaffolding
-ralph run [N]            Run feature loop (N = max iterations)
-ralph understand [N]     Run codebase understanding loop (read-only)
-ralph prd create         Interactive PRD creation wizard
-ralph prd import FILE    Generate PRD from spec via LLM
-ralph prd validate       Validate prd.json schema
-ralph prd status         Show story summary table
-ralph config show        Show current configuration
-ralph config init        Create ralph.toml with defaults
-ralph status             Project status overview
+ralph                     Launch interactive TUI
+ralph init [DIR]          Initialize project scaffolding
+ralph run [N]             Run feature loop (N = max iterations)
+ralph understand [N]      Run codebase understanding loop (read-only)
+ralph prd create          Interactive PRD creation wizard
+ralph prd import FILE     Generate PRD from spec via LLM
+ralph prd validate        Validate prd.json schema
+ralph prd status          Show story summary table
+ralph config show         Show current configuration
+ralph config init         Create ralph.toml with defaults
+ralph status              Project status overview
 ```
 
 ## Configuration
 
-Ralph uses `ralph.toml` at the project root. Environment variables override file settings.
+Ralph uses `ralph.toml` at the project root. Create one with defaults:
 
 ```bash
-# Create config with defaults
 ralph config init
 ```
 
-See `ralph.toml.example` for all options with documentation.
+### Settings
 
-### Key Settings
+```toml
+[agent]
+type = "claude"           # "claude", "codex", or "custom"
+model = ""                # Model override (empty = agent default)
+command = ""              # Custom shell command (type = "custom" only)
 
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `agent.type` | `claude` | Agent: `claude`, `codex`, or `custom` |
-| `agent.model` | `""` (default) | Model: `sonnet`/`opus`/`haiku` (Claude) or `o3`/`o4-mini` (Codex) |
-| `agent.command` | `""` | Custom shell command (type=custom only) |
-| `run.max_iterations` | `10` | Max loop iterations |
-| `run.interactive` | `false` | Pause after each iteration |
-| `paths.allowed` | `[]` | Restrict which files the agent can change |
-| `git.branch` | `""` | Override branch (empty = use PRD branchName) |
+[run]
+max_iterations = 10
+sleep_seconds = 2
+interactive = false       # Pause after each iteration
 
-### Environment Variable Overrides
+[paths]
+prompt = "scripts/ralph/prompt.md"
+prd = "scripts/ralph/prd.json"
+progress = "scripts/ralph/progress.txt"
+codebase_map = "scripts/ralph/codebase_map.md"
+allowed = []              # Guard rail: restrict which files agent can change
 
-| Env Var | Maps To |
-|---------|---------|
-| `AGENT_CMD` | `agent.command` (also sets type=custom) |
+[git]
+branch = ""               # Override branch (empty = use PRD branchName)
+auto_checkout = true
+```
+
+### Environment variable overrides
+
+Environment variables take precedence over ralph.toml:
+
+| Variable | Setting |
+|----------|---------|
+| `AGENT_CMD` | `agent.command` (also sets type = custom) |
 | `MODEL` | `agent.model` |
 | `INTERACTIVE` | `run.interactive` |
 | `SLEEP_SECONDS` | `run.sleep_seconds` |
 | `ALLOWED_PATHS` | `paths.allowed` (comma-separated) |
 | `RALPH_BRANCH` | `git.branch` |
 
-## PRD Schema
+## PRD format
 
-The `prd.json` file must conform to this schema:
+The PRD is a JSON file defining user stories with testable acceptance criteria:
 
 ```json
 {
@@ -150,71 +244,71 @@ The `prd.json` file must conform to this schema:
 }
 ```
 
-## TUI Screens
+The agent updates `passes` to `true` and writes `notes` as it completes each story. Ralph tracks progress across iterations.
 
-- **Main Menu**: mode selection (init, run, understand, PRD, status, settings)
-- **Run Dashboard**: split-pane with live agent output (left) and story progress table (right). Keybindings: `p` pause, `s` stop, `Esc` back.
-- **PRD Wizard**: 5-step form for creating a PRD from scratch
-- **Config Screen**: visual editor for all ralph.toml settings with model selector
-- **Status Screen**: read-only project overview with story table
-- **Init Wizard**: guided project setup with agent auto-detection
+## Guard rails
 
-## Codebase Understanding Mode
+Ralph enforces boundaries on what the agent can modify:
 
-For existing codebases, run a read-only mapping loop before implementing features:
+- **Allowed paths**: If `paths.allowed` is set, the agent can only modify files matching those paths. Changes outside are automatically reverted after each iteration.
+- **Infrastructure protection**: Ralph's own files (ralph.toml, prompts, PRD) are never reverted, even if not in the allowed list.
+- **Consecutive error bail-out**: If the agent fails 3 iterations in a row, the loop stops.
 
-```bash
-ralph understand 10
+## Architecture
+
+```
+src/ralph/
+  cli.py               CLI entry point (Click)
+  loop.py              Core agentic loop
+  agent.py             Agent abstraction + output streaming
+  models.py            Agent/model registry + auto-detection
+  config.py            Configuration loading (toml + env vars)
+  prd.py               PRD schema, validation, markdown parsing
+  conversation.py      Interactive PM conversation + PRD generation
+  prompt.py            Template management
+  git_ops.py           Branch management + path enforcement
+  templates/           Bundled prompt templates
+  tui/
+    app.py             Textual TUI application
+    screens/           11 screen implementations
+    widgets/           Reusable UI components
+    styles/            Textual CSS
 ```
 
-This builds `scripts/ralph/codebase_map.md` with evidence-based findings about the codebase architecture, patterns, and conventions. Only the map file is modified.
+The loop logic (`loop.py`) is decoupled from presentation via a `LoopCallbacks` protocol. Both the CLI (`cli.py`) and TUI (`run_dashboard.py`) implement this protocol, so the same loop drives both interfaces.
 
-## Directory Structure
+## Supported agents
+
+**Claude Code** (`claude`): Recommended. Uses `--output-format stream-json` for real-time streaming with thinking, tool calls, and git operations classified and displayed separately.
+
+**OpenAI Codex** (`codex`): Supported. Output parsed line-by-line from stdout with role detection via transcript markers.
+
+**Custom**: Any command that reads a prompt from stdin and writes output to stdout. Set `agent.type = "custom"` and `agent.command` to your command.
+
+## Project scaffolding
+
+After `ralph init`, your project gets:
 
 ```
 your-project/
-  ralph.toml                      # Configuration
-  scripts/
-    ralph/
-      prompt.md                   # Agent instructions
-      prd.json                    # User stories
-      progress.txt                # Running log
-      codebase_map.md             # Understanding output
-      understand_prompt.md        # Understanding mode prompt
-      prd_prompt.txt              # PRD generation template
+  ralph.toml                          # Configuration
+  scripts/ralph/
+    prompt.md                         # Agent instructions template
+    prd.json                          # User stories (after PRD creation)
+    progress.txt                      # Running iteration log
+    codebase_map.md                   # Understanding mode output
+    understand_prompt.md              # Understanding mode prompt
+    prd_prompt.txt                    # PRD generation template
 ```
-
-## Requirements
-
-- Python 3.11+
-- An agent CLI:
-  - Claude CLI (`claude`) - recommended
-  - OpenAI Codex CLI (`codex`)
-  - Or any command that reads from stdin (`agent.type = "custom"`)
-- git (optional; enables branch management and path enforcement)
 
 ## Development
 
 ```bash
-# Install with dev dependencies
-uv sync
-
-# Run tests
-uv run pytest
-
-# Lint
-uv run ruff check src/ tests/
-
-# Type check
-uv run mypy src/
+uv sync                  # Install with dev dependencies
+uv run pytest            # Run tests
+uv run ruff check src/   # Lint
+uv run mypy src/         # Type check
 ```
-
-## Legacy
-
-The original bash scripts are preserved in `legacy/` for reference:
-- `legacy/ralph.sh` - original loop runner
-- `legacy/ui.sh` - original gum-based UI toolkit
-- `legacy/init.sh` - original initialization script
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,48 +4,32 @@ Ralph is an agentic loop harness for autonomous AI-driven development. It runs a
 
 You define what to build. Ralph drives the agent until it's done.
 
+## Features
+
+- **Autonomous iteration loop** - runs an AI coding agent repeatedly against a PRD until all acceptance criteria pass, with automatic progress tracking between iterations
+- **Multi-agent support** - works with Claude Code, OpenAI Codex, or any custom command that reads stdin and writes stdout
+- **Interactive feature planning** - conversation with an AI PM agent that reviews your spec from product, engineering, and reliability perspectives before generating a structured PRD
+- **Codebase understanding mode** - read-only mapping pass that produces an evidence-based architecture document before you start building
+- **Guard rails** - path restrictions that automatically revert changes outside allowed directories, with infrastructure file protection
+- **Git integration** - automatic branch creation/checkout from PRD, change tracking, and disallowed file reversion per iteration
+- **Real-time streaming** - classified output display (AI text, thinking, tool calls, git operations) with role-based visual hierarchy
+- **Terminal UI and CLI** - full interactive TUI with live dashboard, PRD wizard, config editor, and status views, plus headless CLI for scripting and CI
+- **PRD-driven workflow** - three paths to create a PRD: step-by-step wizard, import from markdown spec, or AI-assisted interactive planning
+- **Configuration layering** - settings resolved from CLI flags, environment variables, and ralph.toml with clear precedence
+
 ## How it works
 
-Ralph's core is a feedback loop between a PRD (product requirements document) and an AI coding agent:
-
-```
-                    +------------------+
-                    |    prd.json      |
-                    | (user stories +  |
-                    |  acceptance      |
-                    |  criteria)       |
-                    +--------+---------+
-                             |
-                             v
-                    +------------------+
-              +---->|   prompt.md      |
-              |     | (instructions +  |
-              |     |  progress        |
-              |     |  context)        |
-              |     +--------+---------+
-              |              |
-              |              v
-              |     +------------------+
-              |     |   AI Agent       |
-              |     | (Claude, Codex,  |
-              |     |  or custom)      |
-              |     +--------+---------+
-              |              |
-              |              v
-              |     +------------------+
-              |     |  Code changes    |
-              |     |  + test results  |
-              |     +--------+---------+
-              |              |
-              |              v
-              |     +------------------+
-              +-----| Guard rails +    |
-                    | completion       |
-                    | check            |
-                    +------------------+
+```mermaid
+flowchart TD
+    PRD[prd.json\nUser stories + acceptance criteria] --> Prompt[prompt.md\nInstructions + progress context]
+    Prompt --> Agent[AI Agent\nClaude / Codex / Custom]
+    Agent --> Code[Code changes + test results]
+    Code --> Guard[Guard rails\nPath enforcement + completion check]
+    Guard -->|Stories incomplete| Prompt
+    Guard -->|All stories pass\nor max iterations| Done[Loop exits]
 ```
 
-Each iteration: Ralph builds a prompt from the PRD and progress log, sends it to the agent, streams the output, checks for the completion marker (`<promise>COMPLETE</promise>`), enforces path restrictions, and logs results. The loop exits when all stories pass or the iteration limit is hit.
+Each iteration: Ralph builds a prompt from the PRD and progress log, sends it to the agent, streams the output, checks for the completion marker (`<promise>COMPLETE</promise>`), enforces path restrictions, and logs results.
 
 ## Installation
 
@@ -90,7 +74,7 @@ Git is optional but recommended for branch management and path enforcement.
 ralph init /path/to/your/project
 ```
 
-This scaffolds `scripts/ralph/` with template files and creates `ralph.toml` with auto-detected agent settings. Ralph auto-detects which agent CLIs are installed.
+This scaffolds `scripts/ralph/` with template files and creates `ralph.toml` with auto-detected agent settings.
 
 ### 2. Create a PRD
 
@@ -120,8 +104,6 @@ ralph run 25 --agent claude --model sonnet
 
 Ralph creates or checks out the branch from the PRD, builds the prompt, and starts iterating. The agent writes code, runs tests, and Ralph tracks progress.
 
-Options:
-
 ```bash
 ralph run              # Default: 10 iterations
 ralph run 50           # 50 iterations
@@ -145,8 +127,6 @@ Running `ralph` with no arguments launches the interactive TUI:
 ```bash
 ralph
 ```
-
-### Screens
 
 | Screen | Purpose |
 |--------|---------|
@@ -250,11 +230,27 @@ The agent updates `passes` to `true` and writes `notes` as it completes each sto
 
 Ralph enforces boundaries on what the agent can modify:
 
-- **Allowed paths**: If `paths.allowed` is set, the agent can only modify files matching those paths. Changes outside are automatically reverted after each iteration.
-- **Infrastructure protection**: Ralph's own files (ralph.toml, prompts, PRD) are never reverted, even if not in the allowed list.
-- **Consecutive error bail-out**: If the agent fails 3 iterations in a row, the loop stops.
+- **Allowed paths** - if `paths.allowed` is set, the agent can only modify files matching those paths. Changes outside are automatically reverted after each iteration.
+- **Infrastructure protection** - Ralph's own files (ralph.toml, prompts, PRD) are never reverted, even if not in the allowed list.
+- **Consecutive error bail-out** - if the agent fails 3 iterations in a row, the loop stops.
 
 ## Architecture
+
+```mermaid
+flowchart LR
+    CLI[cli.py\nClick commands] --> Loop[loop.py\nCore loop]
+    TUI[tui/\nTextual app] --> Loop
+    Loop --> Agent[agent.py\nAgent abstraction]
+    Loop --> PRD[prd.py\nSchema + validation]
+    Loop --> Git[git_ops.py\nBranch + path enforcement]
+    Agent --> Models[models.py\nAgent registry]
+    TUI --> Conv[conversation.py\nInteractive planning]
+    Conv --> Agent
+```
+
+The loop logic (`loop.py`) is decoupled from presentation via a `LoopCallbacks` protocol. Both the CLI and TUI implement this protocol, so the same loop drives both interfaces.
+
+### Source layout
 
 ```
 src/ralph/
@@ -265,25 +261,22 @@ src/ralph/
   config.py            Configuration loading (toml + env vars)
   prd.py               PRD schema, validation, markdown parsing
   conversation.py      Interactive PM conversation + PRD generation
-  prompt.py            Template management
   git_ops.py           Branch management + path enforcement
   templates/           Bundled prompt templates
   tui/
     app.py             Textual TUI application
-    screens/           11 screen implementations
+    screens/           Screen implementations
     widgets/           Reusable UI components
     styles/            Textual CSS
 ```
 
-The loop logic (`loop.py`) is decoupled from presentation via a `LoopCallbacks` protocol. Both the CLI (`cli.py`) and TUI (`run_dashboard.py`) implement this protocol, so the same loop drives both interfaces.
-
 ## Supported agents
 
-**Claude Code** (`claude`): Recommended. Uses `--output-format stream-json` for real-time streaming with thinking, tool calls, and git operations classified and displayed separately.
+**Claude Code** (`claude`) - recommended. Uses `--output-format stream-json` for real-time streaming with thinking, tool calls, and git operations classified and displayed separately.
 
-**OpenAI Codex** (`codex`): Supported. Output parsed line-by-line from stdout with role detection via transcript markers.
+**OpenAI Codex** (`codex`) - supported. Output parsed line-by-line from stdout with role detection via transcript markers.
 
-**Custom**: Any command that reads a prompt from stdin and writes output to stdout. Set `agent.type = "custom"` and `agent.command` to your command.
+**Custom** - any command that reads a prompt from stdin and writes output to stdout. Set `agent.type = "custom"` and `agent.command` to your command.
 
 ## Project scaffolding
 


### PR DESCRIPTION
## Summary

- Restructured README into clear, scannable sections with consistent formatting
- Added flow diagram showing the core iteration loop
- Added prerequisites table with supported agents and models
- Documented all three PRD creation paths (wizard, import, interactive planning)
- Added full CLI reference, configuration reference, env var overrides
- Added guard rails documentation, architecture overview, TUI screen table
- Removed legacy section and redundant content
- Replaced ASCII art with box-drawing flow diagram

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all CLI commands listed match actual `ralph --help` output
- [ ] Check that configuration settings match ralph.toml.example

🤖 Generated with [Claude Code](https://claude.com/claude-code)