### PR TITLE
feat: E3 - typed Finding dataclass as source-of-truth for adversarial findings

### DIFF
--- a/docs/adversarial-design.md
+++ b/docs/adversarial-design.md
@@ -21,6 +21,23 @@ Calibration is the truth signal. The `tests/test_calibration.py` suite (Phase D 
 | **Knowledge distiller** | `ralph_py/knowledge.py` | `DISTILL_PROMPT` | Post-merge | Captures durable facts about the artifact for downstream components. Voyager-style write gate: only fires when Phase 2 review passed. |
 | **Human checkpoint (E6)** | `ralph_py/factory.py` | (interactive) | Pre-merge | Optional. When `FactoryConfig.pause_before_pr_merge=True` and UI is interactive, prompts a human to approve or reject before PR creation. Off by default. |
 
+## Findings model (E3)
+
+Every finding produced by Phase 2 (`ReviewResult`) or Phase 2.5 (`SecurityResult`) is converted into a typed `Finding` (`ralph_py/findings.py`) before landing on `Component.findings: list[Finding]`. The fields are:
+
+| Field | Type | Notes |
+|---|---|---|
+| `phase` | str | `"review"` or `"security"` |
+| `category` | str | Reviewer concern category, security category, or `"prd_criterion"` for failed acceptance criteria |
+| `severity` | str | Native to the role: `"fail" / "advisory"` (review), `"critical" / "high" / "medium" / "low"` (security) |
+| `location` | str | `file:line`, file path, or `"(entire file)"` |
+| `explanation` | str | Free text |
+| `suggestion` | str | Optional |
+| `owasp`, `cwe` | str | Populated for security findings via `SECURITY_CATEGORY_MAP` |
+| `tags` | tuple[str,...] | Free-form; reserved for downstream consumers |
+
+`Component.findings` is the source of truth. The string at `Component.review_findings` is a derived view kept for backward compatibility with PR-body rendering and manifest.json readers. New downstream code (dashboards, evolution-journal queries, retry-context builders that want richer than-string information) should consume the typed list directly.
+
 ## Pipeline
 
 ```

--- a/docs/adversarial-roadmap.md
+++ b/docs/adversarial-roadmap.md
@@ -115,7 +115,7 @@ PR (partial): _pending push_
 
 - [-] E1 - Multi-model rotation - SKIPPED per user decision; documented as known limitation
 - [x] E2 - Strip Self-Critique block from reviewer-visible diff via `git.strip_self_critique_from_diff`; review.py invokes it before truncation
-- [~] E3 - Structured `comp.findings: list[Finding]` - DEFERRED to follow-up PR. Today review/security findings funnel into the stringly-typed `comp.review_findings`. A real typed `Finding` requires changing PR creation paths and breaking serialization compat. Scope is one focused PR; tracked here for visibility.
+- [x] E3 - Typed `Finding` dataclass at `ralph_py/findings.py`. `Component.findings: list[Finding]` is the new source of truth, `Component.review_findings` (string) is a derived view kept for backward compat. `ReviewResult.as_findings()` converts criteria failures + concerns; `SecurityResult.as_findings()` adds OWASP/CWE taxonomy. Factory wires both at the existing phase 2 / 2.5 attachment points. Manifest.json roundtrip handled; legacy manifests without `findings` load as `[]`. 15 new tests; full suite 613 passing.
 - [x] E4 - `FactoryConfig.max_adversarial_calls` shared counter; review/security/distill all consult it; 0 = unbounded (default)
 - [x] E5 - Confidence rename: `verified` -> `review_passed`, new `test_verified` tier added. Legacy `verified` aliased on read for backward compat.
 - [x] E6 - `FactoryConfig.pause_before_pr_merge` HITL checkpoint. Prompts user before push+merge when UI is interactive; warns and proceeds when non-interactive.
@@ -123,7 +123,7 @@ PR (partial): _pending push_
 - [x] E8 - `KnowledgeConfig.dependency_scope: str = "direct"` (default) restricts the Dependencies full-text tier to `Component.dependencies` only. Transitive deps still appear in the sibling first-sentence summary tier (downgraded, not hidden). The old behavior is opt-in via `dependency_scope = "transitive"` or `RALPH_KNOWLEDGE_DEPENDENCY_SCOPE=transitive`. 5 new tests in `test_knowledge.py`.
 - [x] E9 - ReviewResult.infrastructure_error added (parallel to SecurityResult.infrastructure_error); parse failures set it; downstream can distinguish "clean review" from "review never ran"
 
-Status: 5 of 8 items shipped (E2/E4/E5/E6/E9). E3 + E8 deferred with rationale in tracker; E1 permanently skipped per user; E7 folded into Phase G. 10 new tests; full suite 585 passing.
+Status: 7 of 8 items shipped (E2/E3/E4/E5/E6/E8/E9). E1 permanently skipped per user; E7 folded into Phase G. Deferred-follow-up PRs (E3, E8) merged 2026-05-27. 25+ new tests across the E-series.
 
 Done when: PR merged. Deferred items tracked here for the next iteration.
 

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -598,6 +598,9 @@ def run_factory(
                 diff_content=shared_diff,
             )
             comp.review_passed = review_result.passed
+            # E3: typed findings are the source of truth; the rendered
+            # string is a derived view kept for backward-compat consumers.
+            comp.findings.extend(review_result.as_findings())
             comp.review_findings = review_result.as_pr_body_section()
             # Observability gets criterion-only counts to preserve the
             # historical meaning of fail_count = "failed PRD criteria".
@@ -698,7 +701,9 @@ def run_factory(
                     duration=sec_result.duration_seconds,
                 )
 
-                # Attach security findings to the PR body alongside review
+                # E3: source-of-truth typed findings list, plus the
+                # legacy rendered string for PR body / manifest readers.
+                comp.findings.extend(sec_result.as_findings())
                 if sec_result.findings:
                     if comp.review_findings:
                         comp.review_findings = (

--- a/ralph_py/findings.py
+++ b/ralph_py/findings.py
@@ -1,0 +1,72 @@
+"""E3: structured Finding type for adversarial role outputs.
+
+Before this module, review/security findings funneled through
+``Component.review_findings`` as a single rendered string. Downstream
+consumers (dashboards, evolution journal, retry-context builder) had to
+re-parse that string to recover structure. Strings drift, parsers break,
+the typed information is gone.
+
+``Finding`` is the source-of-truth representation. The rendered string at
+``Component.review_findings`` is now a **derived view** kept for backward
+compatibility with manifest.json readers and PR body rendering. New code
+should consume ``Component.findings`` directly.
+
+Phase tag examples: ``"review"`` (Phase 2 reviewer), ``"security"`` (Phase
+2.5 security reviewer). Severity uses each role's native taxonomy
+(``critical/high/medium/low`` for security, ``fail/advisory`` for review).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One adversarial finding produced by a Phase 2 or 2.5 role.
+
+    Frozen so a list[Finding] is safe to share across threads / pickling
+    boundaries; the factory's ProcessPoolExecutor path (Phase C1) needs
+    structurally-comparable items.
+    """
+
+    phase: str
+    category: str
+    severity: str
+    location: str
+    explanation: str
+    suggestion: str = ""
+    owasp: str = ""
+    cwe: str = ""
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "phase": self.phase,
+            "category": self.category,
+            "severity": self.severity,
+            "location": self.location,
+            "explanation": self.explanation,
+            "suggestion": self.suggestion,
+            "owasp": self.owasp,
+            "cwe": self.cwe,
+            "tags": list(self.tags),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Finding:
+        tags_raw = data.get("tags", []) or []
+        if not isinstance(tags_raw, (list, tuple)):
+            tags_raw = []
+        return cls(
+            phase=str(data.get("phase", "")),
+            category=str(data.get("category", "")),
+            severity=str(data.get("severity", "")),
+            location=str(data.get("location", "")),
+            explanation=str(data.get("explanation", "")),
+            suggestion=str(data.get("suggestion", "")),
+            owasp=str(data.get("owasp", "")),
+            cwe=str(data.get("cwe", "")),
+            tags=tuple(str(t) for t in tags_raw),
+        )

--- a/ralph_py/manifest.py
+++ b/ralph_py/manifest.py
@@ -11,6 +11,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from ralph_py.findings import Finding
+
 
 class ComponentStatus(str, Enum):
     """Component execution states."""
@@ -46,6 +48,12 @@ class Component:
     # Verification/review results
     verification_passed: bool | None = None
     review_passed: bool | None = None
+    # E3: source-of-truth typed findings from review + security roles.
+    # Populated by factory.run_one via ReviewResult.as_findings() and
+    # SecurityResult.as_findings(). The rendered string ``review_findings``
+    # below is a derived view kept for backward compat with downstream
+    # consumers (PR body, manifest.json readers).
+    findings: list[Finding] = field(default_factory=list)
     review_findings: str = ""
     # Optional scaffold script to run before the agent
     scaffold: str = ""
@@ -134,6 +142,11 @@ class Manifest:
                 iteration_count=c.get("iterationCount", 0),
                 verification_passed=c.get("verificationPassed"),
                 review_passed=c.get("reviewPassed"),
+                findings=[
+                    Finding.from_dict(d)
+                    for d in c.get("findings", [])
+                    if isinstance(d, dict)
+                ],
                 review_findings=c.get("reviewFindings", ""),
                 scaffold=c.get("scaffold", ""),
             )
@@ -176,6 +189,7 @@ class Manifest:
                     "iterationCount": c.iteration_count,
                     "verificationPassed": c.verification_passed,
                     "reviewPassed": c.review_passed,
+                    "findings": [f.to_dict() for f in c.findings],
                     "reviewFindings": c.review_findings,
                     "scaffold": c.scaffold,
                 }
@@ -245,7 +259,7 @@ class Manifest:
             "status", "error", "retries", "prNumber", "prUrl",
             "startedAt", "completedAt", "durationSeconds", "iterationCount",
             "verificationPassed", "reviewPassed", "reviewFindings",
-            "scaffold",
+            "findings", "scaffold",
         }
         component_all = component_required | component_optional
 

--- a/ralph_py/review.py
+++ b/ralph_py/review.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ralph_py import git
+from ralph_py.findings import Finding
 from ralph_py.decompose import (
     AgentOutputTooLarge,
     _extract_json,
@@ -207,6 +208,39 @@ class ReviewResult:
         """Total advisories across criteria AND concerns. See
         fail_count docstring for the breakdown properties."""
         return self.criterion_advisory_count + self.concern_advisory_count
+
+    def as_findings(self) -> list[Finding]:
+        """E3: typed representation of every non-PASS criterion + every
+        concern. Used by factory to populate ``Component.findings``.
+
+        Criteria with verdict=PASS are skipped (they're not findings).
+        ADVISORY criteria carry severity="advisory"; FAIL criteria carry
+        severity="fail". Concerns carry their native severity field
+        (already "fail" or "advisory" -- see ReviewConcern).
+        """
+        out: list[Finding] = []
+        for cr in self.criteria:
+            if cr.verdict == ReviewVerdict.PASS.value:
+                continue
+            sev = "fail" if cr.verdict == ReviewVerdict.FAIL.value else "advisory"
+            out.append(Finding(
+                phase="review",
+                category="prd_criterion",
+                severity=sev,
+                location="",
+                explanation=f"{cr.criterion}: {cr.explanation}",
+                suggestion=cr.suggestion,
+            ))
+        for concern in self.concerns:
+            out.append(Finding(
+                phase="review",
+                category=concern.category,
+                severity=concern.severity,
+                location=concern.location,
+                explanation=concern.explanation,
+                suggestion=concern.suggestion,
+            ))
+        return out
 
 
 REVIEWER_PROMPT_VERSION = "1.0.0"

--- a/ralph_py/security.py
+++ b/ralph_py/security.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ralph_py import git
+from ralph_py.findings import Finding
 from ralph_py.decompose import (
     AgentOutputTooLarge,
     _extract_json,
@@ -165,6 +166,24 @@ class SecurityResult:
     @property
     def high_count(self) -> int:
         return sum(1 for f in self.findings if f.severity == "high")
+
+    def as_findings(self) -> list[Finding]:
+        """E3: typed representation of every SecurityFinding, enriched
+        with the OWASP/CWE taxonomy from SECURITY_CATEGORY_MAP. Used by
+        factory to populate ``Component.findings``."""
+        return [
+            Finding(
+                phase="security",
+                category=f.category,
+                severity=f.severity,
+                location=f.location,
+                explanation=f.explanation,
+                suggestion=f.suggestion,
+                owasp=category_owasp(f.category),
+                cwe=category_cwe(f.category),
+            )
+            for f in self.findings
+        ]
 
 
 @dataclass

--- a/tests/test_findings.py
+++ b/tests/test_findings.py
@@ -1,0 +1,278 @@
+"""E3: tests for the typed Finding dataclass and the as_findings()
+hooks on ReviewResult / SecurityResult, plus the manifest roundtrip
+that persists Component.findings to disk."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ralph_py.findings import Finding
+from ralph_py.manifest import Component, Manifest
+from ralph_py.review import (
+    CriterionReview,
+    ReviewConcern,
+    ReviewResult,
+    ReviewVerdict,
+)
+from ralph_py.security import SecurityFinding, SecurityMode, SecurityResult
+
+
+def _make_component(comp_id: str = "comp-1") -> Component:
+    return Component(
+        id=comp_id,
+        title="t",
+        description="d",
+        dependencies=[],
+        prd_path="prd.json",
+        branch_name="ralph/comp-1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestFinding:
+    def test_round_trip_minimal(self) -> None:
+        f = Finding(
+            phase="review", category="dead_code", severity="fail",
+            location="src/x.py:10", explanation="unused",
+        )
+        roundtripped = Finding.from_dict(f.to_dict())
+        assert roundtripped == f
+
+    def test_round_trip_full(self) -> None:
+        f = Finding(
+            phase="security", category="injection", severity="critical",
+            location="src/db.py:42", explanation="raw sql",
+            suggestion="parametrize", owasp="A03:2021-Injection",
+            cwe="CWE-89", tags=("sql", "userinput"),
+        )
+        roundtripped = Finding.from_dict(f.to_dict())
+        assert roundtripped == f
+
+    def test_from_dict_tolerates_missing_keys(self) -> None:
+        f = Finding.from_dict({"phase": "review", "category": "scope_creep"})
+        assert f.phase == "review"
+        assert f.category == "scope_creep"
+        assert f.severity == ""
+        assert f.tags == ()
+
+    def test_from_dict_coerces_non_string_tags(self) -> None:
+        # Defensive: a manifest.json corrupted to have a non-list tags
+        # should not crash the loader.
+        f = Finding.from_dict({"phase": "review", "tags": "not-a-list"})
+        assert f.tags == ()
+
+    def test_frozen(self) -> None:
+        import dataclasses
+        import pytest
+
+        f = Finding(phase="review", category="x", severity="fail",
+                    location="", explanation="")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            f.severity = "advisory"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ReviewResult.as_findings
+# ---------------------------------------------------------------------------
+
+
+class TestReviewResultAsFindings:
+    def test_pass_criteria_excluded(self) -> None:
+        result = ReviewResult(
+            passed=True, mode="hard",
+            criteria=[
+                CriterionReview(
+                    criterion="A",
+                    verdict=ReviewVerdict.PASS.value,
+                    explanation="ok", suggestion="",
+                ),
+            ],
+        )
+        assert result.as_findings() == []
+
+    def test_fail_and_advisory_criteria_typed(self) -> None:
+        result = ReviewResult(
+            passed=False, mode="hard",
+            criteria=[
+                CriterionReview(
+                    criterion="must X",
+                    verdict=ReviewVerdict.FAIL.value,
+                    explanation="missing X", suggestion="add X",
+                ),
+                CriterionReview(
+                    criterion="should Y",
+                    verdict=ReviewVerdict.ADVISORY.value,
+                    explanation="weak Y", suggestion="",
+                ),
+            ],
+        )
+        findings = result.as_findings()
+        assert len(findings) == 2
+        assert findings[0].phase == "review"
+        assert findings[0].category == "prd_criterion"
+        assert findings[0].severity == "fail"
+        assert "must X" in findings[0].explanation
+        assert findings[0].suggestion == "add X"
+        assert findings[1].severity == "advisory"
+
+    def test_concerns_typed(self) -> None:
+        result = ReviewResult(
+            passed=False, mode="hard",
+            concerns=[
+                ReviewConcern(
+                    category="scope_creep", severity="fail",
+                    location="src/logger.py",
+                    explanation="unrelated logger added",
+                    suggestion="remove",
+                ),
+            ],
+        )
+        findings = result.as_findings()
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.phase == "review"
+        assert f.category == "scope_creep"
+        assert f.severity == "fail"
+        assert f.location == "src/logger.py"
+        assert f.suggestion == "remove"
+
+
+# ---------------------------------------------------------------------------
+# SecurityResult.as_findings
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityResultAsFindings:
+    def test_findings_enriched_with_owasp_cwe(self) -> None:
+        result = SecurityResult(
+            passed=False, mode=SecurityMode.HARD.value,
+            findings=[
+                SecurityFinding(
+                    category="injection", severity="critical",
+                    location="src/db.py:7", explanation="raw sql",
+                    suggestion="parametrize",
+                ),
+            ],
+        )
+        findings = result.as_findings()
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.phase == "security"
+        assert f.category == "injection"
+        assert f.severity == "critical"
+        assert f.location == "src/db.py:7"
+        # The Phase D5 SECURITY_CATEGORY_MAP should fill these.
+        assert "A03" in f.owasp
+        assert f.cwe.startswith("CWE-")
+
+    def test_empty_findings(self) -> None:
+        result = SecurityResult(
+            passed=True, mode=SecurityMode.ADVISORY.value, findings=[],
+        )
+        assert result.as_findings() == []
+
+    def test_unknown_category_still_serializes(self) -> None:
+        result = SecurityResult(
+            passed=False, mode=SecurityMode.HARD.value,
+            findings=[
+                SecurityFinding(
+                    category="some_new_thing", severity="medium",
+                    location="x.py", explanation="...", suggestion="",
+                ),
+            ],
+        )
+        findings = result.as_findings()
+        assert len(findings) == 1
+        # No OWASP / CWE entry yet, but the finding still surfaces.
+        assert findings[0].category == "some_new_thing"
+
+
+# ---------------------------------------------------------------------------
+# Manifest roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestManifestFindingsRoundtrip:
+    def test_findings_persisted_to_json(self, tmp_path: Path) -> None:
+        comp = _make_component()
+        comp.findings = [
+            Finding(
+                phase="review", category="dead_code", severity="fail",
+                location="src/a.py:1-5", explanation="unused",
+            ),
+            Finding(
+                phase="security", category="injection", severity="critical",
+                location="src/b.py:7", explanation="raw sql",
+                owasp="A03:2021-Injection", cwe="CWE-89",
+            ),
+        ]
+        manifest = Manifest(
+            version="1", spec_file="", project_name="p",
+            base_branch="main", single_pr=False, components=[comp],
+        )
+        path = tmp_path / "manifest.json"
+        manifest.save(path)
+
+        # Sanity-check the on-disk JSON shape.
+        raw = json.loads(path.read_text())
+        assert raw["components"][0]["findings"][0]["category"] == "dead_code"
+        assert raw["components"][0]["findings"][1]["owasp"] == "A03:2021-Injection"
+
+        loaded = Manifest.load(path)
+        assert loaded.components[0].findings == comp.findings
+
+    def test_findings_default_empty_on_legacy_manifest(
+        self, tmp_path: Path,
+    ) -> None:
+        """A manifest.json written before this PR has no `findings` key.
+        Loading it should produce an empty list, not raise."""
+        legacy = {
+            "version": "1", "specFile": "", "projectName": "p",
+            "baseBranch": "main", "singlePr": False,
+            "components": [{
+                "id": "c1", "title": "t", "description": "d",
+                "dependencies": [], "prdPath": "p.json",
+                "branchName": "ralph/c1",
+            }],
+        }
+        path = tmp_path / "manifest.json"
+        path.write_text(json.dumps(legacy))
+        loaded = Manifest.load(path)
+        assert loaded.components[0].findings == []
+
+    def test_findings_in_validate_schema_optional(self) -> None:
+        legacy = {
+            "version": "1", "specFile": "", "projectName": "p",
+            "baseBranch": "main", "singlePr": False,
+            "components": [{
+                "id": "c1", "title": "t", "description": "d",
+                "dependencies": [], "prdPath": "p.json",
+                "branchName": "ralph/c1",
+                "findings": [],
+            }],
+        }
+        assert Manifest.validate_schema(legacy) == []
+
+    def test_malformed_finding_entry_skipped(self, tmp_path: Path) -> None:
+        # A non-dict entry in findings (corruption) should be skipped, not
+        # crash the load.
+        legacy = {
+            "version": "1", "specFile": "", "projectName": "p",
+            "baseBranch": "main", "singlePr": False,
+            "components": [{
+                "id": "c1", "title": "t", "description": "d",
+                "dependencies": [], "prdPath": "p.json",
+                "branchName": "ralph/c1",
+                "findings": ["not-a-dict", {"phase": "review", "category": "x"}],
+            }],
+        }
+        path = tmp_path / "manifest.json"
+        path.write_text(json.dumps(legacy))
+        loaded = Manifest.load(path)
+        assert len(loaded.components[0].findings) == 1
+        assert loaded.components[0].findings[0].category == "x"


### PR DESCRIPTION
## Summary

Closes E3 from the deferred-follow-up bucket. Before this PR, every Phase 2 and Phase 2.5 finding funneled through ``Component.review_findings`` as a single rendered string. Downstream consumers had to re-parse that string to recover structure -- fragile and lossy.

### The change

New ``ralph_py/findings.py``:

```python
@dataclass(frozen=True)
class Finding:
    phase: str                 # "review" | "security"
    category: str              # role-native category or "prd_criterion"
    severity: str              # role-native severity
    location: str
    explanation: str
    suggestion: str = ""
    owasp: str = ""            # filled for security findings
    cwe: str = ""              # filled for security findings
    tags: tuple[str, ...] = ()
```

``Component`` gains ``findings: list[Finding]`` alongside the existing ``review_findings`` string. The typed list is the **source of truth**; the string is a derived view kept for backward compatibility with PR body rendering (pr.py) and existing manifest.json readers (``reviewFindings`` key).

### Conversion

- ``ReviewResult.as_findings()`` -- converts each non-PASS criterion to a ``prd_criterion``-category Finding plus every ``ReviewConcern`` to a Finding.
- ``SecurityResult.as_findings()`` -- maps ``SecurityFinding`` -> Finding while enriching with OWASP / CWE from the Phase D5 ``SECURITY_CATEGORY_MAP``.

Factory wiring is a one-line append at each existing attachment point in ``factory.py``:

```python
comp.findings.extend(review_result.as_findings())   # phase 2
comp.findings.extend(sec_result.as_findings())      # phase 2.5
```

### Serialization

Manifest.json gains an optional ``findings`` array per component:

```json
{
  "findings": [
    {"phase": "review", "category": "dead_code", "severity": "fail", ...},
    {"phase": "security", "category": "injection", "severity": "critical",
     "owasp": "A03:2021-Injection", "cwe": "CWE-89", ...}
  ]
}
```

Legacy manifests with no ``findings`` key load as ``[]``. Malformed entries (non-dict items in the list) are skipped, not crashed on -- same defensive posture as Phase A1's fact coercion.

### Tests

15 new in ``tests/test_findings.py``:

- ``TestFinding`` -- round-trip (minimal + full), tolerates missing keys, defensive against non-list tags, frozen enforcement (mutation raises ``FrozenInstanceError``)
- ``TestReviewResultAsFindings`` -- PASS criteria excluded; FAIL + ADVISORY typed correctly; concerns typed
- ``TestSecurityResultAsFindings`` -- OWASP/CWE enriched; empty findings handled; unknown category still serializes (no KeyError)
- ``TestManifestFindingsRoundtrip`` -- round-trip equality; legacy manifest loads as ``[]``; validate_schema accepts ``findings`` as optional; malformed entries skipped

Plus the existing 103 manifest/factory/review/security tests pass unchanged.

## Test plan

- [x] ``uv run pytest tests/test_findings.py`` -- 15 passing
- [x] ``uv run pytest tests/test_manifest.py tests/test_factory.py tests/test_review.py tests/test_security.py`` -- 103 passing (unchanged)
- [x] Full suite: 613 passing (was 598, +15 from E3)

## Tracker

``docs/adversarial-roadmap.md``: E3 moves from ``[~]`` deferred to ``[x]`` done. The E series is now 7-of-8 shipped (E1 permanently skipped per user decision).
``docs/adversarial-design.md``: new "Findings model (E3)" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)