### PR TITLE
feat: harness engineering - feedforward, structured sensors, learning, fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,50 @@
 # Ralph
 
-Ralph lets you hand a feature spec to an AI coding agent and walk away. It runs the agent in a loop - writing code, running tests, checking results - and keeps going until every requirement passes or it hits a retry limit.
+Ralph is a harness for AI coding agents. You hand it a feature spec and walk away. It steers the agent with codebase context, verifies the output with structured checks, retries with actionable feedback, and learns from its mistakes across runs.
 
-The problem it solves: AI coding agents like Claude Code and Codex are powerful, but they work on a single prompt at a time. If the agent doesn't finish in one shot, you're back to manually re-prompting, checking progress, and deciding what to try next. Ralph automates that outer loop. You define the requirements up front as testable acceptance criteria, and Ralph handles the iteration, progress tracking, and guardrails.
+The problem it solves: AI coding agents are powerful, but they work on a single prompt at a time. If the agent doesn't finish in one shot, you're back to manually re-prompting, checking progress, and deciding what to try next. And even when the agent says "done," there's no guarantee the code actually works. Ralph automates the outer loop - iteration, verification, and improvement - so the agent produces working code, not just code that claims to work.
 
-## What a session looks like
+## What makes ralph different
 
-You start with an idea. Ralph helps you turn it into a structured spec, then drives an agent to implement it:
+Most agent wrappers are retry loops: run the agent, check if it's done, retry if not. Ralph applies harness engineering - a combination of feedforward controls (steer the agent before it acts) and feedback sensors (verify after it acts) to systematically increase confidence in agent output.
 
 ```
-$ ralph init .                         # scaffold ralph config in your project
-$ ralph prd create                     # define what you want to build
-$ ralph run 25 --agent claude          # let the agent work for up to 25 iterations
+                        Feedforward (Phase 0)
+                        Codebase structure, conventions,
+                        dependency graph, scaffolding
+                                |
+                                v
+PRD + Prompt  ------>  [ AI Coding Agent ]  ------->  Output
+                                |
+                                v
+                        Feedback (Phases 1-3)
+                        Tests, typecheck, lint, review,
+                        contract testing
+                                |
+                          pass? |
+                         /      \
+                       yes       no
+                        |         |
+                      Done    Structured retry context
+                              with source lines, fix hints
+                                |
+                                v
+                        [ Evolution Journal ]
+                        Track patterns across runs,
+                        propose harness improvements
 ```
 
-Behind the scenes, each iteration:
-
-1. Ralph reads your requirements (a JSON file of user stories with acceptance criteria)
-2. It builds a prompt that includes the requirements, the agent's instructions, and a log of what happened in previous iterations
-3. It sends the prompt to the agent, which writes code, runs tests, and reports back
-4. Ralph checks whether the agent signaled completion and whether any file changes violated path restrictions
-5. If stories remain incomplete, it loops back to step 2 with updated context
-
-The loop exits when the agent marks all stories as passing, or when the iteration limit is reached.
-
-```mermaid
-flowchart TD
-    PRD["Requirements\n(user stories + acceptance criteria)"] --> Prompt["Build prompt\n(instructions + progress from prior iterations)"]
-    Prompt --> Agent["AI agent writes code and runs tests\n(Claude Code, Codex, or custom)"]
-    Agent --> Check{"All stories\npassing?"}
-    Check -->|No| Prompt
-    Check -->|Yes| Done["Done"]
-    Check -->|Max iterations| Done
-```
-
-## Why not just use Claude Code directly?
-
-You can, and for small tasks you should. Ralph is for when you want to:
-
-- **Define success criteria before starting** - "tests pass, types check, login form works" - and have the agent keep trying until they're met
-- **Walk away** - Ralph runs unattended. You come back to a branch with the work done (or a progress log showing what was attempted)
-- **Constrain the agent** - restrict which files it can touch, automatically revert out-of-scope changes
-- **Track progress across iterations** - each run builds on the last, with full context injection so the agent knows what it already tried
-- **Plan before building** - Ralph's interactive mode lets you have a conversation with an AI PM that stress-tests your spec before any code is written
-
-## Installation
-
-Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/).
+## Quick start
 
 ```bash
-uv tool install ralph-cli
+uv tool install ralph-cli          # install (requires Python 3.11+, uv)
+cd your-project
+ralph init .                       # scaffold config and prompt templates
+ralph prd create                   # define what to build
+ralph run 25                       # let the agent work for up to 25 iterations
 ```
 
-You also need at least one AI coding agent CLI:
+You need at least one AI coding agent CLI:
 
 | Agent | Install | Models |
 |-------|---------|--------|
@@ -60,102 +52,151 @@ You also need at least one AI coding agent CLI:
 | OpenAI Codex | [github.com/openai/codex](https://github.com/openai/codex) | o3, o4-mini |
 | Custom | Any command that reads stdin | - |
 
-## Quick start
+## How it works
 
-### 1. Set up
+### Phase 0: Feedforward - give the agent context before it starts
 
-```bash
-cd your-project
-ralph init .
+Before the agent writes a single line, ralph computationally analyzes the codebase and injects structural context into the prompt. No LLM calls, no token cost - pure static analysis:
+
+- **Module map** - directory tree with file counts and lines of code
+- **Public interfaces** - classes and function signatures extracted via Python's `ast` module
+- **Dependency graph** - internal import relationships between modules
+- **Active conventions** - line length, quote style, type checking mode from pyproject.toml, ruff.toml, .editorconfig
+
+This reduces wasted iterations. The agent knows "this project uses httpx, not requests" before it starts, instead of learning it from a linter failure on iteration 3.
+
+### Phases 1-3: Verification - check the output, not just the completion marker
+
+When the agent signals completion, ralph doesn't just trust it. Every run goes through mechanical verification:
+
+**Phase 1 - Mechanical checks** (computational, fast):
+- Test suite passes
+- Type checker passes
+- Linter passes
+- No changes outside allowed paths
+- No leaked secrets or syntax errors
+- Optional: mutation testing
+
+**Phase 2 - Second-opinion review** (inferential, LLM-based):
+- A separate agent reviews the diff against the acceptance criteria
+- Modes: `hard` (failures block), `advisory` (warn only), `skip`
+
+**Phase 3 - Contract testing** (for multi-component runs):
+- Merges component branches tier-by-tier
+- Runs integration tests at each tier
+- Bisects to identify which component broke integration
+
+When verification fails, ralph doesn't dump raw stderr into the retry prompt. It parses tool output into structured failures with file paths, source context, and fix hints:
+
+```
+1. src/api/auth.py:23
+   error: Argument 1 to "verify_password" has incompatible type "str | None"
+
+   21 |     password = request.form.get("password")
+   22 |     user = get_user(username)
+ > 23 |     if verify_password(password, user.password_hash):
+   24 |         return create_token(user)
+
+   FIX: Add a None check before calling verify_password, or provide a default value.
 ```
 
-This creates `ralph.toml` (configuration) and `scripts/ralph/` (prompt templates, progress log). Ralph auto-detects which agent CLIs you have installed.
+### Continuous learning - the harness improves itself
 
-### 2. Define what to build
-
-Three options depending on how fleshed out your idea is:
-
-**You have a rough idea** - talk it through with an AI PM first:
-```bash
-ralph                    # launch TUI, select "Interactive Feature"
-```
-Ralph starts a conversation where an AI reviewer asks probing questions from product, engineering, and reliability perspectives. When the spec is tight enough, it generates a structured PRD automatically.
-
-**You have a spec document** - import and convert it:
-```bash
-ralph prd import spec.md --agent claude
-```
-
-**You want to define stories manually** - use the step-by-step wizard:
-```bash
-ralph prd create
-```
-
-All three produce the same output: a `prd.json` file with user stories, acceptance criteria, priorities, and a branch name.
-
-### 3. Run
+After each factory run, ralph records outcomes to an evolution journal. Over multiple runs, it identifies recurring failure patterns and proposes harness improvements:
 
 ```bash
-ralph run 25
+ralph evolve              # analyze recent runs, find patterns
+ralph evolve --status     # show experiment trends (retry rate over time)
 ```
 
-Ralph checks out (or creates) the branch from the PRD, then starts iterating. You'll see the agent reading files, writing code, running tests. Progress is logged between iterations so each run builds on the last.
+If the agent keeps triggering the same linter rule across components, `ralph evolve` proposes adding a convention to CLAUDE.md. If typecheck failures recur on Optional types, it proposes a mypy config change. Proposals are written as markdown files for human review.
+
+This is the meta-loop: ralph doesn't just retry - it learns what causes failures and updates its own controls to prevent them.
+
+## Factory mode - parallel multi-component execution
+
+For large features, ralph decomposes a spec into independent components and runs them in parallel:
 
 ```bash
-ralph run                  # 10 iterations (default)
-ralph run 50 --model opus  # 50 iterations with a specific model
-ralph run --interactive    # pause after each iteration for review
+ralph decompose --spec features.md --project-name myproject
+ralph factory --manifest scripts/ralph/manifest.json --max-parallel 4
 ```
 
-### 4. (Optional) Understand an unfamiliar codebase first
+Each component runs in an isolated git worktree with its own PRD. The factory orchestrator:
 
-Before building features on a codebase you don't know well:
+1. Validates the component DAG (topological sort, cycle detection)
+2. Schedules components respecting dependency order
+3. Runs each through the full Phase 0-2 pipeline
+4. Creates and merges PRs automatically
+5. Runs contract tests across merged tiers
+6. Retries failed components with accumulated context
 
-```bash
-ralph understand 10
+`ralph run` is actually factory mode with a single component. The same verification pipeline runs whether you're building one feature or twenty.
+
+## Approved fixtures - behavioral verification you control
+
+Agent-generated tests can be written to pass trivially. Approved fixtures are human-written input/output pairs that the agent's code must satisfy:
+
+```json
+{
+  "branchName": "ralph/auth",
+  "fixtures": [
+    {
+      "description": "Login returns token",
+      "fixture_type": "cli",
+      "input_data": {"command": "curl -s localhost:8000/api/login -d '{\"user\":\"test\"}'"},
+      "expected": {"exit_code": 0, "stdout_contains": ["token"]}
+    },
+    {
+      "description": "Config is importable",
+      "fixture_type": "function",
+      "input_data": {"module": "src.config", "function": "get_settings", "args": []},
+      "expected": {"returns": {"debug": false}}
+    },
+    {
+      "description": "Migration file exists",
+      "fixture_type": "file",
+      "input_data": {"path": "migrations/001_users.sql"},
+      "expected": {"exists": true, "contains": ["CREATE TABLE users"]}
+    }
+  ],
+  "userStories": [...]
+}
 ```
 
-This runs the agent in read-only mode for 10 iterations, producing `scripts/ralph/codebase_map.md` - an evidence-based document about the architecture, patterns, and conventions. The agent reads but does not modify source files.
+Three fixture types: `cli` (run a command, check output), `function` (import and call, check return), `file` (check existence and content). Fixtures run during Phase 1 alongside tests and typecheck. Snapshot regression detects when a previously-passing fixture breaks.
 
-## Features
+## Why not just use Claude Code directly?
 
-- **Autonomous iteration** - runs the agent in a loop until acceptance criteria pass, with progress context injected between iterations
-- **Interactive feature planning** - AI PM conversation that stress-tests your spec before generating a PRD
-- **Codebase understanding** - read-only mode that maps architecture before you start building
-- **Guard rails** - path restrictions auto-revert out-of-scope changes; infrastructure files are protected; 3 consecutive errors trigger bail-out
-- **Git integration** - auto branch creation/checkout, change tracking, per-iteration reversion of disallowed files
-- **Multi-agent** - Claude Code (streaming with classified output), OpenAI Codex, or any stdin/stdout command
-- **Terminal UI** - live dashboard with agent output and story progress, PRD wizard, config editor, status view
-- **Headless CLI** - every TUI feature available as a command for scripting and CI
+You can, and for small tasks you should. Ralph is for when you want to:
 
-## Terminal UI
-
-```bash
-ralph                    # launch TUI
-```
-
-| Screen | What it does |
-|--------|-------------|
-| Run dashboard | Live agent output alongside story progress table. `p` pause, `s` stop |
-| Interactive feature | Chat with an AI PM to refine your spec and generate a PRD |
-| PRD wizard | Step-by-step story creation form |
-| Config | Visual editor for ralph.toml |
-| Status | Project overview with story table |
+- **Define success criteria before starting** - acceptance criteria, golden fixtures, path restrictions - not just "make it work"
+- **Walk away** - Ralph runs unattended with structured verification, not just a completion marker
+- **Give the agent context** - feedforward injection means fewer wasted iterations discovering the codebase
+- **Get structured retries** - parsed failures with source context and fix hints, not raw stderr
+- **Build multiple components in parallel** - factory mode with worktree isolation and contract testing
+- **Improve over time** - the evolution journal tracks patterns so the same mistakes don't keep recurring
+- **Plan before building** - interactive mode stress-tests your spec with an AI PM before any code is written
 
 ## CLI reference
 
 ```
-ralph                     Launch TUI
-ralph init [DIR]          Set up Ralph in a project
-ralph run [N]             Run the agent loop (N = max iterations, default 10)
-ralph understand [N]      Run read-only codebase mapping
-ralph prd create          PRD creation wizard
-ralph prd import FILE     Generate PRD from a spec document
-ralph prd validate        Check prd.json schema
-ralph prd status          Story summary table
-ralph config show         Print current config
-ralph config init         Create ralph.toml with defaults
-ralph status              Project overview
+ralph                         Launch TUI
+ralph init [DIR]              Set up Ralph in a project
+ralph run [N]                 Run with verification (factory pipeline)
+ralph run [N] --no-verify     Run without verification (faster, less safe)
+ralph run [N] --legacy        Run with old direct loop (no factory)
+ralph understand [N]          Run read-only codebase mapping
+ralph feature                 Two-phase: understand then implement
+ralph decompose --spec FILE   Decompose spec into component DAG
+ralph factory                 Run multi-component factory
+ralph evolve                  Analyze runs, propose harness improvements
+ralph evolve --status         Show experiment trends
+ralph prd create              PRD creation wizard
+ralph prd import FILE         Generate PRD from a spec document
+ralph prd validate            Check prd.json schema
+ralph config show             Print current config
+ralph status                  Project overview
 ```
 
 ## Configuration
@@ -164,9 +205,9 @@ Ralph uses `ralph.toml` at the project root:
 
 ```toml
 [agent]
-type = "claude"           # "claude", "codex", or "custom"
-model = ""                # model override (empty = agent default)
-command = ""              # shell command for custom agents
+type = "claude"               # "claude", "codex", or "custom"
+model = ""                    # model override
+command = ""                  # shell command for custom agents
 
 [run]
 max_iterations = 10
@@ -174,16 +215,46 @@ sleep_seconds = 2
 interactive = false
 
 [paths]
-allowed = []              # restrict which files the agent can change
+allowed = []                  # restrict which files the agent can change
 
 [git]
-branch = ""               # override branch (empty = use PRD branch name)
+branch = ""                   # override branch (empty = use PRD)
 auto_checkout = true
+
+# Feedforward controls (Phase 0)
+[feedforward]
+enabled = true
+module_map = true             # directory tree with LOC counts
+public_interfaces = true      # extract public symbols via ast
+dependency_graph = true       # internal import analysis
+conventions = true            # extract from pyproject.toml, ruff.toml, etc.
+max_context_tokens = 4000     # cap to avoid prompt bloat
+
+# Sensor output optimization
+[sensors]
+parse_output = true           # structured parsing of test/lint output
+include_source_context = true # include source lines around failures
+max_failures_per_check = 10   # cap failures per check in retry context
+
+# Continuous learning
+[evolution]
+enabled = true
+journal_path = ".ralph/evolution.jsonl"
+experiments_path = ".ralph/experiments.tsv"
+min_pattern_frequency = 2     # pattern must recur N times before proposal
+lookback_runs = 10            # how many past runs to analyze
+auto_propose = true           # generate proposals after each factory run
+
+# Approved fixtures
+[fixtures]
+enabled = false               # opt-in
+snapshot_on_success = true    # auto-snapshot outputs after verification pass
+snapshot_dir = ".ralph/snapshots"
 ```
 
 Environment variables override ralph.toml: `AGENT_CMD`, `MODEL`, `INTERACTIVE`, `SLEEP_SECONDS`, `ALLOWED_PATHS`, `RALPH_BRANCH`.
 
-## How the PRD works
+## The PRD
 
 The PRD (`prd.json`) is a list of user stories with testable acceptance criteria:
 
@@ -207,113 +278,70 @@ The PRD (`prd.json`) is a list of user stories with testable acceptance criteria
 }
 ```
 
-The agent updates `passes` and `notes` as it works. Ralph reads these between iterations to decide whether to continue or stop. Acceptance criteria should be concrete and testable - commands the agent can run, behavior it can verify.
+The agent updates `passes` and `notes` as it works. Ralph reads these between iterations to decide whether to continue. Acceptance criteria should be concrete and testable - commands the agent can run, behavior it can verify.
+
+Optionally, add a `fixtures` array for behavioral verification (see [Approved fixtures](#approved-fixtures---behavioral-verification-you-control)).
 
 ## Architecture
 
-### System overview
-
 ```mermaid
 flowchart TB
-    subgraph Interface["Interface layer"]
-        CLI["cli.py\nClick commands\n+ RichCallbacks"]
-        TUI["tui/app.py\nTextual app"]
-        subgraph TUI_Screens["TUI screens"]
-            Dashboard["Run dashboard\nDashboardCallbacks"]
-            FeatureConv["Feature conversation"]
-            PRDWiz["PRD wizard"]
-            ConfigScr["Config editor"]
-        end
-        TUI --> TUI_Screens
+    subgraph Input
+        Spec["Feature spec / PRD"]
+        Fixtures["Approved fixtures"]
     end
 
-    subgraph Core["Core engine"]
-        Loop["loop.py\nrun_loop()"]
-        Agent["agent.py\nAgent abstraction"]
-        Conv["conversation.py\nInteractive planning"]
+    subgraph Phase0["Phase 0: Feedforward"]
+        ModMap["Module map"]
+        Interfaces["Public interfaces"]
+        DepGraph["Dependency graph"]
+        Conventions["Conventions"]
     end
 
-    subgraph Data["Data and state"]
-        Config["config.py\nralph.toml + env vars"]
-        PRD["prd.py\nSchema + validation"]
-        Git["git_ops.py\nBranch + path enforcement"]
-        Models["models.py\nAgent registry + detection"]
-        Templates["templates/\nPrompt templates"]
+    subgraph Execution["Agent execution"]
+        Loop["Agentic loop\n(iterate until COMPLETE)"]
     end
 
-    subgraph External["External"]
-        Claude["Claude Code CLI"]
-        Codex["Codex CLI"]
-        Custom["Custom command"]
-        Repo["Git repository"]
+    subgraph Phase1["Phase 1: Mechanical verification"]
+        Tests["Test suite"]
+        Types["Type checker"]
+        Lint["Linter"]
+        Scope["Diff scope check"]
+        Patterns["Bad pattern scan"]
+        FixtureCheck["Fixture checks"]
     end
 
-    CLI -->|LoopCallbacks protocol| Loop
-    Dashboard -->|LoopCallbacks protocol| Loop
+    subgraph Phase2["Phase 2: Review"]
+        Review["Second-opinion agent\nreviews diff against spec"]
+    end
 
-    Loop --> Agent
-    Loop --> PRD
-    Loop --> Git
-    Loop --> Config
-    Loop --> Templates
+    subgraph Phase3["Phase 3: Contract testing"]
+        Contract["Tier-by-tier merge\n+ integration tests"]
+    end
 
-    FeatureConv --> Conv
-    Conv --> Agent
+    subgraph Learning["Continuous learning"]
+        Journal["Evolution journal"]
+        Experiments["Experiment tracker"]
+        Proposals["Harness proposals"]
+    end
 
-    Agent --> Models
-    Agent --> Claude
-    Agent --> Codex
-    Agent --> Custom
-
-    Git --> Repo
-
-    Models -.->|auto-detect| Claude
-    Models -.->|auto-detect| Codex
+    Spec --> Phase0
+    Fixtures --> FixtureCheck
+    Phase0 --> Loop
+    Loop --> Phase1
+    Phase1 -->|pass| Phase2
+    Phase1 -->|fail| Loop
+    Phase2 -->|pass| Phase3
+    Phase2 -->|fail| Loop
+    Phase3 -->|pass| Done["Done"]
+    Phase3 -->|fail| Loop
+    Phase1 --> Journal
+    Phase2 --> Journal
+    Journal --> Experiments
+    Experiments --> Proposals
 ```
 
-### Iteration lifecycle
-
-This is what happens inside `run_loop()` on each iteration:
-
-```mermaid
-flowchart TD
-    subgraph Init["Initialization (once)"]
-        A1["load_config()\ntoml + env vars + CLI flags"] --> A2["load_prd()"]
-        A2 --> A3["checkout_branch(prd.branch_name)"]
-        A3 --> A4["on_loop_start(config, prd)"]
-    end
-
-    subgraph Iteration["Iteration (repeats up to N times)"]
-        B1["on_iteration_start(i, max)"] --> B2["run_agent_async()\nBuild prompt with progress context"]
-        B2 --> B3["Spawn agent subprocess\nStream AgentOutput lines"]
-        B3 --> B4["on_agent_line(output)\nfor each streamed line"]
-        B4 --> B5["detect_completion()\nCheck for COMPLETE marker"]
-        B5 --> B6{"Guard rails\nenabled?"}
-        B6 -->|Yes| B7["find_disallowed_files()\nrevert_files()\non_guard_violation()"]
-        B6 -->|No| B8["on_iteration_end(i, elapsed)"]
-        B7 --> B8
-    end
-
-    subgraph Exit["Exit conditions"]
-        C1["All stories pass"] --> C4["on_complete(success)"]
-        C2["Max iterations reached"] --> C4
-        C3["3 consecutive errors"] --> C4
-    end
-
-    A4 --> B1
-    B8 --> C1
-    B8 -->|"Stories incomplete"| B1
-```
-
-### Key design decisions
-
-**Callback protocol**: The loop (`loop.py`) knows nothing about how output is displayed. It fires events via `LoopCallbacks` - a protocol that both the CLI (`RichCallbacks`) and TUI (`DashboardCallbacks`) implement. This means the same loop drives headless CLI runs and the live TUI dashboard.
-
-**Agent abstraction**: `agent.py` dispatches to three implementations: Claude (stream-json parsing with deduplication), Codex (line-by-line transcript parsing), or a generic stdin/stdout command. All three yield the same `AgentOutput(line, role)` stream.
-
-**Progress injection**: Between iterations, `agent.py` reads the last 5 entries from `progress.txt` and appends them to the prompt as handoff context. This gives the agent memory of what it already tried.
-
-**Guard rails**: After each iteration, `git_ops.py` checks all changed files against `paths.allowed`. Files outside the allowed set are automatically reverted (tracked files restored, untracked files deleted). Ralph's own infrastructure files are always protected.
+For multi-component factory runs, each component goes through this pipeline independently in parallel git worktrees, with contract testing merging them tier-by-tier after individual verification.
 
 ## Development
 
@@ -322,7 +350,7 @@ git clone https://github.com/0xfauzi/ralph-loop.git
 cd ralph-loop
 uv sync
 uv tool install -e .
-uv run pytest
+uv run pytest                  # 333 tests
 ```
 
 ## License

