### PR TITLE
feat: Phase E (partial) - architectural refinements E2/E4/E5/E6/E9

### DIFF
--- a/docs/adversarial-roadmap.md
+++ b/docs/adversarial-roadmap.md
@@ -111,19 +111,21 @@ Done when: PR merged.
 
 ## Phase E - Architectural refinements (minus E1)
 
-PR: _pending_
+PR (partial): _pending push_
 
 - [-] E1 - Multi-model rotation - SKIPPED per user decision; documented as known limitation
-- [ ] E2 - Strip Self-Critique from reviewer-visible diff (or invert ordering)
-- [ ] E3 - Structured `comp.findings: list[Finding]` replacing stringly-typed `comp.review_findings`
-- [ ] E4 - Per-run LLM budget cap in `FactoryConfig`; enforced via shared counter in `agents`
-- [ ] E5 - Rename `confidence: verified` -> `review_passed`; add `test_verified` tier
-- [ ] E6 - Configurable HITL checkpoint (`FactoryConfig.pause_before_pr_merge`, opt-in)
-- [ ] E7 - Feedforward/knowledge overlap doc + dedupe
-- [ ] E8 - Fact scope by import surface
-- [ ] E9 - Standardize `infrastructure_error` / `Result[T, E]` across all roles
+- [x] E2 - Strip Self-Critique block from reviewer-visible diff via `git.strip_self_critique_from_diff`; review.py invokes it before truncation
+- [~] E3 - Structured `comp.findings: list[Finding]` - DEFERRED to follow-up PR. Today review/security findings funnel into the stringly-typed `comp.review_findings`. A real typed `Finding` requires changing PR creation paths and breaking serialization compat. Scope is one focused PR; tracked here for visibility.
+- [x] E4 - `FactoryConfig.max_adversarial_calls` shared counter; review/security/distill all consult it; 0 = unbounded (default)
+- [x] E5 - Confidence rename: `verified` -> `review_passed`, new `test_verified` tier added. Legacy `verified` aliased on read for backward compat.
+- [x] E6 - `FactoryConfig.pause_before_pr_merge` HITL checkpoint. Prompts user before push+merge when UI is interactive; warns and proceeds when non-interactive.
+- [~] E7 - Feedforward/knowledge overlap doc - DEFERRED to Phase G (documentation). The dedupe analysis itself is small; addressed there.
+- [~] E8 - Fact scope by import surface - DEFERRED to follow-up PR. Today every transitive dependency's facts get injected; filtering by import surface needs Component-level import metadata that the manifest doesn't carry yet.
+- [x] E9 - ReviewResult.infrastructure_error added (parallel to SecurityResult.infrastructure_error); parse failures set it; downstream can distinguish "clean review" from "review never ran"
 
-Done when: each refinement lands with tests; rationale captured in `docs/adversarial-design.md`.
+Status: 5 of 8 items shipped (E2/E4/E5/E6/E9). E3 + E8 deferred with rationale in tracker; E1 permanently skipped per user; E7 folded into Phase G. 10 new tests; full suite 585 passing.
+
+Done when: PR merged. Deferred items tracked here for the next iteration.
 
 ---
 

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -57,6 +57,15 @@ class FactoryConfig:
     feedforward_config: FeedforwardConfig | None = None
     # Observability
     progress_log_path: Path | None = None
+    # E4: per-run hard cap on adversarial LLM calls (review + security
+    # + knowledge distill). 0 means unbounded. Once exceeded the
+    # remaining components skip those phases with an informational log
+    # line; mechanical verify + the implementing agent continue. This
+    # protects against runaway-cost factory runs.
+    max_adversarial_calls: int = 0
+    # E6: when True, pause and prompt the user before each component's
+    # PR creation step. Off by default; opt-in for sensitive projects.
+    pause_before_pr_merge: bool = False
 
     @classmethod
     def from_env(cls) -> FactoryConfig:
