### PR TITLE
docs: Phase G - close out the adversarial hardening roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md - Ralph
+
+## Project Overview
+
+- **Language**: Python (FastAPI / pytest / uv toolchain)
+- **Project**: Ralph - an adversarial coding-agent harness
+- **Layout**: `ralph_py/` is the canonical factory implementation. `src/ralph/` is the legacy single-component loop (out of scope for the adversarial roadmap).
+
+## Verification commands
+
+- **Test**: `uv run pytest tests/ -v`
+- **Calibration (opt-in, real LLMs)**: `RALPH_RUN_CALIBRATION=1 uv run pytest tests/test_calibration.py -v`
+- **Typecheck**: `uv run mypy ralph_py/ --strict`
+- **Lint**: `uv run ruff check ralph_py/ tests/`
+
+## Adversarial role taxonomy
+
+Ralph's factory uses eight distinct roles. Three are LLM-driven adversarial passes; the rest are mechanical or computational. Full taxonomy with file:line references is in [docs/adversarial-design.md](docs/adversarial-design.md).
+
+| Role | Prompt | What it catches |
+|---|---|---|
+| Architect / PRD red-team | `decompose.DECOMPOSE_PROMPT` | Spec ambiguity, missing failure modes, unstated assumptions |
+| Engineer | per-project `scripts/ralph/prompt.md` | Implements one story per iteration; emits required `## Self-Critique` block |
+| Mechanical verifier | `verify.run_mechanical_verification` (no LLM) | tests / typecheck / lint / diff-scope / bad-patterns / self-critique-shape |
+| Code reviewer | `review.REVIEWER_PROMPT` | PRD criteria + concerns (scope_creep, security_concern, test_quality, etc.) |
+| Security reviewer | `security.SECURITY_PROMPT` | OWASP-mapped vuln categories |
+| Contract tester | `contract.run_contract_testing` (no LLM) | Cross-component integration tests on merged tier branches |
+| Knowledge distiller | `knowledge.DISTILL_PROMPT` | Durable facts about the artifact, written post-PR |
+| Human checkpoint (E6) | interactive UI | Optional opt-in approval before PR merge |
+
+## When working on this codebase
+
+- **Do not run `/code-review` on your own code.** Per H1 of `docs/adversarial-roadmap.md`, AI self-review of AI-generated code is prohibited. The user or `/code-review ultra` is the gating reviewer.
+- **Calibration is the truth signal.** When changing an adversarial prompt (`DECOMPOSE_PROMPT`, `REVIEWER_PROMPT`, `SECURITY_PROMPT`, `DISTILL_PROMPT`, the engineer prompt), re-run the calibration suite and compare detection rates against the saved baseline. A prompt edit without a calibration check is treated as untested (H2).
+- **Be explicit about what was tested vs assumed.** "Smoke passed" without listing what was checked is presence-testing, not behavior-testing (H4).
+- **All adversarial-roadmap policies are tracked in `docs/adversarial-roadmap.md`**. Read it before changing the role architecture.
+
+## Coding standards
+
+- Type hints on all function signatures
+- `from __future__ import annotations` at the top of every file
+- `T | None` over `Optional[T]`; `A | B` over `Union[A, B]`
+- `@dataclass` for data containers, `frozen=True` when immutable
+- `Protocol` for interfaces (structural subtyping over inheritance)
+- snake_case for functions/variables, PascalCase for classes, UPPER_SNAKE for constants
+- Absolute imports grouped: stdlib, third-party, local
+- No bare `except:` - always specify the exception type
+- No mutable default arguments
+
+## Implementation principles
+
+### Adversarial mindset for any role-related code
+
+The whole factory rests on the idea that adversarial framing causes the LLM to find bugs it would otherwise miss. When editing prompts or role code, ask: "does this make the role more skeptical, or more eager to please?" Prefer the former.
+
+### Calibration over claims
+
+Any change to an adversarial role should include either a calibration delta or a test against the planted-bug fixtures in `tests/adversarial_fixtures/`. Self-reported flags like `exhaustively_searched` are hints, not signals - they cannot be trusted alone.
+
+### Halt over heroics
+
+The architect halts on blocker-severity spec issues; hard-mode reviewers halt on findings at or above the threshold. The pipeline should fail loudly when something is wrong, not silently degrade.
+
+### Audit trail
+
+Every adversarial decision writes a record: review/security findings go to PR bodies, knowledge facts go to disk, evolution journal records component outcomes. Don't add silent code paths - if it's worth deciding, it's worth recording.
+
+## What NOT to do
+
+- Do NOT run `/code-review` on your own code (H1).
+- Do NOT ship a prompt change without re-running calibration (H2).
+- Do NOT use `pickle` to load untrusted data; the existing `tests/test_phase_c_coverage.py` C8 pickling test only round-trips configs we constructed in-test.
+- Do NOT add unverifiable self-report claims to results without flagging them as hints (E9 added `infrastructure_error` precisely to distinguish verified from claimed).
+- Do NOT bypass the budget cap (`max_adversarial_calls`) without explicit user opt-in.
+
+## Agent Learnings
+
+> Maintained by agents working on this codebase.
+> Append patterns, gotchas, and conventions discovered below.
+
+### Codebase Patterns
+
+- Atomic file writes use `tempfile.mkstemp` + `os.replace` (`manifest.py:189`, mirrored in `knowledge.py::write_facts`).
+- Cross-module JSON extraction from agent output reuses `decompose._extract_json` + `decompose._select_agent_output`.
+- Diff truncation uses the shared `git.truncate_diff_for_prompt` helper.
+
+### Gotchas
+
+- `os.replace` is not atomic on Windows; the codebase is POSIX-first.
+- `fcntl.flock` (Phase A4 concurrent worktree lock) is POSIX-only; tests skip on Windows.
+- Confidence value `"verified"` is legacy and aliased to `"review_passed"` on read; new code should use the new tier names.
+
+### Conventions
+
+- Phase numbers are sticky: Phase 0 feedforward, Phase 1 verify, Phase 2 review, Phase 2.5 security, Phase 3 contract. New phases get fractional numbers to preserve ordering semantics.
+- Every config dataclass should have `from_env()` AND `load(root_dir)`; the load method reads `[<section>]` from `ralph.toml` and overlays env on top.