--- a/docs/spec-harness-engineering.md
+++ b/docs/spec-harness-engineering.md
@@ -1,0 +1,601 @@
+# Spec: Harness Engineering for Ralph
+
+**Status**: Draft
+**Date**: 2026-04-09
+**Source**: Bockeleer, "Harness Engineering for Coding Agent Users" (martinfowler.com, April 2026); hwchase17/autoresearch-agents; aiming-lab/AutoResearchClaw
+
+---
+
+## 1. Problem statement
+
+Ralph's factory mode has strong feedback sensors (3-phase verification: mechanical, review, contract) but weak feedforward controls. The agent runs, then we check. When it fails, we inject failure context and retry - but we never improve the harness itself between runs. This creates two problems:
+
+1. **Wasted iterations**: The agent frequently makes mistakes that could be prevented by giving it structural information before it starts (type signatures, module boundaries, codebase conventions). Each wasted iteration costs time and tokens.
+
+2. **No learning across runs**: Ralph retries with context but never accumulates reusable knowledge. The same architectural mistakes recur across components and across factory runs. AutoResearchClaw's "evolution directory" and autoresearch-agents' `results.tsv` both demonstrate that structured experiment journals dramatically improve convergence.
+
+Additionally, factory mode is currently a secondary command (`ralph factory`) despite being the more capable execution path. Single-component `ralph run` should be a degenerate case of factory, not the default.
+
+---
+
+## 2. Design principles
+
+These are drawn directly from the article's cybernetics framework:
+
+- **Feedforward + feedback in balance**: "You get either an agent that keeps repeating the same mistakes (feedback-only) or an agent that encodes rules but never finds out whether they worked (feedforward-only)." Ralph today is feedback-dominant.
+
+- **Computational before inferential**: Deterministic checks (tests, linters, type checkers, structural analysis) are cheap, fast, and reliable. LLM-based checks (review, spec compliance) are expensive and non-deterministic. Run computational controls first, always.
+
+- **Keep quality left**: Run cheap checks before expensive ones. Catch errors before they propagate. The current Phase 1 -> Phase 2 -> Phase 3 ordering is correct; we need to add a Phase 0 (feedforward) before the agent even starts.
+
+- **Ashby's Law (variety reduction)**: "An LLM-based coding agent can produce almost anything, but committing to a topology narrows that space, making a comprehensive harness more achievable." Constrain the agent's output space through structural context, not open-ended generation.
+
+- **Leverage existing tools, don't reinvent them**: Ruff, mypy, pytest, eslint already catch problems. Ralph's job is to make their output actionable for agents (structured parsing, source context, convention awareness) - not to build a parallel rule engine.
+
+- **The steering loop improves the harness, not just the output**: When issues recur, the controls themselves should be updated. This is the meta-loop that transforms ralph from a retry system into an adaptive one.
+
+---
+
+## 3. Changes
+
+### 3.1 Factory mode as default
+
+**What**: `ralph run` becomes a thin wrapper that creates a single-component manifest and delegates to factory execution. The `factory` command becomes the primary code path. `ralph run` is preserved as a convenience alias.
+
+**Why**: Factory mode has 3-phase verification, worktree isolation, structured progress logging, and retry-with-context. Single-component mode has none of these. Users currently get the weaker path by default.
+
+**Behavior change**:
+
+```
+# Before: ralph run uses loop.py directly, no verification
+ralph run 25
+
+# After: ralph run creates a 1-component manifest and runs factory
+# with verification enabled by default
+ralph run 25
+```
+
+**Implementation**:
+
+- `ralph run` synthesizes a `Manifest` with one component from the existing PRD
+- Delegates to `run_factory()` with sensible defaults:
+  - `max_parallel=1` (single component, no worktree needed)
+  - `use_worktrees=False` (runs in place like today)
+  - `verify_config=VerifyConfig()` (mechanical checks enabled)
+  - `review_mode="advisory"` (warn but don't block for single-component)
+  - `contract_config=None` (no contract testing for single component)
+  - `create_prs=False` (preserve current behavior - user decides when to PR)
+- `ralph run --no-verify` preserves the old behavior (raw loop, no verification)
+- `ralph run --legacy` invokes `run_loop()` directly as an escape hatch during migration
+
+**Files to modify**:
+- `ralph_py/cli.py`: Rewrite `run` command to build manifest and call `run_factory`
+- `ralph_py/factory.py`: Support `use_worktrees=False` with `max_parallel=1` (already works, just needs testing)
+- `ralph_py/manifest.py`: Add `Manifest.from_prd(prd_path, branch)` class method for single-component manifests
+
+**Risks**:
+- Users relying on `ralph run` completing faster because it skips verification. Mitigation: `--no-verify` flag.
+- The factory's `PlainUI` override (line 1335-1336 of cli.py) would suppress rich output for single-component runs. Fix: only force plain UI for parallel workers, not the orchestrator.
+
+---
+
+### 3.2 Feedforward controls (Phase 0)
+
+**What**: A new pre-execution phase that runs before the agent starts each component. Injects structural context, codebase intelligence, and constraint information into the prompt - computationally derived, not LLM-guessed.
+
+**Why**: The article identifies feedforward as the most impactful gap in most coding agent harnesses: "Increase the probability that the agent creates good results in the first attempt." Every feedforward signal that prevents one failure iteration saves 1-30 minutes of agent time.
+
+#### 3.2.1 Structural analysis injection
+
+**What**: Before each component runs, ralph collects codebase structure and injects it into the prompt:
+
+```
+=== CODEBASE CONTEXT (auto-generated, do not modify) ===
+
+## Module map
+src/
+  auth/           # Authentication (4 files, 380 LOC)
+  api/            # REST endpoints (12 files, 2100 LOC)
+  db/             # Database layer (6 files, 890 LOC)
+
+## Public interfaces (files you will likely need)
+src/db/models.py: class User, class Session, class Token
+src/api/router.py: def register_routes(app: FastAPI) -> None
+src/auth/middleware.py: class AuthMiddleware
+
+## Dependency graph (your component's neighbors)
+auth -> db (imports: User, Session)
+api -> auth (imports: AuthMiddleware, require_auth)
+api -> db (imports: User, get_session)
+
+## Active conventions (from .editorconfig, ruff.toml, pyproject.toml)
+- Line length: 88
+- Quote style: double
+- Import sort: isort-compatible (I sections)
+- Type checking: mypy strict mode
+
+=== END CODEBASE CONTEXT ===
+```
+
+**How**: Computational (no LLM calls). Use:
+- `ast` module to extract public symbols from Python files
+- `importlib.metadata` or `pyproject.toml` parsing for project structure
+- Existing `codebase_map.md` if available (from `ralph understand`)
+- `ruff.toml` / `pyproject.toml` / `.editorconfig` for convention extraction
+- Git diff against base branch for "what's already changed" context
+
+**New file**: `ralph_py/feedforward.py`
+
+**Key function**:
+```python
+def build_feedforward_context(
+    worktree_path: Path,
+    component: Component,
+    manifest: Manifest,
+    config: FeedforwardConfig,
+) -> str:
+    """Build pre-execution context string for prompt injection.
+    
+    Returns a formatted string to prepend to the agent prompt.
+    All analysis is computational (no LLM calls).
+    """
+```
+
+**Configuration** (`ralph.toml`):
+```toml
+[feedforward]
+enabled = true
+module_map = true          # directory tree with LOC counts
+public_interfaces = true   # extract public symbols from changed modules
+dependency_graph = true    # import-based dependency analysis
+conventions = true         # extract from config files
+max_context_tokens = 4000  # cap to avoid prompt bloat
+```
+
+#### 3.2.2 Why not custom ralph rules?
+
+The article advocates for "custom linter messages that include instructions for self-correction." This is a valid insight, but we don't need a ralph-specific rule engine to achieve it. Ruff, mypy, eslint, and other existing linters already catch the problems. What's missing is making their output actionable for agents.
+
+Ralph addresses this through two mechanisms that already exist in this spec:
+
+1. **Feedforward convention extraction (3.2.1)**: If the agent knows from structural analysis that "this project uses httpx, not requests," it won't make the mistake in the first place. The convention data comes from config files and codebase analysis - no custom rules needed.
+
+2. **LLM-optimized sensor output (3.3)**: When ruff flags S608, ralph parses it into a structured message with the file path, source context, and the relevant convention from feedforward. The agent gets project-specific guidance without ralph reinventing linting.
+
+If this proves insufficient after measuring iteration counts, a lightweight annotation mapping (ruff rule code -> project-specific fix hint) could be added to `ralph.toml` later. But start without it.
+
+#### 3.2.3 Bootstrap scaffolding
+
+**What**: Before the agent starts a component, ralph can optionally run a scaffolding step that creates file stubs, interface definitions, or test harnesses. This constrains the agent's solution space structurally.
+
+**How**: A `scaffold` command or script configured per-component in the manifest:
+
+```json
+{
+  "id": "auth-service",
+  "scaffold": "scripts/ralph/scaffolds/auth-service.sh",
+  "userStories": [...]
+}
+```
+
+The scaffold script runs before the agent and can:
+- Create directory structure
+- Generate interface stubs from OpenAPI specs
+- Copy template files
+- Run code generators (protobuf, sqlalchemy models, etc.)
+
+**Configuration**: Optional `scaffold` field on Component (manifest.py). Runs during `_launch_component` in factory.py, after worktree setup but before `_run_component`.
+
+---
+
+### 3.3 LLM-optimized sensor output
+
+**What**: Parse mechanical verification output into structured, actionable context instead of dumping raw stderr. The article emphasizes sensors are "particularly powerful when they produce signals optimized for LLM consumption."
+
+**Current behavior** (context.py `format_for_prompt`):
+```
+## Verification Failures
+- test_suite: FAIL - Tests failed (exit code 1)
+  FAILED tests/test_auth.py::test_login - AssertionError
+  FAILED tests/test_auth.py::test_signup - TypeError: missing argument
+  ... (50 lines of raw pytest output)
+```
+
+**New behavior**:
+```
+## Verification Failures
+
+### test_suite: 2 failures
+
+1. tests/test_auth.py::test_login (line 45)
+   AssertionError: expected status 200, got 401
+   FIX: The login endpoint at src/api/auth.py:login() is returning 401.
+   Check that the password hash comparison uses bcrypt.checkpw().
+
+2. tests/test_auth.py::test_signup (line 72)
+   TypeError: create_user() missing required argument 'email'
+   FIX: The function signature at src/db/models.py:create_user() expects
+   (username, email, password_hash). The test calls it with (username, password_hash).
+
+### typecheck: 1 error
+
+1. src/api/auth.py:23
+   error: Argument 1 to "verify_password" has incompatible type "str | None"; expected "str"
+   FIX: Add a None check before calling verify_password(), or use
+   `password: str = request.password or ""` with appropriate error handling.
+```
+
+**Implementation**:
+
+- Parse pytest output into structured failure objects (file, line, assertion, message)
+- Parse mypy output into (file, line, error_code, message) tuples
+- Parse ruff output into (file, line, rule, message) tuples
+- For each failure, attempt to include the relevant source lines (read the file, show context)
+- Generate a "FIX:" line using pattern matching on common error types (no LLM needed for common cases)
+
+**Files to modify**:
+- `ralph_py/verify.py`: Each `check_*` function returns structured `CheckResult` with parsed details instead of raw output lines
+- `ralph_py/context.py`: `format_for_prompt` uses structured data to generate targeted fix suggestions
+- New: `ralph_py/parsers.py` for pytest, mypy, ruff output parsing
+
+**Configuration** (`ralph.toml`):
+```toml
+[sensors]
+parse_output = true         # enable structured parsing
+include_source_context = true  # include relevant source lines in failure messages
+max_failures_per_check = 10    # cap to avoid prompt bloat
+```
+
+---
+
+### 3.4 Continuous learning (meta-steering loop)
+
+**What**: After each factory run, ralph analyzes recurring failure patterns and proposes harness improvements. This is the meta-loop: the harness improves itself, not just the code.
+
+**Why**: From the article: "Whenever an issue happens multiple times, the feedforward and feedback controls should be improved to make the issue less probable to occur in the future." From autoresearch-agents: experiment journals (`results.tsv`) that track what worked and what didn't enable the agent to learn which modification types are effective. From AutoResearchClaw: the "evolution directory" extracts structured lessons from each run, and MetaClaw demonstrates +18.3% robustness improvement from cross-run learning.
+
+**Architecture**:
+
+```
+Factory Run N
+    |
+    v
+[Execution + 3-Phase Verification]
+    |
+    v
+[Failure Pattern Extraction]  <-- computational, runs post-factory
+    |
+    v
+[Evolution Journal]           <-- persistent, grows across runs
+    |
+    v
+[Harness Improvement Proposals]  <-- inferential (LLM), optional
+    |
+    v
+[Human Review Gate]           <-- proposals shown, human approves/rejects
+    |
+    v
+[Apply to Harness]            <-- update rules.toml, feedforward config, CLAUDE.md
+    |
+    v
+Factory Run N+1               <-- benefits from accumulated improvements
+```
+
+#### 3.4.1 Evolution journal
+
+Inspired by AutoResearchClaw's evolution directory. A structured JSONL file that accumulates across factory runs.
+
+**File**: `.ralph/evolution.jsonl`
+
+**Entry schema**:
+```json
+{
+  "timestamp": "2026-04-09T14:30:00Z",
+  "run_id": "factory-20260409-143000",
+  "project": "auth-service",
+  "component_id": "login-endpoint",
+  "event_type": "failure_pattern",
+  "category": "verification|review|contract|iteration",
+  "pattern": {
+    "description": "Agent used raw SQL instead of ORM in 3/5 components",
+    "frequency": 3,
+    "total_components": 5,
+    "affected_components": ["login-endpoint", "user-profile", "session-mgmt"],
+    "check_name": "linter",
+    "error_signature": "S608: possible SQL injection"
+  },
+  "resolution": {
+    "applied": true,
+    "type": "feedforward_updated",
+    "detail": "Added ORM convention to feedforward context extraction"
+  }
+}
+```
+
+**New file**: `ralph_py/evolution.py`
+
+**Key functions**:
+```python
+class EvolutionJournal:
+    """Persistent learning journal across factory runs."""
+    
+    def __init__(self, path: Path): ...
+    
+    def record_run(self, manifest: Manifest, factory_result: FactoryResult) -> None:
+        """Extract and record patterns from a completed factory run."""
+    
+    def extract_failure_patterns(
+        self, manifest: Manifest, min_frequency: int = 2
+    ) -> list[FailurePattern]:
+        """Identify recurring failures across components."""
+    
+    def get_recurring_patterns(
+        self, lookback_runs: int = 10
+    ) -> list[FailurePattern]:
+        """Get patterns that recur across multiple factory runs."""
+    
+    def propose_harness_improvements(
+        self, patterns: list[FailurePattern]
+    ) -> list[HarnessProposal]:
+        """Generate concrete harness improvement proposals.
+        
+        Computational proposals (new rules, config changes) are generated
+        deterministically. Complex proposals (CLAUDE.md updates, prompt
+        changes) use an LLM call.
+        """
+```
+
+#### 3.4.2 Experiment tracking
+
+Inspired by autoresearch-agents' `results.tsv`. Each factory run produces a structured result entry that enables trend analysis.
+
+**File**: `.ralph/experiments.tsv`
+
+**Columns**:
+```
+run_id | timestamp | project | components_total | completed | failed | skipped |
+avg_iterations | avg_duration_s | p1_fail_rate | p2_fail_rate | p3_fail_rate |
+retry_rate | common_failure | harness_changes_applied
+```
+
+This is a flat, greppable file that answers: "Are we getting better over time?" If retry rate is declining across runs, the harness is working. If it's flat or increasing, the meta-loop isn't catching the right patterns.
+
+#### 3.4.3 Automatic harness proposals
+
+After extracting patterns, ralph proposes concrete changes:
+
+**Computational proposals** (deterministic, no LLM):
+- Pattern: Agent keeps importing `requests` -> Propose CLAUDE.md convention entry ("use httpx")
+- Pattern: Typecheck failures on Optional types -> Propose `strict = true` in mypy config
+- Pattern: Tests fail on import errors -> Propose dependency check in feedforward
+- Pattern: Ruff rule X fires on every component -> Propose ruff config change or CLAUDE.md guidance
+
+**Inferential proposals** (LLM-assisted, human-gated):
+- Pattern: Agents consistently misunderstand auth flow -> Propose CLAUDE.md section explaining auth
+- Pattern: Review keeps flagging missing error handling -> Propose prompt addendum about error handling conventions
+- Pattern: Components drift from API contract -> Propose structural test for API schema validation
+
+**Human review gate**: Proposals are written to `.ralph/proposals/` as markdown files. The user reviews and applies them:
+
+```bash
+ralph evolve                    # analyze recent runs, generate proposals
+ralph evolve --apply            # apply all approved proposals
+ralph evolve --apply PROP-003   # apply a specific proposal
+```
+
+**Configuration** (`ralph.toml`):
+```toml
+[evolution]
+enabled = true
+journal_path = ".ralph/evolution.jsonl"
+experiments_path = ".ralph/experiments.tsv"
+min_pattern_frequency = 2      # pattern must occur N times before proposal
+lookback_runs = 10             # how many past runs to analyze
+auto_propose = true            # generate proposals after each factory run
+auto_apply_computational = false  # auto-apply rule additions (no human gate)
+```
+
+---
+
+### 3.5 Behavior harness strengthening
+
+**What**: Address the article's "elephant in the room" - functional correctness verification. Ralph currently relies on agent-generated tests, which the article warns "puts a lot of faith into AI-generated tests, that's not good enough yet."
+
+#### 3.5.1 Approved fixtures
+
+**What**: Pre-approved input/output pairs that the agent's implementation must satisfy. These are human-written or human-approved golden tests that exist before the agent starts.
+
+**How**: An optional `fixtures` field in the PRD:
+
+```json
+{
+  "branchName": "ralph/auth",
+  "fixtures": [
+    {
+      "description": "Login with valid credentials returns 200 + token",
+      "type": "http",
+      "input": {
+        "method": "POST",
+        "path": "/api/login",
+        "body": {"username": "test", "password": "test123"}
+      },
+      "expected": {
+        "status": 200,
+        "body_contains": ["token", "expires_at"]
+      }
+    },
+    {
+      "description": "Login with wrong password returns 401",
+      "type": "http",
+      "input": {
+        "method": "POST",
+        "path": "/api/login",
+        "body": {"username": "test", "password": "wrong"}
+      },
+      "expected": {
+        "status": 401
+      }
+    }
+  ],
+  "userStories": [...]
+}
+```
+
+**Verification**: Fixtures are checked during Phase 1 as a new mechanical check (`check_fixtures`). They run the application and validate input/output pairs. This provides behavioral verification that's independent of agent-generated tests.
+
+**Types supported**:
+- `http`: HTTP request/response pairs (requires app server to be running)
+- `function`: Direct function call with args and expected return
+- `cli`: Command-line invocation with expected stdout/exit code
+- `file`: File content assertions after execution
+
+**New file**: `ralph_py/fixtures.py`
+**Modified file**: `ralph_py/verify.py` (add `check_fixtures`)
+**Modified file**: `ralph_py/prd.py` (add optional `fixtures` field)
+
+#### 3.5.2 Snapshot regression
+
+**What**: After a component passes all verification phases, ralph snapshots key outputs (API responses, rendered HTML, CLI output). On subsequent runs or retries, regression is detected by comparing against snapshots.
+
+**How**: Snapshots stored in `.ralph/snapshots/<component_id>/`. During Phase 1, if snapshots exist from a previous successful run, they're compared against current output.
+
+**Configuration** (`ralph.toml`):
+```toml
+[fixtures]
+enabled = false             # opt-in
+snapshot_on_success = true  # auto-snapshot after Phase 2 pass
+snapshot_dir = ".ralph/snapshots"
+```
+
+---
+
+## 4. Execution order
+
+These changes have dependencies. Implementation order:
+
+```
+Phase A (foundation):
+  3.1 Factory as default       # restructure CLI, no new capabilities
+  3.3 LLM-optimized sensors    # improve existing feedback quality
+
+Phase B (feedforward):
+  3.2.1 Structural analysis    # new feedforward.py module
+  3.2.3 Bootstrap scaffold     # optional scaffold field on Component
+
+Phase C (learning):
+  3.4.1 Evolution journal      # post-run analysis
+  3.4.2 Experiment tracking    # trend analysis
+  3.4.3 Harness proposals      # meta-steering loop
+
+Phase D (behavior):
+  3.5.1 Approved fixtures      # human-written golden tests
+  3.5.2 Snapshot regression    # automated regression detection
+```
+
+Phase A and Phase B can begin in parallel. Phase C depends on Phase A (needs factory as default to have consistent data). Phase D is independent and can begin whenever.
+
+---
+
+## 5. Configuration surface
+
+All new configuration lives in `ralph.toml` under new sections. No new config files required.
+
+```toml
+# Existing sections (unchanged)
+[agent]
+[run]
+[paths]
+[git]
+[ui]
+
+# New sections
+[feedforward]
+enabled = true
+module_map = true
+public_interfaces = true
+dependency_graph = true
+conventions = true
+max_context_tokens = 4000
+
+[sensors]
+parse_output = true
+include_source_context = true
+max_failures_per_check = 10
+
+[evolution]
+enabled = true
+journal_path = ".ralph/evolution.jsonl"
+experiments_path = ".ralph/experiments.tsv"
+min_pattern_frequency = 2
+lookback_runs = 10
+auto_propose = true
+auto_apply_computational = false
+
+[fixtures]
+enabled = false
+snapshot_on_success = true
+snapshot_dir = ".ralph/snapshots"
+```
+
+---
+
+## 6. New CLI commands
+
+```
+ralph run [N]                  # now delegates to factory (single-component)
+ralph run --no-verify [N]      # skip verification (lightweight mode)
+ralph run --legacy [N]         # old behavior (direct loop.py)
+
+ralph evolve                   # analyze runs, show proposals
+ralph evolve --apply           # apply approved proposals
+ralph evolve --status          # show experiment trends
+```
+
+---
+
+## 7. New files
+
+```
+ralph_py/
+  feedforward.py       # Phase 0: structural analysis, convention extraction
+  parsers.py           # Structured output parsing for pytest, mypy, ruff
+  fixtures.py          # Approved fixtures verification
+  evolution.py         # Evolution journal, experiment tracking, proposals
+```
+
+---
+
+## 8. Failure modes and mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Feedforward context bloats prompt beyond context window | Agent ignores or hallucinates from excess context | `max_context_tokens` cap; prioritize most relevant modules based on component's PRD |
+| Evolution journal proposes bad harness changes | Degraded future runs | Human review gate for inferential proposals; computational proposals are reversible |
+| Approved fixtures require running infrastructure | CI/local environments diverge | Fixture types include `function` (no infra needed) and `file` (filesystem only) |
+| Factory-as-default breaks existing `ralph run` scripts | User CI pipelines break | `--legacy` flag for exact old behavior; `--no-verify` for lightweight factory |
+| Structured output parsing fails on non-standard test runners | Falls back to raw output, losing value | Parsers are pluggable; unknown output format falls through to existing raw-dump behavior |
+
+---
+
+## 9. Success metrics
+
+These should be measured empirically before and after each phase ships:
+
+- **Iterations to completion**: Average number of iterations per component before all acceptance criteria pass. Feedforward (3.2) should reduce this.
+- **First-attempt success rate**: Percentage of components that pass Phase 1 on the first attempt. Feedforward should increase this.
+- **Retry rate**: Percentage of components that need retries. The meta-learning loop (3.4) should decrease this over time within a project.
+- **Time to completion**: Wall-clock time per component. LLM-optimized sensors (3.3) should reduce retry time even if retry rate stays constant.
+- **Cross-run improvement**: For projects with multiple factory runs, does retry rate decrease across runs? This measures whether the evolution journal is working.
+
+Measure these on a set of reference specs before implementing each phase to establish baselines. The measurements themselves should be scripts, not estimates.
+
+---
+
+## 10. What this spec does NOT cover
+
+- **Agent-internal improvements**: This spec is about the external harness, not the agent's own capabilities. We don't modify how Claude Code or Codex work internally.
+- **Real-time monitoring / alerting**: No `ralph watch` or continuous background monitoring. The evolution journal runs post-hoc, not in real-time. Background monitoring can be a follow-up.
+- **Multi-repo orchestration**: Factory mode operates within a single repository. Cross-repo coordination is out of scope.
+- **Cost optimization**: Token usage tracking and budget guardrails (like AutoResearchClaw's cost guardrails) are valuable but separate from harness engineering. Could be a follow-up.
+- **Custom ralph lint rules**: Existing linters (ruff, mypy, eslint) already catch problems. Ralph's value is making their output actionable, not reimplementing linting. See section 3.2.2 for rationale.
+- **Harness templates**: Pre-built configurations for project topologies (python-api, react-app, etc.) are valuable but premature. Build the feedforward and evolution primitives first; templates are a packaging concern on top of them.

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -177,6 +177,16 @@ def cli() -> None:
     is_flag=True,
     help="Use ASCII characters only",
 )
+@click.option(
+    "--no-verify",
+    is_flag=True,
+    help="Skip mechanical verification (raw loop, no post-checks)",
+)
+@click.option(
+    "--legacy",
+    is_flag=True,
+    help="Use legacy direct loop (bypass factory pipeline)",
+)
 def run(
     max_iterations: int,
     root: Path | None,
@@ -192,10 +202,15 @@ def run(
     ui: str,
     no_color: bool,
     ascii: bool,
+    no_verify: bool,
+    legacy: bool,
 ) -> None:
     """Run the agentic loop.
 
     MAX_ITERATIONS is the maximum number of iterations (default: 10).
+
+    By default, delegates to the factory pipeline with mechanical verification.
+    Use --no-verify to skip verification or --legacy for the old direct loop.
     """
     ctx = click.get_current_context()
     env_prompt = os.environ.get("PROMPT_FILE")
@@ -272,12 +287,74 @@ def run(
         ui_impl.info("Install codex or use --agent-cmd to specify a custom agent")
         sys.exit(1)
 
-    # Get UI and agent
-    agent = get_agent(config.agent_cmd, config.model, config.model_reasoning_effort)
+    # Legacy mode: use direct loop (old behavior)
+    if legacy:
+        agent = get_agent(config.agent_cmd, config.model, config.model_reasoning_effort)
+        result = run_loop(config, ui_impl, agent, root_dir)
+        sys.exit(result.exit_code)
 
-    # Run loop
-    result = run_loop(config, ui_impl, agent, root_dir)
-    sys.exit(result.exit_code)
+    # Default: delegate to factory pipeline as single-component run
+    from ralph_py.feedforward import FeedforwardConfig
+    from ralph_py.manifest import Manifest
+    from ralph_py.verify import VerifyConfig
+
+    # Determine branch from config or PRD
+    prd_branch = ""
+    if config.prd_file.exists():
+        try:
+            from ralph_py.prd import PRD as PRDLoader
+            prd_doc = PRDLoader.load(config.prd_file)
+            prd_branch = prd_doc.branch_name
+        except Exception:
+            pass
+
+    effective_branch = config.ralph_branch or prd_branch or "ralph/run"
+
+    # Detect base branch from git
+    detected_base = "main"
+    try:
+        import subprocess as _sp
+        head_ref = _sp.run(
+            ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+            cwd=root_dir, capture_output=True, text=True, timeout=5,
+        )
+        if head_ref.returncode == 0:
+            # "refs/remotes/origin/main" -> "main"
+            detected_base = head_ref.stdout.strip().rsplit("/", 1)[-1]
+    except Exception:
+        pass
+
+    # Build single-component manifest from PRD
+    rel_prd = str(config.prd_file)
+    try:
+        rel_prd = str(config.prd_file.relative_to(root_dir))
+    except ValueError:
+        pass
+
+    manifest = Manifest.from_prd(
+        prd_path=Path(rel_prd),
+        branch=effective_branch,
+        base_branch=detected_base,
+    )
+
+    # Build factory config for single-component mode
+    v_config = None if no_verify else VerifyConfig()
+    ff_config = FeedforwardConfig() if not no_verify else None
+
+    factory_cfg = FactoryConfig(
+        max_parallel=1,
+        max_retries=3,
+        use_worktrees=False,
+        single_pr=False,
+        create_prs=False,
+        verify_config=v_config,
+        review_mode="advisory",
+        contract_config=None,
+        feedforward_config=ff_config,
+    )
+
+    factory_result = run_factory(manifest, factory_cfg, config, ui_impl, root_dir)
+    sys.exit(factory_result.exit_code)
 
 
 @cli.command()
@@ -1343,6 +1420,120 @@ def factory(
 
     result = run_factory(manifest, factory_config, base_config, ui_impl, root_dir)
     sys.exit(result.exit_code)
+
+
+@cli.command()
+@click.option(
+    "--apply",
+    "apply_id",
+    type=str,
+    default=None,
+    help="Apply a specific proposal (e.g. PROP-001) or 'all' for all proposals",
+)
+@click.option(
+    "--status",
+    "show_status",
+    is_flag=True,
+    help="Show experiment trends",
+)
+@click.option(
+    "--root",
+    type=click.Path(path_type=Path),
+    help="Project root path",
+)
+@click.option(
+    "--ui",
+    type=click.Choice(["auto", "rich", "plain"]),
+    default="auto",
+    help="UI mode",
+)
+@click.option(
+    "--no-color",
+    is_flag=True,
+    help="Disable colors",
+)
+def evolve(
+    apply_id: str | None,
+    show_status: bool,
+    root: Path | None,
+    ui: str,
+    no_color: bool,
+) -> None:
+    """Analyze factory runs and propose harness improvements.
+
+    Without arguments, analyzes recent runs and shows proposals.
+    Use --status to see experiment trends.
+    Use --apply to apply proposals.
+    """
+    from ralph_py.evolution import EvolutionConfig, EvolutionJournal
+
+    root_dir = root.resolve() if root else Path.cwd()
+    force_rich = os.environ.get("GUM_FORCE") == "1"
+    ui_impl = get_ui(_normalize_ui_mode(ui), no_color, force_rich=force_rich)
+
+    evo_config = EvolutionConfig()
+
+    if not evo_config.enabled:
+        ui_impl.err("Evolution is disabled in config")
+        sys.exit(1)
+
+    journal = EvolutionJournal(evo_config)
+
+    if show_status:
+        ui_impl.section("Experiment Trends")
+        trends = journal.get_experiment_trends(last_n=10)
+        if not trends:
+            ui_impl.info("No experiments recorded yet. Run `ralph factory` first.")
+            sys.exit(0)
+
+        for entry in trends:
+            ui_impl.info(
+                f"  {entry.get('run_id', '?')} | "
+                f"completed={entry.get('completed', '?')} "
+                f"failed={entry.get('failed', '?')} "
+                f"retry_rate={entry.get('retry_rate', '?')}"
+            )
+        sys.exit(0)
+
+    if apply_id:
+        proposals_dir = root_dir / ".ralph" / "proposals"
+        if not proposals_dir.exists():
+            ui_impl.err("No proposals found. Run `ralph evolve` first.")
+            sys.exit(1)
+
+        ui_impl.info(f"Applying proposal: {apply_id}")
+        ui_impl.warn("Proposal application is not yet automated. Review proposals in .ralph/proposals/ and apply manually.")
+        sys.exit(0)
+
+    # Default: analyze and propose
+    ui_impl.section("Evolution: Analyzing Runs")
+    patterns = journal.get_cross_run_patterns(lookback_runs=evo_config.lookback_runs)
+
+    if not patterns:
+        ui_impl.info("No recurring failure patterns found across recent runs.")
+        ui_impl.info("Run more factory sessions to accumulate data.")
+        sys.exit(0)
+
+    ui_impl.ok(f"Found {len(patterns)} recurring patterns")
+    for pattern in patterns:
+        ui_impl.info(
+            f"  [{pattern.check_name}] {pattern.description} "
+            f"(seen in {pattern.frequency} components)"
+        )
+
+    proposals = journal.propose_improvements(patterns)
+    if proposals:
+        proposals_dir = root_dir / ".ralph" / "proposals"
+        paths = journal.save_proposals(proposals, proposals_dir)
+        ui_impl.section("Proposals Generated")
+        for path in paths:
+            ui_impl.info(f"  {path}")
+        ui_impl.info("")
+        ui_impl.info("Review proposals and apply with `ralph evolve --apply <ID>`")
+    else:
+        ui_impl.info("No actionable proposals generated from current patterns.")
+
+    sys.exit(0)
 
 
 def main() -> None:

--- a/ralph_py/evolution.py
+++ b/ralph_py/evolution.py
@@ -1,0 +1,614 @@
+"""Continuous learning - evolution journal, experiment tracking, and harness proposals.
+
+Records factory run outcomes and extracts recurring failure patterns across runs.
+Inspired by AutoResearchClaw's evolution directory and autoresearch-agents' results.tsv.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ralph_py.factory import FactoryResult
+    from ralph_py.manifest import Component, Manifest
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EvolutionConfig:
+    enabled: bool = True
+    journal_path: Path = field(default_factory=lambda: Path(".ralph/evolution.jsonl"))
+    experiments_path: Path = field(default_factory=lambda: Path(".ralph/experiments.tsv"))
+    min_pattern_frequency: int = 2
+    lookback_runs: int = 10
+    auto_propose: bool = True
+    auto_apply_computational: bool = False
+
+
+@dataclass
+class FailurePattern:
+    description: str
+    frequency: int
+    total_components: int
+    affected_components: list[str]
+    check_name: str  # e.g. "test_suite", "typecheck", "linter", "review"
+    error_signature: str  # normalized error pattern (e.g. "S608" for ruff, "missing-argument" for pytest)
+    category: str  # "verification", "review", "contract", "iteration"
+
+
+@dataclass
+class HarnessProposal:
+    id: str  # e.g. "PROP-001"
+    title: str
+    description: str
+    proposal_type: str  # "computational" or "inferential"
+    target: str  # what to change: "claude_md", "pyproject", "feedforward_config"
+    suggested_change: str  # the actual proposed content/config change
+    source_patterns: list[str]  # pattern descriptions that led to this proposal
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Regex for linter rule codes like S608, E501, W291, etc.
+_LINTER_CODE_RE = re.compile(r"\b([A-Z]\d{3,4})\b")
+
+# Regex to strip file paths (unix and windows style)
+_PATH_RE = re.compile(r"(?:/[\w./-]+|[A-Z]:\\[\w.\\-]+)")
+
+# Regex to strip line/column numbers like ":42:" or "line 42"
+_LINENO_RE = re.compile(r"(?::\d+:?\d*|line \d+|col(?:umn)? \d+)", re.IGNORECASE)
+
+# Regex to strip quoted variable/argument names
+_QUOTED_NAME_RE = re.compile(r"['\"][\w.]+['\"]")
+
+
+def _normalize_error(error: str) -> str:
+    """Normalize an error string into a stable signature.
+
+    - Keeps linter rule codes as-is (e.g. S608, E501).
+    - Strips file paths, line numbers, and variable names.
+    - Converts the remaining message to a slug.
+    """
+    if not error:
+        return ""
+
+    # Check for a linter rule code first - it is the most stable identifier.
+    code_match = _LINTER_CODE_RE.search(error)
+    if code_match:
+        return code_match.group(1)
+
+    normalized = error
+    normalized = _PATH_RE.sub("", normalized)
+    normalized = _LINENO_RE.sub("", normalized)
+    normalized = _QUOTED_NAME_RE.sub("", normalized)
+
+    # Take the first meaningful line only.
+    first_line = normalized.strip().split("\n")[0].strip()
+
+    # Extract "ErrorType: message" pattern if present.
+    colon_idx = first_line.find(":")
+    if colon_idx > 0:
+        error_type = first_line[:colon_idx].strip()
+        message = first_line[colon_idx + 1:].strip()
+        # Slugify message portion.
+        slug = re.sub(r"[^a-z0-9]+", "-", message.lower()).strip("-")
+        if slug:
+            return slug[:80]
+        return re.sub(r"[^a-z0-9]+", "-", error_type.lower()).strip("-")[:80]
+
+    slug = re.sub(r"[^a-z0-9]+", "-", first_line.lower()).strip("-")
+    return slug[:80] if slug else "unknown"
+
+
+def _classify_check(error: str) -> tuple[str, str]:
+    """Return (check_name, category) inferred from the error text."""
+    lower = error.lower()
+
+    if any(kw in lower for kw in ("ruff", "flake8", "pylint", "lint")):
+        return "linter", "verification"
+    if any(kw in lower for kw in ("mypy", "pyright", "typecheck", "type error")):
+        return "typecheck", "verification"
+    if any(kw in lower for kw in ("pytest", "test", "assert", "unittest")):
+        return "test_suite", "verification"
+    if any(kw in lower for kw in ("review", "finding", "reviewer")):
+        return "review", "review"
+    if any(kw in lower for kw in ("contract", "integration")):
+        return "contract", "contract"
+    if any(kw in lower for kw in ("mechanical verification failed",)):
+        return "verification", "verification"
+
+    return "unknown", "iteration"
+
+
+def _timestamp_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Journal
+# ---------------------------------------------------------------------------
+
+
+class EvolutionJournal:
+    def __init__(self, config: EvolutionConfig) -> None:
+        self.config = config
+
+    # ------------------------------------------------------------------
+    # record_run
+    # ------------------------------------------------------------------
+
+    def record_run(
+        self,
+        run_id: str,
+        manifest: Manifest,
+        factory_result: FactoryResult,
+    ) -> None:
+        """Record a completed factory run to the journal.
+
+        Writes individual component outcomes as JSONL entries.
+        Also appends a summary line to experiments.tsv.
+        """
+        from ralph_py.manifest import ComponentStatus
+
+        timestamp = _timestamp_now()
+
+        # --- JSONL entries per component ---
+        entries: list[dict] = []
+        for comp in manifest.components:
+            has_error = bool(comp.error) and comp.status in (
+                ComponentStatus.FAILED.value,
+                ComponentStatus.PENDING.value,  # retried components reset to pending
+            )
+            check_name = ""
+            error_sig = ""
+            if has_error:
+                check_name, _ = _classify_check(comp.error)
+                error_sig = _normalize_error(comp.error)
+            entry = {
+                "timestamp": timestamp,
+                "run_id": run_id,
+                "project": manifest.project_name,
+                "component_id": comp.id,
+                "event_type": "component_result",
+                "status": comp.status,
+                "retries": comp.retries,
+                "error": comp.error,
+                "check_name": check_name,
+                "error_signature": error_sig,
+                "duration_seconds": comp.duration_seconds,
+                "iteration_count": comp.iteration_count,
+            }
+            entries.append(entry)
+
+        try:
+            self.config.journal_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.config.journal_path, "a") as f:
+                for entry in entries:
+                    f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+        except OSError:
+            pass
+
+        # --- Experiments TSV summary line ---
+        total = len(manifest.components)
+        completed = len(factory_result.completed)
+        failed = len(factory_result.failed)
+        skipped = len(factory_result.skipped)
+
+        iteration_counts = [c.iteration_count for c in manifest.components if c.iteration_count > 0]
+        avg_iterations = (
+            sum(iteration_counts) / len(iteration_counts) if iteration_counts else 0.0
+        )
+
+        durations = [c.duration_seconds for c in manifest.components if c.duration_seconds > 0]
+        avg_duration = sum(durations) / len(durations) if durations else 0.0
+
+        retry_total = sum(c.retries for c in manifest.components)
+        retry_rate = retry_total / total if total > 0 else 0.0
+
+        # Most common failure signature
+        failure_sigs: dict[str, int] = {}
+        for comp in manifest.components:
+            if comp.status == ComponentStatus.FAILED.value and comp.error:
+                sig = _normalize_error(comp.error)
+                failure_sigs[sig] = failure_sigs.get(sig, 0) + 1
+        common_failure = max(failure_sigs, key=failure_sigs.get, default="") if failure_sigs else ""  # type: ignore[arg-type]
+
+        header = (
+            "run_id\ttimestamp\tproject\tcomponents_total\tcompleted\tfailed\t"
+            "skipped\tavg_iterations\tavg_duration_s\tretry_rate\tcommon_failure"
+        )
+        row = (
+            f"{run_id}\t{timestamp}\t{manifest.project_name}\t{total}\t"
+            f"{completed}\t{failed}\t{skipped}\t{avg_iterations:.2f}\t"
+            f"{avg_duration:.1f}\t{retry_rate:.2f}\t{common_failure}"
+        )
+
+        try:
+            self.config.experiments_path.parent.mkdir(parents=True, exist_ok=True)
+            needs_header = (
+                not self.config.experiments_path.exists()
+                or self.config.experiments_path.stat().st_size == 0
+            )
+            with open(self.config.experiments_path, "a") as f:
+                if needs_header:
+                    f.write(header + "\n")
+                f.write(row + "\n")
+        except OSError:
+            pass
+
+    # ------------------------------------------------------------------
+    # extract_failure_patterns (single run)
+    # ------------------------------------------------------------------
+
+    def extract_failure_patterns(
+        self,
+        manifest: Manifest,
+        min_frequency: int = 2,
+    ) -> list[FailurePattern]:
+        """Extract recurring failure patterns from a single run.
+
+        Looks at failed/retried components to find common error signatures.
+        Groups by check_name and error_signature.
+        """
+        from ralph_py.manifest import ComponentStatus
+
+        # Collect components that failed or were retried.
+        troubled: list[Component] = [
+            c
+            for c in manifest.components
+            if c.status == ComponentStatus.FAILED.value or c.retries > 0
+        ]
+
+        if not troubled:
+            return []
+
+        # Group by (check_name, error_signature).
+        groups: dict[tuple[str, str], list[str]] = {}
+        sig_errors: dict[tuple[str, str], str] = {}
+        for comp in troubled:
+            if not comp.error:
+                continue
+            check_name, category = _classify_check(comp.error)
+            sig = _normalize_error(comp.error)
+            key = (check_name, sig)
+            groups.setdefault(key, []).append(comp.id)
+            sig_errors.setdefault(key, comp.error)
+
+        total = len(manifest.components)
+        patterns: list[FailurePattern] = []
+        for (check_name, sig), comp_ids in groups.items():
+            if len(comp_ids) < min_frequency:
+                continue
+            _, category = _classify_check(sig_errors[(check_name, sig)])
+            patterns.append(
+                FailurePattern(
+                    description=(
+                        f"{check_name} failure '{sig}' in {len(comp_ids)}/{total} components"
+                    ),
+                    frequency=len(comp_ids),
+                    total_components=total,
+                    affected_components=comp_ids,
+                    check_name=check_name,
+                    error_signature=sig,
+                    category=category,
+                )
+            )
+
+        patterns.sort(key=lambda p: p.frequency, reverse=True)
+        return patterns
+
+    # ------------------------------------------------------------------
+    # get_cross_run_patterns
+    # ------------------------------------------------------------------
+
+    def get_cross_run_patterns(
+        self,
+        lookback_runs: int = 10,
+    ) -> list[FailurePattern]:
+        """Get patterns that recur across multiple factory runs.
+
+        Reads the journal, groups entries by error_signature,
+        returns patterns that appear in >= min_pattern_frequency runs.
+        """
+        entries = self._read_journal_entries(lookback_runs)
+        if not entries:
+            return []
+
+        # Group by error_signature across distinct run_ids.
+        sig_runs: dict[str, set[str]] = {}
+        sig_components: dict[str, list[str]] = {}
+        sig_check: dict[str, str] = {}
+        sig_error: dict[str, str] = {}
+
+        for entry in entries:
+            sig = entry.get("error_signature", "")
+            if not sig:
+                continue
+            run_id = entry.get("run_id", "")
+            comp_id = entry.get("component_id", "")
+            check = entry.get("check_name", "unknown")
+            error = entry.get("error", "")
+
+            sig_runs.setdefault(sig, set()).add(run_id)
+            sig_components.setdefault(sig, []).append(comp_id)
+            sig_check.setdefault(sig, check)
+            sig_error.setdefault(sig, error)
+
+        total_runs = len({e.get("run_id") for e in entries})
+        patterns: list[FailurePattern] = []
+
+        for sig, run_ids in sig_runs.items():
+            if len(run_ids) < self.config.min_pattern_frequency:
+                continue
+            _, category = _classify_check(sig_error.get(sig, ""))
+            unique_comps = list(dict.fromkeys(sig_components.get(sig, [])))
+            patterns.append(
+                FailurePattern(
+                    description=(
+                        f"'{sig}' appeared in {len(run_ids)}/{total_runs} runs "
+                        f"across {len(unique_comps)} components"
+                    ),
+                    frequency=len(run_ids),
+                    total_components=total_runs,
+                    affected_components=unique_comps,
+                    check_name=sig_check.get(sig, "unknown"),
+                    error_signature=sig,
+                    category=category,
+                )
+            )
+
+        patterns.sort(key=lambda p: p.frequency, reverse=True)
+        return patterns
+
+    # ------------------------------------------------------------------
+    # propose_improvements
+    # ------------------------------------------------------------------
+
+    def propose_improvements(
+        self,
+        patterns: list[FailurePattern],
+    ) -> list[HarnessProposal]:
+        """Generate concrete harness improvement proposals from patterns.
+
+        Computational proposals only (no LLM calls):
+        - Recurring linter errors - suggest CLAUDE.md convention entry
+        - Recurring typecheck patterns - suggest config change
+        - Recurring test failures on same module - suggest feedforward focus
+        """
+        proposals: list[HarnessProposal] = []
+        counter = 0
+
+        for pattern in patterns:
+            counter += 1
+            proposal_id = f"PROP-{counter:03d}"
+
+            if pattern.check_name == "linter":
+                proposals.append(
+                    HarnessProposal(
+                        id=proposal_id,
+                        title=f"Add linter convention for {pattern.error_signature} to CLAUDE.md",
+                        description=(
+                            f"Linter rule {pattern.error_signature} triggered in "
+                            f"{pattern.frequency} components. Adding an explicit convention "
+                            f"to CLAUDE.md will help the agent avoid this pattern."
+                        ),
+                        proposal_type="computational",
+                        target="claude_md",
+                        suggested_change=(
+                            f"Add to CLAUDE.md:\n"
+                            f"> Avoid triggering linter rule {pattern.error_signature}. "
+                            f"Check ruff/flake8 docs for the correct pattern."
+                        ),
+                        source_patterns=[pattern.description],
+                    )
+                )
+
+            elif pattern.check_name == "typecheck":
+                proposals.append(
+                    HarnessProposal(
+                        id=proposal_id,
+                        title=f"Adjust type-checking config for '{pattern.error_signature}'",
+                        description=(
+                            f"Type error pattern '{pattern.error_signature}' recurred in "
+                            f"{pattern.frequency} components. Consider adjusting pyproject.toml "
+                            f"or adding a CLAUDE.md note about the expected typing style."
+                        ),
+                        proposal_type="computational",
+                        target="pyproject",
+                        suggested_change=(
+                            f"Review [tool.mypy] or [tool.pyright] settings in pyproject.toml. "
+                            f"If this is a known false positive, add to ignore list. "
+                            f"Otherwise add to CLAUDE.md:\n"
+                            f"> Ensure all functions have return type annotations to avoid "
+                            f"'{pattern.error_signature}'."
+                        ),
+                        source_patterns=[pattern.description],
+                    )
+                )
+
+            elif pattern.check_name == "test_suite":
+                proposals.append(
+                    HarnessProposal(
+                        id=proposal_id,
+                        title=f"Add feedforward focus for test pattern '{pattern.error_signature}'",
+                        description=(
+                            f"Test failure '{pattern.error_signature}' hit "
+                            f"{pattern.frequency} components: "
+                            f"{', '.join(pattern.affected_components[:5])}. "
+                            f"Focusing feedforward context on this pattern may help the agent "
+                            f"fix the root cause earlier in the iteration loop."
+                        ),
+                        proposal_type="computational",
+                        target="feedforward_config",
+                        suggested_change=(
+                            f"Add to feedforward config or CLAUDE.md:\n"
+                            f"> Known recurring test issue: '{pattern.error_signature}'. "
+                            f"When tests fail with this pattern, check the affected modules "
+                            f"before re-running."
+                        ),
+                        source_patterns=[pattern.description],
+                    )
+                )
+
+            elif pattern.check_name == "review":
+                proposals.append(
+                    HarnessProposal(
+                        id=proposal_id,
+                        title=f"Add review guidance for '{pattern.error_signature}'",
+                        description=(
+                            f"Review finding '{pattern.error_signature}' appeared in "
+                            f"{pattern.frequency} components. Adding explicit guidance to "
+                            f"CLAUDE.md can help the agent avoid this in the first pass."
+                        ),
+                        proposal_type="computational",
+                        target="claude_md",
+                        suggested_change=(
+                            f"Add to CLAUDE.md:\n"
+                            f"> Reviewer repeatedly flags '{pattern.error_signature}'. "
+                            f"Address this pattern proactively."
+                        ),
+                        source_patterns=[pattern.description],
+                    )
+                )
+
+            else:
+                # Generic proposal for unknown/iteration category patterns.
+                proposals.append(
+                    HarnessProposal(
+                        id=proposal_id,
+                        title=f"Investigate recurring failure: {pattern.error_signature}",
+                        description=(
+                            f"Pattern '{pattern.error_signature}' ({pattern.check_name}) "
+                            f"occurred {pattern.frequency} times. Manual investigation "
+                            f"recommended."
+                        ),
+                        proposal_type="computational",
+                        target="claude_md",
+                        suggested_change=(
+                            f"Add to CLAUDE.md:\n"
+                            f"> Known issue: '{pattern.error_signature}'. "
+                            f"Take extra care with this pattern."
+                        ),
+                        source_patterns=[pattern.description],
+                    )
+                )
+
+        return proposals
+
+    # ------------------------------------------------------------------
+    # save_proposals
+    # ------------------------------------------------------------------
+
+    def save_proposals(
+        self,
+        proposals: list[HarnessProposal],
+        output_dir: Path,
+    ) -> list[Path]:
+        """Write proposals as markdown files to output_dir.
+
+        Returns list of written file paths.
+        """
+        written: list[Path] = []
+        try:
+            output_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return written
+
+        for proposal in proposals:
+            filename = f"{proposal.id.lower()}.md"
+            filepath = output_dir / filename
+
+            sources_block = "\n".join(
+                f"- {s}" for s in proposal.source_patterns
+            )
+
+            content = (
+                f"# {proposal.id}: {proposal.title}\n"
+                f"\n"
+                f"**Type**: {proposal.proposal_type}\n"
+                f"**Target**: {proposal.target}\n"
+                f"**Source patterns**:\n"
+                f"{sources_block}\n"
+                f"\n"
+                f"## Description\n"
+                f"\n"
+                f"{proposal.description}\n"
+                f"\n"
+                f"## Suggested change\n"
+                f"\n"
+                f"{proposal.suggested_change}\n"
+            )
+
+            try:
+                filepath.write_text(content)
+                written.append(filepath)
+            except OSError:
+                pass
+
+        return written
+
+    # ------------------------------------------------------------------
+    # get_experiment_trends
+    # ------------------------------------------------------------------
+
+    def get_experiment_trends(self, last_n: int = 10) -> list[dict]:
+        """Read experiments.tsv and return the last N entries as dicts."""
+        try:
+            text = self.config.experiments_path.read_text()
+        except OSError:
+            return []
+
+        reader = csv.DictReader(io.StringIO(text), delimiter="\t")
+        rows = list(reader)
+        return rows[-last_n:]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _read_journal_entries(self, lookback_runs: int = 10) -> list[dict]:
+        """Read JSONL journal and return entries from the last N distinct runs."""
+        try:
+            lines = self.config.journal_path.read_text().strip().splitlines()
+        except OSError:
+            return []
+
+        entries: list[dict] = []
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+        if not entries:
+            return []
+
+        # Determine the last N distinct run_ids (preserving order of appearance).
+        seen_runs: list[str] = []
+        seen_set: set[str] = set()
+        for entry in reversed(entries):
+            rid = entry.get("run_id", "")
+            if rid and rid not in seen_set:
+                seen_set.add(rid)
+                seen_runs.append(rid)
+            if len(seen_runs) >= lookback_runs:
+                break
+
+        allowed = set(seen_runs)
+        return [e for e in entries if e.get("run_id", "") in allowed]

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from ralph_py.config import RalphConfig
 from ralph_py.context import IterationContext
 from ralph_py.contract import ContractConfig, ContractMode, run_contract_testing
+from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
 from ralph_py.manifest import Component, ComponentStatus, Manifest
 from ralph_py.observability import NullProgressLog, ProgressLog
 from ralph_py.pr import create_prs_in_order, create_single_pr
@@ -43,6 +44,8 @@ class FactoryConfig:
     review_model: str | None = None
     # Phase 3: contract testing
     contract_config: ContractConfig | None = None
+    # Phase 0: feedforward
+    feedforward_config: FeedforwardConfig | None = None
     # Observability
     progress_log_path: Path | None = None
 
@@ -136,6 +139,9 @@ def _run_component(
     agent_type: str | None,
     sleep_seconds: float,
     previous_context_json: str | None = None,
+    feedforward_config_dict: dict | None = None,
+    scaffold_cmd: str | None = None,
+    component_deps: list[str] | None = None,
 ) -> ComponentResult:
     """Run a single component's implementation loop.
 
@@ -168,27 +174,62 @@ def _run_component(
 
     # Copy CLAUDE.md into worktree. AGENTS.md is a symlink to CLAUDE.md,
     # so copying CLAUDE.md and recreating the symlink gives the agent both.
-    repo_root = worktree_path.parent.parent.parent  # .ralph/worktrees/<id> -> root
+    # When use_worktrees=False, worktree_path IS the repo root so CLAUDE.md
+    # is already in place - the .exists() guards handle this correctly.
+    worktree_base = worktree_path / ".ralph" / "worktrees"
+    if worktree_base.exists() and worktree_path.name != worktree_path.parent.name:
+        # This is a real worktree: .ralph/worktrees/<id> -> root is 3 levels up
+        repo_root = worktree_path.parent.parent.parent
+    else:
+        # No worktree (use_worktrees=False) - worktree_path is the repo root
+        repo_root = worktree_path
     claude_dest = worktree_path / "CLAUDE.md"
     if not claude_dest.exists():
         claude_src = repo_root / "CLAUDE.md"
         if claude_src.exists():
-            # Resolve symlinks to get actual content
             claude_dest.write_text(claude_src.read_text())
     agents_dest = worktree_path / "AGENTS.md"
     if not agents_dest.exists() and claude_dest.exists():
         agents_dest.symlink_to("CLAUDE.md")
 
+    # Run scaffold script if configured
+    if scaffold_cmd:
+        try:
+            subprocess.run(
+                scaffold_cmd, shell=True, cwd=worktree_path,
+                capture_output=True, timeout=120,
+            )
+        except Exception:
+            pass  # scaffold failure is non-fatal
+
+    # Build feedforward context (Phase 0)
+    feedforward_prefix: str = ""
+    if feedforward_config_dict:
+        try:
+            ff_config = FeedforwardConfig(**feedforward_config_dict)
+            feedforward_prefix = build_feedforward_context(
+                worktree_path, ff_config,
+                component_id=component_id,
+                component_deps=component_deps,
+            )
+        except Exception:
+            pass  # feedforward failure is non-fatal
+
     # Build context prefix from previous retries
     context_prefix: str | None = None
+    parts: list[str] = []
+    if feedforward_prefix:
+        parts.append(feedforward_prefix)
     if previous_context_json:
         ctx = IterationContext.from_json(previous_context_json)
         formatted = ctx.format_for_prompt()
         if formatted.strip():
-            context_prefix = formatted
+            parts.append(formatted)
+    if parts:
+        context_prefix = "\n\n".join(parts)
 
     config = RalphConfig(
-        max_iterations=15,
+        max_iterations=30,
         prompt_file=worktree_prompt,
         prd_file=worktree_prd,
         sleep_seconds=sleep_seconds,
@@ -295,7 +336,18 @@ def run_factory(
     component_contexts: dict[str, str] = {}  # comp_id -> context JSON
 
     if base_config.prompt_file.is_absolute():
-        prompt_file_rel = base_config.prompt_file.relative_to(root_dir).as_posix()
+        try:
+            prompt_file_rel = base_config.prompt_file.relative_to(root_dir).as_posix()
+        except ValueError:
+            # Symlink or mount differences - try with resolved paths
+            try:
+                prompt_file_rel = (
+                    base_config.prompt_file.resolve()
+                    .relative_to(root_dir.resolve())
+                    .as_posix()
+                )
+            except ValueError:
+                prompt_file_rel = str(base_config.prompt_file)
     else:
         prompt_file_rel = str(base_config.prompt_file)
 
@@ -482,6 +534,19 @@ def run_factory(
             manifest.save(manifest_path)
             return None
 
+    # Build feedforward config dict for serialization to worker processes
+    ff_config_dict: dict | None = None
+    if factory_config.feedforward_config and factory_config.feedforward_config.enabled:
+        fc = factory_config.feedforward_config
+        ff_config_dict = {
+            "enabled": fc.enabled,
+            "module_map": fc.module_map,
+            "public_interfaces": fc.public_interfaces,
+            "dependency_graph": fc.dependency_graph,
+            "conventions": fc.conventions,
+            "max_context_tokens": fc.max_context_tokens,
+        }
+
     def _submit_args(comp: Component, wt_path: Path) -> tuple:
         ctx_json = component_contexts.get(comp.id)
         return (
@@ -489,6 +554,9 @@ def run_factory(
             prompt_file_rel, base_config.agent_cmd, base_config.model,
             base_config.model_reasoning_effort, base_config.agent_type,
             base_config.sleep_seconds, ctx_json,
+            ff_config_dict,
+            comp.scaffold or None,
+            comp.dependencies or None,
         )
 
     # Main scheduling loop
@@ -640,5 +708,17 @@ def run_factory(
         factory_result.exit_code = 1
     elif factory_result.skipped and not factory_result.completed:
         factory_result.exit_code = 1
+
+    # Record run to evolution journal
+    try:
+        from ralph_py.evolution import EvolutionConfig, EvolutionJournal
+
+        evo_config = EvolutionConfig()
+        if evo_config.enabled:
+            journal = EvolutionJournal(evo_config)
+            run_id = f"factory-{time.strftime('%Y%m%d-%H%M%S', time.gmtime())}"
+            journal.record_run(run_id, manifest, factory_result)
+    except Exception:
+        pass  # evolution recording is non-fatal
 
     return factory_result

--- a/ralph_py/feedforward.py
+++ b/ralph_py/feedforward.py
@@ -1,0 +1,742 @@
+"""Phase 0: Feedforward controls - structural analysis and convention extraction.
+
+All analysis is computational (no LLM calls). Builds a context string
+to prepend to the agent prompt before each component runs.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+# Directories to always skip during tree walks
+_SKIP_DIRS = frozenset({
+    "__pycache__", "node_modules", ".git", "venv", ".venv", ".ralph",
+})
+
+# Source file extensions we care about
+_SOURCE_EXTENSIONS = frozenset({
+    ".py", ".ts", ".js", ".tsx", ".jsx", ".go", ".rs",
+})
+
+# Max directories in module map to avoid bloat
+_MAX_MODULE_MAP_DIRS = 50
+
+# Max files to scan for public interfaces
+_MAX_PUBLIC_INTERFACE_FILES = 30
+
+
+@dataclass
+class FeedforwardConfig:
+    """Configuration for feedforward context generation."""
+
+    enabled: bool = True
+    module_map: bool = True          # directory tree with LOC counts
+    public_interfaces: bool = True   # extract public symbols
+    dependency_graph: bool = True    # import-based dependency analysis
+    conventions: bool = True         # extract from config files
+    max_context_tokens: int = 4000   # rough cap (estimate 4 chars per token)
+
+
+def _is_hidden(name: str) -> bool:
+    """Check if a file or directory name is hidden (starts with dot)."""
+    return name.startswith(".")
+
+
+def _should_skip_dir(name: str) -> bool:
+    """Check if a directory should be skipped during traversal."""
+    return name in _SKIP_DIRS or _is_hidden(name)
+
+
+def _count_lines(path: Path) -> int:
+    """Count lines in a file. Returns 0 on any error."""
+    try:
+        return len(path.read_text(encoding="utf-8", errors="replace").splitlines())
+    except Exception:
+        return 0
+
+
+def _walk_source_dirs(root: Path) -> list[tuple[Path, int, int]]:
+    """Walk directory tree and collect source directories with file/LOC counts.
+
+    Returns list of (dir_path, file_count, line_count) tuples,
+    sorted by path depth then alphabetically. Capped at _MAX_MODULE_MAP_DIRS.
+    """
+    results: list[tuple[Path, int, int]] = []
+
+    def _walk(directory: Path) -> None:
+        if len(results) >= _MAX_MODULE_MAP_DIRS:
+            return
+
+        try:
+            entries = sorted(directory.iterdir(), key=lambda e: e.name)
+        except PermissionError:
+            return
+
+        file_count = 0
+        line_count = 0
+
+        subdirs: list[Path] = []
+        for entry in entries:
+            if entry.is_dir():
+                if not _should_skip_dir(entry.name):
+                    subdirs.append(entry)
+            elif entry.is_file() and entry.suffix in _SOURCE_EXTENSIONS:
+                file_count += 1
+                line_count += _count_lines(entry)
+
+        if file_count > 0:
+            results.append((directory, file_count, line_count))
+
+        for subdir in subdirs:
+            _walk(subdir)
+
+    _walk(root)
+    return results
+
+
+def build_module_map(root: Path) -> str:
+    """Build an indented tree of source directories with file and LOC counts.
+
+    Skips hidden dirs, __pycache__, node_modules, .git, venv, .venv, .ralph.
+    Caps at 50 directories.
+    """
+    entries = _walk_source_dirs(root)
+    if not entries:
+        return ""
+
+    lines: list[str] = []
+    for dir_path, file_count, line_count in entries:
+        try:
+            rel = dir_path.relative_to(root)
+        except ValueError:
+            continue
+
+        depth = len(rel.parts)
+        indent = "  " * depth
+        dir_name = rel.as_posix() + "/" if depth > 0 else "./"
+
+        if depth > 0:
+            dir_name = rel.name + "/"
+            # Build proper indented name
+            lines.append(
+                f"{indent}{dir_name:<20s} # {file_count} files, {line_count} lines"
+            )
+        else:
+            lines.append(
+                f"{dir_name:<22s} # {file_count} files, {line_count} lines"
+            )
+
+    return "\n".join(lines)
+
+
+def _find_top_source_dirs(root: Path) -> list[Path]:
+    """Find top-level source directories to scan for public interfaces.
+
+    Looks for common patterns: src/, lib/, or a directory matching the project name.
+    Falls back to any directory at root level that contains .py files.
+    """
+    candidates: list[Path] = []
+
+    for name in ("src", "lib"):
+        candidate = root / name
+        if candidate.is_dir():
+            candidates.append(candidate)
+
+    # Look for package directories (contain __init__.py at root level)
+    try:
+        for entry in root.iterdir():
+            if (
+                entry.is_dir()
+                and not _should_skip_dir(entry.name)
+                and not _is_hidden(entry.name)
+                and (entry / "__init__.py").exists()
+                and entry not in candidates
+            ):
+                candidates.append(entry)
+    except PermissionError:
+        pass
+
+    return candidates
+
+
+def _extract_symbols_from_file(filepath: Path) -> list[str]:
+    """Extract public class and function names from a Python file using ast.
+
+    Returns formatted strings like:
+      'class User'
+      'def register_routes(app: FastAPI) -> None'
+    """
+    try:
+        source = filepath.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(source, filename=str(filepath))
+    except (SyntaxError, Exception):
+        return []
+
+    symbols: list[str] = []
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ClassDef):
+            if not node.name.startswith("_"):
+                symbols.append(f"class {node.name}")
+        elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            if not node.name.startswith("_"):
+                sig = _format_function_signature(node)
+                symbols.append(sig)
+
+    return symbols
+
+
+def _format_function_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    """Format a function node into a readable signature string."""
+    prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
+    params: list[str] = []
+
+    for arg in node.args.args:
+        name = arg.arg
+        if name == "self" or name == "cls":
+            continue
+        if arg.annotation:
+            try:
+                ann = ast.unparse(arg.annotation)
+                params.append(f"{name}: {ann}")
+            except Exception:
+                params.append(name)
+        else:
+            params.append(name)
+
+    sig = f"{prefix} {node.name}({', '.join(params)})"
+
+    if node.returns:
+        try:
+            ret = ast.unparse(node.returns)
+            sig += f" -> {ret}"
+        except Exception:
+            pass
+
+    return sig
+
+
+def extract_public_interfaces(root: Path) -> str:
+    """Extract public classes and functions from Python files.
+
+    Skips files starting with '_' or 'test'. Only scans top-level source
+    directories. Caps at 30 files.
+    """
+    source_dirs = _find_top_source_dirs(root)
+    if not source_dirs:
+        return ""
+
+    file_symbols: list[tuple[str, list[str]]] = []
+
+    for src_dir in source_dirs:
+        try:
+            py_files = sorted(src_dir.rglob("*.py"))
+        except PermissionError:
+            continue
+
+        for py_file in py_files:
+            if len(file_symbols) >= _MAX_PUBLIC_INTERFACE_FILES:
+                break
+
+            # Skip private and test files
+            if py_file.name.startswith("_") or py_file.name.startswith("test"):
+                continue
+
+            symbols = _extract_symbols_from_file(py_file)
+            if symbols:
+                try:
+                    rel = py_file.relative_to(root)
+                except ValueError:
+                    continue
+                file_symbols.append((rel.as_posix(), symbols))
+
+    if not file_symbols:
+        return ""
+
+    lines: list[str] = []
+    for filepath, symbols in file_symbols:
+        lines.append(f"{filepath}: {', '.join(symbols)}")
+
+    return "\n".join(lines)
+
+
+def _find_project_package_names(root: Path) -> set[str]:
+    """Identify the project's own package names for internal import detection.
+
+    Looks for directories with __init__.py and src/ subdirectories.
+    """
+    packages: set[str] = set()
+
+    # Check for top-level packages
+    try:
+        for entry in root.iterdir():
+            if (
+                entry.is_dir()
+                and not _should_skip_dir(entry.name)
+                and not _is_hidden(entry.name)
+                and (entry / "__init__.py").exists()
+            ):
+                packages.add(entry.name)
+    except PermissionError:
+        pass
+
+    # Check src/ for packages
+    src = root / "src"
+    if src.is_dir():
+        try:
+            for entry in src.iterdir():
+                if entry.is_dir() and (entry / "__init__.py").exists():
+                    packages.add(entry.name)
+        except PermissionError:
+            pass
+
+    return packages
+
+
+def build_dependency_graph(root: Path) -> str:
+    """Build a module-level dependency graph from Python imports.
+
+    Only tracks internal imports (within the project). Parses all .py files
+    and builds edges between modules.
+    """
+    packages = _find_project_package_names(root)
+    if not packages:
+        return ""
+
+    # Collect all .py files in project packages
+    all_py_files: list[Path] = []
+    for pkg_name in packages:
+        pkg_dir = root / pkg_name
+        if pkg_dir.is_dir():
+            try:
+                all_py_files.extend(sorted(pkg_dir.rglob("*.py")))
+            except PermissionError:
+                pass
+
+    src = root / "src"
+    if src.is_dir():
+        for pkg_name in packages:
+            pkg_dir = src / pkg_name
+            if pkg_dir.is_dir():
+                try:
+                    all_py_files.extend(sorted(pkg_dir.rglob("*.py")))
+                except PermissionError:
+                    pass
+
+    # Parse imports from each file
+    # edges: dict of (source_module -> dict of target_module -> set of imported names)
+    edges: dict[str, dict[str, set[str]]] = {}
+
+    for py_file in all_py_files:
+        try:
+            source = py_file.read_text(encoding="utf-8", errors="replace")
+            tree = ast.parse(source, filename=str(py_file))
+        except (SyntaxError, Exception):
+            continue
+
+        # Determine the module name for this file
+        source_module = _path_to_module(py_file, root, packages)
+        if not source_module:
+            continue
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.module is None:
+                    continue
+                top_level = node.module.split(".")[0]
+                if top_level not in packages:
+                    continue
+
+                target_module = _simplify_module(node.module, packages)
+                if target_module == source_module:
+                    continue
+
+                names = set()
+                for alias in (node.names or []):
+                    if alias.name != "*":
+                        names.add(alias.name)
+
+                if source_module not in edges:
+                    edges[source_module] = {}
+                if target_module not in edges[source_module]:
+                    edges[source_module][target_module] = set()
+                edges[source_module][target_module].update(names)
+
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    top_level = alias.name.split(".")[0]
+                    if top_level not in packages:
+                        continue
+                    target_module = _simplify_module(alias.name, packages)
+                    if target_module == source_module:
+                        continue
+
+                    if source_module not in edges:
+                        edges[source_module] = {}
+                    if target_module not in edges[source_module]:
+                        edges[source_module][target_module] = set()
+
+    if not edges:
+        return ""
+
+    lines: list[str] = []
+    for src_mod in sorted(edges):
+        for tgt_mod in sorted(edges[src_mod]):
+            names = sorted(edges[src_mod][tgt_mod])
+            if names:
+                lines.append(f"{src_mod} -> {tgt_mod} (imports: {', '.join(names)})")
+            else:
+                lines.append(f"{src_mod} -> {tgt_mod}")
+
+    return "\n".join(lines)
+
+
+def _path_to_module(filepath: Path, root: Path, packages: set[str]) -> str | None:
+    """Convert a file path to a simplified module name.
+
+    For example: root/ralph_py/factory.py -> 'factory'
+    """
+    try:
+        rel = filepath.relative_to(root)
+    except ValueError:
+        return None
+
+    parts = list(rel.parts)
+
+    # Strip 'src/' prefix if present
+    if parts and parts[0] == "src":
+        parts = parts[1:]
+
+    if not parts:
+        return None
+
+    # Strip the package name prefix
+    if parts[0] in packages:
+        parts = parts[1:]
+
+    if not parts:
+        return None
+
+    # Convert file to module name
+    module_parts = []
+    for part in parts:
+        if part.endswith(".py"):
+            name = part[:-3]
+            if name == "__init__":
+                continue
+            module_parts.append(name)
+        else:
+            module_parts.append(part)
+
+    return ".".join(module_parts) if module_parts else None
+
+
+def _simplify_module(module_path: str, packages: set[str]) -> str:
+    """Simplify a dotted module path by stripping the top-level package.
+
+    For example: 'ralph_py.factory' -> 'factory'
+    """
+    parts = module_path.split(".")
+    if parts and parts[0] in packages:
+        parts = parts[1:]
+    return ".".join(parts) if parts else module_path
+
+
+def extract_conventions(root: Path) -> str:
+    """Extract coding conventions from config files.
+
+    Reads pyproject.toml, ruff.toml, .editorconfig, tsconfig.json, package.json.
+    Returns a bullet-point list of discovered conventions.
+    """
+    bullets: list[str] = []
+
+    _extract_pyproject_conventions(root, bullets)
+    _extract_ruff_toml_conventions(root, bullets)
+    _extract_editorconfig_conventions(root, bullets)
+    _extract_tsconfig_conventions(root, bullets)
+    _extract_package_json_conventions(root, bullets)
+
+    if not bullets:
+        return ""
+
+    return "\n".join(f"- {b}" for b in bullets)
+
+
+def _extract_pyproject_conventions(root: Path, bullets: list[str]) -> None:
+    """Extract conventions from pyproject.toml."""
+    path = root / "pyproject.toml"
+    if not path.is_file():
+        return
+
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return
+
+    # Python version requirement
+    try:
+        requires_python = data.get("project", {}).get("requires-python")
+        if requires_python:
+            bullets.append(f"Python version: {requires_python}")
+    except Exception:
+        pass
+
+    # Ruff config in pyproject.toml
+    try:
+        ruff = data.get("tool", {}).get("ruff", {})
+        if "line-length" in ruff:
+            bullets.append(f"Line length (ruff): {ruff['line-length']}")
+        if "target-version" in ruff:
+            bullets.append(f"Target version (ruff): {ruff['target-version']}")
+
+        lint = ruff.get("lint", {})
+        if "select" in lint:
+            bullets.append(f"Ruff rules: {', '.join(lint['select'])}")
+    except Exception:
+        pass
+
+    # Black config in pyproject.toml
+    try:
+        black = data.get("tool", {}).get("black", {})
+        if "line-length" in black:
+            bullets.append(f"Line length (black): {black['line-length']}")
+        if "target-version" in black:
+            versions = black["target-version"]
+            if isinstance(versions, list):
+                bullets.append(f"Target versions (black): {', '.join(versions)}")
+    except Exception:
+        pass
+
+
+def _extract_ruff_toml_conventions(root: Path, bullets: list[str]) -> None:
+    """Extract conventions from ruff.toml."""
+    path = root / "ruff.toml"
+    if not path.is_file():
+        return
+
+    try:
+        data = tomllib.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return
+
+    try:
+        if "line-length" in data:
+            bullets.append(f"Line length (ruff.toml): {data['line-length']}")
+        if "target-version" in data:
+            bullets.append(f"Target version (ruff.toml): {data['target-version']}")
+
+        lint = data.get("lint", {})
+        if "select" in lint:
+            bullets.append(f"Ruff rules (ruff.toml): {', '.join(lint['select'])}")
+
+        format_cfg = data.get("format", {})
+        if "quote-style" in format_cfg:
+            bullets.append(f"Quote style: {format_cfg['quote-style']}")
+    except Exception:
+        pass
+
+
+def _extract_editorconfig_conventions(root: Path, bullets: list[str]) -> None:
+    """Extract conventions from .editorconfig."""
+    path = root / ".editorconfig"
+    if not path.is_file():
+        return
+
+    try:
+        content = path.read_text(encoding="utf-8")
+    except Exception:
+        return
+
+    # Simple .editorconfig parsing - just look for key values
+    try:
+        for line in content.splitlines():
+            line = line.strip()
+            if line.startswith("#") or line.startswith(";") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip().lower()
+            value = value.strip()
+
+            if key == "indent_style":
+                bullets.append(f"Indent style: {value}")
+            elif key == "indent_size":
+                bullets.append(f"Indent size: {value}")
+    except Exception:
+        pass
+
+
+def _extract_tsconfig_conventions(root: Path, bullets: list[str]) -> None:
+    """Extract conventions from tsconfig.json."""
+    path = root / "tsconfig.json"
+    if not path.is_file():
+        return
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return
+
+    try:
+        compiler = data.get("compilerOptions", {})
+        if compiler.get("strict"):
+            bullets.append("TypeScript strict mode: enabled")
+        if "target" in compiler:
+            bullets.append(f"TypeScript target: {compiler['target']}")
+    except Exception:
+        pass
+
+
+def _extract_package_json_conventions(root: Path, bullets: list[str]) -> None:
+    """Extract conventions from package.json."""
+    path = root / "package.json"
+    if not path.is_file():
+        return
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return
+
+    try:
+        module_type = data.get("type")
+        if module_type:
+            bullets.append(f"Module type: {module_type}")
+    except Exception:
+        pass
+
+
+def build_feedforward_context(
+    worktree_path: Path,
+    config: FeedforwardConfig | None = None,
+    component_id: str = "",
+    component_deps: list[str] | None = None,
+) -> str:
+    """Build the full feedforward context string for agent prompt injection.
+
+    Main entry point. Calls each sub-function if enabled, assembles into
+    a formatted string with header/footer markers.
+
+    When *component_id* and *component_deps* are provided, the dependency
+    graph section is filtered to show only edges relevant to this component
+    and its direct dependencies.
+
+    Applies max_context_tokens cap by estimating total chars and truncating
+    sections in order of priority (conventions first to drop, module map last).
+    """
+    if config is None:
+        config = FeedforwardConfig()
+
+    if not config.enabled:
+        return ""
+
+    # Build sections in priority order (highest priority first - last to be dropped)
+    # Priority: module_map > dependency_graph > public_interfaces > conventions
+    sections: list[tuple[str, str]] = []
+
+    if config.module_map:
+        try:
+            content = build_module_map(worktree_path)
+            if content:
+                sections.append(("Module map", content))
+        except Exception:
+            pass
+
+    if config.dependency_graph:
+        try:
+            content = build_dependency_graph(worktree_path)
+            # Filter to relevant edges when component context is available
+            if content and component_deps:
+                relevant = set(component_deps)
+                if component_id:
+                    relevant.add(component_id)
+                filtered_lines = []
+                for line in content.splitlines():
+                    # Keep lines that mention any relevant component
+                    if any(dep in line for dep in relevant):
+                        filtered_lines.append(line)
+                if filtered_lines:
+                    content = "\n".join(filtered_lines)
+            if content:
+                sections.append(("Dependency graph", content))
+        except Exception:
+            pass
+
+    if config.public_interfaces:
+        try:
+            content = extract_public_interfaces(worktree_path)
+            if content:
+                sections.append(("Public interfaces", content))
+        except Exception:
+            pass
+
+    if config.conventions:
+        try:
+            content = extract_conventions(worktree_path)
+            if content:
+                sections.append(("Conventions", content))
+        except Exception:
+            pass
+
+    if not sections:
+        return ""
+
+    # Apply token cap by dropping lowest-priority sections first.
+    # Priority order in 'sections' is highest first, so we drop from the end.
+    max_chars = config.max_context_tokens * 4
+    sections = _truncate_to_budget(sections, max_chars)
+
+    if not sections:
+        return ""
+
+    # Assemble final output
+    parts: list[str] = ["=== CODEBASE CONTEXT (auto-generated) ===", ""]
+
+    for heading, content in sections:
+        parts.append(f"## {heading}")
+        parts.append(content)
+        parts.append("")
+
+    parts.append("=== END CODEBASE CONTEXT ===")
+
+    return "\n".join(parts)
+
+
+def _truncate_to_budget(
+    sections: list[tuple[str, str]],
+    max_chars: int,
+) -> list[tuple[str, str]]:
+    """Truncate sections to fit within a character budget.
+
+    Drops lowest-priority sections first (last in list).
+    If still over budget after dropping all but one section,
+    truncates the remaining section content.
+    """
+    # Calculate overhead per section (heading + blank lines)
+    header_footer_overhead = len("=== CODEBASE CONTEXT (auto-generated) ===\n\n") + len(
+        "\n=== END CODEBASE CONTEXT ==="
+    )
+
+    def _total_chars(secs: list[tuple[str, str]]) -> int:
+        total = header_footer_overhead
+        for heading, content in secs:
+            total += len(f"## {heading}\n") + len(content) + len("\n\n")
+        return total
+
+    # Drop lowest-priority sections (end of list) until under budget
+    while sections and _total_chars(sections) > max_chars:
+        if len(sections) == 1:
+            # Last section - truncate content instead of dropping it
+            heading, content = sections[0]
+            available = max_chars - header_footer_overhead - len(f"## {heading}\n") - len("\n\n")
+            if available > 100:
+                truncated = content[:available - 20] + "\n... (truncated)"
+                sections[0] = (heading, truncated)
+            else:
+                sections = []
+            break
+        sections.pop()
+
+    return sections

--- a/ralph_py/fixtures.py
+++ b/ralph_py/fixtures.py
@@ -1,0 +1,492 @@
+"""Approved fixtures - pre-approved input/output pairs for behavioral verification.
+
+Provides behavioral verification independent of agent-generated tests.
+Fixtures are defined in the PRD and checked during Phase 1 mechanical verification.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
+
+from ralph_py.verify import CheckResult
+
+
+@dataclass
+class Fixture:
+    """A single approved fixture - an input/output pair for behavioral verification."""
+
+    description: str
+    fixture_type: str  # "cli", "function", "file"
+    input_data: dict[str, Any]  # type-specific input configuration
+    expected: dict[str, Any]  # type-specific expected output
+
+
+@dataclass
+class FixtureResult:
+    """Result of running a single fixture."""
+
+    fixture: Fixture
+    passed: bool
+    actual: str = ""
+    message: str = ""
+
+
+@dataclass
+class FixturesConfig:
+    """Configuration for the fixtures check."""
+
+    enabled: bool = False
+    snapshot_on_success: bool = True
+    snapshot_dir: Path = field(default_factory=lambda: Path(".ralph/snapshots"))
+    timeout: float = 30.0
+
+
+def run_cli_fixture(
+    fixture: Fixture, cwd: Path, timeout: float,
+) -> FixtureResult:
+    """Run a CLI fixture by executing a command and checking output expectations.
+
+    Checks exit_code, stdout_contains, and stdout_not_contains from expected.
+    """
+    command = fixture.input_data.get("command")
+    if not command:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message="No 'command' in input_data",
+        )
+
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message=f"Command timed out after {timeout}s",
+        )
+    except OSError as exc:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message=f"Failed to run command: {exc}",
+        )
+
+    stdout = result.stdout
+    failures: list[str] = []
+
+    # Check exit code
+    if "exit_code" in fixture.expected:
+        expected_code = fixture.expected["exit_code"]
+        if result.returncode != expected_code:
+            failures.append(
+                f"exit code: expected {expected_code}, got {result.returncode}"
+            )
+
+    # Check stdout_contains
+    for substring in fixture.expected.get("stdout_contains", []):
+        if substring not in stdout:
+            failures.append(f"stdout missing expected string: {substring!r}")
+
+    # Check stdout_not_contains
+    for substring in fixture.expected.get("stdout_not_contains", []):
+        if substring in stdout:
+            failures.append(f"stdout contains forbidden string: {substring!r}")
+
+    if failures:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            actual=stdout,
+            message="; ".join(failures),
+        )
+
+    return FixtureResult(
+        fixture=fixture,
+        passed=True,
+        actual=stdout,
+        message="CLI fixture passed",
+    )
+
+
+def run_function_fixture(fixture: Fixture, cwd: Path) -> FixtureResult:
+    """Run a function fixture by importing a module and calling a function.
+
+    Checks expected return value or expected exception type.
+    """
+    import sys
+
+    module_name = fixture.input_data.get("module")
+    function_name = fixture.input_data.get("function")
+    args = fixture.input_data.get("args", [])
+    kwargs = fixture.input_data.get("kwargs", {})
+
+    if not isinstance(module_name, str) or not module_name:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message="Missing or invalid 'module' in input_data",
+        )
+    if not isinstance(function_name, str) or not function_name:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message="Missing or invalid 'function' in input_data",
+        )
+
+    cwd_str = str(cwd)
+    added_to_path = cwd_str not in sys.path
+    if added_to_path:
+        sys.path.insert(0, cwd_str)
+
+    try:
+        mod = importlib.import_module(module_name)
+
+        func = getattr(mod, function_name, None)
+        if func is None:
+            return FixtureResult(
+                fixture=fixture,
+                passed=False,
+                message=f"Function '{function_name}' not found in module '{module_name}'",
+            )
+
+        # Check if we expect an exception
+        expected_raises = fixture.expected.get("raises")
+        if expected_raises:
+            try:
+                func(*args, **kwargs)
+            except Exception as exc:
+                exc_type_name = type(exc).__name__
+                if exc_type_name == expected_raises:
+                    return FixtureResult(
+                        fixture=fixture,
+                        passed=True,
+                        actual=f"raised {exc_type_name}",
+                        message="Function fixture passed - expected exception raised",
+                    )
+                return FixtureResult(
+                    fixture=fixture,
+                    passed=False,
+                    actual=f"raised {exc_type_name}",
+                    message=f"Expected {expected_raises}, got {exc_type_name}",
+                )
+            return FixtureResult(
+                fixture=fixture,
+                passed=False,
+                actual="no exception raised",
+                message=f"Expected {expected_raises} but no exception was raised",
+            )
+
+        # Normal return value check
+        try:
+            actual = func(*args, **kwargs)
+        except Exception as exc:
+            return FixtureResult(
+                fixture=fixture,
+                passed=False,
+                actual=f"raised {type(exc).__name__}: {exc}",
+                message=f"Unexpected exception: {type(exc).__name__}: {exc}",
+            )
+
+        if "returns" not in fixture.expected:
+            return FixtureResult(
+                fixture=fixture,
+                passed=True,
+                actual=repr(actual),
+                message="Function fixture passed (no expected return specified)",
+            )
+
+        expected_value = fixture.expected["returns"]
+        if actual == expected_value:
+            return FixtureResult(
+                fixture=fixture,
+                passed=True,
+                actual=repr(actual),
+                message="Function fixture passed",
+            )
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            actual=repr(actual),
+            message=f"Expected {expected_value!r}, got {actual!r}",
+        )
+
+    except ImportError as exc:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message=f"Failed to import module '{module_name}': {exc}",
+        )
+    finally:
+        # Clean up sys.modules to force re-import on next call
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+        if added_to_path:
+            try:
+                sys.path.remove(cwd_str)
+            except ValueError:
+                pass
+
+
+def run_file_fixture(fixture: Fixture, cwd: Path) -> FixtureResult:
+    """Run a file fixture by checking file existence and content.
+
+    Checks expected existence, contains, and not_contains expectations.
+    """
+    rel_path = fixture.input_data.get("path")
+    if not rel_path:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message="No 'path' in input_data",
+        )
+
+    full_path = cwd / rel_path
+    file_exists = full_path.exists()
+
+    # Check existence expectation
+    expected_exists = fixture.expected.get("exists", True)
+    if not expected_exists and not file_exists:
+        return FixtureResult(
+            fixture=fixture,
+            passed=True,
+            actual=f"{rel_path} does not exist (as expected)",
+            message="File fixture passed",
+        )
+
+    if expected_exists and not file_exists:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            actual=f"{rel_path} does not exist",
+            message=f"Expected file '{rel_path}' to exist but it does not",
+        )
+
+    if not expected_exists and file_exists:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            actual=f"{rel_path} exists",
+            message=f"Expected file '{rel_path}' to not exist but it does",
+        )
+
+    # File exists and was expected to exist - check content
+    try:
+        content = full_path.read_text()
+    except OSError as exc:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message=f"Failed to read file '{rel_path}': {exc}",
+        )
+
+    failures: list[str] = []
+
+    for substring in fixture.expected.get("contains", []):
+        if substring not in content:
+            failures.append(f"file missing expected string: {substring!r}")
+
+    for substring in fixture.expected.get("not_contains", []):
+        if substring in content:
+            failures.append(f"file contains forbidden string: {substring!r}")
+
+    if failures:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            actual=content[:500],
+            message="; ".join(failures),
+        )
+
+    return FixtureResult(
+        fixture=fixture,
+        passed=True,
+        actual=f"{rel_path} exists with expected content",
+        message="File fixture passed",
+    )
+
+
+def _dispatch_fixture(
+    fixture: Fixture, cwd: Path, timeout: float,
+) -> FixtureResult:
+    """Dispatch a fixture to the appropriate runner."""
+    if fixture.fixture_type == "cli":
+        return run_cli_fixture(fixture, cwd, timeout)
+    if fixture.fixture_type == "function":
+        return run_function_fixture(fixture, cwd)
+    if fixture.fixture_type == "file":
+        return run_file_fixture(fixture, cwd)
+    return FixtureResult(
+        fixture=fixture,
+        passed=False,
+        message=f"Unknown fixture type: {fixture.fixture_type}",
+    )
+
+
+def check_fixtures(
+    fixtures: list[Fixture],
+    cwd: Path,
+    config: FixturesConfig,
+) -> CheckResult:
+    """Run all fixtures and return a single CheckResult for the verification pipeline.
+
+    Each fixture is dispatched to the appropriate runner based on fixture_type.
+    Results are aggregated into one CheckResult compatible with verify.py.
+    """
+    start = time.monotonic()
+
+    if not fixtures:
+        return CheckResult(
+            name="fixtures",
+            passed=True,
+            message="No fixtures defined",
+            duration_seconds=time.monotonic() - start,
+        )
+
+    results: list[FixtureResult] = []
+    details: list[str] = []
+
+    for fixture in fixtures:
+        result = _dispatch_fixture(fixture, cwd, config.timeout)
+        results.append(result)
+
+        status = "PASS" if result.passed else "FAIL"
+        details.append(f"[{status}] {fixture.description}: {result.message}")
+
+    passed_count = sum(1 for r in results if r.passed)
+    total = len(results)
+    all_passed = passed_count == total
+
+    return CheckResult(
+        name="fixtures",
+        passed=all_passed,
+        message=f"{passed_count}/{total} fixtures passed",
+        details=details,
+        duration_seconds=time.monotonic() - start,
+    )
+
+
+def load_fixtures_from_prd_data(prd_data: dict[str, Any]) -> list[Fixture]:
+    """Parse the optional 'fixtures' array from PRD JSON data.
+
+    Returns an empty list if no fixtures field is present.
+    Each fixture entry should have: description, fixture_type, input_data, expected.
+    """
+    raw_fixtures = prd_data.get("fixtures", [])
+    fixtures: list[Fixture] = []
+
+    for entry in raw_fixtures:
+        try:
+            fixture = Fixture(
+                description=entry["description"],
+                fixture_type=entry["fixture_type"],
+                input_data=entry.get("input_data", {}),
+                expected=entry.get("expected", {}),
+            )
+            fixtures.append(fixture)
+        except KeyError:
+            continue
+
+    return fixtures
+
+
+def save_snapshot(
+    component_id: str,
+    fixtures: list[Fixture],
+    results: list[FixtureResult],
+    snapshot_dir: Path,
+) -> None:
+    """Save successful fixture outputs as a JSON snapshot for regression detection.
+
+    Only saves results for fixtures that passed. The snapshot captures the actual
+    output so future runs can detect behavioral regressions.
+    """
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_path = snapshot_dir / f"{component_id}.json"
+
+    snapshot_entries = []
+    for fixture, result in zip(fixtures, results):
+        if result.passed:
+            snapshot_entries.append({
+                "description": fixture.description,
+                "fixture_type": fixture.fixture_type,
+                "actual": result.actual,
+            })
+
+    snapshot_data = {
+        "component_id": component_id,
+        "fixture_count": len(snapshot_entries),
+        "entries": snapshot_entries,
+    }
+
+    snapshot_path.write_text(json.dumps(snapshot_data, indent=2) + "\n")
+
+
+def check_snapshot_regression(
+    component_id: str,
+    results: list[FixtureResult],
+    snapshot_dir: Path,
+) -> list[str]:
+    """Compare current results against saved snapshots to detect regressions.
+
+    Returns a list of regression descriptions. An empty list means no regressions.
+    A regression is detected when a fixture that previously passed now fails,
+    or when its actual output has changed.
+    """
+    snapshot_path = snapshot_dir / f"{component_id}.json"
+
+    if not snapshot_path.exists():
+        return []
+
+    try:
+        snapshot_data = json.loads(snapshot_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return ["Failed to read snapshot file - cannot check for regressions"]
+
+    previous_entries = {
+        entry["description"]: entry
+        for entry in snapshot_data.get("entries", [])
+    }
+
+    regressions: list[str] = []
+
+    for result in results:
+        description = result.fixture.description
+        previous = previous_entries.get(description)
+
+        if previous is None:
+            # New fixture - no regression possible
+            continue
+
+        # Previously passed but now fails
+        if not result.passed:
+            regressions.append(
+                f"Regression in '{description}': previously passed, now fails "
+                f"- {result.message}"
+            )
+            continue
+
+        # Output changed from previous snapshot
+        if result.actual != previous.get("actual", ""):
+            regressions.append(
+                f"Output changed in '{description}': "
+                f"previous={previous.get('actual', '')!r}, "
+                f"current={result.actual!r}"
+            )
+
+    return regressions

--- a/ralph_py/manifest.py
+++ b/ralph_py/manifest.py
@@ -47,6 +47,8 @@ class Component:
     verification_passed: bool | None = None
     review_passed: bool | None = None
     review_findings: str = ""
+    # Optional scaffold script to run before the agent
+    scaffold: str = ""
 
 
 @dataclass
@@ -59,6 +61,49 @@ class Manifest:
     base_branch: str
     single_pr: bool
     components: list[Component] = field(default_factory=list)
+
+    @classmethod
+    def from_prd(
+        cls,
+        prd_path: Path,
+        branch: str,
+        project_name: str = "",
+        base_branch: str = "main",
+    ) -> Manifest:
+        """Create a single-component manifest from an existing PRD.
+
+        Used by ``ralph run`` to delegate to the factory pipeline.
+        If *project_name* is not given, it is derived from the branch name
+        (e.g. ``ralph/auth`` becomes ``auth``) or the PRD file stem.
+        """
+        rel_prd = str(prd_path)
+
+        # Derive a meaningful project name when not provided
+        if not project_name:
+            if branch:
+                # "ralph/auth-service" -> "auth-service"
+                project_name = branch.rsplit("/", 1)[-1]
+            else:
+                project_name = prd_path.stem or "run"
+
+        comp = Component(
+            id="main",
+            title=project_name,
+            description="Single-component run via ralph run",
+            dependencies=[],
+            prd_path=rel_prd,
+            branch_name=branch or f"ralph/{project_name}",
+            status=ComponentStatus.PENDING.value,
+        )
+
+        return cls(
+            version="1",
+            spec_file="",
+            project_name=project_name,
+            base_branch=base_branch,
+            single_pr=False,
+            components=[comp],
+        )
 
     @classmethod
     def load(cls, path: Path) -> Manifest:
@@ -90,6 +135,7 @@ class Manifest:
                 verification_passed=c.get("verificationPassed"),
                 review_passed=c.get("reviewPassed"),
                 review_findings=c.get("reviewFindings", ""),
+                scaffold=c.get("scaffold", ""),
             )
             for c in data["components"]
         ]
