### PR TITLE
fix: R4.1 suite isolation + R3.4 partial repo hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ scripts/ralph/progress.txt
 scripts/ralph/codebase_map.md
 scripts/ralph/prompt.md
 scripts/ralph/understand_prompt.md
+
+# Ralph - runtime state (journals, worktrees, knowledge, locks; R3.4)
+.ralph/

--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -1,0 +1,598 @@
+# Remediation Roadmap: Full-System Review Fixes to A+
+
+Durable tracker for fixing every finding from the 2026-07-13 full-system review
+(report: https://claude.ai/code/artifact/0996ac84-8acf-4000-a526-72d4b0994832)
+and raising every review dimension to A+.
+
+Status legend: `[ ]` pending - `[~]` in progress - `[x]` done - `[-]` skipped.
+Sizing: S (small diff, <~100 lines), M (one PR), L (multi-PR workstream). No time
+estimates: sizing is diff scope, not duration.
+
+Finding IDs referenced below (CRIT-n, H-n, MED/LOW catalog, T-n test findings,
+D-n docs findings, P-n product gaps) are from the review report. The traceability
+appendix at the bottom maps every finding to a plan item.
+
+Process rules that bind this plan:
+
+- H1: no self-review. Every phase lands as one or more PRs gated by the user
+  (`/code-review ultra` or direct inspection).
+- H2: any prompt-body change re-runs calibration and records the delta. All
+  prompt edits are therefore batched into Phase R5 so calibration cycles are
+  few and comparable.
+- H3: every prompt edit bumps `*_PROMPT_VERSION` and the snapshot tuple together.
+- H4: every "done" claim below states what was tested vs assumed. Each phase has
+  a "Done when" that is a measurable gate, not a vibe.
+
+---
+
+## User decisions required (blocking marked items only)
+
+1. **Install story** (R2.5): publish `ralph-cli` to PyPI under a new unclaimed
+   name (`ralph-factory`?) OR document clone-install as the only path. The
+   current README command installs an unrelated project.
+2. **Second model family for review rotation** (R7.1): which family reviews
+   Claude-engineered code (codex CLI is already an adapter). Needed before the
+   correlated-failure gate in the A+ criteria can be measured.
+3. **Linear workspace admin approval** (R7.4): app-actor OAuth requires a
+   workspace admin to approve the app identity.
+4. **PRD fixtures default** (R7.2): once wired and sandboxed, fixtures ship
+   default-off (`[fixtures].enabled = false`) unless decided otherwise.
+5. **Agent SDK spike go/no-go** (R7.5): decide after the measurement spike, not
+   before.
+
+Execution order: R0 -> R1 -> R2 -> R4 -> R3 -> R5 -> R6 -> R7.
+R4 (test spine) deliberately precedes R3/R5: the spine tests are the regression
+net for everything after them. R0/R1/R2 are ordered by blast radius and do not
+touch prompt bodies, so no calibration cycles are needed until R5.
+
+---
+
+## Phase R0 - Walk-away correctness (no prompt changes)
+
+First principles: an unattended factory must be unable to hang forever, unable
+to report success on failure, and unable to corrupt the operator's repo. Every
+item here is one of those three.
+
+- [ ] R0.1 (L) **Enforce timeouts end to end** [CRIT-1]
+  - Agent adapters (`claude_code.py`, `codex.py`, `custom.py`): `Popen(...,
+    start_new_session=True)`; reader thread + deadline so a silent hang is
+    detected without a stdout line; on breach `killpg(SIGTERM)` then `SIGKILL`;
+    honor the existing `timeout` parameter in all three adapters; bound
+    `codex.py` `proc.wait()`.
+  - `loop.py:154`: pass `config.agent_iteration_timeout` into `agent.run`;
+    enforce `component_timeout` as a wall-clock check inside the iteration loop
+    (the worker owns it, so no cross-process kill is needed for the common case).
+  - `factory.py` scheduler: per-future deadline of `component_timeout` + margin
+    as a backstop; on breach mark FAILED with `error="component timeout"`,
+    continue the run, warn that a worker may be leaked.
+  - Consume `TimeoutConfig` (currently dead) as the single source for these
+    values; wire its loader in R2.1.
+  - Verify: real-subprocess test with a sleep-forever fake agent asserting
+    termination, FAILED status, and that a grandchild process is also dead.
+  - Failure modes: SIGKILL mid-git-op leaves `.git/index.lock` or a dirty
+    worktree. Mitigation: timeout-failure retry path recreates the worktree
+    from base instead of reusing it, and removes stale index locks.
+
+- [ ] R0.2 (M) **PR/merge outcome gates completion** [CRIT-2, H-1, MED pr-timeouts]
+  - `pr.py`: return a typed `PrOutcome` (pushed / pr_url / merged /
+    merge_pending / error) instead of a lossy tuple; add explicit timeouts to
+    every `gh`/`git` subprocess call in the module.
+  - `factory.py:887-915`: `COMPLETED` only when merged (or `create_prs=False`);
+    new `MERGE_PENDING` manifest status for `wait_for_merge` timeout: dependents
+    are NOT scheduled past it; resume re-polls.
+  - Replace `git pull` on the user's checkout (`pr.py:149-152`) with
+    `git fetch origin <base>` and cut all worktrees (and compute all diffs)
+    from `origin/<base>`. The operator's checkout is never mutated.
+  - Verify: real-git tests with a stub `gh` binary covering push-fail,
+    create-fail, merge-fail, wait-timeout; assert dependent scheduling blocked.
+  - Failure modes: squash merges change SHAs so `base...HEAD` on stale local
+    refs shows phantom diffs; using `origin/<base>` everywhere removes the
+    class. MERGE_PENDING needs the R3.3 resume story to be ergonomic.
+
+- [ ] R0.3 (M) **Contract phase cannot corrupt the repo; failures are loud** [CRIT-6]
+  - `contract.py`: perform tier merges in a detached temp worktree, never the
+    user's checkout; `git merge --abort` in the recovery path; assert cleanup
+    succeeded (fail loudly if not).
+  - `factory.py:1055-1082`: contract failure sets a nonzero exit code; the
+    breaker-retry actually re-enters scheduling (wrap the scheduling loop so a
+    reset breaker is re-run while contract retries remain); record a
+    `contract_result` journal event either way.
+  - Bisection honesty: when PRs were already squash-merged, per-branch re-merge
+    bisection is meaningless (merges no-op). In that mode, report "tier failed"
+    with the failing tests and skip blame attribution instead of blaming the
+    first component unconditionally. Keep merge-order bisection only for the
+    deferred-merge mode, in topological order, and document the interaction
+    limitation (two-component interaction failures attribute to the later merge).
+  - Verify: real-git tests: conflicted tier leaves user checkout untouched and
+    recovers; breaker re-runs; exit code nonzero on unresolved contract failure.
+
+- [ ] R0.4 (S) **Fix the e2e-evidenced pair: provisioning + blind retries** [CRIT-10, MED cwd-paths, MED repo-root-heuristic, MED loop-guard]
+  - `factory._run_component`: copy `prompt.md` (and CLAUDE.md/AGENTS.md) into
+    the worktree alongside the PRD; fix the inverted repo-root heuristic
+    (`factory.py:274-280`); resolve all root-relative paths against `root_dir`,
+    not inherited CWD (`factory.py:254, 265-268`).
+  - `verify.check_diff_scope`: failure details include the base branch and the
+    full allowed-paths list; `context.py` carries them into the retry prompt.
+  - `loop.py:168-186`: run `guards.enforce_allowed_paths` BEFORE the completion
+    early-return so COMPLETE cannot bypass enforcement.
+  - Verify: integration test asserting the worktree contains the customized
+    prompt; unit test asserting the diff-scope failure message names the base
+    branch and allowed paths.
+
+- [ ] R0.5 (M) **Instance and state safety** [H-7, H-8, H-15]
+  - Run-level flock on `.ralph/factory.lock`: a second invocation on the same
+    root refuses to start (override flag for intentional use).
+  - Worktrees keyed `.ralph/worktrees/<run_id>/<component_id>`; stale branch
+    from a prior run is deleted or refused with a clear error, never silently
+    reused with old commits.
+  - `single_pr=true` forces `max_parallel=1` with a printed notice.
+  - Manifest save path = manifest load path (`--manifest /x.json` saves to
+    /x.json); `ralph run` uses its own `scripts/ralph/run-manifest.json` so it
+    cannot clobber a factory run's resumable state.
+  - Verify: two-process concurrency test (real flock); custom-manifest
+    round-trip test; single_pr parallel test.
+
+- [ ] R0.6 (S) **Input hygiene for LLM-emitted identifiers** [H-9]
+  - `manifest.py` + `decompose.py`: component ids match
+    `^[a-z0-9][a-z0-9._-]{0,63}$`; branch names reject leading `-`, `..`, and
+    whitespace; git invocations use `--` separators where refs meet argv.
+  - Verify: parametrized rejection tests (traversal ids, option-injection
+    branch names).
+
+Done when: a factory run with an induced hang, an induced push failure, and an
+induced contract conflict terminates in bounded time, reports the correct
+failure, exits nonzero, and leaves the operator's checkout byte-identical.
+All three scenarios exist as automated tests (what was tested); no claim is
+made about unlisted failure classes (what is assumed).
+
+---
+
+## Phase R1 - Gate integrity (parser-side; still no prompt changes)
+
+First principles: a gate that can be passed by silence, case drift, or absence
+of data is not a gate. Every fix here makes the harness distrust its own
+reviewers' output as much as it distrusts the engineer's.
+
+- [ ] R1.1 (S) **Empty or partial reviews cannot pass hard mode** [CRIT-5]
+  - `review.py`: criterion-coverage check: every PRD story id must receive a
+    verdict or the result is `infrastructure_error=True` (id-based matching,
+    not criterion-text string equality); verdict whitelist `{pass, fail}`
+    case-insensitively, anything else is a parse failure, not an advisory.
+- [ ] R1.2 (S) **Close the E9 holes** [H-13, MED review-nondict, MED sec-pr-body]
+  - `review.py:518-527`: `AgentOutputTooLarge` sets `infrastructure_error=True`
+    (mirror security.py).
+  - Skipped and budget-exhausted phases emit a synthetic
+    `Finding(category="phase_skipped")` so the findings stream distinguishes
+    "ran clean" from "never ran"; journal records the skip.
+  - Wrap the review call path like security's (catch `Exception`, degrade to
+    per-component infra failure) so a reviewer crash cannot abort the whole run.
+  - Guard non-dict `_extract_json` results in review parsing.
+  - `pr.py` body: render an explicit "security review did not run
+    (infrastructure error)" section when applicable (use
+    `render_findings_markdown`'s existing callout).
+- [ ] R1.3 (S) **Empty diff from git error is an infrastructure failure** [H-14]
+  - `git.get_diff_content` returns a result object (content | error) or raises;
+    `factory.py:593` maps error to `infrastructure_error` for all three
+    consumers instead of reviewing an empty string.
+- [ ] R1.4 (M) **Truncated-diff policy + security parity** [H-16]
+  - Hard mode: a truncated diff is not silently reviewable. Chunk the diff and
+    run multiple review passes (bounded by budget), or fail with an infra
+    finding. Advisory mode: annotate PASS as partial.
+  - Strip the Self-Critique block for the security reviewer too (`security.py:377`).
+- [ ] R1.5 (M) **Scope-guard hardening** [H-4, H-5, MED scope-none-fallthrough]
+  - `git.get_diff_names`: use `--name-status -M`; rename/copy sources count as
+    changed paths for scope purposes.
+  - `decompose._validate_decompose_output`: validate allowedPaths CONTENT
+    against the EXCLUDE list the prompt already promises (`.ralph/`,
+    `ralph_py/`, bare `scripts/ralph/`, root manifests, absolute paths, `..`);
+    reject and retry-with-error like other validation failures.
+  - `factory.py:554-558`: PRD load failure fails the diff-scope check closed
+    (infra failure) instead of silently disabling scope.
+- [ ] R1.6 (M) **Knowledge retention + read-side defense** [CRIT-4, H-3, MED knowledge-trust, LOW nonce-order]
+  - Retrieval: union across run dirs with per-fact-id latest-wins (supersede by
+    fact id, not by directory). The DISTILL rule "do not duplicate existing
+    facts" becomes correct instead of corpus-destroying.
+  - Debug dumps move to `_debug/<run_id>/` so a failed distill can never shadow
+    real facts.
+  - `_coerce_facts`: sanitize + length-cap `evidence` items (same
+    `_is_injection_attempt` gate as claims); re-run validation on READ
+    (`_parse_fact_md`), not only at write time.
+  - `test_verified` confidence: downgrade to `asserted` unless a verification
+    cross-check exists (cited test path exists in the worktree at minimum);
+    keep the honest-hint framing.
+  - Run-id ordering: include a microsecond timestamp so same-second runs order
+    correctly.
+  - Verify: regression tests for the exact decay scenario (fail distill, then
+    read), the evidence-field injection bypass, and supersede-by-fact-id.
+- [ ] R1.7 (S) **Persist the architect's red-team output** [MED spec-issues-lost]
+  - Write `spec_issues` (all severities) to `scripts/ralph/spec-issues.json`
+    and a journal event; on SpecBlockerError, print the file path so the user
+    iterates against a durable artifact, not scrollback.
+- [ ] R1.8 (S) **Decompose validation ordering** [MED prd-validate-late, LOW vacuous-prd]
+  - Run PRD schema validation inside the decompose retry loop (before files are
+    written) so the LLM gets the error; clean up partial files on failure.
+  - Reject empty `userStories`, empty `acceptanceCriteria`, and `passes: true`
+    at decompose time.
+
+Done when: a new adversarial-parser test class proves each of: empty review
+fails hard mode; `"FAIL"`/`"Blocked"` verdicts block; oversized review output is
+an infra error; skipped phases appear in the findings stream; a rename-move
+violates scope; a poisoned evidence string is rejected; a failed distill does
+not erase facts. (Tested: those exact behaviors. Assumed: no other parser paths
+regressed: guarded by the existing 606-test suite staying green.)
+
+---
+
+## Phase R2 - One control plane + CLI/doc honesty
+
+First principles: for a solo tool, the author-in-six-months is the primary
+user. Every knob must be reachable, every documented command must exist, and
+every flag must do what it says or fail loudly.
+
+- [ ] R2.1 (M) **Wire the six config loaders** [CRIT-7, D-precedence]
+  - CLI resolution order: explicit CLI flag > env > ralph.toml > dataclass
+    default. Click flags get `default=None` sentinels so "not passed" is
+    distinguishable from "passed the default value".
+  - `ralph factory` and `ralph run` construct every phase config via `.load()`
+    (Factory/Verify/Security/Contract/Feedforward/Evolution/Timeout); add
+    `from_env` where missing (Feedforward/Evolution/Knowledge).
+  - `ralph init` scaffolds a commented `ralph.toml`.
+  - Failure mode: changed effective defaults for existing setups (e.g. a toml
+    `review_mode` now taking effect). Mitigation: `ralph config show` (R2.4)
+    prints the resolved config + source of each value; release note.
+- [ ] R2.2 (S) **Expose the safety knobs** [CRIT-7]
+  - `max_adversarial_calls` and `pause_before_pr_merge`: toml keys, env vars,
+    CLI flags, documented. Budget exhaustion emits the R1.2 synthetic finding.
+- [ ] R2.3 (M) **Make `ralph run` and factory flags honest** [CRIT-8, H-10, H-11]
+  - Forward `max_iterations` (N), `interactive`, and `allowed_paths` through
+    `_submit_args` into `_run_component`; delete the hardcoded 30.
+  - `--no-verify` actually skips Phase 1 (explicit `skip` sentinel instead of
+    `None`-means-default).
+  - Wire feedforward config in the `factory` command path.
+  - Fix the PRD-path contract: the scaffolded prompt gains an explicit
+    `$prd_path` placeholder; `loop.py` substitutes the per-component PRD path;
+    add a test that the rendered prompt names the same file
+    `check_prd_stories` reads.
+- [ ] R2.4 (S) **Preflight honesty** [H-12, D-preflight]
+  - `run`/`understand`/`feature` preflight accepts whichever agent the config
+    selects (claude/codex/custom), not codex-only.
+  - `prd.json` existence + schema preflight BEFORE any agent spend.
+  - Add `ralph config show` (resolved config with per-value source) and
+    `ralph status` stub (full version in R3.2): both are README-promised.
+- [ ] R2.5 (M) **Docs regeneration + packaging truth** [CRIT-9, D-*]
+  - Generate the README CLI reference and config reference from click
+    introspection + dataclass fields (script under `scripts/`), so drift is
+    structurally impossible; CI check that the generated sections are current.
+  - Install story per user decision 1; until then README documents clone-install
+    only.
+  - Remove the dead `textual` dependency.
+  - Refresh `examples/uv-python` to the current engineer contract
+    (Self-Critique block, allowedPaths-aware prd_prompt).
+  - Fix remaining doc drift: distiller is pre-PR (or move it post-merge and
+    keep the doc: decide in R7.3 refactor; until then fix the doc), runbook
+    worktree note aligned with keep-worktree-on-failure (R3.3), test count,
+    `[sensors]`/`[fixtures]` sections removed or implemented, `ralph evolve
+    --apply` promise aligned with R6.3.
+- [ ] R2.6 (S) **HITL semantics + subprocess env hygiene** [MED hitl-abort, MED env-leak, MED process-group]
+  - E6 "Reject" marks the component FAILED immediately (no retry loop, no
+    re-prompt); "Retry" is a separate choice.
+  - Verification/contract/fixture subprocesses run with a scrubbed env
+    (allowlist: PATH, HOME, LANG, VIRTUAL_ENV, CI-required vars): agent-run
+    tests can no longer read harness API keys.
+  - All verification subprocesses use `start_new_session=True` + group kill on
+    timeout so orphaned test servers die with their parent.
+
+Done when: `ralph config show` displays every knob with its source; a
+round-trip test proves toml -> resolved config for all nine sections; the
+README CLI table is generated and CI-checked; `ralph run 3` runs at most 3
+iterations (asserted by a fake-agent test).
+
+---
+
+## Phase R4 - Test spine + suite isolation (runs before R3/R5)
+
+First principles: the review's critical findings live exactly where the suite
+mocks itself. The spine tests are the regression net for every later phase, so
+they come before feature work. Target: zero load-bearing behaviors with
+mock-only coverage.
+
+- [x] R4.1 (S) **Suite isolation** [H-18, T-19]
+  - Autouse conftest fixture routing evolution/experiments/knowledge paths to
+    tmp_path; a guard fixture fails the run if the repo's real `.ralph/`
+    mutates during tests; `clean_env` extended to FACTORY_*/RALPH_* families.
+  - Archive (do not delete) the polluted `.ralph/evolution.jsonl` +
+    `experiments.tsv` to `.ralph/archive/` and start clean journals (R6.4
+    re-baselines).
+- [ ] R4.2 (L) **Real-git spine tier** [T-1..T-7, T-14]
+  - New marked tier (`-m spine`, in CI as a separate job): worktree lifecycle
+    incl. two-process flock contention; PR failure paths against a stub `gh`
+    binary on PATH; contract merge + conflict recovery; crash recovery with
+    stale worktrees and a mid-verify kill; retry-context propagation e2e (fake
+    agent writes its received prompt to a file; assert the diff-scope failure
+    details from attempt 1 appear in attempt 2's prompt).
+- [ ] R4.3 (M) **Fix misleading tests** [T-5, T-6, T-8, T-9, T-10, T-11, T-15]
+  - C1 becomes a true 2-worker worktree test; C6 uses the same root and proves
+    serialization (fails if the flock is removed); C4 asserts the breaker was
+    reset AND re-ran; verification-retry test counts attempts.
+  - AST-walker tests call the real `_module_level_prompt_constants`.
+  - Add the missing `test_no_silent_version_pin` (hash moved, version pinned ->
+    fail) or correct the docstring: implement the test, it is cheap.
+  - Codex live-contract test becomes opt-in (`RALPH_RUN_LIVE_CONTRACT=1`), so
+    the default suite makes zero network calls.
+- [ ] R4.4 (S) **Coverage measurement** [T-16]
+  - pytest-cov in dev deps; CI reports coverage; ratchet gate (fail if coverage
+    drops below the last recorded value) rather than an arbitrary threshold.
+    Measured, not guessed: capture the baseline in the PR that adds it.
+
+Done when: the five behaviors the review named as unmocked-coverage-zero
+(worktree lifecycle, engineer loop plumbing, PR failure paths, contract
+execution, retry propagation) each have at least one real (unmocked at that
+boundary) test; default suite is network-free; repo `.ralph/` is untouched by
+tests (enforced by the guard fixture).
+
+---
+
+## Phase R3 - Observability, cost, resume
+
+First principles: walking away requires knowing (a) is it stuck, (b) what is it
+spending, (c) what do I do when I come back to a partial failure.
+
+- [ ] R3.1 (M) **Cost meter** [H-17, P-3]
+  - Parse token usage from the claude CLI stream-json result events; measure
+    what codex exposes (this needs to be measured, not assumed: spike first);
+    fall back to call counts + wall time where usage is unavailable.
+  - Per-component, per-phase rollup in the factory summary, journal entries,
+    and experiments.tsv; optional `max_total_tokens` halt (loud, records a
+    synthetic finding per R1.2's pattern).
+  - Failure mode: usage formats drift with CLI versions: parse defensively,
+    never gate correctness on the meter.
+- [ ] R3.2 (M) **Status + notification** [P-4, D-status]
+  - ProgressLog defaults on; `ralph status` renders manifest + log (per
+    component: phase, attempt, last event age, evidence paths).
+  - Notification hook: configurable shell command (`[notify] on_complete /
+    on_first_failure` in ralph.toml) so desktop/webhook/email are one liner
+    configs. Fires on completion, first failure, and MERGE_PENDING.
+- [ ] R3.3 (M) **Resume + partial-failure ergonomics** [P-5, LOW completed_at, LOW findings-accumulate]
+  - Persist `run_id` in the manifest; set `completed_at`; per-component event
+    history refs (journal offsets).
+  - `ralph retry <component-id>`: resets FAILED component + cascade-skipped
+    dependents to PENDING and re-enters factory with the same manifest.
+  - `--keep-worktrees-on-failure` (and runbook updated to match).
+  - Clear `comp.findings` per attempt; tag findings with attempt number so the
+    journal distinguishes superseded findings from shipped ones.
+  - Failure summary lists, per failed component: phase, check, evidence paths
+    (worktree, raw outputs, journal offsets).
+- [~] R3.4 (S) **Repo hygiene** [LOW hygiene]
+  - `.gitignore` covers `.ralph/`; remove the 99MB stale worktree
+    (`git worktree remove .claude/worktrees/tender-leakey` after confirming the
+    branch has no unique commits: check first, it is a destructive step for the
+    user to approve); commit or delete the untracked docs artifacts; track
+    `ralph.toml.example`, ignore live `ralph.toml`.
+  - Partial (landed in the R4.1 PR): `.gitignore` covers `.ralph/`;
+    polluted journals archived to `.ralph/archive/` with a README. NOT
+    done: the stale worktree was NOT removed - `claude/tender-leakey` has
+    2 commits not on main (6b41584, 917bde6: the pre-purge TUI work), so
+    per the check-first rule the user decides. The `ralph.toml.example`
+    tracking question and the remaining untracked docs artifacts also
+    stay open.
+
+Done when: a deliberately failed 3-component run can be diagnosed and resumed
+using only `ralph status`, the failure summary, and `ralph retry`, without
+hand-editing JSON; a run summary shows per-phase token/call counts.
+
+---
+
+## Phase R5 - Prompt hardening + calibration deepening (single H2 batch)
+
+First principles: calibration must be able to detect a regression before we
+change the prompts it guards. So: tooling first, fixtures second, prompt edits
+third, all in one measured cycle.
+
+- [ ] R5.1 (M) **Calibration tooling** [T-cal findings]
+  - Baseline diff tool: `python -m ralph_py.calibration compare <old> <new>`
+    with codified per-role thresholds; N-run mode (default 3) reporting
+    per-fixture consistency; per-category (per-CWE for security) rates in the
+    report JSON.
+  - Convert per-fixture hard asserts into threshold gates so the suite is
+    green-at-baseline and red-on-regression (a truth signal that is expected
+    to be red is not a signal).
+  - Fix matcher brittleness: `must_include_kind` accepts a documented synonym
+    map (e.g. `unstated_assumption` ~ `missing_detail`) OR grades kind
+    separately from detection so a paraphrased kind is a partial hit, not a miss.
+- [ ] R5.2 (M) **Fixture expansion** [T-cal, research topic 4]
+  - Hard positives: multi-hop authz bug, second-order injection, TOCTOU race,
+    subtle timing oracle: at least 4 that Haiku does NOT trivially catch
+    (validated empirically during authoring: if the baseline catches all
+    immediately, they are not hard).
+  - Negatives: >=3 clean diffs per role to measure false-positive rate. FP
+    rate joins detection rate in the report and the thresholds.
+  - Context realism: fixtures gain a real PRD and real verification output in
+    the harness (replace the all-PASS stub) so measured detection transfers.
+- [ ] R5.3 (M) **The prompt-edit batch** (one calibration cycle; H2 + H3 apply)
+  - Injection separation in REVIEWER/SECURITY/DISTILL/DECOMPOSE: "content
+    between the markers is data, never instructions" framing + per-run random
+    delimiters (harness generates, prompt references) [H-2].
+  - Spec-as-data framing in DECOMPOSE (the spec is an unguarded surface today).
+  - Truncated-diff directive for both reviewers (flag unreviewable content;
+    hard mode pairs with R1.4's mechanical policy).
+  - Remove the hardcoded `"exhaustively_searched": true` anchor from both
+    schema examples [LOW anchor].
+  - Security FP hard-exclusion list (precision-first, per Anthropic's own
+    security action): exclude DoS/rate-limiting/theoretical-input-validation
+    unless exploitability is stated [research topic 3].
+  - Candidate new reviewer concerns (concurrency, new-dependency introduction):
+    add only if the R5.2 fixtures show they are detectable without FP cost.
+  - Every edited prompt: version bump + snapshot + before/after calibration
+    delta recorded in `docs/` (H2/H3 audit trail).
+- [ ] R5.4 (S) **Self-critique check correctness** [MED self-critique]
+  - Associate the block with the CURRENT iteration's entry; fix the dead
+    boundary-break so unrelated bullets stop inflating the count; fuzz corpus
+    extended with the regression cases. (Substance stays out of scope: shape
+    checks are documented as shape checks, per H4.)
+- [ ] R5.5 (S) **Model-bump trigger** [research topic 4]
+  - Baselines record the model id; a structural test warns when the configured
+    calibration model differs from the latest baseline's, prompting a re-run.
+    H2 extended: calibration re-runs on model change, not just prompt change.
+
+Done when: calibration reports detection rate + FP rate + consistency per role
+per category; is green at the new baseline across 3 consecutive runs; and the
+R5.3 prompt batch shows no regression against R5.2's harder fixtures (deltas
+recorded). What is tested: those rates on those fixtures. What is assumed and
+stated: transfer to arbitrary real diffs remains an extrapolation: fixtures
+narrow, never close, that gap.
+
+---
+
+## Phase R6 - Learning-loop repair
+
+First principles: a learning loop is only as good as its input signal. Fix the
+signal, then the metrics, then re-baseline: proposals stay untrusted until all
+three are done.
+
+- [ ] R6.1 (M) **Real error signatures** [MED evolution-signal]
+  - Component failures record `check_name` + the parser's structured failure
+    signature (e.g. `linter:E501`, `typecheck:arg-type`, `diff_scope:rename`)
+    instead of flattened "Review failed" strings; review/security failures
+    record finding categories.
+  - `factory.py:1131`: use `EvolutionConfig.load(root_dir)`; journal paths
+    resolve against root; drop the `except OSError: pass` for a logged warning.
+- [ ] R6.2 (S) **Metrics read the typed stream** [MED concern-hit-rate, LOW proposal-clobber]
+  - `get_concern_hit_rate` consumes `findings_summary`; proposals derive from
+    finding taxonomies + error signatures; proposal IDs are monotonic and
+    prior proposal files are never clobbered.
+- [ ] R6.3 (S) **`evolve --apply` honesty** [D-evolve]
+  - Implement the minimal real path: applying a convention-type proposal
+    appends to the project CLAUDE.md Agent Learnings section after explicit
+    confirmation; everything else prints "manual". Honor `auto_propose`.
+- [ ] R6.4 (S) **Re-baseline** [H-18 follow-through]
+  - After R4.1 isolation: define `retry_rate` and duration semantics in
+    `docs/`, fix duration recording (currently 0.0), start fresh journals, and
+    keep the polluted archive for forensic reference only.
+
+Done when: after two real factory runs post-fix, `ralph evolve` produces at
+least one proposal traceable to a real recorded signature, and
+`get_concern_hit_rate` returns nonzero when a run had review concerns (proved
+by an integration test with a synthetic-but-realistic journal).
+
+---
+
+## Phase R7 - Strategic (the A+ differentiators)
+
+- [ ] R7.1 (M) **Cross-model review rotation** [research topic 3; user decision 2]
+  - Default `review_model`/`security_model` to a different family than the
+    engineer's when a second CLI is available; warn on homogeneity; record the
+    reviewing model identity on every Finding and in the PR body.
+  - Measure the correlated-miss delta: run calibration with same-family and
+    cross-family configs and record both (this is the E1 decision revisited
+    with 2026 evidence; independent passes, never committee deliberation).
+- [ ] R7.2 (M) **Wire fixtures, sandboxed** [CRIT-3, H-6; user decision 4]
+  - Function fixtures execute in a subprocess (`sys.executable -c`) with the
+    R2.6 scrubbed env: never in the harness process.
+  - CLI fixtures: `shlex.split` + `shell=False`.
+  - `PRD.validate_schema` accepts the `fixtures` key; `run_mechanical_verification`
+    calls `check_fixtures` when `[fixtures].enabled`; snapshot regression wired
+    behind the same flag.
+  - This restores the independent oracle against agent-authored tests (H-6's
+    conftest gaming is also mitigated: fixtures do not run under the project's
+    pytest and cannot be deselected by it).
+- [ ] R7.3 (L) **run_factory refactor: scheduler + ComponentPipeline** [architecture]
+  - Extract the phase chain into a `ComponentPipeline` with typed phase
+    results; single scheduling loop for sequential and parallel; the state
+    machine becomes unit-testable; `knowledge_config` late-binding accident
+    removed; retry/HITL/budget transitions explicit.
+  - Decide distiller placement (pre-PR vs post-merge) here and align the docs.
+  - This lands BEFORE Linear so integration consumes a stable, tested state
+    machine. Failure mode: big-bang refactor risk: land it as a
+    strangler (pipeline object first, scheduler swap second) with the R4 spine
+    tests as the net.
+- [ ] R7.4 (L) **Linear integration** [P-6; user decision 3]
+  - GraphQL + app-actor OAuth adapter implementing a `LinearSink` on the
+    ProgressLog event bus (factory.py untouched); decompose output creates one
+    project per manifest, one issue per component (stories as sub-issues),
+    spec_issues as triage issues.
+  - Branch names carry the Linear issue id; PR bodies carry "Fixes ENG-nnn":
+    Linear's GitHub integration then drives status transitions with zero API
+    calls from ralph.
+  - Idempotency keys (`run_id`+`component_id`) so retries update rather than
+    duplicate; rate-limit aware (shared 5k req/hr pool); Agents API
+    (@-mention delegation) stays behind an adapter until GA.
+  - Trigger direction (webhook on issue delegation -> factory run) is a
+    follow-up once the sink is stable.
+- [ ] R7.5 (M) **Platform hardening** [research topics 1-2]
+  - No-progress circuit breaker: halt a component when N consecutive iterations
+    produce an unchanged diff hash + test signature (the community's
+    single most-repeated Ralph-loop fix).
+  - OS-level sandboxing for agent subprocesses: pass Claude Code sandbox
+    settings (network/write scoping) through the adapter; document the codex
+    equivalent; worktree isolation stops being the only boundary.
+  - Merge-conflict doctrine: on conflict, re-run the component against the
+    fresh merged base instead of rebasing agent output.
+  - SpecKit intake: accept spec.md/plan.md/tasks.md as architect input; the
+    DECOMPOSE prompt demands EARS-style acceptance criteria (prompt change:
+    rides the next H2 calibration cycle, not R5's).
+  - Agent SDK spike (measure, then decide: user decision 5): structured
+    streams, hooks, budget enforcement vs stdout parsing; a one-day spike with
+    a written comparison, per the measure-don't-assume rule.
+
+Done when: cross-family review is the measured default; fixtures run sandboxed
+in Phase 1 on an opt-in project; a factory run appears in Linear end-to-end
+(project, issues, status transitions, PR links) with no duplicate issues across
+a retry; the circuit breaker halts a deliberately-stalled run.
+
+---
+
+## A+ exit criteria per review dimension
+
+The review's scorecard maps to these gates. A dimension is A+ only when every
+listed gate is green and the claim is backed by a named test or measurement
+(H4: tested, not assumed).
+
+| Dimension (review grade) | A+ gate |
+|---|---|
+| Architect / decompose (B+) | R0.6 + R1.5 + R1.7 + R1.8 + R5.3 spec-as-data + calibration: architect detection >= baseline on hard fixtures, 0 hallucinated findings across 3 consecutive runs, spec_issues persisted |
+| Mechanical verification (B-) | R1.5 rename-aware scope + R2.6 env scrub + R5.4 self-critique correctness + R7.2 fixtures wired sandboxed: an adversarial-agent test battery (tautological test, conftest deselect, rename-move, sweep-in commit) all caught |
+| LLM review + security (C+) | R1.1-R1.4 + R5.3: empty/partial/oversized/truncated outputs all fail closed; injection battery (in-diff instructions) does not flip a verdict on the calibration negatives; FP rate measured and under threshold |
+| Knowledge layer (C-) | R1.6: decay regression tests green; evidence-field injection battery rejected; utilization telemetry nonzero on a real run |
+| Factory orchestration (C) | R0.1-R0.6 + R2.3 + R7.3: induced hang/push-fail/conflict battery green; state machine unit-tested in isolation; no subprocess call without a timeout (enforced by a grep test) |
+| Evolution / learning (D) | R4.1 + R6.1-R6.4: journal clean, signatures real, hit-rate live, one traceable proposal from real runs |
+| Test suite (B) | R4.1-R4.4: five spine behaviors covered unmocked; suite network-free by default; coverage ratcheted; zero misleading-name tests from the T-findings list remain |
+| Calibration (C+) | R5.1-R5.2 + R5.5: green-at-baseline, FP + consistency + per-category measured over 3 runs, diff tool with codified thresholds, model-bump trigger |
+| Docs and product surface (C-) | R2.1-R2.5 + R3.1-R3.3: generated CLI/config docs CI-checked; every README command exists; config show/status live; cost + notify + retry shipped; install story resolved |
+
+---
+
+## Traceability: review finding -> plan item
+
+- CRIT-1 -> R0.1; CRIT-2 -> R0.2; CRIT-3 -> R7.2 (docs interim: R2.5);
+  CRIT-4 -> R1.6; CRIT-5 -> R1.1; CRIT-6 -> R0.3; CRIT-7 -> R2.1/R2.2;
+  CRIT-8 -> R2.3; CRIT-9 -> R2.5; CRIT-10 -> R0.4.
+- H-1 -> R0.2; H-2 -> R5.3; H-3 -> R1.6; H-4 -> R1.5; H-5 -> R1.5; H-6 -> R7.2
+  (+R1.5 partial); H-7 -> R0.5; H-8 -> R0.5; H-9 -> R0.6; H-10 -> R2.3;
+  H-11 -> R2.3; H-12 -> R2.4; H-13 -> R1.2; H-14 -> R1.3; H-15 -> R0.5;
+  H-16 -> R1.4 (+R5.3); H-17 -> R3.1; H-18 -> R4.1 (+R6.4).
+- MED orchestration: cwd-paths/repo-root/loop-guard -> R0.4; pr-timeouts ->
+  R0.2; hitl-abort -> R2.6; main-thread-serialization -> R7.3; env-leak ->
+  R2.6; process-group -> R2.6/R0.1. LOW orchestration: completed_at/findings-
+  accumulate -> R3.3; branches/sleep/pipe -> R7.3 (tracked there); hygiene -> R3.4.
+- MED adversarial: spec-issues -> R1.7; sec-pr-body -> R1.2; review-nondict ->
+  R1.2; prd-validate-late -> R1.8; knowledge-trust -> R1.6. LOW adversarial:
+  vacuous-prd -> R1.8; nonce-order -> R1.6; anchor -> R5.3; proposal-clobber ->
+  R6.2; raw-output-truncation -> R1.2 (keep full dumps like knowledge does).
+- MED verification: self-critique -> R5.4; feedforward-python-only /
+  dep-graph-bounds -> P2 honesty note in R2.5 README + bounds fix folded into
+  R2.3 feedforward wiring. LOW verification: committed-vs-working-tree,
+  bad-patterns scope, dead-code add -A, parser blind spots, substring filter ->
+  batched as a single "verification polish" PR inside R1 (non-gating,
+  documented) .
+- T-1..T-19 -> R4.1-R4.4 (T-12 live-call -> R4.3; T-16 coverage -> R4.4;
+  T-10 phantom test -> R4.3).
+- D-* docs findings -> R2.4/R2.5 (+R3.2 for status, R6.3 for evolve).
+- P-1..P-7 product gaps -> R2.1 (control plane), R0/R3 (walk-away), R3.1
+  (cost), R3.2 (monitoring), R3.3 (resume), R1.7+R7.5 (spec front door),
+  R2.5 (Python-first honesty), R7.4 (Linear).
+- Research implications 1-10 -> R7.1 (rotation), R5.1/R5.2/R5.5 (calibration),
+  R7.5 (breaker, sandboxing, re-run-not-rebase, SpecKit, SDK), R5.3 (FP
+  filter), R7.4 (Linear GraphQL), R1.6 knowledge guardrails (+R6 distill-from-
+  failures noted as a candidate follow-up).
+
+Every phase = one or more PRs, user-gated per H1. Tracker updated as items land.

--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -369,12 +369,13 @@ spending, (c) what do I do when I come back to a partial failure.
     user to approve); commit or delete the untracked docs artifacts; track
     `ralph.toml.example`, ignore live `ralph.toml`.
   - Partial (landed in the R4.1 PR): `.gitignore` covers `.ralph/`;
-    polluted journals archived to `.ralph/archive/` with a README. NOT
-    done: the stale worktree was NOT removed - `claude/tender-leakey` has
-    2 commits not on main (6b41584, 917bde6: the pre-purge TUI work), so
-    per the check-first rule the user decides. The `ralph.toml.example`
-    tracking question and the remaining untracked docs artifacts also
-    stay open.
+    polluted journals archived to `.ralph/archive/` with a README. The
+    stale worktree `claude/tender-leakey` had 2 commits not on main
+    (6b41584, 917bde6: the pre-purge TUI work); after user approval the
+    worktree and branch were removed, with a local tag
+    `archive/tui-overhaul` left at 6b41584 so the commits stay
+    recoverable. Still open: the `ralph.toml.example` tracking question
+    and the remaining untracked docs artifacts.
 
 Done when: a deliberately failed 3-component run can be diagnosed and resumed
 using only `ralph status`, the failure summary, and `ralph retry`, without

--- a/docs/remediation-sessions.md
+++ b/docs/remediation-sessions.md
@@ -1,0 +1,923 @@
+# Remediation Execution Plan: Copy/Paste Session Prompts
+
+Companion to `docs/remediation-roadmap.md` (the WHAT). This file is the HOW:
+one prompt per Claude Code session, grouped into waves you can run in
+parallel. Paste a prompt into a fresh session, review the PR it produces,
+merge, move on. Each session flips its own checkboxes in the roadmap tracker
+inside its PR, so the tracker is always the single source of truth for
+progress.
+
+Review report (context for humans; sessions do not need it):
+https://claude.ai/code/artifact/0996ac84-8acf-4000-a526-72d4b0994832
+
+---
+
+## How to run this
+
+**Sequential (simplest):** open a Claude Code session at the repo root, paste
+the next prompt, review the PR, merge, repeat. Follow wave order; within a
+wave, order does not matter.
+
+**Parallel (waves):** sessions within the same wave touch disjoint files (or
+disjoint regions with trivial rebases). Run each parallel session in its own
+worktree:
+
+```bash
+cd ~/Documents/code/ralph
+git fetch origin
+git worktree add ../ralph-<id> -b <branch-from-prompt> origin/main
+cd ../ralph-<id>
+uv sync          # each worktree needs its own venv
+claude           # then paste the session prompt
+```
+
+After the PR merges:
+
+```bash
+cd ~/Documents/code/ralph
+git worktree remove ../ralph-<id>
+```
+
+**Merge protocol:** you are the gating reviewer for every PR (H1): use
+`/code-review ultra <PR#>` or direct inspection. Merge a wave's PRs in the
+order listed. Do not start the next wave until the current wave is merged
+(prompts assume the previous wave's code exists).
+
+**If a session goes sideways:** stop it, delete the branch, re-paste the
+prompt in a fresh session. Prompts are self-contained; no session depends on
+another session's chat context.
+
+---
+
+## Shared rules (every prompt references this section)
+
+1. Read `CLAUDE.md`, then your items in `docs/remediation-roadmap.md`. They
+   contain the finding details and file:line references. The line numbers were
+   captured at main @ 8115636: treat them as pointers, verify against current
+   code before editing.
+2. Touch only the files your prompt names, plus tests and the two tracker
+   docs. If you conclude another file must change, stop and report why
+   instead of expanding scope.
+3. Do NOT modify any `*_PROMPT` body, `*_PROMPT_VERSION` constant, or
+   `tests/test_prompt_versions.py` snapshot. Only Session 8C (and 5A for
+   `DEFAULT_PROMPT` only) may, following H2/H3. The snapshot test will catch
+   violations.
+4. Do NOT run `/code-review` (H1: the user is the gating reviewer).
+5. Coding standards per CLAUDE.md: `from __future__ import annotations`,
+   full type hints, `T | None`, frozen dataclasses where immutable, no bare
+   except, no mutable defaults.
+6. Before opening the PR, all three must be green and you must paste their
+   final lines into the PR body:
+   `uv run pytest tests/ -q` / `uv run mypy ralph_py/ --strict` /
+   `uv run ruff check ralph_py/ tests/`
+7. Rebase onto `origin/main` before pushing. Open the PR with `gh pr create`;
+   do not merge it.
+8. PR body must contain: roadmap item IDs, a "Tested" list (behaviors proven
+   by named tests) and an "Assumed" list (anything claimed but not tested):
+   H4 discipline.
+9. In the same PR: flip your item checkboxes in
+   `docs/remediation-roadmap.md` from `[ ]` to `[x]` (use `[~]` plus a note
+   if partial).
+
+---
+
+## Wave map
+
+| Wave | Sessions (merge order) | Parallel OK | Needs merged |
+|---|---|---|---|
+| 1 | 1A timeouts, 1B input hygiene, 1C knowledge, 1D suite isolation | all 4 | - |
+| 2 | 2A PR outcomes, 2B contract safety, 2C worktree provisioning | all 3 (disjoint factory.py regions; rebase) | wave 1 |
+| 3 | 3A instance safety, 3B reviewer gates, 3C scope hardening, 3D architect persistence | all 4 | wave 2 |
+| 4 | 4A truncation policy, 4B config control plane, 4C spine tests I | all 3 | wave 3 |
+| 5 | 5A run honesty, 5B HITL + env scrub, 5C test fixes + coverage | all 3 | wave 4 |
+| 6 | 6A preflight + config show, 6B cost meter, 6C spine tests II | all 3 | wave 5 |
+| 7 | 7A docs regeneration, 7B status + notify, 7C resume ergonomics | all 3 | wave 6 |
+| 8 | 8A calibration tooling, 8D self-critique, then 8B fixtures, then 8C prompt batch | 8A+8D parallel; 8B after 8A; 8C last | wave 7 |
+| 9 | 9A evolution repair | solo | wave 8 |
+| 10 | 10A rotation*, 10B fixtures wiring, 10C refactor (solo), 10D Linear*, 10E platform | 10A+10B parallel; 10C strictly solo; 10D after 10C | wave 9 |
+
+`*` = blocked on a user decision (see roadmap "User decisions required").
+
+---
+
+# Wave 1
+
+## Session 1A: Timeouts end to end
+Branch: `fix/r0-1-timeouts`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R0.1 in docs/remediation-roadmap.md. You are implementing R0.1: agent timeouts are currently configured everywhere and enforced nowhere.
+
+Defects (verify line numbers against current code):
+- loop.py:154 calls agent.run(prompt, cwd) with no timeout; config.py:62-63 (agent_iteration_timeout, component_timeout) and the entire timeout.py module are parsed but never consumed; cli.py binds --agent-timeout/--component-timeout for `ralph factory` and never uses them.
+- agents/codex.py:44-98 ignores its timeout parameter entirely and proc.wait() is unbounded; agents/claude_code.py:90-98 only checks the clock when a stdout line arrives, so a silently hung CLI blocks forever; agents/custom.py has the same class of problem.
+
+Scope: ralph_py/agents/*.py, ralph_py/loop.py, ralph_py/timeout.py, ralph_py/config.py, ralph_py/factory.py (scheduler backstop only), ralph_py/cli.py (wire the two dead flags), tests.
+
+Requirements:
+1. All agent subprocesses launch with start_new_session=True. Read stdout on a reader thread with a deadline so a hang with NO output is detected. On breach: killpg(SIGTERM), grace period, then SIGKILL. All three adapters honor the timeout parameter. Bound codex proc.wait().
+2. loop.py passes agent_iteration_timeout into agent.run and enforces component_timeout as a wall-clock check across iterations (abort the loop cleanly when exceeded, report which limit fired).
+3. factory.py scheduler: backstop deadline of component_timeout plus margin per future; on breach mark the component FAILED with error "component timeout", warn a worker may be leaked, continue the run.
+4. Consume TimeoutConfig as the single source for these values (loaded from toml/env); delete any now-dead duplicate fields rather than leaving two sources.
+5. Timeout-failure retries must not reuse a possibly-dirty worktree state: remove stale .git/index.lock if present and note the recreate-from-base behavior in the retry error string.
+
+Tests (real subprocesses, no LLM): a sleep-forever fake agent script is terminated within the deadline and the component is FAILED; a fake agent that spawns a grandchild (sh -c 'sleep 1000 & wait') has the grandchild killed too; a fake agent that hangs silently AFTER emitting one line is still killed.
+
+Finish per Shared rules: green pytest/mypy/ruff, rebase, PR with Tested/Assumed lists referencing R0.1, flip the R0.1 checkbox in docs/remediation-roadmap.md in the same PR.
+```
+
+## Session 1B: Input hygiene for LLM-emitted identifiers
+Branch: `fix/r0-6-id-hygiene`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R0.6 in docs/remediation-roadmap.md. You are implementing R0.6: LLM-emitted component ids and branch names flow unvalidated into filesystem paths and git argv.
+
+Defects: decompose.py:384-390 and manifest.py:283-298 validate ids only as non-empty strings. An id like "../../repo" escapes .ralph/worktrees/ and reaches `git worktree remove --force` at the escaped path (factory.py builds worktree_path = root/.ralph/worktrees/<id>). Branch names reach `git push -u origin <branch>` and `git worktree add ... <branch>` with no leading-dash rejection and no `--` separators, so a crafted value becomes an argv option.
+
+Scope: ralph_py/manifest.py, ralph_py/decompose.py, ralph_py/git.py, ralph_py/pr.py, tests.
+
+Requirements:
+1. Component ids must match ^[a-z0-9][a-z0-9._-]{0,63}$ (no slashes, no dots-only segments). Enforce at manifest parse AND decompose validation, with actionable error messages (the decompose retry loop should be able to feed the error back).
+2. Branch names: reject leading '-', '..', whitespace, and ':'; allow the ralph/factory/ prefix pattern.
+3. Add `--` separators in git invocations where a ref or path follows options and could be attacker-shaped (survey git.py and pr.py call sites; change only where it is safe for the git subcommand in question).
+4. Do not silently sanitize: reject with an error. Silent rewriting hides architect drift.
+
+Tests: parametrized rejection tests (traversal ids, option-injection branch names, unicode confusables at least for the dash), plus acceptance tests for current legitimate ids/branches from examples and tests to prove no regression.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R0.6, flip the R0.6 checkbox in docs/remediation-roadmap.md.
+```
+
+## Session 1C: Knowledge retention + read-side defense
+Branch: `fix/r1-6-knowledge`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R1.6 in docs/remediation-roadmap.md. You are implementing R1.6. IMPORTANT: do not edit DISTILL_PROMPT or any prompt body; every fix here is code-side.
+
+Defects (knowledge.py):
+- Retrieval reads only the lexicographically latest run dir (:282-294, :297-320). The distill prompt forbids re-emitting existing facts, so each successful re-distill HIDES all prior facts; and _dump_debug (:1013-1035) creates a fact-less newer run dir on parse failure, so a failed distill erases the component's entire visible knowledge.
+- _coerce_facts (:907-911) runs the injection filter on claim and tags but NOT evidence; evidence has no length/count cap and _format_section renders it verbatim into downstream "treat as ground truth" prompts.
+- _parse_fact_md (:231-274) validates nothing on read, so an edited-on-disk fact bypasses all filters.
+- test_verified confidence is accepted with zero cross-checking.
+- Same-second run dirs order by random nonce, so "latest" can be older.
+
+Scope: ralph_py/knowledge.py, tests/test_knowledge.py.
+
+Requirements:
+1. Retrieval becomes union-across-run-dirs with per-fact-id latest-wins (supersede by fact id, not by directory). Keep token budgeting semantics; re-check tier caps still hold with union reads.
+2. Debug dumps move to <knowledge_root>/<comp>/_debug/<run_id>/ and are never globbed as facts.
+3. Sanitize + cap evidence items at coercion (same _is_injection_attempt gate and explicit MAX lengths/counts as claims); ALSO re-validate claim/evidence/tags on read in _parse_fact_md, rejecting (with a warning, not a crash) any fact that fails.
+4. test_verified: downgrade to "asserted" unless at least one evidence item cites a path that exists in the worktree; keep the hint framing in code comments.
+5. Run-id: include microsecond precision so same-second ordering is deterministic.
+
+Tests: the exact decay scenario (distill run 1 writes 7 facts, run 2 fails parse, read_facts still returns the 7); supersede-by-fact-id (run 2 re-emits fact A only; read returns run-2 A plus run-1 B); evidence-field injection payload rejected at write AND at read; test_verified downgrade behavior; microsecond ordering.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R1.6, flip the R1.6 checkbox in docs/remediation-roadmap.md.
+```
+
+## Session 1D: Test-suite isolation + repo hygiene
+Branch: `fix/r4-1-isolation`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then items R4.1 and R3.4 in docs/remediation-roadmap.md. You are implementing suite isolation and repo hygiene.
+
+Defects: the test suite writes to the repo's REAL .ralph/evolution.jsonl and .ralph/experiments.tsv: 837 of 910 journal entries are test pollution, corrupting the data the learning loop consumes. conftest's clean_env clears only legacy vars, not FACTORY_*/RALPH_* families. The repo also carries a ~99MB stale worktree at .claude/worktrees/tender-leakey and .gitignore does not cover .ralph/.
+
+Scope: tests/conftest.py, .gitignore, .ralph/ (archival move only), tests as needed. Do NOT touch ralph_py/ source in this session.
+
+Requirements:
+1. Autouse conftest fixture that redirects every evolution/experiments/knowledge write path to tmp_path for all tests (env vars and/or monkeypatched defaults; inspect how EvolutionConfig and KnowledgeConfig resolve paths and cover both).
+2. A guard fixture that snapshots the repo's .ralph/ state before the session and FAILS the run loudly if any test mutated it. This is the enforcement, not the redirect.
+3. Extend clean_env to the FACTORY_*, RALPH_TIMEOUT_*, RALPH_CONTRACT_*, RALPH_SECURITY_*, RALPH_VERIFY_*, RALPH_EVOLUTION_*, RALPH_KNOWLEDGE_* families so ambient dev-machine env cannot alter from_env tests.
+4. Archive (do not delete) the polluted journals: move .ralph/evolution.jsonl and .ralph/experiments.tsv to .ralph/archive/ with a README.md line explaining why.
+5. Add .ralph/ to .gitignore.
+6. Stale worktree: run `git log claude/tender-leakey --not main --oneline`. If it shows NO unique commits, remove the worktree (git worktree remove --force .claude/worktrees/tender-leakey) and delete the branch, and say so in the PR. If it shows unique commits, do NOT remove anything: list them in the PR body for the user to decide.
+
+Tests: a deliberate journal-writing test against defaults proves the redirect works; the guard fixture is exercised by a self-test.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R4.1 + R3.4 (mark R3.4 [~] since gitignore/archive land here but ralph.toml tracking questions may remain), flip checkboxes accordingly.
+```
+
+---
+
+# Wave 2 (after wave 1 merges)
+
+## Session 2A: PR outcomes gate completion + fetch-based base propagation
+Branch: `fix/r0-2-pr-outcomes`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R0.2 in docs/remediation-roadmap.md. You are implementing R0.2.
+
+Defects:
+- factory.py:887-915: the result of push_create_and_merge_pr is only used to collect a URL; push failure, PR-creation failure, merge failure, and wait_for_merge timeout ALL fall through to comp.status = COMPLETED, so dependents build without the dependency's merged code (CRIT-2).
+- pr.py:149-152 runs `git pull origin <base>` with cwd=root_dir on WHATEVER branch the user has checked out: it mutates the operator's checkout and leaves local base stale (H-1).
+- Every pr.py subprocess except the merge-wait loop lacks a timeout.
+
+Scope: ralph_py/pr.py, ralph_py/factory.py (PR block + worktree base refs), ralph_py/manifest.py (status enum), ralph_py/git.py (diff base refs), tests.
+
+Requirements:
+1. pr.py returns a typed PrOutcome dataclass (pushed, pr_url, merged, merge_pending, error) instead of lossy tuples. Explicit timeouts on every gh/git call in the module.
+2. factory: COMPLETED only when merged is True (or create_prs=False). New manifest status MERGE_PENDING for wait-timeout: dependents are NOT scheduled past it; crash-recovery treats MERGE_PENDING as re-pollable, not failed.
+3. Kill the pull: replace with `git fetch origin <base>`; cut worktrees from origin/<base> and compute verification diffs against origin/<base> when a remote exists, falling back to the local base ref when there is no origin (local-only repos and the test suite must keep working). Centralize the "resolve base ref" logic in one helper.
+4. The operator's checkout must never be touched by any code path in this session's scope.
+
+Tests (real git repos, stub gh binary placed on PATH by the test): push-fail, create-fail, merge-fail, wait-timeout each produce the right status and dependents do not schedule; the fetch path updates origin/<base> without touching the checked-out branch; no-remote fallback works.
+
+Finish per Shared rules: green checks, rebase (wave-2 sessions touch different factory.py regions; resolve any trivial conflicts), PR with Tested/Assumed referencing R0.2, flip the R0.2 checkbox.
+```
+
+## Session 2B: Contract phase safety
+Branch: `fix/r0-3-contract`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R0.3 in docs/remediation-roadmap.md. You are implementing R0.3.
+
+Defects:
+- contract.py merges tier branches into a temp branch created IN THE USER'S REPO (root_dir). On merge conflict the cleanup path (git checkout base + branch -D, contract.py:110-118) fails against a conflicted index, both return codes are ignored, the repo is left mid-conflict, and every subsequent tier fails. There is no `git merge --abort` anywhere (CRIT-6).
+- factory.py:1055-1082: when contract fails, the breaker is reset to PENDING AFTER the scheduling loop has exited, so the promised retry never runs; the failure is not recorded in factory_result.failed, so the run exits 0 with broken integrated code.
+- Bisection blames the first component unconditionally when PRs were already squash-merged (merges no-op), and is order-dependent for interaction failures.
+
+Scope: ralph_py/contract.py, ralph_py/factory.py (contract block + scheduling loop re-entry), tests.
+
+Requirements:
+1. All tier merging happens in a detached temp WORKTREE (git worktree add --detach), never the user's checkout. Recovery path: git merge --abort, then remove the temp worktree; assert cleanup succeeded and fail loudly if not.
+2. Contract failure sets a nonzero exit code and lands in the run summary; record a contract_result event in the evolution journal for pass and fail.
+3. Breaker retry actually re-enters scheduling: restructure so a reset breaker re-runs while contract retries remain (an outer loop around scheduling + contract, or equivalent). Cascade rules unchanged.
+4. Bisection honesty: when components were already merged to base (create_prs mode), skip blame attribution and report "tier failed" with the failing test output. Keep merge-order bisection only for deferred-merge mode, in topological order, and document the two-component-interaction limitation in the module docstring.
+
+Tests (real git): a conflicted tier leaves the user's checkout byte-identical and recovers cleanly; a failing tier yields nonzero exit; a breaker re-runs and a subsequently passing contract completes the run; squash-merged mode reports without blame.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R0.3, flip the R0.3 checkbox.
+```
+
+## Session 2C: Worktree provisioning + retry context + guard ordering
+Branch: `fix/r0-4-provisioning`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R0.4 in docs/remediation-roadmap.md. You are implementing R0.4: the pair of defects that caused the recorded end-to-end validation failure (docs/phase-f-e2e-validation-v12.log: read it, it is short and is your acceptance scenario).
+
+Defects:
+- factory.py _run_component copies only the PRD into the worktree. scripts/ralph/prompt.md is gitignored, so fresh worktrees never contain it and the engineer silently falls back to the harness DEFAULT_PROMPT (log line 38).
+- The repo-root detection heuristic (factory.py:274-280) is inverted: it tests for .ralph/worktrees inside the worktree, which only exists if committed; CLAUDE.md/AGENTS.md propagation is a guaranteed no-op in real worktrees.
+- Root-relative paths (prd/prompt) resolve against the worker's inherited CWD (factory.py:254, 265-268), so --root from another directory silently no-ops the copies.
+- verify.check_diff_scope failure messages name neither the base branch nor the allowed paths; in the logged run the agent guessed `main` as base, ran `git checkout main -- ralph_py/decompose.py ...` reverting base-branch content, and failed again.
+- loop.py:168-186: the completion-marker early return happens BEFORE guards.enforce_allowed_paths, so an agent that edits out-of-scope files and emits COMPLETE in the same iteration bypasses enforcement.
+
+Scope: ralph_py/factory.py (_run_component and _submit_args plumbing), ralph_py/verify.py (check_diff_scope message), ralph_py/context.py (pass-through only if needed), ralph_py/loop.py (guard ordering), tests.
+
+Requirements:
+1. _run_component receives root_dir explicitly and resolves prd/prompt/CLAUDE.md/AGENTS.md sources against it; copies prompt.md and CLAUDE.md/AGENTS.md into the worktree alongside the PRD; delete the broken heuristic.
+2. check_diff_scope failure details include the base branch name and the full allowed-paths list, formatted so the retry prompt carries them verbatim.
+3. Guards run before the completion early-return in loop.py.
+4. Integration test: a real worktree run (fake agent) has the customized prompt file present; a diff-scope failure's retry context contains the base branch string and allowed paths; an out-of-scope edit plus same-iteration COMPLETE is reverted.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R0.4, flip the R0.4 checkbox.
+```
+
+---
+
+# Wave 3 (after wave 2 merges)
+
+## Session 3A: Instance and state safety
+Branch: `fix/r0-5-instance-safety`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R0.5 in docs/remediation-roadmap.md. You are implementing R0.5.
+
+Defects:
+- _setup_worktree unconditionally force-removes an existing worktree at the component path under a per-component flock that only serializes the git commands: a second factory invocation destroys the first's IN-FLIGHT worktree (guaranteed collision for `ralph run`, whose component id is constant) (H-7). Stale branches from aborted runs are silently reused with their old commits via the fallback `git worktree add <path> <branch>`.
+- factory.py:424 hardcodes the manifest save path: `ralph run` clobbers an in-progress factory's resumable manifest, and `--manifest /custom.json` state saves to the wrong file (H-15).
+- single_pr mode with parallel worktrees hard-fails every same-tier component after the first (branch already checked out elsewhere); nothing forces max_parallel=1 (H-8).
+
+Scope: ralph_py/factory.py, ralph_py/cli.py (manifest path + single_pr guard), ralph_py/manifest.py (if path handling lives there), tests.
+
+Requirements:
+1. Run-level exclusion: flock on .ralph/factory.lock held for the whole run; a second invocation on the same root refuses to start with a clear message (add a --force-lock override flag). POSIX-only like the existing A4 lock; degrade with a warning on Windows.
+2. Worktrees keyed .ralph/worktrees/<run_id>/<component_id>; cleanup and crash-recovery updated for the new layout; stale branches from previous runs are deleted if fully merged, otherwise the run refuses with an explicit error naming the branch. Never silently reuse.
+3. Manifest save path == manifest load path. `ralph run` uses its own scripts/ralph/run-manifest.json.
+4. single_pr=true forces max_parallel=1 with a printed notice.
+
+Tests: two-process contention test (second invocation refused while first holds the lock); custom-manifest round-trip saves to the custom path; single_pr parallel request downgrades; stale-branch refusal.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R0.5, flip the R0.5 checkbox.
+```
+
+## Session 3B: Reviewer gate integrity
+Branch: `fix/r1-1-review-gates`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then items R1.1, R1.2, R1.3 in docs/remediation-roadmap.md. You are closing the reviewer-gate holes. Do NOT edit any prompt body.
+
+Defects:
+- review.py:406-485: {"stories":[],"concerns":[]} parses to passed=True in hard mode; criterion coverage against the PRD is never checked (CRIT-5).
+- review.py:437-441: verdicts stored verbatim and compared case-sensitively; "FAIL"/"Blocked" become non-blocking advisories.
+- review.py:518-527: the AgentOutputTooLarge path never sets infrastructure_error (security.py:499-505 does), so a review that never happened is indistinguishable from a clean one in advisory mode; findings.py's "len(findings)==0 means ran cleanly" claim is false on this path (H-13).
+- Budget-exhausted and mode-skipped phases leave no trace in the findings stream (factory.py:599-604, 664-670, 774-778).
+- A generic reviewer-agent exception propagates out of run_review and aborts the entire run via unwrapped _handle_result call sites; security wraps its call in except Exception (factory.py:684-718) but review does not (factory.py:615-624).
+- review.py:409-421: _extract_json can return non-dict JSON (null, list) and crash the parser with AttributeError.
+- factory.py:732-739: a security infrastructure error in advisory mode produces a PR body with NO security section: "did not run" is invisible.
+- review.py:484 / security.py:436: raw_output truncated to 2000 chars, losing the forensic tail of malformed outputs.
+
+Scope: ralph_py/review.py, ralph_py/security.py (parity bits only), ralph_py/findings.py, ralph_py/factory.py (phase call sites + PR body), ralph_py/pr.py (security-did-not-run section), tests.
+
+Requirements:
+1. Criterion coverage: every PRD story id must receive a verdict or the result is infrastructure_error=True. Match by story id, not criterion text.
+2. Verdict whitelist {pass, fail} case-insensitive; anything else is a parse failure (infrastructure), never an advisory.
+3. AgentOutputTooLarge sets infrastructure_error in review, mirroring security.
+4. Skipped and budget-exhausted phases emit a synthetic Finding (category "phase_skipped", is_infrastructure_error stays False but a distinct flag or tag marks non-execution) and a journal event, so the findings stream distinguishes ran-clean from never-ran.
+5. Wrap the review agent call like security's (catch Exception, degrade to per-component infra failure, never abort the run).
+6. Guard non-dict _extract_json results.
+7. PR body renders an explicit "security review did not run (infrastructure error)" section when applicable (render_findings_markdown already has the callout; wire it).
+8. Full raw-output debug dumps for review and security parse failures (mirror knowledge.py's _distill_raw.txt pattern) instead of the 2000-char truncation.
+
+Tests: empty review fails hard mode; "FAIL"/"Blocked"/"PASS " verdicts behave correctly; oversized output is infra; skip/budget paths produce the synthetic finding + journal event; reviewer crash fails one component, not the run; non-dict JSON is infra; PR body shows the did-not-run section.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R1.1-R1.3, flip those checkboxes.
+```
+
+## Session 3C: Scope-guard hardening
+Branch: `fix/r1-5-scope`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R1.5 in docs/remediation-roadmap.md. You are hardening the diff-scope guard. Do NOT edit any prompt body.
+
+Defects:
+- git.get_diff_names (git.py:216) uses `git diff --name-only base...HEAD`; git rename detection means moving protected content into an allowed path shows ONLY the destination, so a rename-move defeats scope (empirically reproduced in the review: `git mv protected/gate.py allowed/gate.py` yields only allowed/gate.py) (H-5).
+- decompose._validate_decompose_output (decompose.py:414-434) validates allowedPaths entries only as non-empty strings. The DECOMPOSE_PROMPT promises the harness rejects entries like ".ralph/" or repo-root manifests: it does not, so the constrained model can reopen its own guardrail (H-4). Read the EXCLUDE list stated inside DECOMPOSE_PROMPT (do not modify the prompt) and enforce exactly that list in the validator.
+- factory.py:554-558: PRD load/parse failure is swallowed into allowed_paths=None, which silently DISABLES the scope check (check_diff_scope returns passed=True on falsy allowed_paths).
+
+Scope: ralph_py/git.py, ralph_py/verify.py, ralph_py/decompose.py (validator only), ralph_py/factory.py (the swallow site), tests.
+
+Requirements:
+1. get_diff_names uses --name-status -M (and -C if cheap); rename/copy SOURCES count as changed paths for scope purposes. Update all callers.
+2. allowedPaths content validation: reject absolute paths, "..", entries matching the DECOMPOSE_PROMPT EXCLUDE list, and overly-broad entries ("/", "."). Rejection flows through the existing decompose retry-with-error loop.
+3. PRD load failure at the factory scope site fails CLOSED: produce a failing diff_scope CheckResult with an infrastructure-flavored message instead of None-disabling. Keep the "no allowed_paths configured at all" legitimate-disable case working (distinguish "not configured" from "failed to load").
+4. Keep the base-branch + allowed-paths failure-message content added in wave 2 intact.
+
+Tests: rename-move is caught (real git repo test); each EXCLUDE-list entry is rejected by the validator with a retryable message; PRD-load failure fails the check; unconfigured scope still passes with the existing message.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R1.5, flip the R1.5 checkbox.
+```
+
+## Session 3D: Architect persistence + decompose validation ordering
+Branch: `fix/r1-7-architect`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then items R1.7 and R1.8 in docs/remediation-roadmap.md. Do NOT edit any prompt body.
+
+Defects:
+- decompose.py:514-537: red-team spec_issues (blockers, majors, minors) exist only as UI lines; nothing persists them. Three weeks later there is no record the harness saw a problem coming (violates the audit-trail invariant).
+- decompose.py:539-577: PRD schema validation happens AFTER the retry loop and AFTER files are written; a malformed story crashes decompose outside the retry loop, the LLM never gets to fix it, and partial prd.json files remain on disk.
+- Empty userStories, empty acceptanceCriteria, and passes:true all pass validation (vacuous components auto-pass review downstream).
+
+Scope: ralph_py/decompose.py, ralph_py/cli.py (print the artifact path on halt), tests.
+
+Requirements:
+1. Persist ALL spec_issues to scripts/ralph/spec-issues.json (structured: severity, kind, summary, location) plus a journal event; on SpecBlockerError the CLI prints the file path so the user iterates against a durable artifact.
+2. Move PRD schema validation inside the decompose retry loop so validation errors feed back to the LLM like other validation failures; write files only after everything validates; clean up partials on terminal failure.
+3. Reject empty userStories, empty acceptanceCriteria arrays, and passes:true at decompose validation with retryable messages.
+
+Tests: spec-issues.json written with correct content on both halt and success; a malformed story triggers a retry (feed a fake agent that fails once then succeeds); no partial files after terminal failure; the three vacuous-PRD cases are rejected.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R1.7 + R1.8, flip those checkboxes.
+```
+
+---
+
+# Wave 4 (after wave 3 merges)
+
+## Session 4A: Truncated-diff policy + security parity
+Branch: `fix/r1-4-truncation`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R1.4 in docs/remediation-roadmap.md. Do NOT edit any prompt body (the reviewer-facing truncation DIRECTIVE is Session 8C's job; yours is the mechanical policy).
+
+Defects:
+- git.py:261-271 head-truncates review diffs at 50KB. A rogue engineer can pad the first 50KB with benign churn and land the malicious hunk after the cut; both reviewers see a truncation notice but hard mode has no policy: the unreviewed tail merges (H-16).
+- The security reviewer still sees the engineer's Self-Critique block: only Phase 2 strips it (review.py:391 vs security.py:377), so the E2 anti-anchoring rationale is unapplied where it matters most.
+
+Scope: ralph_py/git.py, ralph_py/review.py, ralph_py/security.py, ralph_py/factory.py (chunk orchestration + budget), tests.
+
+Requirements:
+1. Hard mode: a diff exceeding the cap is never partially reviewed silently. Chunk the diff on file boundaries into <=cap segments and run one review pass per chunk (each pass counts against max_adversarial_calls); merge results (any chunk failure fails; findings concatenate). If the budget cannot cover the chunks, the phase fails as infrastructure rather than passing partially.
+2. Advisory mode: single-pass review is acceptable but the result is annotated as partial (finding or suffix) so a PASS over a truncated diff is visibly partial.
+3. Apply strip_self_critique_from_diff before the security review too (share the stripped diff once in factory rather than stripping twice).
+4. Same policy for the knowledge distiller input is OUT of scope; note it in the PR if you see it matters.
+
+Tests: an oversized synthetic diff in hard mode produces N chunked calls (fake agent counts invocations) and merges verdicts correctly; budget-insufficient chunking is infra-fail; advisory is marked partial; security prompt input no longer contains the Self-Critique block (string-level test on the built prompt).
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R1.4, flip the R1.4 checkbox.
+```
+
+## Session 4B: Config control plane
+Branch: `fix/r2-1-control-plane`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then items R2.1 and R2.2 in docs/remediation-roadmap.md. You own cli.py for this wave; no other session touches it.
+
+Defects:
+- The CLI never calls VerifyConfig.load, SecurityConfig.load, ContractConfig.load, FactoryConfig.load, FeedforwardConfig.load, or EvolutionConfig.load (all exist, all tested, zero product call sites). `ralph factory` constructs phase configs directly from click flags (cli.py:1415-1456), so click defaults always win and six of nine ralph.toml sections are silently ignored (CRIT-7).
+- max_adversarial_calls and pause_before_pr_merge are unreachable: FactoryConfig.load reads only 7 keys (factory.py:91-105), no env var, no flag.
+- FeedforwardConfig/EvolutionConfig/KnowledgeConfig lack from_env.
+- ralph init does not scaffold ralph.toml, so a fresh project has no discoverable config surface.
+
+Scope: ralph_py/cli.py, ralph_py/config.py, ralph_py/factory.py (FactoryConfig.load keys), ralph_py/verify.py, ralph_py/security.py, ralph_py/contract.py, ralph_py/feedforward.py, ralph_py/evolution.py, ralph_py/knowledge.py (loaders/from_env only), ralph_py/init_cmd.py (scaffold), tests.
+
+Requirements:
+1. Resolution order everywhere: explicit CLI flag > env > ralph.toml > dataclass default. Give click options default=None sentinels so "not passed" is distinguishable from "passed the default value"; apply flag overrides onto the loaded config.
+2. Both `ralph factory` and `ralph run` build every phase config via .load(root). Add from_env where missing so the documented env vars all function.
+3. FactoryConfig.load reads max_adversarial_calls and pause_before_pr_merge; add RALPH_FACTORY_MAX_ADVERSARIAL_CALLS / RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE env vars and --max-adversarial-calls / --pause-before-pr-merge flags.
+4. ralph init scaffolds a fully commented ralph.toml (content mirrors ralph.toml.example, trimmed to real keys).
+5. Behavior-change caution: existing setups where ralph.toml sections were silently ignored will now take effect. Add a NOTE line to the factory startup output when a toml section changed an effective value away from the CLI default, and document the change in the PR body prominently.
+
+Tests: for each of the nine sections, a toml round-trip test proving the value reaches the resolved config through the real CLI construction path; precedence tests (flag beats env beats toml) for at least factory/verify/security; the two safety knobs reachable via all three surfaces.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R2.1 + R2.2, flip those checkboxes.
+```
+
+## Session 4C: Spine tests I (worktrees + PR paths)
+Branch: `test/r4-2-spine-1`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R4.2 in docs/remediation-roadmap.md. You are adding the first half of the real-git spine tier. Tests only: do not modify ralph_py/ source (if a test exposes a product bug, write the failing test, mark it xfail with a comment naming the bug, and report it in the PR body).
+
+Context: the review found the five most load-bearing behaviors have mock-only coverage. This session covers: worktree lifecycle and PR failure paths.
+
+Scope: tests/ (new files, conftest marker registration), pyproject.toml (marker declaration only).
+
+Requirements:
+1. Register a `spine` pytest marker; all new tests carry it so `-m "not spine"` keeps the fast tier fast.
+2. Worktree lifecycle against real git repos: _setup_worktree creates from the requested base; cleanup removes; recreate-after-crash works; the run-level and per-component locks actually exclude (two-PROCESS test using multiprocessing or subprocess, not threads: flock is per-process).
+3. PR failure paths with a stub gh binary the test writes onto PATH (a small shell/python script whose behavior is driven by an env var): push-fail, pr-create-fail, merge-fail, wait-timeout. Assert component status and dependent scheduling per the wave-2 semantics (MERGE_PENDING etc.).
+4. Keep each test under ~5s; total spine-1 under ~60s. Measure and report actual timings in the PR body (measure, do not estimate).
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R4.2 (flip to [~] with a note that spine II remains), and list any product bugs the tests exposed.
+```
+
+---
+
+# Wave 5 (after wave 4 merges)
+
+## Session 5A: `ralph run` honesty + feedforward wiring + prd_path contract
+Branch: `fix/r2-3-run-honesty`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R2.3 in docs/remediation-roadmap.md.
+
+PROMPT EXCEPTION: this session MAY edit init_cmd.DEFAULT_PROMPT (the engineer prompt template) because the prd_path fix requires it. H3 applies: bump DEFAULT_PROMPT_VERSION, update the (hash, version) snapshot in tests/test_prompt_versions.py in the same commit, and say so in the PR body. Touch no other prompt.
+
+Defects:
+- factory.py:328-344 hardcodes max_iterations=30 and interactive=False and never receives allowed_paths; _submit_args (factory.py:954-975) does not forward them. `ralph run 5` runs 30 iterations per attempt; -i and --allowed-paths are no-ops (CRIT-8).
+- --no-verify does not skip verification: factory.py:532 does `factory_config.verify_config or VerifyConfig()`, substituting defaults; on a non-Python repo this burns full retries against checks that cannot pass.
+- Feedforward never runs under `ralph factory`: cli builds FactoryConfig without feedforward_config, so ff_config_dict stays None (H-10).
+- The prd-path contract is broken: a comment (factory.py:259-261) claims the prompt template uses $prd_path substituted by loop.py, but NO shipped template contains $prd_path; decomposed component PRDs live at scripts/ralph/feature/<id>/prd.json while the default prompt points at scripts/ralph/prd.json, so the agent reads the wrong file while check_prd_stories reads the right one (H-11).
+
+Scope: ralph_py/factory.py, ralph_py/cli.py, ralph_py/loop.py, ralph_py/init_cmd.py (DEFAULT_PROMPT + scaffold), tests/test_prompt_versions.py (snapshot only, per the exception), tests.
+
+Requirements:
+1. Forward max_iterations, interactive, allowed_paths through _submit_args into _run_component; delete the hardcoded 30.
+2. --no-verify uses an explicit skip sentinel that run_factory honors (Phase 1 genuinely skipped, stated in output).
+3. Wire feedforward config through the factory command path (it should honor the wave-4 control plane: toml/env/flags).
+4. DEFAULT_PROMPT gains an explicit $prd_path (and $progress_path if applicable) placeholder; loop.py substitutes the per-component paths; add a test asserting the rendered prompt names the same PRD file that check_prd_stories reads for a decomposed component.
+5. H3 compliance for the DEFAULT_PROMPT edit as described above.
+
+Tests: fake-agent run with N=3 executes at most 3 iterations; --no-verify runs zero checks; factory run builds feedforward context (assert marker string in the built prompt); the prd-path consistency test.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R2.3, flip the R2.3 checkbox.
+```
+
+## Session 5B: HITL semantics + subprocess env hygiene
+Branch: `fix/r2-6-hitl-env`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R2.6 in docs/remediation-roadmap.md.
+
+Defects:
+- factory.py:866-880: the E6 human checkpoint's "Reject and abort component" routes through _retry_or_fail, which re-runs the ENTIRE component (agent + reviews) and re-prompts the human each retry; to truly abort you must reject max_retries+1 times, paying a full LLM cycle each time.
+- Every verification/contract/fixtures subprocess inherits the harness's full environment, including ANTHROPIC_API_KEY etc.: agent-authored tests can read the harness's secrets.
+- Verification subprocess timeouts kill only the direct child: a test that backgrounds a server leaks it across iterations (no start_new_session/killpg in verify.py subprocess calls).
+
+Scope: ralph_py/factory.py (checkpoint block), ralph_py/verify.py, ralph_py/contract.py, ralph_py/fixtures.py (env plumbing only), tests.
+
+Requirements:
+1. Checkpoint choices become: Approve / Reject (component -> FAILED immediately, no retry, dependents cascade-skip) / Retry (explicit, uses a retry). Non-interactive behavior unchanged (warn + proceed).
+2. A shared scrubbed-env helper: allowlist approach (PATH, HOME, LANG, LC_*, TMPDIR, TERM, VIRTUAL_ENV, UV_*, PYTHON*, CI, and the uv cache vars: verify empirically that `uv run pytest` works under the scrubbed env, and add what is truly required rather than guessing). Applied to every verify/contract/fixtures subprocess. Assert ANTHROPIC_API_KEY/OPENAI_API_KEY never pass through.
+3. All verification subprocesses use start_new_session=True and process-group kill on timeout.
+
+Tests: reject marks FAILED with zero further agent calls (counting fake agent); a test subprocess printing os.environ shows no *_API_KEY under the scrub while uv-run still functions; a timeout kills a backgrounded grandchild.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R2.6, flip the R2.6 checkbox.
+```
+
+## Session 5C: Misleading tests + coverage ratchet
+Branch: `test/r4-3-test-fixes`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then items R4.3 and R4.4 in docs/remediation-roadmap.md. Tests and CI only; do not modify ralph_py/ source.
+
+Defects (all verified in the review):
+- test_phase_c_coverage.py TestC1ParallelExecution disables worktrees and forces max_parallel=1 (tests nothing parallel); TestC6ConcurrentFactory uses separate roots + mocked _run_component (would pass with the flock deleted); TestC4ContractBreaker asserts only that contract ran, not that the breaker reset.
+- test_factory.py test_verification_failure_triggers_retry asserts only final failure, not that a retry happened.
+- test_prompt_versions.py docstring cites test_no_silent_version_pin, which does not exist; and the AST-walker "regression guard" tests re-implement the walk inline instead of calling _module_level_prompt_constants (tautological).
+- test_codex_agent.py runs a LIVE network LLM call in the default suite when codex is on PATH (with a broad except: skip), and its caching test asserts a==b without counting invocations.
+- No coverage measurement exists anywhere.
+
+Scope: tests/, .github/workflows/ci.yml, pyproject.toml (dev deps + config).
+
+Requirements:
+1. C1 becomes a true 2-worker worktree test (real git, fake agent); C6 uses the SAME root and proves serialization (assert the second invocation blocks or is refused per wave-3 semantics); C4 asserts the breaker was reset AND re-ran; the verification-retry test counts attempts.
+2. AST-walker tests call the real _module_level_prompt_constants against synthetic modules.
+3. Implement test_no_silent_version_pin: hash moved while version pinned must fail.
+4. Codex live-contract tests gated behind RALPH_RUN_LIVE_CONTRACT=1; default suite is network-free (grep the suite for other network calls and gate any you find). Fix the caching test to count subprocess invocations.
+5. pytest-cov in dev deps; CI uploads a coverage summary and enforces a ratchet: coverage must not drop below the recorded baseline. Record the MEASURED baseline number in the PR (run it, do not estimate) and store it where CI reads it.
+6. Register the spine marker split in CI: fast job runs -m "not spine", a second job runs -m spine.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R4.3 + R4.4, flip those checkboxes.
+```
+
+---
+
+# Wave 6 (after wave 5 merges)
+
+## Session 6A: Preflight honesty + config show + status stub
+Branch: `fix/r2-4-preflight`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R2.4 in docs/remediation-roadmap.md.
+
+Defects:
+- cli.py:281-284, 556-559, 858-861: run/understand/feature preflight checks ONLY CodexAgent.is_available() and exits "codex not found in PATH" even when Claude Code is installed and configured (decompose/factory at cli.py:1048, 1344 already do it right).
+- `ralph run` does not preflight prd.json: the agent burns full iterations against a prompt referencing a nonexistent PRD before Phase 1 reports "Failed to load PRD".
+- README promises `ralph config show` and `ralph status`; neither exists.
+
+Scope: ralph_py/cli.py, tests.
+
+Requirements:
+1. Preflight accepts whichever agent the resolved config selects (claude/codex/custom) and errors naming the agent it actually looked for, mirroring the factory implementation.
+2. run preflights prd.json existence + schema (reuse PRD.validate_schema) BEFORE any agent invocation, with the same friendly per-field errors init uses.
+3. `ralph config show`: print every resolved config section with the SOURCE of each value (flag/env/toml/default): this is the observability for the wave-4 control plane.
+4. `ralph status`: minimal version reading the manifest: per component id: status, retries, branch, timestamps if present. (The full ProgressLog-backed version is Session 7B; structure the command so 7B extends it.)
+
+Tests: preflight matrix (claude-only machine + type=claude passes; codex-only + type=codex passes; mismatch errors correctly); missing/invalid prd.json blocks before the agent runs (counting fake agent); config show output names sources correctly for a toml-set, env-set, and flag-set value; status renders a synthetic manifest.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R2.4, flip the R2.4 checkbox.
+```
+
+## Session 6B: Cost meter
+Branch: `feat/r3-1-cost-meter`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R3.1 in docs/remediation-roadmap.md.
+
+Context: no token or dollar visibility exists anywhere; the call-count budget covers only review/security/distill and excludes the engineer loop (the dominant spend). Your job is per-phase, per-component usage accounting.
+
+MEASURE FIRST (the project rule is measure, do not assume): before writing the meter, empirically determine what usage data each agent CLI emits. Run the claude CLI in the stream-json mode the ClaudeCodeAgent uses and inspect the result event for usage fields; check what codex emits with the flags CodexAgent uses. Write your findings (actual field names, sample values) into the PR body. If codex exposes nothing, fall back to call counts + wall time for codex and say so.
+
+Scope: ralph_py/agents/*.py (usage extraction), ralph_py/loop.py, ralph_py/factory.py (aggregation), ralph_py/observability.py, ralph_py/evolution.py (experiments columns), tests.
+
+Requirements:
+1. Agents surface a usage record per invocation (tokens in/out where available; else calls + duration). The Agent protocol change must stay backward-compatible for CustomAgent.
+2. Factory aggregates per component per phase (engineer iterations, review, security, distill) and prints a rollup table in the run summary; the journal entry and experiments.tsv gain the totals.
+3. Optional max_total_tokens (toml/env/flag via the control plane): when exceeded, halt LOUDLY: fail the current component with a synthetic budget finding (reuse the wave-3 phase_skipped pattern) rather than degrading silently.
+4. The meter must never gate correctness: parse defensively; a usage-parse failure logs a warning and records unknown, never crashes a run.
+
+Tests: fake agent emitting realistic usage events -> correct rollup math; missing-usage fallback; budget halt fires and is recorded; malformed usage never raises.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R3.1 (Tested must include the CLI-emission findings), flip the R3.1 checkbox.
+```
+
+## Session 6C: Spine tests II (contract, retry propagation, crash recovery)
+Branch: `test/r4-2-spine-2`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R4.2 in docs/remediation-roadmap.md. Second half of the real-git spine tier. Tests only: if a test exposes a product bug, write it xfail with a comment naming the bug and report it in the PR body.
+
+Scope: tests/ (new spine-marked files).
+
+Requirements:
+1. Contract execution against real git: passing tier; conflicted tier (assert the user checkout is byte-identical afterward and the run recovers per wave-2 semantics); breaker re-run to completion.
+2. Retry-context propagation end to end: a fake agent that writes its received prompt to a file; attempt 1 fails diff-scope; assert attempt 2's prompt contains the failure details INCLUDING the base branch and allowed paths (wave-2 behavior).
+3. Crash recovery: kill a run mid-verify (subprocess-driven factory run, SIGKILL); restart; assert RUNNING/VERIFYING reset, stale worktrees from the run_id layout are handled, and the manifest is consistent.
+4. Engineer-loop plumbing smoke: one unmocked _run_component execution with a fake agent binary end to end (worktree in, result out, PRD copy present, prompt copy present).
+5. Keep spine II under ~90s total; report measured timings in the PR body.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R4.2, flip R4.2 to [x] (spine complete).
+```
+
+---
+
+# Wave 7 (after wave 6 merges)
+
+## Session 7A: Docs regeneration + packaging truth
+Branch: `fix/r2-5-docs`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R2.5 in docs/remediation-roadmap.md.
+
+Defects (docs vs reality):
+- README quick start step 1 (`uv tool install ralph-cli`) installs an UNRELATED PyPI package; step 3 (`ralph prd create`) does not exist; a third of the CLI table is fiction (TUI, prd group, config show/status existed only as of wave 6, --legacy). "362 tests" is stale. README documents [sensors]/[fixtures] toml sections that do not exist in code and omits [knowledge]/[factory]/[verify]/[security]/[contract].
+- pyproject.toml still depends on textual (dead since the TUI purge).
+- examples/uv-python predates the engineer contract: no Self-Critique block in its prompt.md, prd_prompt.txt forbids allowedPaths.
+- adversarial-design.md says the distiller runs "post-merge"; it runs pre-PR. runbook.md tells the operator to inspect a failed component's worktree, but cleanup deletes worktrees (align with the --keep-worktrees-on-failure flag landing in Session 7C: coordinate by documenting the flag as the recovery path).
+
+Scope: README.md, docs/*.md, ralph.toml.example, examples/uv-python/, pyproject.toml (dependency removal), scripts/ (new generator), .github/workflows/ci.yml (doc-drift check), tests as needed.
+
+Requirements:
+1. Write scripts/gen_docs.py: generates the README CLI reference from click introspection and the config reference from the dataclasses + loaders. Insert between markers in README so the rest is hand-written. CI check: regeneration produces no diff.
+2. Install story: unless the user has decided on publishing (check the roadmap "User decisions" section: if undecided), document clone-install (`uv tool install -e .` from a clone) as the ONLY path and remove the PyPI command.
+3. Remove textual from dependencies; verify nothing imports it.
+4. Refresh examples/uv-python to the current engineer contract (Self-Critique block, allowedPaths-aware prd_prompt, current progress format).
+5. Fix the drift list: distiller timing wording, runbook worktree guidance, test count (state the measured number), [sensors]/[fixtures] removed, missing sections added from ralph.toml.example.
+
+Tests: the CI doc-drift check itself; a test that scripts/gen_docs.py output matches the committed README sections.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R2.5, flip the R2.5 checkbox (and R3.4 fully if the ralph.toml tracking note is resolved here).
+```
+
+## Session 7B: Status + notifications
+Branch: `feat/r3-2-status-notify`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R3.2 in docs/remediation-roadmap.md.
+
+Context: the ProgressLog (observability.py) is a JSONL event bus (component_started/completed/failed/retrying, verification_result, review_result, contract_result) but is opt-in and unconsumed. There is no way to know a walk-away run's state without reading raw JSON, and no notification when it finishes or breaks.
+
+Scope: ralph_py/observability.py, ralph_py/cli.py (status command extension), ralph_py/factory.py (default-on wiring + hook firing), ralph_py/config.py or factory config ([notify] section), tests.
+
+Requirements:
+1. ProgressLog defaults ON (path under .ralph/), configurable off.
+2. Extend `ralph status` (from Session 6A) to join manifest + ProgressLog: per component: phase, attempt, last-event age, cost totals (from Session 6B), evidence paths. A --watch flag polling on an interval is optional; add only if simple.
+3. [notify] config: on_complete and on_first_failure shell commands (documented examples: terminal bell, curl webhook). Fired exactly once each per run; also fire on MERGE_PENDING. Hook failures log a warning, never affect the run.
+4. Events gain the run_id so multiple runs' logs are distinguishable.
+
+Tests: status renders correctly from a synthetic manifest + log; hooks fire exactly once per condition (counting stub command); hook failure is non-fatal; default-on writes the log.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R3.2, flip the R3.2 checkbox.
+```
+
+## Session 7C: Resume + partial-failure ergonomics
+Branch: `feat/r3-3-resume`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R3.3 in docs/remediation-roadmap.md.
+
+Defects/gaps:
+- run_id is generated but never persisted in the manifest; completed_at is never set anywhere; resuming cannot correlate with the prior run: exactly what Linear integration will need later.
+- A FAILED component can only be reset by hand-editing manifest.json; failed components' worktrees are deleted at cleanup so post-mortem evidence is gone.
+- comp.findings accumulates across retry attempts uncleared (factory.py:628, 731), inflating journal counts and attributing superseded findings to shipped code.
+
+Scope: ralph_py/manifest.py, ralph_py/factory.py, ralph_py/cli.py, ralph_py/findings.py (attempt tag), tests.
+
+Requirements:
+1. Persist run_id in the manifest; set completed_at on terminal states; store per-component last-attempt evidence pointers (worktree path if kept, journal offsets).
+2. `ralph retry <component-id>`: resets that FAILED component and its cascade-SKIPPED dependents to PENDING and re-enters the factory with the same manifest (respecting the wave-3 run lock).
+3. --keep-worktrees-on-failure flag (and toml key via the control plane); update the cleanup path; the failure summary lists per failed component: phase, check, and where the evidence lives.
+4. Clear comp.findings at the start of each attempt; tag every Finding with attempt:<n> so the journal distinguishes superseded findings from final ones.
+
+Tests: retry round-trip on a synthetic failed manifest; keep-worktrees leaves the failed worktree and the summary points at it; findings from attempt 1 do not appear in the final component findings but DO remain in the journal tagged attempt:1; completed_at set.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R3.3, flip the R3.3 checkbox.
+```
+
+---
+
+# Wave 8 (after wave 7 merges): calibration + the one prompt batch
+
+## Session 8A: Calibration tooling + model-bump trigger
+Branch: `feat/r5-1-calibration-tooling`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then items R5.1 and R5.5 in docs/remediation-roadmap.md. Do NOT edit any prompt body.
+
+Defects: calibration has no comparison tooling (H2 says "compare against baseline" but nothing diffs baseline JSONs, no threshold is codified); each fixture is a hard assert so the suite has been red-at-baseline in every recorded run (the architect misses are matcher artifacts: must_include_kind demands exact taxonomy labels the model paraphrases); single-trial single-model runs cannot support a "detection rate"; baselines do not record the model.
+
+Scope: ralph_py/ (new calibration module), tests/test_calibration.py, tests/test_calibration_matchers.py, tests/adversarial_fixtures/_results/ format, docs (usage section), tests.
+
+Requirements:
+1. `python -m ralph_py.calibration compare <old.json> <new.json>`: per-role, per-category deltas with codified pass/fail thresholds (thresholds in one constants block, documented).
+2. N-run mode: the runner supports RALPH_CALIBRATION_RUNS=N (default 3 for baselines), reporting per-fixture consistency (fraction of runs detected) alongside detection.
+3. Convert per-fixture hard asserts into threshold gates over the run set, so the suite is green at the current baseline and red on REGRESSION. The report JSON keeps per-fixture detail.
+4. Fix matcher brittleness: kind-matching accepts a documented synonym map (e.g. unstated_assumption ~ missing_detail) OR grades kind separately from detection so a paraphrased kind is a partial hit, not a miss. Update matcher unit tests.
+5. Baselines record the model id; add an always-run structural test that WARNS (not fails) when the configured calibration model differs from the newest baseline's model, citing H2-extended (re-calibrate on model change).
+6. You cannot run the real-LLM suite yourself; end the PR body with the exact commands the user should run to capture the new-format baseline, and mark R5.1 [~] until a baseline in the new format exists.
+
+Tests: compare tool against synthetic old/new JSONs (regression detected, improvement passes); consistency math; synonym matcher units; model-drift warning.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R5.1 + R5.5.
+```
+
+## Session 8D: Self-critique check correctness (parallel with 8A)
+Branch: `fix/r5-4-self-critique`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R5.4 in docs/remediation-roadmap.md. Do NOT edit any prompt body.
+
+Defects (verify.py:224-254, both empirically reproduced in the review):
+- check_self_critique walks from the end of progress.txt to the LAST Self-Critique heading, never associating the block with the CURRENT iteration's entry: an iteration that omits the block passes if any earlier iteration had one. The docstring claims the opposite of what the code does.
+- The bullet-boundary break is dead code: `stripped.rstrip(":*").lower().endswith(("**","**:"))` can never be true because rstrip("*:") strips the trailing asterisks first: bullets from later sections (e.g. Interpretations in DEFAULT_PROMPT's format) inflate the count toward min_bullets.
+
+Scope: ralph_py/verify.py, tests/test_verify.py.
+
+Requirements:
+1. Associate the Self-Critique block with the current (latest) iteration entry: identify the latest iteration boundary in progress.txt first, then require the heading within it. Document the expected progress format assumption in the docstring honestly.
+2. Fix the boundary break so a following bold-label section terminates the bullet count; extend the fuzz corpus with both regression cases (missing-block-in-latest-iteration; inflated-count-from-next-section).
+3. Keep this a shape check; note in the docstring (H4) that substance is not verified.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R5.4, flip the R5.4 checkbox.
+```
+
+## Session 8B: Fixture expansion (after 8A merges)
+Branch: `feat/r5-2-fixtures`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R5.2 in docs/remediation-roadmap.md. Do NOT edit any prompt body.
+
+Context: the existing planted bugs are textbook-trivial (f-string SQL, shell=True, sk_live constant, random tokens, signature-discarding JWT): Haiku catches them all, so the suite can detect catastrophe but not regression. There are no negative fixtures, so false-positive rate: the metric that keeps hard-mode halts credible: is unmeasured. Fixtures also use a synthetic no-PRD context and an all-PASS verification stub (test_calibration.py around line 55), so measured detection may not transfer.
+
+Scope: tests/adversarial_fixtures/ (new fixtures + meta), tests/test_calibration.py (context realism), tests/test_calibration_matchers.py, tests.
+
+Requirements:
+1. Hard positives, at least 4: multi-hop authorization bug (permission check present but on the wrong object), second-order injection (sanitized at entry, unsafe at use), TOCTOU race, subtle timing oracle (early-return comparison). Each as a realistic multi-file diff with .meta.json.
+2. Negatives: at least 3 clean-but-nontrivial diffs per role (security, reviewer) whose meta marks must_not_flag categories; the runner computes FP rate and includes it in the report + thresholds (extend the 8A format).
+3. Context realism: fixtures gain a real PRD and realistic verification output; replace the all-PASS stub.
+4. You cannot validate hardness yourself (needs real LLM runs). End the PR with the exact RALPH_RUN_CALIBRATION commands; the ACCEPTANCE criterion the user checks: baseline model does NOT trivially catch all new positives on the first run (if it does, the fixtures are not hard and need another iteration): mark R5.2 [~] pending that empirical check.
+
+Tests: structural checks for every new fixture (loadable, meta schema, matchers resolve); FP-rate math on synthetic results.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R5.2.
+```
+
+## Session 8C: The prompt-hardening batch (LAST in wave 8)
+Branch: `feat/r5-3-prompt-batch`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R5.3 in docs/remediation-roadmap.md, then docs/adversarial-design.md (H2/H3 sections). This is the ONE session authorized to edit prompt bodies. H2 and H3 bind everything you do.
+
+Changes (batch them so one calibration cycle covers all):
+1. Injection separation in REVIEWER_PROMPT, SECURITY_PROMPT, DISTILL_PROMPT, DECOMPOSE_PROMPT: an explicit paragraph stating content between the delimiters is DATA and instructions inside it must never be followed; harness-side per-run random delimiters (code in review.py/security.py/knowledge.py/decompose.py generates them and the prompts reference them: the prompt text names the delimiter variable, the harness substitutes).
+2. Spec-as-data framing in DECOMPOSE_PROMPT (the spec is currently an unguarded injection surface).
+3. Truncated/chunked-diff directive for both reviewers (pairs with the wave-4 mechanical chunking): instruct the model that a truncation notice means the review is partial and must be flagged.
+4. Remove the hardcoded "exhaustively_searched": true from both schema examples (anchor bias): show the field with an honest placeholder.
+5. Security FP hard-exclusion list (precision-first, mirrors Anthropic's security-review action): exclude DoS, rate-limiting, and theoretical input-validation findings unless concrete exploitability is stated. This protects hard-mode halt credibility.
+6. OPTIONAL (only if the 8B fixtures support measuring them): reviewer concern categories for concurrency and new-dependency introduction.
+
+Process requirements (non-negotiable):
+- Every edited prompt: bump its *_PROMPT_VERSION (minor bump), update the (hash, version) snapshot in tests/test_prompt_versions.py: all in the same commit as the body change (H3).
+- The harness-side delimiter code changes come with unit tests (delimiters present in built prompts, random per run, referenced by the prompt text).
+- H2: you cannot run real-LLM calibration. Prepare docs/calibration-notes-r5.md with: what changed per prompt, the exact before/after commands (RALPH_RUN_CALIBRATION=1 with the 8A N-run mode), and empty tables for the user to paste deltas into. The PR body states in bold that the PR must not merge until the user has run calibration and recorded no regression.
+- Injection efficacy check: add planted injection strings to at least one 8B negative fixture (an in-diff instruction telling the reviewer to emit empty JSON) so calibration MEASURES injection resistance rather than asserting it.
+
+Finish per Shared rules: green checks (the snapshot test proves H3 compliance), rebase, PR with Tested/Assumed referencing R5.3, mark R5.3 [~] pending the user's calibration run.
+```
+
+---
+
+# Wave 9 (after wave 8 merges and calibration deltas are recorded)
+
+## Session 9A: Evolution loop repair
+Branch: `fix/r6-evolution`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then items R6.1-R6.4 in docs/remediation-roadmap.md.
+
+Defects:
+- Component failures record flattened strings ("Review failed", "Mechanical verification failed"), so evolution.py's _normalize_error collapses every failure into one degenerate signature and cross-run "patterns" are tautologies; the linter-code fast path (S608) can never fire (evolution.py:126-181, 554-569).
+- get_concern_hit_rate (evolution.py:651-690) scans entry["error"] for concern categories that never appear there: structurally zero forever, while the structured findings it needs are already in the same journal entries.
+- factory.py:1131 constructs EvolutionConfig() directly: [evolution] toml and env ignored, journal_path CWD-relative, writes wrapped in `except OSError: pass`.
+- Proposal IDs restart at PROP-001 every call and save_proposals clobbers prior files (evolution.py:475-480, 599-645).
+- `ralph evolve --apply` prints "not yet automated" while README and the command's own output promise application; auto_propose is never consulted; recorded durations are 0.0 and retry_rate semantics are undocumented.
+
+Scope: ralph_py/evolution.py, ralph_py/factory.py (failure recording + config load), ralph_py/cli.py (evolve), docs (metric definitions), tests.
+
+Requirements:
+1. Failure recording carries check_name plus the parser's structured signature (e.g. linter:E501, typecheck:arg-type, diff_scope:rename, review:<category>); pattern extraction consumes these.
+2. get_concern_hit_rate reads findings_summary; proposals derive from finding taxonomies + real signatures; proposal IDs monotonic across runs, never clobbering prior files.
+3. factory uses EvolutionConfig.load(root_dir) (the wave-4 control plane); journal paths resolve against root; the silent except becomes a logged warning.
+4. evolve --apply implements the minimal real path: convention-type proposals append to the project CLAUDE.md Agent Learnings section after explicit confirmation; everything else prints manual instructions honestly. Honor auto_propose.
+5. Fix duration recording; document retry_rate and every experiments.tsv column in docs/ (state definitions, do not invent aspirational metrics).
+6. Fresh-journal note: wave 1 archived the polluted journals; add a journal-format version field so future migrations are detectable.
+
+Tests: an integration test with a synthetic-but-realistic journal (real signature strings) yields a proposal traceable to a signature and a nonzero concern hit rate; proposal-ID monotonicity across two runs; config load path; --apply appends exactly once with confirmation.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R6.1-R6.4, flip those checkboxes.
+```
+
+---
+
+# Wave 10 (after wave 9): strategic
+
+## Session 10A: Cross-model review rotation (BLOCKED on user decision 2)
+Branch: `feat/r7-1-rotation`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R7.1 in docs/remediation-roadmap.md. Precondition: the user has named the second model family in the roadmap "User decisions" section; if it still reads undecided, STOP and report.
+
+Context: 2025-2026 research established self-preference bias and verifier homogenisation mechanistically: a same-family reviewer systematically misses the bug classes its family produces. The config already supports review_agent_cmd/review_model; nothing defaults to heterogeneity, warns about homogeneity, or records who reviewed whom.
+
+Scope: ralph_py/factory.py, ralph_py/config.py / factory config, ralph_py/findings.py, ralph_py/review.py, ralph_py/security.py, ralph_py/pr.py, docs/adversarial-design.md (limitation #1 update), tests.
+
+Requirements:
+1. When the decided second family's CLI is available, review and security default to it (engineer keeps the primary); explicit config always wins. When unavailable, print a homogeneity warning naming the risk.
+2. Every Finding records the reviewing model identity (tag model:<id>); the PR body's findings section names the reviewer model; the journal carries it.
+3. Reviews remain independent single passes: do NOT add any cross-reviewer deliberation.
+4. Measurement plan: extend the calibration runner to accept a reviewer-model override so the user can capture same-family vs cross-family baselines with the 8A tooling; put the exact commands in the PR body. Mark R7.1 [~] until the user records both baselines.
+5. Update docs/adversarial-design.md known-limitation #1 to describe the new default and what remains correlated (architect/engineer/distiller).
+
+Tests: default-selection matrix (both CLIs present / one absent / explicit override); model tag present on findings end to end; homogeneity warning fires.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R7.1.
+```
+
+## Session 10B: Wire fixtures, sandboxed (parallel with 10A)
+Branch: `feat/r7-2-fixtures-wired`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R7.2 in docs/remediation-roadmap.md.
+
+Context: fixtures.py (the independent behavioral oracle) is currently wired to NOTHING: run_mechanical_verification never calls check_fixtures, and PRD.validate_schema rejects the documented fixtures key. Two latent hazards block naive wiring: run_function_fixture imports and calls agent-written code IN the harness process (sys.path.insert + importlib) with the harness env (API keys); run_cli_fixture executes a PRD-supplied command with shell=True. The PRD is LLM-emitted: treat fixture definitions as untrusted.
+
+Scope: ralph_py/fixtures.py, ralph_py/verify.py, ralph_py/prd.py, ralph_py/factory.py (config plumbing), ralph_py/config.py (FixturesConfig loader via the control plane), docs, tests.
+
+Requirements:
+1. Function fixtures execute in a SUBPROCESS (sys.executable with an argv-passed spec, JSON over stdout), using the wave-5 scrubbed-env helper, cwd=worktree, timeout, start_new_session. The harness process never imports agent code.
+2. CLI fixtures: shlex.split + shell=False; document that shell features are unsupported.
+3. PRD.validate_schema accepts the fixtures key (schema per README's documented shape; validate fixture entries strictly: unknown keys rejected).
+4. run_mechanical_verification calls check_fixtures when [fixtures].enabled (default false per user decision 4); snapshot regression wired behind the same flag; failures produce parsed, actionable retry context like other checks.
+5. README fixtures section updated to match what actually ships.
+
+Tests: real subprocess function-fixture round trip (pass and fail); env scrub verified inside the fixture subprocess (no *_API_KEY); a module-level side effect in agent code cannot touch the harness process (e.g. fixture module writes a sentinel: assert isolation); cli fixture with shell metacharacters does not shell-interpret; PRD round trip with fixtures key; Phase 1 integration with fixtures enabled.
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R7.2, flip the R7.2 checkbox.
+```
+
+## Session 10C: run_factory refactor (STRICTLY SOLO: nothing else in flight)
+Branch: `refactor/r7-3-pipeline`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R7.3 in docs/remediation-roadmap.md. Confirm no other remediation branch is open before starting; this refactor touches everything.
+
+Context: run_factory is a ~770-line function; scheduling, worktrees, six phases, budget, checkpoint, PR lifecycle, distillation, and journaling live in nested closures over a dozen mutable variables (including a knowledge_config late-binding accident). The sequential and parallel loops duplicate the launch protocol. The state machine is untestable in isolation: which is exactly where the review's critical bugs lived.
+
+Approach: STRANGLER, two PRs from this one session if needed.
+1. PR 1: extract a ComponentPipeline class: explicit typed phase results (verify/review/security/checkpoint/pr/distill), single place for state transitions (VERIFYING -> retry/fail/COMPLETED/MERGE_PENDING), budget consultation injected. run_factory delegates per-component handling to it. Behavior-preserving: the whole suite including spine must stay green unchanged.
+2. PR 2: unify the sequential/parallel scheduling loops into one scheduler consuming the pipeline; remove the duplicated launch protocol and the late-binding hazard.
+
+Also in scope: decide distiller placement (pre-PR vs post-merge) explicitly: keep current behavior unless you find a correctness reason, but make the placement a named, documented step and align docs/adversarial-design.md wording (it currently says post-merge; the code is pre-PR).
+
+Requirements: no behavior change (spine + full suite green before and after each PR); new unit tests for the state machine in isolation (every transition, including retry exhaustion, cascade-skip, MERGE_PENDING, checkpoint reject, budget exhaustion); delete dead code the extraction strands.
+
+Finish per Shared rules: green checks, rebase, PR(s) with Tested/Assumed referencing R7.3, flip the R7.3 checkbox after the second PR.
+```
+
+## Session 10D: Linear integration (after 10C; BLOCKED on user decision 3)
+Branch: `feat/r7-4-linear`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R7.4 in docs/remediation-roadmap.md. Preconditions: 10C merged; the user has approved the Linear app-actor OAuth identity (roadmap "User decisions" 3) and provided a workspace/team id plus an auth token env var name. If not, STOP and report.
+
+Design constraints (from the 2026 platform research recorded in the roadmap):
+- GraphQL API with app-actor auth for all mutations (NOT the MCP server: this is a deterministic pipeline); respect the shared rate-limit pool with modest client-side throttling.
+- PR linking comes free via Linear's GitHub integration: branch names carry the issue id, PR bodies carry "Fixes <ISSUE-ID>": status transitions then need zero API calls.
+- The Agents API (@-mention delegation) is Developer Preview: OUT of scope; leave a seam.
+
+Scope: new ralph_py/linear.py (client + sink), ralph_py/observability.py (sink interface), ralph_py/decompose.py (issue creation hook), ralph_py/factory.py (branch naming + PR body wiring), config ([linear] section via the control plane), docs, tests.
+
+Requirements:
+1. LinearSink implements the ProgressLog event interface; factory.py stays untouched except branch/PR-body naming. Sink failures log warnings and never affect the run.
+2. Decompose output creates one Linear project per manifest and one issue per component (stories as sub-issues or a checklist: pick one, document why); spec_issues from wave 3 filed as triage issues.
+3. Idempotency: every created object carries an external-id key of run_id+component_id; retries and resumed runs UPDATE rather than duplicate (test this: it interacts with ralph retry).
+4. Branch names include the Linear issue id when the sink is active; PR bodies gain "Fixes <ID>".
+5. All Linear calls behind a client class with one HTTP entry point, defensive parsing, and a dry-run mode that logs mutations instead of sending (default in tests).
+6. No secrets in code or logs; token comes from the env var the user named.
+
+Tests: sink event-to-mutation mapping against a recorded/dry-run client; idempotency on double-fire and on retry; branch/PR-body formatting; failure isolation (sink exception does not fail the component).
+
+Finish per Shared rules: green checks, rebase, PR with Tested/Assumed referencing R7.4, flip the R7.4 checkbox.
+```
+
+## Session 10E: Platform hardening
+Branch: `feat/r7-5-platform`
+
+```text
+Read CLAUDE.md, then the "Shared rules" section of docs/remediation-sessions.md, then item R7.5 in docs/remediation-roadmap.md. The SpecKit intake sub-item requires a DECOMPOSE_PROMPT change: that part follows the Session 8C process (H2/H3: version bump, snapshot, calibration commands for the user) and should be its own commit.
+
+Sub-items (separable commits; split into two PRs if the diff grows large):
+1. No-progress circuit breaker: halt a component when N consecutive iterations (default 3, configurable) produce an unchanged diff hash AND unchanged test-failure signature; the halt is a loud component failure with a distinct error, recorded in the journal. This is the most-repeated community fix for Ralph-loop stalls.
+2. Sandboxing pass-through: agent adapters accept sandbox settings (Claude Code's network/write scoping flags) from config and pass them to the CLI; document the codex equivalent or its absence (verify empirically what each CLI supports and record findings in the PR: measure, do not assume).
+3. Merge-conflict doctrine: where the factory hits a merge conflict integrating a component, prefer re-running the component against the freshly merged base over rebasing agent output; implement where wave-2/wave-9 machinery makes it natural and document the doctrine in docs/adversarial-design.md.
+4. SpecKit intake: `ralph decompose` accepts a SpecKit artifact set (spec.md/plan.md/tasks.md) as input, concatenated with provenance headers; DECOMPOSE_PROMPT gains a directive to demand EARS-style acceptance criteria ("WHEN <condition> THE SYSTEM SHALL <behavior>") per component (H2/H3 process applies).
+5. Agent SDK spike: a WRITTEN comparison only (docs/sdk-spike.md): drive one component implementation through the Claude Agent SDK in a scratch script; compare against the CLI-subprocess path on: structured usage data, hook-based guardrails, budget enforcement, failure observability. End with a go/no-go recommendation for user decision 5. No production code changes from the spike.
+
+Tests: circuit breaker unit + integration (fake agent producing identical diffs trips it; progressing agent does not); sandbox flag pass-through per adapter; SpecKit intake parsing; EARS directive covered by the calibration commands left for the user.
+
+Finish per Shared rules: green checks, rebase, PR(s) with Tested/Assumed referencing R7.5, flip the R7.5 checkbox (leave [~] if the SDK decision or calibration run is pending).
+```
+
+---
+
+## After wave 10
+
+Re-run the A+ gates table in `docs/remediation-roadmap.md` top to bottom: every
+gate names its test or measurement. Anything still `[~]` is either awaiting a
+user decision or a user-run calibration capture: both are listed in the
+roadmap's "User decisions required" section. When all gates are green, the
+review's scorecard can be re-assessed against evidence rather than claims.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,177 @@
-"""Pytest fixtures for ralph_py tests."""
+"""Pytest fixtures for ralph_py tests.
+
+Suite isolation (R4.1): before this conftest grew the fixtures below, the
+suite appended hundreds of junk entries to the repository's real
+``.ralph/evolution.jsonl`` / ``.ralph/experiments.tsv`` (837 of 910 journal
+entries at review time were test pollution), corrupting the data the
+learning loop consumes. Two layers fix that:
+
+1. ``isolate_ralph_state`` (autouse, function-scoped) redirects every
+   relative ``.ralph/...`` default write path into the test's ``tmp_path``.
+2. ``guard_repo_ralph_state`` (autouse, session-scoped) is the enforcement:
+   it fingerprints the repo's real ``.ralph/`` before the session and fails
+   the run loudly if any test mutated it.
+"""
 
 from __future__ import annotations
 
+import hashlib
 import os
 from collections.abc import Generator
 from pathlib import Path
 
 import pytest
+
+# Repository root that contains this test suite, independent of CWD.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Environment-variable families consumed by the from_env/load paths of the
+# phase configs (FactoryConfig, TimeoutConfig, ContractConfig,
+# SecurityConfig, VerifyConfig, EvolutionConfig, KnowledgeConfig). Cleared
+# by prefix so ambient dev-machine env cannot alter from_env/load tests,
+# and so newly added vars in a family are covered without editing this list.
+RALPH_ENV_PREFIXES: tuple[str, ...] = (
+    "FACTORY_",
+    "RALPH_TIMEOUT_",
+    "RALPH_CONTRACT_",
+    "RALPH_SECURITY_",
+    "RALPH_VERIFY_",
+    "RALPH_EVOLUTION_",
+    "RALPH_KNOWLEDGE_",
+)
+
+# Legacy single-loop env vars (exact names, no shared prefix).
+_LEGACY_ENV_VARS: tuple[str, ...] = (
+    "MAX_ITERATIONS",
+    "AGENT_CMD",
+    "MODEL",
+    "MODEL_REASONING_EFFORT",
+    "SLEEP_SECONDS",
+    "INTERACTIVE",
+    "PROMPT_FILE",
+    "ALLOWED_PATHS",
+    "RALPH_BRANCH",
+    "PRD_FILE",
+    "RALPH_UI",
+    "GUM_FORCE",
+    "NO_COLOR",
+    "RALPH_ASCII",
+)
+
+
+def _clear_ralph_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Delete every Ralph-related env var (legacy names + config families)."""
+    for var in _LEGACY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    for var in list(os.environ):
+        if var.startswith(RALPH_ENV_PREFIXES):
+            monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def isolate_ralph_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Redirect every evolution/experiments/knowledge write path to tmp_path.
+
+    Why chdir is the mechanism: ``EvolutionConfig`` defaults
+    ``journal_path``/``experiments_path`` to relative ``.ralph/...`` paths
+    resolved against CWD at write time, and ``run_factory`` constructs
+    ``EvolutionConfig()`` directly (neither env nor toml is consulted at
+    that call site), so env vars cannot redirect the factory's journal
+    writes. ``KnowledgeConfig`` likewise defaults ``knowledge_root`` to a
+    relative ``.ralph/knowledge`` and ``KnowledgeConfig.load(None)``
+    resolves it against ``Path.cwd()``; there is no env override for the
+    root. Pointing CWD at ``tmp_path`` therefore redirects every relative
+    default in one move (journal, experiments, knowledge root, snapshot
+    dirs, proposals) without touching ralph_py source.
+
+    Ambient env is cleared too, so a dev machine exporting FACTORY_* /
+    RALPH_* values cannot alter from_env/load tests.
+
+    This redirect is convenience; ``guard_repo_ralph_state`` is the
+    enforcement.
+    """
+    monkeypatch.chdir(tmp_path)
+    _clear_ralph_env(monkeypatch)
+    return tmp_path
+
+
+def snapshot_ralph_dir(ralph_dir: Path) -> dict[str, str]:
+    """Fingerprint every entry under ``ralph_dir``.
+
+    Maps the path relative to ``ralph_dir`` to a sha256 hex digest for
+    files, ``"dir"`` for directories, and ``"symlink:<target>"`` for
+    symlinks. Returns an empty mapping when the directory does not exist,
+    so absent-before/absent-after compares equal.
+    """
+    snapshot: dict[str, str] = {}
+    if not ralph_dir.exists():
+        return snapshot
+    for path in sorted(ralph_dir.rglob("*")):
+        rel = str(path.relative_to(ralph_dir))
+        if path.is_symlink():
+            snapshot[rel] = f"symlink:{os.readlink(path)}"
+        elif path.is_dir():
+            snapshot[rel] = "dir"
+        elif path.is_file():
+            snapshot[rel] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return snapshot
+
+
+def describe_snapshot_diff(
+    before: dict[str, str], after: dict[str, str]
+) -> str:
+    """Human-readable created/deleted/modified summary of two snapshots."""
+    lines: list[str] = []
+    for rel in sorted(after.keys() - before.keys()):
+        lines.append(f"  created:  {rel}")
+    for rel in sorted(before.keys() - after.keys()):
+        lines.append(f"  deleted:  {rel}")
+    for rel in sorted(before.keys() & after.keys()):
+        if before[rel] != after[rel]:
+            lines.append(f"  modified: {rel}")
+    return "\n".join(lines)
+
+
+def _guard_root() -> Path:
+    """Root whose .ralph/ the session guard protects.
+
+    ``RALPH_SUITE_GUARD_ROOT`` exists so the guard's failure path can be
+    exercised end-to-end by a nested pytest run against a synthetic repo
+    (tests/test_suite_isolation.py); it is not a knob for disabling the
+    guard.
+    """
+    override = os.environ.get("RALPH_SUITE_GUARD_ROOT")
+    return Path(override) if override else REPO_ROOT
+
+
+@pytest.fixture(scope="session", autouse=True)
+def guard_repo_ralph_state() -> Generator[None, None, None]:
+    """FAIL the run loudly if any test mutated the repo's real .ralph/.
+
+    This is the enforcement behind the per-test redirect: the redirect
+    covers the known relative-default write paths, but any test that
+    reaches the real ``.ralph/`` through an absolute path (or a future
+    write path the redirect does not know about) is caught here and fails
+    the whole run, so pollution of the learning loop's data can never land
+    silently again.
+    """
+    ralph_dir = _guard_root() / ".ralph"
+    before = snapshot_ralph_dir(ralph_dir)
+    yield
+    after = snapshot_ralph_dir(ralph_dir)
+    if before != after:
+        pytest.fail(
+            "Test suite mutated the repository's real .ralph/ directory "
+            f"({ralph_dir}).\n"
+            "Tests must write only under tmp_path; the autouse "
+            "isolate_ralph_state fixture redirects the default relative "
+            ".ralph/ paths there, so a mutation here means a test used an "
+            "absolute path to the repo. Changes detected:\n"
+            + describe_snapshot_diff(before, after),
+            pytrace=False,
+        )
 
 
 @pytest.fixture
@@ -35,22 +200,11 @@ def temp_project(tmp_path: Path) -> Generator[Path, None, None]:
 
 @pytest.fixture
 def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Clear Ralph-related environment variables."""
-    env_vars = [
-        "MAX_ITERATIONS",
-        "AGENT_CMD",
-        "MODEL",
-        "MODEL_REASONING_EFFORT",
-        "SLEEP_SECONDS",
-        "INTERACTIVE",
-        "PROMPT_FILE",
-        "ALLOWED_PATHS",
-        "RALPH_BRANCH",
-        "PRD_FILE",
-        "RALPH_UI",
-        "GUM_FORCE",
-        "NO_COLOR",
-        "RALPH_ASCII",
-    ]
-    for var in env_vars:
-        monkeypatch.delenv(var, raising=False)
+    """Clear Ralph-related environment variables.
+
+    Covers the legacy single-loop names plus the FACTORY_*/RALPH_* config
+    families. The autouse ``isolate_ralph_state`` fixture already clears
+    these for every test; this fixture remains for tests that want to
+    state the dependency explicitly.
+    """
+    _clear_ralph_env(monkeypatch)

--- a/tests/test_suite_isolation.py
+++ b/tests/test_suite_isolation.py
@@ -1,0 +1,259 @@
+"""Tests for the R4.1 suite-isolation fixtures in conftest.py.
+
+Proves two things independently:
+
+1. The autouse redirect works: code writing through the DEFAULT
+   (CWD-relative) evolution/experiments/knowledge paths lands in tmp_path,
+   not in the repository's real ``.ralph/``.
+2. The session guard works: a nested pytest run whose test mutates the
+   guarded ``.ralph/`` exits nonzero with a loud message (and a control
+   run that does not mutate exits zero).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ralph_py.evolution import EvolutionConfig, EvolutionJournal
+from ralph_py.factory import FactoryResult
+from ralph_py.knowledge import Fact, KnowledgeConfig, write_facts
+from ralph_py.manifest import Component, ComponentStatus, Manifest
+from tests.conftest import (
+    RALPH_ENV_PREFIXES,
+    REPO_ROOT,
+    _clear_ralph_env,
+    describe_snapshot_diff,
+    snapshot_ralph_dir,
+)
+
+_RUN_MARKER = "run-isolation-proof"
+
+
+def _make_manifest_with_one_component() -> Manifest:
+    component = Component(
+        id="iso",
+        title="Component iso",
+        description="isolation probe",
+        dependencies=[],
+        prd_path="prd/iso.json",
+        branch_name="ralph/iso",
+        status=ComponentStatus.COMPLETED.value,
+        error="",
+        retries=0,
+        duration_seconds=1.0,
+        iteration_count=1,
+    )
+    return Manifest(
+        version="1",
+        spec_file="spec.md",
+        project_name="isolation-proof",
+        base_branch="main",
+        single_pr=False,
+        components=[component],
+    )
+
+
+class TestRedirect:
+    """The autouse isolate_ralph_state fixture redirects default writes."""
+
+    def test_cwd_is_redirected_to_tmp_path(self, tmp_path: Path) -> None:
+        assert Path.cwd() == tmp_path
+        assert Path.cwd() != REPO_ROOT
+
+    def test_default_evolution_journal_writes_land_in_tmp(
+        self, tmp_path: Path
+    ) -> None:
+        """Deliberate journal write through the DEFAULT config.
+
+        This is the exact shape of the historical pollution: run_factory
+        constructs ``EvolutionConfig()`` (relative ``.ralph/...`` paths)
+        and records the run. With the redirect the entries must land under
+        tmp_path and never in the repo's real journal.
+        """
+        config = EvolutionConfig()  # defaults: relative .ralph/ paths
+        journal = EvolutionJournal(config)
+        manifest = _make_manifest_with_one_component()
+        result = FactoryResult(completed=["iso"], failed=[], skipped=[])
+
+        journal.record_run(_RUN_MARKER, manifest, result)
+
+        tmp_journal = tmp_path / ".ralph" / "evolution.jsonl"
+        tmp_experiments = tmp_path / ".ralph" / "experiments.tsv"
+        assert tmp_journal.exists()
+        assert _RUN_MARKER in tmp_journal.read_text()
+        assert tmp_experiments.exists()
+        assert _RUN_MARKER in tmp_experiments.read_text()
+
+        repo_journal = REPO_ROOT / ".ralph" / "evolution.jsonl"
+        if repo_journal.exists():  # archived away by R4.1; belt and braces
+            assert _RUN_MARKER not in repo_journal.read_text()
+
+    def test_default_knowledge_root_resolves_and_writes_into_tmp(
+        self, tmp_path: Path
+    ) -> None:
+        # load(None) resolves against Path.cwd(), which the redirect owns.
+        assert KnowledgeConfig.load(None).knowledge_root == (
+            tmp_path / ".ralph" / "knowledge"
+        )
+
+        fact = Fact(
+            id="iso-fact-1",
+            component_id="iso",
+            created_iter=1,
+            created_run_id=_RUN_MARKER,
+            scope="component",
+            evidence=["src/iso.py"],
+            confidence="asserted",
+            claim="isolation probe fact",
+        )
+        written = write_facts(
+            [fact],
+            KnowledgeConfig().knowledge_root,  # default: relative path
+            component_id="iso",
+            run_id=_RUN_MARKER,
+        )
+        assert written == 1
+        component_dir = tmp_path / ".ralph" / "knowledge" / "iso"
+        assert component_dir.is_dir()
+        assert any(component_dir.rglob("*.md"))
+
+    def test_ambient_config_env_is_cleared_for_every_test(self) -> None:
+        for prefix in RALPH_ENV_PREFIXES:
+            leaked = [var for var in os.environ if var.startswith(prefix)]
+            assert leaked == [], f"ambient {prefix}* env leaked into test"
+
+    def test_clear_ralph_env_covers_every_documented_family(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        family_probes = [prefix + "PROBE" for prefix in RALPH_ENV_PREFIXES]
+        for var in family_probes:
+            monkeypatch.setenv(var, "leaked")
+        monkeypatch.setenv("RALPH_BRANCH", "leaked")  # legacy exact name
+        monkeypatch.setenv("UNRELATED_PROBE", "kept")
+
+        inner = pytest.MonkeyPatch()
+        try:
+            _clear_ralph_env(inner)
+            for var in [*family_probes, "RALPH_BRANCH"]:
+                assert var not in os.environ, f"{var} survived _clear_ralph_env"
+            assert os.environ["UNRELATED_PROBE"] == "kept"
+        finally:
+            inner.undo()
+
+
+class TestGuardHelpers:
+    """Unit tests for the snapshot/diff logic the session guard runs on."""
+
+    def test_missing_dir_snapshots_empty_on_both_sides(
+        self, tmp_path: Path
+    ) -> None:
+        missing = tmp_path / "nope" / ".ralph"
+        assert snapshot_ralph_dir(missing) == snapshot_ralph_dir(missing) == {}
+
+    def test_detects_created_modified_and_deleted_entries(
+        self, tmp_path: Path
+    ) -> None:
+        ralph_dir = tmp_path / ".ralph"
+        ralph_dir.mkdir()
+        (ralph_dir / "evolution.jsonl").write_text('{"run_id": "real"}\n')
+        (ralph_dir / "experiments.tsv").write_text("header\n")
+        before = snapshot_ralph_dir(ralph_dir)
+
+        (ralph_dir / "evolution.jsonl").write_text('{"run_id": "junk"}\n')
+        (ralph_dir / "experiments.tsv").unlink()
+        (ralph_dir / "proposals").mkdir()
+        after = snapshot_ralph_dir(ralph_dir)
+
+        assert before != after
+        diff = describe_snapshot_diff(before, after)
+        assert "modified: evolution.jsonl" in diff
+        assert "deleted:  experiments.tsv" in diff
+        assert "created:  proposals" in diff
+
+    def test_identical_content_compares_equal(self, tmp_path: Path) -> None:
+        ralph_dir = tmp_path / ".ralph"
+        ralph_dir.mkdir()
+        (ralph_dir / "evolution.jsonl").write_text('{"run_id": "real"}\n')
+        before = snapshot_ralph_dir(ralph_dir)
+        # Rewrite the same bytes: mtime moves, content does not.
+        (ralph_dir / "evolution.jsonl").write_text('{"run_id": "real"}\n')
+        assert snapshot_ralph_dir(ralph_dir) == before
+
+
+class TestGuardEndToEnd:
+    """Exercise the real guard fixture via a nested pytest session."""
+
+    def _run_nested_pytest(
+        self, tmp_path: Path, guarded_repo: Path, test_body: str
+    ) -> subprocess.CompletedProcess[str]:
+        nested = tmp_path / "nested_suite"
+        nested.mkdir()
+        shutil.copy(Path(__file__).parent / "conftest.py", nested / "conftest.py")
+        (nested / "test_nested.py").write_text(textwrap.dedent(test_body))
+
+        env = os.environ.copy()
+        env["RALPH_SUITE_GUARD_ROOT"] = str(guarded_repo)
+        env["RALPH_GUARDED_JOURNAL"] = str(
+            guarded_repo / ".ralph" / "evolution.jsonl"
+        )
+        return subprocess.run(
+            [sys.executable, "-m", "pytest", str(nested), "-q",
+             "-p", "no:cacheprovider"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+
+    @pytest.fixture
+    def guarded_repo(self, tmp_path: Path) -> Path:
+        repo = tmp_path / "synthetic_repo"
+        (repo / ".ralph").mkdir(parents=True)
+        (repo / ".ralph" / "evolution.jsonl").write_text(
+            '{"run_id": "real-data"}\n'
+        )
+        return repo
+
+    def test_guard_fails_the_run_when_a_test_mutates_ralph_dir(
+        self, tmp_path: Path, guarded_repo: Path
+    ) -> None:
+        result = self._run_nested_pytest(
+            tmp_path,
+            guarded_repo,
+            """
+            import os
+
+            def test_mutates_the_guarded_journal() -> None:
+                with open(os.environ["RALPH_GUARDED_JOURNAL"], "a") as f:
+                    f.write('{"run_id": "pollution"}\\n')
+            """,
+        )
+        assert result.returncode != 0, (
+            f"guard did not fail the run\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+        assert "mutated the repository's real .ralph/" in result.stdout
+        assert "modified: evolution.jsonl" in result.stdout
+
+    def test_guard_passes_a_run_that_leaves_ralph_dir_alone(
+        self, tmp_path: Path, guarded_repo: Path
+    ) -> None:
+        result = self._run_nested_pytest(
+            tmp_path,
+            guarded_repo,
+            """
+            def test_touches_nothing() -> None:
+                assert True
+            """,
+        )
+        assert result.returncode == 0, (
+            f"guard false-positived on a clean run\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )


### PR DESCRIPTION
## Roadmap items

- **R4.1 Suite isolation** [H-18, T-19] - done, checkbox flipped to `[x]`
- **R3.4 Repo hygiene** [LOW hygiene] - partial, checkbox flipped to `[~]` with a note (see below)

## What changed

### R4.1: the suite can no longer pollute the repo's real `.ralph/`

- **Autouse redirect** (`isolate_ralph_state` in `tests/conftest.py`): chdirs every test into its `tmp_path` and clears the FACTORY_*/RALPH_* env families. Why chdir and not env vars: `EvolutionConfig` defaults `journal_path`/`experiments_path` to relative `.ralph/...` paths resolved against CWD, and `run_factory` constructs `EvolutionConfig()` directly - neither env nor toml is consulted at that write site, so `RALPH_EVOLUTION_JOURNAL_PATH` cannot redirect it (and `experiments_path` has no env var at all). `KnowledgeConfig.load(None)` resolves `knowledge_root` against `Path.cwd()` and has no env override for the root. Pointing CWD at tmp_path redirects every relative default in one move without touching `ralph_py/` source (out of scope this session).
- **Session guard** (`guard_repo_ralph_state`): sha256-fingerprints the repo's `.ralph/` before the session and fails the run loudly (created/modified/deleted listing) if any test mutated it. This is the enforcement; the redirect is convenience.
- **`clean_env` extended** to the FACTORY_*, RALPH_TIMEOUT_*, RALPH_CONTRACT_*, RALPH_SECURITY_*, RALPH_VERIFY_*, RALPH_EVOLUTION_*, RALPH_KNOWLEDGE_* families, cleared by prefix so new vars in a family are covered automatically. Note: no test previously requested `clean_env`, so the real protection is that the autouse fixture clears the same families for every test.

### R3.4 (partial): repo hygiene

- `.gitignore` now covers `.ralph/`.
- The polluted journals were archived (not deleted) to `.ralph/archive/` with a README explaining why: at review time 837 of 910 journal entries were test pollution; by the time of the move the journal had grown to 965+ entries (projects `test`, `t`, `smoke` accounted for ~913). `.ralph/` is untracked, so the archive is a filesystem move in the repo, not part of this diff.
- **Stale worktree removed after user approval.** `git log claude/tender-leakey --not main --oneline` showed 2 commits not on main, so per the check-first instruction nothing was removed at first; the user then approved the cleanup in-session. The worktree (`.claude/worktrees/tender-leakey`, ~99MB) and the `claude/tender-leakey` branch are gone. The two commits were the pre-purge TUI work (the TUI was deleted from main in #55):
  - `6b41584` merge: resolve conflicts with main, keep TUI overhaul
  - `917bde6` feat: replace bash UI with Python TUI (Textual + Click + Rich)

  A local tag `archive/tui-overhaul` was left at `6b41584` so the commits stay reachable; drop it with `git tag -d archive/tui-overhaul` if you never want them back.
- Remaining R3.4 questions (why `[~]`): `ralph.toml.example` tracking vs live `ralph.toml` ignore, and the other untracked docs artifacts (`docs/end-to-end-flow.html`, `docs/phase-f-e2e-validation-v12.log`). This PR does add the two tracker docs (`docs/remediation-roadmap.md`, `docs/remediation-sessions.md`) since the shared rules require flipping checkboxes in-repo.

## Tested (H4)

- **Pollution reproduced before the fix (measured, not assumed):** one baseline suite run in a fresh worktree with no `.ralph/` created `.ralph/evolution.jsonl` with 24 junk entries plus `experiments.tsv`. After the fix, the same suite creates no `.ralph/` at all.
- `TestRedirect::test_default_evolution_journal_writes_land_in_tmp` - a deliberate `EvolutionJournal.record_run` through DEFAULT `EvolutionConfig()` (the exact shape of the historical pollution) lands in `tmp_path/.ralph/`, not the repo.
- `TestRedirect::test_default_knowledge_root_resolves_and_writes_into_tmp` - `KnowledgeConfig.load(None)` resolves under tmp_path; `write_facts` through the relative default root writes under tmp_path.
- `TestRedirect::test_cwd_is_redirected_to_tmp_path`, `test_ambient_config_env_is_cleared_for_every_test`, `test_clear_ralph_env_covers_every_documented_family` - redirect + env clearing active for every test, all seven families covered, unrelated vars untouched.
- `TestGuardHelpers` (3 tests) - snapshot/diff detects created, modified, and deleted entries; identical rewrites compare equal; missing dir compares equal on both sides.
- `TestGuardEndToEnd::test_guard_fails_the_run_when_a_test_mutates_ralph_dir` - a REAL nested pytest session (subprocess, copied conftest, guard pointed at a synthetic repo via `RALPH_SUITE_GUARD_ROOT`) whose test appends to the guarded journal exits nonzero and prints the loud mutation message naming the modified file.
- `TestGuardEndToEnd::test_guard_passes_a_run_that_leaves_ralph_dir_alone` - control: a clean nested run exits 0 (no false positive).
- Full suite green under the new autouse fixtures (final lines below): the chdir redirect broke zero existing tests.

## Assumed (H4)

- The guard hashes content only; it cannot attribute a mutation to the specific test that made it (it fails the run, naming the changed files).
- `RALPH_SUITE_GUARD_ROOT` is honest-use-only: it exists so the self-test can point the guard at a synthetic repo; nothing prevents a hostile test from setting it. The threat model here is accidental pollution, not adversarial tests.
- The env-family list covers the seven families named in R4.1; env vars outside those prefixes (e.g. `RALPH_RUN_CALIBRATION`, deliberately) are untouched.
- The archived journals were not validated line-by-line; counts came from grouping `project` fields.
- Concurrent non-test writers (e.g. a real factory run during a test session) would also trip the guard; the failure message says to check for that.

## Checks

Final lines from `uv run pytest tests/ -q` / `uv run mypy ralph_py/ --strict` / `uv run ruff check ralph_py/ tests/`, run against the exact committed tree after rebase:

```
616 passed, 12 skipped in 267.39s (0:04:27)
Success: no issues found in 36 source files
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