--- a/README.md
+++ b/README.md
@@ -11,18 +11,27 @@ Most agent wrappers are retry loops: run the agent, check if it's done, retry if
 ```mermaid
 flowchart TD
     PRD["PRD + Prompt"] --> FF["Phase 0: Feedforward\nModule map, interfaces,\ndependency graph, conventions"]
-    FF --> Agent["AI Coding Agent\nClaude Code, Codex, or custom"]
-    Agent --> P1["Phase 1: Mechanical verification\nTests, typecheck, lint,\nscope, secrets, fixtures"]
+    FF --> Knowledge["Knowledge prefix\nDurable facts from prior components"]
+    Knowledge --> Agent["Implementing agent\nClaude Code, Codex, or custom"]
+    Agent --> P1["Phase 1: Mechanical verification\nTests, typecheck, lint, scope,\nbad patterns, optional self-critique"]
     P1 -->|fail| Retry["Structured retry context\nSource lines + fix hints"]
     Retry --> Agent
-    P1 -->|pass| P2["Phase 2: Second-opinion review\nSeparate agent reviews diff\nagainst acceptance criteria"]
+    P1 -->|pass| P2["Phase 2: Code reviewer\nPRD criteria + concerns:\nscope_creep, test_quality,\ndead_code, error_handling..."]
     P2 -->|fail| Retry
-    P2 -->|pass| P3["Phase 3: Contract testing\nTier-by-tier merge +\nintegration tests"]
-    P3 -->|fail| Retry
+    P2 -->|pass| P25["Phase 2.5: Security reviewer\nInjection, auth_bypass,\nhardcoded_secret, crypto,\nrace, SSRF, XSS, DoS\nMapped to OWASP+CWE"]
+    P25 -->|fail| Retry
+    P25 -->|pass| HITL["Optional human checkpoint\npause_before_pr_merge"]
+    HITL --> PR["Create + merge PR"]
+    PR --> Distill["Knowledge distiller\nDurable facts written to\n.ralph/knowledge/<comp>/<run>/"]
+    Distill --> P3["Phase 3: Contract testing\nTier-by-tier merge +\nintegration tests"]
+    P3 -->|fail breaker| Retry
     P3 -->|pass| Done["Done"]
-    P1 --> Journal["Evolution Journal\nTrack patterns across runs,\npropose harness improvements"]
+    P1 --> Journal["Evolution journal\nPatterns, concern hit-rate,\nharness improvement proposals"]
     P2 --> Journal
+    P25 --> Journal
 ```
+
+Phase 0 also includes an architect/PRD-red-team pass at decompose time that halts on blocker-severity spec issues. See [docs/adversarial-design.md](docs/adversarial-design.md) for the full 8-role taxonomy, [docs/env-vars.md](docs/env-vars.md) for every env var, and [docs/runbook.md](docs/runbook.md) for operator failure recovery.
 
 ## Quick start
 