@@ -434,6 +443,21 @@ def run_factory(
     worktree_paths: dict[str, Path] = {}
     component_contexts: dict[str, str] = {}  # comp_id -> context JSON
 
+    # E4: adversarial-call counter shared across review / security /
+    # knowledge phases. When max_adversarial_calls is 0 the budget is
+    # unbounded (current behavior); otherwise we skip the LLM phase
+    # once the budget is exhausted, with an informational log line.
+    adversarial_calls: dict[str, int] = {"count": 0}
+
+    def _adversarial_budget_ok() -> bool:
+        cap = factory_config.max_adversarial_calls
+        if cap <= 0:
+            return True
+        return adversarial_calls["count"] < cap
+
+    def _adversarial_budget_consume() -> None:
+        adversarial_calls["count"] += 1
+
     def _path_relative_to_root(path: Path) -> str:
         """Render `path` relative to root_dir for use inside per-component
         worktrees. Falls back to the absolute path string when relativization
@@ -547,7 +571,14 @@ def run_factory(
 
         # PHASE 2: Second-opinion review
         review_mode = ReviewMode(factory_config.review_mode)
+        if review_mode != ReviewMode.SKIP and not _adversarial_budget_ok():
+            ui.warn(
+                f"  Phase 2 SKIPPED for {comp_id}: "
+                f"adversarial LLM budget ({factory_config.max_adversarial_calls}) exhausted"
+            )
+            review_mode = ReviewMode.SKIP
         if review_mode != ReviewMode.SKIP:
+            _adversarial_budget_consume()
             ui.info(f"  Phase 2: review ({review_mode.value}) for {comp_id}...")
 
             review_agent = get_agent(
@@ -600,7 +631,17 @@ def run_factory(
         # fails the component on findings at or above
         # SecurityConfig.fail_threshold OR on infrastructure errors.
         sec_config = factory_config.security_config
+        if (
+            sec_config and sec_config.mode != SecurityMode.SKIP.value
+            and not _adversarial_budget_ok()
+        ):
+            ui.warn(
+                f"  Phase 2.5 SKIPPED for {comp_id}: "
+                f"adversarial LLM budget exhausted"
+            )
+            sec_config = None
         if sec_config and sec_config.mode != SecurityMode.SKIP.value:
+            _adversarial_budget_consume()
             from ralph_py.agents import get_agent as _get_sec_agent
 
             ui.info(
@@ -700,7 +741,13 @@ def run_factory(
                 f"  Knowledge: skipped for {comp_id} "
                 f"(single_pr mode produces a polluted per-component diff)"
             )
+        elif knowledge_config.enabled and not _adversarial_budget_ok():
+            ui.info(
+                f"  Knowledge: skipped for {comp_id} "
+                f"(adversarial budget exhausted)"
+            )
         elif knowledge_config.enabled:
+            _adversarial_budget_consume()
             try:
                 from ralph_py.agents import get_agent as _get_agent
 
@@ -770,7 +817,44 @@ def run_factory(
         if factory_config.create_prs:
             from ralph_py.pr import push_create_and_merge_pr, is_gh_available
 
-            if is_gh_available():
+            # E6: human-in-the-loop checkpoint. When opt-in, prompt
+            # before pushing+merging so a human can inspect the diff,
+            # the review findings, and the security findings before
+            # the PR goes through. Skip the prompt when no UI is
+            # interactive - automation should fail loudly rather than
+            # block indefinitely.
+            proceed = True
+            if factory_config.pause_before_pr_merge:
+                if ui.can_prompt():
+                    ui.section(f"Human checkpoint: {comp_id}")
+                    ui.info(comp.review_findings or "(no review findings)")
+                    choice = ui.choose(
+                        f"Approve PR creation and merge for {comp_id}?",
+                        ["Approve", "Reject and abort component"],
+                        default=0,
+                    )
+                    proceed = choice == 0
+                    if not proceed:
+                        ui.warn(
+                            f"  Human rejected {comp_id} at PR checkpoint"
+                        )
+                        ctx = IterationContext.from_json(
+                            comp_result.context_json or "{}",
+                        )
+                        ctx.add_review_finding(
+                            "Human reviewer rejected at PR checkpoint",
+                        )
+                        _retry_or_fail(
+                            comp, "Rejected at HITL checkpoint", ctx.to_json(),
+                        )
+                        return
+                else:
+                    ui.warn(
+                        f"  pause_before_pr_merge requested but UI is "
+                        f"non-interactive; proceeding without prompt for {comp_id}"
+                    )
+
+            if proceed and is_gh_available():
                 ui.info(f"  Creating and merging PR for {comp_id}...")
                 pr_result = push_create_and_merge_pr(
                     comp, manifest, root_dir, ui,

--- a/ralph_py/git.py
+++ b/ralph_py/git.py
@@ -270,6 +270,42 @@ def truncate_diff_for_prompt(
     return diff_content[:limit] + f"\n... (diff truncated at {limit // 1000}KB)"
 
 
+# E2: regex matches a Self-Critique block in a diff. Used by the
+# reviewer-prep step to remove the engineer's self-reported failure
+# modes from what the reviewer sees, so the reviewer is not biased
+# toward "the implementer already thought of that" and skips checking.
+import re as _re
+
+_SELF_CRITIQUE_BLOCK_RE = _re.compile(
+    r"""
+    \+\#{2,3}\s+Self[-\s]Critique[\s\S]*?       # heading + content
+    (?=                                          # stop before:
+        ^\+\#{1,6}\s                             #   any other heading
+      | ^\+---\s*$                               #   ---  separator
+      | ^[^+]                                    #   non-add line
+      | \Z                                       #   end of string
+    )
+    """,
+    _re.MULTILINE | _re.VERBOSE | _re.IGNORECASE,
+)
+
+
+def strip_self_critique_from_diff(diff_content: str) -> str:
+    """Remove the engineer's Self-Critique block from a diff before
+    showing it to the reviewer.
+
+    The Self-Critique block is the engineer's self-reported list of
+    failure modes (verify.py mandates >=3 bullets). If the reviewer
+    sees it inline in progress.txt's diff, the reviewer is biased to
+    think those failure modes are already handled. The reviewer should
+    arrive at its concerns independently.
+
+    Returns the diff with the block stripped; if no block is found,
+    returns the input unchanged.
+    """
+    return _SELF_CRITIQUE_BLOCK_RE.sub("", diff_content)
+
+
 def merge_branch(
     branch: str,
     cwd: Path | None = None,

--- a/ralph_py/knowledge.py
+++ b/ralph_py/knowledge.py
@@ -136,7 +136,22 @@ class KnowledgeConfig:
 VALID_SCOPES = frozenset(
     {"handler", "adapter", "schema", "contract", "invariant", "gotcha"}
 )
-VALID_CONFIDENCES = frozenset({"verified", "asserted"})
+# E5: confidence taxonomy.
+# - "review_passed" replaces "verified" - more honest about what the
+#   signal actually means (Phase 2 review LLM said pass; not "this is
+#   true").
+# - "test_verified" is a stronger claim - the fact cites at least one
+#   passing test as evidence. Reserved for distillation paths that
+#   confirm the claim against test output, not just review verdicts.
+# - "asserted" is the bottom of the scale; the LLM stated the claim
+#   but no review or test confirmed it.
+# "verified" is kept as a backward-compat alias so old fact files on
+# disk continue to load. New facts should use review_passed.
+VALID_CONFIDENCES = frozenset({
+    "review_passed", "test_verified", "asserted", "verified",
+})
+# Map legacy values to the canonical name on read.
+_CONFIDENCE_ALIASES: dict[str, str] = {"verified": "review_passed"}
 
 
 @dataclass
@@ -219,7 +234,10 @@ def _parse_fact_md(content: str) -> Fact:
         created_run_id=str(meta.get("created_run_id", "")),
         scope=str(meta.get("scope", "")),
         evidence=[str(e) for e in meta.get("evidence", []) if isinstance(e, str)],
-        confidence=str(meta.get("confidence", "asserted")),
+        confidence=_CONFIDENCE_ALIASES.get(
+            str(meta.get("confidence", "asserted")),
+            str(meta.get("confidence", "asserted")),
+        ),
         tags=[str(t) for t in meta.get("tags", []) if isinstance(t, str)],
         claim=claim,
     )
@@ -356,7 +374,10 @@ def _sort_for_packing(facts: list[Fact]) -> list[Fact]:
     """Sort facts: verified before asserted, then newest run first."""
     # Python sort is stable: secondary sort first, then primary.
     by_recency = sorted(facts, key=lambda f: f.created_run_id, reverse=True)
-    by_recency.sort(key=lambda f: 0 if f.confidence == "verified" else 1)
+    # Sort: test_verified first, then review_passed, then asserted.
+    # Higher confidence packs first so the budget keeps the strongest.
+    _rank = {"test_verified": 0, "review_passed": 1, "verified": 1, "asserted": 2}
+    by_recency.sort(key=lambda f: _rank.get(f.confidence, 3))
     return by_recency
 
 
@@ -585,7 +606,7 @@ explanation). Schema:
     {{
       "id": "fact-001",
       "scope": "handler|adapter|schema|contract|invariant|gotcha",
-      "confidence": "verified|asserted",
+      "confidence": "review_passed|test_verified|asserted",
       "evidence": ["path/to/file.py:42-58", "tests/test_x.py:101"],
       "tags": ["auth", "tokens"],
       "claim": "A single durable assertion in 1-5 sentences. State it as a fact about the artifact, not the iteration. Cite the evidence inline if helpful."
@@ -601,8 +622,13 @@ Rules:
    files exist or what tests were run.
 3. Every fact must cite at least one path:line-range in the diff. If you
    cannot ground a claim in concrete evidence, do not write it.
-4. confidence="verified" only if the claim is backed by passing tests or
-   explicit acceptance criteria. Otherwise use "asserted".
+4. confidence values:
+   - "test_verified": the claim is backed by at least one passing test cited
+     by file:line in evidence. Strongest signal.
+   - "review_passed": the implementation passed Phase 2 reviewer judgment
+     but no specific test grounds the claim.
+   - "asserted": the claim is plausible from the diff but neither tests
+     nor the reviewer specifically confirmed it.
 5. Maximum {max_facts} facts. If nothing durable was established (e.g.
    pure refactor with no behavioral change), return {{"facts": []}}.
 6. fact ids must be unique within this response and match /^fact-\\d{{3}}$/.
@@ -863,9 +889,16 @@ def distill_facts(
         config.max_facts_per_distill,
     )
 
-    # Confidence ceiling: only Phase-2-passed work earns "verified"
+    # Confidence ceiling: only Phase-2-passed work earns the
+    # review_passed / test_verified tiers. When review is skipped or
+    # failed, downgrade any non-asserted claim back to asserted.
     if review_passed is not True:
-        facts = [replace(f, confidence="asserted") for f in facts]
+        facts = [
+            replace(f, confidence="asserted")
+            if f.confidence in {"review_passed", "test_verified", "verified"}
+            else f
+            for f in facts
+        ]
 
     if not facts:
         # Surface a brief sample of the rejected raw output so the user

--- a/ralph_py/review.py
+++ b/ralph_py/review.py
@@ -93,6 +93,11 @@ class ReviewResult:
     # (runs with RALPH_RUN_CALIBRATION=1) which catches reviewers that
     # claim exhaustive coverage but miss known bugs.
     exhaustively_searched: bool = False
+    # E9: parallel to SecurityResult.infrastructure_error - True when
+    # the agent failed to run or returned unparseable output, so
+    # downstream callers can distinguish "clean review found nothing"
+    # from "review never actually happened".
+    infrastructure_error: bool = False
 
     def as_retry_context(self) -> str:
         """Format failing/advisory findings for injection into retry prompt."""
@@ -332,6 +337,10 @@ def build_review_prompt(
 
     if diff_content is None:
         diff_content = git.get_diff_content(base_branch, worktree_path)
+    # E2: hide the engineer's Self-Critique block from the reviewer.
+    # Otherwise the reviewer sees "Failure mode 1: X" inline and may
+    # uncritically conclude X is handled.
+    diff_content = git.strip_self_critique_from_diff(diff_content)
     diff_content = git.truncate_diff_for_prompt(diff_content)
 
     verify_lines: list[str] = []
@@ -356,6 +365,7 @@ def parse_review_output(raw_output: str) -> ReviewResult:
             mode="",
             overall_notes="Failed to parse reviewer output as JSON",
             raw_output=raw_output[:2000],
+            infrastructure_error=True,
         )
 
     criteria: list[CriterionReview] = []
@@ -367,6 +377,7 @@ def parse_review_output(raw_output: str) -> ReviewResult:
             mode="",
             overall_notes="Invalid review output: 'stories' is not an array",
             raw_output=raw_output[:2000],
+            infrastructure_error=True,
         )
 
     for story in stories:

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -46,7 +46,7 @@ def _make_fact(
     fact_id: str = "fact-001",
     component_id: str = "comp-a",
     scope: str = "handler",
-    confidence: str = "verified",
+    confidence: str = "review_passed",
     claim: str = "The handler validates the request body before invoking the service.",
     evidence: list[str] | None = None,
     tags: list[str] | None = None,
@@ -363,7 +363,7 @@ class TestPackFacts:
         # Make claims sized so only one fact fits per call after the verified one
         big_claim = "x" * 800  # ~200 tokens
         verified = _make_fact(
-            fact_id="fact-001", confidence="verified", claim=big_claim,
+            fact_id="fact-001", confidence="review_passed", claim=big_claim,
         )
         asserted_recent = _make_fact(
             fact_id="fact-002", confidence="asserted", claim=big_claim,
@@ -395,12 +395,12 @@ class TestPackFacts:
         kept."""
         huge = _make_fact(
             fact_id="fact-001",
-            confidence="verified",
+            confidence="review_passed",
             claim="x" * 1000,  # render cost ~300 tokens
         )
         small_a = _make_fact(
             fact_id="fact-002",
-            confidence="verified",
+            confidence="review_passed",
             claim="short A",
         )
         # Budget chosen so huge cannot fit AND the truncation branch
@@ -422,12 +422,12 @@ class TestPackFacts:
         # entire claim is the "first sentence".
         huge = _make_fact(
             fact_id="fact-001",
-            confidence="verified",
+            confidence="review_passed",
             claim="A" * 4000,
         )
         small_a = _make_fact(
             fact_id="fact-002",
-            confidence="verified",
+            confidence="review_passed",
             claim="short",
         )
         kept, over = _pack_facts_summary([huge, small_a], 60)
@@ -442,13 +442,13 @@ class TestPackFacts:
         # All three are too large at full size; only first should be
         # truncated to fit, the rest dropped.
         f1 = _make_fact(
-            fact_id="fact-001", confidence="verified", claim="A" * 800,
+            fact_id="fact-001", confidence="review_passed", claim="A" * 800,
         )
         f2 = _make_fact(
-            fact_id="fact-002", confidence="verified", claim="B" * 800,
+            fact_id="fact-002", confidence="review_passed", claim="B" * 800,
         )
         f3 = _make_fact(
-            fact_id="fact-003", confidence="verified", claim="C" * 800,
+            fact_id="fact-003", confidence="review_passed", claim="C" * 800,
         )
         kept, over = _pack_facts_full([f1, f2, f3], 200)
         truncated = [f for f in kept if f.claim.endswith("...")]
@@ -815,7 +815,8 @@ class TestDistillFacts:
         assert "wrote 1" in status
         facts = read_facts(knowledge_root, "comp-a")
         assert len(facts) == 1
-        assert facts[0].confidence == "verified"
+        # Legacy "verified" string is aliased to "review_passed" on read (E5).
+        assert facts[0].confidence == "review_passed"
 
     def test_invalid_json_nonfatal(self, tmp_path: Path) -> None:
         component = _make_component("comp-a")
@@ -1070,7 +1071,7 @@ class TestFactUtilization:
                 created_run_id="factory-20260101-120000-aaaaaa",
                 scope="contract",
                 evidence=["src/x.py:1"],
-                confidence="verified",
+                confidence="review_passed",
                 claim=claim,
             )
             for i, claim in enumerate(claims)

