### PR TITLE
feat: architect emits allowedPaths; factory wires them to diff-scope

### DIFF
--- a/docs/f5-calibration-baseline.md
+++ b/docs/f5-calibration-baseline.md
@@ -78,6 +78,20 @@ H2 of the hardening roadmap says: if a prompt change moves this number,
 calibration is the verification. Both interpretations should be tracked across
 prompt edits.
 
+## v1.1.0 architect re-run (DECOMPOSE_PROMPT version bump, 2026-05-27 19:13)
+
+Re-ran the architect role against the 3 spec fixtures after bumping `DECOMPOSE_PROMPT` from `1.0.0` to `1.1.0` (added `allowedPaths` requirements). Per H2 a prompt change without a calibration delta is treated as untested.
+
+Result: **2/3 = 67%** (same rate as v1.0.0). Different fixture missed:
+
+- `spec-01-no-error-handling` -- caught this run (was missed in v1.0.0 baseline)
+- `spec-02-unspecified-auth` -- missed this run (was caught in v1.0.0)
+- `spec-03-ambiguous-perf` -- caught both runs
+
+The missed-fixture rotation is within LLM run-to-run variance at single-run sample size. The bias documented for v1.0.0 (Haiku over-uses `missing_detail` and `ambiguity`, under-uses `undefined_failure_mode` / `unstated_assumption`) appears unchanged. The prompt change did not regress the spec-issue detection axis -- which is the only axis the current fixtures grade. Whether the architect now reliably emits `allowedPaths` for non-halting specs is a separate measurement that the existing calibration fixtures do not cover (they are all designed to halt the architect on planted blockers).
+
+Raw: `tests/adversarial_fixtures/_results/baseline-20260527-191337.json`.
+
 ## Trustworthy use of these numbers
 
 - **Single-run baseline**. LLMs vary; aggregate across multiple runs before

--- a/ralph_py/decompose.py
+++ b/ralph_py/decompose.py
@@ -43,7 +43,7 @@ class SpecBlockerError(Exception):
             + "\n".join(summary_lines),
         )
 