--- a/docs/adversarial-design.md
+++ b/docs/adversarial-design.md
@@ -1,0 +1,94 @@
+# Adversarial Factory Design
+
+This document explains the roles, phases, and invariants that make up the Ralph factory's adversarial design, and the known limitations a user must keep in mind.
+
+## Why adversarial
+
+The factory orchestrates LLM agents to implement software. An LLM left to its own devices is helpful by default - it will tell you the diff is good, the spec is clear, and the code is safe. Adversarial design assumes the opposite: that at every step something is wrong, and that the only way to find it is to commit a specific role to looking for it. Each role's prompt is framed to be skeptical, evidence-required, and gated by a check the LLM cannot lie its way around.
+
+Calibration is the truth signal. The `tests/test_calibration.py` suite (Phase D of the hardening roadmap) feeds planted bugs to each role and measures detection rate. The whole adversarial design is only as good as that number says it is.
+
+## Roles
+
+| Role | Module | Prompt | Phase | What it catches |
+|---|---|---|---|---|
+| **Architect / PRD red-team** | `ralph_py/decompose.py` | `DECOMPOSE_PROMPT` | Spec | Ambiguities, missing failure modes, unstated assumptions, undefined auth, ambiguous quantifiers. Halts the pipeline via `SpecBlockerError` when any blocker-severity issue is found. |
+| **Engineer** | `ralph_py/init_cmd.py` (`DEFAULT_PROMPT`) + per-project `scripts/ralph/prompt.md` | (project-specific) | Iteration | Implements one story per iteration. Required to emit a `## Self-Critique` block with >=3 substantive failure-mode bullets before declaring done (mechanically enforced by `verify.check_self_critique` when `VerifyConfig.require_self_critique` is True). |
+| **Mechanical verifier** | `ralph_py/verify.py` | (no LLM) | Phase 1 | PRD stories pass-marked, tests/typecheck/lint green, diff-scope and bad-pattern checks, optional dead-code / mutation / self-critique. |
+| **Code reviewer** | `ralph_py/review.py` | `REVIEWER_PROMPT` | Phase 2 | PRD criterion verdicts plus a separate `concerns` array (scope_creep, security_concern, test_quality, unrelated_change, dead_code, error_handling, copy_paste). Self-Critique block is stripped from the diff before review so the reviewer is not biased by the engineer's own failure-mode list. |
+| **Security reviewer** | `ralph_py/security.py` | `SECURITY_PROMPT` | Phase 2.5 | Threat-model framing: injection, auth_bypass, hardcoded_secret, unsafe_deserialization, broken_crypto, predictable_randomness, missing_input_validation, race_condition, SSRF, XSS, open_redirect, information_disclosure, denial_of_service. Each category mapped to OWASP Top 10 + CWE via `SECURITY_CATEGORY_MAP`. |
+| **Contract tester** | `ralph_py/contract.py` | (no LLM) | Phase 3 | Cross-component integration tests on merged tier branches. Failing tier identifies a breaker component, sent back through Phase 1+ for retry. |
+| **Knowledge distiller** | `ralph_py/knowledge.py` | `DISTILL_PROMPT` | Post-merge | Captures durable facts about the artifact for downstream components. Voyager-style write gate: only fires when Phase 2 review passed. |
+| **Human checkpoint (E6)** | `ralph_py/factory.py` | (interactive) | Pre-merge | Optional. When `FactoryConfig.pause_before_pr_merge=True` and UI is interactive, prompts a human to approve or reject before PR creation. Off by default. |
+
+## Pipeline
+
+```
+spec.md
+  -> [Architect] decompose + red-team
+        -> manifest.json + per-component PRDs
+        -> SpecBlockerError if any blocker (halt; human resolves spec)
+  -> for each component (DAG order, optionally parallel):
+       -> [Phase 0] feedforward (computational structural scan)
+       -> [Engineer] iterate until COMPLETE
+       -> [Phase 1] mechanical verify (incl. optional self-critique check)
+       -> [Phase 2] code reviewer (criteria + concerns)
+       -> [Phase 2.5] security reviewer
+       -> [HITL checkpoint] if enabled
+       -> create + merge PR
+       -> [Knowledge distiller] post-merge write
+  -> [Phase 3] contract testing across merged tiers
+  -> evolution journal recorded
+```
+
+## Invariants
+
+1. **Halt over heroics.** Architect's `SpecBlockerError` stops the pipeline rather than proceeding with a vague spec. Mechanical verification failures retry up to `FactoryConfig.max_retries` then mark the component failed and cascade-skip dependents.
+2. **Hard mode means hard fail.** Phase 2 / Phase 2.5 in `hard` mode block on findings at or above the configured threshold. Infrastructure failures (agent crash, parse error) in hard mode count as failures, not silent passes (Phase A1 + E9).
+3. **Latest-run-dir wins for facts.** Knowledge files at `.ralph/knowledge/<component_id>/<run_id>/<fact_id>.md`. A breaker retry naturally orphans the old run dir.
+4. **No prompt injection through knowledge.** Fact claims that match role markers (`<system>`, `<|im_*|>`), `ignore previous instructions` patterns, or `## Instructions` headings are rejected at coercion time (Phase A1).
+5. **No infinite cost.** `FactoryConfig.max_adversarial_calls` is a hard cap across review + security + distill (Phase E4). Stream-size cap of 5MB per agent invocation prevents pathological output (Phase A5).
+6. **Audit trail.** Evolution journal records every component result. Concerns surface to `EvolutionJournal.get_concern_hit_rate()` for aggregate dashboards. Knowledge fact utilization is measured per component via `knowledge.measure_fact_utilization()`.
+
+## Calibration
+
+Calibration is the trustworthy verification path for "do the adversarial roles actually catch bugs." Without it, every "exhaustively_searched: true" claim is unverifiable.
+
+To run:
+```bash
+RALPH_RUN_CALIBRATION=1 RALPH_CALIBRATION_MODEL=haiku uv run pytest tests/test_calibration.py -v
+```
+
+Each run writes `tests/adversarial_fixtures/_results/baseline-<UTC>.json` with per-role detection rates. Fixtures cover security (5), reviewer concerns (3), and vague specs (3).
+
+The fixtures themselves live in `tests/adversarial_fixtures/{security,concerns,specs}/` with paired `.meta.json` files describing the planted bug and the must-detect category.
+
+## Feedforward vs knowledge (E7)
+
+Two memory surfaces exist for the implementing agent. They look similar but serve different jobs:
+
+- **Feedforward** (`ralph_py/feedforward.py`) is *computed* fresh each iteration. Walks the worktree, builds a module map with LOC counts, lists public interfaces from `__init__.py` / `__all__`, infers a dependency graph from imports, and extracts conventions from `pyproject.toml` / `package.json` / etc. No LLM, no persistence. Used to ground the implementing agent in the current code shape.
+- **Knowledge** (`ralph_py/knowledge.py`) is *distilled* by an LLM after a component completes and persists across runs. Stored at `.ralph/knowledge/<component>/<run>/<fact>.md`. Three-tier retrieval (core / dependency / sibling) injects relevant facts into the prompt of downstream components.
+
+The overlap: both can describe what a component exports. The distinction:
+- Feedforward describes what *exists* at this instant (computationally extracted).
+- Knowledge describes what was *learned* about an artifact's contract or invariants (LLM-distilled, durable).
+
+If a feedforward entry says `auth.middleware.verify_token(token: str) -> User`, that's the current signature. If a knowledge fact says "the middleware rejects expired tokens at the handler layer, before the route guard runs," that's the *behavior* the LLM extracted from passing tests + the diff. They complement, but neither replaces the other.
+
+## Known limitations
+
+1. **Correlated failure.** The architect, engineer, reviewer, security reviewer, and distiller can all be the same model. They will fail on the same inputs in the same way. Multi-model rotation (roadmap E1) was deliberately deferred; until it lands, treat "all roles agree" as one data point, not several.
+2. **`exhaustively_searched` is self-reported.** Both reviewer and security results expose the flag, but it cannot be verified at runtime. The trustworthy signal is calibration rate, not the flag.
+3. **Fact-utilization is a lower bound.** `measure_fact_utilization` uses a 30-character case-insensitive substring match. LLMs paraphrase, so a false negative just means we under-count.
+4. **Calibration baseline is non-deterministic.** LLMs vary; a single calibration run is one data point. Aggregate across multiple runs before trusting a detection rate as a stable measurement.
+5. **Windows is not supported for concurrent worktrees.** `fcntl.flock` is POSIX-only (Phase A4); on Windows the lock is silently skipped and concurrent factory invocations against the same worktree directory can clobber each other.
+6. **The fact-injection prompt is trusted code.** A future model that ignores the engineer prompt's "treat as ground truth" framing could be misled by injected facts. The Phase A1 sanitizer is a defense-in-depth pattern, not a guarantee.
+
+## Process: how this design stays trustworthy
+
+H1 of the hardening roadmap: the assistant does not run `/code-review` on its own code. The user, or `/code-review ultra`, is the gating reviewer for changes that touch this design.
+
+H2: when an adversarial prompt changes, calibration is re-run. A prompt edit without a calibration delta is treated as untested.
+
+H4: when reporting "tested" or "verified", be explicit about what was checked vs. what was assumed. Smoke tests are presence checks; calibration is behavior verification.

