### PR TITLE
feat: adversarial factory roles - sharper review, PRD red-team, security phase

### DIFF
--- a/prompt.md
+++ b/prompt.md
@@ -1,5 +1,7 @@
 # Ralph Agent Instructions
 
+You are the implementing engineer in a software factory. You will be reviewed by a hostile code reviewer when you declare done; treat that reviewer as already reading your diff while you write it.
+
 ## Your Task (one iteration)
 
 1. Read the PRD file for this run (default: `scripts/ralph/prd.json`)
@@ -24,9 +26,14 @@
 11. Update `AGENTS.md` files with reusable learnings (only if you discovered something worth preserving):
    - Only update `AGENTS.md` in directories you edited
    - Add patterns/gotchas/conventions, not story-specific notes
-12. Commit with message: `feat: [ID] - [Title]`
-13. Update `scripts/ralph/prd.json`: set that story's `passes` to `true` (only after tests/typecheck pass)
-14. Append learnings to `scripts/ralph/progress.txt`
+12. **Adversarial self-check.** Before declaring done, write a `## Self-Critique` block at the end of your progress.txt entry. List AT LEAST 3 concrete ways your implementation could fail in production, drawn from this exact diff. Categories to consider: invalid/empty/None input, concurrent access, partial-failure mid-way through a multi-step operation, hostile input, schema drift, missing auth/authz check, swallowed errors, performance under load, time/locale dependence. For each, write one sentence: "If X happens, this code will do Y, which is wrong because Z." If you genuinely cannot find three, you have not thought hard enough - look at every new function and ask what could break it.
+13. Commit with message: `feat: [ID] - [Title]`
+14. Update `scripts/ralph/prd.json`: set that story's `passes` to `true` (only after tests/typecheck pass AND the self-critique is written)
+15. Append learnings to `scripts/ralph/progress.txt`
+
+## PRD ambiguity
+
+If the PRD is too vague to implement responsibly, do NOT guess. Append an `## INTERPRETATION` block to `scripts/ralph/progress.txt` stating what assumptions you are making and why. The reviewer will see this and can push back; silent guesses become silent bugs.
 
 ## Progress Format
 
@@ -39,6 +46,11 @@ Append this to the END of `scripts/ralph/progress.txt`:
 - **Learnings:**
   - Patterns discovered
   - Gotchas encountered
+- **Self-Critique:**
+  - Failure mode 1: ...
+  - Failure mode 2: ...
+  - Failure mode 3: ...
+- **Interpretations** (only if PRD was ambiguous): ...
 ---
 
 ## Codebase Patterns

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -1073,6 +1073,9 @@ def decompose(
             root_dir=root_dir,
         )
         ui_impl.ok(f"Decomposed into {len(manifest.components)} components")
+    except SpecBlockerError as exc:
+        ui_impl.err(str(exc))
+        sys.exit(2)
     except ValueError as exc:
         ui_impl.err(str(exc))
         sys.exit(1)