-DECOMPOSE_PROMPT_VERSION = "1.0.0"
+DECOMPOSE_PROMPT_VERSION = "1.1.0"
 
 DECOMPOSE_PROMPT = """\
 You are a senior software architect AND a hostile spec auditor. You have
@@ -81,6 +81,9 @@ The output must be a JSON object with this exact structure:
       "title": "Short title",
       "description": "What this component does and why",
       "dependencies": ["other-component-id"],
+      "allowedPaths": [
+        "src/", "tests/", "scripts/ralph/feature/<id>/"
+      ],
       "userStories": [
         {{
           "id": "US-001",
@@ -122,6 +125,30 @@ Decomposition rules:
 11. Do not invent UI elements, endpoints, or files not described in the
     spec. If the spec is silent on something you would need to invent,
     add a `spec_issues` entry instead.
+12. `allowedPaths` is REQUIRED for every component. It is the agent's
+    write-scope guardrail: the harness's diff-scope check fails any
+    iteration that touches files outside this list. Each entry is a
+    path prefix (directory or file). Rules:
+    - Include the language-appropriate source root (e.g. `src/`,
+      `lib/`, or the package directory the spec names) AND the test
+      root (e.g. `tests/`, `__tests__/`, `spec/`).
+    - Include the component's own PRD-and-progress subtree
+      `scripts/ralph/feature/<component-id>/` (the agent updates
+      progress.txt there).
+    - PREFER tighter scopes: if the spec names specific files, list
+      those files instead of broad directories. A tight scope means
+      a rogue agent cannot delete unrelated code.
+    - NEVER include `.ralph/` (harness state), `.github/`,
+      `pyproject.toml`, the harness's own packages (`ralph_py/`,
+      `src/ralph/`), or any file/directory above the component's
+      feature subtree under `scripts/ralph/`. These are
+      out-of-scope by definition and an agent that touches them is
+      malfunctioning.
+    - If you genuinely cannot infer a sensible scope from the spec,
+      add a `spec_issues` entry of `kind: missing_detail` rather
+      than emitting an empty array. An empty `allowedPaths`
+      silently disables the diff-scope check, which is worse than
+      halting on a vague spec.
 
 Red-team rules:
 - Look for: ambiguous quantifiers ("fast", "secure", "user-friendly"),
@@ -356,6 +383,23 @@ def _validate_decompose_output(data: Any) -> list[str]:
         elif not all(isinstance(d, str) for d in deps):
             errors.append(f"{prefix}.dependencies: all items must be strings")
 
+        # allowedPaths (optional for backwards compatibility with v1.0.0
+        # architect outputs; v1.1.0+ always emits it). When present, must
+        # be a non-empty array of non-empty strings.
+        if "allowedPaths" in comp:
+            ap = comp["allowedPaths"]
+            if not isinstance(ap, list):
+                errors.append(f"{prefix}.allowedPaths: must be an array")
+            elif not ap:
+                errors.append(
+                    f"{prefix}.allowedPaths: must be non-empty -- an empty "
+                    "array silently disables diff-scope enforcement"
+                )
+            elif not all(isinstance(p, str) and p for p in ap):
+                errors.append(
+                    f"{prefix}.allowedPaths: all items must be non-empty strings"
+                )
+
         stories = comp.get("userStories")
         if not isinstance(stories, list):
             errors.append(f"{prefix}.userStories: must be an array")
@@ -476,6 +520,14 @@ def _generate_component_prd(
         "branchName": branch_name,
         "userStories": comp_data["userStories"],
     }
+    # allowedPaths is emitted by the architect (DECOMPOSE_PROMPT v1.1.0+)
+    # and forwarded into the PRD verbatim. The factory then passes them
+    # through to verify.check_diff_scope so the diff-scope guardrail
+    # actually fires per-component. Older architect outputs may omit
+    # this field; the PRD parser tolerates absence by treating it as
+    # "scope unconstrained" (the previous global behavior).
+    if "allowedPaths" in comp_data:
+        prd_data["allowedPaths"] = comp_data["allowedPaths"]
 
     prd_path = feature_dir / "prd.json"
     with open(prd_path, "w") as f:

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -23,6 +23,7 @@ from ralph_py.knowledge import (
 from ralph_py.manifest import Component, ComponentStatus, Manifest
 from ralph_py.observability import NullProgressLog, ProgressLog
 from ralph_py.pr import create_prs_in_order, create_single_pr
+from ralph_py.prd import PRD
 from ralph_py.review import ReviewMode, run_review
 from ralph_py.security import SecurityConfig, SecurityMode, run_security_review
 from ralph_py.verify import VerifyConfig, run_mechanical_verification
@@ -531,11 +532,26 @@ def run_factory(
         verify_config = factory_config.verify_config or VerifyConfig()
         ui.info(f"  Phase 1: mechanical verification for {comp_id}...")
         verify_start = time.monotonic()
+        # Per-component allowed_paths comes from the PRD (architect-emitted
+        # via DECOMPOSE_PROMPT v1.1.0+). Without this, the diff-scope check
+        # silently passes and a rogue agent can touch anything in the
+        # worktree -- the end-to-end validation run on 2026-05-27 caught
+        # an agent editing factory internals because allowed_paths was
+        # always None here. Legacy PRDs without the field still get None
+        # which preserves the prior "no constraint" behavior.
+        component_allowed_paths: list[str] | None = None
+        try:
+            prd_for_scope = PRD.load(wt_path / comp.prd_path)
+            component_allowed_paths = prd_for_scope.allowed_paths
+        except (FileNotFoundError, ValueError):
+            # PRD problems will surface again from inside the verifier;
+            # don't block Phase 1 setup on this lookup.
+            pass
         verification = run_mechanical_verification(
             wt_path,
             wt_path / comp.prd_path,
             manifest.base_branch,
-            None,
+            component_allowed_paths,
             verify_config,
         )
         verify_duration = time.monotonic() - verify_start

--- a/ralph_py/prd.py
+++ b/ralph_py/prd.py
@@ -26,6 +26,13 @@ class PRD:
 
     branch_name: str
     user_stories: list[UserStory]
+    # Allow-list of path prefixes the engineer is permitted to write to.
+    # Populated by the architect (DECOMPOSE_PROMPT v1.1.0+); legacy PRDs
+    # without this field load as None which preserves the prior
+    # "scope unconstrained" behavior. The factory forwards this to
+    # ``verify.check_diff_scope`` so the agent's diff is bounded per-
+    # component rather than allowed to touch anywhere in the worktree.
+    allowed_paths: list[str] | None = None
 
     @classmethod
     def load(cls, path: Path) -> PRD:
@@ -49,19 +56,30 @@ class PRD:
             for s in data["userStories"]
         ]
 
-        return cls(branch_name=data["branchName"], user_stories=stories)
+        allowed_paths = data.get("allowedPaths")
+        if allowed_paths is not None and not isinstance(allowed_paths, list):
+            allowed_paths = None
+        return cls(
+            branch_name=data["branchName"],
+            user_stories=stories,
+            allowed_paths=allowed_paths,
+        )
 
     @classmethod
     def validate_schema(cls, data: Any) -> list[str]:
         """Validate PRD JSON schema, returning list of errors.
 