--- a/docs/adversarial-roadmap.md
+++ b/docs/adversarial-roadmap.md
@@ -131,29 +131,29 @@ Done when: PR merged. Deferred items tracked here for the next iteration.
 
 ## Phase G - Documentation
 
-PR: _pending_
+PR: _pending push_
 
-- [ ] G1 - Phase diagram in `README.md`
-- [ ] G2 - Role taxonomy in `CLAUDE.md`
-- [ ] G3 - Single env-var reference: `docs/env-vars.md`
-- [ ] G4 - `ralph.toml.example` with every section (depends on B)
-- [ ] G5 - Replace stale plan file (point to this roadmap instead)
-- [ ] G6 - `docs/adversarial-design.md` (why each role, known limitations)
-- [ ] G7 - `docs/runbook.md` for operator phase-failure recovery
+- [x] G1 - README.md phase diagram extended to show all 8 roles (architect, engineer, P1 mechanical, P2 reviewer, P2.5 security, HITL, knowledge distiller, P3 contract)
+- [x] G2 - CLAUDE.md created at repo root with role taxonomy and H1-H4 process rules
+- [x] G3 - docs/env-vars.md - single canonical env-var reference across every config
+- [x] G4 - ralph.toml.example extended with [factory] [verify] [security] [contract] [feedforward] [evolution] sections
+- [x] G5 - ~/.claude/plans/zazzy-orbiting-sketch.md marked SUPERSEDED; points to this tracker
+- [x] G6 - docs/adversarial-design.md - role taxonomy, pipeline, invariants, known limitations, E7 feedforward-vs-knowledge clarification
+- [x] G7 - docs/runbook.md - operator recovery procedures for every named failure mode
 
-Done when: every feature shipped in #35, #36, and this hardening cycle has user-facing docs.
+Done when: PR merged.
 
 ---
 
-## Phase H - Process (non-code; adopt as policies)
+## Phase H - Process (non-code; adopted as policies)
 
