### PR TITLE
fix: detect result event in stream-json to prevent factory hang

### DIFF
--- a/ralph_py/agents/claude_code.py
+++ b/ralph_py/agents/claude_code.py
@@ -31,6 +31,7 @@ class ClaudeCodeAgent:
         self._model = model
         self._effort = effort
         self._final_message: str | None = None
+        self._saw_result: bool = False
 
     @property
     def name(self) -> str:
@@ -53,6 +54,7 @@ class ClaudeCodeAgent:
         Yields human-readable lines describing what the agent is doing.
         """
         self._final_message = None
+        self._saw_result = False
         accumulated_text: list[str] = []
         start = time.monotonic()
 
@@ -99,16 +101,32 @@ class ClaudeCodeAgent:
                     if not raw_line.strip():
                         continue
 
+                    # Check for result event (final output, process should exit soon)
+                    result_text = _extract_result_text(raw_line)
+                    if result_text is not None:
+                        self._saw_result = True
+                        self._final_message = result_text
+                        break
+
                     # Parse stream-json events
                     for display_line in _parse_stream_event(raw_line):
                         if display_line.strip():
                             accumulated_text.append(display_line)
                         yield display_line
 
-            proc.wait()
+            # Wait for process to exit, but don't hang forever
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
 
-            # Set final_message to the last result text
-            if accumulated_text:
+            # Set final_message from accumulated text if not already set by result event
+            if self._final_message is None and accumulated_text:
                 self._final_message = accumulated_text[-1]
 
         except FileNotFoundError:
@@ -118,6 +136,22 @@ class ClaudeCodeAgent:
     def final_message(self) -> str | None:
         """Return last non-empty output line."""
         return self._final_message
+
+
+def _extract_result_text(raw_line: str) -> str | None:
+    """Extract final result text from a stream-json result event.
+
+    Returns the result text if this is a result event, None otherwise.
+    The result event is the last event in a Claude Code stream-json
+    session and signals that the process is about to exit.
+    """
+    try:
+        evt = json.loads(raw_line)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if evt.get("type") == "result":
+        return evt.get("result", "")
+    return None
 
 
 def _parse_stream_event(raw_line: str) -> Iterator[str]:

--- a/tests/test_claude_code_agent.py
+++ b/tests/test_claude_code_agent.py
@@ -128,3 +128,64 @@ class TestClaudeCodeAgent:
             list(agent.run("test", cwd=tmp_path))
 
         assert agent.final_message == "content"
+
+    def test_result_event_breaks_stdout_loop(self, tmp_path: Path) -> None:
+        """When a result event arrives, stop reading stdout and set final_message."""
+        import json
+
+        assistant_event = json.dumps({
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "working..."}]},
+        })
+        result_event = json.dumps({
+            "type": "result",
+            "subtype": "success",
+            "result": "All done",
+            "duration_ms": 1000,
+        })
+        # Lines after result should never be read
+        unreachable = "THIS SHOULD NOT BE YIELDED\n"
+
+        mock_proc = MagicMock()
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = iter([
+            assistant_event + "\n",
+            result_event + "\n",
+            unreachable,
+        ])
+        mock_proc.wait.return_value = 0
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            agent = ClaudeCodeAgent()
+            lines = list(agent.run("test", cwd=tmp_path))
+
+        # Should see the assistant text but not the unreachable line
+        assert "working..." in lines
+        assert "THIS SHOULD NOT BE YIELDED" not in lines
+        assert agent.final_message == "All done"
+
+    def test_proc_wait_timeout_terminates(self, tmp_path: Path) -> None:
+        """If proc.wait times out after result, terminate the process."""
+        import json
+        import subprocess
+
+        result_event = json.dumps({
+            "type": "result",
+            "result": "done",
+        })
+
+        mock_proc = MagicMock()
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = iter([result_event + "\n"])
+        mock_proc.wait.side_effect = [
+            subprocess.TimeoutExpired("claude", 10),  # first wait times out
+            0,  # wait after terminate succeeds
+        ]
+        mock_proc.terminate = MagicMock()
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            agent = ClaudeCodeAgent()
+            list(agent.run("test", cwd=tmp_path))
+
+        mock_proc.terminate.assert_called_once()
+        assert agent.final_message == "done"


### PR DESCRIPTION
## Summary
- Factory hangs indefinitely when Claude Code subprocess completes but the stdout reader keeps waiting for EOF
- The `result` event (final output in stream-json format) was silently skipped, and `proc.wait()` had no timeout
- Now detects `result` events, breaks the read loop immediately, and applies a 10s timeout to `proc.wait()`

## Root cause
Claude Code's stream-json format emits `{"type": "result", "result": "..."}` as the last event. The `_parse_stream_event` function had a comment `# Skip result` which dropped this entirely. The stdout `for` loop then blocked waiting for EOF, which sometimes didn't arrive promptly.

## Test plan
- [x] `test_result_event_breaks_stdout_loop` - verifies result event stops reading and sets final_message
- [x] `test_proc_wait_timeout_terminates` - verifies hung process gets terminated after timeout
- [x] All 270 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)