--- a/tests/test_phase_e.py
+++ b/tests/test_phase_e.py
@@ -1,0 +1,293 @@
+"""Phase E: architectural refinements (subset E2/E4/E5/E6/E9).
+
+E3 (structured findings) and E8 (fact scope by import surface) are
+deferred to follow-up PRs - see docs/adversarial-roadmap.md for the
+rationale and exact follow-up scope.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ralph_py.config import RalphConfig
+from ralph_py.factory import ComponentResult, FactoryConfig, run_factory
+from ralph_py.git import strip_self_critique_from_diff
+from ralph_py.knowledge import Fact, _coerce_facts, _parse_fact_md, _render_fact_md
+from ralph_py.manifest import Component, Manifest
+from ralph_py.review import ReviewResult, parse_review_output
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+
+# ---------------------------------------------------------------------------
+# E5 - confidence rename + backwards compat
+# ---------------------------------------------------------------------------
+
+
+class TestE5ConfidenceRename:
+    def test_new_review_passed_accepted(self) -> None:
+        raw = [{
+            "id": "fact-001", "scope": "handler",
+            "confidence": "review_passed",
+            "evidence": ["x:1"], "claim": "ok",
+        }]
+        facts = _coerce_facts(raw, "c", 1, "r", 7)
+        assert len(facts) == 1
+        assert facts[0].confidence == "review_passed"
+
+    def test_test_verified_tier_accepted(self) -> None:
+        raw = [{
+            "id": "fact-001", "scope": "handler",
+            "confidence": "test_verified",
+            "evidence": ["x:1"], "claim": "ok",
+        }]
+        facts = _coerce_facts(raw, "c", 1, "r", 7)
+        assert facts[0].confidence == "test_verified"
+
+    def test_legacy_verified_value_maps_on_read(self, tmp_path: Path) -> None:
+        """An old fact file with confidence=verified must still load,
+        with the value rewritten to review_passed on read."""
+        legacy = (
+            "---\n"
+            '{"id":"fact-001","component_id":"x","created_iter":1,'
+            '"created_run_id":"factory-20260101-120000-aaaaaa",'
+            '"scope":"handler","evidence":["x:1"],'
+            '"confidence":"verified","tags":[]}\n'
+            "---\n\n"
+            "Legacy fact body.\n"
+        )
+        fact = _parse_fact_md(legacy)
+        assert fact.confidence == "review_passed"
+
+
+# ---------------------------------------------------------------------------
+# E4 - LLM budget cap
+# ---------------------------------------------------------------------------
+
+
+class TestE4BudgetCap:
+    def _scaffold(self, tmp_path: Path, comp_id: str) -> Path:
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+        (tmp_path / "scripts" / "ralph" / "prompt.md").write_text("p")
+        (tmp_path / "scripts" / "ralph" / "prd.json").write_text(
+            '{"branchName": "test", "userStories": []}'
+        )
+        feature_dir = tmp_path / "scripts" / "ralph" / "feature" / comp_id
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "prd.json").write_text(json.dumps({
+            "branchName": "t",
+            "userStories": [{
+                "id": "US-1", "title": "t", "acceptanceCriteria": ["AC"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+        return tmp_path
+
+    def _make_manifest(self, ids: list[str]) -> Manifest:
+        return Manifest(
+            version="1", spec_file="s", project_name="t",
+            base_branch="main", single_pr=False,
+            components=[
+                Component(
+                    id=i, title=i, description="", dependencies=[],
+                    prd_path=f"scripts/ralph/feature/{i}/prd.json",
+                    branch_name=f"ralph/{i}",
+                )
+                for i in ids
+            ],
+        )
+
+    def _base_config(self, root: Path) -> RalphConfig:
+        return RalphConfig(
+            prompt_file=root / "scripts/ralph/prompt.md",
+            prd_file=root / "scripts/ralph/prd.json",
+            sleep_seconds=0, agent_cmd="echo test",
+            ralph_branch="", ralph_branch_explicit=True,
+            ui_mode="plain", no_color=True,
+        )
+
+    def test_budget_zero_means_unbounded(self, tmp_path: Path) -> None:
+        """max_adversarial_calls=0 is the default and must not change
+        the existing review/security behavior."""
+        root = self._scaffold(tmp_path, "comp-a")
+        manifest = self._make_manifest(["comp-a"])
+        config = FactoryConfig(
+            use_worktrees=False, create_prs=False, max_parallel=1,
+            review_mode="hard", max_adversarial_calls=0,
+            verify_config=VerifyConfig(
+                test_command="true", typecheck_command="true",
+                lint_command="true", check_diff_scope=False,
+                check_bad_patterns=False, subprocess_timeout=5.0,
+            ),
+        )
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        passing_review = ReviewResult(passed=True, mode="hard")
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.factory.run_review", return_value=passing_review,
+        ) as mock_review:
+            run_factory(
+                manifest, config, self._base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        # Unbounded budget means review fires
+        assert mock_review.called
+
+    def test_budget_one_skips_second_component_review(
+        self, tmp_path: Path,
+    ) -> None:
+        root = self._scaffold(tmp_path, "comp-a")
+        feature_b = root / "scripts/ralph/feature/comp-b"
+        feature_b.mkdir(parents=True)
+        (feature_b / "prd.json").write_text(json.dumps({
+            "branchName": "t",
+            "userStories": [{
+                "id": "US-B", "title": "t", "acceptanceCriteria": ["AC"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+        manifest = self._make_manifest(["comp-a", "comp-b"])
+        config = FactoryConfig(
+            use_worktrees=False, create_prs=False, max_parallel=1,
+            review_mode="hard", max_adversarial_calls=1,
+            verify_config=VerifyConfig(
+                test_command="true", typecheck_command="true",
+                lint_command="true", check_diff_scope=False,
+                check_bad_patterns=False, subprocess_timeout=5.0,
+            ),
+        )
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        passing_review = ReviewResult(passed=True, mode="hard")
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.factory.run_review", return_value=passing_review,
+        ) as mock_review:
+            run_factory(
+                manifest, config, self._base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        # Budget=1; second component's review is budget-skipped
+        assert mock_review.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# E6 - HITL checkpoint (non-interactive path)
+# ---------------------------------------------------------------------------
+
+
+class TestE6HitlCheckpoint:
+    def test_non_interactive_ui_warns_and_proceeds(self, tmp_path: Path) -> None:
+        """When pause_before_pr_merge=True but the UI can't prompt
+        (PlainUI in tests), the factory must log a warning and proceed
+        rather than block indefinitely."""
+        from ralph_py.factory import ComponentResult
+        scaffold = tmp_path / "scripts" / "ralph"
+        scaffold.mkdir(parents=True)
+        (scaffold / "prompt.md").write_text("p")
+        (scaffold / "prd.json").write_text(
+            '{"branchName": "t", "userStories": []}'
+        )
+        feature_dir = scaffold / "feature" / "comp-a"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "prd.json").write_text(json.dumps({
+            "branchName": "t",
+            "userStories": [{
+                "id": "US-1", "title": "t", "acceptanceCriteria": ["AC"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+        manifest = Manifest(
+            version="1", spec_file="s", project_name="t",
+            base_branch="main", single_pr=False,
+            components=[Component(
+                id="comp-a", title="A", description="", dependencies=[],
+                prd_path="scripts/ralph/feature/comp-a/prd.json",
+                branch_name="ralph/a",
+            )],
+        )
+        config = FactoryConfig(
+            use_worktrees=False, create_prs=True, max_parallel=1,
+            review_mode="skip",
+            pause_before_pr_merge=True,
+            verify_config=VerifyConfig(
+                test_command="true", typecheck_command="true",
+                lint_command="true", check_diff_scope=False,
+                check_bad_patterns=False, subprocess_timeout=5.0,
+            ),
+        )
+        base = RalphConfig(
+            prompt_file=scaffold / "prompt.md",
+            prd_file=scaffold / "prd.json",
+            sleep_seconds=0, agent_cmd="echo test",
+            ralph_branch="", ralph_branch_explicit=True,
+            ui_mode="plain", no_color=True,
+        )
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch("ralph_py.pr.is_gh_available", return_value=False):
+            result = run_factory(
+                manifest, config, base, PlainUI(no_color=True), tmp_path,
+            )
+        # PlainUI returns False for can_prompt() so HITL skips and the
+        # component completes (no gh available so no PR is actually
+        # created, but the path executed cleanly).
+        assert "comp-a" in result.completed
+
+
+# ---------------------------------------------------------------------------
+# E2 - strip Self-Critique from diff
+# ---------------------------------------------------------------------------
+
+
+class TestE2StripSelfCritique:
+    def test_strips_self_critique_block(self) -> None:
+        diff = """\
+diff --git a/scripts/ralph/progress.txt b/scripts/ralph/progress.txt
++## Iteration 1 - US-001
++- What I did: added the function
++## Self-Critique
++- Failure mode 1: empty input crashes the parser
++- Failure mode 2: concurrent writes race
++- Failure mode 3: timeout swallowed silently
++---
++
+diff --git a/src/x.py b/src/x.py
++def add(a, b): return a + b
+"""
+        result = strip_self_critique_from_diff(diff)
+        assert "Failure mode 1" not in result
+        assert "Self-Critique" not in result
+        # The actual code change must survive
+        assert "def add(a, b)" in result
+
+    def test_no_block_returns_unchanged(self) -> None:
+        diff = "+def f(): pass\n"
+        assert strip_self_critique_from_diff(diff) == diff
+
+
+# ---------------------------------------------------------------------------
+# E9 - infrastructure_error on ReviewResult
+# ---------------------------------------------------------------------------
+
+
+class TestE9ReviewInfrastructureError:
+    def test_parse_failure_sets_infrastructure_error(self) -> None:
+        result = parse_review_output("not json at all")
+        assert result.passed is False
+        assert result.infrastructure_error is True
+
+    def test_clean_review_has_no_infrastructure_error(self) -> None:
+        result = parse_review_output(json.dumps({
+            "stories": [],
+            "concerns": [],
+            "exhaustively_searched": True,
+        }))
+        assert result.passed is True
+        assert result.infrastructure_error is False


### PR DESCRIPTION
## Summary

Phase E of the adversarial-factory hardening roadmap. 5 of 8 items shipped; E3 and E8 deferred to focused follow-up PRs with rationale captured in `docs/adversarial-roadmap.md`.

- **E2** — `git.strip_self_critique_from_diff()` removes the engineer's `## Self-Critique` block from the diff before the reviewer sees it. The reviewer no longer gets biased by "the engineer already thought of failure mode X".
- **E4** — `FactoryConfig.max_adversarial_calls` shared counter gates Phase 2 / Phase 2.5 / knowledge distillation. Default 0 = unbounded; once exceeded the remaining phases log a budget-skip and the mechanical pipeline continues.
- **E5** — confidence rename: `verified` → `review_passed`, new `test_verified` tier. Legacy `verified` aliased on read for backward compat.
- **E6** — `FactoryConfig.pause_before_pr_merge` HITL checkpoint, opt-in. Pauses before PR push+merge to let a human approve/reject; non-interactive UI proceeds with a warning.
- **E9** — `ReviewResult.infrastructure_error` mirrors `SecurityResult.infrastructure_error` so callers can distinguish "clean review found nothing" from "review never ran".

## Test plan

- [x] **585 passing** (+10). 11 calibration tests still gated behind `RALPH_RUN_CALIBRATION=1`.
- [x] Backwards compat: legacy `verified` fact files load and migrate to `review_passed` on read.
- [x] Budget cap test asserts second-component review is skipped when `max_adversarial_calls=1`.
- [x] HITL test asserts non-interactive UI doesn't block.

Merging on green CI per H1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)