-- [ ] H1 - Policy: I do NOT self-review my own code. User invokes `/code-review ultra` or reads diffs directly.
-- [ ] H2 - Calibration runs on every prompt change (CI hook once D lands)
-- [ ] H3 - Prompt-versioning policy (PR + human approval or operator-tunable?)
-- [ ] H4 - "Verified" claim discipline: state what I actually checked vs assumed
-- [ ] H5 - Independent review of merged PRs #35, #36 (user runs `/code-review ultra` retroactively)
+- [x] H1 - Adopted 2026-05-27. Assistant does NOT self-review its own code. PRs #37-#43 in this hardening cycle all merged without `/code-review`; user is the gating reviewer via `/code-review ultra` or direct diff inspection. Codified in CLAUDE.md "What NOT to do".
+- [x] H2 - Adopted 2026-05-27. Calibration suite (`tests/test_calibration.py`) is the verification path for prompt changes. CI hook still TBD (env var gating is the manual-trigger mechanism today). Codified in CLAUDE.md.
+- [~] H3 - Prompt-versioning policy: today prompts are module-level constants edited under PR review. A versioning policy beyond that (e.g. per-prompt version field, semantic-versioned prompt files) is deferred — would be a separate cross-cutting change.
+- [x] H4 - Adopted 2026-05-27. Claim discipline codified in CLAUDE.md "What NOT to do" and docs/adversarial-design.md "Process" section: be explicit about checked vs assumed; smoke tests are presence checks, not behavior checks.
+- [ ] H5 - User-driven: user runs `/code-review ultra` retroactively on PRs #35, #36 and the seven hardening PRs #37-#43. Not something the assistant can do (H1).
 
