### PR TITLE
feat: per-component semantic knowledge layer + ralph.toml config loader

### DIFF
--- a/ralph.toml.example
+++ b/ralph.toml.example
@@ -26,3 +26,26 @@ auto_checkout = true
 
 [ui]
 ascii = false
+
+# Per-component semantic knowledge layer.
+# A third memory surface (alongside .ralph/evolution.jsonl and progress.txt)
+# that captures durable facts about WHAT WAS BUILT: interfaces, invariants,
+# contracts, gotchas. Written after Phase 2 review passes, read by
+# downstream components automatically.
+#
+# Storage: .ralph/knowledge/<component_id>/<run_id>/<fact_id>.md
+# Latest run dir per component wins; contract-breaker retries naturally
+# orphan stale facts.
+#
+# LLM-driven consolidation/rewriting of existing facts is intentionally
+# NOT a tunable. This is a permanent design decision: atomic fact files
+# plus latest-run-dir-wins gives audit history without the rewrite drift
+# observed when LLMs are allowed to update memory in place.
+[knowledge]
+enabled = true
+max_core_tokens = 2000             # current component's facts (full text)
+max_dependency_tokens = 1000       # transitive deps' facts (full text)
+max_sibling_tokens = 500           # other components' facts (first sentence only)
+distill_timeout_seconds = 300
+distill_model = ""                 # empty = falls back to [agent].model
+max_facts_per_distill = 7

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -229,8 +229,8 @@ def run(
     root_value = root if _use_cli_value(ctx, "root") else None
     root_dir = _resolve_root(root_value, prompt_for_root, prd_for_root)
 
-    # Build config from environment defaults first.
-    config = RalphConfig.from_env(root_dir)
+    # Build config from ralph.toml + environment defaults first.
+    config = RalphConfig.load(root_dir)
 
     # Apply CLI overrides when explicitly provided.
     if _use_cli_value(ctx, "max_iterations"):
@@ -495,7 +495,7 @@ def understand(
         codebase_map.parent.mkdir(parents=True, exist_ok=True)
         codebase_map.write_text(DEFAULT_CODEBASE_MAP)
 
-    config = RalphConfig.from_env(root_dir)
+    config = RalphConfig.load(root_dir)
 
     # Apply CLI overrides when explicitly provided.
     if _use_cli_value(ctx, "max_iterations"):
@@ -704,7 +704,7 @@ def feature(
     root_dir = _resolve_root(root_value, prompt_for_root, prd_for_root)
     ralph_dir = root_dir / "scripts" / "ralph"
 
-    base_config = RalphConfig.from_env(root_dir)
+    base_config = RalphConfig.load(root_dir)
 
     # Apply CLI overrides that should affect both phases.
     if _use_cli_value(ctx, "sleep"):
@@ -1411,7 +1411,7 @@ def factory(
     )
 
     ralph_dir = root_dir / "scripts" / "ralph"
-    base_config = RalphConfig.from_env(root_dir)
+    base_config = RalphConfig.load(root_dir)
     if _use_cli_value(ctx, "agent_cmd"):
         base_config.agent_cmd = agent_cmd
     if _use_cli_value(ctx, "model"):

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -535,7 +535,14 @@ def understand(
         config.prompt_file = ralph_dir / "understand_prompt.md"
     if not _use_cli_value(ctx, "allowed_paths") and "ALLOWED_PATHS" not in os.environ:
         config.allowed_paths = ["scripts/ralph/codebase_map.md"]
-    if not _use_cli_value(ctx, "branch") and "RALPH_BRANCH" not in os.environ:
+    # Only fall back to the understand-mode branch default when no other
+    # source (CLI / env / TOML) supplied a branch. RalphConfig.load sets
+    # ralph_branch_explicit=True when TOML provides a non-empty [git].branch.
+    if (
+        not _use_cli_value(ctx, "branch")
+        and "RALPH_BRANCH" not in os.environ
+        and not config.ralph_branch_explicit
+    ):
         config.ralph_branch = "ralph/understanding"
         config.ralph_branch_explicit = False
 

--- a/ralph_py/config.py
+++ b/ralph_py/config.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import os
 import re
+import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 
 def _parse_bool(value: str | None) -> bool:
@@ -22,6 +24,14 @@ def _parse_paths(value: str | None) -> list[str]:
     return [p.strip() for p in value.split(",") if p.strip()]
 
 
+def _resolve_path(value: str, root_dir: Path) -> Path:
+    """Resolve a path string against root_dir if relative."""
+    p = Path(value)
+    if p.is_absolute():
+        return p
+    return root_dir / p
+
+
 @dataclass
 class RalphConfig:
     """Configuration for Ralph agentic loop."""
@@ -29,6 +39,10 @@ class RalphConfig:
     max_iterations: int = 10
     prompt_file: Path = field(default_factory=lambda: Path("scripts/ralph/prompt.md"))
     prd_file: Path = field(default_factory=lambda: Path("scripts/ralph/prd.json"))
+    progress_file: Path = field(default_factory=lambda: Path("scripts/ralph/progress.txt"))
+    codebase_map_file: Path = field(
+        default_factory=lambda: Path("scripts/ralph/codebase_map.md")
+    )
     sleep_seconds: float = 2.0
     interactive: bool = False
     allowed_paths: list[str] = field(default_factory=list)
@@ -36,6 +50,7 @@ class RalphConfig:
     # Branch config - None means use PRD, "" means skip
     ralph_branch: str | None = None
     ralph_branch_explicit: bool = False  # Was RALPH_BRANCH env var set?
+    auto_checkout: bool = True
 
     # Agent config
     agent_cmd: str | None = None
@@ -55,42 +70,59 @@ class RalphConfig:
 
     @classmethod
     def from_env(cls, root_dir: Path | None = None) -> RalphConfig:
-        """Load configuration from environment variables."""
+        """Load configuration from environment variables only."""
         if root_dir is None:
             root_dir = Path.cwd()
+        config = cls()
+        # Default file paths are resolved against root_dir so the config is
+        # immediately usable regardless of cwd at the call site.
+        config.prompt_file = root_dir / "scripts/ralph/prompt.md"
+        config.prd_file = root_dir / "scripts/ralph/prd.json"
+        config.progress_file = root_dir / "scripts/ralph/progress.txt"
+        config.codebase_map_file = root_dir / "scripts/ralph/codebase_map.md"
+        _apply_env_overrides(config, root_dir)
+        return config
 
-        # Check if RALPH_BRANCH is explicitly set (even if empty)
-        ralph_branch_explicit = "RALPH_BRANCH" in os.environ
-        ralph_branch: str | None = os.environ.get("RALPH_BRANCH")
-        if not ralph_branch_explicit:
-            ralph_branch = None
+    @classmethod
+    def from_toml(cls, toml_path: Path, root_dir: Path | None = None) -> RalphConfig:
+        """Load configuration from a ralph.toml file (no env overlay)."""
+        if root_dir is None:
+            root_dir = toml_path.parent if toml_path.is_absolute() else Path.cwd()
+        config = cls()
+        config.prompt_file = root_dir / "scripts/ralph/prompt.md"
+        config.prd_file = root_dir / "scripts/ralph/prd.json"
+        config.progress_file = root_dir / "scripts/ralph/progress.txt"
+        config.codebase_map_file = root_dir / "scripts/ralph/codebase_map.md"
+        if toml_path.exists():
+            _apply_toml_overrides(config, toml_path, root_dir)
+        return config
 
-        return cls(
-            max_iterations=int(os.environ.get("MAX_ITERATIONS", "10")),
-            prompt_file=root_dir / os.environ.get("PROMPT_FILE", "scripts/ralph/prompt.md"),
-            prd_file=root_dir / os.environ.get("PRD_FILE", "scripts/ralph/prd.json"),
-            sleep_seconds=float(os.environ.get("SLEEP_SECONDS", "2")),
-            interactive=_parse_bool(os.environ.get("INTERACTIVE")),
-            allowed_paths=_parse_paths(os.environ.get("ALLOWED_PATHS")),
-            ralph_branch=ralph_branch,
-            ralph_branch_explicit=ralph_branch_explicit,
-            agent_cmd=os.environ.get("AGENT_CMD"),
-            model=os.environ.get("MODEL"),
-            model_reasoning_effort=os.environ.get("MODEL_REASONING_EFFORT"),
-            agent_type=os.environ.get("RALPH_AGENT_TYPE"),
-            agent_iteration_timeout=float(
-                os.environ.get("RALPH_TIMEOUT_AGENT_ITERATION", "1800")
-            ),
-            component_timeout=float(
-                os.environ.get("RALPH_TIMEOUT_COMPONENT", "7200")
-            ),
-            subprocess_timeout=float(
-                os.environ.get("RALPH_TIMEOUT_DEFAULT", "60")
-            ),
-            ui_mode=os.environ.get("RALPH_UI", "auto"),
-            no_color="NO_COLOR" in os.environ,
-            ascii_only=_parse_bool(os.environ.get("RALPH_ASCII")),
-        )
+    @classmethod
+    def load(
+        cls,
+        root_dir: Path | None = None,
+        toml_path: Path | None = None,
+    ) -> RalphConfig:
+        """Load configuration with precedence: env > toml > dataclass defaults.
+
+        If ``toml_path`` is omitted, ``<root_dir>/ralph.toml`` is auto-discovered.
+        Missing TOML file is fine (defaults are used). Malformed TOML raises.
+        """
+        if root_dir is None:
+            root_dir = Path.cwd()
+        if toml_path is None:
+            toml_path = root_dir / "ralph.toml"
+
+        config = cls()
+        config.prompt_file = root_dir / "scripts/ralph/prompt.md"
+        config.prd_file = root_dir / "scripts/ralph/prd.json"
+        config.progress_file = root_dir / "scripts/ralph/progress.txt"
+        config.codebase_map_file = root_dir / "scripts/ralph/codebase_map.md"
+
+        if toml_path.exists():
+            _apply_toml_overrides(config, toml_path, root_dir)
+        _apply_env_overrides(config, root_dir)
+        return config
 
     def validate(self) -> list[str]:
         """Validate configuration, returning list of errors."""
@@ -103,3 +135,129 @@ class RalphConfig:
             errors.append(f"Prompt file not found: {self.prompt_file}")
 
         return errors
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    """Load and parse a TOML file. Raises ValueError on malformed input."""
+    try:
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"Invalid TOML in {path}: {exc}") from exc
+
+
+def _apply_toml_overrides(
+    config: RalphConfig, toml_path: Path, root_dir: Path,
+) -> None:
+    """Mutate config in place from a ralph.toml file.
+
+    Maps the documented section structure (agent, run, paths, git, ui) onto
+    the flat RalphConfig dataclass. Unknown keys are silently ignored.
+    """
+    data = _load_toml(toml_path)
+
+    agent = data.get("agent")
+    if isinstance(agent, dict):
+        agent_type = agent.get("type")
+        if isinstance(agent_type, str) and agent_type:
+            config.agent_type = agent_type
+        command = agent.get("command")
+        if isinstance(command, str) and command:
+            config.agent_cmd = command
+        model = agent.get("model")
+        if isinstance(model, str) and model:
+            config.model = model
+        reasoning = agent.get("reasoning_effort")
+        if isinstance(reasoning, str) and reasoning:
+            config.model_reasoning_effort = reasoning
+
+    run = data.get("run")
+    if isinstance(run, dict):
+        if "max_iterations" in run:
+            config.max_iterations = int(run["max_iterations"])
+        if "sleep_seconds" in run:
+            config.sleep_seconds = float(run["sleep_seconds"])
+        if "interactive" in run:
+            config.interactive = bool(run["interactive"])
+
+    paths = data.get("paths")
+    if isinstance(paths, dict):
+        if isinstance(paths.get("prompt"), str) and paths["prompt"]:
+            config.prompt_file = _resolve_path(paths["prompt"], root_dir)
+        if isinstance(paths.get("prd"), str) and paths["prd"]:
+            config.prd_file = _resolve_path(paths["prd"], root_dir)
+        if isinstance(paths.get("progress"), str) and paths["progress"]:
+            config.progress_file = _resolve_path(paths["progress"], root_dir)
+        if isinstance(paths.get("codebase_map"), str) and paths["codebase_map"]:
+            config.codebase_map_file = _resolve_path(paths["codebase_map"], root_dir)
+        allowed = paths.get("allowed")
+        if isinstance(allowed, list):
+            config.allowed_paths = [str(p) for p in allowed if isinstance(p, str)]
+
+    git_section = data.get("git")
+    if isinstance(git_section, dict):
+        if "branch" in git_section:
+            branch = git_section["branch"]
+            if isinstance(branch, str):
+                config.ralph_branch = branch
+                config.ralph_branch_explicit = True
+        if "auto_checkout" in git_section:
+            config.auto_checkout = bool(git_section["auto_checkout"])
+
+    ui = data.get("ui")
+    if isinstance(ui, dict):
+        if "ascii" in ui:
+            config.ascii_only = bool(ui["ascii"])
+
+
+def _apply_env_overrides(config: RalphConfig, root_dir: Path) -> None:
+    """Mutate config in place from environment variables.
+
+    Only env vars that are explicitly set in the environment are applied -
+    unset vars leave the existing config value untouched.
+    """
+    if "MAX_ITERATIONS" in os.environ:
+        config.max_iterations = int(os.environ["MAX_ITERATIONS"])
+    if "PROMPT_FILE" in os.environ:
+        config.prompt_file = _resolve_path(os.environ["PROMPT_FILE"], root_dir)
+    if "PRD_FILE" in os.environ:
+        config.prd_file = _resolve_path(os.environ["PRD_FILE"], root_dir)
+    if "PROGRESS_FILE" in os.environ:
+        config.progress_file = _resolve_path(os.environ["PROGRESS_FILE"], root_dir)
+    if "CODEBASE_MAP_FILE" in os.environ:
+        config.codebase_map_file = _resolve_path(
+            os.environ["CODEBASE_MAP_FILE"], root_dir
+        )
+    if "SLEEP_SECONDS" in os.environ:
+        config.sleep_seconds = float(os.environ["SLEEP_SECONDS"])
+    if "INTERACTIVE" in os.environ:
+        config.interactive = _parse_bool(os.environ.get("INTERACTIVE"))
+    if "ALLOWED_PATHS" in os.environ:
+        config.allowed_paths = _parse_paths(os.environ.get("ALLOWED_PATHS"))
+    if "RALPH_BRANCH" in os.environ:
+        config.ralph_branch = os.environ["RALPH_BRANCH"]
+        config.ralph_branch_explicit = True
+    if "RALPH_AUTO_CHECKOUT" in os.environ:
+        config.auto_checkout = _parse_bool(os.environ.get("RALPH_AUTO_CHECKOUT"))
+    if "AGENT_CMD" in os.environ:
+        config.agent_cmd = os.environ["AGENT_CMD"]
+    if "MODEL" in os.environ:
+        config.model = os.environ["MODEL"]
+    if "MODEL_REASONING_EFFORT" in os.environ:
+        config.model_reasoning_effort = os.environ["MODEL_REASONING_EFFORT"]
+    if "RALPH_AGENT_TYPE" in os.environ:
+        config.agent_type = os.environ["RALPH_AGENT_TYPE"]
+    if "RALPH_TIMEOUT_AGENT_ITERATION" in os.environ:
+        config.agent_iteration_timeout = float(
+            os.environ["RALPH_TIMEOUT_AGENT_ITERATION"]
+        )
+    if "RALPH_TIMEOUT_COMPONENT" in os.environ:
+        config.component_timeout = float(os.environ["RALPH_TIMEOUT_COMPONENT"])
+    if "RALPH_TIMEOUT_DEFAULT" in os.environ:
+        config.subprocess_timeout = float(os.environ["RALPH_TIMEOUT_DEFAULT"])
+    if "RALPH_UI" in os.environ:
+        config.ui_mode = os.environ["RALPH_UI"]
+    if "NO_COLOR" in os.environ:
+        config.no_color = True
+    if "RALPH_ASCII" in os.environ:
+        config.ascii_only = _parse_bool(os.environ.get("RALPH_ASCII"))

--- a/ralph_py/config.py
+++ b/ralph_py/config.py
@@ -198,7 +198,12 @@ def _apply_toml_overrides(
     if isinstance(git_section, dict):
         if "branch" in git_section:
             branch = git_section["branch"]
-            if isinstance(branch, str):
+            # Only treat the TOML branch as an explicit override when it
+            # is non-empty. `branch = ""` in the shipped example means
+            # "no override, fall back to PRD branchName", whereas the env
+            # var `RALPH_BRANCH=""` (handled below) keeps its historical
+            # meaning of "explicit skip".
+            if isinstance(branch, str) and branch:
                 config.ralph_branch = branch
                 config.ralph_branch_explicit = True
         if "auto_checkout" in git_section:

--- a/ralph_py/decompose.py
+++ b/ralph_py/decompose.py
@@ -109,6 +109,64 @@ def _extract_json(text: str) -> Any:
     raise ValueError("No valid JSON found in output")
 
 
+def _select_agent_output(agent: Any, output_lines: list[str]) -> str:
+    """Return the best text candidate for JSON extraction from a finished
+    agent run.
+
+    Returns :attr:`agent.final_message` if it contains parseable JSON;
+    otherwise returns the joined streamed output. This shields callers
+    that pass the result through :func:`_extract_json` (e.g. via a
+    domain-specific parser) from codex's prompt-echo behavior.
+    """
+    streamed = "\n".join(output_lines)
+    final = getattr(agent, "final_message", None)
+    if not final:
+        return streamed
+    try:
+        _extract_json(final)
+    except ValueError:
+        return streamed
+    return final
+
+
+def _extract_agent_json(agent: Any, output_lines: list[str]) -> Any:
+    """Extract JSON from a completed agent run, trying agent.final_message
+    first and falling back to the streamed output.
+
+    Codex CLI (and other agents that echo the input prompt back) include
+    the JSON schema example inside their stdout, which can trip the
+    first-brace heuristic in :func:`_extract_json`. ``agent.final_message``
+    is populated by codex via ``--output-last-message`` and by
+    ClaudeCodeAgent from its result event, and contains only the model's
+    actual reply. Preferring it sidesteps the echoed-prompt problem.
+
+    For CustomAgent (whose final_message is just the last non-empty line
+    of streamed output), the multi-line JSON case is handled by the
+    streamed-output fallback when final_message fails to parse.
+
+    Raises :class:`ValueError` if neither candidate parses.
+    """
+    streamed = "\n".join(output_lines)
+    final = getattr(agent, "final_message", None)
+
+    candidates: list[str] = []
+    if final:
+        candidates.append(final)
+    if streamed and streamed != final:
+        candidates.append(streamed)
+
+    last_error: ValueError | None = None
+    for candidate in candidates:
+        try:
+            return _extract_json(candidate)
+        except ValueError as exc:
+            last_error = exc
+
+    if last_error is None:
+        raise ValueError("No agent output to parse")
+    raise last_error
+
+
 def _validate_decompose_output(data: Any) -> list[str]:
     """Validate the decomposition output structure."""
     errors: list[str] = []
@@ -275,10 +333,8 @@ def decompose_spec(
             output_lines.append(line)
             ui.stream_line("AI", line)
 
-        full_output = "\n".join(output_lines)
-
         try:
-            data = _extract_json(full_output)
+            data = _extract_agent_json(agent, output_lines)
         except ValueError as exc:
             last_error = str(exc)
             ui.warn(f"JSON extraction failed: {last_error}")

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -14,6 +14,11 @@ from ralph_py.config import RalphConfig
 from ralph_py.context import IterationContext
 from ralph_py.contract import ContractConfig, ContractMode, run_contract_testing
 from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
+from ralph_py.knowledge import (
+    KnowledgeConfig,
+    build_knowledge_context,
+    distill_facts,
+)
 from ralph_py.manifest import Component, ComponentStatus, Manifest
 from ralph_py.observability import NullProgressLog, ProgressLog
 from ralph_py.pr import create_prs_in_order, create_single_pr
@@ -142,6 +147,7 @@ def _run_component(
     feedforward_config_dict: dict | None = None,
     scaffold_cmd: str | None = None,
     component_deps: list[str] | None = None,
+    knowledge_prefix: str = "",
 ) -> ComponentResult:
     """Run a single component's implementation loop.
 
@@ -222,6 +228,8 @@ def _run_component(
     # Build context prefix from previous retries
     context_prefix: str | None = None
     parts: list[str] = []
+    if knowledge_prefix:
+        parts.append(knowledge_prefix)
     if feedforward_prefix:
         parts.append(feedforward_prefix)
     if previous_context_json:
@@ -286,6 +294,8 @@ def run_factory(
 
     factory_start = time.monotonic()
     factory_result = FactoryResult()
+    # Stable run id shared by evolution journal and knowledge layer
+    run_id = f"factory-{time.strftime('%Y%m%d-%H%M%S', time.gmtime())}"
 
     # Set up progress log
     if factory_config.progress_log_path:
@@ -483,6 +493,46 @@ def run_factory(
         else:
             comp.review_passed = None
 
+        # Knowledge distillation (Voyager-style post-gate write).
+        # Runs after Phase 2 succeeds (or is skipped) but BEFORE the PR
+        # merge step pulls main into the worktree, so the diff is the
+        # component's true delta. Non-fatal on any failure.
+        if knowledge_config.enabled:
+            try:
+                from ralph_py import git as git_ops
+                from ralph_py.agents import get_agent as _get_agent
+
+                diff_content = git_ops.get_diff_content(
+                    manifest.base_branch, wt_path,
+                )
+                distill_model = (
+                    knowledge_config.distill_model or base_config.model
+                )
+                distill_agent = _get_agent(
+                    base_config.agent_cmd,
+                    distill_model,
+                    base_config.model_reasoning_effort,
+                    base_config.agent_type,
+                )
+                written, status = distill_facts(
+                    distill_agent,
+                    comp,
+                    diff_content,
+                    wt_path / comp.prd_path,
+                    comp_result.iterations,
+                    run_id,
+                    knowledge_config.knowledge_root,
+                    knowledge_config,
+                    wt_path,
+                    comp.review_passed,
+                )
+                if written > 0:
+                    ui.ok(f"  Knowledge: {status}")
+                else:
+                    ui.info(f"  Knowledge: {status}")
+            except Exception as exc:  # noqa: BLE001 - non-fatal
+                ui.warn(f"  Knowledge distillation failed: {exc}")
+
         # All verification phases passed - create PR and merge
         if factory_config.create_prs:
             from ralph_py.pr import push_create_and_merge_pr, is_gh_available
@@ -551,8 +601,19 @@ def run_factory(
             "max_context_tokens": fc.max_context_tokens,
         }
 
+    # Load knowledge config once for the entire factory run
+    knowledge_config = KnowledgeConfig.load(root_dir)
+
     def _submit_args(comp: Component, wt_path: Path) -> tuple:
         ctx_json = component_contexts.get(comp.id)
+        knowledge_prefix = ""
+        if knowledge_config.enabled:
+            try:
+                knowledge_prefix = build_knowledge_context(
+                    manifest, comp, knowledge_config.knowledge_root, knowledge_config,
+                )
+            except Exception:
+                pass  # knowledge retrieval is non-fatal
         return (
             comp.id, comp.prd_path, str(wt_path),
             prompt_file_rel, base_config.agent_cmd, base_config.model,
@@ -561,6 +622,7 @@ def run_factory(
             ff_config_dict,
             comp.scaffold or None,
             comp.dependencies or None,
+            knowledge_prefix,
         )
 
     # Main scheduling loop
@@ -720,7 +782,6 @@ def run_factory(
         evo_config = EvolutionConfig()
         if evo_config.enabled:
             journal = EvolutionJournal(evo_config)
-            run_id = f"factory-{time.strftime('%Y%m%d-%H%M%S', time.gmtime())}"
             journal.record_run(run_id, manifest, factory_result)
     except Exception:
         pass  # evolution recording is non-fatal

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -148,6 +148,8 @@ def _run_component(
     scaffold_cmd: str | None = None,
     component_deps: list[str] | None = None,
     knowledge_prefix: str = "",
+    progress_file_str: str = "scripts/ralph/progress.txt",
+    codebase_map_file_str: str = "scripts/ralph/codebase_map.md",
 ) -> ComponentResult:
     """Run a single component's implementation loop.
 
@@ -244,6 +246,8 @@ def _run_component(
         max_iterations=30,
         prompt_file=worktree_prompt,
         prd_file=worktree_prd,
+        progress_file=worktree_path / progress_file_str,
+        codebase_map_file=worktree_path / codebase_map_file_str,
         sleep_seconds=sleep_seconds,
         interactive=False,
         ralph_branch="",
@@ -349,21 +353,23 @@ def run_factory(
     worktree_paths: dict[str, Path] = {}
     component_contexts: dict[str, str] = {}  # comp_id -> context JSON
 
-    if base_config.prompt_file.is_absolute():
+    def _path_relative_to_root(path: Path) -> str:
+        """Render `path` relative to root_dir for use inside per-component
+        worktrees. Falls back to the absolute path string when relativization
+        fails (e.g. a path on a different mount)."""
+        if not path.is_absolute():
+            return str(path)
         try:
-            prompt_file_rel = base_config.prompt_file.relative_to(root_dir).as_posix()
+            return path.relative_to(root_dir).as_posix()
         except ValueError:
-            # Symlink or mount differences - try with resolved paths
             try:
-                prompt_file_rel = (
-                    base_config.prompt_file.resolve()
-                    .relative_to(root_dir.resolve())
-                    .as_posix()
-                )
+                return path.resolve().relative_to(root_dir.resolve()).as_posix()
             except ValueError:
-                prompt_file_rel = str(base_config.prompt_file)
-    else:
-        prompt_file_rel = str(base_config.prompt_file)
+                return str(path)
+
+    prompt_file_rel = _path_relative_to_root(base_config.prompt_file)
+    progress_file_rel = _path_relative_to_root(base_config.progress_file)
+    codebase_map_file_rel = _path_relative_to_root(base_config.codebase_map_file)
 
     def _retry_or_fail(comp: Component, error: str, context_json: str | None) -> None:
         """Retry a component or mark it as failed."""
@@ -623,6 +629,8 @@ def run_factory(
             comp.scaffold or None,
             comp.dependencies or None,
             knowledge_prefix,
+            progress_file_rel,
+            codebase_map_file_rel,
         )
 
     # Main scheduling loop

--- a/ralph_py/knowledge.py
+++ b/ralph_py/knowledge.py
@@ -1,0 +1,780 @@
+"""Per-component semantic knowledge layer.
+
+A third memory surface (alongside evolution.jsonl and progress.txt) that
+captures durable facts about *the artifact being built*: interfaces,
+invariants, contracts, gotchas. Written after Phase 2 review passes and
+read by downstream components as part of the prompt context.
+
+Design constraints (see plans/zazzy-orbiting-sketch.md for rationale):
+
+- Atomic-fact files - never a single growing doc.
+- Latest run dir per component wins - simple, no supersede logic needed.
+- No LLM-driven consolidation or rewriting of existing facts. This is a
+  permanent design decision motivated by reports of memory-update
+  degradation in LLM-driven memory systems.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import time
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ralph_py.decompose import _extract_json
+
+if TYPE_CHECKING:
+    from ralph_py.agents.base import Agent
+    from ralph_py.manifest import Component, Manifest
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class KnowledgeConfig:
+    """Configuration for the per-component knowledge layer."""
+
+    enabled: bool = True
+    knowledge_root: Path = field(default_factory=lambda: Path(".ralph/knowledge"))
+    max_core_tokens: int = 2000
+    max_dependency_tokens: int = 1000
+    max_sibling_tokens: int = 500
+    distill_timeout_seconds: float = 300.0
+    distill_model: str = ""  # empty = falls back to base config's model
+    max_facts_per_distill: int = 7
+
+    @classmethod
+    def load(cls, root_dir: Path | None = None) -> KnowledgeConfig:
+        """Load configuration with precedence: env > toml > defaults.
+
+        Reads the [knowledge] section from ``<root_dir>/ralph.toml`` if
+        present, then applies any matching environment variable overrides.
+        """
+        import tomllib
+
+        if root_dir is None:
+            root_dir = Path.cwd()
+
+        config = cls()
+        config.knowledge_root = root_dir / ".ralph" / "knowledge"
+
+        toml_path = root_dir / "ralph.toml"
+        if toml_path.exists():
+            try:
+                with open(toml_path, "rb") as f:
+                    data = tomllib.load(f)
+            except tomllib.TOMLDecodeError:
+                data = {}
+            section = data.get("knowledge")
+            if isinstance(section, dict):
+                if "enabled" in section:
+                    config.enabled = bool(section["enabled"])
+                if "max_core_tokens" in section:
+                    config.max_core_tokens = int(section["max_core_tokens"])
+                if "max_dependency_tokens" in section:
+                    config.max_dependency_tokens = int(section["max_dependency_tokens"])
+                if "max_sibling_tokens" in section:
+                    config.max_sibling_tokens = int(section["max_sibling_tokens"])
+                if "distill_timeout_seconds" in section:
+                    config.distill_timeout_seconds = float(
+                        section["distill_timeout_seconds"]
+                    )
+                if "distill_model" in section:
+                    config.distill_model = str(section["distill_model"])
+                if "max_facts_per_distill" in section:
+                    config.max_facts_per_distill = int(section["max_facts_per_distill"])
+
+        # Env overrides
+        if "RALPH_KNOWLEDGE_ENABLED" in os.environ:
+            config.enabled = _parse_bool(os.environ["RALPH_KNOWLEDGE_ENABLED"])
+        if "RALPH_KNOWLEDGE_MAX_CORE_TOKENS" in os.environ:
+            config.max_core_tokens = int(os.environ["RALPH_KNOWLEDGE_MAX_CORE_TOKENS"])
+        if "RALPH_KNOWLEDGE_MAX_DEPENDENCY_TOKENS" in os.environ:
+            config.max_dependency_tokens = int(
+                os.environ["RALPH_KNOWLEDGE_MAX_DEPENDENCY_TOKENS"]
+            )
+        if "RALPH_KNOWLEDGE_MAX_SIBLING_TOKENS" in os.environ:
+            config.max_sibling_tokens = int(
+                os.environ["RALPH_KNOWLEDGE_MAX_SIBLING_TOKENS"]
+            )
+        if "RALPH_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS" in os.environ:
+            config.distill_timeout_seconds = float(
+                os.environ["RALPH_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS"]
+            )
+        if "RALPH_KNOWLEDGE_DISTILL_MODEL" in os.environ:
+            config.distill_model = os.environ["RALPH_KNOWLEDGE_DISTILL_MODEL"]
+        if "RALPH_KNOWLEDGE_MAX_FACTS_PER_DISTILL" in os.environ:
+            config.max_facts_per_distill = int(
+                os.environ["RALPH_KNOWLEDGE_MAX_FACTS_PER_DISTILL"]
+            )
+
+        return config
+
+
+# ---------------------------------------------------------------------------
+# Fact dataclass
+# ---------------------------------------------------------------------------
+
+
+VALID_SCOPES = frozenset(
+    {"handler", "adapter", "schema", "contract", "invariant", "gotcha"}
+)
+VALID_CONFIDENCES = frozenset({"verified", "asserted"})
+
+
+@dataclass
+class Fact:
+    """An atomic, durable semantic fact about a component."""
+
+    id: str
+    component_id: str
+    created_iter: int
+    created_run_id: str
+    scope: str
+    evidence: list[str]
+    confidence: str
+    claim: str
+    tags: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Serialization (markdown with JSON frontmatter)
+# ---------------------------------------------------------------------------
+
+
+_FRONTMATTER_DELIMITER = "---"
+
+
+def _render_fact_md(fact: Fact) -> str:
+    """Render a fact as a markdown file with a one-line JSON frontmatter block."""
+    meta = {
+        "id": fact.id,
+        "component_id": fact.component_id,
+        "created_iter": fact.created_iter,
+        "created_run_id": fact.created_run_id,
+        "scope": fact.scope,
+        "evidence": fact.evidence,
+        "confidence": fact.confidence,
+        "tags": fact.tags,
+    }
+    return (
+        f"{_FRONTMATTER_DELIMITER}\n"
+        f"{json.dumps(meta, separators=(',', ':'))}\n"
+        f"{_FRONTMATTER_DELIMITER}\n\n"
+        f"{fact.claim.rstrip()}\n"
+    )
+
+
+def _parse_fact_md(content: str) -> Fact:
+    """Parse a fact markdown file. Raises ValueError on malformed input."""
+    lines = content.split("\n")
+    if len(lines) < 3 or lines[0] != _FRONTMATTER_DELIMITER:
+        raise ValueError("missing opening frontmatter delimiter")
+
+    # Find the closing delimiter
+    closing_idx: int | None = None
+    for i in range(2, len(lines)):
+        if lines[i] == _FRONTMATTER_DELIMITER:
+            closing_idx = i
+            break
+    if closing_idx is None:
+        raise ValueError("missing closing frontmatter delimiter")
+
+    meta_json = "\n".join(lines[1:closing_idx])
+    try:
+        meta = json.loads(meta_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"frontmatter is not valid JSON: {exc}") from exc
+
+    if not isinstance(meta, dict):
+        raise ValueError("frontmatter must be a JSON object")
+
+    claim_lines = lines[closing_idx + 1:]
+    # Drop leading blank lines
+    while claim_lines and not claim_lines[0].strip():
+        claim_lines = claim_lines[1:]
+    claim = "\n".join(claim_lines).rstrip("\n")
+
+    return Fact(
+        id=str(meta.get("id", "")),
+        component_id=str(meta.get("component_id", "")),
+        created_iter=int(meta.get("created_iter", 0)),
+        created_run_id=str(meta.get("created_run_id", "")),
+        scope=str(meta.get("scope", "")),
+        evidence=[str(e) for e in meta.get("evidence", []) if isinstance(e, str)],
+        confidence=str(meta.get("confidence", "asserted")),
+        tags=[str(t) for t in meta.get("tags", []) if isinstance(t, str)],
+        claim=claim,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Read / write
+# ---------------------------------------------------------------------------
+
+
+def _latest_run_dir(component_root: Path) -> Path | None:
+    """Return the most-recent run directory for a component, or None.
+
+    Run dirs are named like ``factory-YYYYMMDD-HHMMSS`` - lexicographic
+    sort matches chronological order.
+    """
+    if not component_root.is_dir():
+        return None
+    candidates = [d for d in component_root.iterdir() if d.is_dir()]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda p: p.name, reverse=True)
+    return candidates[0]
+
+
+def read_facts(knowledge_root: Path, component_id: str) -> list[Fact]:
+    """Read all facts for a component from its latest run dir.
+
+    Returns an empty list if the component has no recorded facts, the
+    knowledge root does not exist, or files cannot be parsed. Individual
+    parse failures are skipped silently (they indicate a corrupted file,
+    not a crash-worthy condition).
+    """
+    component_root = knowledge_root / component_id
+    run_dir = _latest_run_dir(component_root)
+    if run_dir is None:
+        return []
+
+    facts: list[Fact] = []
+    for path in sorted(run_dir.glob("*.md")):
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        try:
+            facts.append(_parse_fact_md(content))
+        except ValueError:
+            continue
+    return facts
+
+
+def write_facts(
+    facts: list[Fact],
+    knowledge_root: Path,
+    component_id: str,
+    run_id: str,
+) -> int:
+    """Atomically write facts under ``<knowledge_root>/<component_id>/<run_id>/``.
+
+    Returns the number of facts successfully written. Disk failures are
+    non-fatal: a fact that fails to write is skipped (no exception
+    raised). The directory is created if missing.
+    """
+    if not facts:
+        return 0
+
+    run_dir = knowledge_root / component_id / run_id
+    try:
+        run_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return 0
+
+    written = 0
+    for fact in facts:
+        content = _render_fact_md(fact)
+        target = run_dir / f"{fact.id}.md"
+        try:
+            fd, tmp_path = tempfile.mkstemp(
+                dir=str(run_dir), suffix=".tmp", prefix=f".{fact.id}-",
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(content)
+                os.replace(tmp_path, str(target))
+                written += 1
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+        except OSError:
+            continue
+
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Retrieval / context building
+# ---------------------------------------------------------------------------
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token count - 4 chars per token, matching feedforward convention."""
+    return max(1, len(text) // 4)
+
+
+def _first_sentence(claim: str) -> str:
+    """Return the first sentence of a claim (everything up to the first '.', '!', or '?')."""
+    stripped = claim.strip()
+    if not stripped:
+        return ""
+    match = re.search(r"[.!?](?:\s|$)", stripped)
+    if match is None:
+        return stripped
+    return stripped[: match.end()].rstrip()
+
+
+def _sort_for_packing(facts: list[Fact]) -> list[Fact]:
+    """Sort facts: verified before asserted, then newest run first."""
+    # Python sort is stable: secondary sort first, then primary.
+    by_recency = sorted(facts, key=lambda f: f.created_run_id, reverse=True)
+    by_recency.sort(key=lambda f: 0 if f.confidence == "verified" else 1)
+    return by_recency
+
+
+def _pack_facts_full(
+    facts: list[Fact], budget_tokens: int,
+) -> tuple[list[Fact], bool]:
+    """Pack facts into budget. Returns (kept_facts, overflowed).
+
+    Drops asserted before verified, then oldest first. Within a single
+    fact, the body is truncated to fit only if that buys more than 30
+    tokens of payload (otherwise the fact is dropped entirely).
+    """
+    if not facts:
+        return [], False
+    ordered = _sort_for_packing(facts)
+    kept: list[Fact] = []
+    used = 0
+    overflowed = False
+    for fact in ordered:
+        rendered = _render_fact_md(fact)
+        cost = _estimate_tokens(rendered)
+        if used + cost <= budget_tokens:
+            kept.append(fact)
+            used += cost
+            continue
+
+        # Try truncating the body to fit the remaining budget.
+        meta_only = _render_fact_md(replace(fact, claim=""))
+        meta_cost = _estimate_tokens(meta_only)
+        remaining = budget_tokens - used - meta_cost
+        if remaining > 30:
+            chars_available = remaining * 4
+            truncated_claim = fact.claim[: chars_available - 20].rstrip() + "..."
+            kept.append(replace(fact, claim=truncated_claim))
+            used = budget_tokens
+        overflowed = True
+        break
+
+    if len(kept) < len(facts):
+        overflowed = True
+    return kept, overflowed
+
+
+def _pack_facts_summary(
+    facts: list[Fact], budget_tokens: int,
+) -> tuple[list[Fact], bool]:
+    """Pack first-sentence summaries into budget. Returns (kept_facts_with_summary_claim, overflowed)."""
+    if not facts:
+        return [], False
+    ordered = _sort_for_packing(facts)
+    kept: list[Fact] = []
+    used = 0
+    overflowed = False
+    for fact in ordered:
+        summary = _first_sentence(fact.claim)
+        summary_fact = replace(fact, claim=summary)
+        rendered = _render_fact_md(summary_fact)
+        cost = _estimate_tokens(rendered)
+        if used + cost <= budget_tokens:
+            kept.append(summary_fact)
+            used += cost
+        else:
+            overflowed = True
+            break
+    if len(kept) < len(facts):
+        overflowed = True
+    return kept, overflowed
+
+
+def _format_section(title: str, facts: list[Fact]) -> str:
+    if not facts:
+        return ""
+    lines: list[str] = [f"### {title}"]
+    for fact in facts:
+        scope_label = f"[{fact.scope}]" if fact.scope else ""
+        evidence_label = (
+            f" (evidence: {', '.join(fact.evidence)})" if fact.evidence else ""
+        )
+        confidence_label = f" {{{fact.confidence}}}"
+        lines.append(
+            f"- **{fact.component_id}**{scope_label}{confidence_label}: "
+            f"{fact.claim}{evidence_label}"
+        )
+    return "\n".join(lines)
+
+
+def build_knowledge_context(
+    manifest: Manifest,
+    component: Component,
+    knowledge_root: Path,
+    config: KnowledgeConfig,
+) -> str:
+    """Build the three-tier knowledge prefix for a component's prompt.
+
+    Tiers (each token-capped from config):
+    - Core: full text of all facts for ``component``.
+    - Dependency: full text of facts for every transitive dependency.
+    - Sibling: first-sentence summary of facts for every other component.
+
+    Returns the empty string when there is nothing to surface or when
+    knowledge is disabled.
+    """
+    if not config.enabled:
+        return ""
+    if not knowledge_root.is_dir():
+        return ""
+
+    # Core
+    core_facts = read_facts(knowledge_root, component.id)
+    core_kept, core_overflow = _pack_facts_full(core_facts, config.max_core_tokens)
+
+    # Dependency (transitive closure)
+    dep_ids = _transitive_dependencies(manifest, component.id)
+    dep_facts: list[Fact] = []
+    for dep_id in dep_ids:
+        dep_facts.extend(read_facts(knowledge_root, dep_id))
+    dep_kept, dep_overflow = _pack_facts_full(
+        dep_facts, config.max_dependency_tokens,
+    )
+
+    # Sibling: everything else
+    excluded = {component.id} | dep_ids
+    sibling_facts: list[Fact] = []
+    for comp in manifest.components:
+        if comp.id in excluded:
+            continue
+        sibling_facts.extend(read_facts(knowledge_root, comp.id))
+    sibling_kept, sibling_overflow = _pack_facts_summary(
+        sibling_facts, config.max_sibling_tokens,
+    )
+
+    if not (core_kept or dep_kept or sibling_kept):
+        return ""
+
+    parts: list[str] = ["## Component Knowledge"]
+    parts.append(
+        "Durable facts captured from prior successful iterations. Treat as"
+        " ground truth unless contradicted by the current diff."
+    )
+    parts.append("")
+
+    core_section = _format_section(f"Current component ({component.id})", core_kept)
+    if core_section:
+        parts.append(core_section)
+        parts.append("")
+    dep_section = _format_section("Dependencies", dep_kept)
+    if dep_section:
+        parts.append(dep_section)
+        parts.append("")
+    sibling_section = _format_section("Other components (summary)", sibling_kept)
+    if sibling_section:
+        parts.append(sibling_section)
+        parts.append("")
+
+    overflow_flags: list[str] = []
+    if core_overflow:
+        overflow_flags.append("core")
+    if dep_overflow:
+        overflow_flags.append("dependency")
+    if sibling_overflow:
+        overflow_flags.append("sibling")
+    if overflow_flags:
+        parts.append(
+            "*Note: "
+            f"{', '.join(overflow_flags)} tier"
+            f"{'s' if len(overflow_flags) > 1 else ''}"
+            " exceeded the token budget; some facts were truncated or dropped.*"
+        )
+        parts.append("")
+
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def _transitive_dependencies(manifest: Manifest, component_id: str) -> set[str]:
+    """Return the set of transitive dependency component IDs for ``component_id``."""
+    dep_ids: set[str] = set()
+    visited: set[str] = set()
+    queue: list[str] = [component_id]
+    while queue:
+        current = queue.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+        for comp in manifest.components:
+            if comp.id != current:
+                continue
+            for dep in comp.dependencies:
+                if dep not in dep_ids:
+                    dep_ids.add(dep)
+                    queue.append(dep)
+            break
+    dep_ids.discard(component_id)
+    return dep_ids
+
+
+# ---------------------------------------------------------------------------
+# Distillation (Voyager-style post-gate write trigger)
+# ---------------------------------------------------------------------------
+
+
+DISTILL_PROMPT = """\
+You are a knowledge-distillation agent. The implementing agent has just
+completed an iteration on a single component, and that work has passed
+mechanical verification AND second-opinion review. Your job is to extract
+durable semantic facts about WHAT WAS BUILT that downstream components
+(and future iterations of this same component) need to know.
+
+You must output ONLY valid JSON (no Markdown, no code fences, no
+explanation). Schema:
+
+{{
+  "facts": [
+    {{
+      "id": "fact-001",
+      "scope": "handler|adapter|schema|contract|invariant|gotcha",
+      "confidence": "verified|asserted",
+      "evidence": ["path/to/file.py:42-58", "tests/test_x.py:101"],
+      "tags": ["auth", "tokens"],
+      "claim": "A single durable assertion in 1-5 sentences. State it as a fact about the artifact, not the iteration. Cite the evidence inline if helpful."
+    }}
+  ]
+}}
+
+Rules:
+1. Facts must be DURABLE - things that will remain true unless the
+   component is rewritten. Skip implementation details that change every
+   iteration.
+2. Facts must be SEMANTIC - what the code DOES or PROMISES, not what
+   files exist or what tests were run.
+3. Every fact must cite at least one path:line-range in the diff. If you
+   cannot ground a claim in concrete evidence, do not write it.
+4. confidence="verified" only if the claim is backed by passing tests or
+   explicit acceptance criteria. Otherwise use "asserted".
+5. Maximum {max_facts} facts. If nothing durable was established (e.g.
+   pure refactor with no behavioral change), return {{"facts": []}}.
+6. fact ids must be unique within this response and match /^fact-\\d{{3}}$/.
+7. Do not duplicate existing facts (shown below). If an existing fact is
+   wrong or stale, do not "fix" it - that is handled separately. Just
+   omit it from your output.
+
+Component being distilled: {component_id}
+Title: {component_title}
+Description: {component_description}
+Dependencies: {dependencies}
+
+================================================================================
+ACCEPTANCE CRITERIA (from PRD)
+================================================================================
+
+{prd_content}
+
+================================================================================
+EXISTING FACTS FROM PRIOR RUNS (do not duplicate)
+================================================================================
+
+{existing_facts}
+
+================================================================================
+GIT DIFF (the work that just passed verification + review)
+================================================================================
+
+{diff_content}
+"""
+
+
+def _summarize_existing_facts(facts: list[Fact]) -> str:
+    if not facts:
+        return "(none)"
+    lines: list[str] = []
+    for fact in facts:
+        first = _first_sentence(fact.claim) or fact.claim[:120]
+        lines.append(f"- [{fact.scope}] {first}")
+    return "\n".join(lines)
+
+
+def _read_prd_text(prd_path: Path) -> str:
+    try:
+        text = prd_path.read_text(encoding="utf-8")
+    except OSError:
+        return "(PRD not readable)"
+    return text
+
+
+def _parse_distill_output(raw_output: str) -> list[dict]:
+    """Extract the facts array from raw agent output. Returns [] on any failure."""
+    try:
+        data = _extract_json(raw_output)
+    except ValueError:
+        return []
+    if not isinstance(data, dict):
+        return []
+    facts = data.get("facts")
+    if not isinstance(facts, list):
+        return []
+    return [f for f in facts if isinstance(f, dict)]
+
+
+_FACT_ID_RE = re.compile(r"^fact-\d{3}$")
+
+
+def _coerce_facts(
+    raw_facts: list[dict],
+    component_id: str,
+    iteration_count: int,
+    run_id: str,
+    max_facts: int,
+) -> list[Fact]:
+    """Validate and coerce raw fact dicts into Fact instances.
+
+    Invalid facts (missing required fields, bad scope, etc.) are skipped
+    rather than crashing distillation.
+    """
+    facts: list[Fact] = []
+    seen_ids: set[str] = set()
+    for raw in raw_facts:
+        if len(facts) >= max_facts:
+            break
+
+        fact_id = str(raw.get("id", "")).strip()
+        if not _FACT_ID_RE.match(fact_id) or fact_id in seen_ids:
+            continue
+        scope = str(raw.get("scope", "")).strip()
+        if scope not in VALID_SCOPES:
+            continue
+        confidence = str(raw.get("confidence", "")).strip()
+        if confidence not in VALID_CONFIDENCES:
+            continue
+        evidence_raw = raw.get("evidence", [])
+        if not isinstance(evidence_raw, list) or not evidence_raw:
+            continue
+        evidence = [str(e).strip() for e in evidence_raw if isinstance(e, str)]
+        evidence = [e for e in evidence if e]
+        if not evidence:
+            continue
+        claim = str(raw.get("claim", "")).strip()
+        if not claim:
+            continue
+        tags_raw = raw.get("tags", [])
+        tags = (
+            [str(t).strip() for t in tags_raw if isinstance(t, str)]
+            if isinstance(tags_raw, list)
+            else []
+        )
+
+        facts.append(
+            Fact(
+                id=fact_id,
+                component_id=component_id,
+                created_iter=iteration_count,
+                created_run_id=run_id,
+                scope=scope,
+                evidence=evidence,
+                confidence=confidence,
+                claim=claim,
+                tags=tags,
+            )
+        )
+        seen_ids.add(fact_id)
+    return facts
+
+
+def distill_facts(
+    agent: Agent,
+    component: Component,
+    diff_content: str,
+    prd_path: Path,
+    iteration_count: int,
+    run_id: str,
+    knowledge_root: Path,
+    config: KnowledgeConfig,
+    worktree_path: Path,
+    review_passed: bool | None,
+) -> tuple[int, str]:
+    """Run the LLM distillation call and persist any facts returned.
+
+    Returns ``(written_count, status_message)``. Failures are reported in
+    the status message rather than raised - distillation is non-fatal.
+
+    ``review_passed`` controls the confidence ceiling: ``True`` allows
+    "verified", ``None`` (skip mode) and ``False`` (shouldn't happen but
+    handled defensively) cap at "asserted".
+    """
+    if not config.enabled:
+        return 0, "knowledge.disabled"
+
+    # Truncate diff to match review.py's 50KB convention
+    diff_for_prompt = diff_content
+    if len(diff_for_prompt) > 50000:
+        diff_for_prompt = diff_for_prompt[:50000] + "\n... (diff truncated at 50KB)"
+
+    existing = read_facts(knowledge_root, component.id)
+
+    prompt = DISTILL_PROMPT.format(
+        max_facts=config.max_facts_per_distill,
+        component_id=component.id,
+        component_title=component.title,
+        component_description=component.description,
+        dependencies=", ".join(component.dependencies) or "(none)",
+        prd_content=_read_prd_text(prd_path),
+        existing_facts=_summarize_existing_facts(existing),
+        diff_content=diff_for_prompt,
+    )
+
+    output_lines: list[str] = []
+    try:
+        for line in agent.run(
+            prompt, cwd=worktree_path, timeout=config.distill_timeout_seconds,
+        ):
+            output_lines.append(line)
+    except Exception as exc:  # noqa: BLE001 - non-fatal
+        return 0, f"knowledge.agent_error: {exc}"
+
+    raw_output = "\n".join(output_lines)
+    raw_facts = _parse_distill_output(raw_output)
+    if not raw_facts:
+        return 0, "knowledge.no_facts"
+
+    facts = _coerce_facts(
+        raw_facts, component.id, iteration_count, run_id,
+        config.max_facts_per_distill,
+    )
+
+    # Confidence ceiling: only Phase-2-passed work earns "verified"
+    if review_passed is not True:
+        facts = [replace(f, confidence="asserted") for f in facts]
+
+    if not facts:
+        return 0, "knowledge.no_valid_facts"
+
+    written = write_facts(facts, knowledge_root, component.id, run_id)
+    return written, f"knowledge.wrote {written}/{len(facts)} facts"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_bool(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes"}
+
+
+def current_run_id() -> str:
+    """Construct a run id of the same shape factory.py uses for evolution.jsonl."""
+    return f"factory-{time.strftime('%Y%m%d-%H%M%S', time.gmtime())}"

--- a/ralph_py/knowledge.py
+++ b/ralph_py/knowledge.py
@@ -745,9 +745,37 @@ def distill_facts(
     except Exception as exc:  # noqa: BLE001 - non-fatal
         return 0, f"knowledge.agent_error: {exc}"
 
-    raw_output = "\n".join(output_lines)
+    streamed_output = "\n".join(output_lines)
+
+    # Prefer the agent's final_message when set (codex populates this via
+    # --output-last-message). The streamed output often echoes the prompt
+    # back, and _extract_json's first-brace heuristic would otherwise
+    # latch onto the JSON schema example inside the echoed prompt.
+    final_message = getattr(agent, "final_message", None)
+    raw_output = final_message if final_message else streamed_output
+
+    def _dump_debug(label: str) -> None:
+        """Persist raw distiller output so failure modes are diagnosable
+        without re-running. Best-effort; ignore disk errors."""
+        try:
+            debug_dir = knowledge_root / component.id / run_id
+            debug_dir.mkdir(parents=True, exist_ok=True)
+            (debug_dir / "_distill_raw.txt").write_text(
+                streamed_output, encoding="utf-8",
+            )
+            if final_message and final_message != streamed_output:
+                (debug_dir / "_distill_final.txt").write_text(
+                    final_message, encoding="utf-8",
+                )
+            (debug_dir / "_distill_status.txt").write_text(label, encoding="utf-8")
+        except OSError:
+            pass
+
     raw_facts = _parse_distill_output(raw_output)
     if not raw_facts:
+        # Could be a clean empty response or a parse failure - dump so we
+        # can tell which without re-running.
+        _dump_debug("no_facts")
         return 0, "knowledge.no_facts"
 
     facts = _coerce_facts(
@@ -760,7 +788,11 @@ def distill_facts(
         facts = [replace(f, confidence="asserted") for f in facts]
 
     if not facts:
-        return 0, "knowledge.no_valid_facts"
+        # Surface a brief sample of the rejected raw output so the user
+        # can see why coercion failed without grepping the dump.
+        sample = raw_output[:200].replace("\n", " ")
+        _dump_debug("no_valid_facts")
+        return 0, f"knowledge.no_valid_facts (raw: {sample}...)"
 
     written = write_facts(facts, knowledge_root, component.id, run_id)
     return written, f"knowledge.wrote {written}/{len(facts)} facts"

--- a/ralph_py/knowledge.py
+++ b/ralph_py/knowledge.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from ralph_py.decompose import _extract_json
+from ralph_py.decompose import _extract_json, _select_agent_output
 
 if TYPE_CHECKING:
     from ralph_py.agents.base import Agent
@@ -56,6 +56,9 @@ class KnowledgeConfig:
 
         Reads the [knowledge] section from ``<root_dir>/ralph.toml`` if
         present, then applies any matching environment variable overrides.
+        Raises ValueError on malformed TOML, matching the error policy of
+        :meth:`RalphConfig.load` so the two loaders treat the same file
+        consistently.
         """
         import tomllib
 
@@ -66,30 +69,32 @@ class KnowledgeConfig:
         config.knowledge_root = root_dir / ".ralph" / "knowledge"
 
         toml_path = root_dir / "ralph.toml"
+        data: dict = {}
         if toml_path.exists():
             try:
                 with open(toml_path, "rb") as f:
                     data = tomllib.load(f)
-            except tomllib.TOMLDecodeError:
-                data = {}
-            section = data.get("knowledge")
-            if isinstance(section, dict):
-                if "enabled" in section:
-                    config.enabled = bool(section["enabled"])
-                if "max_core_tokens" in section:
-                    config.max_core_tokens = int(section["max_core_tokens"])
-                if "max_dependency_tokens" in section:
-                    config.max_dependency_tokens = int(section["max_dependency_tokens"])
-                if "max_sibling_tokens" in section:
-                    config.max_sibling_tokens = int(section["max_sibling_tokens"])
-                if "distill_timeout_seconds" in section:
-                    config.distill_timeout_seconds = float(
-                        section["distill_timeout_seconds"]
-                    )
-                if "distill_model" in section:
-                    config.distill_model = str(section["distill_model"])
-                if "max_facts_per_distill" in section:
-                    config.max_facts_per_distill = int(section["max_facts_per_distill"])
+            except tomllib.TOMLDecodeError as exc:
+                raise ValueError(f"Invalid TOML in {toml_path}: {exc}") from exc
+
+        section = data.get("knowledge")
+        if isinstance(section, dict):
+            if "enabled" in section:
+                config.enabled = bool(section["enabled"])
+            if "max_core_tokens" in section:
+                config.max_core_tokens = int(section["max_core_tokens"])
+            if "max_dependency_tokens" in section:
+                config.max_dependency_tokens = int(section["max_dependency_tokens"])
+            if "max_sibling_tokens" in section:
+                config.max_sibling_tokens = int(section["max_sibling_tokens"])
+            if "distill_timeout_seconds" in section:
+                config.distill_timeout_seconds = float(
+                    section["distill_timeout_seconds"]
+                )
+            if "distill_model" in section:
+                config.distill_model = str(section["distill_model"])
+            if "max_facts_per_distill" in section:
+                config.max_facts_per_distill = int(section["max_facts_per_distill"])
 
         # Env overrides
         if "RALPH_KNOWLEDGE_ENABLED" in os.environ:
@@ -317,12 +322,26 @@ def _estimate_tokens(text: str) -> int:
     return max(1, len(text) // 4)
 
 
+# Sentence-end regex: terminal punctuation followed by either end-of-string
+# or whitespace + an uppercase ASCII letter. This avoids splitting on
+# common abbreviations like "e.g.", "i.e.", "Mr." where the period is
+# followed by a lowercase continuation.
+_SENTENCE_END_RE = re.compile(r"[.!?](?=\s+[A-Z]|\s*$)")
+
+
 def _first_sentence(claim: str) -> str:
-    """Return the first sentence of a claim (everything up to the first '.', '!', or '?')."""
+    """Return the first sentence of a claim.
+
+    Splits on '.', '!', or '?' only when followed by whitespace + a
+    capital letter (or end of string). This is a heuristic - it
+    deliberately keeps abbreviations like "e.g." intact at the cost of
+    occasionally missing a real boundary when the next sentence starts
+    with a lowercase word.
+    """
     stripped = claim.strip()
     if not stripped:
         return ""
-    match = re.search(r"[.!?](?:\s|$)", stripped)
+    match = _SENTENCE_END_RE.search(stripped)
     if match is None:
         return stripped
     return stripped[: match.end()].rstrip()
@@ -341,9 +360,10 @@ def _pack_facts_full(
 ) -> tuple[list[Fact], bool]:
     """Pack facts into budget. Returns (kept_facts, overflowed).
 
-    Drops asserted before verified, then oldest first. Within a single
-    fact, the body is truncated to fit only if that buys more than 30
-    tokens of payload (otherwise the fact is dropped entirely).
+    Drops asserted before verified, then oldest first. The first
+    overflowing fact may have its body truncated to fit the remaining
+    budget if doing so buys more than 30 tokens of payload. Subsequent
+    smaller facts that still fit are kept (no greedy abort).
     """
     if not facts:
         return [], False
@@ -351,6 +371,7 @@ def _pack_facts_full(
     kept: list[Fact] = []
     used = 0
     overflowed = False
+    truncation_used = False
     for fact in ordered:
         rendered = _render_fact_md(fact)
         cost = _estimate_tokens(rendered)
@@ -359,17 +380,24 @@ def _pack_facts_full(
             used += cost
             continue
 
-        # Try truncating the body to fit the remaining budget.
-        meta_only = _render_fact_md(replace(fact, claim=""))
-        meta_cost = _estimate_tokens(meta_only)
-        remaining = budget_tokens - used - meta_cost
-        if remaining > 30:
-            chars_available = remaining * 4
-            truncated_claim = fact.claim[: chars_available - 20].rstrip() + "..."
-            kept.append(replace(fact, claim=truncated_claim))
-            used = budget_tokens
+        # Doesn't fit at full size. Try truncating once (only the first
+        # overflowing fact gets this treatment) to soak up remaining
+        # budget; subsequent overflowing facts are dropped but smaller
+        # facts after them may still fit.
+        if not truncation_used:
+            meta_only = _render_fact_md(replace(fact, claim=""))
+            meta_cost = _estimate_tokens(meta_only)
+            remaining = budget_tokens - used - meta_cost
+            if remaining > 30:
+                chars_available = remaining * 4
+                truncated_claim = (
+                    fact.claim[: chars_available - 20].rstrip() + "..."
+                )
+                kept.append(replace(fact, claim=truncated_claim))
+                used = budget_tokens
+                truncation_used = True
         overflowed = True
-        break
+        # Don't break: smaller subsequent facts may still fit.
 
     if len(kept) < len(facts):
         overflowed = True
@@ -379,7 +407,11 @@ def _pack_facts_full(
 def _pack_facts_summary(
     facts: list[Fact], budget_tokens: int,
 ) -> tuple[list[Fact], bool]:
-    """Pack first-sentence summaries into budget. Returns (kept_facts_with_summary_claim, overflowed)."""
+    """Pack first-sentence summaries into budget. Returns (kept_facts_with_summary_claim, overflowed).
+
+    A summary that doesn't fit is dropped, but the loop continues so
+    smaller subsequent summaries are still considered.
+    """
     if not facts:
         return [], False
     ordered = _sort_for_packing(facts)
@@ -396,7 +428,7 @@ def _pack_facts_summary(
             used += cost
         else:
             overflowed = True
-            break
+            # Don't break: smaller subsequent summaries may still fit.
     if len(kept) < len(facts):
         overflowed = True
     return kept, overflowed
@@ -746,13 +778,12 @@ def distill_facts(
         return 0, f"knowledge.agent_error: {exc}"
 
     streamed_output = "\n".join(output_lines)
-
-    # Prefer the agent's final_message when set (codex populates this via
-    # --output-last-message). The streamed output often echoes the prompt
-    # back, and _extract_json's first-brace heuristic would otherwise
-    # latch onto the JSON schema example inside the echoed prompt.
+    # Select the best candidate: prefer agent.final_message when it
+    # parses (codex/claude path), else use streamed (CustomAgent or any
+    # agent that emits multi-line JSON without populating final_message
+    # with the full response).
+    raw_output = _select_agent_output(agent, output_lines)
     final_message = getattr(agent, "final_message", None)
-    raw_output = final_message if final_message else streamed_output
 
     def _dump_debug(label: str) -> None:
         """Persist raw distiller output so failure modes are diagnosable

--- a/ralph_py/loop.py
+++ b/ralph_py/loop.py
@@ -83,8 +83,8 @@ def run_loop(
     raw_prompt = config.prompt_file.read_text()
     prompt = Template(raw_prompt).safe_substitute(
         prd_path=str(config.prd_file),
-        progress_path=str(config.progress_file) if hasattr(config, "progress_file") else "scripts/ralph/progress.txt",
-        codebase_map_path="scripts/ralph/codebase_map.md",
+        progress_path=str(config.progress_file),
+        codebase_map_path=str(config.codebase_map_file),
     )
 
     # Prepend CLAUDE.md project context if it exists in the working directory
@@ -111,6 +111,8 @@ def run_loop(
 
     if not is_repo:
         ui.warn("Not a git repository")
+    elif not config.auto_checkout:
+        ui.info("Branch: auto_checkout disabled; using current branch")
     else:
         branch, source = _determine_branch(config)
         if branch:

--- a/ralph_py/review.py
+++ b/ralph_py/review.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ralph_py import git
-from ralph_py.decompose import _extract_json
+from ralph_py.decompose import _extract_json, _select_agent_output
 from ralph_py.prd import PRD
 from ralph_py.verify import VerificationResult
 
@@ -270,7 +270,7 @@ def run_review(
     for line in agent.run(prompt, cwd=worktree_path, timeout=timeout):
         output_lines.append(line)
 
-    raw_output = "\n".join(output_lines)
+    raw_output = _select_agent_output(agent, output_lines)
     result = parse_review_output(raw_output)
     result.mode = mode.value
     result.duration_seconds = time.monotonic() - start

--- a/tests/test_config_toml.py
+++ b/tests/test_config_toml.py
@@ -261,9 +261,14 @@ def test_load_env_paths_resolved_against_root(
     assert config.prompt_file == tmp_path / "custom/prompt.md"
 
 
-def test_load_toml_branch_marks_explicit_even_when_empty(
+def test_load_toml_empty_branch_does_not_mark_explicit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """ralph.toml.example documents `branch = ""` as 'empty = use PRD
+    branchName'. An empty TOML branch must therefore NOT mark explicit,
+    so loop._determine_branch falls through to PRD lookup instead of
+    skipping checkout. Env var RALPH_BRANCH="" retains its historical
+    explicit-skip meaning - that path is tested elsewhere."""
     for var in ("RALPH_BRANCH",):
         monkeypatch.delenv(var, raising=False)
     _write_toml(
@@ -274,7 +279,24 @@ branch = ""
 """,
     )
     config = RalphConfig.load(tmp_path)
-    assert config.ralph_branch == ""
+    assert config.ralph_branch is None
+    assert config.ralph_branch_explicit is False
+
+
+def test_load_toml_nonempty_branch_marks_explicit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in ("RALPH_BRANCH",):
+        monkeypatch.delenv(var, raising=False)
+    _write_toml(
+        tmp_path / "ralph.toml",
+        """
+[git]
+branch = "feature/foo"
+""",
+    )
+    config = RalphConfig.load(tmp_path)
+    assert config.ralph_branch == "feature/foo"
     assert config.ralph_branch_explicit is True
 
 

--- a/tests/test_config_toml.py
+++ b/tests/test_config_toml.py
@@ -1,0 +1,313 @@
+"""Tests for the ralph_py.config TOML loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ralph_py.config import RalphConfig
+
+
+def _write_toml(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# from_toml: mapping table
+# ---------------------------------------------------------------------------
+
+
+def test_from_toml_maps_agent_section(tmp_path: Path) -> None:
+    toml_path = tmp_path / "ralph.toml"
+    _write_toml(
+        toml_path,
+        """
+[agent]
+type = "codex"
+command = "my-agent --stdin"
+model = "o3"
+reasoning_effort = "high"
+""",
+    )
+    config = RalphConfig.from_toml(toml_path, tmp_path)
+    assert config.agent_type == "codex"
+    assert config.agent_cmd == "my-agent --stdin"
+    assert config.model == "o3"
+    assert config.model_reasoning_effort == "high"
+
+
+def test_from_toml_maps_run_section(tmp_path: Path) -> None:
+    toml_path = tmp_path / "ralph.toml"
+    _write_toml(
+        toml_path,
+        """
+[run]
+max_iterations = 42
+sleep_seconds = 5
+interactive = true
+""",
+    )
+    config = RalphConfig.from_toml(toml_path, tmp_path)
+    assert config.max_iterations == 42
+    assert config.sleep_seconds == 5.0
+    assert config.interactive is True
+
+
+def test_from_toml_maps_paths_section(tmp_path: Path) -> None:
+    toml_path = tmp_path / "ralph.toml"
+    _write_toml(
+        toml_path,
+        """
+[paths]
+prompt = "custom/prompt.md"
+prd = "custom/prd.json"
+progress = "custom/progress.txt"
+codebase_map = "custom/map.md"
+allowed = ["src/", "tests/"]
+""",
+    )
+    config = RalphConfig.from_toml(toml_path, tmp_path)
+    assert config.prompt_file == tmp_path / "custom/prompt.md"
+    assert config.prd_file == tmp_path / "custom/prd.json"
+    assert config.progress_file == tmp_path / "custom/progress.txt"
+    assert config.codebase_map_file == tmp_path / "custom/map.md"
+    assert config.allowed_paths == ["src/", "tests/"]
+
+
+def test_from_toml_maps_git_section(tmp_path: Path) -> None:
+    toml_path = tmp_path / "ralph.toml"
+    _write_toml(
+        toml_path,
+        """
+[git]
+branch = "feature/x"
+auto_checkout = false
+""",
+    )
+    config = RalphConfig.from_toml(toml_path, tmp_path)
+    assert config.ralph_branch == "feature/x"
+    assert config.ralph_branch_explicit is True
+    assert config.auto_checkout is False
+
+
+def test_from_toml_maps_ui_section(tmp_path: Path) -> None:
+    toml_path = tmp_path / "ralph.toml"
+    _write_toml(
+        toml_path,
+        """
+[ui]
+ascii = true
+""",
+    )
+    config = RalphConfig.from_toml(toml_path, tmp_path)
+    assert config.ascii_only is True
+
+
+def test_from_toml_empty_file_uses_defaults(tmp_path: Path) -> None:
+    toml_path = tmp_path / "ralph.toml"
+    _write_toml(toml_path, "")
+    config = RalphConfig.from_toml(toml_path, tmp_path)
+    assert config.max_iterations == 10
+    assert config.sleep_seconds == 2.0
+    assert config.agent_type is None
+
+
+def test_from_toml_missing_file_uses_defaults(tmp_path: Path) -> None:
+    config = RalphConfig.from_toml(tmp_path / "nonexistent.toml", tmp_path)
+    assert config.max_iterations == 10
+    assert config.agent_cmd is None
+
+
+def test_from_toml_malformed_raises_clear_error(tmp_path: Path) -> None:
+    toml_path = tmp_path / "ralph.toml"
+    _write_toml(toml_path, "this is not = valid = toml = [\n")
+    with pytest.raises(ValueError, match="Invalid TOML"):
+        RalphConfig.from_toml(toml_path, tmp_path)
+
+
+def test_from_toml_resolves_absolute_paths(tmp_path: Path) -> None:
+    toml_path = tmp_path / "ralph.toml"
+    abs_prompt = tmp_path / "elsewhere" / "p.md"
+    _write_toml(
+        toml_path,
+        f"""
+[paths]
+prompt = "{abs_prompt}"
+""",
+    )
+    config = RalphConfig.from_toml(toml_path, tmp_path)
+    assert config.prompt_file == abs_prompt
+
+
+def test_from_toml_ignores_unknown_keys(tmp_path: Path) -> None:
+    toml_path = tmp_path / "ralph.toml"
+    _write_toml(
+        toml_path,
+        """
+[agent]
+type = "claude"
+unknown_field = "ignored"
+
+[unknown_section]
+foo = "bar"
+""",
+    )
+    config = RalphConfig.from_toml(toml_path, tmp_path)
+    assert config.agent_type == "claude"
+
+
+# ---------------------------------------------------------------------------
+# load: env > toml > defaults precedence
+# ---------------------------------------------------------------------------
+
+
+def test_load_env_overrides_toml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    toml_path = tmp_path / "ralph.toml"
+    _write_toml(
+        toml_path,
+        """
+[run]
+max_iterations = 25
+
+[agent]
+model = "sonnet"
+""",
+    )
+    monkeypatch.setenv("MAX_ITERATIONS", "99")
+    monkeypatch.setenv("MODEL", "opus")
+    config = RalphConfig.load(tmp_path)
+    assert config.max_iterations == 99
+    assert config.model == "opus"
+
+
+def test_load_toml_wins_over_defaults_when_env_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Clear env vars that might leak from the test environment
+    for var in ("MAX_ITERATIONS", "MODEL", "SLEEP_SECONDS", "INTERACTIVE"):
+        monkeypatch.delenv(var, raising=False)
+    toml_path = tmp_path / "ralph.toml"
+    _write_toml(
+        toml_path,
+        """
+[run]
+max_iterations = 25
+""",
+    )
+    config = RalphConfig.load(tmp_path)
+    assert config.max_iterations == 25
+
+
+def test_load_defaults_when_no_toml_and_no_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in (
+        "MAX_ITERATIONS", "MODEL", "SLEEP_SECONDS", "INTERACTIVE",
+        "ALLOWED_PATHS", "AGENT_CMD", "MODEL_REASONING_EFFORT",
+        "RALPH_AGENT_TYPE", "RALPH_BRANCH", "RALPH_ASCII",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    config = RalphConfig.load(tmp_path)
+    assert config.max_iterations == 10
+    assert config.sleep_seconds == 2.0
+    assert config.agent_type is None
+    assert config.agent_cmd is None
+    assert config.ralph_branch is None
+    assert config.ralph_branch_explicit is False
+
+
+def test_load_auto_discovers_ralph_toml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in ("MAX_ITERATIONS",):
+        monkeypatch.delenv(var, raising=False)
+    _write_toml(
+        tmp_path / "ralph.toml",
+        """
+[run]
+max_iterations = 7
+""",
+    )
+    config = RalphConfig.load(tmp_path)
+    assert config.max_iterations == 7
+
+
+def test_load_missing_toml_falls_back_silently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in ("MAX_ITERATIONS",):
+        monkeypatch.delenv(var, raising=False)
+    config = RalphConfig.load(tmp_path)
+    assert config.max_iterations == 10
+
+
+def test_load_env_branch_marks_explicit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RALPH_BRANCH", "")
+    config = RalphConfig.load(tmp_path)
+    assert config.ralph_branch == ""
+    assert config.ralph_branch_explicit is True
+
+
+def test_load_env_paths_resolved_against_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PROMPT_FILE", "custom/prompt.md")
+    config = RalphConfig.load(tmp_path)
+    assert config.prompt_file == tmp_path / "custom/prompt.md"
+
+
+def test_load_toml_branch_marks_explicit_even_when_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in ("RALPH_BRANCH",):
+        monkeypatch.delenv(var, raising=False)
+    _write_toml(
+        tmp_path / "ralph.toml",
+        """
+[git]
+branch = ""
+""",
+    )
+    config = RalphConfig.load(tmp_path)
+    assert config.ralph_branch == ""
+    assert config.ralph_branch_explicit is True
+
+
+# ---------------------------------------------------------------------------
+# from_env: backwards compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_still_works(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MAX_ITERATIONS", "13")
+    monkeypatch.setenv("MODEL", "haiku")
+    config = RalphConfig.from_env(tmp_path)
+    assert config.max_iterations == 13
+    assert config.model == "haiku"
+    assert config.prompt_file == tmp_path / "scripts/ralph/prompt.md"
+
+
+def test_from_env_does_not_read_toml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in ("MAX_ITERATIONS",):
+        monkeypatch.delenv(var, raising=False)
+    _write_toml(
+        tmp_path / "ralph.toml",
+        """
+[run]
+max_iterations = 999
+""",
+    )
+    # Change cwd to tmp_path so any auto-discovery would pick up the toml
+    monkeypatch.chdir(tmp_path)
+    config = RalphConfig.from_env(tmp_path)
+    # from_env must ignore toml
+    assert config.max_iterations == 10

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,0 +1,866 @@
+"""Tests for the per-component knowledge layer."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ralph_py.config import RalphConfig
+from ralph_py.factory import ComponentResult, FactoryConfig, run_factory
+from ralph_py.knowledge import (
+    DISTILL_PROMPT,
+    Fact,
+    KnowledgeConfig,
+    _coerce_facts,
+    _first_sentence,
+    _pack_facts_full,
+    _pack_facts_summary,
+    _parse_distill_output,
+    _parse_fact_md,
+    _render_fact_md,
+    _transitive_dependencies,
+    build_knowledge_context,
+    current_run_id,
+    distill_facts,
+    read_facts,
+    write_facts,
+)
+from ralph_py.manifest import Component, Manifest
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fact(
+    fact_id: str = "fact-001",
+    component_id: str = "comp-a",
+    scope: str = "handler",
+    confidence: str = "verified",
+    claim: str = "The handler validates the request body before invoking the service.",
+    evidence: list[str] | None = None,
+    tags: list[str] | None = None,
+    created_run_id: str = "factory-20260101-120000",
+    created_iter: int = 1,
+) -> Fact:
+    return Fact(
+        id=fact_id,
+        component_id=component_id,
+        created_iter=created_iter,
+        created_run_id=created_run_id,
+        scope=scope,
+        evidence=evidence or ["src/handler.py:10-25"],
+        confidence=confidence,
+        claim=claim,
+        tags=tags or [],
+    )
+
+
+class _FakeAgent:
+    """Minimal Agent stand-in. Yields canned lines from .run()."""
+
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = lines
+
+    @property
+    def name(self) -> str:
+        return "fake"
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        for line in self._lines:
+            yield line
+
+    @property
+    def final_message(self) -> str | None:
+        return None
+
+
+def _make_manifest(components: list[Component]) -> Manifest:
+    return Manifest(
+        version="1",
+        spec_file="spec.md",
+        project_name="test",
+        base_branch="main",
+        single_pr=False,
+        components=components,
+    )
+
+
+def _make_component(
+    component_id: str, dependencies: list[str] | None = None,
+) -> Component:
+    return Component(
+        id=component_id,
+        title=f"Component {component_id}",
+        description=f"Description of {component_id}",
+        dependencies=dependencies or [],
+        prd_path=f"feature/{component_id}/prd.json",
+        branch_name=f"ralph/{component_id}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeConfig
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeConfig:
+    def test_defaults(self) -> None:
+        config = KnowledgeConfig()
+        assert config.enabled is True
+        assert config.max_core_tokens == 2000
+        assert config.max_dependency_tokens == 1000
+        assert config.max_sibling_tokens == 500
+        assert config.distill_timeout_seconds == 300.0
+        assert config.max_facts_per_distill == 7
+
+    def test_load_no_toml_uses_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        for var in (
+            "RALPH_KNOWLEDGE_ENABLED",
+            "RALPH_KNOWLEDGE_MAX_CORE_TOKENS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        config = KnowledgeConfig.load(tmp_path)
+        assert config.enabled is True
+        assert config.max_core_tokens == 2000
+        assert config.knowledge_root == tmp_path / ".ralph" / "knowledge"
+
+    def test_load_reads_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        for var in (
+            "RALPH_KNOWLEDGE_ENABLED",
+            "RALPH_KNOWLEDGE_MAX_CORE_TOKENS",
+            "RALPH_KNOWLEDGE_MAX_DEPENDENCY_TOKENS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        (tmp_path / "ralph.toml").write_text(
+            """
+[knowledge]
+enabled = false
+max_core_tokens = 9999
+max_dependency_tokens = 50
+""",
+        )
+        config = KnowledgeConfig.load(tmp_path)
+        assert config.enabled is False
+        assert config.max_core_tokens == 9999
+        assert config.max_dependency_tokens == 50
+
+    def test_env_overrides_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            """
+[knowledge]
+max_core_tokens = 9999
+""",
+        )
+        monkeypatch.setenv("RALPH_KNOWLEDGE_MAX_CORE_TOKENS", "111")
+        config = KnowledgeConfig.load(tmp_path)
+        assert config.max_core_tokens == 111
+
+
+# ---------------------------------------------------------------------------
+# Serialization roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestFactSerialization:
+    def test_render_then_parse_roundtrip(self) -> None:
+        original = _make_fact(
+            claim="Line one of the claim.\nLine two with more detail.",
+            evidence=["a.py:1-5", "b.py:42"],
+            tags=["a", "b"],
+        )
+        content = _render_fact_md(original)
+        parsed = _parse_fact_md(content)
+        assert parsed == original
+
+    def test_parse_missing_opening_delimiter(self) -> None:
+        with pytest.raises(ValueError, match="opening frontmatter"):
+            _parse_fact_md("not a frontmatter file")
+
+    def test_parse_missing_closing_delimiter(self) -> None:
+        content = "---\n{\"id\": \"x\"}\nno closing"
+        with pytest.raises(ValueError, match="closing frontmatter"):
+            _parse_fact_md(content)
+
+    def test_parse_invalid_json(self) -> None:
+        content = "---\nthis is not json\n---\nbody"
+        with pytest.raises(ValueError, match="not valid JSON"):
+            _parse_fact_md(content)
+
+
+# ---------------------------------------------------------------------------
+# Read / write
+# ---------------------------------------------------------------------------
+
+
+class TestReadWriteFacts:
+    def test_write_then_read(self, tmp_path: Path) -> None:
+        fact = _make_fact()
+        written = write_facts([fact], tmp_path, "comp-a", "factory-20260101-120000")
+        assert written == 1
+        facts = read_facts(tmp_path, "comp-a")
+        assert facts == [fact]
+
+    def test_read_nonexistent_returns_empty(self, tmp_path: Path) -> None:
+        assert read_facts(tmp_path, "nonexistent") == []
+
+    def test_read_prefers_latest_run_dir(self, tmp_path: Path) -> None:
+        old = _make_fact(
+            fact_id="fact-001", claim="old fact",
+            created_run_id="factory-20260101-120000",
+        )
+        new = _make_fact(
+            fact_id="fact-001", claim="new fact",
+            created_run_id="factory-20260201-120000",
+        )
+        write_facts([old], tmp_path, "comp-a", "factory-20260101-120000")
+        write_facts([new], tmp_path, "comp-a", "factory-20260201-120000")
+        facts = read_facts(tmp_path, "comp-a")
+        assert len(facts) == 1
+        assert facts[0].claim == "new fact"
+
+    def test_write_atomic_no_partial_files(self, tmp_path: Path) -> None:
+        write_facts(
+            [_make_fact()], tmp_path, "comp-a", "factory-20260101-120000",
+        )
+        run_dir = tmp_path / "comp-a" / "factory-20260101-120000"
+        leftovers = [p for p in run_dir.iterdir() if p.name.startswith(".")]
+        assert leftovers == [], f"atomic write left tmp files: {leftovers}"
+
+    def test_write_skips_corrupt_files_on_read(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "comp-a" / "factory-20260101-120000"
+        run_dir.mkdir(parents=True)
+        (run_dir / "broken.md").write_text("not a valid fact file")
+        good = _make_fact()
+        write_facts([good], tmp_path, "comp-a", "factory-20260101-120000")
+        facts = read_facts(tmp_path, "comp-a")
+        assert facts == [good]
+
+    def test_write_to_unwritable_dir_is_nonfatal(self, tmp_path: Path) -> None:
+        if os.geteuid() == 0:
+            pytest.skip("Running as root: cannot test permission denial")
+        # Make parent read-only
+        readonly = tmp_path / "readonly"
+        readonly.mkdir()
+        readonly.chmod(stat.S_IREAD | stat.S_IEXEC)
+        try:
+            written = write_facts(
+                [_make_fact()], readonly, "comp-a", "factory-20260101-120000",
+            )
+            assert written == 0
+        finally:
+            readonly.chmod(stat.S_IRWXU)
+
+    def test_write_empty_returns_zero(self, tmp_path: Path) -> None:
+        assert write_facts([], tmp_path, "comp-a", "run-id") == 0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_first_sentence_period(self) -> None:
+        assert _first_sentence("Hello world. More text.") == "Hello world."
+
+    def test_first_sentence_no_terminator(self) -> None:
+        assert _first_sentence("just one phrase") == "just one phrase"
+
+    def test_first_sentence_question_mark(self) -> None:
+        assert _first_sentence("What does it do? It works.") == "What does it do?"
+
+    def test_first_sentence_empty(self) -> None:
+        assert _first_sentence("") == ""
+
+    def test_transitive_dependencies_chain(self) -> None:
+        manifest = _make_manifest([
+            _make_component("a"),
+            _make_component("b", dependencies=["a"]),
+            _make_component("c", dependencies=["b"]),
+        ])
+        deps = _transitive_dependencies(manifest, "c")
+        assert deps == {"a", "b"}
+
+    def test_transitive_dependencies_no_self_reference(self) -> None:
+        manifest = _make_manifest([_make_component("a")])
+        assert _transitive_dependencies(manifest, "a") == set()
+
+    def test_transitive_dependencies_diamond(self) -> None:
+        manifest = _make_manifest([
+            _make_component("a"),
+            _make_component("b", dependencies=["a"]),
+            _make_component("c", dependencies=["a"]),
+            _make_component("d", dependencies=["b", "c"]),
+        ])
+        assert _transitive_dependencies(manifest, "d") == {"a", "b", "c"}
+
+
+# ---------------------------------------------------------------------------
+# Budget capping
+# ---------------------------------------------------------------------------
+
+
+class TestPackFacts:
+    def test_pack_empty(self) -> None:
+        kept, over = _pack_facts_full([], 1000)
+        assert kept == []
+        assert over is False
+
+    def test_pack_fits_within_budget(self) -> None:
+        facts = [_make_fact(fact_id=f"fact-{i:03d}") for i in range(1, 4)]
+        kept, over = _pack_facts_full(facts, 10000)
+        assert len(kept) == 3
+        assert over is False
+
+    def test_pack_drops_asserted_before_verified(self) -> None:
+        # Make claims sized so only one fact fits per call after the verified one
+        big_claim = "x" * 800  # ~200 tokens
+        verified = _make_fact(
+            fact_id="fact-001", confidence="verified", claim=big_claim,
+        )
+        asserted_recent = _make_fact(
+            fact_id="fact-002", confidence="asserted", claim=big_claim,
+            created_run_id="factory-20260301-120000",
+        )
+        asserted_old = _make_fact(
+            fact_id="fact-003", confidence="asserted", claim=big_claim,
+            created_run_id="factory-20260101-120000",
+        )
+        kept, over = _pack_facts_full(
+            [asserted_old, asserted_recent, verified], 250,
+        )
+        # Verified takes the budget; both asserted are dropped
+        kept_ids = [f.id for f in kept]
+        assert "fact-001" in kept_ids
+        assert over is True
+
+    def test_pack_summary_uses_first_sentence(self) -> None:
+        fact = _make_fact(
+            claim="First sentence. Second sentence that should be dropped.",
+        )
+        kept, _over = _pack_facts_summary([fact], 10000)
+        assert len(kept) == 1
+        assert kept[0].claim == "First sentence."
+
+
+# ---------------------------------------------------------------------------
+# build_knowledge_context
+# ---------------------------------------------------------------------------
+
+
+class TestBuildKnowledgeContext:
+    def test_empty_when_no_facts(self, tmp_path: Path) -> None:
+        manifest = _make_manifest([_make_component("a"), _make_component("b")])
+        comp = manifest.components[0]
+        config = KnowledgeConfig(
+            knowledge_root=tmp_path / "knowledge", enabled=True,
+        )
+        # Even with no knowledge dir at all
+        result = build_knowledge_context(
+            manifest, comp, config.knowledge_root, config,
+        )
+        assert result == ""
+
+    def test_empty_when_disabled(self, tmp_path: Path) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        knowledge_root.mkdir()
+        write_facts([_make_fact()], knowledge_root, "comp-a", "run-1")
+        manifest = _make_manifest([_make_component("comp-a")])
+        config = KnowledgeConfig(knowledge_root=knowledge_root, enabled=False)
+        result = build_knowledge_context(
+            manifest, manifest.components[0], knowledge_root, config,
+        )
+        assert result == ""
+
+    def test_three_tiers(self, tmp_path: Path) -> None:
+        knowledge_root = tmp_path / "knowledge"
+        manifest = _make_manifest([
+            _make_component("dep-1"),
+            _make_component("comp-current", dependencies=["dep-1"]),
+            _make_component("unrelated"),
+        ])
+        write_facts(
+            [_make_fact(
+                fact_id="fact-001", component_id="comp-current",
+                claim="Current component fact.",
+            )],
+            knowledge_root, "comp-current", "factory-20260101-120000",
+        )
+        write_facts(
+            [_make_fact(
+                fact_id="fact-002", component_id="dep-1",
+                claim="Dependency fact full body. Second sentence.",
+            )],
+            knowledge_root, "dep-1", "factory-20260101-120000",
+        )
+        write_facts(
+            [_make_fact(
+                fact_id="fact-003", component_id="unrelated",
+                claim="Unrelated sibling fact. Second sentence trimmed.",
+            )],
+            knowledge_root, "unrelated", "factory-20260101-120000",
+        )
+
+        config = KnowledgeConfig(knowledge_root=knowledge_root)
+        result = build_knowledge_context(
+            manifest, manifest.components[1], knowledge_root, config,
+        )
+        assert "## Component Knowledge" in result
+        assert "Current component fact." in result
+        assert "Dependency fact full body. Second sentence." in result
+        # Sibling shows only first sentence
+        assert "Unrelated sibling fact." in result
+        assert "Second sentence trimmed." not in result
+
+
+# ---------------------------------------------------------------------------
+# _coerce_facts / _parse_distill_output
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceFacts:
+    def test_valid_fact(self) -> None:
+        raw = [{
+            "id": "fact-001",
+            "scope": "handler",
+            "confidence": "verified",
+            "evidence": ["src/a.py:1-10"],
+            "claim": "a claim",
+            "tags": ["x"],
+        }]
+        facts = _coerce_facts(raw, "comp-a", 1, "run-1", 7)
+        assert len(facts) == 1
+        assert facts[0].id == "fact-001"
+        assert facts[0].scope == "handler"
+
+    def test_invalid_id_skipped(self) -> None:
+        raw = [{
+            "id": "not-a-fact-id",
+            "scope": "handler",
+            "confidence": "verified",
+            "evidence": ["a.py:1"],
+            "claim": "x",
+        }]
+        assert _coerce_facts(raw, "c", 1, "r", 7) == []
+
+    def test_unknown_scope_skipped(self) -> None:
+        raw = [{
+            "id": "fact-001",
+            "scope": "weird-scope",
+            "confidence": "verified",
+            "evidence": ["a.py:1"],
+            "claim": "x",
+        }]
+        assert _coerce_facts(raw, "c", 1, "r", 7) == []
+
+    def test_missing_evidence_skipped(self) -> None:
+        raw = [{
+            "id": "fact-001",
+            "scope": "handler",
+            "confidence": "verified",
+            "evidence": [],
+            "claim": "x",
+        }]
+        assert _coerce_facts(raw, "c", 1, "r", 7) == []
+
+    def test_empty_claim_skipped(self) -> None:
+        raw = [{
+            "id": "fact-001",
+            "scope": "handler",
+            "confidence": "verified",
+            "evidence": ["a:1"],
+            "claim": "",
+        }]
+        assert _coerce_facts(raw, "c", 1, "r", 7) == []
+
+    def test_duplicate_id_skipped(self) -> None:
+        raw = [
+            {"id": "fact-001", "scope": "handler", "confidence": "verified",
+             "evidence": ["a:1"], "claim": "first"},
+            {"id": "fact-001", "scope": "handler", "confidence": "verified",
+             "evidence": ["a:2"], "claim": "second"},
+        ]
+        facts = _coerce_facts(raw, "c", 1, "r", 7)
+        assert len(facts) == 1
+        assert facts[0].claim == "first"
+
+    def test_max_facts_enforced(self) -> None:
+        raw = [
+            {"id": f"fact-{i:03d}", "scope": "handler", "confidence": "verified",
+             "evidence": ["a:1"], "claim": "x"}
+            for i in range(1, 11)
+        ]
+        assert len(_coerce_facts(raw, "c", 1, "r", 3)) == 3
+
+
+class TestParseDistillOutput:
+    def test_valid_json(self) -> None:
+        output = json.dumps({"facts": [{"id": "fact-001"}]})
+        assert _parse_distill_output(output) == [{"id": "fact-001"}]
+
+    def test_fenced_json(self) -> None:
+        output = '```json\n{"facts": [{"id": "fact-001"}]}\n```'
+        assert _parse_distill_output(output) == [{"id": "fact-001"}]
+
+    def test_invalid_json_returns_empty(self) -> None:
+        assert _parse_distill_output("garbage") == []
+
+    def test_missing_facts_key_returns_empty(self) -> None:
+        assert _parse_distill_output('{"other": 1}') == []
+
+    def test_facts_not_a_list_returns_empty(self) -> None:
+        assert _parse_distill_output('{"facts": "not a list"}') == []
+
+
+# ---------------------------------------------------------------------------
+# distill_facts
+# ---------------------------------------------------------------------------
+
+
+class TestDistillFacts:
+    def _setup_prd(self, tmp_path: Path, component_id: str) -> Path:
+        prd_path = tmp_path / "feature" / component_id / "prd.json"
+        prd_path.parent.mkdir(parents=True)
+        prd_path.write_text(
+            json.dumps({
+                "branchName": "test",
+                "userStories": [],
+            }),
+        )
+        return prd_path
+
+    def test_writes_facts_on_valid_output(self, tmp_path: Path) -> None:
+        component = _make_component("comp-a")
+        prd_path = self._setup_prd(tmp_path, "comp-a")
+        knowledge_root = tmp_path / "knowledge"
+        config = KnowledgeConfig(knowledge_root=knowledge_root)
+        agent = _FakeAgent([
+            json.dumps({
+                "facts": [{
+                    "id": "fact-001",
+                    "scope": "handler",
+                    "confidence": "verified",
+                    "evidence": ["src/handler.py:10-25"],
+                    "claim": "Handler validates input.",
+                    "tags": [],
+                }],
+            }),
+        ])
+
+        written, status = distill_facts(
+            agent, component, "diff text", prd_path, 1,
+            "factory-20260101-120000", knowledge_root, config, tmp_path,
+            review_passed=True,
+        )
+
+        assert written == 1
+        assert "wrote 1" in status
+        facts = read_facts(knowledge_root, "comp-a")
+        assert len(facts) == 1
+        assert facts[0].confidence == "verified"
+
+    def test_invalid_json_nonfatal(self, tmp_path: Path) -> None:
+        component = _make_component("comp-a")
+        prd_path = self._setup_prd(tmp_path, "comp-a")
+        knowledge_root = tmp_path / "knowledge"
+        config = KnowledgeConfig(knowledge_root=knowledge_root)
+        agent = _FakeAgent(["garbage that is not json"])
+
+        written, status = distill_facts(
+            agent, component, "diff", prd_path, 1, "run-1",
+            knowledge_root, config, tmp_path, review_passed=True,
+        )
+        assert written == 0
+        assert "no_facts" in status
+
+    def test_empty_facts_returns_no_files(self, tmp_path: Path) -> None:
+        component = _make_component("comp-a")
+        prd_path = self._setup_prd(tmp_path, "comp-a")
+        knowledge_root = tmp_path / "knowledge"
+        config = KnowledgeConfig(knowledge_root=knowledge_root)
+        agent = _FakeAgent([json.dumps({"facts": []})])
+
+        written, status = distill_facts(
+            agent, component, "diff", prd_path, 1, "run-1",
+            knowledge_root, config, tmp_path, review_passed=True,
+        )
+        assert written == 0
+        assert "no_facts" in status
+        assert not (knowledge_root / "comp-a").exists()
+
+    def test_disabled_short_circuits(self, tmp_path: Path) -> None:
+        component = _make_component("comp-a")
+        prd_path = self._setup_prd(tmp_path, "comp-a")
+        knowledge_root = tmp_path / "knowledge"
+        config = KnowledgeConfig(knowledge_root=knowledge_root, enabled=False)
+        agent = _FakeAgent([json.dumps({"facts": [{"id": "fact-001"}]})])
+
+        written, status = distill_facts(
+            agent, component, "diff", prd_path, 1, "run-1",
+            knowledge_root, config, tmp_path, review_passed=True,
+        )
+        assert written == 0
+        assert status == "knowledge.disabled"
+
+    def test_review_skip_caps_confidence_at_asserted(
+        self, tmp_path: Path,
+    ) -> None:
+        component = _make_component("comp-a")
+        prd_path = self._setup_prd(tmp_path, "comp-a")
+        knowledge_root = tmp_path / "knowledge"
+        config = KnowledgeConfig(knowledge_root=knowledge_root)
+        agent = _FakeAgent([
+            json.dumps({
+                "facts": [{
+                    "id": "fact-001",
+                    "scope": "handler",
+                    "confidence": "verified",  # agent claims verified
+                    "evidence": ["a.py:1"],
+                    "claim": "x",
+                }],
+            }),
+        ])
+
+        written, _status = distill_facts(
+            agent, component, "diff", prd_path, 1, "run-1",
+            knowledge_root, config, tmp_path,
+            review_passed=None,  # skip mode
+        )
+        assert written == 1
+        facts = read_facts(knowledge_root, "comp-a")
+        # downgraded because Phase 2 was skipped
+        assert facts[0].confidence == "asserted"
+
+    def test_diff_truncated_at_50kb(self, tmp_path: Path) -> None:
+        component = _make_component("comp-a")
+        prd_path = self._setup_prd(tmp_path, "comp-a")
+        knowledge_root = tmp_path / "knowledge"
+        config = KnowledgeConfig(knowledge_root=knowledge_root)
+        captured: dict[str, str] = {}
+
+        class _CapturingAgent:
+            @property
+            def name(self) -> str:
+                return "fake"
+
+            def run(
+                self, prompt: str, cwd: Path | None = None,
+                timeout: float | None = None,
+            ) -> Iterator[str]:
+                captured["prompt"] = prompt
+                yield json.dumps({"facts": []})
+
+            @property
+            def final_message(self) -> str | None:
+                return None
+
+        huge_diff = "X" * 60000
+        distill_facts(
+            _CapturingAgent(), component, huge_diff, prd_path, 1, "r",
+            knowledge_root, config, tmp_path, review_passed=True,
+        )
+        assert "(diff truncated at 50KB)" in captured["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+def test_current_run_id_matches_factory_format() -> None:
+    rid = current_run_id()
+    assert rid.startswith("factory-")
+    # Same shape factory.py uses
+    assert len(rid) == len("factory-20260101-120000")
+
+
+def test_distill_prompt_includes_all_placeholders() -> None:
+    rendered = DISTILL_PROMPT.format(
+        max_facts=7,
+        component_id="comp-a",
+        component_title="title",
+        component_description="desc",
+        dependencies="(none)",
+        prd_content="prd",
+        existing_facts="(none)",
+        diff_content="diff",
+    )
+    assert "comp-a" in rendered
+    assert "prd" in rendered
+    assert "diff" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Factory integration: distillation called only on green gate
+# ---------------------------------------------------------------------------
+
+
+def _setup_factory_project(tmp_path: Path, component_id: str) -> Path:
+    """Create a minimal project layout that satisfies the factory."""
+    ralph_dir = tmp_path / "scripts" / "ralph"
+    ralph_dir.mkdir(parents=True)
+    (ralph_dir / "prompt.md").write_text("test prompt")
+    (ralph_dir / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    feature_dir = tmp_path / "scripts" / "ralph" / "feature" / component_id
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "prd.json").write_text(
+        json.dumps({
+            "branchName": "test",
+            "userStories": [{
+                "id": "US-001", "title": "Test",
+                "acceptanceCriteria": ["AC1"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }),
+    )
+    return tmp_path
+
+
+def _factory_base_config(root: Path) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root / "scripts/ralph/prompt.md",
+        prd_file=root / "scripts/ralph/prd.json",
+        sleep_seconds=0,
+        agent_cmd="echo test",
+        ralph_branch="",
+        ralph_branch_explicit=True,
+        ui_mode="plain",
+        no_color=True,
+    )
+
+
+class TestFactoryDistillIntegration:
+    def test_distill_called_on_success(self, tmp_path: Path) -> None:
+        root = _setup_factory_project(tmp_path, "comp-a")
+        manifest = _make_manifest([_make_component("comp-a", dependencies=[])])
+        # ensure component has the prd_path matching what factory expects
+        manifest.components[0].prd_path = (
+            "scripts/ralph/feature/comp-a/prd.json"
+        )
+        config = FactoryConfig(
+            use_worktrees=False, create_prs=False, max_parallel=1,
+            review_mode="skip",
+            verify_config=VerifyConfig(
+                test_command="true", typecheck_command="true",
+                lint_command="true", check_diff_scope=False,
+                check_bad_patterns=False, subprocess_timeout=5.0,
+            ),
+        )
+        base = _factory_base_config(root)
+        ui = PlainUI(no_color=True)
+        success = ComponentResult("comp-a", success=True, iterations=2)
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.factory.distill_facts", return_value=(2, "ok"),
+        ) as mock_distill:
+            result = run_factory(manifest, config, base, ui, root)
+
+        assert "comp-a" in result.completed
+        mock_distill.assert_called_once()
+
+    def test_distill_not_called_on_verification_failure(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _setup_factory_project(tmp_path, "comp-a")
+        manifest = _make_manifest([_make_component("comp-a", dependencies=[])])
+        manifest.components[0].prd_path = (
+            "scripts/ralph/feature/comp-a/prd.json"
+        )
+        config = FactoryConfig(
+            use_worktrees=False, create_prs=False, max_parallel=1,
+            max_retries=0, retry_delay=0, review_mode="skip",
+        )
+        base = _factory_base_config(root)
+        ui = PlainUI(no_color=True)
+        fail = ComponentResult("comp-a", success=False, error="test failure")
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=fail,
+        ), patch(
+            "ralph_py.factory.distill_facts", return_value=(0, "skipped"),
+        ) as mock_distill:
+            result = run_factory(manifest, config, base, ui, root)
+
+        assert "comp-a" in result.failed
+        mock_distill.assert_not_called()
+
+    def test_distill_disabled_via_env_skips_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "false")
+        root = _setup_factory_project(tmp_path, "comp-a")
+        manifest = _make_manifest([_make_component("comp-a", dependencies=[])])
+        manifest.components[0].prd_path = (
+            "scripts/ralph/feature/comp-a/prd.json"
+        )
+        config = FactoryConfig(
+            use_worktrees=False, create_prs=False, max_parallel=1,
+            review_mode="skip",
+            verify_config=VerifyConfig(
+                test_command="true", typecheck_command="true",
+                lint_command="true", check_diff_scope=False,
+                check_bad_patterns=False, subprocess_timeout=5.0,
+            ),
+        )
+        base = _factory_base_config(root)
+        ui = PlainUI(no_color=True)
+        success = ComponentResult("comp-a", success=True, iterations=2)
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.factory.distill_facts", return_value=(0, "disabled"),
+        ) as mock_distill:
+            run_factory(manifest, config, base, ui, root)
+
+        mock_distill.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Latest-run-dir-wins handles contract-breaker rollback scenario
+# ---------------------------------------------------------------------------
+
+
+def test_latest_run_dir_orphans_old_facts(tmp_path: Path) -> None:
+    """If a component re-runs (e.g. contract-breaker retry), the new run
+    dir wins and old facts are orphaned without explicit supersede logic."""
+    knowledge_root = tmp_path
+    old = _make_fact(
+        fact_id="fact-001", claim="OLD - should be ignored",
+        created_run_id="factory-20260101-120000",
+    )
+    new = _make_fact(
+        fact_id="fact-001", claim="NEW",
+        created_run_id="factory-20260201-120000",
+    )
+    write_facts([old], knowledge_root, "comp-a", "factory-20260101-120000")
+    # Simulate breaker retry creating a new run dir
+    time.sleep(0.01)
+    write_facts([new], knowledge_root, "comp-a", "factory-20260201-120000")
+
+    facts = read_facts(knowledge_root, "comp-a")
+    assert len(facts) == 1
+    assert facts[0].claim == "NEW"

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -605,7 +605,11 @@ class TestDistillFacts:
         )
         assert written == 0
         assert "no_facts" in status
-        assert not (knowledge_root / "comp-a").exists()
+        # No fact files were written (a debug dump may exist alongside;
+        # that's a diagnostic, not a knowledge artifact).
+        assert read_facts(knowledge_root, "comp-a") == []
+        fact_files = list(knowledge_root.glob("comp-a/*/fact-*.md"))
+        assert fact_files == []
 
     def test_disabled_short_circuits(self, tmp_path: Path) -> None:
         component = _make_component("comp-a")
@@ -649,6 +653,77 @@ class TestDistillFacts:
         facts = read_facts(knowledge_root, "comp-a")
         # downgraded because Phase 2 was skipped
         assert facts[0].confidence == "asserted"
+
+    def test_final_message_preferred_over_streamed_output(
+        self, tmp_path: Path,
+    ) -> None:
+        """When the agent echoes the prompt back (as codex does), the streamed
+        output contains the JSON schema example. _extract_json's first-brace
+        heuristic would latch onto the schema's example fact (with the literal
+        scope string "handler|adapter|...") and reject it during coercion.
+        distill_facts must prefer agent.final_message when set."""
+        component = _make_component("comp-a")
+        prd_path = self._setup_prd(tmp_path, "comp-a")
+        knowledge_root = tmp_path / "knowledge"
+        config = KnowledgeConfig(knowledge_root=knowledge_root)
+
+        schema_example_dump = """
+prompt echoed back: schema is
+{
+  "facts": [
+    {
+      "id": "fact-001",
+      "scope": "handler|adapter|schema|contract|invariant|gotcha",
+      "confidence": "verified|asserted",
+      "evidence": ["path/to/file.py:42-58"],
+      "tags": ["x"],
+      "claim": "example"
+    }
+  ]
+}
+... and so on ...
+"""
+        real_response = json.dumps({
+            "facts": [{
+                "id": "fact-001",
+                "scope": "handler",
+                "confidence": "verified",
+                "evidence": ["src/x.py:1-2"],
+                "claim": "real fact from final_message",
+                "tags": [],
+            }],
+        })
+
+        class _EchoingAgent:
+            @property
+            def name(self) -> str:
+                return "fake-codex"
+
+            def run(
+                self, prompt: str, cwd: Path | None = None,
+                timeout: float | None = None,
+            ) -> Iterator[str]:
+                # Mimic codex: echo prompt back, then output JSON
+                for line in schema_example_dump.split("\n"):
+                    yield line
+                yield real_response
+
+            @property
+            def final_message(self) -> str | None:
+                return real_response
+
+        written, _status = distill_facts(
+            _EchoingAgent(), component, "diff", prd_path, 1, "run-1",
+            knowledge_root, config, tmp_path, review_passed=True,
+        )
+
+        assert written == 1
+        facts = read_facts(knowledge_root, "comp-a")
+        assert len(facts) == 1
+        assert facts[0].claim == "real fact from final_message"
+        # If we'd parsed the streamed echo, scope would have been the
+        # pipe-separated schema string and the fact would have been rejected.
+        assert facts[0].scope == "handler"
 
     def test_diff_truncated_at_50kb(self, tmp_path: Path) -> None:
         component = _make_component("comp-a")

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -161,6 +161,16 @@ max_dependency_tokens = 50
         assert config.max_core_tokens == 9999
         assert config.max_dependency_tokens == 50
 
+    def test_malformed_toml_raises(self, tmp_path: Path) -> None:
+        """KnowledgeConfig.load must raise ValueError on bad TOML, matching
+        RalphConfig.load. Silently falling back to defaults would hide
+        user typos in the [knowledge] section."""
+        (tmp_path / "ralph.toml").write_text(
+            "this is not = valid = toml = [\n",
+        )
+        with pytest.raises(ValueError, match="Invalid TOML"):
+            KnowledgeConfig.load(tmp_path)
+
     def test_env_overrides_toml(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -291,6 +301,24 @@ class TestHelpers:
     def test_first_sentence_empty(self) -> None:
         assert _first_sentence("") == ""
 
+    def test_first_sentence_preserves_eg_abbreviation(self) -> None:
+        assert (
+            _first_sentence(
+                "Handler returns 200, e.g. for GET /health. Returns 500 otherwise.",
+            )
+            == "Handler returns 200, e.g. for GET /health."
+        )
+
+    def test_first_sentence_preserves_ie_abbreviation(self) -> None:
+        assert (
+            _first_sentence("Maps i.e. simply. Done.")
+            == "Maps i.e. simply."
+        )
+
+    def test_first_sentence_single_sentence_ending_period(self) -> None:
+        # No continuation after the terminal period - $ branch fires.
+        assert _first_sentence("A single sentence.") == "A single sentence."
+
     def test_transitive_dependencies_chain(self) -> None:
         manifest = _make_manifest([
             _make_component("a"),
@@ -360,6 +388,72 @@ class TestPackFacts:
         kept, _over = _pack_facts_summary([fact], 10000)
         assert len(kept) == 1
         assert kept[0].claim == "First sentence."
+
+    def test_pack_full_does_not_drop_smaller_facts_after_overflow(self) -> None:
+        """A single oversized fact must not abort the whole pack: smaller
+        subsequent facts that still fit in the remaining budget should be
+        kept."""
+        huge = _make_fact(
+            fact_id="fact-001",
+            confidence="verified",
+            claim="x" * 1000,  # render cost ~300 tokens
+        )
+        small_a = _make_fact(
+            fact_id="fact-002",
+            confidence="verified",
+            claim="short A",
+        )
+        # Budget chosen so huge cannot fit AND the truncation branch
+        # can't fire (remaining < 30 tokens after subtracting meta size).
+        # Without the greedy-break fix, the loop aborts on huge and the
+        # subsequent small fact never gets considered.
+        kept, over = _pack_facts_full([huge, small_a], 70)
+        kept_ids = [f.id for f in kept]
+        assert "fact-001" not in kept_ids
+        assert "fact-002" in kept_ids
+        assert over is True
+
+    def test_pack_summary_does_not_drop_smaller_facts_after_overflow(
+        self,
+    ) -> None:
+        """Same fix in _pack_facts_summary: an oversized first sentence
+        must not block smaller subsequent sentences."""
+        # _first_sentence is greedy; use claims with no terminator so the
+        # entire claim is the "first sentence".
+        huge = _make_fact(
+            fact_id="fact-001",
+            confidence="verified",
+            claim="A" * 4000,
+        )
+        small_a = _make_fact(
+            fact_id="fact-002",
+            confidence="verified",
+            claim="short",
+        )
+        kept, over = _pack_facts_summary([huge, small_a], 60)
+        kept_ids = [f.id for f in kept]
+        assert "fact-002" in kept_ids
+        assert "fact-001" not in kept_ids
+        assert over is True
+
+    def test_pack_full_truncates_only_first_overflowing_fact(self) -> None:
+        """The truncation branch should fire at most once per pack call,
+        not repeatedly squeezing fact bodies down to nothing."""
+        # All three are too large at full size; only first should be
+        # truncated to fit, the rest dropped.
+        f1 = _make_fact(
+            fact_id="fact-001", confidence="verified", claim="A" * 800,
+        )
+        f2 = _make_fact(
+            fact_id="fact-002", confidence="verified", claim="B" * 800,
+        )
+        f3 = _make_fact(
+            fact_id="fact-003", confidence="verified", claim="C" * 800,
+        )
+        kept, over = _pack_facts_full([f1, f2, f3], 200)
+        truncated = [f for f in kept if f.claim.endswith("...")]
+        assert len(truncated) <= 1
+        assert over is True
 
 
 # ---------------------------------------------------------------------------
@@ -724,6 +818,59 @@ prompt echoed back: schema is
         # If we'd parsed the streamed echo, scope would have been the
         # pipe-separated schema string and the fact would have been rejected.
         assert facts[0].scope == "handler"
+
+    def test_falls_back_to_streamed_when_final_message_unparseable(
+        self, tmp_path: Path,
+    ) -> None:
+        """If agent.final_message is set but doesn't contain valid JSON
+        (e.g. CustomAgent that emits multi-line JSON and records only the
+        last line as final_message), distill_facts must fall back to the
+        streamed output rather than silently dropping the response."""
+        component = _make_component("comp-a")
+        prd_path = self._setup_prd(tmp_path, "comp-a")
+        knowledge_root = tmp_path / "knowledge"
+        config = KnowledgeConfig(knowledge_root=knowledge_root)
+
+        multi_line_json = json.dumps({
+            "facts": [{
+                "id": "fact-001",
+                "scope": "handler",
+                "confidence": "verified",
+                "evidence": ["src/x.py:1"],
+                "claim": "valid claim from streamed output",
+                "tags": [],
+            }],
+        })
+
+        class _PartialFinalAgent:
+            """Mimics CustomAgent: final_message is just the last
+            non-empty line of streamed output, not the full response."""
+
+            @property
+            def name(self) -> str:
+                return "fake-custom"
+
+            def run(
+                self, prompt: str, cwd: Path | None = None,
+                timeout: float | None = None,
+            ) -> Iterator[str]:
+                # Stream the JSON across multiple lines
+                for line in multi_line_json.split(","):
+                    yield line + ("," if line != multi_line_json.split(",")[-1] else "")
+
+            @property
+            def final_message(self) -> str | None:
+                # Only the last line, like CustomAgent records
+                return multi_line_json.split(",")[-1]
+
+        written, status = distill_facts(
+            _PartialFinalAgent(), component, "diff", prd_path, 1, "run-1",
+            knowledge_root, config, tmp_path, review_passed=True,
+        )
+
+        assert written == 1, f"expected fallback to streamed; got status={status}"
+        facts = read_facts(knowledge_root, "comp-a")
+        assert facts[0].claim == "valid claim from streamed output"
 
     def test_diff_truncated_at_50kb(self, tmp_path: Path) -> None:
         component = _make_component("comp-a")

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -131,6 +131,65 @@ class TestRunLoop:
         assert result.completed is True
         assert result.exit_code == 0
 
+    def test_auto_checkout_false_skips_branch_checkout(
+        self, tmp_path: Path,
+    ) -> None:
+        """When config.auto_checkout is False, run_loop must skip both the
+        branch resolution AND the checkout call, even if a non-empty
+        branch is configured. Otherwise the documented [git].auto_checkout
+        setting has no effect."""
+        import subprocess
+
+        # Real git repo so the is_git_repo check passes
+        subprocess.run(
+            ["git", "init", "-q", "-b", "main", str(tmp_path)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.email", "t@t"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.name", "t"],
+            check=True, capture_output=True,
+        )
+        (tmp_path / "stub").write_text("stub")
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "add", "stub"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "commit", "-q", "-m", "init"],
+            check=True, capture_output=True,
+        )
+
+        ralph_dir = tmp_path / "scripts" / "ralph"
+        ralph_dir.mkdir(parents=True)
+        (ralph_dir / "prompt.md").write_text("hi")
+        (ralph_dir / "prd.json").write_text(
+            '{"branchName": "feature/should-not-checkout", "userStories": []}'
+        )
+
+        config = RalphConfig(
+            max_iterations=1,
+            prompt_file=ralph_dir / "prompt.md",
+            prd_file=ralph_dir / "prd.json",
+            sleep_seconds=0,
+            auto_checkout=False,
+        )
+        ui = PlainUI(no_color=True)
+        agent = MockAgent([COMPLETION_MARKER])
+
+        result = run_loop(config, ui, agent, tmp_path)
+        assert result.completed is True
+
+        current = subprocess.run(
+            ["git", "-C", str(tmp_path), "branch", "--show-current"],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+        # Did not switch to feature/should-not-checkout
+        assert current == "main"
+
     def test_inline_marker_does_not_trigger_completion(self, tmp_path: Path) -> None:
         """Inline marker should not end the loop."""
         ralph_dir = tmp_path / "scripts" / "ralph"


### PR DESCRIPTION
## Summary

Adds a third memory surface alongside `.ralph/evolution.jsonl` (episodic) and `progress.txt` (handoff): a **per-component semantic knowledge store** that captures durable facts about WHAT WAS BUILT (interfaces, invariants, contracts, gotchas).

- Facts are distilled by an LLM after Phase 2 review passes, persisted under `.ralph/knowledge/<component_id>/<run_id>/<fact_id>.md`, and automatically injected into downstream components' prompts via three-tier retrieval (core / dependency / sibling) with hard token caps.
- Storage uses latest-run-dir-wins semantics: a contract-breaker retry naturally orphans stale facts without explicit supersede logic.
- LLM-driven consolidation is **permanently excluded** by design (atomic-files + latest-run-dir-wins avoids the rewrite-drift failure mode documented in the Lee 2026 ARC-AGI study).
- Draws on Voyager's verified-success write gate, Devin's per-knowledge-item atomic schema, and A-MEM / Claude-Code's atomic-fact-file approach.

Also wires the previously inert `ralph.toml` as a real config loader for `ralph_py`:
- `RalphConfig.load()` reads every documented section (`[agent]`, `[run]`, `[paths]`, `[git]`, `[ui]`, plus new `[knowledge]`) with precedence env > toml > defaults.
- Adds missing fields (`progress_file`, `codebase_map_file`, `auto_checkout`) so the TOML documentation matches reality.

## Test plan

- [x] Unit tests: 74 new (20 TOML loader, 54 knowledge layer). Full suite: **443 passing** locally.
- [x] End-to-end smoke against a 2-component toy spec (`greeter` -> `shouter`) with `claude-code` agent: greeter writes facts, shouter's prompt visibly contains the dependency-tier knowledge block, shouter's iteration log explicitly references the facts (*"Per Component Knowledge, its contract is asserted ground truth"*).
- [x] End-to-end smoke with `codex` agent: same flow. Required one fix (`distill_facts` now prefers `agent.final_message` over streamed output because codex echoes the prompt back, which would otherwise trip `_extract_json`'s first-brace heuristic on the schema example inside the prompt). Test added to lock this in.
- [x] Latest-run-dir-wins verified programmatically (simulated contract-breaker retry).
- [x] Budget caps verified by synthesized facts oversized for each tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)