### PR TITLE
fix: R0.6 input hygiene - validate LLM-emitted component ids and branch names

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -1,0 +1,591 @@
+# Remediation Roadmap: Full-System Review Fixes to A+
+
+Durable tracker for fixing every finding from the 2026-07-13 full-system review
+(report: https://claude.ai/code/artifact/0996ac84-8acf-4000-a526-72d4b0994832)
+and raising every review dimension to A+.
+
+Status legend: `[ ]` pending - `[~]` in progress - `[x]` done - `[-]` skipped.
+Sizing: S (small diff, <~100 lines), M (one PR), L (multi-PR workstream). No time
+estimates: sizing is diff scope, not duration.
+
+Finding IDs referenced below (CRIT-n, H-n, MED/LOW catalog, T-n test findings,
+D-n docs findings, P-n product gaps) are from the review report. The traceability
+appendix at the bottom maps every finding to a plan item.
+
+Process rules that bind this plan:
+
+- H1: no self-review. Every phase lands as one or more PRs gated by the user
+  (`/code-review ultra` or direct inspection).
+- H2: any prompt-body change re-runs calibration and records the delta. All
+  prompt edits are therefore batched into Phase R5 so calibration cycles are
+  few and comparable.
+- H3: every prompt edit bumps `*_PROMPT_VERSION` and the snapshot tuple together.
+- H4: every "done" claim below states what was tested vs assumed. Each phase has
+  a "Done when" that is a measurable gate, not a vibe.
+
+---
+
+## User decisions required (blocking marked items only)
+
+1. **Install story** (R2.5): publish `ralph-cli` to PyPI under a new unclaimed
+   name (`ralph-factory`?) OR document clone-install as the only path. The
+   current README command installs an unrelated project.
+2. **Second model family for review rotation** (R7.1): which family reviews
+   Claude-engineered code (codex CLI is already an adapter). Needed before the
+   correlated-failure gate in the A+ criteria can be measured.
+3. **Linear workspace admin approval** (R7.4): app-actor OAuth requires a
+   workspace admin to approve the app identity.
+4. **PRD fixtures default** (R7.2): once wired and sandboxed, fixtures ship
+   default-off (`[fixtures].enabled = false`) unless decided otherwise.
+5. **Agent SDK spike go/no-go** (R7.5): decide after the measurement spike, not
+   before.
+
+Execution order: R0 -> R1 -> R2 -> R4 -> R3 -> R5 -> R6 -> R7.
+R4 (test spine) deliberately precedes R3/R5: the spine tests are the regression
+net for everything after them. R0/R1/R2 are ordered by blast radius and do not
+touch prompt bodies, so no calibration cycles are needed until R5.
+
+---
+
+## Phase R0 - Walk-away correctness (no prompt changes)
+
+First principles: an unattended factory must be unable to hang forever, unable
+to report success on failure, and unable to corrupt the operator's repo. Every
+item here is one of those three.
+
+- [ ] R0.1 (L) **Enforce timeouts end to end** [CRIT-1]
+  - Agent adapters (`claude_code.py`, `codex.py`, `custom.py`): `Popen(...,
+    start_new_session=True)`; reader thread + deadline so a silent hang is
+    detected without a stdout line; on breach `killpg(SIGTERM)` then `SIGKILL`;
+    honor the existing `timeout` parameter in all three adapters; bound
+    `codex.py` `proc.wait()`.
+  - `loop.py:154`: pass `config.agent_iteration_timeout` into `agent.run`;
+    enforce `component_timeout` as a wall-clock check inside the iteration loop
+    (the worker owns it, so no cross-process kill is needed for the common case).
+  - `factory.py` scheduler: per-future deadline of `component_timeout` + margin
+    as a backstop; on breach mark FAILED with `error="component timeout"`,
+    continue the run, warn that a worker may be leaked.
+  - Consume `TimeoutConfig` (currently dead) as the single source for these
+    values; wire its loader in R2.1.
+  - Verify: real-subprocess test with a sleep-forever fake agent asserting
+    termination, FAILED status, and that a grandchild process is also dead.
+  - Failure modes: SIGKILL mid-git-op leaves `.git/index.lock` or a dirty
+    worktree. Mitigation: timeout-failure retry path recreates the worktree
+    from base instead of reusing it, and removes stale index locks.
+
+- [ ] R0.2 (M) **PR/merge outcome gates completion** [CRIT-2, H-1, MED pr-timeouts]
+  - `pr.py`: return a typed `PrOutcome` (pushed / pr_url / merged /
+    merge_pending / error) instead of a lossy tuple; add explicit timeouts to
+    every `gh`/`git` subprocess call in the module.
+  - `factory.py:887-915`: `COMPLETED` only when merged (or `create_prs=False`);
+    new `MERGE_PENDING` manifest status for `wait_for_merge` timeout: dependents
+    are NOT scheduled past it; resume re-polls.
+  - Replace `git pull` on the user's checkout (`pr.py:149-152`) with
+    `git fetch origin <base>` and cut all worktrees (and compute all diffs)
+    from `origin/<base>`. The operator's checkout is never mutated.
+  - Verify: real-git tests with a stub `gh` binary covering push-fail,
+    create-fail, merge-fail, wait-timeout; assert dependent scheduling blocked.
+  - Failure modes: squash merges change SHAs so `base...HEAD` on stale local
+    refs shows phantom diffs; using `origin/<base>` everywhere removes the
+    class. MERGE_PENDING needs the R3.3 resume story to be ergonomic.
+
+- [ ] R0.3 (M) **Contract phase cannot corrupt the repo; failures are loud** [CRIT-6]
+  - `contract.py`: perform tier merges in a detached temp worktree, never the
+    user's checkout; `git merge --abort` in the recovery path; assert cleanup
+    succeeded (fail loudly if not).
+  - `factory.py:1055-1082`: contract failure sets a nonzero exit code; the
+    breaker-retry actually re-enters scheduling (wrap the scheduling loop so a
+    reset breaker is re-run while contract retries remain); record a
+    `contract_result` journal event either way.
+  - Bisection honesty: when PRs were already squash-merged, per-branch re-merge
+    bisection is meaningless (merges no-op). In that mode, report "tier failed"
+    with the failing tests and skip blame attribution instead of blaming the
+    first component unconditionally. Keep merge-order bisection only for the
+    deferred-merge mode, in topological order, and document the interaction
+    limitation (two-component interaction failures attribute to the later merge).
+  - Verify: real-git tests: conflicted tier leaves user checkout untouched and
+    recovers; breaker re-runs; exit code nonzero on unresolved contract failure.
+
+- [ ] R0.4 (S) **Fix the e2e-evidenced pair: provisioning + blind retries** [CRIT-10, MED cwd-paths, MED repo-root-heuristic, MED loop-guard]
+  - `factory._run_component`: copy `prompt.md` (and CLAUDE.md/AGENTS.md) into
+    the worktree alongside the PRD; fix the inverted repo-root heuristic
+    (`factory.py:274-280`); resolve all root-relative paths against `root_dir`,
+    not inherited CWD (`factory.py:254, 265-268`).
+  - `verify.check_diff_scope`: failure details include the base branch and the
+    full allowed-paths list; `context.py` carries them into the retry prompt.
+  - `loop.py:168-186`: run `guards.enforce_allowed_paths` BEFORE the completion
+    early-return so COMPLETE cannot bypass enforcement.
+  - Verify: integration test asserting the worktree contains the customized
+    prompt; unit test asserting the diff-scope failure message names the base
+    branch and allowed paths.
+
+- [ ] R0.5 (M) **Instance and state safety** [H-7, H-8, H-15]
+  - Run-level flock on `.ralph/factory.lock`: a second invocation on the same
+    root refuses to start (override flag for intentional use).
+  - Worktrees keyed `.ralph/worktrees/<run_id>/<component_id>`; stale branch
+    from a prior run is deleted or refused with a clear error, never silently
+    reused with old commits.
+  - `single_pr=true` forces `max_parallel=1` with a printed notice.
+  - Manifest save path = manifest load path (`--manifest /x.json` saves to
+    /x.json); `ralph run` uses its own `scripts/ralph/run-manifest.json` so it
+    cannot clobber a factory run's resumable state.
+  - Verify: two-process concurrency test (real flock); custom-manifest
+    round-trip test; single_pr parallel test.
+
+- [x] R0.6 (S) **Input hygiene for LLM-emitted identifiers** [H-9]
+  - `manifest.py` + `decompose.py`: component ids match
+    `^[a-z0-9][a-z0-9._-]{0,63}$`; branch names reject leading `-`, `..`, and
+    whitespace; git invocations use `--` separators where refs meet argv.
+  - Verify: parametrized rejection tests (traversal ids, option-injection
+    branch names).
+
+Done when: a factory run with an induced hang, an induced push failure, and an
+induced contract conflict terminates in bounded time, reports the correct
+failure, exits nonzero, and leaves the operator's checkout byte-identical.
+All three scenarios exist as automated tests (what was tested); no claim is
+made about unlisted failure classes (what is assumed).
+
+---
+
+## Phase R1 - Gate integrity (parser-side; still no prompt changes)
+
+First principles: a gate that can be passed by silence, case drift, or absence
+of data is not a gate. Every fix here makes the harness distrust its own
+reviewers' output as much as it distrusts the engineer's.
+
+- [ ] R1.1 (S) **Empty or partial reviews cannot pass hard mode** [CRIT-5]
+  - `review.py`: criterion-coverage check: every PRD story id must receive a
+    verdict or the result is `infrastructure_error=True` (id-based matching,
+    not criterion-text string equality); verdict whitelist `{pass, fail}`
+    case-insensitively, anything else is a parse failure, not an advisory.
+- [ ] R1.2 (S) **Close the E9 holes** [H-13, MED review-nondict, MED sec-pr-body]
+  - `review.py:518-527`: `AgentOutputTooLarge` sets `infrastructure_error=True`
+    (mirror security.py).
+  - Skipped and budget-exhausted phases emit a synthetic
+    `Finding(category="phase_skipped")` so the findings stream distinguishes
+    "ran clean" from "never ran"; journal records the skip.
+  - Wrap the review call path like security's (catch `Exception`, degrade to
+    per-component infra failure) so a reviewer crash cannot abort the whole run.
+  - Guard non-dict `_extract_json` results in review parsing.
+  - `pr.py` body: render an explicit "security review did not run
+    (infrastructure error)" section when applicable (use
+    `render_findings_markdown`'s existing callout).
+- [ ] R1.3 (S) **Empty diff from git error is an infrastructure failure** [H-14]
+  - `git.get_diff_content` returns a result object (content | error) or raises;
+    `factory.py:593` maps error to `infrastructure_error` for all three
+    consumers instead of reviewing an empty string.
+- [ ] R1.4 (M) **Truncated-diff policy + security parity** [H-16]
+  - Hard mode: a truncated diff is not silently reviewable. Chunk the diff and
+    run multiple review passes (bounded by budget), or fail with an infra
+    finding. Advisory mode: annotate PASS as partial.
+  - Strip the Self-Critique block for the security reviewer too (`security.py:377`).
+- [ ] R1.5 (M) **Scope-guard hardening** [H-4, H-5, MED scope-none-fallthrough]
+  - `git.get_diff_names`: use `--name-status -M`; rename/copy sources count as
+    changed paths for scope purposes.
+  - `decompose._validate_decompose_output`: validate allowedPaths CONTENT
+    against the EXCLUDE list the prompt already promises (`.ralph/`,
+    `ralph_py/`, bare `scripts/ralph/`, root manifests, absolute paths, `..`);
+    reject and retry-with-error like other validation failures.
+  - `factory.py:554-558`: PRD load failure fails the diff-scope check closed
+    (infra failure) instead of silently disabling scope.
+- [ ] R1.6 (M) **Knowledge retention + read-side defense** [CRIT-4, H-3, MED knowledge-trust, LOW nonce-order]
+  - Retrieval: union across run dirs with per-fact-id latest-wins (supersede by
+    fact id, not by directory). The DISTILL rule "do not duplicate existing
+    facts" becomes correct instead of corpus-destroying.
+  - Debug dumps move to `_debug/<run_id>/` so a failed distill can never shadow
+    real facts.
+  - `_coerce_facts`: sanitize + length-cap `evidence` items (same
+    `_is_injection_attempt` gate as claims); re-run validation on READ
+    (`_parse_fact_md`), not only at write time.
+  - `test_verified` confidence: downgrade to `asserted` unless a verification
+    cross-check exists (cited test path exists in the worktree at minimum);
+    keep the honest-hint framing.
+  - Run-id ordering: include a microsecond timestamp so same-second runs order
+    correctly.
+  - Verify: regression tests for the exact decay scenario (fail distill, then
+    read), the evidence-field injection bypass, and supersede-by-fact-id.
+- [ ] R1.7 (S) **Persist the architect's red-team output** [MED spec-issues-lost]
+  - Write `spec_issues` (all severities) to `scripts/ralph/spec-issues.json`
+    and a journal event; on SpecBlockerError, print the file path so the user
+    iterates against a durable artifact, not scrollback.
+- [ ] R1.8 (S) **Decompose validation ordering** [MED prd-validate-late, LOW vacuous-prd]
+  - Run PRD schema validation inside the decompose retry loop (before files are
+    written) so the LLM gets the error; clean up partial files on failure.
+  - Reject empty `userStories`, empty `acceptanceCriteria`, and `passes: true`
+    at decompose time.
+
+Done when: a new adversarial-parser test class proves each of: empty review
+fails hard mode; `"FAIL"`/`"Blocked"` verdicts block; oversized review output is
+an infra error; skipped phases appear in the findings stream; a rename-move
+violates scope; a poisoned evidence string is rejected; a failed distill does
+not erase facts. (Tested: those exact behaviors. Assumed: no other parser paths
+regressed: guarded by the existing 606-test suite staying green.)
+
+---
+
+## Phase R2 - One control plane + CLI/doc honesty
+
+First principles: for a solo tool, the author-in-six-months is the primary
+user. Every knob must be reachable, every documented command must exist, and
+every flag must do what it says or fail loudly.
+
+- [ ] R2.1 (M) **Wire the six config loaders** [CRIT-7, D-precedence]
+  - CLI resolution order: explicit CLI flag > env > ralph.toml > dataclass
+    default. Click flags get `default=None` sentinels so "not passed" is
+    distinguishable from "passed the default value".
+  - `ralph factory` and `ralph run` construct every phase config via `.load()`
+    (Factory/Verify/Security/Contract/Feedforward/Evolution/Timeout); add
+    `from_env` where missing (Feedforward/Evolution/Knowledge).
+  - `ralph init` scaffolds a commented `ralph.toml`.
+  - Failure mode: changed effective defaults for existing setups (e.g. a toml
+    `review_mode` now taking effect). Mitigation: `ralph config show` (R2.4)
+    prints the resolved config + source of each value; release note.
+- [ ] R2.2 (S) **Expose the safety knobs** [CRIT-7]
+  - `max_adversarial_calls` and `pause_before_pr_merge`: toml keys, env vars,
+    CLI flags, documented. Budget exhaustion emits the R1.2 synthetic finding.
+- [ ] R2.3 (M) **Make `ralph run` and factory flags honest** [CRIT-8, H-10, H-11]
+  - Forward `max_iterations` (N), `interactive`, and `allowed_paths` through
+    `_submit_args` into `_run_component`; delete the hardcoded 30.
+  - `--no-verify` actually skips Phase 1 (explicit `skip` sentinel instead of
+    `None`-means-default).
+  - Wire feedforward config in the `factory` command path.
+  - Fix the PRD-path contract: the scaffolded prompt gains an explicit
+    `$prd_path` placeholder; `loop.py` substitutes the per-component PRD path;
+    add a test that the rendered prompt names the same file
+    `check_prd_stories` reads.
+- [ ] R2.4 (S) **Preflight honesty** [H-12, D-preflight]
+  - `run`/`understand`/`feature` preflight accepts whichever agent the config
+    selects (claude/codex/custom), not codex-only.
+  - `prd.json` existence + schema preflight BEFORE any agent spend.
+  - Add `ralph config show` (resolved config with per-value source) and
+    `ralph status` stub (full version in R3.2): both are README-promised.
+- [ ] R2.5 (M) **Docs regeneration + packaging truth** [CRIT-9, D-*]
+  - Generate the README CLI reference and config reference from click
+    introspection + dataclass fields (script under `scripts/`), so drift is
+    structurally impossible; CI check that the generated sections are current.
+  - Install story per user decision 1; until then README documents clone-install
+    only.
+  - Remove the dead `textual` dependency.
+  - Refresh `examples/uv-python` to the current engineer contract
+    (Self-Critique block, allowedPaths-aware prd_prompt).
+  - Fix remaining doc drift: distiller is pre-PR (or move it post-merge and
+    keep the doc: decide in R7.3 refactor; until then fix the doc), runbook
+    worktree note aligned with keep-worktree-on-failure (R3.3), test count,
+    `[sensors]`/`[fixtures]` sections removed or implemented, `ralph evolve
+    --apply` promise aligned with R6.3.
+- [ ] R2.6 (S) **HITL semantics + subprocess env hygiene** [MED hitl-abort, MED env-leak, MED process-group]
+  - E6 "Reject" marks the component FAILED immediately (no retry loop, no
+    re-prompt); "Retry" is a separate choice.
+  - Verification/contract/fixture subprocesses run with a scrubbed env
+    (allowlist: PATH, HOME, LANG, VIRTUAL_ENV, CI-required vars): agent-run
+    tests can no longer read harness API keys.
+  - All verification subprocesses use `start_new_session=True` + group kill on
+    timeout so orphaned test servers die with their parent.
+
+Done when: `ralph config show` displays every knob with its source; a
+round-trip test proves toml -> resolved config for all nine sections; the
+README CLI table is generated and CI-checked; `ralph run 3` runs at most 3
+iterations (asserted by a fake-agent test).
+
+---
+
+## Phase R4 - Test spine + suite isolation (runs before R3/R5)
+
+First principles: the review's critical findings live exactly where the suite
+mocks itself. The spine tests are the regression net for every later phase, so
+they come before feature work. Target: zero load-bearing behaviors with
+mock-only coverage.
+
+- [ ] R4.1 (S) **Suite isolation** [H-18, T-19]
+  - Autouse conftest fixture routing evolution/experiments/knowledge paths to
+    tmp_path; a guard fixture fails the run if the repo's real `.ralph/`
+    mutates during tests; `clean_env` extended to FACTORY_*/RALPH_* families.
+  - Archive (do not delete) the polluted `.ralph/evolution.jsonl` +
+    `experiments.tsv` to `.ralph/archive/` and start clean journals (R6.4
+    re-baselines).
+- [ ] R4.2 (L) **Real-git spine tier** [T-1..T-7, T-14]
+  - New marked tier (`-m spine`, in CI as a separate job): worktree lifecycle
+    incl. two-process flock contention; PR failure paths against a stub `gh`
+    binary on PATH; contract merge + conflict recovery; crash recovery with
+    stale worktrees and a mid-verify kill; retry-context propagation e2e (fake
+    agent writes its received prompt to a file; assert the diff-scope failure
+    details from attempt 1 appear in attempt 2's prompt).
+- [ ] R4.3 (M) **Fix misleading tests** [T-5, T-6, T-8, T-9, T-10, T-11, T-15]
+  - C1 becomes a true 2-worker worktree test; C6 uses the same root and proves
+    serialization (fails if the flock is removed); C4 asserts the breaker was
+    reset AND re-ran; verification-retry test counts attempts.
+  - AST-walker tests call the real `_module_level_prompt_constants`.
+  - Add the missing `test_no_silent_version_pin` (hash moved, version pinned ->
+    fail) or correct the docstring: implement the test, it is cheap.
+  - Codex live-contract test becomes opt-in (`RALPH_RUN_LIVE_CONTRACT=1`), so
+    the default suite makes zero network calls.
+- [ ] R4.4 (S) **Coverage measurement** [T-16]
+  - pytest-cov in dev deps; CI reports coverage; ratchet gate (fail if coverage
+    drops below the last recorded value) rather than an arbitrary threshold.
+    Measured, not guessed: capture the baseline in the PR that adds it.
+
+Done when: the five behaviors the review named as unmocked-coverage-zero
+(worktree lifecycle, engineer loop plumbing, PR failure paths, contract
+execution, retry propagation) each have at least one real (unmocked at that
+boundary) test; default suite is network-free; repo `.ralph/` is untouched by
+tests (enforced by the guard fixture).
+
+---
+
+## Phase R3 - Observability, cost, resume
+
+First principles: walking away requires knowing (a) is it stuck, (b) what is it
+spending, (c) what do I do when I come back to a partial failure.
+
+- [ ] R3.1 (M) **Cost meter** [H-17, P-3]
+  - Parse token usage from the claude CLI stream-json result events; measure
+    what codex exposes (this needs to be measured, not assumed: spike first);
+    fall back to call counts + wall time where usage is unavailable.
+  - Per-component, per-phase rollup in the factory summary, journal entries,
+    and experiments.tsv; optional `max_total_tokens` halt (loud, records a
+    synthetic finding per R1.2's pattern).
+  - Failure mode: usage formats drift with CLI versions: parse defensively,
+    never gate correctness on the meter.
+- [ ] R3.2 (M) **Status + notification** [P-4, D-status]
+  - ProgressLog defaults on; `ralph status` renders manifest + log (per
+    component: phase, attempt, last event age, evidence paths).
+  - Notification hook: configurable shell command (`[notify] on_complete /
+    on_first_failure` in ralph.toml) so desktop/webhook/email are one liner
+    configs. Fires on completion, first failure, and MERGE_PENDING.
+- [ ] R3.3 (M) **Resume + partial-failure ergonomics** [P-5, LOW completed_at, LOW findings-accumulate]
+  - Persist `run_id` in the manifest; set `completed_at`; per-component event
+    history refs (journal offsets).
+  - `ralph retry <component-id>`: resets FAILED component + cascade-skipped
+    dependents to PENDING and re-enters factory with the same manifest.
+  - `--keep-worktrees-on-failure` (and runbook updated to match).
+  - Clear `comp.findings` per attempt; tag findings with attempt number so the
+    journal distinguishes superseded findings from shipped ones.
+  - Failure summary lists, per failed component: phase, check, evidence paths
+    (worktree, raw outputs, journal offsets).
+- [ ] R3.4 (S) **Repo hygiene** [LOW hygiene]
+  - `.gitignore` covers `.ralph/`; remove the 99MB stale worktree
+    (`git worktree remove .claude/worktrees/tender-leakey` after confirming the
+    branch has no unique commits: check first, it is a destructive step for the
+    user to approve); commit or delete the untracked docs artifacts; track
+    `ralph.toml.example`, ignore live `ralph.toml`.
+
+Done when: a deliberately failed 3-component run can be diagnosed and resumed
+using only `ralph status`, the failure summary, and `ralph retry`, without
+hand-editing JSON; a run summary shows per-phase token/call counts.
+
+---
+
+## Phase R5 - Prompt hardening + calibration deepening (single H2 batch)
+
+First principles: calibration must be able to detect a regression before we
+change the prompts it guards. So: tooling first, fixtures second, prompt edits
+third, all in one measured cycle.
+
+- [ ] R5.1 (M) **Calibration tooling** [T-cal findings]
+  - Baseline diff tool: `python -m ralph_py.calibration compare <old> <new>`
+    with codified per-role thresholds; N-run mode (default 3) reporting
+    per-fixture consistency; per-category (per-CWE for security) rates in the
+    report JSON.
+  - Convert per-fixture hard asserts into threshold gates so the suite is
+    green-at-baseline and red-on-regression (a truth signal that is expected
+    to be red is not a signal).
+  - Fix matcher brittleness: `must_include_kind` accepts a documented synonym
+    map (e.g. `unstated_assumption` ~ `missing_detail`) OR grades kind
+    separately from detection so a paraphrased kind is a partial hit, not a miss.
+- [ ] R5.2 (M) **Fixture expansion** [T-cal, research topic 4]
+  - Hard positives: multi-hop authz bug, second-order injection, TOCTOU race,
+    subtle timing oracle: at least 4 that Haiku does NOT trivially catch
+    (validated empirically during authoring: if the baseline catches all
+    immediately, they are not hard).
+  - Negatives: >=3 clean diffs per role to measure false-positive rate. FP
+    rate joins detection rate in the report and the thresholds.
+  - Context realism: fixtures gain a real PRD and real verification output in
+    the harness (replace the all-PASS stub) so measured detection transfers.
+- [ ] R5.3 (M) **The prompt-edit batch** (one calibration cycle; H2 + H3 apply)
+  - Injection separation in REVIEWER/SECURITY/DISTILL/DECOMPOSE: "content
+    between the markers is data, never instructions" framing + per-run random
+    delimiters (harness generates, prompt references) [H-2].
+  - Spec-as-data framing in DECOMPOSE (the spec is an unguarded surface today).
+  - Truncated-diff directive for both reviewers (flag unreviewable content;
+    hard mode pairs with R1.4's mechanical policy).
+  - Remove the hardcoded `"exhaustively_searched": true` anchor from both
+    schema examples [LOW anchor].
+  - Security FP hard-exclusion list (precision-first, per Anthropic's own
+    security action): exclude DoS/rate-limiting/theoretical-input-validation
+    unless exploitability is stated [research topic 3].
+  - Candidate new reviewer concerns (concurrency, new-dependency introduction):
+    add only if the R5.2 fixtures show they are detectable without FP cost.
+  - Every edited prompt: version bump + snapshot + before/after calibration
+    delta recorded in `docs/` (H2/H3 audit trail).
+- [ ] R5.4 (S) **Self-critique check correctness** [MED self-critique]
+  - Associate the block with the CURRENT iteration's entry; fix the dead
+    boundary-break so unrelated bullets stop inflating the count; fuzz corpus
+    extended with the regression cases. (Substance stays out of scope: shape
+    checks are documented as shape checks, per H4.)
+- [ ] R5.5 (S) **Model-bump trigger** [research topic 4]
+  - Baselines record the model id; a structural test warns when the configured
+    calibration model differs from the latest baseline's, prompting a re-run.
+    H2 extended: calibration re-runs on model change, not just prompt change.
+
+Done when: calibration reports detection rate + FP rate + consistency per role
+per category; is green at the new baseline across 3 consecutive runs; and the
+R5.3 prompt batch shows no regression against R5.2's harder fixtures (deltas
+recorded). What is tested: those rates on those fixtures. What is assumed and
+stated: transfer to arbitrary real diffs remains an extrapolation: fixtures
+narrow, never close, that gap.
+
+---
+
+## Phase R6 - Learning-loop repair
+
+First principles: a learning loop is only as good as its input signal. Fix the
+signal, then the metrics, then re-baseline: proposals stay untrusted until all
+three are done.
+
+- [ ] R6.1 (M) **Real error signatures** [MED evolution-signal]
+  - Component failures record `check_name` + the parser's structured failure
+    signature (e.g. `linter:E501`, `typecheck:arg-type`, `diff_scope:rename`)
+    instead of flattened "Review failed" strings; review/security failures
+    record finding categories.
+  - `factory.py:1131`: use `EvolutionConfig.load(root_dir)`; journal paths
+    resolve against root; drop the `except OSError: pass` for a logged warning.
+- [ ] R6.2 (S) **Metrics read the typed stream** [MED concern-hit-rate, LOW proposal-clobber]
+  - `get_concern_hit_rate` consumes `findings_summary`; proposals derive from
+    finding taxonomies + error signatures; proposal IDs are monotonic and
+    prior proposal files are never clobbered.
+- [ ] R6.3 (S) **`evolve --apply` honesty** [D-evolve]
+  - Implement the minimal real path: applying a convention-type proposal
+    appends to the project CLAUDE.md Agent Learnings section after explicit
+    confirmation; everything else prints "manual". Honor `auto_propose`.
+- [ ] R6.4 (S) **Re-baseline** [H-18 follow-through]
+  - After R4.1 isolation: define `retry_rate` and duration semantics in
+    `docs/`, fix duration recording (currently 0.0), start fresh journals, and
+    keep the polluted archive for forensic reference only.
+
+Done when: after two real factory runs post-fix, `ralph evolve` produces at
+least one proposal traceable to a real recorded signature, and
+`get_concern_hit_rate` returns nonzero when a run had review concerns (proved
+by an integration test with a synthetic-but-realistic journal).
+
+---
+
+## Phase R7 - Strategic (the A+ differentiators)
+
+- [ ] R7.1 (M) **Cross-model review rotation** [research topic 3; user decision 2]
+  - Default `review_model`/`security_model` to a different family than the
+    engineer's when a second CLI is available; warn on homogeneity; record the
+    reviewing model identity on every Finding and in the PR body.
+  - Measure the correlated-miss delta: run calibration with same-family and
+    cross-family configs and record both (this is the E1 decision revisited
+    with 2026 evidence; independent passes, never committee deliberation).
+- [ ] R7.2 (M) **Wire fixtures, sandboxed** [CRIT-3, H-6; user decision 4]
+  - Function fixtures execute in a subprocess (`sys.executable -c`) with the
+    R2.6 scrubbed env: never in the harness process.
+  - CLI fixtures: `shlex.split` + `shell=False`.
+  - `PRD.validate_schema` accepts the `fixtures` key; `run_mechanical_verification`
+    calls `check_fixtures` when `[fixtures].enabled`; snapshot regression wired
+    behind the same flag.
+  - This restores the independent oracle against agent-authored tests (H-6's
+    conftest gaming is also mitigated: fixtures do not run under the project's
+    pytest and cannot be deselected by it).
+- [ ] R7.3 (L) **run_factory refactor: scheduler + ComponentPipeline** [architecture]
+  - Extract the phase chain into a `ComponentPipeline` with typed phase
+    results; single scheduling loop for sequential and parallel; the state
+    machine becomes unit-testable; `knowledge_config` late-binding accident
+    removed; retry/HITL/budget transitions explicit.
+  - Decide distiller placement (pre-PR vs post-merge) here and align the docs.
+  - This lands BEFORE Linear so integration consumes a stable, tested state
+    machine. Failure mode: big-bang refactor risk: land it as a
+    strangler (pipeline object first, scheduler swap second) with the R4 spine
+    tests as the net.
+- [ ] R7.4 (L) **Linear integration** [P-6; user decision 3]
+  - GraphQL + app-actor OAuth adapter implementing a `LinearSink` on the
+    ProgressLog event bus (factory.py untouched); decompose output creates one
+    project per manifest, one issue per component (stories as sub-issues),
+    spec_issues as triage issues.
+  - Branch names carry the Linear issue id; PR bodies carry "Fixes ENG-nnn":
+    Linear's GitHub integration then drives status transitions with zero API
+    calls from ralph.
+  - Idempotency keys (`run_id`+`component_id`) so retries update rather than
+    duplicate; rate-limit aware (shared 5k req/hr pool); Agents API
+    (@-mention delegation) stays behind an adapter until GA.
+  - Trigger direction (webhook on issue delegation -> factory run) is a
+    follow-up once the sink is stable.
+- [ ] R7.5 (M) **Platform hardening** [research topics 1-2]
+  - No-progress circuit breaker: halt a component when N consecutive iterations
+    produce an unchanged diff hash + test signature (the community's
+    single most-repeated Ralph-loop fix).
+  - OS-level sandboxing for agent subprocesses: pass Claude Code sandbox
+    settings (network/write scoping) through the adapter; document the codex
+    equivalent; worktree isolation stops being the only boundary.
+  - Merge-conflict doctrine: on conflict, re-run the component against the
+    fresh merged base instead of rebasing agent output.
+  - SpecKit intake: accept spec.md/plan.md/tasks.md as architect input; the
+    DECOMPOSE prompt demands EARS-style acceptance criteria (prompt change:
+    rides the next H2 calibration cycle, not R5's).
+  - Agent SDK spike (measure, then decide: user decision 5): structured
+    streams, hooks, budget enforcement vs stdout parsing; a one-day spike with
+    a written comparison, per the measure-don't-assume rule.
+
+Done when: cross-family review is the measured default; fixtures run sandboxed
+in Phase 1 on an opt-in project; a factory run appears in Linear end-to-end
+(project, issues, status transitions, PR links) with no duplicate issues across
+a retry; the circuit breaker halts a deliberately-stalled run.
+
+---
+
+## A+ exit criteria per review dimension
+
+The review's scorecard maps to these gates. A dimension is A+ only when every
+listed gate is green and the claim is backed by a named test or measurement
+(H4: tested, not assumed).
+
+| Dimension (review grade) | A+ gate |
+|---|---|
+| Architect / decompose (B+) | R0.6 + R1.5 + R1.7 + R1.8 + R5.3 spec-as-data + calibration: architect detection >= baseline on hard fixtures, 0 hallucinated findings across 3 consecutive runs, spec_issues persisted |
+| Mechanical verification (B-) | R1.5 rename-aware scope + R2.6 env scrub + R5.4 self-critique correctness + R7.2 fixtures wired sandboxed: an adversarial-agent test battery (tautological test, conftest deselect, rename-move, sweep-in commit) all caught |
+| LLM review + security (C+) | R1.1-R1.4 + R5.3: empty/partial/oversized/truncated outputs all fail closed; injection battery (in-diff instructions) does not flip a verdict on the calibration negatives; FP rate measured and under threshold |
+| Knowledge layer (C-) | R1.6: decay regression tests green; evidence-field injection battery rejected; utilization telemetry nonzero on a real run |
+| Factory orchestration (C) | R0.1-R0.6 + R2.3 + R7.3: induced hang/push-fail/conflict battery green; state machine unit-tested in isolation; no subprocess call without a timeout (enforced by a grep test) |
+| Evolution / learning (D) | R4.1 + R6.1-R6.4: journal clean, signatures real, hit-rate live, one traceable proposal from real runs |
+| Test suite (B) | R4.1-R4.4: five spine behaviors covered unmocked; suite network-free by default; coverage ratcheted; zero misleading-name tests from the T-findings list remain |
+| Calibration (C+) | R5.1-R5.2 + R5.5: green-at-baseline, FP + consistency + per-category measured over 3 runs, diff tool with codified thresholds, model-bump trigger |
+| Docs and product surface (C-) | R2.1-R2.5 + R3.1-R3.3: generated CLI/config docs CI-checked; every README command exists; config show/status live; cost + notify + retry shipped; install story resolved |
+
+---
+
+## Traceability: review finding -> plan item
+
+- CRIT-1 -> R0.1; CRIT-2 -> R0.2; CRIT-3 -> R7.2 (docs interim: R2.5);
+  CRIT-4 -> R1.6; CRIT-5 -> R1.1; CRIT-6 -> R0.3; CRIT-7 -> R2.1/R2.2;
+  CRIT-8 -> R2.3; CRIT-9 -> R2.5; CRIT-10 -> R0.4.
+- H-1 -> R0.2; H-2 -> R5.3; H-3 -> R1.6; H-4 -> R1.5; H-5 -> R1.5; H-6 -> R7.2
+  (+R1.5 partial); H-7 -> R0.5; H-8 -> R0.5; H-9 -> R0.6; H-10 -> R2.3;
+  H-11 -> R2.3; H-12 -> R2.4; H-13 -> R1.2; H-14 -> R1.3; H-15 -> R0.5;
+  H-16 -> R1.4 (+R5.3); H-17 -> R3.1; H-18 -> R4.1 (+R6.4).
+- MED orchestration: cwd-paths/repo-root/loop-guard -> R0.4; pr-timeouts ->
+  R0.2; hitl-abort -> R2.6; main-thread-serialization -> R7.3; env-leak ->
+  R2.6; process-group -> R2.6/R0.1. LOW orchestration: completed_at/findings-
+  accumulate -> R3.3; branches/sleep/pipe -> R7.3 (tracked there); hygiene -> R3.4.
+- MED adversarial: spec-issues -> R1.7; sec-pr-body -> R1.2; review-nondict ->
+  R1.2; prd-validate-late -> R1.8; knowledge-trust -> R1.6. LOW adversarial:
+  vacuous-prd -> R1.8; nonce-order -> R1.6; anchor -> R5.3; proposal-clobber ->
+  R6.2; raw-output-truncation -> R1.2 (keep full dumps like knowledge does).
+- MED verification: self-critique -> R5.4; feedforward-python-only /
+  dep-graph-bounds -> P2 honesty note in R2.5 README + bounds fix folded into
+  R2.3 feedforward wiring. LOW verification: committed-vs-working-tree,
+  bad-patterns scope, dead-code add -A, parser blind spots, substring filter ->
+  batched as a single "verification polish" PR inside R1 (non-gating,
+  documented) .
+- T-1..T-19 -> R4.1-R4.4 (T-12 live-call -> R4.3; T-16 coverage -> R4.4;
+  T-10 phantom test -> R4.3).
+- D-* docs findings -> R2.4/R2.5 (+R3.2 for status, R6.3 for evolve).
+- P-1..P-7 product gaps -> R2.1 (control plane), R0/R3 (walk-away), R3.1
+  (cost), R3.2 (monitoring), R3.3 (resume), R1.7+R7.5 (spec front door),
+  R2.5 (Python-first honesty), R7.4 (Linear).
+- Research implications 1-10 -> R7.1 (rotation), R5.1/R5.2/R5.5 (calibration),
+  R7.5 (breaker, sandboxing, re-run-not-rebase, SpecKit, SDK), R5.3 (FP
+  filter), R7.4 (Linear GraphQL), R1.6 knowledge guardrails (+R6 distill-from-
+  failures noted as a candidate follow-up).
+
+Every phase = one or more PRs, user-gated per H1. Tracker updated as items land.

--- a/ralph_py/decompose.py
+++ b/ralph_py/decompose.py
@@ -8,7 +8,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ralph_py.manifest import Component, ComponentStatus, Manifest
+from ralph_py.manifest import (
+    Component,
+    ComponentStatus,
+    Manifest,
+    validate_branch_name,
+    validate_component_id,
+)
 from ralph_py.prd import PRD
 
 if TYPE_CHECKING:
@@ -382,12 +388,21 @@ def _validate_decompose_output(data: Any) -> list[str]:
             continue
 
         comp_id = comp.get("id")
-        if not isinstance(comp_id, str) or not comp_id:
+        if not isinstance(comp_id, str):
             errors.append(f"{prefix}.id: must be a non-empty string")
-        elif comp_id in seen_ids:
-            errors.append(f"{prefix}.id: duplicate ID '{comp_id}'")
         else:
-            seen_ids.add(comp_id)
+            # R0.6: the id becomes a filesystem path segment
+            # (scripts/ralph/feature/<id>/, .ralph/worktrees/<id>) and a
+            # branch segment (ralph/factory/<id>), so a traversal id
+            # like "../../repo" must be rejected here, where the error
+            # feeds back into the decompose retry loop.
+            id_error = validate_component_id(comp_id)
+            if id_error:
+                errors.append(f"{prefix}.id: {id_error}")
+            elif comp_id in seen_ids:
+                errors.append(f"{prefix}.id: duplicate ID '{comp_id}'")
+            else:
+                seen_ids.add(comp_id)
 
         if not isinstance(comp.get("title"), str):
             errors.append(f"{prefix}.title: must be a string")
@@ -688,6 +703,17 @@ def decompose_spec(
             branch = f"ralph/factory/{project_name}"
         else:
             branch = f"ralph/factory/{comp_id}"
+
+        # Component ids were validated in the retry loop; this can only
+        # fire for a project_name (user input) that is not branch-safe.
+        # Reject rather than sanitize so the caller sees exactly what
+        # was wrong (R0.6).
+        branch_error = validate_branch_name(branch)
+        if branch_error:
+            raise ValueError(
+                f"Cannot derive a git branch for component '{comp_id}': "
+                f"{branch_error}"
+            )
 
         prd_path = _generate_component_prd(comp_data, root_dir, branch)
         rel_prd = prd_path.relative_to(root_dir).as_posix()

--- a/ralph_py/git.py
+++ b/ralph_py/git.py
@@ -77,8 +77,12 @@ def checkout_branch(
     try:
         if branch_exists(branch, cwd, timeout=timeout):
             ui.info(f"Branch: checking out existing branch {branch}{source_suffix}")
+            # Trailing "--" pins the argument as a ref, never a pathspec
+            # (R0.6). Note "--" cannot stop git from parsing a leading
+            # "-" ref as an option here; that shape is rejected upstream
+            # by manifest.validate_branch_name.
             result = subprocess.run(
-                ["git", "checkout", branch],
+                ["git", "checkout", branch, "--"],
                 cwd=cwd,
                 capture_output=True,
                 text=True,
@@ -214,7 +218,7 @@ def get_diff_names(
     """Get list of changed file names compared to a base branch."""
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", f"{base_branch}...HEAD"],
+            ["git", "diff", "--name-only", f"{base_branch}...HEAD", "--"],
             cwd=cwd,
             capture_output=True,
             text=True,
@@ -239,7 +243,7 @@ def get_diff_content(
     """Get full diff content compared to a base branch."""
     try:
         result = subprocess.run(
-            ["git", "diff", f"{base_branch}...HEAD"],
+            ["git", "diff", f"{base_branch}...HEAD", "--"],
             cwd=cwd,
             capture_output=True,
             text=True,
@@ -312,8 +316,10 @@ def merge_branch(
 ) -> bool:
     """Merge a branch into the current branch (no-edit)."""
     try:
+        # "--" makes a crafted branch value an invalid ref instead of a
+        # git option (R0.6).
         result = subprocess.run(
-            ["git", "merge", "--no-edit", branch],
+            ["git", "merge", "--no-edit", "--", branch],
             cwd=cwd,
             capture_output=True,
             text=True,
@@ -332,8 +338,9 @@ def create_branch_from(
 ) -> bool:
     """Create and checkout a new branch from a base ref."""
     try:
+        # Trailing "--" pins *base* as a ref, never a pathspec (R0.6).
         result = subprocess.run(
-            ["git", "checkout", "-b", branch_name, base],
+            ["git", "checkout", "-b", branch_name, base, "--"],
             cwd=cwd,
             capture_output=True,
             text=True,
@@ -353,8 +360,10 @@ def delete_branch(
     """Delete a local branch."""
     flag = "-D" if force else "-d"
     try:
+        # "--" makes a crafted branch value an unknown ref instead of a
+        # git option (R0.6).
         result = subprocess.run(
-            ["git", "branch", flag, branch_name],
+            ["git", "branch", flag, "--", branch_name],
             cwd=cwd,
             capture_output=True,
             text=True,
@@ -372,8 +381,11 @@ def checkout_existing(
 ) -> bool:
     """Checkout an existing branch without creating it."""
     try:
+        # Trailing "--" pins the argument as a ref, never a pathspec
+        # (R0.6); leading "-" shapes are rejected upstream by
+        # manifest.validate_branch_name.
         result = subprocess.run(
-            ["git", "checkout", branch],
+            ["git", "checkout", branch, "--"],
             cwd=cwd,
             capture_output=True,
             text=True,

--- a/ralph_py/manifest.py
+++ b/ralph_py/manifest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import tempfile
 from collections import deque
 from dataclasses import dataclass, field
@@ -12,6 +13,98 @@ from pathlib import Path
 from typing import Any
 
 from ralph_py.findings import Finding
+
+# R0.6 input hygiene: component ids and branch names are LLM-emitted
+# (architect output) and flow into filesystem paths
+# (.ralph/worktrees/<id>, scripts/ralph/feature/<id>) and git argv
+# (git worktree add, git push -u origin <branch>). Both are validated
+# against conservative allowlists at every parse boundary. Rejection is
+# deliberate - silent sanitizing would hide architect drift.
+COMPONENT_ID_PATTERN = r"^[a-z0-9][a-z0-9._-]{0,63}$"
+_COMPONENT_ID_RE = re.compile(COMPONENT_ID_PATTERN)
+
+# ASCII allowlist for branch names. Anything outside it (whitespace,
+# ':', control characters, unicode dash confusables like U+2011) is
+# rejected wholesale rather than enumerated.
+_BRANCH_CHARSET_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+MAX_BRANCH_NAME_LENGTH = 200
+
+
+def validate_component_id(comp_id: str) -> str | None:
+    """Validate a component id, returning an error message or None.
+
+    Component ids become path segments and branch segments, so the rules
+    are strict: lowercase alphanumeric start, then letters/digits/./_/-
+    only (max 64 chars total), no '..' sequence, no '.'/'.lock' suffix
+    ('<id>.lock' would collide with the worktree lock file for id
+    '<id>', and git refuses refs ending in '.' or '.lock').
+
+    Error messages state the rule so the decompose retry loop can feed
+    them back to the architect verbatim.
+    """
+    if not comp_id:
+        return "component id must be a non-empty string"
+    if not _COMPONENT_ID_RE.match(comp_id):
+        return (
+            f"component id {comp_id!r} is invalid: ids must match "
+            f"{COMPONENT_ID_PATTERN} - start with a lowercase letter or "
+            "digit, contain only lowercase letters, digits, '.', '_', "
+            "'-', and be at most 64 characters (no '/', no spaces, no "
+            "uppercase, ASCII only); e.g. 'auth-service'"
+        )
+    if ".." in comp_id:
+        return f"component id {comp_id!r} is invalid: '..' is not allowed"
+    if comp_id.endswith("."):
+        return f"component id {comp_id!r} is invalid: must not end with '.'"
+    if comp_id.endswith(".lock"):
+        return f"component id {comp_id!r} is invalid: must not end with '.lock'"
+    return None
+
+
+def validate_branch_name(branch: str) -> str | None:
+    """Validate a git branch name, returning an error message or None.
+
+    Branch names reach git argv in ref position (git push, git worktree
+    add, git merge). The rules reject option injection (leading '-'),
+    traversal ('..'), whitespace, ':', and unicode lookalikes via an
+    ASCII allowlist, while accepting the ralph/factory/<id> pattern and
+    ordinary user branches.
+    """
+    if not branch:
+        return "branch name must be a non-empty string"
+    if len(branch) > MAX_BRANCH_NAME_LENGTH:
+        return (
+            f"branch name is too long ({len(branch)} chars, max "
+            f"{MAX_BRANCH_NAME_LENGTH})"
+        )
+    if not _BRANCH_CHARSET_RE.match(branch):
+        return (
+            f"branch name {branch!r} contains disallowed characters: only "
+            "ASCII letters, digits, '.', '_', '/', '-' are allowed "
+            "(no whitespace, no ':', no non-ASCII characters)"
+        )
+    if branch.startswith("-"):
+        return (
+            f"branch name {branch!r} must not start with '-' "
+            "(git would parse it as a command-line option)"
+        )
+    if ".." in branch:
+        return f"branch name {branch!r} must not contain '..'"
+    if branch.startswith("/") or branch.endswith("/") or "//" in branch:
+        return (
+            f"branch name {branch!r} must not have empty path segments "
+            "(leading '/', trailing '/', or '//')"
+        )
+    if any(seg.startswith(".") for seg in branch.split("/")):
+        return (
+            f"branch name {branch!r} must not have a path segment "
+            "starting with '.'"
+        )
+    if branch.endswith("."):
+        return f"branch name {branch!r} must not end with '.'"
+    if branch.endswith(".lock"):
+        return f"branch name {branch!r} must not end with '.lock'"
+    return None
 
 
 class ComponentStatus(StrEnum):
@@ -94,13 +187,21 @@ class Manifest:
             else:
                 project_name = prd_path.stem or "run"
 
+        effective_branch = branch or f"ralph/{project_name}"
+        branch_error = validate_branch_name(effective_branch)
+        if branch_error:
+            raise ValueError(f"Invalid branch name for run: {branch_error}")
+        base_error = validate_branch_name(base_branch)
+        if base_error:
+            raise ValueError(f"Invalid base branch for run: {base_error}")
+
         comp = Component(
             id="main",
             title=project_name,
             description="Single-component run via ralph run",
             dependencies=[],
             prd_path=rel_prd,
-            branch_name=branch or f"ralph/{project_name}",
+            branch_name=effective_branch,
             status=ComponentStatus.PENDING.value,
         )
 
@@ -244,8 +345,10 @@ class Manifest:
             errors.append("projectName must be non-empty")
         if not isinstance(data.get("baseBranch"), str):
             errors.append("baseBranch must be a string")
-        elif not data["baseBranch"]:
-            errors.append("baseBranch must be non-empty")
+        else:
+            base_error = validate_branch_name(data["baseBranch"])
+            if base_error:
+                errors.append(f"baseBranch: {base_error}")
         if not isinstance(data.get("singlePr"), bool):
             errors.append("singlePr must be a boolean")
 
@@ -282,8 +385,10 @@ class Manifest:
 
             if not isinstance(comp.get("id"), str):
                 errors.append(f"{prefix}.id: must be a string")
-            elif not comp["id"]:
-                errors.append(f"{prefix}.id: must be non-empty")
+            else:
+                id_error = validate_component_id(comp["id"])
+                if id_error:
+                    errors.append(f"{prefix}.id: {id_error}")
             if not isinstance(comp.get("title"), str):
                 errors.append(f"{prefix}.title: must be a string")
             if not isinstance(comp.get("description"), str):
@@ -296,6 +401,10 @@ class Manifest:
                 errors.append(f"{prefix}.prdPath: must be a string")
             if not isinstance(comp.get("branchName"), str):
                 errors.append(f"{prefix}.branchName: must be a string")
+            else:
+                branch_error = validate_branch_name(comp["branchName"])
+                if branch_error:
+                    errors.append(f"{prefix}.branchName: {branch_error}")
 
         return errors
 

--- a/ralph_py/pr.py
+++ b/ralph_py/pr.py
@@ -28,8 +28,10 @@ def is_gh_available() -> bool:
 
 def push_branch(branch: str, cwd: Path) -> bool:
     """Push a branch to the remote with tracking."""
+    # "--" makes a crafted branch value an invalid refspec instead of a
+    # git option (R0.6).
     result = subprocess.run(
-        ["git", "push", "-u", "origin", branch],
+        ["git", "push", "-u", "--", "origin", branch],
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -145,9 +147,10 @@ def push_create_and_merge_pr(
     # Wait for merge
     if wait_for_merge(pr_number, cwd, timeout=merge_timeout):
         ui.ok(f"  PR #{pr_number} merged")
-        # Pull main so downstream worktrees start from merged state
+        # Pull main so downstream worktrees start from merged state.
+        # "--" keeps a crafted base branch out of option position (R0.6).
         subprocess.run(
-            ["git", "pull", "origin", manifest.base_branch],
+            ["git", "pull", "--", "origin", manifest.base_branch],
             cwd=cwd, capture_output=True,
         )
         return (pr_number, pr_url)
@@ -222,13 +225,15 @@ def create_component_pr(
     body = _generate_pr_body(component, manifest)
     title = f"[{manifest.project_name}] {component.title}"
 
+    # --base=/--head= bind the branch values to their flags even if a
+    # crafted value starts with "-" (R0.6).
     result = subprocess.run(
         [
             "gh", "pr", "create",
             "--title", title,
             "--body", body,
-            "--base", manifest.base_branch,
-            "--head", component.branch_name,
+            f"--base={manifest.base_branch}",
+            f"--head={component.branch_name}",
         ],
         cwd=cwd,
         capture_output=True,
@@ -360,13 +365,15 @@ def create_single_pr(
     body = "\n".join(lines)
     title = f"[{manifest.project_name}] Factory: all components"
 
+    # --base=/--head= bind the branch values to their flags even if a
+    # crafted value starts with "-" (R0.6).
     result = subprocess.run(
         [
             "gh", "pr", "create",
             "--title", title,
             "--body", body,
-            "--base", manifest.base_branch,
-            "--head", branch,
+            f"--base={manifest.base_branch}",
+            f"--head={branch}",
         ],
         cwd=cwd,
         capture_output=True,

--- a/tests/test_input_hygiene.py
+++ b/tests/test_input_hygiene.py
@@ -1,0 +1,495 @@
+"""R0.6 input hygiene: LLM-emitted component ids and branch names.
+
+Component ids become filesystem path segments (.ralph/worktrees/<id>,
+scripts/ralph/feature/<id>) and branch segments (ralph/factory/<id>);
+branch names reach git argv in ref position. These tests prove that
+traversal ids, option-injection branch names, and unicode confusables
+are rejected at every parse boundary, and that the legitimate shapes
+used across the codebase still pass.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from ralph_py import pr as pr_module
+from ralph_py.decompose import _validate_decompose_output, decompose_spec
+from ralph_py.git import (
+    checkout_existing,
+    create_branch_from,
+    delete_branch,
+    get_diff_names,
+    merge_branch,
+)
+from ralph_py.manifest import (
+    Component,
+    Manifest,
+    validate_branch_name,
+    validate_component_id,
+)
+from ralph_py.pr import push_branch
+from ralph_py.ui.plain import PlainUI
+
+# Unicode dash confusables: non-breaking hyphen, minus sign, en dash.
+NB_HYPHEN = "‑"
+MINUS_SIGN = "−"
+EN_DASH = "–"
+
+
+REJECTED_COMPONENT_IDS = [
+    "../../repo",
+    "..",
+    "a/../b",
+    "foo/bar",
+    "/etc",
+    "-foo",
+    "--force",
+    ".hidden",
+    "_leading-underscore",
+    "Uppercase",
+    "foo bar",
+    "foo\tbar",
+    "foo\nbar",
+    "foo..bar",
+    "trailing-dot.",
+    "collides.lock",
+    "",
+    "a" * 65,
+    f"auth{NB_HYPHEN}service",
+    f"auth{MINUS_SIGN}service",
+    f"auth{EN_DASH}service",
+    "føo",
+]
+
+ACCEPTED_COMPONENT_IDS = [
+    "main",  # Manifest.from_prd
+    "auth-service",
+    "comp-a",
+    "database",
+    "api",
+    "c1",
+    "a",
+    "0start-digit",
+    "api.v2",
+    "data_models",
+    "a" * 64,
+]
+
+REJECTED_BRANCH_NAMES = [
+    "-evil",
+    "--force",
+    "-u",
+    f"{NB_HYPHEN}evil",
+    f"{MINUS_SIGN}evil",
+    f"br{EN_DASH}anch",
+    "..",
+    "a..b",
+    "ralph/../main",
+    " main",
+    "main ",
+    "my branch",
+    "branch\tname",
+    "branch\nname",
+    "re:branch",
+    "/leading-slash",
+    "trailing-slash/",
+    "a//b",
+    ".hidden",
+    "ralph/.hidden",
+    "branch.",
+    "branch.lock",
+    "",
+    "a" * 201,
+]
+
+ACCEPTED_BRANCH_NAMES = [
+    "main",
+    "master",
+    "develop",
+    "ralph/run",  # ralph run default
+    "ralph/factory/auth-service",
+    "ralph/factory/comp-a",
+    "ralph/auth-feature",
+    "ralph/c1",
+    "test-branch",
+    "feature/foo_bar",
+    "release-1.2.3",
+    "ralph/contract-0-20260713",  # contract temp branches
+    "a" * 200,
+]
+
+
+class TestValidateComponentId:
+    @pytest.mark.parametrize("comp_id", REJECTED_COMPONENT_IDS)
+    def test_rejected(self, comp_id: str) -> None:
+        error = validate_component_id(comp_id)
+        assert error is not None
+        assert "component id" in error
+
+    @pytest.mark.parametrize("comp_id", ACCEPTED_COMPONENT_IDS)
+    def test_accepted(self, comp_id: str) -> None:
+        assert validate_component_id(comp_id) is None
+
+    def test_error_is_actionable_for_retry_loop(self) -> None:
+        """The message names the offending id and states the rule, so
+        the decompose retry loop can feed it back to the architect."""
+        error = validate_component_id("../../repo")
+        assert error is not None
+        assert "../../repo" in error
+        assert "must match" in error
+
+
+class TestValidateBranchName:
+    @pytest.mark.parametrize("branch", REJECTED_BRANCH_NAMES)
+    def test_rejected(self, branch: str) -> None:
+        error = validate_branch_name(branch)
+        assert error is not None
+        assert "branch name" in error
+
+    @pytest.mark.parametrize("branch", ACCEPTED_BRANCH_NAMES)
+    def test_accepted(self, branch: str) -> None:
+        assert validate_branch_name(branch) is None
+
+    def test_option_injection_message_explains_risk(self) -> None:
+        error = validate_branch_name("-evil")
+        assert error is not None
+        assert "option" in error
+
+
+def _manifest_data(
+    comp_id: str = "comp-a",
+    branch_name: str = "ralph/factory/comp-a",
+    base_branch: str = "main",
+) -> dict[str, object]:
+    return {
+        "version": "1",
+        "specFile": "spec.md",
+        "projectName": "test-project",
+        "baseBranch": base_branch,
+        "singlePr": False,
+        "components": [
+            {
+                "id": comp_id,
+                "title": "Component A",
+                "description": "A component",
+                "dependencies": [],
+                "prdPath": f"scripts/ralph/feature/{comp_id}/prd.json",
+                "branchName": branch_name,
+            }
+        ],
+    }
+
+
+class TestManifestSchemaHygiene:
+    def test_legitimate_manifest_passes(self) -> None:
+        assert Manifest.validate_schema(_manifest_data()) == []
+
+    @pytest.mark.parametrize("comp_id", ["../../repo", "foo/bar", "-foo"])
+    def test_traversal_id_rejected(self, comp_id: str) -> None:
+        errors = Manifest.validate_schema(_manifest_data(comp_id=comp_id))
+        assert any("components[0].id" in e for e in errors)
+
+    @pytest.mark.parametrize("branch", ["-evil", "a..b", "my branch"])
+    def test_bad_branch_name_rejected(self, branch: str) -> None:
+        errors = Manifest.validate_schema(_manifest_data(branch_name=branch))
+        assert any("components[0].branchName" in e for e in errors)
+
+    @pytest.mark.parametrize("base", ["-evil", "a..b"])
+    def test_bad_base_branch_rejected(self, base: str) -> None:
+        errors = Manifest.validate_schema(_manifest_data(base_branch=base))
+        assert any(e.startswith("baseBranch:") for e in errors)
+
+    def test_load_rejects_traversal_id(self, tmp_path: Path) -> None:
+        path = tmp_path / "manifest.json"
+        path.write_text(json.dumps(_manifest_data(comp_id="../../repo")))
+        with pytest.raises(ValueError, match="Invalid manifest schema"):
+            Manifest.load(path)
+
+
+class TestFromPrdHygiene:
+    def test_legitimate_branch_accepted(self, tmp_path: Path) -> None:
+        manifest = Manifest.from_prd(
+            prd_path=tmp_path / "prd.json", branch="ralph/auth",
+        )
+        assert manifest.components[0].branch_name == "ralph/auth"
+
+    @pytest.mark.parametrize("branch", ["-evil", "my branch", "a..b"])
+    def test_bad_branch_rejected(self, tmp_path: Path, branch: str) -> None:
+        with pytest.raises(ValueError, match="Invalid branch name"):
+            Manifest.from_prd(prd_path=tmp_path / "prd.json", branch=branch)
+
+    def test_bad_base_branch_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Invalid base branch"):
+            Manifest.from_prd(
+                prd_path=tmp_path / "prd.json",
+                branch="ralph/auth",
+                base_branch="-evil",
+            )
+
+
+def _decompose_output(comp_id: str) -> str:
+    return json.dumps({
+        "components": [
+            {
+                "id": comp_id,
+                "title": "Component",
+                "description": "A component",
+                "dependencies": [],
+                "allowedPaths": [
+                    "src/", "tests/", f"scripts/ralph/feature/{comp_id}/",
+                ],
+                "userStories": [
+                    {
+                        "id": "US-001",
+                        "title": "Story",
+                        "acceptanceCriteria": ["Works", "Tests pass"],
+                        "priority": 1,
+                        "passes": False,
+                        "notes": "",
+                    }
+                ],
+            }
+        ]
+    })
+
+
+class SequenceAgent:
+    """Agent returning one canned output per invocation, recording prompts."""
+
+    def __init__(self, outputs: list[str]):
+        self._outputs = outputs
+        self._calls = 0
+        self._final_message: str | None = None
+        self.prompts: list[str] = []
+
+    @property
+    def name(self) -> str:
+        return "sequence-agent"
+
+    def run(self, prompt: str, cwd: Path | None = None) -> Iterator[str]:
+        self.prompts.append(prompt)
+        output = self._outputs[min(self._calls, len(self._outputs) - 1)]
+        self._calls += 1
+        self._final_message = output
+        yield from output.splitlines()
+
+    @property
+    def final_message(self) -> str | None:
+        return self._final_message
+
+
+class TestDecomposeValidationHygiene:
+    @pytest.mark.parametrize(
+        "comp_id", ["../../repo", "foo/bar", "-foo", "Uppercase", ".."],
+    )
+    def test_bad_id_rejected(self, comp_id: str) -> None:
+        data = json.loads(_decompose_output(comp_id))
+        errors = _validate_decompose_output(data)
+        assert any("components[0].id" in e for e in errors)
+
+    def test_legitimate_output_accepted(self) -> None:
+        data = json.loads(_decompose_output("auth-service"))
+        assert _validate_decompose_output(data) == []
+
+    def test_retry_loop_receives_id_error(self, tmp_path: Path) -> None:
+        """A traversal id fails attempt 1; the retry prompt carries the
+        validation error verbatim and attempt 2 succeeds."""
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Feature")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+
+        agent = SequenceAgent([
+            _decompose_output("../../repo"),
+            _decompose_output("auth-service"),
+        ])
+        manifest = decompose_spec(
+            spec_path=spec_file,
+            project_name="test-project",
+            base_branch="main",
+            single_pr=False,
+            agent=agent,
+            ui=PlainUI(no_color=True),
+            root_dir=tmp_path,
+        )
+
+        assert len(agent.prompts) == 2
+        assert "PREVIOUS ATTEMPT FAILED" in agent.prompts[1]
+        assert "../../repo" in agent.prompts[1]
+        assert manifest.components[0].id == "auth-service"
+        assert manifest.components[0].branch_name == "ralph/factory/auth-service"
+
+    def test_unsafe_project_name_rejected_in_single_pr(
+        self, tmp_path: Path,
+    ) -> None:
+        """single_pr derives the branch from project_name (user input);
+        an unsafe name is rejected, not sanitized."""
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Feature")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+
+        agent = SequenceAgent([_decompose_output("auth-service")])
+        with pytest.raises(ValueError, match="Cannot derive a git branch"):
+            decompose_spec(
+                spec_path=spec_file,
+                project_name="my project",
+                base_branch="main",
+                single_pr=True,
+                agent=agent,
+                ui=PlainUI(no_color=True),
+                root_dir=tmp_path,
+            )
+
+
+@pytest.fixture
+def git_repo_with_origin(tmp_path: Path) -> Path:
+    """A real git repo with one commit and a local bare 'origin' remote."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / "f.txt").write_text("a\n")
+    subprocess.run(["git", "add", "f.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=repo, check=True)
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "clone", "-q", "--bare", str(repo), str(origin)],
+        cwd=tmp_path, check=True,
+    )
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(origin)], cwd=repo, check=True,
+    )
+    return repo
+
+
+class TestGitArgvSeparators:
+    """The '--'-separated invocations still work for legitimate names
+    (no regression) and fail closed for option-shaped values."""
+
+    def test_push_branch_legitimate(self, git_repo_with_origin: Path) -> None:
+        repo = git_repo_with_origin
+        subprocess.run(
+            ["git", "checkout", "-qb", "ralph/factory/comp-a"],
+            cwd=repo, check=True,
+        )
+        assert push_branch("ralph/factory/comp-a", repo) is True
+
+    def test_push_branch_option_shape_fails_closed(
+        self, git_repo_with_origin: Path,
+    ) -> None:
+        # With "--", "-evil" is an unknown refspec, not a push option.
+        assert push_branch("-evil", git_repo_with_origin) is False
+
+    def test_merge_branch_legitimate(self, git_repo_with_origin: Path) -> None:
+        repo = git_repo_with_origin
+        subprocess.run(["git", "checkout", "-qb", "feat"], cwd=repo, check=True)
+        (repo / "g.txt").write_text("b\n")
+        subprocess.run(["git", "add", "g.txt"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-qm", "feat"], cwd=repo, check=True)
+        subprocess.run(["git", "checkout", "-q", "main"], cwd=repo, check=True)
+        assert merge_branch("feat", cwd=repo) is True
+
+    def test_merge_branch_option_shape_fails_closed(
+        self, git_repo_with_origin: Path,
+    ) -> None:
+        assert merge_branch("-evil", cwd=git_repo_with_origin) is False
+
+    def test_delete_branch_legitimate(self, git_repo_with_origin: Path) -> None:
+        repo = git_repo_with_origin
+        subprocess.run(["git", "branch", "-q", "doomed"], cwd=repo, check=True)
+        assert delete_branch("doomed", cwd=repo, force=True) is True
+
+    def test_delete_branch_option_shape_fails_closed(
+        self, git_repo_with_origin: Path,
+    ) -> None:
+        assert delete_branch("-evil", cwd=git_repo_with_origin, force=True) is False
+
+    def test_checkout_and_create_branch_from(
+        self, git_repo_with_origin: Path,
+    ) -> None:
+        repo = git_repo_with_origin
+        assert create_branch_from("ralph/factory/api", "main", cwd=repo) is True
+        assert checkout_existing("main", cwd=repo) is True
+
+    # NOTE: no fail-closed test for checkout_existing("-q"): for git
+    # checkout the ref precedes "--", so an option-shaped value is still
+    # parsed as an option ("git checkout -q --" exits 0, measured on git
+    # 2.47.1). The defense for checkout is validate_branch_name upstream.
+
+    def test_get_diff_names_with_range(self, git_repo_with_origin: Path) -> None:
+        repo = git_repo_with_origin
+        subprocess.run(["git", "checkout", "-qb", "delta"], cwd=repo, check=True)
+        (repo / "h.txt").write_text("c\n")
+        subprocess.run(["git", "add", "h.txt"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-qm", "delta"], cwd=repo, check=True)
+        assert get_diff_names("main", cwd=repo) == ["h.txt"]
+
+
+class TestPrArgvShapes:
+    """Argv-shape assertions for the gh invocation: --head=/--base= bind
+    branch values to their flags."""
+
+    def test_create_component_pr_uses_equals_form(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        captured: list[list[str]] = []
+
+        def fake_run(argv: list[str], **kwargs: object) -> object:
+            captured.append(argv)
+            return type(
+                "R", (),
+                {
+                    "returncode": 0,
+                    "stdout": "https://github.com/o/r/pull/7\n",
+                    "stderr": "",
+                },
+            )()
+
+        monkeypatch.setattr(pr_module.subprocess, "run", fake_run)
+
+        component = Component(
+            id="comp-a",
+            title="Component A",
+            description="A component",
+            dependencies=[],
+            prd_path="scripts/ralph/feature/comp-a/prd.json",
+            branch_name="ralph/factory/comp-a",
+        )
+        manifest = Manifest(
+            version="1",
+            spec_file="spec.md",
+            project_name="test-project",
+            base_branch="main",
+            single_pr=False,
+            components=[component],
+        )
+
+        pr_number, pr_url = pr_module.create_component_pr(
+            component, manifest, tmp_path,
+        )
+
+        assert pr_number == 7
+        assert pr_url == "https://github.com/o/r/pull/7"
+        (argv,) = captured
+        assert "--head=ralph/factory/comp-a" in argv
+        assert "--base=main" in argv
+
+    def test_push_branch_uses_separator(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        captured: list[list[str]] = []
+
+        def fake_run(argv: list[str], **kwargs: object) -> object:
+            captured.append(argv)
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr(pr_module.subprocess, "run", fake_run)
+
+        assert push_branch("ralph/factory/comp-a", tmp_path) is True
+        (argv,) = captured
+        assert argv.index("--") < argv.index("ralph/factory/comp-a")


### PR DESCRIPTION
## Roadmap item

R0.6 (Session 1B, branch `fix/r0-6-id-hygiene`) - Input hygiene for LLM-emitted identifiers [H-9].

Component ids and branch names come from architect (LLM) output and flowed unvalidated into filesystem paths (`.ralph/worktrees/<id>` reaches `git worktree remove --force`; `scripts/ralph/feature/<id>` is created on disk) and git argv (`git push -u origin <branch>`, `git worktree add ... <branch>`). A traversal id like `../../repo` escaped the worktree base; a leading-dash branch name became a git option.

## Changes

- `ralph_py/manifest.py`: new `validate_component_id` (`^[a-z0-9][a-z0-9._-]{0,63}$`, plus no `..`, no `.`/`.lock` suffix - `<id>.lock` would collide with the worktree lock file) and `validate_branch_name` (ASCII allowlist `[A-Za-z0-9._/-]`, no leading `-`, no `..`, no whitespace/`:`, git ref shape rules, 200-char cap). Enforced in `Manifest.validate_schema` (component ids, `branchName`, `baseBranch`) and `Manifest.from_prd`. Invalid values are rejected with actionable errors, never sanitized (silent rewriting hides architect drift).
- `ralph_py/decompose.py`: component-id validation moved inside `_validate_decompose_output` so the error text feeds back through the existing decompose retry loop; constructed branch names (`ralph/factory/<id>` / `ralph/factory/<project_name>`) validated before PRD generation.
- `ralph_py/git.py` / `ralph_py/pr.py`: `--` separators added where a ref follows options and the subcommand supports it - `git merge --no-edit -- <branch>`, `git branch -D -- <branch>`, `git push -u -- origin <branch>`, `git pull -- origin <base>`, `git diff <range> --`, trailing `--` on checkout forms; `gh pr create` switched to `--base=`/`--head=` so pflag binds the value even if it starts with `-`.
- `docs/remediation-roadmap.md`: added to the repo (it was untracked in the working copy - no session could otherwise flip checkboxes "in the same PR") with the R0.6 checkbox flipped. Parallel wave-1 PRs adding the same file will need a trivial rebase.

## Tested

All behaviors below are proven by named tests in `tests/test_input_hygiene.py` (105 tests):

- `TestValidateComponentId::test_rejected` - 22 parametrized rejections: traversal (`../../repo`, `..`, `a/../b`), slashes, leading `-`/`.`/`_`, uppercase, whitespace, `..` inside, `.`/`.lock` suffix, >64 chars, unicode dash confusables (U+2011, U+2212, U+2013), non-ASCII.
- `TestValidateComponentId::test_accepted` - 11 legitimate ids used across the codebase (`main`, `comp-a`, `auth-service`, `api.v2`, 64-char max, ...).
- `TestValidateBranchName::test_rejected` - 24 parametrized rejections: option shapes (`-evil`, `--force`, `-u`), unicode dash confusables incl. leading position, `..`, whitespace incl. tab/newline, `:`, empty/double/leading/trailing slash segments, dot-leading segments, `.`/`.lock` suffix, >200 chars.
- `TestValidateBranchName::test_accepted` - 13 legitimate branches (`main`, `ralph/run`, `ralph/factory/<id>`, `ralph/contract-*`, `feature/foo_bar`, `release-1.2.3`, ...).
- `TestManifestSchemaHygiene` - schema-level rejection of bad ids / branchName / baseBranch; `Manifest.load` raises on a traversal id; the current legitimate manifest shape still passes.
- `TestFromPrdHygiene` - `ralph run` manifest path rejects bad branch/base, accepts legitimate ones.
- `TestDecomposeValidationHygiene::test_retry_loop_receives_id_error` - a traversal id fails attempt 1 and the attempt-2 prompt contains the offending id and error text verbatim; `test_unsafe_project_name_rejected_in_single_pr` - unsafe project name is rejected, not sanitized.
- `TestGitArgvSeparators` (real git repos) - `push_branch`/`merge_branch`/`delete_branch`/`create_branch_from`/`checkout_existing`/`get_diff_names` succeed with legitimate names through the new `--` forms (no regression), and `-evil` fails closed for push/merge/delete.
- `TestPrArgvShapes` - argv contains `--head=`/`--base=` and `--` before the pushed branch.
- `--` support measured (not assumed) against git 2.47.1 for every changed form before the change: push/pull/merge/branch -D accept `--` and treat `-evil` after it as an invalid ref; `git checkout -q --` exits 0, which is why checkout gets no fail-closed claim.

## Assumed

- For `git checkout`, the ref precedes `--`, so `--` cannot stop option parsing there; protection for checkout paths relies on upstream `validate_branch_name` (documented in code comments, no test claims otherwise).
- The `git pull -- origin <base>` form in `push_create_and_merge_pr` is exercised only by the manual git 2.47.1 probe, not an automated test (the surrounding function requires a live `gh`).
- `contract.py`'s internally generated temp branch names (`ralph/contract-<tier>-<ts>`) are assumed branch-safe; they are not LLM-emitted and are not validated here.
- Behavior on git versions older than 2.47.1 is untested; `--` separator support in these subcommands is decades old but was not measured on other versions.

## Checks (final lines)

- `uv run pytest tests/ -q`: `711 passed, 12 skipped in 277.03s (0:04:37)`
- `uv run mypy ralph_py/ --strict`: `Success: no issues found in 36 source files`
- `uv run ruff check ralph_py/ tests/`: `All checks passed!`

Note: checks were run in a clean worktree cut from origin/main. The main checkout currently carries another session's uncommitted R0.1 (timeouts) work in `ralph_py/agents/`, `config.py`, `loop.py`, `timeout.py`, which fails 5 `test_loop.py` tests there; none of those files are touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)