-Done when: tracker captures each policy with the date adopted; CI integration where applicable.
+Status: 3 policies fully adopted, 1 partial (H3 deferred), 1 pending user action (H5).
 
 ---
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -1,0 +1,124 @@
+# Ralph Environment Variables Reference
+
+Every config dataclass has a `from_env()` classmethod that reads env vars, and a `load(root_dir)` classmethod that overlays env on top of `ralph.toml` (env wins). This doc enumerates every variable the harness consults.
+
+Precedence: **CLI flag > env var > `ralph.toml` > dataclass default**.
+
+## Global / RalphConfig (`[agent]`, `[run]`, `[paths]`, `[git]`, `[ui]`)
+
+| Env var | Type | Default | Notes |
+|---|---|---|---|
+| `MAX_ITERATIONS` | int | 10 | Per-component max agent iterations |
+| `PROMPT_FILE` | path | `scripts/ralph/prompt.md` | |
+| `PRD_FILE` | path | `scripts/ralph/prd.json` | |
+| `PROGRESS_FILE` | path | `scripts/ralph/progress.txt` | |
+| `CODEBASE_MAP_FILE` | path | `scripts/ralph/codebase_map.md` | |
+| `SLEEP_SECONDS` | float | 2.0 | Inter-iteration sleep |
+| `INTERACTIVE` | bool | false | Pause between iterations for human input |
+| `ALLOWED_PATHS` | comma-list | empty | Restrict agent writes to these prefixes |
+| `RALPH_BRANCH` | str | unset | Override branch checkout; `""` means skip checkout |
+| `RALPH_AUTO_CHECKOUT` | bool | true | When false, run loop skips branch resolution |
+| `AGENT_CMD` | str | unset | Custom shell command for the agent (overrides type) |
+| `MODEL` | str | unset | Model name passed to the agent |
+| `MODEL_REASONING_EFFORT` | str | unset | `low\|medium\|high\|max` |
+| `RALPH_AGENT_TYPE` | str | unset | `claude-code\|codex\|auto` |
+| `RALPH_TIMEOUT_AGENT_ITERATION` | float | 1800 | Per-agent.run() timeout (seconds) |
+| `RALPH_TIMEOUT_COMPONENT` | float | 7200 | Per-component total timeout |
+| `RALPH_TIMEOUT_DEFAULT` | float | 60 | Generic subprocess timeout |
+| `RALPH_UI` | str | auto | `auto\|rich\|plain` |
+| `NO_COLOR` | bool flag | false | Disables colors |
+| `RALPH_ASCII` | bool | false | ASCII-only UI |
+
+## FactoryConfig (`[factory]`)
+
+| Env var | Type | Default |
+|---|---|---|
+| `FACTORY_MAX_PARALLEL` | int | 4 |
+| `FACTORY_MAX_RETRIES` | int | 3 |
+| `FACTORY_RETRY_DELAY` | float | 5.0 |
+
+Plus the new `max_adversarial_calls` (E4) and `pause_before_pr_merge` (E6) which are configured via CLI / programmatic construction; no env var today.
+
+## VerifyConfig (`[verify]`)
+
+| Env var | Type | Default |
+|---|---|---|
+| `RALPH_VERIFY_TEST_CMD` | str | unset (uses `uv run pytest`) |
+| `RALPH_VERIFY_TYPECHECK_CMD` | str | unset (uses `uv run mypy .`) |
+| `RALPH_VERIFY_LINT_CMD` | str | unset (uses `uv run ruff check .`) |
+| `RALPH_DEAD_CODE_CLEANUP` | bool (`1`) | false |
+| `RALPH_DEAD_CODE_CMD` | str | unset |
+| `RALPH_MUTATION_TESTING` | bool (`1`) | false |
+| `RALPH_MUTATION_THRESHOLD` | float | 50 |
+| `RALPH_MUTATION_TIMEOUT` | float | 600 |
+| `RALPH_TIMEOUT_VERIFY` | float | 300 |
+| `RALPH_VERIFY_REQUIRE_SELF_CRITIQUE` | bool (`1`) | false |
+| `RALPH_VERIFY_SELF_CRITIQUE_MIN_BULLETS` | int | 3 |
+| `RALPH_VERIFY_PROGRESS_FILE` | path | `scripts/ralph/progress.txt` |
+
+## ContractConfig (`[contract]`)
+
+| Env var | Type | Default |
+|---|---|---|
+| `RALPH_CONTRACT_MODE` | str | `tier` (`tier\|final\|skip`) |
+| `RALPH_CONTRACT_TEST_CMD` | str | `uv run pytest` |
+| `RALPH_TIMEOUT_CONTRACT` | float | 600 |
+
+Invalid mode raises ValueError (Phase B8).
+
+## SecurityConfig (`[security]`)
+
+| Env var | Type | Default |
+|---|---|---|
+| `RALPH_SECURITY_MODE` | str | `advisory` (`skip\|advisory\|hard`) |
+| `RALPH_SECURITY_AGENT_CMD` | str | unset |
+| `RALPH_SECURITY_AGENT_TYPE` | str | unset |
+| `RALPH_SECURITY_MODEL` | str | unset |
+| `RALPH_SECURITY_TIMEOUT` | float | 600 |
+| `RALPH_SECURITY_FAIL_THRESHOLD` | str | `high` (`critical\|high\|medium\|low`) |
+
+Invalid mode or threshold raises ValueError (Phase B8). Note: the `ralph_py factory` CLI defaults `--security-mode` to `skip` for backward compat; the dataclass default of `advisory` only applies to programmatic construction.
+
+## KnowledgeConfig (`[knowledge]`)
+
+| Env var | Type | Default |
+|---|---|---|
+| `RALPH_KNOWLEDGE_ENABLED` | bool (`1`/`true`) | true |
+| `RALPH_KNOWLEDGE_MAX_CORE_TOKENS` | int | 2000 |
+| `RALPH_KNOWLEDGE_MAX_DEPENDENCY_TOKENS` | int | 1000 |
+| `RALPH_KNOWLEDGE_MAX_SIBLING_TOKENS` | int | 500 |
+| `RALPH_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS` | float | 300 |
+| `RALPH_KNOWLEDGE_DISTILL_MODEL` | str | falls back to `MODEL` |
+| `RALPH_KNOWLEDGE_MAX_FACTS_PER_DISTILL` | int | 7 |
+
+## FeedforwardConfig (`[feedforward]`)
+
+| Env var | Type | Default |
+|---|---|---|
+| `RALPH_FEEDFORWARD_ENABLED` | bool | true |
+| `RALPH_FEEDFORWARD_MODULE_MAP` | bool | true |
+| `RALPH_FEEDFORWARD_PUBLIC_INTERFACES` | bool | true |
+| `RALPH_FEEDFORWARD_DEPENDENCY_GRAPH` | bool | true |
+| `RALPH_FEEDFORWARD_CONVENTIONS` | bool | true |
+| `RALPH_FEEDFORWARD_MAX_TOKENS` | int | 4000 |
+
+## EvolutionConfig (`[evolution]`)
+
+| Env var | Type | Default |
+|---|---|---|
+| `RALPH_EVOLUTION_ENABLED` | bool | true |
+| `RALPH_EVOLUTION_JOURNAL_PATH` | path | `.ralph/evolution.jsonl` |
+| `RALPH_EVOLUTION_LOOKBACK_RUNS` | int | 10 |
+
+## Calibration
+
+| Env var | Default | Notes |
+|---|---|---|
+| `RALPH_RUN_CALIBRATION` | unset | Set to `1` to enable real-LLM calibration tests under `tests/test_calibration.py` |
+| `RALPH_CALIBRATION_MODEL` | `haiku` | Fast model used by the calibration suite |
+
+## Patterns
+
+- Boolean env vars accept `1`, `true`, `yes` (case-insensitive). Anything else is false.
+- Path env vars are resolved against the factory's `root_dir`, not the process cwd. If absolute, used as-is.
+- Enum env vars (`RALPH_SECURITY_MODE`, `RALPH_CONTRACT_MODE`, `RALPH_SECURITY_FAIL_THRESHOLD`) validate in `__post_init__`. A typo raises ValueError at startup rather than silently defaulting.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,115 @@
+# Ralph Operator Runbook
+
+Recovery procedures for the failure modes that actually happen during factory runs.
+
+## Phase 1: mechanical verification failed
+
+**Symptom**: `Phase 1 FAILED for <comp_id>: <check_names>`
+
+**Diagnose**:
+
+- `prd_stories`: the agent never set `passes: true` on its assigned story. Either the iteration ran out, or the agent didn't understand the PRD.
+- `test_suite`, `typecheck`, `linter`: the project's commands failed. Check the worktree at `.ralph/worktrees/<comp_id>/` and rerun the command manually.
+- `diff_scope`: the agent wrote files outside `ALLOWED_PATHS`. Tighten the allowlist or relax it as appropriate.
+- `bad_patterns`: a secret-like pattern landed in the diff.
+- `dead_code` / `mutation`: the optional advanced checks failed.
+- `self_critique`: the engineer prompt's self-critique block is missing, too short, or filled with placeholder content.
+
+**Resolve**: the agent retries automatically up to `FactoryConfig.max_retries` (default 3). After that the component is marked FAILED and cascade-skips dependents. Manual options:
+
+1. Edit the PRD to clarify the story; re-run.
+2. Increase `--max-retries`.
+3. Run the agent loop manually against the worktree to debug interactively.
+
+## Phase 2: review failed (hard mode)
+
+**Symptom**: `Phase 2 FAILED for <comp_id>: N failures`
+
+**Diagnose**:
+
+- Inspect `comp.review_findings` (also written to the PR body when the PR gets created).
+- If the failures are PRD-criterion failures, the diff genuinely does not implement what was asked.
+- If the failures are concerns (`scope_creep`, `security_concern`, `test_quality`, `unrelated_change`, `dead_code`, `error_handling`, `copy_paste`), the reviewer surfaced cross-cutting issues.
+
+**Resolve**: the retry path injects the review findings back into the agent's context so the implementer has a concrete checklist. If the reviewer is wrong, switch the run to `--review-mode advisory` and the failures become warnings.
+
+If `ReviewResult.infrastructure_error=True`, the reviewer agent itself failed (timeout, API outage, parse error). Same retry path, but check API health.
+
+## Phase 2.5: security review failed (hard mode)
+
+**Symptom**: `Phase 2.5 FAILED for <comp_id>: N critical, M high`
+
+**Diagnose**: same logic as Phase 2, but the findings are typed against the security taxonomy. Each finding has `category`, `severity`, `location`, `explanation`, `suggestion`.
+
+**Resolve**:
+
+- For genuine security issues, the retry context goes back to the agent.
+- For false positives, switch to `--security-mode advisory` (findings logged, not blocking) or `--security-fail-threshold critical` (only critical findings block).
+- If `infrastructure_error=True`, the security reviewer didn't actually run. In hard mode this fails the component; in advisory mode it passes with a warning.
+
+## Phase 3: contract test breaker
+
+**Symptom**: `Contract breaker '<comp_id>' sent back for retry`
+
+**Diagnose**: the merged tier branch's tests failed; Phase 3 attributes the failure to a "breaker" component (the most recent one merged into that tier). The breaker gets reset to PENDING and re-runs.
+
+**Resolve**: the system handles this automatically up to `max_retries`. If it keeps breaking, the integration is genuinely broken — inspect the merged tier branch, fix the spec or the components' contracts, re-run.
+
+## Knowledge layer reports `no_valid_facts`
+
+**Symptom**: `Knowledge: knowledge.no_valid_facts (raw: ...)`
+
+**Diagnose**: the distiller LLM returned output, the JSON parsed, but `_coerce_facts` rejected every fact. Common causes:
+
+- Fact ids don't match `/^fact-\d{3}$/` (e.g. `fact-1` instead of `fact-001`)
+- Unknown scope value (the agent invented categories beyond handler/adapter/schema/contract/invariant/gotcha)
+- Empty evidence array
+- Empty claim text
+- Prompt-injection pattern matched in claim text (Phase A1 rejection)
+
+**Resolve**:
+
+- Inspect `.ralph/knowledge/<comp_id>/<run_id>/_distill_raw.txt` (saved automatically on failure paths) to see the agent's actual output.
+- If the agent consistently produces malformed output, the distill prompt may need to be tightened.
+- If the failure is `no_facts` (not `no_valid_facts`), the JSON didn't parse at all; usually means the agent emitted prose around the JSON.
+
+## Concurrent factory runs clobbering each other
+
+**Symptom**: One run's worktree disappears or its branch gets force-pushed by the other.
+
+**Diagnose**: on POSIX, Phase A4's `fcntl.flock` on `.ralph/worktrees/<comp_id>.lock` should prevent this. On Windows there is no flock and the runs race.
+
+**Resolve**: avoid running concurrent factory invocations against the same `root_dir` on Windows. On POSIX, the lock serializes worktree setup but doesn't prevent two runs from doing different work on the same component — use distinct `root_dir`s for distinct factory invocations.
+
+## Adversarial budget exhausted mid-run
+
+**Symptom**: `Phase 2 SKIPPED for <comp_id>: adversarial LLM budget exhausted`
+
+**Diagnose**: `FactoryConfig.max_adversarial_calls` is set and the count of review + security + distillation calls has hit the cap.
+
+**Resolve**: increase the cap, or accept that later components run without adversarial phases. The mechanical pipeline (Phase 1) still gates them.
+
+## Spec was rejected by the architect
+
+**Symptom**: factory exits with code 2; stderr lists `[blocker/<kind>] <summary>` lines.
+
+**Diagnose**: the architect's red-team pass found blocker-severity issues. The pipeline halts rather than implementing against a vague spec.
+
+**Resolve**: read the surfaced issues, edit the spec to address them, re-run. There is no override flag; that's deliberate — the alternative was producing brittle code from ambiguous instructions.
+
+## Calibration suite reports a regression
+
+**Symptom**: `tests/test_calibration.py` test fails after a prompt edit; detection rate dropped.
+
+**Diagnose**: the prompt change made the role miss a planted bug it previously caught.
+
+**Resolve**: either revert the prompt change or update the fixture's `must_detect` if the change deliberately narrowed scope. Do not just unskip the test — a calibration regression is the signal you wrote the system to produce.
+
+## Where to find things
+
+- Tracker for the hardening roadmap: `docs/adversarial-roadmap.md`
+- Adversarial design overview: `docs/adversarial-design.md`
+- Env-var reference: `docs/env-vars.md`
+- Per-run captures: `.ralph/evolution.jsonl`, `.ralph/experiments.tsv`
+- Distillation debug dumps: `.ralph/knowledge/<comp>/<run>/_distill_raw.txt` (on failure)
+- Phase F sample real-world run log: `docs/phase-f-run-log.md`

