### PR TITLE
feat: unified reasoning effort across Claude and Codex agents

### DIFF
--- a/ralph.toml.example
+++ b/ralph.toml.example
@@ -6,7 +6,7 @@
 type = "claude"                    # "claude" | "codex" | "custom"
 command = ""                       # shell command (only used when type = "custom")
 model = ""                         # e.g., "sonnet" for claude, "o3" for codex (empty = default)
-reasoning_effort = ""              # codex-specific: low|medium|high|xhigh
+reasoning_effort = ""              # low|medium|high|max
 
 [run]
 max_iterations = 10

--- a/ralph_py/agents/__init__.py
+++ b/ralph_py/agents/__init__.py
@@ -25,11 +25,11 @@ def get_agent(
     if agent_cmd:
         return CustomAgent(agent_cmd)
     if agent_type == "claude-code":
-        return ClaudeCodeAgent(model=model)
+        return ClaudeCodeAgent(model=model, effort=model_reasoning_effort)
     if agent_type == "codex":
         return CodexAgent(model=model, reasoning_effort=model_reasoning_effort)
     # Auto-detect: prefer claude-code, fall back to codex
     if agent_type is None or agent_type == "auto":
         if ClaudeCodeAgent.is_available():
-            return ClaudeCodeAgent(model=model)
+            return ClaudeCodeAgent(model=model, effort=model_reasoning_effort)
     return CodexAgent(model=model, reasoning_effort=model_reasoning_effort)

--- a/ralph_py/agents/claude_code.py
+++ b/ralph_py/agents/claude_code.py
@@ -21,13 +21,15 @@ class ClaudeCodeAgent:
     execution rather than only showing the final text response.
     """
 
-    def __init__(self, model: str | None = None):
+    def __init__(self, model: str | None = None, effort: str | None = None):
         """Initialize Claude Code agent.
 
         Args:
             model: Model name to pass to claude --model
+            effort: Reasoning effort level (low, medium, high, max)
         """
         self._model = model
+        self._effort = effort
         self._final_message: str | None = None
 
     @property
@@ -62,6 +64,8 @@ class ClaudeCodeAgent:
         ]
         if self._model:
             cmd.extend(["--model", self._model])
+        if self._effort:
+            cmd.extend(["--effort", self._effort])
 
         try:
             proc = subprocess.Popen(

--- a/ralph_py/agents/codex.py
+++ b/ralph_py/agents/codex.py
@@ -58,7 +58,9 @@ class CodexAgent:
         if self._model:
             cmd.extend(["-m", self._model])
         if self._reasoning_effort:
-            cmd.extend(["-c", f'model_reasoning_effort="{self._reasoning_effort}"'])
+            # Translate unified effort levels to codex-specific values
+            codex_effort = "xhigh" if self._reasoning_effort == "max" else self._reasoning_effort
+            cmd.extend(["-c", f'model_reasoning_effort="{codex_effort}"'])
 
         # Use --output-last-message when supported by the codex CLI.
         last_msg_file: Path | None = None

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -140,7 +140,7 @@ def cli() -> None:
 )
 @click.option(
     "--reasoning",
-    help="Reasoning effort for codex (low, medium, high)",
+    help="Reasoning effort (low, medium, high, max)",
 )
 @click.option(
     "--sleep", "-s",
@@ -331,7 +331,7 @@ def init(directory: Path, ui: str, no_color: bool) -> None:
 )
 @click.option(
     "--reasoning",
-    help="Reasoning effort for codex",
+    help="Reasoning effort (low, medium, high, max)",
 )
 @click.option(
     "--sleep", "-s",
@@ -521,7 +521,7 @@ def understand(
 )
 @click.option(
     "--reasoning",
-    help="Reasoning effort for codex (low, medium, high)",
+    help="Reasoning effort (low, medium, high, max)",
 )
 @click.option(
     "--sleep", "-s",
@@ -920,7 +920,7 @@ def feature(
 )
 @click.option(
     "--reasoning",
-    help="Reasoning effort for codex",
+    help="Reasoning effort (low, medium, high, max)",
 )
 @click.option(
     "--agent-type",
@@ -1135,7 +1135,7 @@ def decompose(
 )
 @click.option(
     "--reasoning",
-    help="Reasoning effort for codex",
+    help="Reasoning effort (low, medium, high, max)",
 )
 @click.option(
     "--agent-type",

--- a/src/ralph/agent.py
+++ b/src/ralph/agent.py
@@ -301,6 +301,7 @@ async def run_agent_async(
     if agent_type == "claude":
         async for output in _run_claude_streaming(
             model=model, prompt=prompt_content, cwd=cwd,
+            reasoning_effort=reasoning_effort,
         ):
             yield output
     elif agent_type == "codex":
@@ -383,6 +384,7 @@ async def _run_claude_streaming(
     cwd: Path,
     verbose: bool = True,
     permission_mode: str = "acceptEdits",
+    reasoning_effort: str = "",
 ) -> AsyncIterator[AgentOutput]:
     """Run Claude with stream-json output for real-time streaming."""
     effective_model = model or "sonnet"
@@ -394,6 +396,8 @@ async def _run_claude_streaming(
         cmd_parts.append("--verbose")
     if permission_mode:
         cmd_parts.append(f"--permission-mode {permission_mode}")
+    if reasoning_effort:
+        cmd_parts.append(f"--effort {reasoning_effort}")
     cmd = " ".join(cmd_parts)
 
     # Stream-json lines can be very large (tool results with full file
@@ -446,7 +450,9 @@ async def _run_codex(
     if model:
         parts.extend(["-m", model])
     if reasoning_effort:
-        parts.extend(["-c", f'model_reasoning_effort="{reasoning_effort}"'])
+        # Translate unified effort levels to codex-specific values
+        codex_effort = "xhigh" if reasoning_effort == "max" else reasoning_effort
+        parts.extend(["-c", f'model_reasoning_effort="{codex_effort}"'])
     parts.append("-")
     cmd_str = " ".join(parts)
 

--- a/src/ralph/config.py
+++ b/src/ralph/config.py
@@ -18,7 +18,7 @@ class AgentConfig:
     type: str = "claude"  # "claude" | "codex" | "custom"
     command: str = ""  # only used when type = "custom"
     model: str = ""  # e.g., "sonnet" for claude, "o3" for codex
-    reasoning_effort: str = ""  # codex-specific: low|medium|high|xhigh
+    reasoning_effort: str = ""  # low|medium|high|max
 
 
 @dataclass

--- a/tests/test_claude_code_agent.py
+++ b/tests/test_claude_code_agent.py
@@ -52,8 +52,43 @@ class TestClaudeCodeAgent:
 
         call_args = mock_popen.call_args
         cmd = call_args[0][0]
-        assert cmd == ["claude", "--print", "--model", "claude-sonnet-4-5"]
+        assert "claude" == cmd[0]
+        assert "--print" in cmd
+        assert "--model" in cmd
+        model_idx = cmd.index("--model")
+        assert cmd[model_idx + 1] == "claude-sonnet-4-5"
+        assert "--output-format" in cmd
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--effort" not in cmd  # no effort by default
         assert call_args[1]["cwd"] == tmp_path
+
+    def test_run_includes_effort_flag(self, tmp_path: Path) -> None:
+        mock_proc = MagicMock()
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = iter(["done\n"])
+        mock_proc.wait.return_value = 0
+
+        with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
+            agent = ClaudeCodeAgent(model="sonnet", effort="max")
+            list(agent.run("test", cwd=tmp_path))
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--effort" in cmd
+        effort_idx = cmd.index("--effort")
+        assert cmd[effort_idx + 1] == "max"
+
+    def test_run_omits_effort_when_empty(self, tmp_path: Path) -> None:
+        mock_proc = MagicMock()
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = iter(["done\n"])
+        mock_proc.wait.return_value = 0
+
+        with patch("subprocess.Popen", return_value=mock_proc) as mock_popen:
+            agent = ClaudeCodeAgent(model="sonnet", effort=None)
+            list(agent.run("test", cwd=tmp_path))
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--effort" not in cmd
 
     def test_run_handles_broken_pipe(self, tmp_path: Path) -> None:
         mock_stdin = MagicMock()


### PR DESCRIPTION
## Summary
- Adds `--effort` flag support to the Claude Code agent (low, medium, high, max)
- Translates `max` to `xhigh` for Codex, since that's its equivalent top level
- Updates all CLI help text and config comments to reflect the unified vocabulary

## Test plan
- [x] All 268 tests pass (`uv run pytest tests/ -x`)
- [x] New tests: `test_run_includes_effort_flag`, `test_run_omits_effort_when_empty`
- [x] Fixed pre-existing test `test_run_builds_correct_command` (was asserting old command format before stream-json changes)
- [ ] Manual: `ralph run 1 --reasoning max` with claude agent
- [ ] Manual: `ralph run 1 --reasoning max` with codex agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)