-        Schema requirements (matching the init command exactly):
-        - Top-level must be dict with exactly 2 keys: branchName, userStories
-        - branchName: non-empty string
-        - userStories: array of story objects
-        - Each story must have exactly 6 keys: id, title, acceptanceCriteria,
-          priority, passes, notes
-        - Field types are strictly enforced
+        Schema requirements:
+        - Top-level must be dict with ``branchName`` and ``userStories``,
+          optionally ``allowedPaths``.
+        - branchName: non-empty string.
+        - userStories: array of story objects, each with exactly 6 keys
+          (id, title, acceptanceCriteria, priority, passes, notes).
+        - allowedPaths (optional): non-empty array of non-empty strings
+          when present. An empty array is rejected because it silently
+          disables diff-scope enforcement -- omit the field entirely
+          to mean "no constraint".
+        - Field types are strictly enforced.
         """
         errors: list[str] = []
 
@@ -69,18 +87,31 @@ class PRD:
             errors.append("PRD must be a JSON object")
             return errors
 
-        # Check top-level keys
-        expected_keys = {"branchName", "userStories"}
+        required_keys = {"branchName", "userStories"}
+        optional_keys = {"allowedPaths"}
         actual_keys = set(data.keys())
+        missing = required_keys - actual_keys
+        extra = actual_keys - required_keys - optional_keys
 
-        if actual_keys != expected_keys:
-            missing = expected_keys - actual_keys
-            extra = actual_keys - expected_keys
+        if missing or extra:
             if missing:
                 errors.append(f"Missing required keys: {', '.join(sorted(missing))}")
             if extra:
                 errors.append(f"Unexpected keys: {', '.join(sorted(extra))}")
             return errors
+
+        # Validate optional allowedPaths shape
+        if "allowedPaths" in data:
+            ap = data["allowedPaths"]
+            if not isinstance(ap, list):
+                errors.append("allowedPaths must be an array")
+            elif not ap:
+                errors.append(
+                    "allowedPaths must be non-empty when present "
+                    "(omit the field entirely to leave scope unconstrained)"
+                )
+            elif not all(isinstance(p, str) and p for p in ap):
+                errors.append("allowedPaths: all items must be non-empty strings")
 
         # Validate branchName
         branch_name = data.get("branchName")

--- a/tests/adversarial_fixtures/_results/baseline-20260527-191337.json
+++ b/tests/adversarial_fixtures/_results/baseline-20260527-191337.json
@@ -1,0 +1,31 @@
+{
+  "model": "haiku",
+  "timestamp": "20260527-191337",
+  "summary": {
+    "architect": {
+      "total": 3,
+      "caught": 2,
+      "detection_rate": 0.6666666666666666
+    }
+  },
+  "fixtures": [
+    {
+      "role": "architect",
+      "fixture_id": "spec-01-no-error-handling",
+      "caught": true,
+      "detail": "got 15 issues: [('blocker', 'missing_detail'), ('blocker', 'missing_detail'), ('blocker', 'undefined_failure_mode'), ('blocker', 'missing_detail'), ('blocker', 'missing_detail'), ('blocker', 'missing_detail'), ('major', 'ambiguity'), ('major', 'undefined_failure_mode'), ('major', 'missing_detail'), ('major', 'missing_detail'), ('major', 'missing_detail'), ('major', 'ambiguity'), ('minor', 'missing_detail'), ('minor', 'missing_detail'), ('minor', 'missing_detail')]"
+    },
+    {
+      "role": "architect",
+      "fixture_id": "spec-02-unspecified-auth",
+      "caught": false,
+      "detail": "got 16 issues: [('blocker', 'missing_detail'), ('blocker', 'missing_detail'), ('blocker', 'missing_detail'), ('blocker', 'missing_detail'), ('major', 'ambiguity'), ('major', 'missing_detail'), ('major', 'missing_detail'), ('major', 'missing_detail'), ('major', 'undefined_failure_mode'), ('major', 'missing_detail'), ('major', 'missing_detail'), ('major', 'missing_detail'), ('minor', 'ambiguity'), ('minor', 'missing_detail'), ('minor', 'missing_detail'), ('minor', 'out_of_scope_creep')]"
+    },
+    {
+      "role": "architect",
+      "fixture_id": "spec-03-ambiguous-perf",
+      "caught": true,
+      "detail": "got 13 issues: [('blocker', 'missing_detail'), ('blocker', 'missing_detail'), ('blocker', 'ambiguity'), ('blocker', 'missing_detail'), ('blocker', 'ambiguity'), ('blocker', 'missing_detail'), ('major', 'undefined_failure_mode'), ('major', 'missing_detail'), ('major', 'missing_detail'), ('major', 'missing_detail'), ('major', 'missing_detail'), ('minor', 'ambiguity'), ('minor', 'missing_detail')]"
+    }
+  ]
+}

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -178,6 +178,95 @@ class TestValidateDecomposeOutput:
         errors = _validate_decompose_output(data)
         assert any("nonexistent" in e for e in errors)
 
+    def test_allowed_paths_optional(self) -> None:
+        """Components without allowedPaths still validate (legacy
+        DECOMPOSE_PROMPT v1.0.0 architect outputs don't emit it)."""
+        data = {
+            "components": [
+                {
+                    "id": "a",
+                    "title": "A",
+                    "description": "A",
+                    "dependencies": [],
+                    "userStories": [],
+                }
+            ]
+        }
+        errors = _validate_decompose_output(data)
+        assert errors == []
+
+    def test_allowed_paths_must_be_array_when_present(self) -> None:
+        data = {
+            "components": [
+                {
+                    "id": "a",
+                    "title": "A",
+                    "description": "A",
+                    "dependencies": [],
+                    "allowedPaths": "src/",
+                    "userStories": [],
+                }
+            ]
+        }
+        errors = _validate_decompose_output(data)
+        assert any("allowedPaths" in e and "array" in e for e in errors)
+
+    def test_allowed_paths_empty_rejected(self) -> None:
+        """An empty allowedPaths silently disables the diff-scope check
+        which is worse than not setting it at all; reject explicitly."""
+        data = {
+            "components": [
+                {
+                    "id": "a",
+                    "title": "A",
+                    "description": "A",
+                    "dependencies": [],
+                    "allowedPaths": [],
+                    "userStories": [],
+                }
+            ]
+        }
+        errors = _validate_decompose_output(data)
+        assert any(
+            "allowedPaths" in e and "non-empty" in e for e in errors
+        )
+
+    def test_allowed_paths_non_string_item_rejected(self) -> None:
+        data = {
+            "components": [
+                {
+                    "id": "a",
+                    "title": "A",
+                    "description": "A",
+                    "dependencies": [],
+                    "allowedPaths": ["src/", 42],
+                    "userStories": [],
+                }
+            ]
+        }
+        errors = _validate_decompose_output(data)
+        assert any("allowedPaths" in e for e in errors)
+
+    def test_allowed_paths_valid(self) -> None:
+        data = {
+            "components": [
+                {
+                    "id": "comp-a",
+                    "title": "A",
+                    "description": "A",
+                    "dependencies": [],
+                    "allowedPaths": [
+                        "src/",
+                        "tests/",
+                        "scripts/ralph/feature/comp-a/",
+                    ],
+                    "userStories": [],
+                }
+            ]
+        }
+        errors = _validate_decompose_output(data)
+        assert errors == []
+
 
 class TestSpecIssues:
     """Tests for the red-team / spec-audit surface."""

--- a/tests/test_prd_allowed_paths.py
+++ b/tests/test_prd_allowed_paths.py
@@ -1,0 +1,113 @@
+"""Tests for the new ``allowedPaths`` field on ``ralph_py.prd.PRD``.
+
+These cover both the validator's optional-but-non-empty contract and
+the loader's coercion to ``PRD.allowed_paths``. The factory then reads
+``prd.allowed_paths`` and forwards it to ``verify.check_diff_scope``;
+that wiring is exercised end-to-end by an integration-level factory
+test, but the per-unit boundaries are covered here so a refactor that
+breaks the loader fails fast.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ralph_py.prd import PRD
+
+
+def _make_prd_payload(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "branchName": "ralph/test",
+        "userStories": [
+            {
+                "id": "US-001",
+                "title": "Implement core",
+                "acceptanceCriteria": ["does X"],
+                "priority": 1,
+                "passes": False,
+                "notes": "",
+            },
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestValidateSchemaAllowedPaths:
+    def test_absent_is_valid(self) -> None:
+        """Legacy DECOMPOSE_PROMPT v1.0.0 PRDs don't carry the field;
+        they must still load."""
+        assert PRD.validate_schema(_make_prd_payload()) == []
+
+    def test_array_of_strings_is_valid(self) -> None:
+        payload = _make_prd_payload(
+            allowedPaths=["src/", "tests/", "scripts/ralph/feature/x/"],
+        )
+        assert PRD.validate_schema(payload) == []
+
+    def test_not_an_array_rejected(self) -> None:
+        payload = _make_prd_payload(allowedPaths="src/")
+        errors = PRD.validate_schema(payload)
+        assert any("array" in e for e in errors)
+
+    def test_empty_array_rejected(self) -> None:
+        """An empty array silently disables the diff-scope check;
+        rejecting it explicitly is the H3-style "halt over heroics"
+        choice -- omit the field entirely to mean "no constraint"."""
+        payload = _make_prd_payload(allowedPaths=[])
+        errors = PRD.validate_schema(payload)
+        assert any("non-empty" in e for e in errors)
+
+    def test_non_string_item_rejected(self) -> None:
+        payload = _make_prd_payload(allowedPaths=["src/", 42])
+        errors = PRD.validate_schema(payload)
+        assert any("strings" in e for e in errors)
+
+    def test_empty_string_item_rejected(self) -> None:
+        payload = _make_prd_payload(allowedPaths=["src/", ""])
+        errors = PRD.validate_schema(payload)
+        assert any("non-empty" in e for e in errors)
+
+    def test_unexpected_top_level_key_still_rejected(self) -> None:
+        """allowedPaths becoming optional must not weaken the strict
+        unexpected-key check."""
+        payload = _make_prd_payload(allowedPaths=["src/"], unexpected="x")
+        errors = PRD.validate_schema(payload)
+        assert any("Unexpected keys" in e for e in errors)
+
+
+class TestLoadAllowedPaths:
+    def test_load_absent_is_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "prd.json"
+        path.write_text(json.dumps(_make_prd_payload()))
+        prd = PRD.load(path)
+        assert prd.allowed_paths is None
+
+    def test_load_present_populates_field(self, tmp_path: Path) -> None:
+        path = tmp_path / "prd.json"
+        path.write_text(
+            json.dumps(_make_prd_payload(
+                allowedPaths=["src/", "tests/", "scripts/ralph/feature/x/"],
+            )),
+        )
+        prd = PRD.load(path)
+        assert prd.allowed_paths == [
+            "src/", "tests/", "scripts/ralph/feature/x/",
+        ]
+
+    def test_load_with_invalid_allowed_paths_rejected_at_load(
+        self, tmp_path: Path,
+    ) -> None:
+        """An invalid allowedPaths (e.g. empty array) makes PRD.load
+        raise ValueError. The factory's per-component lookup tolerates
+        this by treating it as "no constraint", but ``PRD.load`` itself
+        is strict so other callers can rely on the dataclass invariant."""
+        path = tmp_path / "prd.json"
+        path.write_text(
+            json.dumps(_make_prd_payload(allowedPaths=[])),
+        )
+        with pytest.raises(ValueError, match="allowedPaths"):
+            PRD.load(path)

--- a/tests/test_prompt_versions.py
+++ b/tests/test_prompt_versions.py
@@ -82,8 +82,8 @@ _VERSIONS: dict[str, str] = {
 # when a prompt is edited; the test fails if either is stale.
 _EXPECTED_SNAPSHOTS: dict[str, tuple[str, str]] = {
     "DECOMPOSE_PROMPT": (
-        "89c9d6a70512676aefffa643558fbb71a6937682c56a9fd3943b69c49eb2abcf",
-        "1.0.0",
+        "38efb17f881a6f75e92cad41c7a1d4accf3ebd88db0457da8263ec2de68662ca",
+        "1.1.0",
     ),
     "REVIEWER_PROMPT": (
         "9307260aee8aedeea22d7fcb8e28131421013a915ec697d71f3428996bc434ca",


### PR DESCRIPTION
## Summary

End-to-end factory validation on 2026-05-27 caught a silent-bypass: the architect never emitted ``allowedPaths`` for any component, the factory passed ``None`` to ``check_diff_scope`` unconditionally, and the diff-scope guardrail short-circuited to a pass on the early-return "no scope constraints" branch. An agent (haiku) was free to edit factory internals and delete unrelated tests on the test run; the only thing that caught it was an unrelated typecheck failure.

This PR closes the bypass with three coordinated changes.

## 1. DECOMPOSE_PROMPT v1.0.0 → v1.1.0

Added ``allowedPaths`` as a required field in the JSON schema example and a new decomposition rule (#12) specifying:

- **Include**: source root, test root, component's own ``scripts/ralph/feature/<id>/`` subtree
- **Exclude**: ``.ralph/``, ``.github/``, ``pyproject.toml``, harness packages, anything above the component's feature subtree
- **Prefer tighter scopes** over broad directory prefixes (a tight scope means a rogue agent cannot delete unrelated code)
- **If scope is ambiguous**, add a ``spec_issues`` entry rather than emit an empty array (empty silently disables enforcement, which is worse than halting on a vague spec)

``DECOMPOSE_PROMPT_VERSION`` bumped to ``1.1.0`` (MINOR — additive). H3 snapshot updated.

## 2. PRD schema + parser

``ralph_py.prd.PRD`` gains optional ``allowed_paths: list[str] | None``. Schema accepts ``allowedPaths`` as an optional 3rd top-level key. When present, must be a non-empty array of non-empty strings; an empty array is rejected explicitly.

``decompose._validate_decompose_output`` gates the architect's output before writing to disk: bad shape halts the pipeline rather than producing a quietly-broken PRD.

Legacy PRDs without the field still load (``allowed_paths=None``) — non-breaking for v1.0.0 architect outputs.

## 3. Factory wiring

``factory.py`` used to call ``run_mechanical_verification(..., allowed_paths=None, ...)`` unconditionally. Now loads the PRD inside Phase 1 setup and forwards ``prd.allowed_paths``. Load errors fall back to ``None`` defensively (the verifier itself surfaces real PRD problems on its own checks).

## H2 compliance

Re-ran the architect calibration on v1.1.0 against Haiku:

| Run | spec-01-no-error-handling | spec-02-unspecified-auth | spec-03-ambiguous-perf | Rate |
|---|---|---|---|---|
| v1.0.0 baseline | missed | caught | caught | 2/3 (67%) |
| v1.1.0 (this PR) | caught | missed | caught | 2/3 (67%) |

Detection rate held at 67%. The missed-fixture rotation is within LLM run-to-run variance at single-run sample size; the same Haiku-taxonomy bias documented for v1.0.0 explains both misses. The prompt change did not regress the spec-issue detection axis (the only axis the existing fixtures grade).

Whether the architect now reliably emits ``allowedPaths`` for non-halting specs is a separate measurement that the current fixtures do not cover (they're all designed to halt). Adding a non-halting fixture to grade ``allowedPaths`` quality is a future calibration-suite improvement.

Raw: ``tests/adversarial_fixtures/_results/baseline-20260527-191337.json``. Interpretation appended to ``docs/f5-calibration-baseline.md``.

## Test plan

- [x] ``uv run pytest`` — **677 passing** (was 662; +15), 11 skipped
- [x] ``uv run mypy ralph_py/ --strict`` — clean
- [x] ``uv run ruff check ralph_py/ tests/`` — clean
- [x] H3 snapshot updated; ``test_prompt_versions`` confirms ``DECOMPOSE_PROMPT`` joint ``(hash, version)`` matches
- [x] H2 calibration re-run against Haiku; no regression
- [x] New unit tests:
  - 5 in ``test_decompose.TestValidateDecomposeOutput`` for allowedPaths shape gating
  - 10 in new ``test_prd_allowed_paths.py`` for PRD schema + loader

## Out of scope for this PR (follow-ups)

- A non-halting calibration fixture that grades whether the architect emits sensible ``allowedPaths``. Today's fixtures all halt the architect on blocker-severity spec issues, so the new prompt rule is unmeasured by the suite.
- End-to-end re-run on ``examples/hmac-signer-spec.md`` to confirm the diff-scope check now fires correctly when an agent goes out of scope. Costs another ~$1-2 in Haiku and depends on this PR merging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)