--- a/ralph.toml.example
+++ b/ralph.toml.example
@@ -49,3 +49,60 @@ max_sibling_tokens = 500           # other components' facts (first sentence onl
 distill_timeout_seconds = 300
 distill_model = ""                 # empty = falls back to [agent].model
 max_facts_per_distill = 7
+
+# Factory orchestrator settings (Phase 0-3 pipeline coordination).
+[factory]
+max_parallel = 4                   # concurrent component workers
+max_retries = 3                    # per-component retry budget across all phases
+retry_delay = 5.0                  # seconds between retry attempts
+use_worktrees = true               # branch each component into .ralph/worktrees/<id>
+single_pr = false                  # one PR for the whole factory vs per-component
+create_prs = true                  # call `gh` to push + merge per component
+review_mode = "hard"               # hard | advisory | skip
+max_adversarial_calls = 0          # 0 = unbounded; otherwise cap review+security+distill calls per run
+pause_before_pr_merge = false      # opt-in HITL checkpoint before each PR push+merge
+
+# Phase 1 mechanical verification.
+[verify]
+# test_command, typecheck_command, lint_command default to uv run pytest / mypy / ruff
+# Override to your project's commands if different.
+check_diff_scope = true
+check_bad_patterns = true
+dead_code_cleanup = false
+mutation_testing = false
+mutation_threshold = 50.0
+subprocess_timeout = 300.0
+require_self_critique = false      # opt-in: fail Phase 1 if engineer's ## Self-Critique block missing/sparse
+self_critique_min_bullets = 3
+progress_file_path = "scripts/ralph/progress.txt"
+
+# Phase 2.5 security review (independent adversarial pass focused on vulns).
+[security]
+mode = "skip"                      # skip | advisory | hard
+fail_threshold = "high"            # critical | high | medium | low (hard mode only)
+timeout_seconds = 600.0
+# agent_cmd / agent_type / model: leave blank to inherit from [agent].
+# Categories mapped to OWASP Top 10 + CWE via SECURITY_CATEGORY_MAP in security.py.
+
+# Phase 3 cross-component contract testing.
+[contract]
+mode = "tier"                      # tier | final | skip
+test_command = "uv run pytest"
+timeout = 600.0
+
+# Phase 0 feedforward (computational structural scan; no LLM).
+[feedforward]
+enabled = true
+module_map = true
+public_interfaces = true
+dependency_graph = true
+conventions = true
+max_context_tokens = 4000
+
+# Continuous-learning journal.
+[evolution]
+enabled = true
+journal_path = ".ralph/evolution.jsonl"
+experiments_path = ".ralph/experiments.tsv"
+min_pattern_frequency = 2
+lookback_runs = 10