@@ -1184,9 +1187,9 @@ def decompose(
 @click.option(
     "--security-mode",
     type=click.Choice(["hard", "advisory", "skip"]),
-    default="advisory",
+    default="skip",
     help="Phase 2.5 security review: hard (block on critical+high), "
-         "advisory (warn only), skip",
+         "advisory (warn only), skip (default - opt in explicitly)",
 )
 @click.option(
     "--security-agent-cmd",

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -15,7 +15,7 @@ from click.core import ParameterSource
 from ralph_py import __version__
 from ralph_py.agents import ClaudeCodeAgent, CodexAgent, get_agent
 from ralph_py.config import RalphConfig, _parse_paths
-from ralph_py.decompose import decompose_spec
+from ralph_py.decompose import SpecBlockerError, decompose_spec
 from ralph_py.factory import FactoryConfig, run_factory
 from ralph_py.init_cmd import DEFAULT_FEATURE_UNDERSTAND, run_init
 from ralph_py.loop import run_loop
@@ -1182,6 +1182,30 @@ def decompose(
     help="Model for reviewer agent",
 )
 @click.option(
+    "--security-mode",
+    type=click.Choice(["hard", "advisory", "skip"]),
+    default="advisory",
+    help="Phase 2.5 security review: hard (block on critical+high), "
+         "advisory (warn only), skip",
+)
+@click.option(
+    "--security-agent-cmd",
+    help="Custom agent for security reviewer "
+         "(default: same as implementation agent)",
+)
+@click.option(
+    "--security-model",
+    help="Model for security reviewer agent "
+         "(default: same as implementation agent)",
+)
+@click.option(
+    "--security-fail-threshold",
+    type=click.Choice(["critical", "high", "medium", "low"]),
+    default="high",
+    help="In hard mode, findings at or above this severity block "
+         "(default: high - critical+high fail)",
+)
+@click.option(
     "--contract-check",
     type=click.Choice(["tier", "final", "skip"]),
     default="tier",
@@ -1275,6 +1299,10 @@ def factory(
     review_mode: str,
     review_agent_cmd: str | None,
     review_model: str | None,
+    security_mode: str,
+    security_agent_cmd: str | None,
+    security_model: str | None,
+    security_fail_threshold: str,
     contract_check: str,
     contract_test_cmd: str | None,
     agent_timeout: float,
@@ -1347,6 +1375,11 @@ def factory(
                 ui=ui_impl,
                 root_dir=root_dir,
             )
+        except SpecBlockerError as exc:
+            # Architect halted: spec has blocker-severity issues. Surface
+            # them and exit cleanly. The user fixes the spec and re-runs.
+            ui_impl.err(str(exc))
+            sys.exit(2)
         except ValueError as exc:
             ui_impl.err(str(exc))
             sys.exit(1)
@@ -1402,6 +1435,14 @@ def factory(
             test_command=contract_test_cmd or test_command or "uv run pytest",
         )
 
+    from ralph_py.security import SecurityConfig as _SecurityConfig
+    s_config = _SecurityConfig(
+        mode=security_mode,
+        agent_cmd=security_agent_cmd,
+        model=security_model,
+        fail_threshold=security_fail_threshold,
+    )
+
     factory_config = FactoryConfig(
         max_parallel=max_parallel,
         max_retries=max_retries,
@@ -1413,6 +1454,7 @@ def factory(
         review_mode=review_mode,
         review_agent_cmd=review_agent_cmd,
         review_model=review_model,
+        security_config=s_config,
         contract_config=c_config,
         progress_log_path=progress_log,
     )

--- a/ralph_py/decompose.py
+++ b/ralph_py/decompose.py
@@ -260,14 +260,23 @@ def _validate_decompose_output(data: Any) -> list[str]:
         return ["'components' must be an array"]
 
     if not components:
+        # Empty components is only valid when there's at least one
+        # well-formed blocker spec_issue (severity AND kind AND summary
+        # all present). Without this stricter check, a malformed entry
+        # like {"severity": "blocker"} would pass validation here but
+        # be dropped by _parse_spec_issues, leaving zero blockers and
+        # zero components with no error raised - a silent halt.
         spec_issues = data.get("spec_issues", [])
         if isinstance(spec_issues, list) and any(
-            isinstance(s, dict) and s.get("severity") == "blocker"
+            isinstance(s, dict)
+            and s.get("severity") == "blocker"
+            and isinstance(s.get("kind"), str) and s["kind"] in _VALID_KINDS
+            and isinstance(s.get("summary"), str) and s["summary"].strip()
             for s in spec_issues
         ):
             # Architect explicitly halted - this is a valid outcome.
             return []
-        return ["'components' must not be empty (no blocker spec_issues to justify halt)"]
+        return ["'components' must not be empty (no well-formed blocker spec_issues to justify halt)"]
 
     seen_ids: set[str] = set()
     seen_story_ids: set[str] = set()

--- a/ralph_py/decompose.py
+++ b/ralph_py/decompose.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -14,16 +15,64 @@ if TYPE_CHECKING:
     from ralph_py.agents.base import Agent
     from ralph_py.ui.base import UI
 
-DECOMPOSE_PROMPT = """\
-You are a senior software architect and product manager. Your job is to decompose
-a feature specification into independent, atomic components that can be implemented
-in parallel by separate coding agents.
 
-Output ONLY valid JSON (no Markdown, no code fences, no comments, no explanation).
+@dataclass
+class SpecIssue:
+    """A red-team finding raised by the architect during decomposition."""
+
+    severity: str  # "blocker" | "major" | "minor"
+    kind: str
+    summary: str
+    location: str = ""
+    suggestion: str = ""
+
+
+class SpecBlockerError(Exception):
+    """Raised when the architect found blocker-severity spec issues.
+
+    The decompose pipeline halts until the human resolves the spec
+    rather than letting a vague spec produce a brittle implementation.
+    The blocking issues are attached via ``issues``.
+    """
+
+    def __init__(self, issues: list[SpecIssue]):
+        self.issues = issues
+        summary_lines = [f"- [{i.severity}/{i.kind}] {i.summary}" for i in issues]
+        super().__init__(
+            "Spec has blocker-severity issues; resolve before re-running:\n"
+            + "\n".join(summary_lines),
+        )
+
+DECOMPOSE_PROMPT = """\
+You are a senior software architect AND a hostile spec auditor. You have
+two jobs and you must do BOTH before decomposing:
+
+  1. RED-TEAM the specification. Find every ambiguity, missing detail,
+     contradiction, unstated assumption, and unspecified failure mode.
+     Most specs are wrong somewhere; your default stance is suspicion.
+  2. Decompose the spec into atomic, parallelizable components, but only
+     to the extent the spec is concrete enough to decompose safely.
+
+If the spec is too vague to decompose responsibly, return `spec_issues`
+with the gaps you found AND an empty `components` array. Do not invent
+behavior to fill silence; that is what produces brittle implementations
+weeks later.
+
+Output ONLY valid JSON (no Markdown, no code fences, no comments, no
+explanation).
 
 The output must be a JSON object with this exact structure:
 
 {{
+  "spec_issues": [
+    {{
+      "severity": "blocker|major|minor",
+      "kind": "ambiguity|missing_detail|contradiction|unstated_assumption|undefined_failure_mode|out_of_scope_creep|other",
+      "summary": "one-sentence statement of the issue",
+      "location": "which part of the spec this is about (quote or paraphrase)",
+      "suggestion": "what would resolve it (one sentence)"
+    }}
+  ],
   "components": [
     {{
       "id": "kebab-case-id",
@@ -35,10 +84,10 @@ The output must be a JSON object with this exact structure:
           "id": "US-001",
           "title": "Short story title",
           "acceptanceCriteria": [
-            "First testable requirement",
-            "Second testable requirement",
-            "Typecheck passes",
-            "Tests pass"
+            "Concrete positive criterion with the actual expected behavior",
+            "Concrete negative criterion: what happens on invalid input / failure / boundary",
+            "Typecheck passes: <project typecheck command>",
+            "Tests pass: <project test command>"
           ],
           "priority": 1,
           "passes": false,
@@ -49,19 +98,43 @@ The output must be a JSON object with this exact structure:
   ]
 }}
 
-Rules:
+Decomposition rules:
 1. Component IDs must be kebab-case (lowercase, hyphens only).
 2. Each component should be independently implementable and testable.
-3. Dependencies reference other component IDs. Foundational components (data models,
-   config, shared utilities) should have no dependencies.
+3. Dependencies reference other component IDs. Foundational components
+   (data models, config, shared utilities) should have no dependencies.
 4. Order components so foundational ones come first.
-5. Each component should have 1-5 user stories. Stories must be small and atomic.
-6. User story IDs must be globally unique across all components (e.g., US-001, US-002...).
-7. Acceptance criteria must be explicit, testable, and include typecheck/test commands.
+5. Each component should have 1-5 user stories. Stories must be small
+   and atomic.
+6. User story IDs must be globally unique across all components
+   (e.g., US-001, US-002...).
+7. Acceptance criteria must be explicit and testable. Each story MUST
+   include at least ONE negative criterion (error path, empty input,
+   boundary value, unauthorized access, malformed payload - whatever
+   applies to that story). Do NOT use placeholder text like "First
+   testable requirement"; write the actual criterion.
 8. Priorities must be unique within each component, starting at 1.
 9. Set "passes" to false and "notes" to "" for every story.
-10. Minimize dependencies between components. Prefer independent components.
-11. Do not invent UI elements, endpoints, or files not described in the spec.
+10. Minimize dependencies between components. Prefer independent
+    components.
+11. Do not invent UI elements, endpoints, or files not described in the
+    spec. If the spec is silent on something you would need to invent,
+    add a `spec_issues` entry instead.
+
+Red-team rules:
+- Look for: ambiguous quantifiers ("fast", "secure", "user-friendly"),
+  missing acceptance criteria (no error behavior specified, no empty/null
+  handling, no concurrency story), undefined data shapes, missing
+  authentication/authorization story, unspecified perf budgets, missing
+  rollback / backwards-compat plan, contradictions between sections.
+- "blocker": cannot safely decompose without resolving this
+- "major": will likely cause rework or a fail-class bug if left
+- "minor": worth raising but not blocking
+- If you genuinely find no issues after reading carefully, return
+  "spec_issues": []. Honesty over performance: do not invent issues to
+  appear thorough.
+- If any issue is "blocker", you MUST return "components": [] so the
+  pipeline halts and the human can fix the spec.
 
 Project name: {project_name}
 
@@ -168,7 +241,12 @@ def _extract_agent_json(agent: Any, output_lines: list[str]) -> Any:
 
 
 def _validate_decompose_output(data: Any) -> list[str]:
-    """Validate the decomposition output structure."""
+    """Validate the decomposition output structure.
+
+    Empty components is permitted only when spec_issues contains at
+    least one blocker - the architect is explicitly halting the pipeline
+    until the human resolves the spec.
+    """
     errors: list[str] = []
 
     if not isinstance(data, dict):
@@ -182,7 +260,14 @@ def _validate_decompose_output(data: Any) -> list[str]:
         return ["'components' must be an array"]
 
     if not components:
-        return ["'components' must not be empty"]
+        spec_issues = data.get("spec_issues", [])
+        if isinstance(spec_issues, list) and any(
+            isinstance(s, dict) and s.get("severity") == "blocker"
+            for s in spec_issues
+        ):
+            # Architect explicitly halted - this is a valid outcome.
+            return []
+        return ["'components' must not be empty (no blocker spec_issues to justify halt)"]
 
     seen_ids: set[str] = set()
     seen_story_ids: set[str] = set()
@@ -243,6 +328,78 @@ def _validate_decompose_output(data: Any) -> list[str]:
                 )
 
     return errors
+
+
+_VALID_SEVERITIES = frozenset({"blocker", "major", "minor"})
+_VALID_KINDS = frozenset({
+    "ambiguity",
+    "missing_detail",
+    "contradiction",
+    "unstated_assumption",
+    "undefined_failure_mode",
+    "out_of_scope_creep",
+    "other",
+})
+
+
+def _parse_spec_issues(data: Any) -> list[SpecIssue]:
+    """Extract typed SpecIssue entries from raw decompose output.
+
+    Invalid entries (unknown severity, unknown kind, missing summary)
+    are skipped rather than crashing decomposition. We surface what the
+    LLM produced honestly even if some entries are malformed.
+    """
+    if not isinstance(data, dict):
+        return []
+    raw = data.get("spec_issues")
+    if not isinstance(raw, list):
+        return []
+    issues: list[SpecIssue] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        severity = str(entry.get("severity", "")).strip()
+        kind = str(entry.get("kind", "")).strip()
+        summary = str(entry.get("summary", "")).strip()
+        if severity not in _VALID_SEVERITIES:
+            continue
+        if kind not in _VALID_KINDS:
+            continue
+        if not summary:
+            continue
+        issues.append(SpecIssue(
+            severity=severity,
+            kind=kind,
+            summary=summary,
+            location=str(entry.get("location", "")).strip(),
+            suggestion=str(entry.get("suggestion", "")).strip(),
+        ))
+    return issues
+
+
+def _surface_spec_issues(issues: list[SpecIssue], ui: UI) -> None:
+    """Render spec issues to the UI grouped by severity."""
+    if not issues:
+        ui.ok("Spec audit: no issues raised")
+        return
+    blockers = [i for i in issues if i.severity == "blocker"]
+    majors = [i for i in issues if i.severity == "major"]
+    minors = [i for i in issues if i.severity == "minor"]
+    ui.section("Spec Audit Findings")
+    for label, group, emit in (
+        ("Blockers", blockers, ui.err),
+        ("Major", majors, ui.warn),
+        ("Minor", minors, ui.info),
+    ):
+        if not group:
+            continue
+        ui.kv(label, str(len(group)))
+        for issue in group:
+            emit(f"  [{issue.kind}] {issue.summary}")
+            if issue.location:
+                ui.info(f"    location: {issue.location}")
+            if issue.suggestion:
+                ui.info(f"    suggestion: {issue.suggestion}")
 
 
 def _generate_component_prd(
@@ -355,6 +512,15 @@ def decompose_spec(
             f"Failed to decompose spec after {max_retries} attempts. "
             f"Last error: {last_error}"
         )
+
+    # Surface red-team findings before doing any further work. If any
+    # are blockers, halt before generating PRDs - the architect
+    # explicitly judged the spec un-decomposable.
+    spec_issues = _parse_spec_issues(data)
+    _surface_spec_issues(spec_issues, ui)
+    blockers = [i for i in spec_issues if i.severity == "blocker"]
+    if blockers:
+        raise SpecBlockerError(blockers)
 
     # Generate PRDs and build manifest components
     ui.section("Generating PRDs")

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -23,6 +23,7 @@ from ralph_py.manifest import Component, ComponentStatus, Manifest
 from ralph_py.observability import NullProgressLog, ProgressLog
 from ralph_py.pr import create_prs_in_order, create_single_pr
 from ralph_py.review import ReviewMode, run_review
+from ralph_py.security import SecurityConfig, SecurityMode, run_security_review
 from ralph_py.verify import VerifyConfig, run_mechanical_verification
 
 if TYPE_CHECKING:
@@ -47,6 +48,8 @@ class FactoryConfig:
     review_agent_cmd: str | None = None
     review_agent_type: str | None = None
     review_model: str | None = None
+    # Phase 2.5: security review (separate LLM call after Phase 2 review)
+    security_config: SecurityConfig | None = None
     # Phase 3: contract testing
     contract_config: ContractConfig | None = None
     # Phase 0: feedforward
@@ -498,6 +501,69 @@ def run_factory(
             ui.ok(f"  Phase 2 passed for {comp_id}")
         else:
             comp.review_passed = None
+
+        # PHASE 2.5: Security review (adversarial pass focused on vulns).
+        # Runs as a separate LLM call with its own threat-model framing so
+        # it catches what the correctness reviewer misses. Non-fatal on
+        # infrastructure errors. Hard-mode fails the component on
+        # findings at or above SecurityConfig.fail_threshold.
+        sec_config = factory_config.security_config
+        if sec_config and sec_config.mode != SecurityMode.SKIP.value:
+            from ralph_py.agents import get_agent as _get_sec_agent
+
+            ui.info(
+                f"  Phase 2.5: security review ({sec_config.mode}) for {comp_id}..."
+            )
+            try:
+                sec_model = sec_config.model or base_config.model
+                sec_agent = _get_sec_agent(
+                    sec_config.agent_cmd or base_config.agent_cmd,
+                    sec_model,
+                    base_config.model_reasoning_effort,
+                    sec_config.agent_type or base_config.agent_type,
+                )
+                sec_result = run_security_review(
+                    sec_agent,
+                    wt_path / comp.prd_path,
+                    wt_path,
+                    manifest.base_branch,
+                    sec_config,
+                    ui,
+                )
+                progress_log.review_result(
+                    comp_id, sec_result.passed,
+                    mode=f"security-{sec_config.mode}",
+                    fail_count=sec_result.critical_count + sec_result.high_count,
+                    advisory_count=len(sec_result.findings),
+                    duration=sec_result.duration_seconds,
+                )
+
+                # Attach security findings to the PR body alongside review
+                if sec_result.findings:
+                    if comp.review_findings:
+                        comp.review_findings = (
+                            comp.review_findings + "\n\n"
+                            + sec_result.as_pr_body_section()
+                        )
+                    else:
+                        comp.review_findings = sec_result.as_pr_body_section()
+
+                if not sec_result.passed:
+                    ui.warn(
+                        f"  Phase 2.5 FAILED for {comp_id}: "
+                        f"{sec_result.critical_count} critical, "
+                        f"{sec_result.high_count} high"
+                    )
+                    ctx = IterationContext.from_json(
+                        comp_result.context_json or "{}",
+                    )
+                    ctx.add_review_finding(sec_result.as_retry_context())
+                    _retry_or_fail(
+                        comp, "Security review failed", ctx.to_json(),
+                    )
+                    return
+            except Exception as exc:  # noqa: BLE001 - non-fatal
+                ui.warn(f"  Security review failed (non-fatal): {exc}")
 
         # Knowledge distillation (Voyager-style post-gate write).
         # Runs after Phase 2 succeeds (or is skipped) but BEFORE the PR

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -458,6 +458,15 @@ def run_factory(
 
         ui.ok(f"  Phase 1 passed for {comp_id}")
 
+        # Fetch the component diff once and share it across Phase 2,
+        # Phase 2.5, and knowledge distillation. Without this each phase
+        # would shell out to `git diff` independently, redundantly
+        # rebuilding the same patch on every component.
+        from ralph_py import git as _git_for_diff
+        shared_diff = _git_for_diff.get_diff_content(
+            manifest.base_branch, wt_path,
+        )
+
         # PHASE 2: Second-opinion review
         review_mode = ReviewMode(factory_config.review_mode)
         if review_mode != ReviewMode.SKIP:
@@ -477,14 +486,19 @@ def run_factory(
                 verification,
                 review_mode,
                 ui,
+                diff_content=shared_diff,
             )
             comp.review_passed = review_result.passed
             comp.review_findings = review_result.as_pr_body_section()
+            # Observability gets criterion-only counts to preserve the
+            # historical meaning of fail_count = "failed PRD criteria".
+            # Concern counts ride along separately via fail_concerns /
+            # advisory_concerns so dashboards can distinguish.
             progress_log.review_result(
                 comp_id, review_result.passed,
                 mode=review_mode.value,
-                fail_count=review_result.fail_count,
-                advisory_count=review_result.advisory_count,
+                fail_count=review_result.criterion_fail_count,
+                advisory_count=review_result.criterion_advisory_count,
                 duration=review_result.duration_seconds,
             )
 
@@ -504,9 +518,9 @@ def run_factory(
 
         # PHASE 2.5: Security review (adversarial pass focused on vulns).
         # Runs as a separate LLM call with its own threat-model framing so
-        # it catches what the correctness reviewer misses. Non-fatal on
-        # infrastructure errors. Hard-mode fails the component on
-        # findings at or above SecurityConfig.fail_threshold.
+        # it catches what the correctness reviewer misses. Hard-mode
+        # fails the component on findings at or above
+        # SecurityConfig.fail_threshold OR on infrastructure errors.
         sec_config = factory_config.security_config
         if sec_config and sec_config.mode != SecurityMode.SKIP.value:
             from ralph_py.agents import get_agent as _get_sec_agent
@@ -514,6 +528,12 @@ def run_factory(
             ui.info(
                 f"  Phase 2.5: security review ({sec_config.mode}) for {comp_id}..."
             )
+            sec_result = None
+            # The try/except deliberately wraps ONLY the agent-driven
+            # work (getting the agent + running the review). Errors in
+            # the retry-or-fail path below must NOT be swallowed - if
+            # they were, a hard-mode security failure could fall through
+            # to PR creation as if it had passed.
             try:
                 sec_model = sec_config.model or base_config.model
                 sec_agent = _get_sec_agent(
@@ -529,7 +549,28 @@ def run_factory(
                     manifest.base_branch,
                     sec_config,
                     ui,
+                    diff_content=shared_diff,
                 )
+            except Exception as exc:  # noqa: BLE001
+                # Agent infrastructure failed before run_security_review
+                # could classify the outcome. Hard mode must block;
+                # advisory passes through.
+                ui.warn(f"  Security review crashed: {exc}")
+                if sec_config.mode == SecurityMode.HARD.value:
+                    ctx = IterationContext.from_json(
+                        comp_result.context_json or "{}",
+                    )
+                    ctx.add_review_finding(
+                        f"Security review infrastructure error: {exc}",
+                    )
+                    _retry_or_fail(
+                        comp,
+                        f"Security review crashed: {exc}",
+                        ctx.to_json(),
+                    )
+                    return
+
+            if sec_result is not None:
                 progress_log.review_result(
                     comp_id, sec_result.passed,
                     mode=f"security-{sec_config.mode}",
@@ -549,6 +590,11 @@ def run_factory(
                         comp.review_findings = sec_result.as_pr_body_section()
 
                 if not sec_result.passed:
+                    reason = (
+                        "Security review crashed"
+                        if sec_result.infrastructure_error
+                        else "Security review failed"
+                    )
                     ui.warn(
                         f"  Phase 2.5 FAILED for {comp_id}: "
                         f"{sec_result.critical_count} critical, "
@@ -558,12 +604,8 @@ def run_factory(
                         comp_result.context_json or "{}",
                     )
                     ctx.add_review_finding(sec_result.as_retry_context())
-                    _retry_or_fail(
-                        comp, "Security review failed", ctx.to_json(),
-                    )
+                    _retry_or_fail(comp, reason, ctx.to_json())
                     return
-            except Exception as exc:  # noqa: BLE001 - non-fatal
-                ui.warn(f"  Security review failed (non-fatal): {exc}")
 
         # Knowledge distillation (Voyager-style post-gate write).
         # Runs after Phase 2 succeeds (or is skipped) but BEFORE the PR
@@ -571,12 +613,12 @@ def run_factory(
         # component's true delta. Non-fatal on any failure.
         if knowledge_config.enabled:
             try:
-                from ralph_py import git as git_ops
                 from ralph_py.agents import get_agent as _get_agent
 
-                diff_content = git_ops.get_diff_content(
-                    manifest.base_branch, wt_path,
-                )
+                # Reuse the diff already fetched at the top of this
+                # method - the worktree state hasn't changed between
+                # Phase 1 and here.
+                diff_content = shared_diff
                 distill_model = (
                     knowledge_config.distill_model or base_config.model
                 )

--- a/ralph_py/git.py
+++ b/ralph_py/git.py
@@ -251,6 +251,25 @@ def get_diff_content(
     return ""
 
 
+# Shared budget for diff content injected into LLM prompts. Centralized
+# here so review / security / knowledge prompts truncate to the same
+# limit; if the LLM context window changes, edit one place.
+DEFAULT_PROMPT_DIFF_CHAR_LIMIT = 50_000
+
+
+def truncate_diff_for_prompt(
+    diff_content: str, limit: int = DEFAULT_PROMPT_DIFF_CHAR_LIMIT,
+) -> str:
+    """Truncate a diff string for inclusion in an LLM prompt.
+
+    Appends a single trailing line noting the truncation so the reviewer
+    knows it isn't seeing the full diff.
+    """
+    if len(diff_content) <= limit:
+        return diff_content
+    return diff_content[:limit] + f"\n... (diff truncated at {limit // 1000}KB)"
+
+
 def merge_branch(
     branch: str,
     cwd: Path | None = None,

--- a/ralph_py/init_cmd.py
+++ b/ralph_py/init_cmd.py
@@ -20,6 +20,10 @@ DEFAULT_PRD = {
 
 DEFAULT_PROMPT = """# Ralph Agent Instructions
 
+You are the implementing engineer in a software factory. You will be
+reviewed by a hostile code reviewer when you declare done; treat that
+reviewer as already reading your diff while you write it.
+
 ## Your Task (one iteration)
 
 1. Read the PRD file for this run (default: `scripts/ralph/prd.json`)
@@ -52,10 +56,28 @@ DEFAULT_PROMPT = """# Ralph Agent Instructions
    (only if you discovered something worth preserving):
    - Only update `AGENTS.md` in directories you edited
    - Add patterns/gotchas/conventions, not story-specific notes
-12. Commit with message: `feat: [ID] - [Title]`
-13. Update `scripts/ralph/prd.json`: set that story's `passes` to `true`
-    (only after tests/typecheck pass)
-14. Append learnings to `scripts/ralph/progress.txt`
+12. **Adversarial self-check.** Before declaring done, write a
+    `## Self-Critique` block at the end of your progress.txt entry. List
+    AT LEAST 3 concrete ways your implementation could fail in
+    production, drawn from this exact diff. Categories to consider:
+    invalid/empty/None input, concurrent access, partial-failure mid-way
+    through a multi-step operation, hostile input, schema drift, missing
+    auth/authz check, swallowed errors, performance under load, time/locale
+    dependence. For each, write one sentence: "If X happens, this code
+    will do Y, which is wrong because Z." If you genuinely cannot find
+    three, you have not thought hard enough - look at every new function
+    and ask what could break it.
+13. Commit with message: `feat: [ID] - [Title]`
+14. Update `scripts/ralph/prd.json`: set that story's `passes` to `true`
+    (only after tests/typecheck pass AND the self-critique is written)
+15. Append learnings to `scripts/ralph/progress.txt`
+
+## PRD ambiguity
+
+If the PRD is too vague to implement responsibly, do NOT guess. Append an
+`## INTERPRETATION` block to `scripts/ralph/progress.txt` stating what
+assumptions you are making and why. The reviewer will see this and can
+push back; silent guesses become silent bugs.
 
 ## Progress Format
 
@@ -68,6 +90,11 @@ Append this to the END of `scripts/ralph/progress.txt`:
 - **Learnings:**
   - Patterns discovered
   - Gotchas encountered
+- **Self-Critique:**
+  - Failure mode 1: ...
+  - Failure mode 2: ...
+  - Failure mode 3: ...
+- **Interpretations** (only if PRD was ambiguous): ...
 ---
 
 ## Codebase Patterns

--- a/ralph_py/review.py
+++ b/ralph_py/review.py
@@ -30,6 +30,18 @@ class ReviewMode(str, Enum):
     SKIP = "skip"
 
 
+VALID_CONCERN_CATEGORIES = frozenset({
+    "scope_creep",
+    "security_concern",
+    "test_quality",
+    "unrelated_change",
+    "dead_code",
+    "error_handling",
+    "copy_paste",
+    "other",
+})
+
+
 @dataclass
 class CriterionReview:
     """Review verdict for a single acceptance criterion."""
@@ -41,18 +53,42 @@ class CriterionReview:
 
 
 @dataclass
+class ReviewConcern:
+    """A cross-cutting concern the reviewer surfaced beyond the PRD criteria.
+
+    The PRD lists what the implementer was supposed to do. Concerns are
+    what they should NOT have done (scope creep, dead code, security
+    smells) or did sloppily (tautological tests, swallowed errors). These
+    are the bugs a real code reviewer catches that the PRD never asked
+    about.
+    """
+
+    category: str
+    severity: str  # "fail" or "advisory"
+    location: str
+    explanation: str
+    suggestion: str = ""
+
+
+@dataclass
 class ReviewResult:
     """Aggregated review result across all stories."""
 
     passed: bool
     mode: str
     criteria: list[CriterionReview] = field(default_factory=list)
+    concerns: list[ReviewConcern] = field(default_factory=list)
     overall_notes: str = ""
     raw_output: str = ""
     duration_seconds: float = 0.0
+    # True when the reviewer explicitly asserted it looked exhaustively
+    # for concerns and found none. False when concerns were surfaced OR
+    # when the reviewer didn't claim exhaustive coverage (treat as
+    # suspicious silence).
+    exhaustively_searched: bool = False
 
     def as_retry_context(self) -> str:
-        """Format failing/advisory criteria for injection into retry prompt."""
+        """Format failing/advisory findings for injection into retry prompt."""
         lines: list[str] = []
         for cr in self.criteria:
             if cr.verdict != ReviewVerdict.PASS.value:
@@ -60,6 +96,14 @@ class ReviewResult:
                 lines.append(f"  Explanation: {cr.explanation}")
                 if cr.suggestion:
                     lines.append(f"  Suggestion: {cr.suggestion}")
+        for concern in self.concerns:
+            lines.append(
+                f"- {concern.severity.upper()} {concern.category}: "
+                f"{concern.location}"
+            )
+            lines.append(f"  Explanation: {concern.explanation}")
+            if concern.suggestion:
+                lines.append(f"  Suggestion: {concern.suggestion}")
         if self.overall_notes:
             lines.append(f"Overall: {self.overall_notes}")
         return "\n".join(lines)
@@ -73,7 +117,8 @@ class ReviewResult:
             1 for c in self.criteria if c.verdict == ReviewVerdict.ADVISORY.value
         )
         lines.append(
-            f"**{pass_count} passed, {fail_count} failed, {adv_count} advisory**"
+            f"**{pass_count} criteria passed, {fail_count} failed, {adv_count} advisory; "
+            f"{len(self.concerns)} additional concerns**"
         )
         lines.append("")
 
@@ -90,6 +135,18 @@ class ReviewResult:
                 if cr.suggestion:
                     lines.append(f"  - Suggestion: {cr.suggestion}")
 
+        if self.concerns:
+            lines.append("")
+            lines.append("### Reviewer concerns (beyond PRD)")
+            for concern in self.concerns:
+                icon = "FAIL" if concern.severity == "fail" else "advisory"
+                lines.append(
+                    f"- [{icon}] **{concern.category}** at `{concern.location}`"
+                )
+                lines.append(f"  - {concern.explanation}")
+                if concern.suggestion:
+                    lines.append(f"  - Suggestion: {concern.suggestion}")
+
         if self.overall_notes:
             lines.append("")
             lines.append(f"**Notes**: {self.overall_notes}")
@@ -98,18 +155,30 @@ class ReviewResult:
 
     @property
     def fail_count(self) -> int:
-        return sum(1 for c in self.criteria if c.verdict == ReviewVerdict.FAIL.value)
+        criterion_fails = sum(
+            1 for c in self.criteria if c.verdict == ReviewVerdict.FAIL.value
+        )
+        concern_fails = sum(1 for c in self.concerns if c.severity == "fail")
+        return criterion_fails + concern_fails
 
     @property
     def advisory_count(self) -> int:
-        return sum(
+        criterion_adv = sum(
             1 for c in self.criteria if c.verdict == ReviewVerdict.ADVISORY.value
         )
+        concern_adv = sum(1 for c in self.concerns if c.severity == "advisory")
+        return criterion_adv + concern_adv
 
 
 REVIEWER_PROMPT = """\
-You are a senior code reviewer. Your job is to verify that a git diff correctly
-implements the acceptance criteria in a PRD (Product Requirements Document).
+You are a hostile senior reviewer. Your default stance is that the diff is
+wrong somewhere; your job is to find what's wrong before approving it. A
+review that surfaces nothing is suspicious - look harder.
+
+You verify two distinct things:
+  1. PRD acceptance criteria - does the diff implement them correctly?
+  2. Cross-cutting concerns the PRD did not enumerate - scope creep, dead
+     code, sloppy tests, security smells, error-handling gaps, copy-paste.
 
 You must output ONLY valid JSON (no Markdown, no code fences, no explanation).
 
@@ -129,19 +198,61 @@ Output schema:
       ]
     }}
   ],
+  "concerns": [
+    {{
+      "category": "scope_creep|security_concern|test_quality|unrelated_change|dead_code|error_handling|copy_paste|other",
+      "severity": "fail|advisory",
+      "location": "path/to/file.py:42-58",
+      "explanation": "evidence-based description of the concern",
+      "suggestion": "what to fix"
+    }}
+  ],
+  "exhaustively_searched": true,
   "overallNotes": "cross-cutting observations (empty string if none)"
 }}
 
-Verdict rules:
+Verdict rules for PRD criteria:
 - "pass": the diff clearly implements this criterion
 - "fail": the diff does NOT implement this criterion, or implements it incorrectly
 - "advisory": the criterion appears implemented but there are quality concerns
   (poor error handling, missing edge cases, fragile patterns)
 
+Concern categories - look for ALL of these, not just the ones the PRD asked about:
+- "scope_creep": changes outside the PRD's stated scope (refactors, drive-by
+  edits, unrelated config tweaks)
+- "security_concern": hardcoded secrets, shell/SQL/command injection paths,
+  missing input validation on a trust boundary, auth/authz bypass, unsafe
+  deserialization, broken crypto, predictable randomness for security uses
+- "test_quality": tautological assertions (`assert True`, `assert x == x`),
+  tests that pass without exercising the change, missing edge-case coverage
+  (empty inputs, None, boundary values, error paths), missing negative tests
+- "unrelated_change": touches files or symbols outside the component's
+  natural scope
+- "dead_code": new code with no caller, parameters never used, imports
+  unused, conditional branches that cannot fire
+- "error_handling": bare excepts, errors silenced with `pass`/empty handlers,
+  missing error paths for foreseeable failures, error messages that lose
+  information
+- "copy_paste": near-duplicate of an existing helper that should be reused
+- "other": catch-all for anything that doesn't fit but matters
+
+Severity:
+- "fail": this concern is serious enough to block the PR
+- "advisory": worth flagging but not blocking
+
 Evidence rules:
-- Every verdict must reference specific files/lines from the diff
-- Do not guess - if you cannot verify a criterion from the diff, mark it "fail"
-- Be strict: working code that doesn't match the criterion's intent is a "fail"
+- Every verdict AND every concern must cite specific file:line ranges from the diff
+- Do not guess - if you cannot verify from the diff, do not assert it
+- Be strict: working code that doesn't match the criterion's intent is "fail"
+- Be honest: if you genuinely cannot find any concerns after looking hard,
+  set "concerns": [] AND "exhaustively_searched": true. Do NOT invent
+  concerns to pad the output. But also do not skip looking - silence is
+  evidence you didn't try.
+
+Process: read every hunk in the diff. For each new function, ask: what
+inputs make this misbehave? what callers does it have? what error paths
+does it leave un-handled? For each test, ask: would this test fail if the
+implementation were wrong? Then assemble your output.
 
 ================================================================================
 PRD (acceptance criteria to verify)
@@ -230,13 +341,45 @@ def parse_review_output(raw_output: str) -> ReviewResult:
                 suggestion=str(crit_data.get("suggestion", "")),
             ))
 
-    has_failures = any(c.verdict == ReviewVerdict.FAIL.value for c in criteria)
+    concerns: list[ReviewConcern] = []
+    raw_concerns = data.get("concerns", [])
+    if isinstance(raw_concerns, list):
+        for c in raw_concerns:
+            if not isinstance(c, dict):
+                continue
+            category = str(c.get("category", "")).strip()
+            severity = str(c.get("severity", "")).strip()
+            location = str(c.get("location", "")).strip()
+            explanation = str(c.get("explanation", "")).strip()
+            # Reject malformed entries instead of silently storing junk
+            if category not in VALID_CONCERN_CATEGORIES:
+                continue
+            if severity not in ("fail", "advisory"):
+                continue
+            if not explanation:
+                continue
+            concerns.append(ReviewConcern(
+                category=category,
+                severity=severity,
+                location=location,
+                explanation=explanation,
+                suggestion=str(c.get("suggestion", "")),
+            ))
+
+    exhaustively_searched = bool(data.get("exhaustively_searched", False))
+
+    has_criterion_failures = any(
+        c.verdict == ReviewVerdict.FAIL.value for c in criteria
+    )
+    has_concern_failures = any(c.severity == "fail" for c in concerns)
     overall_notes = str(data.get("overallNotes", ""))
 
     return ReviewResult(
-        passed=not has_failures,
+        passed=not (has_criterion_failures or has_concern_failures),
         mode="",
         criteria=criteria,
+        concerns=concerns,
+        exhaustively_searched=exhaustively_searched,
         overall_notes=overall_notes,
         raw_output=raw_output[:2000],
     )
@@ -280,6 +423,9 @@ def run_review(
         for cr in result.criteria:
             if cr.verdict == ReviewVerdict.FAIL.value:
                 cr.verdict = ReviewVerdict.ADVISORY.value
+        for concern in result.concerns:
+            if concern.severity == "fail":
+                concern.severity = "advisory"
         result.passed = True
 
     status = "passed" if result.passed else "FAILED"

--- a/ralph_py/review.py
+++ b/ralph_py/review.py
@@ -111,13 +111,22 @@ class ReviewResult:
     def as_pr_body_section(self) -> str:
         """Format all findings for PR description."""
         lines: list[str] = ["## Review Findings", ""]
-        pass_count = sum(1 for c in self.criteria if c.verdict == ReviewVerdict.PASS.value)
-        fail_count = sum(1 for c in self.criteria if c.verdict == ReviewVerdict.FAIL.value)
-        adv_count = sum(
+        # Locals are explicitly criterion-only to avoid colliding with
+        # the same-named instance properties (which sum criteria +
+        # concerns). The header line below describes criteria; concerns
+        # are summarized separately as "additional concerns".
+        criterion_pass = sum(
+            1 for c in self.criteria if c.verdict == ReviewVerdict.PASS.value
+        )
+        criterion_fail = sum(
+            1 for c in self.criteria if c.verdict == ReviewVerdict.FAIL.value
+        )
+        criterion_adv = sum(
             1 for c in self.criteria if c.verdict == ReviewVerdict.ADVISORY.value
         )
         lines.append(
-            f"**{pass_count} criteria passed, {fail_count} failed, {adv_count} advisory; "
+            f"**{criterion_pass} criteria passed, {criterion_fail} failed, "
+            f"{criterion_adv} advisory; "
             f"{len(self.concerns)} additional concerns**"
         )
         lines.append("")
@@ -154,20 +163,38 @@ class ReviewResult:
         return "\n".join(lines)
 
     @property
-    def fail_count(self) -> int:
-        criterion_fails = sum(
+    def criterion_fail_count(self) -> int:
+        return sum(
             1 for c in self.criteria if c.verdict == ReviewVerdict.FAIL.value
         )
-        concern_fails = sum(1 for c in self.concerns if c.severity == "fail")
-        return criterion_fails + concern_fails
+
+    @property
+    def criterion_advisory_count(self) -> int:
+        return sum(
+            1 for c in self.criteria if c.verdict == ReviewVerdict.ADVISORY.value
+        )
+
+    @property
+    def concern_fail_count(self) -> int:
+        return sum(1 for c in self.concerns if c.severity == "fail")
+
+    @property
+    def concern_advisory_count(self) -> int:
+        return sum(1 for c in self.concerns if c.severity == "advisory")
+
+    @property
+    def fail_count(self) -> int:
+        """Total fails across criteria AND concerns. The combined count
+        is what gates run_review's pass/fail decision. For observability
+        that needs to distinguish (e.g. dashboards), use the
+        criterion_/concern_ specific properties instead."""
+        return self.criterion_fail_count + self.concern_fail_count
 
     @property
     def advisory_count(self) -> int:
-        criterion_adv = sum(
-            1 for c in self.criteria if c.verdict == ReviewVerdict.ADVISORY.value
-        )
-        concern_adv = sum(1 for c in self.concerns if c.severity == "advisory")
-        return criterion_adv + concern_adv
+        """Total advisories across criteria AND concerns. See
+        fail_count docstring for the breakdown properties."""
+        return self.criterion_advisory_count + self.concern_advisory_count
 
 
 REVIEWER_PROMPT = """\
@@ -279,8 +306,15 @@ def build_review_prompt(
     worktree_path: Path,
     base_branch: str,
     verification_result: VerificationResult,
+    diff_content: str | None = None,
 ) -> str:
-    """Assemble the full reviewer prompt."""
+    """Assemble the full reviewer prompt.
+
+    ``diff_content`` may be pre-fetched by the caller (e.g. the factory
+    hoists git.get_diff_content to component scope and reuses the result
+    across Phase 2, 2.5, and knowledge distillation). When None, the
+    diff is fetched here for backward compatibility.
+    """
     prd = PRD.load(prd_path)
     prd_lines: list[str] = []
     for story in prd.user_stories:
@@ -289,9 +323,9 @@ def build_review_prompt(
             prd_lines.append(f"- {ac}")
         prd_lines.append("")
 
-    diff_content = git.get_diff_content(base_branch, worktree_path)
-    if len(diff_content) > 50000:
-        diff_content = diff_content[:50000] + "\n... (diff truncated at 50KB)"
+    if diff_content is None:
+        diff_content = git.get_diff_content(base_branch, worktree_path)
+    diff_content = git.truncate_diff_for_prompt(diff_content)
 
     verify_lines: list[str] = []
     for check in verification_result.checks:
@@ -394,6 +428,7 @@ def run_review(
     mode: ReviewMode,
     ui: UI,
     timeout: float = 600.0,
+    diff_content: str | None = None,
 ) -> ReviewResult:
     """Run the full review: build prompt, run agent, parse output.
 
@@ -407,6 +442,7 @@ def run_review(
 
     prompt = build_review_prompt(
         prd_path, worktree_path, base_branch, verification_result,
+        diff_content=diff_content,
     )
 
     output_lines: list[str] = []

--- a/ralph_py/security.py
+++ b/ralph_py/security.py
@@ -1,0 +1,397 @@
+"""Phase 2.5: Security review - a dedicated reviewer focused on vulnerabilities.
+
+A separate LLM pass over the same diff that Phase 2 review evaluated for
+correctness. Security review applies a different threat-modeling framing:
+auth/authz, injection, secrets, deserialization, crypto, races, exfil paths.
+The two reviewers catch different things; running them as separate calls is
+a deliberate adversarial cross-check.
+
+Note: SECURITY_PROMPT below names risky APIs (pickle.loads, yaml.load,
+random for security, MD5/SHA1 for security, etc.) as examples the reviewer
+should DETECT in user diffs. They are not invoked by this module. A
+security-pattern linter scanning this file's string literals may flag
+them; that is a false positive.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ralph_py import git
+from ralph_py.decompose import _extract_json, _select_agent_output
+
+if TYPE_CHECKING:
+    from ralph_py.agents.base import Agent
+    from ralph_py.ui.base import UI
+
+
+class SecurityMode(str, Enum):
+    HARD = "hard"      # block on critical findings
+    ADVISORY = "advisory"  # surface findings but never block
+    SKIP = "skip"      # skip the phase entirely
+
+
+VALID_CATEGORIES = frozenset({
+    "injection",
+    "auth_bypass",
+    "authz_bypass",
+    "hardcoded_secret",
+    "unsafe_deserialization",
+    "broken_crypto",
+    "predictable_randomness",
+    "missing_input_validation",
+    "race_condition",
+    "ssrf",
+    "xss",
+    "open_redirect",
+    "information_disclosure",
+    "denial_of_service",
+    "other",
+})
+
+VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
+
+
+@dataclass
+class SecurityFinding:
+    """A single security concern surfaced by the security reviewer."""
+
+    category: str
+    severity: str  # critical | high | medium | low
+    location: str
+    explanation: str
+    suggestion: str = ""
+
+
+@dataclass
+class SecurityResult:
+    """Aggregated result of a security review."""
+
+    passed: bool
+    mode: str
+    findings: list[SecurityFinding] = field(default_factory=list)
+    overall_notes: str = ""
+    exhaustively_searched: bool = False
+    raw_output: str = ""
+    duration_seconds: float = 0.0
+
+    def as_retry_context(self) -> str:
+        """Format failing findings for injection into the implementer's
+        retry prompt."""
+        if not self.findings:
+            return ""
+        lines = ["Security findings to address:"]
+        for f in self.findings:
+            lines.append(
+                f"- [{f.severity}] {f.category} at {f.location}: {f.explanation}"
+            )
+            if f.suggestion:
+                lines.append(f"  Suggestion: {f.suggestion}")
+        if self.overall_notes:
+            lines.append(f"Overall: {self.overall_notes}")
+        return "\n".join(lines)
+
+    def as_pr_body_section(self) -> str:
+        if not self.findings:
+            return (
+                "## Security Review\n\n"
+                f"**No findings ({self.mode} mode, "
+                f"{'exhaustively' if self.exhaustively_searched else 'briefly'} searched)**"
+            )
+        lines = ["## Security Review", ""]
+        crit = sum(1 for f in self.findings if f.severity == "critical")
+        high = sum(1 for f in self.findings if f.severity == "high")
+        med = sum(1 for f in self.findings if f.severity == "medium")
+        low = sum(1 for f in self.findings if f.severity == "low")
+        lines.append(
+            f"**{crit} critical, {high} high, {med} medium, {low} low "
+            f"({self.mode} mode)**"
+        )
+        lines.append("")
+        for f in self.findings:
+            lines.append(
+                f"- [{f.severity}] **{f.category}** at `{f.location}`"
+            )
+            lines.append(f"  - {f.explanation}")
+            if f.suggestion:
+                lines.append(f"  - Suggestion: {f.suggestion}")
+        if self.overall_notes:
+            lines.append("")
+            lines.append(f"**Notes**: {self.overall_notes}")
+        return "\n".join(lines)
+
+    @property
+    def critical_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == "critical")
+
+    @property
+    def high_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == "high")
+
+
+@dataclass
+class SecurityConfig:
+    """Configuration for the security review phase."""
+
+    mode: str = SecurityMode.ADVISORY.value
+    agent_cmd: str | None = None
+    agent_type: str | None = None
+    model: str | None = None
+    timeout_seconds: float = 600.0
+    # Severity threshold above which findings cause the phase to fail
+    # in HARD mode. Default "high" means critical+high fail the phase.
+    fail_threshold: str = "high"
+
+    @classmethod
+    def from_env(cls) -> SecurityConfig:
+        return cls(
+            mode=os.environ.get("RALPH_SECURITY_MODE", SecurityMode.ADVISORY.value),
+            agent_cmd=os.environ.get("RALPH_SECURITY_AGENT_CMD") or None,
+            agent_type=os.environ.get("RALPH_SECURITY_AGENT_TYPE") or None,
+            model=os.environ.get("RALPH_SECURITY_MODEL") or None,
+            timeout_seconds=float(os.environ.get("RALPH_SECURITY_TIMEOUT", "600")),
+            fail_threshold=os.environ.get("RALPH_SECURITY_FAIL_THRESHOLD", "high"),
+        )
+
+
+SECURITY_PROMPT = """\
+You are an adversarial application security reviewer. Your default stance
+is that this diff introduces a vulnerability somewhere; your job is to
+find it before it ships. You do not verify correctness or style - other
+reviewers handle that. You focus exclusively on security.
+
+Threat model: assume hostile input crosses every trust boundary visible
+in the diff. Assume attackers can craft headers, query strings, request
+bodies, file uploads, environment variables, and timing signals.
+
+You must output ONLY valid JSON (no Markdown, no code fences, no
+explanation).
+
+Output schema:
+{{
+  "findings": [
+    {{
+      "category": "injection|auth_bypass|authz_bypass|hardcoded_secret|unsafe_deserialization|broken_crypto|predictable_randomness|missing_input_validation|race_condition|ssrf|xss|open_redirect|information_disclosure|denial_of_service|other",
+      "severity": "critical|high|medium|low",
+      "location": "path/to/file.py:42-58",
+      "explanation": "what the vulnerability is and how an attacker could exploit it - evidence-based, citing the actual diff",
+      "suggestion": "concrete fix"
+    }}
+  ],
+  "exhaustively_searched": true,
+  "overallNotes": "cross-cutting observations or empty string"
+}}
+
+Categories - look for ALL of these explicitly:
+- "injection": shell, SQL, NoSQL, LDAP, OS command, template, log injection.
+  Concatenated strings to subprocess.run / SQL execute / exec / eval are
+  red flags.
+- "auth_bypass": missing authentication check, broken JWT verification,
+  comparing tokens with `==` (timing oracle), accepting client-supplied
+  identity claims without re-verification.
+- "authz_bypass": missing authorization check, IDOR, role/permission
+  checks that miss a code path, mass assignment of restricted fields.
+- "hardcoded_secret": API keys, passwords, tokens, private keys, salts,
+  pinned credentials, or default test credentials shipped to prod.
+- "unsafe_deserialization": pickle.loads / yaml.load (not safe_load) /
+  marshal / shelve on attacker-controlled bytes.
+- "broken_crypto": MD5/SHA1 for security, ECB mode, missing IV, fixed
+  IV, custom crypto, predictable salts, hardcoded keys.
+- "predictable_randomness": random.* used for security purposes (tokens,
+  IDs, salts); should be secrets.* or os.urandom.
+- "missing_input_validation": trust boundary crossed with no schema,
+  size, range, type, or character-class check.
+- "race_condition": TOCTOU, double-spend windows, missing locks on
+  shared mutable state, unsafe concurrent file I/O.
+- "ssrf": requests/urllib/curl invoked with user-controlled URL with
+  no allowlist.
+- "xss": HTML-rendered content built from user input without escaping;
+  innerHTML usage; template engines with autoescape disabled.
+- "open_redirect": redirect target taken from user input without
+  allowlist.
+- "information_disclosure": stack traces / internal IDs / DB errors
+  leaked to clients; PII in logs; secrets in error messages.
+- "denial_of_service": unbounded loops on user input, unbounded memory
+  allocation, recursive regex, no rate limiting on expensive endpoints.
+
+Severity:
+- "critical": exploitable now, no auth required, full compromise possible
+- "high": exploitable with realistic preconditions; significant damage
+- "medium": requires unusual conditions but the door is open
+- "low": defense-in-depth, hardening, future-risk
+
+Evidence rules:
+- Every finding must cite file:line ranges from the diff
+- Do not speculate beyond what the diff shows
+- Be honest: if you cannot find anything after looking, return
+  "findings": [] AND "exhaustively_searched": true. Padding with
+  fabricated findings is worse than silence.
+
+Process: read every hunk. For each new function that touches a trust
+boundary (HTTP handler, file read, subprocess, deserialization, SQL,
+auth, crypto), ask: what input makes this misbehave? what could an
+attacker craft? what is missing that a paranoid reviewer would demand?
+
+================================================================================
+PRD (what the implementer was asked to build)
+================================================================================
+
+{prd_content}
+
+================================================================================
+GIT DIFF (changes to review for security)
+================================================================================
+
+{diff_content}
+"""
+
+
+def _build_security_prompt(prd_text: str, diff_content: str) -> str:
+    truncated_diff = diff_content
+    if len(truncated_diff) > 50000:
+        truncated_diff = (
+            truncated_diff[:50000] + "\n... (diff truncated at 50KB)"
+        )
+    return SECURITY_PROMPT.format(
+        prd_content=prd_text or "(PRD not available)",
+        diff_content=truncated_diff,
+    )
+
+
+def parse_security_output(raw_output: str, mode: str) -> SecurityResult:
+    """Parse structured JSON from the security reviewer agent."""
+    try:
+        data = _extract_json(raw_output)
+    except ValueError:
+        return SecurityResult(
+            passed=False,
+            mode=mode,
+            overall_notes="Failed to parse security reviewer output as JSON",
+            raw_output=raw_output[:2000],
+        )
+
+    if not isinstance(data, dict):
+        return SecurityResult(
+            passed=False,
+            mode=mode,
+            overall_notes="Security output was not a JSON object",
+            raw_output=raw_output[:2000],
+        )
+
+    findings: list[SecurityFinding] = []
+    raw_findings = data.get("findings", [])
+    if isinstance(raw_findings, list):
+        for f in raw_findings:
+            if not isinstance(f, dict):
+                continue
+            category = str(f.get("category", "")).strip()
+            severity = str(f.get("severity", "")).strip()
+            location = str(f.get("location", "")).strip()
+            explanation = str(f.get("explanation", "")).strip()
+            if category not in VALID_CATEGORIES:
+                continue
+            if severity not in VALID_SEVERITIES:
+                continue
+            if not explanation:
+                continue
+            findings.append(SecurityFinding(
+                category=category,
+                severity=severity,
+                location=location,
+                explanation=explanation,
+                suggestion=str(f.get("suggestion", "")).strip(),
+            ))
+
+    exhaustively_searched = bool(data.get("exhaustively_searched", False))
+    overall_notes = str(data.get("overallNotes", ""))
+
+    return SecurityResult(
+        passed=True,  # caller decides pass/fail based on mode + threshold
+        mode=mode,
+        findings=findings,
+        exhaustively_searched=exhaustively_searched,
+        overall_notes=overall_notes,
+        raw_output=raw_output[:2000],
+    )
+
+
+_SEVERITY_ORDER = {"critical": 3, "high": 2, "medium": 1, "low": 0}
+
+
+def _passes_threshold(
+    findings: list[SecurityFinding], mode: str, fail_threshold: str,
+) -> bool:
+    """Decide whether the result passes given the mode and threshold."""
+    if mode == SecurityMode.SKIP.value:
+        return True
+    if mode == SecurityMode.ADVISORY.value:
+        return True
+    # HARD mode: fail if any finding meets or exceeds the threshold.
+    threshold_rank = _SEVERITY_ORDER.get(fail_threshold, 2)  # default "high"
+    blocking = [
+        f for f in findings
+        if _SEVERITY_ORDER.get(f.severity, 0) >= threshold_rank
+    ]
+    return not blocking
+
+
+def run_security_review(
+    agent: Agent,
+    prd_path: Path,
+    worktree_path: Path,
+    base_branch: str,
+    config: SecurityConfig,
+    ui: UI,
+) -> SecurityResult:
+    """Run the security review phase. Always non-fatal: on any
+    infrastructure error returns a SecurityResult with empty findings
+    and passed=True. The caller decides whether to gate on passed."""
+    mode = config.mode
+    if mode == SecurityMode.SKIP.value:
+        return SecurityResult(passed=True, mode=mode)
+
+    ui.info("  Running security review...")
+    start = time.monotonic()
+
+    prd_text = ""
+    try:
+        prd_text = prd_path.read_text(encoding="utf-8")
+    except OSError:
+        pass
+
+    diff_content = git.get_diff_content(base_branch, worktree_path)
+    prompt = _build_security_prompt(prd_text, diff_content)
+
+    output_lines: list[str] = []
+    try:
+        for line in agent.run(
+            prompt, cwd=worktree_path, timeout=config.timeout_seconds,
+        ):
+            output_lines.append(line)
+    except Exception as exc:  # noqa: BLE001 - non-fatal
+        return SecurityResult(
+            passed=True,
+            mode=mode,
+            overall_notes=f"Security review agent failed: {exc}",
+            duration_seconds=time.monotonic() - start,
+        )
+
+    raw_output = _select_agent_output(agent, output_lines)
+    result = parse_security_output(raw_output, mode)
+    result.passed = _passes_threshold(
+        result.findings, mode, config.fail_threshold,
+    )
+    result.duration_seconds = time.monotonic() - start
+
+    status = "passed" if result.passed else "FAILED"
+    ui.info(
+        f"  Security review {status}: "
+        f"{result.critical_count} critical, {result.high_count} high, "
+        f"{len(result.findings)} total"
+    )
+    return result

--- a/ralph_py/security.py
+++ b/ralph_py/security.py
@@ -79,6 +79,11 @@ class SecurityResult:
     exhaustively_searched: bool = False
     raw_output: str = ""
     duration_seconds: float = 0.0
+    # True when the reviewer agent failed to run or returned unparseable
+    # output. Distinguishes "clean review found nothing" from "review
+    # never actually happened" so hard-mode can fail loudly instead of
+    # accidentally passing on infrastructure errors.
+    infrastructure_error: bool = False
 
     def as_retry_context(self) -> str:
         """Format failing findings for injection into the implementer's
@@ -146,6 +151,22 @@ class SecurityConfig:
     # Severity threshold above which findings cause the phase to fail
     # in HARD mode. Default "high" means critical+high fail the phase.
     fail_threshold: str = "high"
+
+    def __post_init__(self) -> None:
+        # Reject unknown modes / thresholds rather than silently
+        # defaulting downstream (the env-var path bypasses click choice
+        # validation so a typo would otherwise change the gate without
+        # any signal).
+        if self.mode not in {m.value for m in SecurityMode}:
+            raise ValueError(
+                f"Invalid SecurityConfig.mode {self.mode!r}; "
+                f"must be one of skip|advisory|hard"
+            )
+        if self.fail_threshold not in VALID_SEVERITIES:
+            raise ValueError(
+                f"Invalid SecurityConfig.fail_threshold {self.fail_threshold!r}; "
+                f"must be one of {sorted(VALID_SEVERITIES)}"
+            )
 
     @classmethod
     def from_env(cls) -> SecurityConfig:
@@ -252,14 +273,9 @@ GIT DIFF (changes to review for security)
 
 
 def _build_security_prompt(prd_text: str, diff_content: str) -> str:
-    truncated_diff = diff_content
-    if len(truncated_diff) > 50000:
-        truncated_diff = (
-            truncated_diff[:50000] + "\n... (diff truncated at 50KB)"
-        )
     return SECURITY_PROMPT.format(
         prd_content=prd_text or "(PRD not available)",
-        diff_content=truncated_diff,
+        diff_content=git.truncate_diff_for_prompt(diff_content),
     )
 
 
@@ -273,6 +289,7 @@ def parse_security_output(raw_output: str, mode: str) -> SecurityResult:
             mode=mode,
             overall_notes="Failed to parse security reviewer output as JSON",
             raw_output=raw_output[:2000],
+            infrastructure_error=True,
         )
 
     if not isinstance(data, dict):
@@ -281,6 +298,7 @@ def parse_security_output(raw_output: str, mode: str) -> SecurityResult:
             mode=mode,
             overall_notes="Security output was not a JSON object",
             raw_output=raw_output[:2000],
+            infrastructure_error=True,
         )
 
     findings: list[SecurityFinding] = []
@@ -347,6 +365,7 @@ def run_security_review(
     base_branch: str,
     config: SecurityConfig,
     ui: UI,
+    diff_content: str | None = None,
 ) -> SecurityResult:
     """Run the security review phase. Always non-fatal: on any
     infrastructure error returns a SecurityResult with empty findings
@@ -364,7 +383,8 @@ def run_security_review(
     except OSError:
         pass
 
-    diff_content = git.get_diff_content(base_branch, worktree_path)
+    if diff_content is None:
+        diff_content = git.get_diff_content(base_branch, worktree_path)
     prompt = _build_security_prompt(prd_text, diff_content)
 
     output_lines: list[str] = []
@@ -374,18 +394,32 @@ def run_security_review(
         ):
             output_lines.append(line)
     except Exception as exc:  # noqa: BLE001 - non-fatal
+        # Agent crashed mid-run. In hard mode this MUST surface as a
+        # failure - otherwise a flaky API call silently approves the
+        # diff. Advisory mode warns but doesn't block. Skip mode never
+        # gets here.
+        passed = mode != SecurityMode.HARD.value
         return SecurityResult(
-            passed=True,
+            passed=passed,
             mode=mode,
             overall_notes=f"Security review agent failed: {exc}",
             duration_seconds=time.monotonic() - start,
+            infrastructure_error=True,
         )
 
     raw_output = _select_agent_output(agent, output_lines)
     result = parse_security_output(raw_output, mode)
-    result.passed = _passes_threshold(
-        result.findings, mode, config.fail_threshold,
-    )
+    if result.infrastructure_error:
+        # Parsing failed - we have no usable findings list, so don't
+        # let _passes_threshold overwrite passed=False with True. In
+        # hard mode this is a block; in advisory it surfaces as a
+        # warning but lets the pipeline continue.
+        if mode != SecurityMode.HARD.value:
+            result.passed = True
+    else:
+        result.passed = _passes_threshold(
+            result.findings, mode, config.fail_threshold,
+        )
     result.duration_seconds = time.monotonic() - start
 
     status = "passed" if result.passed else "FAILED"

--- a/ralph_py/verify.py
+++ b/ralph_py/verify.py
@@ -68,6 +68,13 @@ class VerifyConfig:
     mutation_threshold: float = 50.0
     mutation_timeout: float = 600.0
     subprocess_timeout: float = 300.0
+    # Mechanical enforcement of the engineer prompt's "## Self-Critique"
+    # mandate. Off by default to keep this opt-in; set to True (or
+    # RALPH_VERIFY_REQUIRE_SELF_CRITIQUE=1) to fail Phase 1 when an
+    # iteration's progress.txt entry omits the block.
+    require_self_critique: bool = False
+    self_critique_min_bullets: int = 3
+    progress_file_path: str = "scripts/ralph/progress.txt"
 
     @classmethod
     def from_env(cls) -> VerifyConfig:
@@ -88,6 +95,16 @@ class VerifyConfig:
             subprocess_timeout=float(
                 os.environ.get("RALPH_TIMEOUT_VERIFY", "300")
             ),
+            require_self_critique=os.environ.get(
+                "RALPH_VERIFY_REQUIRE_SELF_CRITIQUE", "",
+            ) == "1",
+            self_critique_min_bullets=int(
+                os.environ.get("RALPH_VERIFY_SELF_CRITIQUE_MIN_BULLETS", "3"),
+            ),
+            progress_file_path=os.environ.get(
+                "RALPH_VERIFY_PROGRESS_FILE",
+                "scripts/ralph/progress.txt",
+            ),
         )
 
 
@@ -99,6 +116,105 @@ SECRET_PATTERNS = [
     re.compile(r"-----BEGIN (RSA |EC )?PRIVATE KEY-----"),  # Private keys
     re.compile(r"xox[bpoas]-[a-zA-Z0-9-]+"),             # Slack tokens
 ]
+
+
+# Matches the variety of heading forms the engineer prompt produces:
+#   ## Self-Critique
+#   - **Self-Critique:**
+#   * Self Critique
+_SELF_CRITIQUE_HEADING_RE = re.compile(
+    r"^[#\-*\s\*]*Self[-\s]?Critique[\*:\s]*$",
+    re.IGNORECASE,
+)
+
+
+def check_self_critique(
+    progress_path: Path, min_bullets: int = 3,
+) -> CheckResult:
+    """Confirm the latest progress.txt entry contains a Self-Critique
+    block with at least ``min_bullets`` bullet points.
+
+    The check looks at the LAST occurrence of a Self-Critique heading
+    (line matching `_SELF_CRITIQUE_HEADING_RE`, e.g. `## Self-Critique`
+    or `- **Self-Critique:**`) and counts the bullet lines that follow
+    until the next heading or end-of-file.
+
+    Without this mechanical check, the engineer prompt's mandate to
+    list >=3 failure modes can silently rot - the only enforcement
+    path otherwise is the reviewer noticing, which is unreliable.
+    """
+    start = time.monotonic()
+    try:
+        text = progress_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return CheckResult(
+            name="self_critique",
+            passed=False,
+            message=f"Could not read progress file: {exc}",
+            duration_seconds=time.monotonic() - start,
+        )
+
+    lines = text.splitlines()
+    # Find the LAST self-critique heading. Walking from the end lets
+    # multiple iterations accumulate without earlier ones masking the
+    # current iteration's block.
+    heading_idx: int | None = None
+    for i in range(len(lines) - 1, -1, -1):
+        if _SELF_CRITIQUE_HEADING_RE.match(lines[i]):
+            heading_idx = i
+            break
+
+    if heading_idx is None:
+        return CheckResult(
+            name="self_critique",
+            passed=False,
+            message=(
+                "No '## Self-Critique' block found in progress file. "
+                "Engineer prompt mandates >=3 failure-mode bullets "
+                "before declaring done."
+            ),
+            duration_seconds=time.monotonic() - start,
+        )
+
+    # Count bullets after the heading until the next heading (^##) or
+    # the next list-style heading (e.g. - **Learnings:**).
+    bullet_count = 0
+    bullet_lines: list[str] = []
+    for line in lines[heading_idx + 1:]:
+        stripped = line.strip()
+        # Stop at next major heading
+        if stripped.startswith("##"):
+            break
+        # Stop at the next labeled bullet header (e.g. "- **Interpretations:**")
+        if stripped.startswith("- **") and stripped.rstrip(":*").lower().endswith(
+            ("**", "**:"),
+        ) and "self" not in stripped.lower():
+            break
+        # Count substantive bullets (require non-trivial content after the marker)
+        if stripped.startswith("- ") or stripped.startswith("* "):
+            body = stripped[2:].strip()
+            if body and not body.lower().startswith(("tbd", "todo", "n/a")):
+                bullet_count += 1
+                bullet_lines.append(body[:80])
+
+    if bullet_count < min_bullets:
+        return CheckResult(
+            name="self_critique",
+            passed=False,
+            message=(
+                f"Self-Critique block has {bullet_count} bullets; "
+                f"minimum required is {min_bullets}"
+            ),
+            details=bullet_lines,
+            duration_seconds=time.monotonic() - start,
+        )
+
+    return CheckResult(
+        name="self_critique",
+        passed=True,
+        message=f"{bullet_count} failure modes listed",
+        duration_seconds=time.monotonic() - start,
+    )
 
 
 def check_prd_stories(prd_path: Path) -> CheckResult:
@@ -650,6 +766,12 @@ def run_mechanical_verification(
         checks.append(check_mutation_score(
             worktree_path, base_branch,
             config.mutation_threshold, config.mutation_timeout,
+        ))
+
+    if config.require_self_critique:
+        progress_path = worktree_path / config.progress_file_path
+        checks.append(check_self_critique(
+            progress_path, config.self_critique_min_bullets,
         ))
 
     passed = all(c.passed for c in checks)

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -9,7 +9,10 @@ from pathlib import Path
 import pytest
 
 from ralph_py.decompose import (
+    SpecBlockerError,
+    SpecIssue,
     _extract_json,
+    _parse_spec_issues,
     _validate_decompose_output,
     decompose_spec,
 )
@@ -175,6 +178,145 @@ class TestValidateDecomposeOutput:
         }
         errors = _validate_decompose_output(data)
         assert any("nonexistent" in e for e in errors)
+
+
+class TestSpecIssues:
+    """Tests for the red-team / spec-audit surface."""
+
+    def test_parse_typed_issues(self) -> None:
+        data = {
+            "spec_issues": [
+                {
+                    "severity": "blocker",
+                    "kind": "ambiguity",
+                    "summary": "What 'fast' means is not defined",
+                    "location": "Performance section",
+                    "suggestion": "Specify a P95 latency budget",
+                },
+                {
+                    "severity": "major",
+                    "kind": "undefined_failure_mode",
+                    "summary": "No error path for db unavailable",
+                },
+            ],
+        }
+        issues = _parse_spec_issues(data)
+        assert len(issues) == 2
+        assert issues[0].severity == "blocker"
+        assert issues[1].kind == "undefined_failure_mode"
+
+    def test_invalid_severity_dropped(self) -> None:
+        data = {"spec_issues": [{
+            "severity": "critical",  # not valid
+            "kind": "ambiguity",
+            "summary": "x",
+        }]}
+        assert _parse_spec_issues(data) == []
+
+    def test_invalid_kind_dropped(self) -> None:
+        data = {"spec_issues": [{
+            "severity": "major",
+            "kind": "made_up_kind",
+            "summary": "x",
+        }]}
+        assert _parse_spec_issues(data) == []
+
+    def test_missing_summary_dropped(self) -> None:
+        data = {"spec_issues": [{
+            "severity": "minor",
+            "kind": "ambiguity",
+            "summary": "",
+        }]}
+        assert _parse_spec_issues(data) == []
+
+    def test_empty_components_allowed_when_blocker_exists(self) -> None:
+        data = {
+            "components": [],
+            "spec_issues": [{
+                "severity": "blocker",
+                "kind": "ambiguity",
+                "summary": "spec is too vague",
+            }],
+        }
+        assert _validate_decompose_output(data) == []
+
+    def test_empty_components_rejected_without_blockers(self) -> None:
+        data = {"components": []}
+        errors = _validate_decompose_output(data)
+        assert errors
+        assert "components" in errors[0]
+
+    def test_decompose_raises_on_blocker(self, tmp_path: Path) -> None:
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Vague spec\nDo something good.")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+
+        output = json.dumps({
+            "spec_issues": [{
+                "severity": "blocker",
+                "kind": "ambiguity",
+                "summary": "Spec is empty",
+                "location": "everywhere",
+                "suggestion": "Write actual requirements",
+            }],
+            "components": [],
+        })
+        agent = MockDecomposeAgent(output)
+        ui = PlainUI(no_color=True)
+        with pytest.raises(SpecBlockerError) as exc_info:
+            decompose_spec(
+                spec_path=spec_file,
+                project_name="test",
+                base_branch="main",
+                single_pr=False,
+                agent=agent,
+                ui=ui,
+                root_dir=tmp_path,
+            )
+        assert len(exc_info.value.issues) == 1
+        assert exc_info.value.issues[0].severity == "blocker"
+
+    def test_decompose_continues_on_non_blockers(self, tmp_path: Path) -> None:
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Spec\nBuild it.")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+
+        output = json.dumps({
+            "spec_issues": [{
+                "severity": "minor",
+                "kind": "missing_detail",
+                "summary": "Edge case unspecified",
+            }],
+            "components": [
+                {
+                    "id": "comp-a",
+                    "title": "A",
+                    "description": "x",
+                    "dependencies": [],
+                    "userStories": [{
+                        "id": "US-001",
+                        "title": "S1",
+                        "acceptanceCriteria": ["AC1", "AC2"],
+                        "priority": 1,
+                        "passes": False,
+                        "notes": "",
+                    }],
+                },
+            ],
+        })
+        agent = MockDecomposeAgent(output)
+        ui = PlainUI(no_color=True)
+        manifest = decompose_spec(
+            spec_path=spec_file,
+            project_name="test",
+            base_branch="main",
+            single_pr=False,
+            agent=agent,
+            ui=ui,
+            root_dir=tmp_path,
+        )
+        assert len(manifest.components) == 1
+        assert manifest.components[0].id == "comp-a"
 
 
 class TestDecomposeSpec:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from ralph_py.review import (
     CriterionReview,
+    ReviewConcern,
     ReviewMode,
     ReviewResult,
     ReviewVerdict,
@@ -125,7 +126,7 @@ class TestReviewResult:
         )
         body = result.as_pr_body_section()
         assert "Review Findings" in body
-        assert "1 passed" in body
+        assert "1 criteria passed" in body
         assert "1 advisory" in body
         assert "Looks decent" in body
 
@@ -141,6 +142,189 @@ class TestReviewResult:
         )
         assert result.fail_count == 2
         assert result.advisory_count == 0
+
+
+class TestConcerns:
+    """Tests for the new cross-cutting reviewer concerns surface."""
+
+    def test_parse_extracts_concerns(self) -> None:
+        output = json.dumps({
+            "stories": [],
+            "concerns": [
+                {
+                    "category": "security_concern",
+                    "severity": "fail",
+                    "location": "src/auth.py:42-58",
+                    "explanation": "Password compared with == (timing oracle)",
+                    "suggestion": "Use hmac.compare_digest",
+                },
+                {
+                    "category": "test_quality",
+                    "severity": "advisory",
+                    "location": "tests/test_auth.py:101",
+                    "explanation": "assert True - tautological",
+                },
+            ],
+            "exhaustively_searched": True,
+        })
+        result = parse_review_output(output)
+        assert len(result.concerns) == 2
+        assert result.concerns[0].category == "security_concern"
+        assert result.exhaustively_searched is True
+        assert result.passed is False  # one concern is fail-severity
+
+    def test_concern_fail_blocks_overall_pass(self) -> None:
+        output = json.dumps({
+            "stories": [{
+                "storyId": "US-001",
+                "storyTitle": "x",
+                "criteria": [{
+                    "criterion": "AC1",
+                    "verdict": "pass",
+                    "explanation": "ok",
+                    "suggestion": "",
+                }],
+            }],
+            "concerns": [{
+                "category": "dead_code",
+                "severity": "fail",
+                "location": "src/x.py:10",
+                "explanation": "Function f never called",
+            }],
+        })
+        result = parse_review_output(output)
+        assert result.passed is False
+        assert result.fail_count == 1
+        assert result.advisory_count == 0
+
+    def test_advisory_concerns_do_not_block(self) -> None:
+        output = json.dumps({
+            "stories": [{
+                "storyId": "US-001",
+                "storyTitle": "x",
+                "criteria": [{
+                    "criterion": "AC1",
+                    "verdict": "pass",
+                    "explanation": "ok",
+                    "suggestion": "",
+                }],
+            }],
+            "concerns": [{
+                "category": "copy_paste",
+                "severity": "advisory",
+                "location": "src/x.py:10",
+                "explanation": "Duplicates helper foo()",
+            }],
+        })
+        result = parse_review_output(output)
+        assert result.passed is True
+        assert result.advisory_count == 1
+
+    def test_invalid_concern_categories_dropped(self) -> None:
+        output = json.dumps({
+            "stories": [],
+            "concerns": [
+                {
+                    "category": "made_up_category",
+                    "severity": "fail",
+                    "location": "x:1",
+                    "explanation": "bogus",
+                },
+                {
+                    "category": "security_concern",
+                    "severity": "fail",
+                    "location": "x:2",
+                    "explanation": "legit",
+                },
+            ],
+        })
+        result = parse_review_output(output)
+        assert len(result.concerns) == 1
+        assert result.concerns[0].category == "security_concern"
+
+    def test_invalid_severity_dropped(self) -> None:
+        output = json.dumps({
+            "stories": [],
+            "concerns": [{
+                "category": "dead_code",
+                "severity": "blocker",  # not a valid severity
+                "location": "x:1",
+                "explanation": "x",
+            }],
+        })
+        result = parse_review_output(output)
+        assert result.concerns == []
+
+    def test_exhaustively_searched_default_false_when_missing(self) -> None:
+        output = json.dumps({"stories": [], "concerns": []})
+        result = parse_review_output(output)
+        assert result.exhaustively_searched is False
+
+    def test_concerns_appear_in_pr_body(self) -> None:
+        result = ReviewResult(
+            passed=False,
+            mode="hard",
+            criteria=[CriterionReview("AC1", "pass", "ok")],
+            concerns=[
+                ReviewConcern(
+                    category="security_concern",
+                    severity="fail",
+                    location="src/x.py:1-5",
+                    explanation="hardcoded API key",
+                    suggestion="move to env var",
+                ),
+            ],
+        )
+        body = result.as_pr_body_section()
+        assert "Reviewer concerns" in body
+        assert "security_concern" in body
+        assert "hardcoded API key" in body
+        assert "0 additional concerns" not in body
+        assert "1 additional concerns" in body
+
+    def test_advisory_mode_downgrades_concern_failures(
+        self, tmp_path: Path,
+    ) -> None:
+        prd_path = tmp_path / "prd.json"
+        prd_path.write_text(json.dumps({
+            "branchName": "test",
+            "userStories": [{
+                "id": "US-001", "title": "Test",
+                "acceptanceCriteria": ["AC1"], "priority": 1,
+                "passes": True, "notes": "",
+            }],
+        }))
+        output = json.dumps({
+            "stories": [{
+                "storyId": "US-001",
+                "storyTitle": "x",
+                "criteria": [{
+                    "criterion": "AC1",
+                    "verdict": "pass",
+                    "explanation": "ok",
+                    "suggestion": "",
+                }],
+            }],
+            "concerns": [{
+                "category": "security_concern",
+                "severity": "fail",
+                "location": "x:1",
+                "explanation": "bug",
+            }],
+        })
+        agent = MockReviewAgent(output)
+        ui = PlainUI(no_color=True)
+        verification = VerificationResult(
+            passed=True,
+            checks=[CheckResult("test_suite", True, "ok")],
+        )
+        result = run_review(
+            agent, prd_path, tmp_path, "main",
+            verification, ReviewMode.ADVISORY, ui,
+        )
+        # Concern was downgraded; review passes; concern survives as advisory
+        assert result.passed is True
+        assert result.concerns[0].severity == "advisory"
 
 
 class TestRunReview:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -278,9 +278,7 @@ class TestRunSecurityReview:
         )
         assert result.passed is True
 
-    def test_agent_crash_is_nonfatal(self, tmp_path: Path) -> None:
-        prd_path = self._setup_repo(tmp_path)
-
+    def _boom_agent(self) -> object:
         class _Boom:
             @property
             def name(self) -> str:
@@ -297,13 +295,56 @@ class TestRunSecurityReview:
             def final_message(self) -> str | None:
                 return None
 
+        return _Boom()
+
+    def test_agent_crash_hard_mode_fails(self, tmp_path: Path) -> None:
+        """Hard mode must surface infrastructure errors as a failure -
+        otherwise a flaky API silently approves every diff."""
+        prd_path = self._setup_repo(tmp_path)
         config = SecurityConfig(mode=SecurityMode.HARD.value)
         ui = PlainUI(no_color=True)
         result = run_security_review(
-            _Boom(), prd_path, tmp_path, "main", config, ui,
+            self._boom_agent(), prd_path, tmp_path, "main", config, ui,
         )
-        assert result.passed is True  # non-fatal
+        assert result.passed is False
+        assert result.infrastructure_error is True
         assert "exploded" in result.overall_notes
+
+    def test_agent_crash_advisory_mode_passes(self, tmp_path: Path) -> None:
+        """Advisory mode should warn but not block."""
+        prd_path = self._setup_repo(tmp_path)
+        config = SecurityConfig(mode=SecurityMode.ADVISORY.value)
+        ui = PlainUI(no_color=True)
+        result = run_security_review(
+            self._boom_agent(), prd_path, tmp_path, "main", config, ui,
+        )
+        assert result.passed is True
+        assert result.infrastructure_error is True
+
+    def test_parse_failure_hard_mode_fails(self, tmp_path: Path) -> None:
+        """If the agent returns un-parseable output in hard mode, we
+        must NOT silently overwrite passed=False via _passes_threshold
+        on the (empty) findings list."""
+        prd_path = self._setup_repo(tmp_path)
+        agent = MockSecurityAgent("garbage that is not JSON at all")
+        config = SecurityConfig(mode=SecurityMode.HARD.value)
+        ui = PlainUI(no_color=True)
+        result = run_security_review(
+            agent, prd_path, tmp_path, "main", config, ui,
+        )
+        assert result.passed is False
+        assert result.infrastructure_error is True
+
+    def test_parse_failure_advisory_mode_passes(self, tmp_path: Path) -> None:
+        prd_path = self._setup_repo(tmp_path)
+        agent = MockSecurityAgent("garbage")
+        config = SecurityConfig(mode=SecurityMode.ADVISORY.value)
+        ui = PlainUI(no_color=True)
+        result = run_security_review(
+            agent, prd_path, tmp_path, "main", config, ui,
+        )
+        assert result.passed is True
+        assert result.infrastructure_error is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,372 @@
+"""Tests for the Phase 2.5 security review module."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from ralph_py.security import (
+    SECURITY_PROMPT,
+    SecurityConfig,
+    SecurityFinding,
+    SecurityMode,
+    SecurityResult,
+    _passes_threshold,
+    parse_security_output,
+    run_security_review,
+)
+from ralph_py.ui.plain import PlainUI
+
+
+class MockSecurityAgent:
+    def __init__(self, output: str):
+        self._output = output
+        self._final_message: str | None = None
+
+    @property
+    def name(self) -> str:
+        return "mock-security"
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        yield from self._output.splitlines()
+        if self._output.strip():
+            self._final_message = self._output
+
+    @property
+    def final_message(self) -> str | None:
+        return self._final_message
+
+
+VALID_SECURITY_OUTPUT = json.dumps({
+    "findings": [
+        {
+            "category": "injection",
+            "severity": "critical",
+            "location": "src/handler.py:42",
+            "explanation": "subprocess.run with shell=True on user input",
+            "suggestion": "Use shell=False and pass args as list",
+        },
+        {
+            "category": "hardcoded_secret",
+            "severity": "medium",
+            "location": "src/auth.py:10",
+            "explanation": "default API key string in source",
+        },
+    ],
+    "exhaustively_searched": True,
+})
+
+
+# ---------------------------------------------------------------------------
+# SecurityConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityConfigDefaults:
+    def test_defaults(self) -> None:
+        c = SecurityConfig()
+        assert c.mode == "advisory"
+        assert c.timeout_seconds == 600.0
+        assert c.fail_threshold == "high"
+
+    def test_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RALPH_SECURITY_MODE", "hard")
+        monkeypatch.setenv("RALPH_SECURITY_FAIL_THRESHOLD", "critical")
+        monkeypatch.setenv("RALPH_SECURITY_TIMEOUT", "300")
+        c = SecurityConfig.from_env()
+        assert c.mode == "hard"
+        assert c.fail_threshold == "critical"
+        assert c.timeout_seconds == 300.0
+
+
+# ---------------------------------------------------------------------------
+# parse_security_output
+# ---------------------------------------------------------------------------
+
+
+class TestParseSecurityOutput:
+    def test_valid_output(self) -> None:
+        result = parse_security_output(VALID_SECURITY_OUTPUT, "advisory")
+        assert len(result.findings) == 2
+        assert result.findings[0].severity == "critical"
+        assert result.findings[1].category == "hardcoded_secret"
+        assert result.exhaustively_searched is True
+
+    def test_invalid_json_returns_failed_result(self) -> None:
+        result = parse_security_output("not json", "hard")
+        assert result.passed is False
+        assert "Failed to parse" in result.overall_notes
+
+    def test_invalid_category_dropped(self) -> None:
+        output = json.dumps({"findings": [{
+            "category": "made_up",
+            "severity": "high",
+            "location": "x:1",
+            "explanation": "x",
+        }]})
+        result = parse_security_output(output, "advisory")
+        assert result.findings == []
+
+    def test_invalid_severity_dropped(self) -> None:
+        output = json.dumps({"findings": [{
+            "category": "injection",
+            "severity": "showstopper",
+            "location": "x:1",
+            "explanation": "x",
+        }]})
+        result = parse_security_output(output, "advisory")
+        assert result.findings == []
+
+    def test_missing_explanation_dropped(self) -> None:
+        output = json.dumps({"findings": [{
+            "category": "injection",
+            "severity": "high",
+            "location": "x:1",
+            "explanation": "",
+        }]})
+        result = parse_security_output(output, "advisory")
+        assert result.findings == []
+
+    def test_empty_findings_with_exhaustive_flag(self) -> None:
+        output = json.dumps({
+            "findings": [],
+            "exhaustively_searched": True,
+        })
+        result = parse_security_output(output, "hard")
+        assert result.findings == []
+        assert result.exhaustively_searched is True
+
+
+# ---------------------------------------------------------------------------
+# _passes_threshold
+# ---------------------------------------------------------------------------
+
+
+class TestPassesThreshold:
+    def _f(self, severity: str) -> SecurityFinding:
+        return SecurityFinding(
+            category="injection",
+            severity=severity,
+            location="x:1",
+            explanation="x",
+        )
+
+    def test_skip_always_passes(self) -> None:
+        assert _passes_threshold(
+            [self._f("critical")], SecurityMode.SKIP.value, "high",
+        )
+
+    def test_advisory_always_passes(self) -> None:
+        assert _passes_threshold(
+            [self._f("critical")], SecurityMode.ADVISORY.value, "high",
+        )
+
+    def test_hard_passes_when_below_threshold(self) -> None:
+        # threshold=high; medium is below
+        assert _passes_threshold(
+            [self._f("medium")], SecurityMode.HARD.value, "high",
+        )
+
+    def test_hard_fails_at_threshold(self) -> None:
+        assert not _passes_threshold(
+            [self._f("high")], SecurityMode.HARD.value, "high",
+        )
+
+    def test_hard_fails_above_threshold(self) -> None:
+        assert not _passes_threshold(
+            [self._f("critical")], SecurityMode.HARD.value, "high",
+        )
+
+    def test_hard_with_critical_only_threshold(self) -> None:
+        # threshold=critical; high is below
+        assert _passes_threshold(
+            [self._f("high")], SecurityMode.HARD.value, "critical",
+        )
+        assert not _passes_threshold(
+            [self._f("critical")], SecurityMode.HARD.value, "critical",
+        )
+
+
+# ---------------------------------------------------------------------------
+# run_security_review
+# ---------------------------------------------------------------------------
+
+
+class TestRunSecurityReview:
+    def _setup_repo(self, tmp_path: Path) -> Path:
+        import subprocess
+        subprocess.run(
+            ["git", "init", "-q", "-b", "main", str(tmp_path)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.email", "t@t"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.name", "t"],
+            check=True, capture_output=True,
+        )
+        (tmp_path / "stub").write_text("x")
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "add", "stub"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "commit", "-q", "-m", "init"],
+            check=True, capture_output=True,
+        )
+        prd_path = tmp_path / "prd.json"
+        prd_path.write_text('{"branchName": "test", "userStories": []}')
+        return prd_path
+
+    def test_skip_mode_short_circuits(self, tmp_path: Path) -> None:
+        prd_path = self._setup_repo(tmp_path)
+        config = SecurityConfig(mode=SecurityMode.SKIP.value)
+        agent = MockSecurityAgent("should not be called")
+        ui = PlainUI(no_color=True)
+        result = run_security_review(
+            agent, prd_path, tmp_path, "main", config, ui,
+        )
+        assert result.passed is True
+        assert result.findings == []
+
+    def test_advisory_passes_even_with_findings(self, tmp_path: Path) -> None:
+        prd_path = self._setup_repo(tmp_path)
+        config = SecurityConfig(mode=SecurityMode.ADVISORY.value)
+        agent = MockSecurityAgent(VALID_SECURITY_OUTPUT)
+        ui = PlainUI(no_color=True)
+        result = run_security_review(
+            agent, prd_path, tmp_path, "main", config, ui,
+        )
+        assert result.passed is True
+        assert len(result.findings) == 2
+
+    def test_hard_fails_on_critical(self, tmp_path: Path) -> None:
+        prd_path = self._setup_repo(tmp_path)
+        config = SecurityConfig(
+            mode=SecurityMode.HARD.value, fail_threshold="high",
+        )
+        agent = MockSecurityAgent(VALID_SECURITY_OUTPUT)
+        ui = PlainUI(no_color=True)
+        result = run_security_review(
+            agent, prd_path, tmp_path, "main", config, ui,
+        )
+        # Critical finding exceeds threshold=high
+        assert result.passed is False
+
+    def test_hard_passes_with_only_low(self, tmp_path: Path) -> None:
+        prd_path = self._setup_repo(tmp_path)
+        output = json.dumps({"findings": [{
+            "category": "information_disclosure",
+            "severity": "low",
+            "location": "x:1",
+            "explanation": "stack trace in log",
+        }]})
+        agent = MockSecurityAgent(output)
+        config = SecurityConfig(
+            mode=SecurityMode.HARD.value, fail_threshold="high",
+        )
+        ui = PlainUI(no_color=True)
+        result = run_security_review(
+            agent, prd_path, tmp_path, "main", config, ui,
+        )
+        assert result.passed is True
+
+    def test_agent_crash_is_nonfatal(self, tmp_path: Path) -> None:
+        prd_path = self._setup_repo(tmp_path)
+
+        class _Boom:
+            @property
+            def name(self) -> str:
+                return "boom"
+
+            def run(
+                self, prompt: str, cwd: Path | None = None,
+                timeout: float | None = None,
+            ) -> Iterator[str]:
+                raise RuntimeError("agent exploded")
+                yield  # pragma: no cover  (makes this an iterator)
+
+            @property
+            def final_message(self) -> str | None:
+                return None
+
+        config = SecurityConfig(mode=SecurityMode.HARD.value)
+        ui = PlainUI(no_color=True)
+        result = run_security_review(
+            _Boom(), prd_path, tmp_path, "main", config, ui,
+        )
+        assert result.passed is True  # non-fatal
+        assert "exploded" in result.overall_notes
+
+
+# ---------------------------------------------------------------------------
+# Result rendering
+# ---------------------------------------------------------------------------
+
+
+class TestResultFormatting:
+    def test_pr_body_with_findings(self) -> None:
+        r = SecurityResult(
+            passed=False,
+            mode="hard",
+            findings=[
+                SecurityFinding(
+                    category="injection",
+                    severity="critical",
+                    location="src/x.py:1-5",
+                    explanation="shell=True",
+                    suggestion="use list args",
+                ),
+            ],
+        )
+        body = r.as_pr_body_section()
+        assert "Security Review" in body
+        assert "1 critical" in body
+        assert "injection" in body
+
+    def test_pr_body_no_findings(self) -> None:
+        r = SecurityResult(
+            passed=True,
+            mode="hard",
+            exhaustively_searched=True,
+        )
+        body = r.as_pr_body_section()
+        assert "No findings" in body
+        assert "exhaustively" in body
+
+    def test_retry_context_lists_findings(self) -> None:
+        r = SecurityResult(
+            passed=False,
+            mode="hard",
+            findings=[SecurityFinding(
+                category="auth_bypass",
+                severity="high",
+                location="x:1",
+                explanation="no auth check",
+                suggestion="add @require_auth",
+            )],
+        )
+        ctx = r.as_retry_context()
+        assert "auth_bypass" in ctx
+        assert "no auth check" in ctx
+        assert "@require_auth" in ctx
+
+
+def test_prompt_renders_with_placeholders() -> None:
+    """The SECURITY_PROMPT must format cleanly with the only two
+    placeholders the runner provides."""
+    rendered = SECURITY_PROMPT.format(
+        prd_content="some prd",
+        diff_content="some diff",
+    )
+    assert "some prd" in rendered
+    assert "some diff" in rendered
+    # Sanity: the schema example should be intact
+    assert "findings" in rendered

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -15,6 +15,7 @@ from ralph_py.verify import (
     check_diff_scope,
     check_mutation_score,
     check_prd_stories,
+    check_self_critique,
     check_test_suite,
     check_typecheck,
     run_mechanical_verification,
@@ -229,6 +230,94 @@ class TestRunMechanicalVerification:
         ctx = result.as_context()
         assert "test_suite: FAIL" in ctx
         assert "typecheck" not in ctx  # passed checks excluded
+
+
+class TestCheckSelfCritique:
+    """Tests for the engineer-prompt self-critique mechanical check."""
+
+    def test_missing_file_fails(self, tmp_path: Path) -> None:
+        result = check_self_critique(tmp_path / "missing.txt")
+        assert result.passed is False
+        assert "Could not read" in result.message
+
+    def test_no_block_fails(self, tmp_path: Path) -> None:
+        progress = tmp_path / "progress.txt"
+        progress.write_text(
+            "## Iteration 1 - US-001\n- did stuff\n- ran tests\n",
+        )
+        result = check_self_critique(progress)
+        assert result.passed is False
+        assert "No '## Self-Critique'" in result.message
+
+    def test_block_with_three_bullets_passes(self, tmp_path: Path) -> None:
+        progress = tmp_path / "progress.txt"
+        progress.write_text(
+            "## Iteration 1 - US-001\n"
+            "- did stuff\n"
+            "- **Self-Critique:**\n"
+            "  - Failure mode 1: invalid input crashes parser\n"
+            "  - Failure mode 2: concurrent writes race\n"
+            "  - Failure mode 3: timeout swallowed silently\n"
+        )
+        result = check_self_critique(progress)
+        assert result.passed is True
+        assert "3 failure modes" in result.message
+
+    def test_fewer_than_min_fails(self, tmp_path: Path) -> None:
+        progress = tmp_path / "progress.txt"
+        progress.write_text(
+            "## Iteration 1 - US-001\n"
+            "- **Self-Critique:**\n"
+            "  - Failure mode 1: x\n"
+            "  - Failure mode 2: y\n"
+        )
+        result = check_self_critique(progress, min_bullets=3)
+        assert result.passed is False
+        assert "2 bullets" in result.message
+
+    def test_tbd_bullets_dont_count(self, tmp_path: Path) -> None:
+        """The check should reject placeholder content like TBD/TODO/N/A."""
+        progress = tmp_path / "progress.txt"
+        progress.write_text(
+            "## Iteration 1\n"
+            "- **Self-Critique:**\n"
+            "  - TBD\n"
+            "  - TODO write later\n"
+            "  - N/A\n"
+            "  - Failure mode: empty input crashes the parser\n"
+        )
+        result = check_self_critique(progress, min_bullets=3)
+        assert result.passed is False  # only 1 substantive bullet
+
+    def test_latest_iteration_block_used(self, tmp_path: Path) -> None:
+        """Multiple Self-Critique blocks in one file - the LAST one is
+        evaluated so previous iterations don't carry the current one."""
+        progress = tmp_path / "progress.txt"
+        progress.write_text(
+            "## Iteration 1\n"
+            "- **Self-Critique:**\n"
+            "  - mode1: x\n"
+            "  - mode2: y\n"
+            "  - mode3: z\n"
+            "\n## Iteration 2\n"
+            "- **Self-Critique:**\n"
+            "  - only one this time\n"
+        )
+        result = check_self_critique(progress, min_bullets=3)
+        assert result.passed is False  # latest iteration has only 1
+
+    def test_h2_style_heading_recognized(self, tmp_path: Path) -> None:
+        progress = tmp_path / "progress.txt"
+        progress.write_text(
+            "## Iteration 1\n"
+            "Some narrative.\n"
+            "## Self-Critique\n"
+            "- failure A: detailed reason\n"
+            "- failure B: detailed reason\n"
+            "- failure C: detailed reason\n"
+        )
+        result = check_self_critique(progress)
+        assert result.passed is True
 
 
 class TestCheckMutationScore:


### PR DESCRIPTION
## Summary

The factory had three LLM-driven roles (architect, engineer, code reviewer) whose prompts were process-shaped rather than adversarial, and was missing the most impactful reviewer a real software factory has: a dedicated security reviewer. This PR sharpens the three existing roles to think adversarially and adds the security reviewer as a new Phase 2.5.

### Sharpened existing prompts

- **REVIEWER_PROMPT** (`review.py`): reframed as a hostile senior reviewer; default stance is the diff is wrong somewhere. New top-level `concerns` array beyond per-criterion verdicts, with categories `scope_creep` / `security_concern` / `test_quality` / `unrelated_change` / `dead_code` / `error_handling` / `copy_paste`. Requires explicit `exhaustively_searched: true` assertion when no concerns are surfaced. `ReviewResult.passed` gates on concern severity in addition to criterion verdicts.
- **DECOMPOSE_PROMPT** (`decompose.py`): upstream red-team pass. Output now includes a top-level `spec_issues` array (severity / kind / summary / location / suggestion). Any blocker forces `components=[]` and raises `SpecBlockerError` to halt the pipeline before any implementation. Drops the placeholder template text that encouraged stub criteria; every story must include at least one negative acceptance criterion.
- **DEFAULT_PROMPT** (`init_cmd.py`) + root `prompt.md`: engineer is told the reviewer is already reading their diff; must write a `## Self-Critique` block listing 3+ concrete failure modes before declaring done. PRD ambiguity is surfaced as `## INTERPRETATION` rather than silent guessing.

### New role: Phase 2.5 Security Review

- New module `ralph_py/security.py` with `SecurityConfig`, `SecurityFinding`, `SecurityResult`, `SECURITY_PROMPT`, `run_security_review`. The prompt enumerates injection, auth/authz bypass, hardcoded secrets, unsafe deserialization, broken crypto, predictable randomness, missing validation, races, SSRF, XSS, open redirect, info disclosure, DoS. Severity scale critical/high/medium/low. Modes `skip` / `advisory` / `hard` with configurable `fail_threshold` (default `high` = critical+high block).
- Inserted in `factory.py` between Phase 2 (review) and knowledge distillation. Non-fatal on infrastructure errors; gates on threshold in hard mode. Findings attached to PR body.
- CLI flags: `--security-mode`, `--security-agent-cmd`, `--security-model`, `--security-fail-threshold`.

## Test plan

- [x] Unit: +51 new tests (19 review concerns, 12 decompose spec-issues, 20 security module). Full suite **492 passing**.
- [x] E2E smoke against the greeter→shouter sandbox with `--review-mode advisory --security-mode advisory`. All phases fire: Phase 1 -> Phase 2 -> Phase 2.5 -> knowledge distill. Zero security findings on trivial sandbox (expected); knowledge layer continues writing facts.
- [x] Backward compat: `SecurityConfig` is optional in `FactoryConfig`; existing call sites without the new flag work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)