@@ -131,6 +177,7 @@ class Manifest:
                     "verificationPassed": c.verification_passed,
                     "reviewPassed": c.review_passed,
                     "reviewFindings": c.review_findings,
+                    "scaffold": c.scaffold,
                 }
                 for c in self.components
             ],
@@ -198,6 +245,7 @@ class Manifest:
             "status", "error", "retries", "prNumber", "prUrl",
             "startedAt", "completedAt", "durationSeconds", "iterationCount",
             "verificationPassed", "reviewPassed", "reviewFindings",
+            "scaffold",
         }
         component_all = component_required | component_optional
 

--- a/ralph_py/parsers.py
+++ b/ralph_py/parsers.py
@@ -1,0 +1,423 @@
+"""Structured output parsers for test runners, type checkers, and linters.
+
+Transforms raw CLI output into structured failure objects that can generate
+LLM-optimized context for retry prompts.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ParsedFailure:
+    """A single structured failure from a tool's output."""
+
+    file: str = ""
+    line: int = 0
+    rule_or_test: str = ""  # test name, error code, or rule ID
+    message: str = ""
+    source_context: str = ""  # relevant source lines if available
+    fix_hint: str = ""  # generated fix suggestion
+
+
+@dataclass
+class ParsedOutput:
+    """Structured parse result from a tool's raw output."""
+
+    tool: str  # "pytest", "mypy", "ruff"
+    total_errors: int = 0
+    failures: list[ParsedFailure] = field(default_factory=list)
+    raw_summary: str = ""  # last line(s) summary from the tool
+
+    def format_for_prompt(
+        self, max_failures: int = 10, include_source: bool = True
+    ) -> list[str]:
+        """Format failures as structured lines optimized for LLM consumption.
+
+        Returns list of detail strings suitable for CheckResult.details.
+        """
+        lines: list[str] = []
+
+        if self.raw_summary:
+            lines.append(f"[{self.tool}] {self.raw_summary}")
+
+        if not self.failures:
+            return lines
+
+        shown = self.failures[:max_failures]
+        for f in shown:
+            location = f.file
+            if f.line:
+                location += f":{f.line}"
+            tag = f.rule_or_test or "error"
+            lines.append(f"  {location} [{tag}] {f.message}")
+
+            if include_source and f.source_context:
+                for ctx_line in f.source_context.splitlines():
+                    lines.append(f"    | {ctx_line}")
+
+            if f.fix_hint:
+                lines.append(f"    hint: {f.fix_hint}")
+
+        remaining = len(self.failures) - len(shown)
+        if remaining > 0:
+            lines.append(f"  ... and {remaining} more errors")
+
+        return lines
+
+
+# ---------------------------------------------------------------------------
+# Pytest parser
+# ---------------------------------------------------------------------------
+
+# Matches: FAILED tests/test_foo.py::test_bar - AssertionError: some message
+_PYTEST_FAILED_RE = re.compile(
+    r"^FAILED\s+(?P<file>[^\s:]+)::(?P<test>[^\s]+)"
+    r"(?:\s+-\s+(?P<message>.+))?$"
+)
+
+# Matches: ERROR tests/test_foo.py - CollectionError
+_PYTEST_ERROR_RE = re.compile(
+    r"^ERROR\s+(?P<file>[^\s:]+)(?:::(?P<test>[^\s]+))?"
+    r"(?:\s+-\s+(?P<message>.+))?$"
+)
+
+# Matches: === 3 failed, 10 passed, 1 error in 4.52s ===
+_PYTEST_SUMMARY_RE = re.compile(
+    r"=+\s+(?P<summary>.+?)\s+=+\s*$"
+)
+
+# Extract failure count from summary like "3 failed"
+_PYTEST_FAILED_COUNT_RE = re.compile(r"(\d+)\s+failed")
+_PYTEST_ERROR_COUNT_RE = re.compile(r"(\d+)\s+error")
+
+
+def parse_pytest_output(raw: str) -> ParsedOutput:
+    """Parse pytest output into structured failures.
+
+    Handles FAILED lines, ERROR lines, and the summary footer.
+    Falls through gracefully on unparseable input.
+    """
+    result = ParsedOutput(tool="pytest")
+
+    if not raw or not raw.strip():
+        result.raw_summary = raw.strip() if raw else ""
+        return result
+
+    lines = raw.splitlines()
+    in_short_summary = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Detect short test summary section
+        if "short test summary info" in stripped.lower():
+            in_short_summary = True
+            continue
+
+        # End of short summary section (next separator line)
+        if in_short_summary and stripped.startswith("=") and stripped.endswith("="):
+            in_short_summary = False
+            # This is likely the final summary line - fall through to summary match
+
+        # Parse FAILED lines (appear in short summary or standalone)
+        m = _PYTEST_FAILED_RE.match(stripped)
+        if m:
+            result.failures.append(ParsedFailure(
+                file=m.group("file"),
+                rule_or_test=m.group("test"),
+                message=m.group("message") or "",
+            ))
+            continue
+
+        # Parse ERROR lines
+        m = _PYTEST_ERROR_RE.match(stripped)
+        if m:
+            result.failures.append(ParsedFailure(
+                file=m.group("file"),
+                rule_or_test=m.group("test") or "collection",
+                message=m.group("message") or "",
+            ))
+            continue
+
+        # Parse summary line
+        m = _PYTEST_SUMMARY_RE.match(stripped)
+        if m:
+            result.raw_summary = m.group("summary").strip()
+
+    # Extract total error count from summary
+    if result.raw_summary:
+        failed_m = _PYTEST_FAILED_COUNT_RE.search(result.raw_summary)
+        error_m = _PYTEST_ERROR_COUNT_RE.search(result.raw_summary)
+        count = 0
+        if failed_m:
+            count += int(failed_m.group(1))
+        if error_m:
+            count += int(error_m.group(1))
+        result.total_errors = count
+    else:
+        result.total_errors = len(result.failures)
+
+    # Fallback: if we parsed nothing useful, preserve raw tail as summary
+    if not result.failures and not result.raw_summary:
+        tail = lines[-5:] if len(lines) > 5 else lines
+        result.raw_summary = "\n".join(tail)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Mypy parser
+# ---------------------------------------------------------------------------
+
+# Matches: file.py:10: error: Incompatible types [assignment]
+_MYPY_ERROR_RE = re.compile(
+    r"^(?P<file>[^:]+):(?P<line>\d+):\s+error:\s+(?P<message>.+?)(?:\s+\[(?P<code>[^\]]+)\])?\s*$"
+)
+
+# Matches: Found 5 errors in 3 files (checked 12 source files)
+_MYPY_SUMMARY_RE = re.compile(
+    r"Found\s+(?P<count>\d+)\s+error[s]?\s+in\s+(?P<files>\d+)\s+file"
+)
+
+
+def parse_mypy_output(raw: str) -> ParsedOutput:
+    """Parse mypy output into structured failures.
+
+    Handles per-line error messages and the summary footer.
+    Falls through gracefully on unparseable input.
+    """
+    result = ParsedOutput(tool="mypy")
+
+    if not raw or not raw.strip():
+        result.raw_summary = raw.strip() if raw else ""
+        return result
+
+    lines = raw.splitlines()
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Parse error lines
+        m = _MYPY_ERROR_RE.match(stripped)
+        if m:
+            result.failures.append(ParsedFailure(
+                file=m.group("file"),
+                line=int(m.group("line")),
+                rule_or_test=m.group("code") or "",
+                message=m.group("message"),
+            ))
+            continue
+
+        # Parse summary line
+        m = _MYPY_SUMMARY_RE.search(stripped)
+        if m:
+            result.raw_summary = stripped
+            result.total_errors = int(m.group("count"))
+
+    # Fallback total from parsed failures
+    if result.total_errors == 0:
+        result.total_errors = len(result.failures)
+
+    # Fallback summary
+    if not result.failures and not result.raw_summary:
+        tail = lines[-3:] if len(lines) > 3 else lines
+        result.raw_summary = "\n".join(tail)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Ruff parser
+# ---------------------------------------------------------------------------
+
+# Matches: file.py:10:5: E501 Line too long (82 > 79)
+_RUFF_ERROR_RE = re.compile(
+    r"^(?P<file>[^:]+):(?P<line>\d+):(?P<col>\d+):\s+(?P<rule>\S+)\s+(?P<message>.+)$"
+)
+
+# Matches: Found 12 errors.  /  Found 12 errors (8 fixed, 4 remaining).
+_RUFF_SUMMARY_RE = re.compile(
+    r"Found\s+(?P<count>\d+)\s+error"
+)
+
+
+def parse_ruff_output(raw: str) -> ParsedOutput:
+    """Parse ruff output into structured failures.
+
+    Handles per-line diagnostics and the summary footer.
+    Falls through gracefully on unparseable input.
+    """
+    result = ParsedOutput(tool="ruff")
+
+    if not raw or not raw.strip():
+        result.raw_summary = raw.strip() if raw else ""
+        return result
+
+    lines = raw.splitlines()
+
+    for line in lines:
+        stripped = line.strip()
+
+        # Parse error lines
+        m = _RUFF_ERROR_RE.match(stripped)
+        if m:
+            result.failures.append(ParsedFailure(
+                file=m.group("file"),
+                line=int(m.group("line")),
+                rule_or_test=m.group("rule"),
+                message=m.group("message"),
+            ))
+            continue
+
+        # Parse summary line
+        m = _RUFF_SUMMARY_RE.search(stripped)
+        if m:
+            result.raw_summary = stripped
+            result.total_errors = int(m.group("count"))
+
+    # Fallback total from parsed failures
+    if result.total_errors == 0:
+        result.total_errors = len(result.failures)
+
+    # Fallback summary
+    if not result.failures and not result.raw_summary:
+        tail = lines[-3:] if len(lines) > 3 else lines
+        result.raw_summary = "\n".join(tail)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Source context helper
+# ---------------------------------------------------------------------------
+
+
+def add_source_context(
+    failure: ParsedFailure, worktree_path: Path, context_lines: int = 3
+) -> None:
+    """Read the source file and add surrounding lines to the failure.
+
+    Reads `context_lines` above and below the failure line.
+    Silently does nothing if the file cannot be read or the line is invalid.
+    """
+    if not failure.file or failure.line <= 0:
+        return
+
+    source_path = worktree_path / failure.file
+    if not source_path.is_file():
+        return
+
+    try:
+        file_lines = source_path.read_text().splitlines()
+    except (OSError, UnicodeDecodeError):
+        return
+
+    total = len(file_lines)
+    if failure.line > total:
+        return
+
+    start = max(0, failure.line - 1 - context_lines)
+    end = min(total, failure.line + context_lines)
+    snippet_lines: list[str] = []
+    for i in range(start, end):
+        marker = ">" if i == failure.line - 1 else " "
+        snippet_lines.append(f"{marker} {i + 1:4d} | {file_lines[i]}")
+
+    failure.source_context = "\n".join(snippet_lines)
+
+
+# ---------------------------------------------------------------------------
+# Fix hint generator
+# ---------------------------------------------------------------------------
+
+# Each entry: (compiled regex matching the message, hint template)
+# Use {m} in the template to interpolate the regex match object.
+_HINT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Missing positional argument
+    (
+        re.compile(r"missing (\d+) required positional argument", re.IGNORECASE),
+        "Check the function signature - a required argument is missing from the call.",
+    ),
+    # Too many arguments
+    (
+        re.compile(r"takes \d+ positional arguments? but \d+ (?:was|were) given", re.IGNORECASE),
+        "Too many arguments passed - check the function signature for expected parameters.",
+    ),
+    # Optional type not handled (str | None assigned to str, etc.)
+    (
+        re.compile(
+            r"Incompatible types in assignment.*"
+            r"(?:Optional|None)",
+            re.IGNORECASE,
+        ),
+        "The value can be None - add a None check or guard before using it.",
+    ),
+    (
+        re.compile(r'has no attribute "([^"]+)"', re.IGNORECASE),
+        "Attribute not found - check for typos or verify the object type.",
+    ),
+    # Import errors
+    (
+        re.compile(r"(?:No module named|cannot import name|ModuleNotFoundError)", re.IGNORECASE),
+        "Import failed - verify the module is installed and the name is correct.",
+    ),
+    # Name not defined
+    (
+        re.compile(r"name '([^']+)' is not defined", re.IGNORECASE),
+        "Undefined name - check for typos or add the missing import.",
+    ),
+    # Argument type mismatch
+    (
+        re.compile(
+            r'Argument.*has incompatible type "([^"]+)".*expected "([^"]+)"',
+            re.IGNORECASE,
+        ),
+        "Type mismatch in argument - convert or check the value before passing it.",
+    ),
+    # Return type mismatch
+    (
+        re.compile(r"Incompatible return value type", re.IGNORECASE),
+        "Return type does not match the declared signature - fix the return value or annotation.",
+    ),
+    # Assert / comparison failures
+    (
+        re.compile(r"AssertionError|assert .+ == .+", re.IGNORECASE),
+        "Assertion failed - check the expected vs actual values.",
+    ),
+    # Ruff: unused import
+    (
+        re.compile(r"F401", re.IGNORECASE),
+        "Unused import - remove it or use it.",
+    ),
+    # Ruff: undefined name
+    (
+        re.compile(r"F821", re.IGNORECASE),
+        "Undefined name - add the missing import or definition.",
+    ),
+    # Ruff: line too long
+    (
+        re.compile(r"E501", re.IGNORECASE),
+        "Line too long - break it up or shorten the expression.",
+    ),
+]
+
+
+def generate_fix_hint(failure: ParsedFailure) -> str:
+    """Generate a fix hint for common error patterns.
+
+    Uses pattern matching against the failure message and rule.
+    Returns an empty string for uncommon patterns - no hint is better
+    than a bad one.
+    """
+    # Combine message and rule for matching since ruff rules appear in rule_or_test
+    text = f"{failure.message} {failure.rule_or_test}"
+
+    for pattern, hint in _HINT_PATTERNS:
+        if pattern.search(text):
+            return hint
+
+    return ""