### PR DESCRIPTION
## Summary

Final phase of the adversarial-factory hardening roadmap. Documentation only.

- **G1** — README.md mermaid diagram updated to show all 8 roles
- **G2** — `CLAUDE.md` at repo root with role taxonomy, process rules, and an Agent Learnings seed
- **G3** — `docs/env-vars.md` single canonical reference for every `RALPH_*`/`FACTORY_*`/etc. env var
- **G4** — `ralph.toml.example` extended with `[factory]` `[verify]` `[security]` `[contract]` `[feedforward]` `[evolution]` sections (the sections Phase B made loadable)
- **G5** — stale `~/.claude/plans/zazzy-orbiting-sketch.md` marked SUPERSEDED
- **G6** — `docs/adversarial-design.md` explains role taxonomy, pipeline, invariants, feedforward-vs-knowledge (E7), and known limitations
- **G7** — `docs/runbook.md` operator recovery procedures for every named failure mode

Phase H policies (H1, H2, H4) codified in `CLAUDE.md` and `docs/adversarial-design.md`. H3 deferred. H5 is user-driven.

## Test plan

- [x] No production code touched. Full suite remains **585 passing**.

This closes the roadmap: A, D, F, B, C, G shipped; E partial (E2/E4/E5/E6/E9); E3, E8 deferred with rationale in tracker; H adopted as policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)