### PR TITLE
feat: dead code cleanup in Phase 1 verification

### DIFF
--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -1141,6 +1141,15 @@ def decompose(
     help="Skip Phase 1 mechanical verification",
 )
 @click.option(
+    "--dead-code-cleanup",
+    is_flag=True,
+    help="Enable dead code cleanup: ruff auto-fixes unused imports/variables, vulture detects remaining dead code",
+)
+@click.option(
+    "--dead-code-command",
+    help="Custom dead code detection command (default: vulture on changed files)",
+)
+@click.option(
     "--mutation-testing",
     is_flag=True,
     help="Enable mutation testing (requires mutmut, off by default)",
@@ -1252,6 +1261,8 @@ def factory(
     typecheck_command: str | None,
     lint_command: str | None,
     no_verify: bool,
+    dead_code_cleanup: bool,
+    dead_code_command: str | None,
     mutation_testing: bool,
     mutation_threshold: float,
     review_mode: str,
@@ -1371,6 +1382,8 @@ def factory(
             test_command=test_command,
             typecheck_command=typecheck_command,
             lint_command=lint_command,
+            dead_code_cleanup=dead_code_cleanup,
+            dead_code_command=dead_code_command,
             mutation_testing=mutation_testing,
             mutation_threshold=mutation_threshold,
         )

--- a/ralph_py/verify.py
+++ b/ralph_py/verify.py
@@ -62,6 +62,8 @@ class VerifyConfig:
     lint_command: str | None = None
     check_diff_scope: bool = True
     check_bad_patterns: bool = True
+    dead_code_cleanup: bool = False
+    dead_code_command: str | None = None
     mutation_testing: bool = False
     mutation_threshold: float = 50.0
     mutation_timeout: float = 600.0
@@ -74,6 +76,8 @@ class VerifyConfig:
             test_command=os.environ.get("RALPH_VERIFY_TEST_CMD"),
             typecheck_command=os.environ.get("RALPH_VERIFY_TYPECHECK_CMD"),
             lint_command=os.environ.get("RALPH_VERIFY_LINT_CMD"),
+            dead_code_cleanup=os.environ.get("RALPH_DEAD_CODE_CLEANUP", "") == "1",
+            dead_code_command=os.environ.get("RALPH_DEAD_CODE_CMD"),
             mutation_testing=os.environ.get("RALPH_MUTATION_TESTING", "") == "1",
             mutation_threshold=float(
                 os.environ.get("RALPH_MUTATION_THRESHOLD", "50")
@@ -467,6 +471,143 @@ def check_mutation_score(
     )
 
 
+def check_dead_code(
+    cwd: Path,
+    base_branch: str,
+    command: str | None = None,
+    timeout: float = 300.0,
+) -> CheckResult:
+    """Remove dead code with ruff auto-fix, then detect remaining dead code with vulture.
+
+    Two-phase approach:
+    1. ruff --fix --select F401,F811,F841 auto-removes unused imports, redefined
+       unused names, and unused local variables. Changes are staged and committed.
+    2. vulture scans for deeper dead code (unreachable functions, unused classes,
+       unused attributes). If a custom command is provided, it runs instead.
+
+    If ruff fixes anything, those fixes are committed automatically so the worktree
+    stays clean for subsequent checks. Vulture findings (if any) are reported as
+    failures for the agent to fix on retry.
+    """
+    import shutil
+
+    start = time.monotonic()
+
+    # --- Phase A: ruff auto-fix for unused imports/variables ---
+    ruff_cmd = "ruff check --fix --select F401,F811,F841 ."
+    ruff_fixed_count = 0
+
+    if shutil.which("ruff"):
+        try:
+            ruff_result = subprocess.run(
+                ruff_cmd, shell=True, cwd=cwd,
+                capture_output=True, text=True, timeout=timeout,
+            )
+            # Count fixes from ruff output (lines like "Found X errors (Y fixed, ...)")
+            for line in (ruff_result.stdout + ruff_result.stderr).splitlines():
+                if "fixed" in line.lower():
+                    import re as _re
+                    match = _re.search(r"(\d+)\s+fix", line.lower())
+                    if match:
+                        ruff_fixed_count = int(match.group(1))
+        except subprocess.TimeoutExpired:
+            pass  # Non-fatal: continue to vulture
+
+        # If ruff made changes, stage and commit them
+        if ruff_fixed_count > 0:
+            try:
+                # Stage all changes ruff made
+                subprocess.run(
+                    "git add -A", shell=True, cwd=cwd,
+                    capture_output=True, text=True, timeout=30,
+                )
+                subprocess.run(
+                    'git commit -m "chore: auto-remove dead code (ruff F401/F811/F841)"',
+                    shell=True, cwd=cwd,
+                    capture_output=True, text=True, timeout=30,
+                )
+            except subprocess.TimeoutExpired:
+                pass  # Non-fatal
+
+    # --- Phase B: vulture or custom dead code detection ---
+    if command:
+        # User-provided dead code detection command
+        detect_cmd = command
+    elif shutil.which("vulture"):
+        # Default: vulture on changed Python files only
+        changed = git.get_diff_names(base_branch, cwd)
+        py_files = [f for f in changed if f.endswith(".py") and not f.startswith("test")]
+        if not py_files:
+            msg = f"No dead code issues (ruff auto-fixed {ruff_fixed_count})"
+            return CheckResult(
+                name="dead_code",
+                passed=True,
+                message=msg,
+                duration_seconds=time.monotonic() - start,
+            )
+        detect_cmd = f"vulture {' '.join(py_files)} --min-confidence 80"
+    else:
+        # Neither vulture nor custom command available
+        if ruff_fixed_count > 0:
+            return CheckResult(
+                name="dead_code",
+                passed=True,
+                message=f"ruff auto-fixed {ruff_fixed_count} issues (vulture not installed)",
+                duration_seconds=time.monotonic() - start,
+            )
+        return CheckResult(
+            name="dead_code",
+            passed=True,
+            message="Skipped: neither vulture nor custom command available",
+            duration_seconds=time.monotonic() - start,
+        )
+
+    try:
+        result = subprocess.run(
+            detect_cmd, shell=True, cwd=cwd,
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return CheckResult(
+            name="dead_code",
+            passed=True,
+            message=f"Dead code scan timed out after {timeout}s, skipping",
+            duration_seconds=time.monotonic() - start,
+        )
+
+    output = (result.stdout + result.stderr).strip()
+    if result.returncode != 0 and output:
+        # vulture returns exit code 1 when it finds dead code
+        lines = output.splitlines()
+        # Filter out common false positives (e.g., __all__, __init__)
+        real_issues = [
+            line for line in lines
+            if line.strip()
+            and not line.strip().startswith("#")
+            and "__all__" not in line
+        ]
+        if real_issues:
+            prefix = f"ruff auto-fixed {ruff_fixed_count}, " if ruff_fixed_count else ""
+            return CheckResult(
+                name="dead_code",
+                passed=False,
+                message=f"{prefix}{len(real_issues)} dead code issues remaining",
+                details=real_issues[:20],
+                duration_seconds=time.monotonic() - start,
+            )
+
+    msg_parts: list[str] = []
+    if ruff_fixed_count:
+        msg_parts.append(f"ruff auto-fixed {ruff_fixed_count}")
+    msg_parts.append("no remaining dead code")
+    return CheckResult(
+        name="dead_code",
+        passed=True,
+        message=", ".join(msg_parts),
+        duration_seconds=time.monotonic() - start,
+    )
+
+
 def run_mechanical_verification(
     worktree_path: Path,
     prd_path: Path,
@@ -498,6 +639,12 @@ def run_mechanical_verification(
 
     if config.check_bad_patterns:
         checks.append(check_bad_patterns(worktree_path, base_branch))
+
+    if config.dead_code_cleanup:
+        checks.append(check_dead_code(
+            worktree_path, base_branch,
+            config.dead_code_command, config.subprocess_timeout,
+        ))
 
     if config.mutation_testing:
         checks.append(check_mutation_score(

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -11,6 +11,7 @@ from ralph_py.verify import (
     VerificationResult,
     VerifyConfig,
     check_bad_patterns,
+    check_dead_code,
     check_diff_scope,
     check_mutation_score,
     check_prd_stories,
@@ -273,3 +274,151 @@ class TestCheckMutationScore:
             result = check_mutation_score(tmp_path, "main", timeout=600)
         assert result.passed is True
         assert "timed out" in result.message
+
+
+class TestCheckDeadCode:
+    def test_no_tools_available_skips(self, tmp_path: Path) -> None:
+        """When neither ruff nor vulture are installed, skip gracefully."""
+        with patch("shutil.which", return_value=None):
+            result = check_dead_code(tmp_path, "main")
+        assert result.passed is True
+        assert "neither vulture nor custom command" in result.message.lower()
+
+    def test_ruff_fixes_committed(self, tmp_path: Path) -> None:
+        """When ruff finds fixable issues, they are auto-committed."""
+        import subprocess as sp
+
+        calls: list[str] = []
+
+        def mock_run(cmd: str, **kwargs: object) -> sp.CompletedProcess[str]:
+            calls.append(cmd)
+            if "ruff check --fix" in cmd:
+                return sp.CompletedProcess(cmd, 0, "Found 3 errors (2 fixed, 1 remaining).", "")
+            if "git add" in cmd:
+                return sp.CompletedProcess(cmd, 0, "", "")
+            if "git commit" in cmd:
+                return sp.CompletedProcess(cmd, 0, "", "")
+            # vulture
+            return sp.CompletedProcess(cmd, 0, "", "")
+
+        def mock_which(name: str) -> str | None:
+            if name in ("ruff", "vulture"):
+                return f"/usr/bin/{name}"
+            return None
+
+        with (
+            patch("shutil.which", side_effect=mock_which),
+            patch("ralph_py.verify.subprocess.run", side_effect=mock_run),
+            patch("ralph_py.verify.git.get_diff_names", return_value=["src/main.py"]),
+        ):
+            result = check_dead_code(tmp_path, "main")
+
+        assert result.passed is True
+        assert "auto-fixed 2" in result.message
+        assert any("git commit" in c for c in calls)
+
+    def test_vulture_findings_fail(self, tmp_path: Path) -> None:
+        """When vulture finds dead code, the check fails with details."""
+        import subprocess as sp
+
+        def mock_run(cmd: str, **kwargs: object) -> sp.CompletedProcess[str]:
+            if "ruff check --fix" in cmd:
+                return sp.CompletedProcess(cmd, 0, "", "")
+            # vulture output
+            return sp.CompletedProcess(
+                cmd, 1,
+                "src/main.py:10: unused function 'old_handler' (60% confidence)\n"
+                "src/utils.py:25: unused variable 'temp' (90% confidence)\n",
+                "",
+            )
+
+        def mock_which(name: str) -> str | None:
+            if name in ("ruff", "vulture"):
+                return f"/usr/bin/{name}"
+            return None
+
+        with (
+            patch("shutil.which", side_effect=mock_which),
+            patch("ralph_py.verify.subprocess.run", side_effect=mock_run),
+            patch("ralph_py.verify.git.get_diff_names", return_value=["src/main.py", "src/utils.py"]),
+        ):
+            result = check_dead_code(tmp_path, "main")
+
+        assert result.passed is False
+        assert "2 dead code issues" in result.message
+        assert len(result.details) == 2
+
+    def test_custom_command_used(self, tmp_path: Path) -> None:
+        """When a custom command is provided, it runs instead of vulture."""
+        import subprocess as sp
+
+        def mock_run(cmd: str, **kwargs: object) -> sp.CompletedProcess[str]:
+            if "ruff check --fix" in cmd:
+                return sp.CompletedProcess(cmd, 0, "", "")
+            if "my-custom-checker" in cmd:
+                return sp.CompletedProcess(cmd, 0, "", "")
+            return sp.CompletedProcess(cmd, 0, "", "")
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/ruff"),
+            patch("ralph_py.verify.subprocess.run", side_effect=mock_run),
+        ):
+            result = check_dead_code(tmp_path, "main", command="my-custom-checker src/")
+
+        assert result.passed is True
+
+    def test_no_python_files_changed_passes(self, tmp_path: Path) -> None:
+        """When no Python files changed, skip vulture scan."""
+        import subprocess as sp
+
+        def mock_run(cmd: str, **kwargs: object) -> sp.CompletedProcess[str]:
+            return sp.CompletedProcess(cmd, 0, "", "")
+
+        def mock_which(name: str) -> str | None:
+            if name in ("ruff", "vulture"):
+                return f"/usr/bin/{name}"
+            return None
+
+        with (
+            patch("shutil.which", side_effect=mock_which),
+            patch("ralph_py.verify.subprocess.run", side_effect=mock_run),
+            patch("ralph_py.verify.git.get_diff_names", return_value=["README.md", "docs/spec.md"]),
+        ):
+            result = check_dead_code(tmp_path, "main")
+
+        assert result.passed is True
+
+    def test_included_in_verification_when_enabled(self, tmp_path: Path) -> None:
+        """When dead_code_cleanup is True, check_dead_code runs in verification."""
+        config = VerifyConfig(dead_code_cleanup=True)
+
+        # Mock everything to pass
+        with (
+            patch("ralph_py.verify.check_prd_stories", return_value=CheckResult("prd_stories", True)),
+            patch("ralph_py.verify.check_test_suite", return_value=CheckResult("test_suite", True)),
+            patch("ralph_py.verify.check_typecheck", return_value=CheckResult("typecheck", True)),
+            patch("ralph_py.verify.check_linter", return_value=CheckResult("linter", True)),
+            patch("ralph_py.verify.check_diff_scope", return_value=CheckResult("diff_scope", True)),
+            patch("ralph_py.verify.check_bad_patterns", return_value=CheckResult("bad_patterns", True)),
+            patch("ralph_py.verify.check_dead_code", return_value=CheckResult("dead_code", True)) as mock_dc,
+        ):
+            result = run_mechanical_verification(tmp_path, tmp_path / "prd.json", "main", None, config)
+
+        mock_dc.assert_called_once()
+        assert any(c.name == "dead_code" for c in result.checks)
+
+    def test_excluded_from_verification_when_disabled(self, tmp_path: Path) -> None:
+        """When dead_code_cleanup is False (default), check is skipped."""
+        config = VerifyConfig(dead_code_cleanup=False)
+
+        with (
+            patch("ralph_py.verify.check_prd_stories", return_value=CheckResult("prd_stories", True)),
+            patch("ralph_py.verify.check_test_suite", return_value=CheckResult("test_suite", True)),
+            patch("ralph_py.verify.check_typecheck", return_value=CheckResult("typecheck", True)),
+            patch("ralph_py.verify.check_linter", return_value=CheckResult("linter", True)),
+            patch("ralph_py.verify.check_diff_scope", return_value=CheckResult("diff_scope", True)),
+            patch("ralph_py.verify.check_bad_patterns", return_value=CheckResult("bad_patterns", True)),
+        ):
+            result = run_mechanical_verification(tmp_path, tmp_path / "prd.json", "main", None, config)
+
+        assert not any(c.name == "dead_code" for c in result.checks)


### PR DESCRIPTION
## Summary
- Adds `check_dead_code` to Phase 1 mechanical verification (runs per-component after agent finishes)
- Phase A: ruff auto-fixes unused imports/variables (F401, F811, F841) and commits changes
- Phase B: vulture scans changed Python files for remaining dead code (unreachable functions, unused classes)
- Vulture findings feed back into the retry loop so the agent can fix them
- New CLI flags: `--dead-code-cleanup`, `--dead-code-command`
- Env vars: `RALPH_DEAD_CODE_CLEANUP=1`, `RALPH_DEAD_CODE_CMD`

## Test plan
- [x] 7 new unit tests covering: no tools available, ruff auto-fix + commit, vulture findings, custom command, no Python files, integration with run_mechanical_verification (enabled/disabled)
- [x] All 369 existing tests pass

Generated with [Claude Code](https://claude.com/claude-code)