--- a/ralph_py/verify.py
+++ b/ralph_py/verify.py
@@ -12,6 +12,14 @@ from pathlib import Path
 
 from ralph_py import git
 from ralph_py.guards import path_is_allowed
+from ralph_py.parsers import (
+    ParsedOutput,
+    add_source_context,
+    generate_fix_hint,
+    parse_mypy_output,
+    parse_pytest_output,
+    parse_ruff_output,
+)
 from ralph_py.prd import PRD
 
 
@@ -24,6 +32,7 @@ class CheckResult:
     message: str = ""
     details: list[str] = field(default_factory=list)
     duration_seconds: float = 0.0
+    parsed: ParsedOutput | None = None
 
 
 @dataclass
@@ -141,13 +150,18 @@ def check_test_suite(
 
     if result.returncode != 0:
         output = (result.stdout + result.stderr).strip()
-        last_lines = output.splitlines()[-50:] if output else []
+        parsed = parse_pytest_output(output)
+        for failure in parsed.failures:
+            add_source_context(failure, cwd)
+            if not failure.fix_hint:
+                failure.fix_hint = generate_fix_hint(failure)
         return CheckResult(
             name="test_suite",
             passed=False,
             message=f"Tests failed (exit code {result.returncode})",
-            details=last_lines,
+            details=parsed.format_for_prompt(),
             duration_seconds=time.monotonic() - start,
+            parsed=parsed,
         )
 
     return CheckResult(
@@ -180,13 +194,18 @@ def check_typecheck(
 
     if result.returncode != 0:
         output = (result.stdout + result.stderr).strip()
-        last_lines = output.splitlines()[-30:] if output else []
+        parsed = parse_mypy_output(output)
+        for failure in parsed.failures:
+            add_source_context(failure, cwd)
+            if not failure.fix_hint:
+                failure.fix_hint = generate_fix_hint(failure)
         return CheckResult(
             name="typecheck",
             passed=False,
             message=f"Typecheck failed (exit code {result.returncode})",
-            details=last_lines,
+            details=parsed.format_for_prompt(),
             duration_seconds=time.monotonic() - start,
+            parsed=parsed,
         )
 
     return CheckResult(
@@ -219,13 +238,18 @@ def check_linter(
 
     if result.returncode != 0:
         output = (result.stdout + result.stderr).strip()
-        last_lines = output.splitlines()[-30:] if output else []
+        parsed = parse_ruff_output(output)
+        for failure in parsed.failures:
+            add_source_context(failure, cwd)
+            if not failure.fix_hint:
+                failure.fix_hint = generate_fix_hint(failure)
         return CheckResult(
             name="linter",
             passed=False,
             message=f"Linter failed (exit code {result.returncode})",
-            details=last_lines,
+            details=parsed.format_for_prompt(),
             duration_seconds=time.monotonic() - start,
+            parsed=parsed,
         )
 
     return CheckResult(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,6 +94,7 @@ class TestCliValidation:
                 "printf '<promise>COMPLETE</promise>\\n'",
                 "--sleep",
                 "0",
+                "--legacy",
             ],
             env={
                 "PROMPT_FILE": str(ralph_dir / "prompt.md"),

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -1,0 +1,253 @@
+"""Tests for evolution module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ralph_py.evolution import (
+    EvolutionConfig,
+    EvolutionJournal,
+    FailurePattern,
+)
+from ralph_py.factory import FactoryResult
+from ralph_py.manifest import Component, ComponentStatus, Manifest
+
+
+def _make_manifest(
+    components: list[Component] | None = None,
+) -> Manifest:
+    """Build a minimal manifest for testing."""
+    return Manifest(
+        version="1",
+        spec_file="spec.md",
+        project_name="test-project",
+        base_branch="main",
+        single_pr=False,
+        components=components or [],
+    )
+
+
+def _make_component(
+    id: str,
+    status: str = ComponentStatus.PENDING.value,
+    error: str = "",
+    retries: int = 0,
+    duration_seconds: float = 0.0,
+    iteration_count: int = 0,
+) -> Component:
+    return Component(
+        id=id,
+        title=f"Component {id}",
+        description=f"Description of {id}",
+        dependencies=[],
+        prd_path=f"prd/{id}.json",
+        branch_name=f"ralph/{id}",
+        status=status,
+        error=error,
+        retries=retries,
+        duration_seconds=duration_seconds,
+        iteration_count=iteration_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# EvolutionConfig defaults
+# ---------------------------------------------------------------------------
+
+
+class TestEvolutionConfigDefaults:
+    def test_evolution_config_defaults(self) -> None:
+        config = EvolutionConfig()
+        assert config.enabled is True
+        assert config.min_pattern_frequency == 2
+        assert config.lookback_runs == 10
+        assert config.auto_propose is True
+        assert config.auto_apply_computational is False
+        assert str(config.journal_path).endswith("evolution.jsonl")
+        assert str(config.experiments_path).endswith("experiments.tsv")
+
+
+# ---------------------------------------------------------------------------
+# record_run
+# ---------------------------------------------------------------------------
+
+
+class TestRecordRun:
+    def test_record_run_creates_files(self, tmp_path: Path) -> None:
+        journal_path = tmp_path / "evolution.jsonl"
+        experiments_path = tmp_path / "experiments.tsv"
+        config = EvolutionConfig(
+            journal_path=journal_path,
+            experiments_path=experiments_path,
+        )
+        journal = EvolutionJournal(config)
+
+        manifest = _make_manifest([
+            _make_component("a", status=ComponentStatus.COMPLETED.value,
+                            duration_seconds=10.0, iteration_count=2),
+            _make_component("b", status=ComponentStatus.FAILED.value,
+                            error="pytest: assert 1 == 2", retries=3,
+                            duration_seconds=5.0, iteration_count=1),
+        ])
+        factory_result = FactoryResult(completed=["a"], failed=["b"], skipped=[])
+
+        journal.record_run("run-001", manifest, factory_result)
+
+        # JSONL file should exist with 2 entries (one per component).
+        assert journal_path.exists()
+        lines = journal_path.read_text().strip().splitlines()
+        assert len(lines) == 2
+        entry_a = json.loads(lines[0])
+        assert entry_a["component_id"] == "a"
+        assert entry_a["run_id"] == "run-001"
+        entry_b = json.loads(lines[1])
+        assert entry_b["component_id"] == "b"
+        assert entry_b["status"] == ComponentStatus.FAILED.value
+
+        # TSV file should exist with a header and one data row.
+        assert experiments_path.exists()
+        tsv_lines = experiments_path.read_text().strip().splitlines()
+        assert len(tsv_lines) == 2  # header + data row
+        assert "run-001" in tsv_lines[1]
+
+
+# ---------------------------------------------------------------------------
+# extract_failure_patterns
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFailurePatterns:
+    def test_extract_failure_patterns(self) -> None:
+        config = EvolutionConfig()
+        journal = EvolutionJournal(config)
+
+        manifest = _make_manifest([
+            _make_component("a", status=ComponentStatus.FAILED.value,
+                            error="ruff: S608 violation", retries=1),
+            _make_component("b", status=ComponentStatus.FAILED.value,
+                            error="ruff: S608 violation", retries=2),
+            _make_component("c", status=ComponentStatus.COMPLETED.value),
+        ])
+
+        patterns = journal.extract_failure_patterns(manifest, min_frequency=2)
+        assert len(patterns) >= 1
+        # Both a and b share the S608 signature
+        assert any("S608" in p.error_signature for p in patterns)
+        assert any(p.frequency >= 2 for p in patterns)
+
+    def test_extract_failure_patterns_no_failures(self) -> None:
+        config = EvolutionConfig()
+        journal = EvolutionJournal(config)
+        manifest = _make_manifest([
+            _make_component("a", status=ComponentStatus.COMPLETED.value),
+        ])
+        patterns = journal.extract_failure_patterns(manifest)
+        assert patterns == []
+
+
+# ---------------------------------------------------------------------------
+# get_experiment_trends
+# ---------------------------------------------------------------------------
+
+
+class TestGetExperimentTrends:
+    def test_get_experiment_trends(self, tmp_path: Path) -> None:
+        tsv_path = tmp_path / "experiments.tsv"
+        tsv_path.write_text(
+            "run_id\ttimestamp\tproject\tcomponents_total\tcompleted\tfailed\t"
+            "skipped\tavg_iterations\tavg_duration_s\tretry_rate\tcommon_failure\n"
+            "run-001\t2025-01-01T00:00:00Z\ttest\t3\t2\t1\t0\t1.50\t10.0\t0.33\tS608\n"
+            "run-002\t2025-01-02T00:00:00Z\ttest\t3\t3\t0\t0\t1.00\t8.0\t0.00\t\n"
+        )
+
+        config = EvolutionConfig(experiments_path=tsv_path)
+        journal = EvolutionJournal(config)
+        trends = journal.get_experiment_trends(last_n=10)
+        assert len(trends) == 2
+        assert trends[0]["run_id"] == "run-001"
+        assert trends[1]["completed"] == "3"
+
+    def test_get_experiment_trends_missing_file(self, tmp_path: Path) -> None:
+        config = EvolutionConfig(experiments_path=tmp_path / "nonexistent.tsv")
+        journal = EvolutionJournal(config)
+        trends = journal.get_experiment_trends()
+        assert trends == []
+
+
+# ---------------------------------------------------------------------------
+# propose_improvements
+# ---------------------------------------------------------------------------
+
+
+class TestProposeImprovements:
+    def test_propose_improvements(self) -> None:
+        config = EvolutionConfig()
+        journal = EvolutionJournal(config)
+
+        patterns = [
+            FailurePattern(
+                description="linter failure 'S608' in 3/5 components",
+                frequency=3,
+                total_components=5,
+                affected_components=["a", "b", "c"],
+                check_name="linter",
+                error_signature="S608",
+                category="verification",
+            ),
+            FailurePattern(
+                description="test_suite failure 'assert-mismatch' in 2/5 components",
+                frequency=2,
+                total_components=5,
+                affected_components=["d", "e"],
+                check_name="test_suite",
+                error_signature="assert-mismatch",
+                category="verification",
+            ),
+        ]
+
+        proposals = journal.propose_improvements(patterns)
+        assert len(proposals) == 2
+        assert proposals[0].id == "PROP-001"
+        assert "S608" in proposals[0].title
+        assert proposals[0].target == "claude_md"
+        assert proposals[1].target == "feedforward_config"
+
+    def test_propose_improvements_empty(self) -> None:
+        config = EvolutionConfig()
+        journal = EvolutionJournal(config)
+        proposals = journal.propose_improvements([])
+        assert proposals == []
+
+
+# ---------------------------------------------------------------------------
+# save_proposals
+# ---------------------------------------------------------------------------
+
+
+class TestSaveProposals:
+    def test_save_proposals(self, tmp_path: Path) -> None:
+        config = EvolutionConfig()
+        journal = EvolutionJournal(config)
+
+        patterns = [
+            FailurePattern(
+                description="linter failure 'E501' in 4/6 components",
+                frequency=4,
+                total_components=6,
+                affected_components=["a", "b", "c", "d"],
+                check_name="linter",
+                error_signature="E501",
+                category="verification",
+            ),
+        ]
+        proposals = journal.propose_improvements(patterns)
+
+        output_dir = tmp_path / "proposals"
+        written = journal.save_proposals(proposals, output_dir)
+        assert len(written) == 1
+        assert written[0].name == "prop-001.md"
+        content = written[0].read_text()
+        assert "PROP-001" in content
+        assert "E501" in content
+        assert "computational" in content

--- a/tests/test_feedforward.py
+++ b/tests/test_feedforward.py
@@ -1,0 +1,222 @@
+"""Tests for feedforward module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ralph_py.feedforward import (
+    FeedforwardConfig,
+    build_dependency_graph,
+    build_feedforward_context,
+    build_module_map,
+    extract_conventions,
+    extract_public_interfaces,
+)
+
+
+# ---------------------------------------------------------------------------
+# build_module_map
+# ---------------------------------------------------------------------------
+
+
+class TestBuildModuleMap:
+    def test_build_module_map(self, tmp_path: Path) -> None:
+        # Create a small project structure with source files.
+        pkg = tmp_path / "mypackage"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "core.py").write_text("x = 1\ny = 2\n")
+        (pkg / "utils.py").write_text("def helper():\n    pass\n")
+
+        result = build_module_map(tmp_path)
+        assert "mypackage/" in result
+        # __init__.py, core.py, utils.py are all .py so count is 3
+        assert "3 files" in result
+        assert result != ""
+
+    def test_build_module_map_empty(self, tmp_path: Path) -> None:
+        result = build_module_map(tmp_path)
+        assert result == ""
+
+    def test_build_module_map_skips_hidden(self, tmp_path: Path) -> None:
+        hidden = tmp_path / ".hidden"
+        hidden.mkdir()
+        (hidden / "secret.py").write_text("x = 1\n")
+
+        visible = tmp_path / "visible"
+        visible.mkdir()
+        (visible / "code.py").write_text("y = 2\n")
+
+        result = build_module_map(tmp_path)
+        assert ".hidden" not in result
+        assert "visible/" in result
+
+
+# ---------------------------------------------------------------------------
+# extract_public_interfaces
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPublicInterfaces:
+    def test_extract_public_interfaces(self, tmp_path: Path) -> None:
+        pkg = tmp_path / "mylib"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "models.py").write_text(
+            "class User:\n"
+            "    pass\n"
+            "\n"
+            "class _Internal:\n"
+            "    pass\n"
+            "\n"
+            "def create_user(name: str) -> User:\n"
+            "    pass\n"
+            "\n"
+            "def _private_helper():\n"
+            "    pass\n"
+        )
+
+        result = extract_public_interfaces(tmp_path)
+        assert "class User" in result
+        assert "_Internal" not in result
+        assert "create_user" in result
+        assert "_private_helper" not in result
+
+    def test_extract_public_interfaces_empty(self, tmp_path: Path) -> None:
+        result = extract_public_interfaces(tmp_path)
+        assert result == ""
+
+    def test_extract_public_interfaces_skips_test_files(self, tmp_path: Path) -> None:
+        pkg = tmp_path / "mylib"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "test_models.py").write_text("class TestUser:\n    pass\n")
+        (pkg / "core.py").write_text("class Engine:\n    pass\n")
+
+        result = extract_public_interfaces(tmp_path)
+        assert "TestUser" not in result
+        assert "Engine" in result
+
+
+# ---------------------------------------------------------------------------
+# build_dependency_graph
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDependencyGraph:
+    def test_build_dependency_graph(self, tmp_path: Path) -> None:
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "models.py").write_text("class Foo:\n    pass\n")
+        (pkg / "service.py").write_text(
+            "from mypkg.models import Foo\n"
+            "\n"
+            "def run(f: Foo) -> None:\n"
+            "    pass\n"
+        )
+
+        result = build_dependency_graph(tmp_path)
+        assert "service" in result
+        assert "models" in result
+        assert "Foo" in result
+
+    def test_build_dependency_graph_no_packages(self, tmp_path: Path) -> None:
+        # No __init__.py means no packages detected
+        subdir = tmp_path / "plain"
+        subdir.mkdir()
+        (subdir / "code.py").write_text("import os\n")
+
+        result = build_dependency_graph(tmp_path)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# extract_conventions
+# ---------------------------------------------------------------------------
+
+
+class TestExtractConventions:
+    def test_extract_conventions_pyproject(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\n'
+            'requires-python = ">=3.11"\n'
+            '\n'
+            '[tool.ruff]\n'
+            'line-length = 100\n'
+            'target-version = "py311"\n'
+            '\n'
+            '[tool.ruff.lint]\n'
+            'select = ["E", "F", "W"]\n'
+        )
+
+        result = extract_conventions(tmp_path)
+        assert "Python version: >=3.11" in result
+        assert "Line length (ruff): 100" in result
+        assert "Target version (ruff): py311" in result
+        assert "Ruff rules: E, F, W" in result
+
+    def test_extract_conventions_empty(self, tmp_path: Path) -> None:
+        result = extract_conventions(tmp_path)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# build_feedforward_context
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFeedforwardContext:
+    def test_build_feedforward_context_disabled(self, tmp_path: Path) -> None:
+        config = FeedforwardConfig(enabled=False)
+        result = build_feedforward_context(tmp_path, config)
+        assert result == ""
+
+    def test_build_feedforward_context_full(self, tmp_path: Path) -> None:
+        # Set up a minimal project so some sections produce output.
+        pkg = tmp_path / "testpkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        (pkg / "core.py").write_text(
+            "class Widget:\n"
+            "    pass\n"
+            "\n"
+            "def build_widget(name: str) -> Widget:\n"
+            "    pass\n"
+        )
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\n'
+            'requires-python = ">=3.11"\n'
+        )
+
+        config = FeedforwardConfig(enabled=True)
+        result = build_feedforward_context(tmp_path, config)
+        assert "CODEBASE CONTEXT" in result
+        assert "END CODEBASE CONTEXT" in result
+        # Should contain at least one section header
+        assert "##" in result
+
+    def test_build_feedforward_context_empty_project(self, tmp_path: Path) -> None:
+        config = FeedforwardConfig(enabled=True)
+        result = build_feedforward_context(tmp_path, config)
+        # No source files, no config files - should return empty
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# FeedforwardConfig defaults
+# ---------------------------------------------------------------------------
+
+
+class TestFeedforwardConfigDefaults:
+    def test_feedforward_config_defaults(self) -> None:
+        config = FeedforwardConfig()
+        assert config.enabled is True
+        assert config.module_map is True
+        assert config.public_interfaces is True
+        assert config.dependency_graph is True
+        assert config.conventions is True
+        assert config.max_context_tokens == 4000

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,318 @@
+"""Tests for fixtures module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ralph_py.fixtures import (
+    Fixture,
+    FixtureResult,
+    FixturesConfig,
+    check_fixtures,
+    check_snapshot_regression,
+    load_fixtures_from_prd_data,
+    run_cli_fixture,
+    run_file_fixture,
+    save_snapshot,
+)
+
+
+# ---------------------------------------------------------------------------
+# FixturesConfig defaults
+# ---------------------------------------------------------------------------
+
+
+class TestFixtureConfigDefaults:
+    def test_fixture_config_defaults(self) -> None:
+        config = FixturesConfig()
+        assert config.enabled is False
+        assert config.snapshot_on_success is True
+        assert config.timeout == 30.0
+        assert str(config.snapshot_dir).endswith("snapshots")
+
+
+# ---------------------------------------------------------------------------
+# run_cli_fixture
+# ---------------------------------------------------------------------------
+
+
+class TestRunCliFixture:
+    def test_run_cli_fixture_success(self, tmp_path: Path) -> None:
+        fixture = Fixture(
+            description="echo test",
+            fixture_type="cli",
+            input_data={"command": "echo hello"},
+            expected={"exit_code": 0, "stdout_contains": ["hello"]},
+        )
+        result = run_cli_fixture(fixture, tmp_path, timeout=5.0)
+        assert result.passed is True
+        assert "hello" in result.actual
+
+    def test_run_cli_fixture_failure(self, tmp_path: Path) -> None:
+        fixture = Fixture(
+            description="false command",
+            fixture_type="cli",
+            input_data={"command": "false"},
+            expected={"exit_code": 0},
+        )
+        result = run_cli_fixture(fixture, tmp_path, timeout=5.0)
+        assert result.passed is False
+        assert "exit code" in result.message
+
+    def test_run_cli_fixture_no_command(self, tmp_path: Path) -> None:
+        fixture = Fixture(
+            description="no command",
+            fixture_type="cli",
+            input_data={},
+            expected={},
+        )
+        result = run_cli_fixture(fixture, tmp_path, timeout=5.0)
+        assert result.passed is False
+        assert "No 'command'" in result.message
+
+    def test_run_cli_fixture_stdout_not_contains(self, tmp_path: Path) -> None:
+        fixture = Fixture(
+            description="check forbidden output",
+            fixture_type="cli",
+            input_data={"command": "echo secret"},
+            expected={"exit_code": 0, "stdout_not_contains": ["secret"]},
+        )
+        result = run_cli_fixture(fixture, tmp_path, timeout=5.0)
+        assert result.passed is False
+        assert "forbidden" in result.message
+
+
+# ---------------------------------------------------------------------------
+# run_file_fixture
+# ---------------------------------------------------------------------------
+
+
+class TestRunFileFixture:
+    def test_run_file_fixture_exists(self, tmp_path: Path) -> None:
+        target = tmp_path / "output.txt"
+        target.write_text("generated content\n")
+
+        fixture = Fixture(
+            description="check output file exists",
+            fixture_type="file",
+            input_data={"path": "output.txt"},
+            expected={"exists": True},
+        )
+        result = run_file_fixture(fixture, tmp_path)
+        assert result.passed is True
+
+    def test_run_file_fixture_missing(self, tmp_path: Path) -> None:
+        fixture = Fixture(
+            description="check missing file",
+            fixture_type="file",
+            input_data={"path": "nonexistent.txt"},
+            expected={"exists": True},
+        )
+        result = run_file_fixture(fixture, tmp_path)
+        assert result.passed is False
+        assert "exist" in result.message
+
+    def test_run_file_fixture_contains(self, tmp_path: Path) -> None:
+        target = tmp_path / "readme.md"
+        target.write_text("# My Project\nThis is the readme.\n")
+
+        fixture = Fixture(
+            description="readme has title",
+            fixture_type="file",
+            input_data={"path": "readme.md"},
+            expected={"exists": True, "contains": ["# My Project"]},
+        )
+        result = run_file_fixture(fixture, tmp_path)
+        assert result.passed is True
+
+    def test_run_file_fixture_contains_failure(self, tmp_path: Path) -> None:
+        target = tmp_path / "readme.md"
+        target.write_text("# Other Title\n")
+
+        fixture = Fixture(
+            description="readme has expected title",
+            fixture_type="file",
+            input_data={"path": "readme.md"},
+            expected={"contains": ["# My Project"]},
+        )
+        result = run_file_fixture(fixture, tmp_path)
+        assert result.passed is False
+        assert "missing expected string" in result.message
+
+    def test_run_file_fixture_expected_missing(self, tmp_path: Path) -> None:
+        """Test that expecting a file to not exist passes when it is absent."""
+        fixture = Fixture(
+            description="file should not exist",
+            fixture_type="file",
+            input_data={"path": "gone.txt"},
+            expected={"exists": False},
+        )
+        result = run_file_fixture(fixture, tmp_path)
+        assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# load_fixtures_from_prd_data
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFixturesFromPrdData:
+    def test_load_fixtures_from_prd_data(self) -> None:
+        prd_data = {
+            "fixtures": [
+                {
+                    "description": "echo test",
+                    "fixture_type": "cli",
+                    "input_data": {"command": "echo hi"},
+                    "expected": {"exit_code": 0},
+                },
+                {
+                    "description": "file check",
+                    "fixture_type": "file",
+                    "input_data": {"path": "out.txt"},
+                    "expected": {"exists": True},
+                },
+            ]
+        }
+        fixtures = load_fixtures_from_prd_data(prd_data)
+        assert len(fixtures) == 2
+        assert fixtures[0].fixture_type == "cli"
+        assert fixtures[1].fixture_type == "file"
+
+    def test_load_fixtures_from_prd_data_empty(self) -> None:
+        prd_data = {"branchName": "test", "userStories": []}
+        fixtures = load_fixtures_from_prd_data(prd_data)
+        assert fixtures == []
+
+    def test_load_fixtures_from_prd_data_skips_invalid(self) -> None:
+        prd_data = {
+            "fixtures": [
+                {"fixture_type": "cli"},  # missing description
+                {
+                    "description": "valid",
+                    "fixture_type": "file",
+                    "input_data": {"path": "x.txt"},
+                    "expected": {"exists": True},
+                },
+            ]
+        }
+        fixtures = load_fixtures_from_prd_data(prd_data)
+        assert len(fixtures) == 1
+        assert fixtures[0].description == "valid"
+
+
+# ---------------------------------------------------------------------------
+# check_fixtures integration
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFixturesIntegration:
+    def test_check_fixtures_integration(self, tmp_path: Path) -> None:
+        target = tmp_path / "hello.txt"
+        target.write_text("hello world\n")
+
+        fixtures = [
+            Fixture(
+                description="echo passes",
+                fixture_type="cli",
+                input_data={"command": "echo ok"},
+                expected={"exit_code": 0},
+            ),
+            Fixture(
+                description="file exists",
+                fixture_type="file",
+                input_data={"path": "hello.txt"},
+                expected={"exists": True, "contains": ["hello"]},
+            ),
+        ]
+        config = FixturesConfig(enabled=True, timeout=5.0)
+        result = check_fixtures(fixtures, tmp_path, config)
+        assert result.passed is True
+        assert result.name == "fixtures"
+        assert "2/2" in result.message
+        assert len(result.details) == 2
+
+    def test_check_fixtures_empty(self, tmp_path: Path) -> None:
+        config = FixturesConfig(enabled=True)
+        result = check_fixtures([], tmp_path, config)
+        assert result.passed is True
+        assert "No fixtures defined" in result.message
+
+    def test_check_fixtures_partial_failure(self, tmp_path: Path) -> None:
+        fixtures = [
+            Fixture(
+                description="echo passes",
+                fixture_type="cli",
+                input_data={"command": "echo ok"},
+                expected={"exit_code": 0},
+            ),
+            Fixture(
+                description="missing file",
+                fixture_type="file",
+                input_data={"path": "nonexistent.txt"},
+                expected={"exists": True},
+            ),
+        ]
+        config = FixturesConfig(enabled=True, timeout=5.0)
+        result = check_fixtures(fixtures, tmp_path, config)
+        assert result.passed is False
+        assert "1/2" in result.message
+
+
+# ---------------------------------------------------------------------------
+# save_snapshot and check_snapshot_regression
+# ---------------------------------------------------------------------------
+
+
+class TestSaveAndCheckSnapshot:
+    def test_save_and_check_snapshot(self, tmp_path: Path) -> None:
+        snapshot_dir = tmp_path / "snapshots"
+
+        fixture_a = Fixture(
+            description="echo test",
+            fixture_type="cli",
+            input_data={"command": "echo hi"},
+            expected={"exit_code": 0},
+        )
+        result_a = FixtureResult(
+            fixture=fixture_a,
+            passed=True,
+            actual="hi\n",
+            message="CLI fixture passed",
+        )
+
+        # Save snapshot
+        save_snapshot("comp-a", [fixture_a], [result_a], snapshot_dir)
+        snapshot_file = snapshot_dir / "comp-a.json"
+        assert snapshot_file.exists()
+        data = json.loads(snapshot_file.read_text())
+        assert data["component_id"] == "comp-a"
+        assert data["fixture_count"] == 1
+        assert data["entries"][0]["actual"] == "hi\n"
+
+        # Check no regression when output is the same
+        regressions = check_snapshot_regression("comp-a", [result_a], snapshot_dir)
+        assert regressions == []
+
+        # Check regression when output changes
+        result_changed = FixtureResult(
+            fixture=fixture_a,
+            passed=True,
+            actual="bye\n",
+            message="CLI fixture passed",
+        )
+        regressions = check_snapshot_regression("comp-a", [result_changed], snapshot_dir)
+        assert len(regressions) == 1
+        assert "Output changed" in regressions[0]
+
+    def test_check_snapshot_no_previous(self, tmp_path: Path) -> None:
+        fixture = Fixture(
+            description="test",
+            fixture_type="cli",
+            input_data={"command": "echo x"},
+            expected={},
+        )
+        result = FixtureResult(fixture=fixture, passed=True, actual="x\n")
+        regressions = check_snapshot_regression("new-comp", [result], tmp_path)
+        assert regressions == []

--- a/tests/test_harness_integration.py
+++ b/tests/test_harness_integration.py
@@ -1,0 +1,635 @@
+"""Integration test: exercises every harness engineering feature against a real
+tiny Python project.  No agent needed -- just the harness machinery.
+
+Creates a temp project with real Python files, then runs:
+  1. Feedforward  - structural analysis produces useful context
+  2. Parsers      - real pytest/mypy/ruff output gets structured
+  3. Verification - mechanical checks run and report structured failures
+  4. Fixtures     - cli/file/function fixtures pass and fail correctly
+  5. Evolution    - journal records a run and extracts patterns
+  6. Manifest     - from_prd creates a valid single-component manifest
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_project(root: Path) -> None:
+    """Scaffold a tiny but real Python project in *root*."""
+    # Package
+    pkg = root / "src" / "myapp"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    (pkg / "models.py").write_text(textwrap.dedent("""\
+        class User:
+            def __init__(self, name: str, email: str) -> None:
+                self.name = name
+                self.email = email
+
+        class Session:
+            token: str
+            user: User
+
+        def create_user(name: str, email: str) -> User:
+            return User(name=name, email=email)
+    """))
+    (pkg / "api.py").write_text(textwrap.dedent("""\
+        from myapp.models import User, create_user
+
+        def register(name: str, email: str) -> User:
+            return create_user(name, email)
+
+        def health() -> dict:
+            return {"status": "ok"}
+    """))
+    (pkg / "utils.py").write_text(textwrap.dedent("""\
+        import json
+
+        def to_json(obj: object) -> str:
+            return json.dumps(obj, default=str)
+    """))
+
+    # Tests
+    tests = root / "tests"
+    tests.mkdir()
+    (tests / "__init__.py").write_text("")
+    (tests / "test_models.py").write_text(textwrap.dedent("""\
+        from myapp.models import User, create_user
+
+        def test_create_user():
+            user = create_user("alice", "alice@example.com")
+            assert user.name == "alice"
+            assert user.email == "alice@example.com"
+
+        def test_user_missing_arg():
+            # intentionally wrong - tests the parser when this fails
+            user = User("bob")  # type: ignore
+    """))
+
+    # pyproject.toml
+    (root / "pyproject.toml").write_text(textwrap.dedent("""\
+        [project]
+        name = "myapp"
+        version = "0.1.0"
+        requires-python = ">=3.11"
+
+        [tool.ruff]
+        line-length = 100
+        target-version = "py311"
+
+        [tool.ruff.lint]
+        select = ["E", "F", "W"]
+    """))
+
+
+# ---------------------------------------------------------------------------
+# 1. Feedforward
+# ---------------------------------------------------------------------------
+
+class TestFeedforward:
+    def test_module_map(self, tmp_path: Path) -> None:
+        _create_project(tmp_path)
+        from ralph_py.feedforward import build_module_map
+
+        result = build_module_map(tmp_path)
+        assert "src/" in result or "myapp/" in result
+        # Should mention file counts
+        assert "file" in result.lower()
+
+    def test_public_interfaces(self, tmp_path: Path) -> None:
+        _create_project(tmp_path)
+        from ralph_py.feedforward import extract_public_interfaces
+
+        result = extract_public_interfaces(tmp_path)
+        assert "User" in result
+        assert "create_user" in result
+        assert "Session" in result
+
+    def test_dependency_graph(self, tmp_path: Path) -> None:
+        _create_project(tmp_path)
+        from ralph_py.feedforward import build_dependency_graph
+
+        result = build_dependency_graph(tmp_path)
+        # api.py imports from models.py
+        assert "models" in result.lower() or "User" in result
+
+    def test_conventions(self, tmp_path: Path) -> None:
+        _create_project(tmp_path)
+        from ralph_py.feedforward import extract_conventions
+
+        result = extract_conventions(tmp_path)
+        assert "100" in result  # line-length
+        assert "py311" in result or "3.11" in result
+
+    def test_full_context(self, tmp_path: Path) -> None:
+        _create_project(tmp_path)
+        from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
+
+        ctx = build_feedforward_context(tmp_path, FeedforwardConfig())
+        assert "=== CODEBASE CONTEXT" in ctx
+        assert "END CODEBASE CONTEXT" in ctx
+        # Should have at least two sections
+        assert "## " in ctx
+
+    def test_disabled(self, tmp_path: Path) -> None:
+        from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
+
+        ctx = build_feedforward_context(tmp_path, FeedforwardConfig(enabled=False))
+        assert ctx == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. Parsers - real tool output
+# ---------------------------------------------------------------------------
+
+class TestParsersIntegration:
+    def test_parse_real_pytest_failure(self) -> None:
+        from ralph_py.parsers import parse_pytest_output
+
+        output = textwrap.dedent("""\
+            ============================= test session starts ==============================
+            collected 2 items
+
+            tests/test_models.py .F                                                  [100%]
+
+            =================================== FAILURES ===================================
+            __________________________ test_user_missing_arg ___________________________
+
+            def test_user_missing_arg():
+                user = User("bob")
+            >       assert user.email == "bob@example.com"
+            E       AttributeError: 'User' object has no attribute 'email'
+
+            tests/test_models.py:10: AttributeError
+            =========================== short test summary info ============================
+            FAILED tests/test_models.py::test_user_missing_arg - AttributeError: 'User' object has no attribute 'email'
+            ========================= 1 failed, 1 passed in 0.02s =========================
+        """)
+        parsed = parse_pytest_output(output)
+        assert parsed.tool == "pytest"
+        assert parsed.total_errors >= 1
+        assert len(parsed.failures) >= 1
+        assert parsed.failures[0].file == "tests/test_models.py"
+        assert "test_user_missing_arg" in parsed.failures[0].rule_or_test
+
+    def test_parse_real_mypy_output(self) -> None:
+        from ralph_py.parsers import parse_mypy_output
+
+        output = textwrap.dedent("""\
+            src/myapp/api.py:4: error: Missing return statement  [return]
+            src/myapp/models.py:12: error: Incompatible return value type (got "None", expected "User")  [return-value]
+            Found 2 errors in 2 files (checked 5 source files)
+        """)
+        parsed = parse_mypy_output(output)
+        assert parsed.tool == "mypy"
+        assert parsed.total_errors == 2
+        assert len(parsed.failures) == 2
+        assert parsed.failures[0].file == "src/myapp/api.py"
+        assert parsed.failures[0].line == 4
+
+    def test_parse_real_ruff_output(self) -> None:
+        from ralph_py.parsers import parse_ruff_output
+
+        output = textwrap.dedent("""\
+            src/myapp/utils.py:1:8: F401 `json` imported but unused
+            src/myapp/api.py:1:1: E302 Expected 2 blank lines, got 1
+            Found 2 errors.
+        """)
+        parsed = parse_ruff_output(output)
+        assert parsed.tool == "ruff"
+        assert parsed.total_errors == 2
+        assert parsed.failures[0].rule_or_test == "F401"
+
+    def test_source_context_on_real_file(self, tmp_path: Path) -> None:
+        _create_project(tmp_path)
+        from ralph_py.parsers import ParsedFailure, add_source_context
+
+        failure = ParsedFailure(
+            file="src/myapp/models.py",
+            line=4,
+            rule_or_test="test",
+            message="some error",
+        )
+        add_source_context(failure, tmp_path)
+        assert failure.source_context != ""
+        assert ">" in failure.source_context  # marker line
+
+    def test_fix_hints(self) -> None:
+        from ralph_py.parsers import ParsedFailure, generate_fix_hint
+
+        # Missing argument
+        f = ParsedFailure(message="TypeError: create_user() missing 1 required positional argument: 'email'")
+        hint = generate_fix_hint(f)
+        assert hint != ""
+        assert "argument" in hint.lower() or "parameter" in hint.lower()
+
+        # Unused import
+        f2 = ParsedFailure(rule_or_test="F401", message="`json` imported but unused")
+        hint2 = generate_fix_hint(f2)
+        assert hint2 != ""
+
+    def test_format_for_prompt(self) -> None:
+        from ralph_py.parsers import ParsedFailure, ParsedOutput
+
+        parsed = ParsedOutput(
+            tool="pytest",
+            total_errors=1,
+            failures=[
+                ParsedFailure(
+                    file="tests/test_auth.py",
+                    line=10,
+                    rule_or_test="test_login",
+                    message="AssertionError: expected 200 got 401",
+                    source_context="> assert response.status == 200",
+                    fix_hint="Check auth middleware.",
+                ),
+            ],
+        )
+        lines = parsed.format_for_prompt()
+        assert len(lines) >= 1
+        text = "\n".join(lines)
+        assert "test_auth.py" in text
+        assert "hint:" in text.lower() or "fix:" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# 3. Fixtures
+# ---------------------------------------------------------------------------
+
+class TestFixturesIntegration:
+    def test_cli_fixture_passes(self, tmp_path: Path) -> None:
+        from ralph_py.fixtures import Fixture, FixturesConfig, run_cli_fixture
+
+        f = Fixture(
+            description="echo works",
+            fixture_type="cli",
+            input_data={"command": "echo hello world"},
+            expected={"exit_code": 0, "stdout_contains": ["hello"]},
+        )
+        result = run_cli_fixture(f, tmp_path, timeout=10.0)
+        assert result.passed
+        assert "hello" in result.actual
+
+    def test_cli_fixture_fails(self, tmp_path: Path) -> None:
+        from ralph_py.fixtures import Fixture, run_cli_fixture
+
+        f = Fixture(
+            description="false fails",
+            fixture_type="cli",
+            input_data={"command": "false"},
+            expected={"exit_code": 0},
+        )
+        result = run_cli_fixture(f, tmp_path, timeout=10.0)
+        assert not result.passed
+
+    def test_file_fixture_on_real_project(self, tmp_path: Path) -> None:
+        _create_project(tmp_path)
+        from ralph_py.fixtures import Fixture, run_file_fixture
+
+        f = Fixture(
+            description="models.py exists and has User",
+            fixture_type="file",
+            input_data={"path": "src/myapp/models.py"},
+            expected={"exists": True, "contains": ["class User"]},
+        )
+        result = run_file_fixture(f, tmp_path)
+        assert result.passed
+
+    def test_file_fixture_missing_content(self, tmp_path: Path) -> None:
+        _create_project(tmp_path)
+        from ralph_py.fixtures import Fixture, run_file_fixture
+
+        f = Fixture(
+            description="models.py should NOT have class Admin",
+            fixture_type="file",
+            input_data={"path": "src/myapp/models.py"},
+            expected={"exists": True, "contains": ["class Admin"]},
+        )
+        result = run_file_fixture(f, tmp_path)
+        assert not result.passed
+
+    def test_function_fixture(self, tmp_path: Path) -> None:
+        # Create a simple module to import
+        (tmp_path / "adder.py").write_text("def add(a, b): return a + b\n")
+        from ralph_py.fixtures import Fixture, run_function_fixture
+
+        f = Fixture(
+            description="add(2, 3) returns 5",
+            fixture_type="function",
+            input_data={"module": "adder", "function": "add", "args": [2, 3]},
+            expected={"returns": 5},
+        )
+        result = run_function_fixture(f, tmp_path)
+        assert result.passed
+
+    def test_function_fixture_wrong_return(self, tmp_path: Path) -> None:
+        (tmp_path / "adder.py").write_text("def add(a, b): return a + b\n")
+        from ralph_py.fixtures import Fixture, run_function_fixture
+
+        f = Fixture(
+            description="add(2, 3) returns 6 (wrong)",
+            fixture_type="function",
+            input_data={"module": "adder", "function": "add", "args": [2, 3]},
+            expected={"returns": 6},
+        )
+        result = run_function_fixture(f, tmp_path)
+        assert not result.passed
+        assert "Expected 6" in result.message
+
+    def test_function_fixture_with_kwargs(self, tmp_path: Path) -> None:
+        (tmp_path / "greeter.py").write_text(
+            "def greet(name, greeting='hello'): return f'{greeting} {name}'\n"
+        )
+        from ralph_py.fixtures import Fixture, run_function_fixture
+
+        f = Fixture(
+            description="greet with kwargs",
+            fixture_type="function",
+            input_data={
+                "module": "greeter",
+                "function": "greet",
+                "args": ["alice"],
+                "kwargs": {"greeting": "hi"},
+            },
+            expected={"returns": "hi alice"},
+        )
+        result = run_function_fixture(f, tmp_path)
+        assert result.passed
+
+    def test_check_fixtures_pipeline(self, tmp_path: Path) -> None:
+        _create_project(tmp_path)
+        from ralph_py.fixtures import Fixture, FixturesConfig, check_fixtures
+
+        fixtures = [
+            Fixture(
+                description="echo test",
+                fixture_type="cli",
+                input_data={"command": "echo ok"},
+                expected={"exit_code": 0},
+            ),
+            Fixture(
+                description="models exists",
+                fixture_type="file",
+                input_data={"path": "src/myapp/models.py"},
+                expected={"exists": True},
+            ),
+        ]
+        result = check_fixtures(fixtures, tmp_path, FixturesConfig(enabled=True))
+        assert result.passed
+        assert result.name == "fixtures"
+        assert "2/2" in result.message or "2 passed" in result.message
+
+    def test_snapshot_roundtrip(self, tmp_path: Path) -> None:
+        from ralph_py.fixtures import (
+            Fixture,
+            FixtureResult,
+            check_snapshot_regression,
+            save_snapshot,
+        )
+
+        fixture = Fixture(
+            description="test", fixture_type="cli",
+            input_data={}, expected={},
+        )
+        results = [
+            FixtureResult(fixture=fixture, passed=True, actual="ok", message="passed"),
+        ]
+        snap_dir = tmp_path / "snapshots"
+        save_snapshot("comp-1", [fixture], results, snap_dir)
+
+        regressions = check_snapshot_regression("comp-1", results, snap_dir)
+        assert regressions == []
+
+        # Now change the output - should detect regression
+        changed = [
+            FixtureResult(fixture=fixture, passed=True, actual="changed", message="passed"),
+        ]
+        regressions = check_snapshot_regression("comp-1", changed, snap_dir)
+        assert len(regressions) >= 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Evolution
+# ---------------------------------------------------------------------------
+
+class TestEvolutionIntegration:
+    def test_record_and_extract(self, tmp_path: Path) -> None:
+        from ralph_py.evolution import EvolutionConfig, EvolutionJournal
+        from ralph_py.factory import FactoryResult
+        from ralph_py.manifest import Component, ComponentStatus, Manifest
+
+        manifest = Manifest(
+            version="1", spec_file="spec.md", project_name="test-project",
+            base_branch="main", single_pr=False,
+            components=[
+                Component(
+                    id="auth", title="Auth", description="",
+                    dependencies=[], prd_path="prd.json",
+                    branch_name="ralph/auth",
+                    status=ComponentStatus.FAILED.value,
+                    error="Tests failed (exit code 1)",
+                    retries=2,
+                    iteration_count=5,
+                    duration_seconds=120.0,
+                ),
+                Component(
+                    id="api", title="API", description="",
+                    dependencies=["auth"], prd_path="prd.json",
+                    branch_name="ralph/api",
+                    status=ComponentStatus.COMPLETED.value,
+                    error="",
+                    retries=0,
+                    iteration_count=3,
+                    duration_seconds=60.0,
+                ),
+                Component(
+                    id="db", title="DB", description="",
+                    dependencies=[], prd_path="prd.json",
+                    branch_name="ralph/db",
+                    status=ComponentStatus.FAILED.value,
+                    error="Tests failed (exit code 1)",
+                    retries=1,
+                    iteration_count=4,
+                    duration_seconds=90.0,
+                ),
+            ],
+        )
+        factory_result = FactoryResult(
+            completed=["api"], failed=["auth", "db"], skipped=[],
+        )
+
+        config = EvolutionConfig(
+            journal_path=tmp_path / "evolution.jsonl",
+            experiments_path=tmp_path / "experiments.tsv",
+            min_pattern_frequency=2,
+        )
+        journal = EvolutionJournal(config)
+
+        # Record the run
+        journal.record_run("run-001", manifest, factory_result)
+
+        # Verify files were created
+        assert config.journal_path.exists()
+        assert config.experiments_path.exists()
+
+        # Verify JSONL has 3 entries (one per component)
+        lines = config.journal_path.read_text().strip().splitlines()
+        assert len(lines) == 3
+        entry = json.loads(lines[0])
+        assert entry["run_id"] == "run-001"
+        assert entry["project"] == "test-project"
+
+        # Verify TSV has header + 1 data line
+        tsv_lines = config.experiments_path.read_text().strip().splitlines()
+        assert len(tsv_lines) == 2  # header + 1 run
+
+        # Extract patterns - both failed with "Tests failed" so should match
+        patterns = journal.extract_failure_patterns(manifest, min_frequency=2)
+        assert len(patterns) >= 1
+        assert patterns[0].frequency >= 2
+        assert "auth" in patterns[0].affected_components or "db" in patterns[0].affected_components
+
+    def test_experiment_trends(self, tmp_path: Path) -> None:
+        from ralph_py.evolution import EvolutionConfig, EvolutionJournal
+        from ralph_py.factory import FactoryResult
+        from ralph_py.manifest import Component, ComponentStatus, Manifest
+
+        config = EvolutionConfig(
+            journal_path=tmp_path / "evolution.jsonl",
+            experiments_path=tmp_path / "experiments.tsv",
+        )
+        journal = EvolutionJournal(config)
+
+        # Record 3 runs to see trends
+        for i in range(3):
+            m = Manifest(
+                version="1", spec_file="spec.md", project_name="proj",
+                base_branch="main", single_pr=False,
+                components=[
+                    Component(
+                        id=f"comp-{i}", title="C", description="",
+                        dependencies=[], prd_path="prd.json",
+                        branch_name=f"ralph/c{i}",
+                        status=ComponentStatus.COMPLETED.value,
+                    ),
+                ],
+            )
+            journal.record_run(f"run-{i:03d}", m, FactoryResult(completed=[f"comp-{i}"]))
+
+        trends = journal.get_experiment_trends(last_n=10)
+        assert len(trends) == 3
+        assert trends[0]["run_id"] == "run-000"
+        assert trends[2]["run_id"] == "run-002"
+
+    def test_propose_improvements(self, tmp_path: Path) -> None:
+        from ralph_py.evolution import (
+            EvolutionConfig,
+            EvolutionJournal,
+            FailurePattern,
+        )
+
+        config = EvolutionConfig(
+            journal_path=tmp_path / "evolution.jsonl",
+            experiments_path=tmp_path / "experiments.tsv",
+        )
+        journal = EvolutionJournal(config)
+
+        patterns = [
+            FailurePattern(
+                description="Agent used raw SQL in 3 components",
+                frequency=3,
+                total_components=5,
+                affected_components=["auth", "api", "db"],
+                check_name="linter",
+                error_signature="S608",
+                category="verification",
+            ),
+        ]
+        proposals = journal.propose_improvements(patterns)
+        assert len(proposals) >= 1
+        assert proposals[0].target == "claude_md"
+
+        # Save and verify
+        paths = journal.save_proposals(proposals, tmp_path / "proposals")
+        assert len(paths) >= 1
+        content = paths[0].read_text()
+        assert "PROP-" in content
+        assert "S608" in content
+
+
+# ---------------------------------------------------------------------------
+# 5. Manifest.from_prd
+# ---------------------------------------------------------------------------
+
+class TestManifestFromPrd:
+    def test_creates_valid_manifest(self, tmp_path: Path) -> None:
+        from ralph_py.manifest import Manifest
+
+        prd_path = tmp_path / "prd.json"
+        prd_path.write_text(json.dumps({
+            "branchName": "ralph/auth-feature",
+            "userStories": [],
+        }))
+
+        m = Manifest.from_prd(
+            prd_path=prd_path,
+            branch="ralph/auth-feature",
+            base_branch="main",
+        )
+        assert len(m.components) == 1
+        assert m.components[0].id == "main"
+        assert m.base_branch == "main"
+        # Project name derived from branch
+        assert m.project_name == "auth-feature"
+
+    def test_derives_project_name_from_branch(self) -> None:
+        from ralph_py.manifest import Manifest
+
+        m = Manifest.from_prd(
+            prd_path=Path("prd.json"),
+            branch="ralph/user-dashboard",
+        )
+        assert m.project_name == "user-dashboard"
+
+    def test_derives_project_name_from_prd_stem(self) -> None:
+        from ralph_py.manifest import Manifest
+
+        m = Manifest.from_prd(
+            prd_path=Path("scripts/ralph/feature/login/prd.json"),
+            branch="",
+        )
+        assert m.project_name == "prd"
+        assert m.components[0].branch_name == "ralph/prd"
+
+    def test_roundtrip_serialize(self, tmp_path: Path) -> None:
+        from ralph_py.manifest import Manifest
+
+        m = Manifest.from_prd(
+            prd_path=Path("scripts/ralph/prd.json"),
+            branch="ralph/test",
+        )
+        out = tmp_path / "manifest.json"
+        m.save(out)
+        loaded = Manifest.load(out)
+        assert loaded.project_name == m.project_name
+        assert len(loaded.components) == 1
+        assert loaded.components[0].id == "main"
+
+    def test_dag_validation_passes(self) -> None:
+        from ralph_py.manifest import Manifest
+
+        m = Manifest.from_prd(
+            prd_path=Path("prd.json"),
+            branch="ralph/x",
+        )
+        errors = m.validate_dag()
+        assert errors == []

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,292 @@
+"""Tests for parsers module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ralph_py.parsers import (
+    ParsedFailure,
+    ParsedOutput,
+    add_source_context,
+    generate_fix_hint,
+    parse_mypy_output,
+    parse_pytest_output,
+    parse_ruff_output,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_pytest_output
+# ---------------------------------------------------------------------------
+
+
+class TestParsePytestOutput:
+    def test_parse_pytest_output(self) -> None:
+        raw = (
+            "============================= test session starts =============================\n"
+            "collected 5 items\n"
+            "\n"
+            "tests/test_foo.py ..F..\n"
+            "\n"
+            "=========================== short test summary info ===========================\n"
+            "FAILED tests/test_foo.py::test_bar - AssertionError: expected 1, got 2\n"
+            "FAILED tests/test_foo.py::test_baz - TypeError: unsupported operand\n"
+            "============================= 2 failed, 3 passed in 1.23s =============================\n"
+        )
+        result = parse_pytest_output(raw)
+        assert result.tool == "pytest"
+        assert result.total_errors == 2
+        assert len(result.failures) == 2
+        assert result.failures[0].file == "tests/test_foo.py"
+        assert result.failures[0].rule_or_test == "test_bar"
+        assert "expected 1" in result.failures[0].message
+        assert result.failures[1].rule_or_test == "test_baz"
+        assert "2 failed" in result.raw_summary
+
+    def test_parse_pytest_output_empty(self) -> None:
+        result = parse_pytest_output("")
+        assert result.tool == "pytest"
+        assert result.total_errors == 0
+        assert result.failures == []
+        assert result.raw_summary == ""
+
+    def test_parse_pytest_output_none_input(self) -> None:
+        result = parse_pytest_output(None)  # type: ignore[arg-type]
+        assert result.tool == "pytest"
+        assert result.total_errors == 0
+
+    def test_parse_pytest_output_error_lines(self) -> None:
+        raw = (
+            "=========================== short test summary info ===========================\n"
+            "ERROR tests/test_foo.py - CollectionError: cannot import module\n"
+            "============================= 1 error in 0.50s =============================\n"
+        )
+        result = parse_pytest_output(raw)
+        assert len(result.failures) == 1
+        assert result.failures[0].rule_or_test == "collection"
+        assert result.total_errors == 1
+
+
+# ---------------------------------------------------------------------------
+# parse_mypy_output
+# ---------------------------------------------------------------------------
+
+
+class TestParseMypyOutput:
+    def test_parse_mypy_output(self) -> None:
+        raw = (
+            "ralph_py/factory.py:10: error: Incompatible types in assignment [assignment]\n"
+            "ralph_py/manifest.py:25: error: Missing return statement [return]\n"
+            "Found 2 errors in 2 files (checked 10 source files)\n"
+        )
+        result = parse_mypy_output(raw)
+        assert result.tool == "mypy"
+        assert result.total_errors == 2
+        assert len(result.failures) == 2
+        assert result.failures[0].file == "ralph_py/factory.py"
+        assert result.failures[0].line == 10
+        assert result.failures[0].rule_or_test == "assignment"
+        assert "Incompatible types" in result.failures[0].message
+        assert result.failures[1].file == "ralph_py/manifest.py"
+        assert result.failures[1].rule_or_test == "return"
+
+    def test_parse_mypy_output_empty(self) -> None:
+        result = parse_mypy_output("")
+        assert result.tool == "mypy"
+        assert result.total_errors == 0
+        assert result.failures == []
+
+    def test_parse_mypy_output_no_errors(self) -> None:
+        raw = "Success: no issues found in 5 source files\n"
+        result = parse_mypy_output(raw)
+        assert result.tool == "mypy"
+        assert result.total_errors == 0
+        assert result.failures == []
+
+
+# ---------------------------------------------------------------------------
+# parse_ruff_output
+# ---------------------------------------------------------------------------
+
+
+class TestParseRuffOutput:
+    def test_parse_ruff_output(self) -> None:
+        raw = (
+            "ralph_py/factory.py:15:1: E501 Line too long (95 > 79)\n"
+            "ralph_py/factory.py:20:1: F401 `os` imported but unused\n"
+            "ralph_py/manifest.py:5:1: F821 Undefined name `foo`\n"
+            "Found 3 errors.\n"
+        )
+        result = parse_ruff_output(raw)
+        assert result.tool == "ruff"
+        assert result.total_errors == 3
+        assert len(result.failures) == 3
+        assert result.failures[0].file == "ralph_py/factory.py"
+        assert result.failures[0].line == 15
+        assert result.failures[0].rule_or_test == "E501"
+        assert "Line too long" in result.failures[0].message
+        assert result.failures[1].rule_or_test == "F401"
+        assert result.failures[2].rule_or_test == "F821"
+
+    def test_parse_ruff_output_empty(self) -> None:
+        result = parse_ruff_output("")
+        assert result.tool == "ruff"
+        assert result.total_errors == 0
+        assert result.failures == []
+
+    def test_parse_ruff_output_with_fix_summary(self) -> None:
+        raw = (
+            "ralph_py/factory.py:10:5: W291 trailing whitespace\n"
+            "Found 1 error (1 fixed, 0 remaining).\n"
+        )
+        result = parse_ruff_output(raw)
+        assert result.total_errors == 1
+        assert len(result.failures) == 1
+
+
+# ---------------------------------------------------------------------------
+# add_source_context
+# ---------------------------------------------------------------------------
+
+
+class TestAddSourceContext:
+    def test_add_source_context(self, tmp_path: Path) -> None:
+        src_file = tmp_path / "example.py"
+        src_file.write_text(
+            "line1\n"
+            "line2\n"
+            "line3\n"
+            "line4_error_here\n"
+            "line5\n"
+            "line6\n"
+            "line7\n"
+        )
+        failure = ParsedFailure(file="example.py", line=4, message="some error")
+        add_source_context(failure, tmp_path, context_lines=2)
+        assert failure.source_context != ""
+        assert "line4_error_here" in failure.source_context
+        # The error line should be marked with >
+        assert ">" in failure.source_context
+
+    def test_add_source_context_no_file(self, tmp_path: Path) -> None:
+        failure = ParsedFailure(file="nonexistent.py", line=1, message="err")
+        add_source_context(failure, tmp_path)
+        assert failure.source_context == ""
+
+    def test_add_source_context_no_line(self, tmp_path: Path) -> None:
+        src_file = tmp_path / "example.py"
+        src_file.write_text("line1\n")
+        failure = ParsedFailure(file="example.py", line=0, message="err")
+        add_source_context(failure, tmp_path)
+        assert failure.source_context == ""
+
+
+# ---------------------------------------------------------------------------
+# generate_fix_hint
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateFixHint:
+    def test_missing_argument(self) -> None:
+        failure = ParsedFailure(
+            message="missing 1 required positional argument: 'name'",
+            rule_or_test="test_create",
+        )
+        hint = generate_fix_hint(failure)
+        assert "required argument" in hint.lower() or "function signature" in hint.lower()
+
+    def test_type_mismatch(self) -> None:
+        failure = ParsedFailure(
+            message='Argument "x" has incompatible type "str"; expected "int"',
+            rule_or_test="assignment",
+        )
+        hint = generate_fix_hint(failure)
+        assert "type mismatch" in hint.lower() or "convert" in hint.lower()
+
+    def test_import_error(self) -> None:
+        failure = ParsedFailure(
+            message="ModuleNotFoundError: No module named 'foo'",
+            rule_or_test="test_import",
+        )
+        hint = generate_fix_hint(failure)
+        assert "import" in hint.lower()
+
+    def test_no_hint_for_uncommon_error(self) -> None:
+        failure = ParsedFailure(
+            message="something completely unique and unusual happened",
+            rule_or_test="test_weird",
+        )
+        hint = generate_fix_hint(failure)
+        assert hint == ""
+
+    def test_ruff_unused_import(self) -> None:
+        failure = ParsedFailure(
+            message="`os` imported but unused",
+            rule_or_test="F401",
+        )
+        hint = generate_fix_hint(failure)
+        assert "unused import" in hint.lower()
+
+
+# ---------------------------------------------------------------------------
+# format_for_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestFormatForPrompt:
+    def test_format_for_prompt_with_failures(self) -> None:
+        output = ParsedOutput(
+            tool="pytest",
+            total_errors=2,
+            failures=[
+                ParsedFailure(
+                    file="test_foo.py", line=10,
+                    rule_or_test="test_bar", message="assert 1 == 2",
+                    source_context="  10 | assert 1 == 2",
+                    fix_hint="Check expected vs actual values.",
+                ),
+                ParsedFailure(
+                    file="test_foo.py", line=20,
+                    rule_or_test="test_baz", message="KeyError",
+                ),
+            ],
+            raw_summary="2 failed, 3 passed in 1.5s",
+        )
+        lines = output.format_for_prompt()
+        assert len(lines) >= 3
+        assert "[pytest]" in lines[0]
+        assert "test_foo.py:10" in lines[1]
+        assert "[test_bar]" in lines[1]
+        # Source context should be included
+        assert any("| assert 1 == 2" in line for line in lines)
+        # Hint should be included
+        assert any("hint:" in line for line in lines)
+
+    def test_format_for_prompt_empty(self) -> None:
+        output = ParsedOutput(tool="ruff", raw_summary="All good")
+        lines = output.format_for_prompt()
+        assert len(lines) == 1
+        assert "[ruff]" in lines[0]
+
+    def test_format_for_prompt_truncation(self) -> None:
+        failures = [
+            ParsedFailure(file=f"f{i}.py", line=i, message=f"err{i}")
+            for i in range(15)
+        ]
+        output = ParsedOutput(tool="ruff", total_errors=15, failures=failures)
+        lines = output.format_for_prompt(max_failures=5)
+        # Should show 5 failures + "... and 10 more errors"
+        assert any("10 more errors" in line for line in lines)
+
+    def test_format_for_prompt_no_source(self) -> None:
+        output = ParsedOutput(
+            tool="mypy",
+            failures=[
+                ParsedFailure(
+                    file="x.py", line=1, message="err",
+                    source_context="  1 | x = 1",
+                ),
+            ],
+        )
+        lines = output.format_for_prompt(include_source=False)
+        assert not any("|" in line for line in lines)


### PR DESCRIPTION
## Summary

- **Factory as default**: `ralph run` now delegates to the factory pipeline with mechanical verification. `--no-verify` and `--legacy` flags preserve backward compatibility.
- **Feedforward controls (Phase 0)**: Computational codebase analysis (module map, public interfaces, dependency graph, conventions) injected into the prompt before the agent starts. Zero LLM cost.
- **LLM-optimized sensors**: pytest/mypy/ruff output parsed into structured failures with source context and fix hints instead of raw stderr.
- **Continuous learning**: Evolution journal and experiment tracker record outcomes across runs. `ralph evolve` identifies recurring failure patterns and proposes harness improvements.
- **Approved fixtures**: Human-written golden tests (cli, function, file types) verified independently of agent-generated tests. Snapshot regression detection.
- **Bootstrap scaffolding**: Optional per-component scaffold scripts to constrain the solution space.

## Details

Source: [Harness Engineering for Coding Agent Users](https://martinfowler.com/articles/harness-engineering.html) (Bockeleer, April 2026), with continuous learning patterns from [autoresearch-agents](https://github.com/hwchase17/autoresearch-agents) and [AutoResearchClaw](https://github.com/aiming-lab/AutoResearchClaw).

Full spec at `docs/spec-harness-engineering.md`.

### New files
- `ralph_py/parsers.py` - Structured output parsing for pytest, mypy, ruff
- `ralph_py/feedforward.py` - Phase 0 codebase analysis and convention extraction
- `ralph_py/evolution.py` - Evolution journal, experiment tracking, harness proposals
- `ralph_py/fixtures.py` - Approved fixtures and snapshot regression

### Modified files
- `ralph_py/cli.py` - `ralph run` delegates to factory, added `ralph evolve` command
- `ralph_py/factory.py` - Feedforward/scaffold integration, evolution recording, path resolution fix
- `ralph_py/manifest.py` - `Manifest.from_prd()`, scaffold field, project name derivation
- `ralph_py/verify.py` - Structured parser integration for all check functions
- `README.md` - Rewritten to document the full harness engineering model

## Test plan

- [x] 362 tests passing (270 existing + 92 new)
- [x] Integration test (`test_harness_integration.py`) exercises every feature against a real temp Python project
- [x] Existing `ralph run` test updated to use `--legacy` flag
- [x] `Manifest.from_prd` roundtrip serialization verified
- [ ] Manual: run `ralph run 5` against a real project with verification enabled
- [ ] Manual: run `ralph factory` and verify evolution journal is written
- [ ] Manual: run `ralph evolve --status` after a factory run

🤖 Generated with [Claude Code](https://claude.com/claude-code)