### PR TITLE
fix: R0.1 enforce agent timeouts end to end

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -53,7 +53,7 @@ First principles: an unattended factory must be unable to hang forever, unable
 to report success on failure, and unable to corrupt the operator's repo. Every
 item here is one of those three.
 
-- [ ] R0.1 (L) **Enforce timeouts end to end** [CRIT-1]
+- [x] R0.1 (L) **Enforce timeouts end to end** [CRIT-1]
   - Agent adapters (`claude_code.py`, `codex.py`, `custom.py`): `Popen(...,
     start_new_session=True)`; reader thread + deadline so a silent hang is
     detected without a stdout line; on breach `killpg(SIGTERM)` then `SIGKILL`;

--- a/ralph_py/agents/claude_code.py
+++ b/ralph_py/agents/claude_code.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 import shutil
-import subprocess
-import time
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
+
+from ralph_py.agents.proc import DeadlineStreamer, timeout_message
 
 COMPLETION_MARKER = "<promise>COMPLETE</promise>"
 
@@ -52,11 +52,12 @@ class ClaudeCodeAgent:
 
         Uses stream-json output format to capture tool calls in real-time.
         Yields human-readable lines describing what the agent is doing.
+        When ``timeout`` is set and the CLI hangs (with or without output),
+        its process group is killed and a timeout error line is yielded last.
         """
         self._final_message = None
         self._saw_result = False
         accumulated_text: list[str] = []
-        start = time.monotonic()
 
         cmd = [
             "claude", "--print",
@@ -70,67 +71,40 @@ class ClaudeCodeAgent:
             cmd.extend(["--effort", self._effort])
 
         try:
-            proc = subprocess.Popen(
-                cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                cwd=cwd,
+            streamer = DeadlineStreamer(
+                cmd, cwd=cwd, stdin_text=prompt, timeout=timeout,
             )
-
-            if proc.stdin:
-                try:
-                    proc.stdin.write(prompt)
-                    proc.stdin.close()
-                except BrokenPipeError:
-                    pass
-
-            if proc.stdout:
-                for raw_line in proc.stdout:
-                    if timeout and (time.monotonic() - start) > timeout:
-                        proc.terminate()
-                        try:
-                            proc.wait(timeout=5)
-                        except subprocess.TimeoutExpired:
-                            proc.kill()
-                        yield f"ERROR: agent timed out after {timeout}s"
-                        return
-
-                    raw_line = raw_line.rstrip("\n")
-                    if not raw_line.strip():
-                        continue
-
-                    # Check for result event (final output, process should exit soon)
-                    result_text = _extract_result_text(raw_line)
-                    if result_text is not None:
-                        self._saw_result = True
-                        self._final_message = result_text
-                        break
-
-                    # Parse stream-json events
-                    for display_line in _parse_stream_event(raw_line):
-                        if display_line.strip():
-                            accumulated_text.append(display_line)
-                        yield display_line
-
-            # Wait for process to exit, but don't hang forever
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                proc.terminate()
-                try:
-                    proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-                    proc.wait()
-
-            # Set final_message from accumulated text if not already set by result event
-            if self._final_message is None and accumulated_text:
-                self._final_message = accumulated_text[-1]
-
         except FileNotFoundError:
             yield "ERROR: claude CLI not found in PATH"
+            return
+
+        for raw_line in streamer.lines():
+            if not raw_line.strip():
+                continue
+
+            # Check for result event (final output, process should exit soon)
+            result_text = _extract_result_text(raw_line)
+            if result_text is not None:
+                self._saw_result = True
+                self._final_message = result_text
+                break
+
+            # Parse stream-json events
+            for display_line in _parse_stream_event(raw_line):
+                if display_line.strip():
+                    accumulated_text.append(display_line)
+                yield display_line
+
+        if streamer.timed_out:
+            yield timeout_message(timeout)
+            return
+
+        # Wait for process to exit, but don't hang forever
+        streamer.finish(timeout=10)
+
+        # Set final_message from accumulated text if not already set by result event
+        if self._final_message is None and accumulated_text:
+            self._final_message = accumulated_text[-1]
 
     @property
     def final_message(self) -> str | None:

--- a/ralph_py/agents/codex.py
+++ b/ralph_py/agents/codex.py
@@ -8,6 +8,8 @@ import tempfile
 from collections.abc import Iterator
 from pathlib import Path
 
+from ralph_py.agents.proc import DeadlineStreamer, timeout_message
+
 
 class CodexAgent:
     """Agent that uses the Codex CLI."""
@@ -46,7 +48,9 @@ class CodexAgent:
     ) -> Iterator[str]:
         """Run codex with prompt piped to stdin.
 
-        Yields output lines as they arrive.
+        Yields output lines as they arrive. When ``timeout`` is set and the
+        CLI hangs (with or without output), its process group is killed and
+        a timeout error line is yielded last.
         """
         self._final_message = None
         last_non_empty_line: str | None = None
@@ -70,32 +74,24 @@ class CodexAgent:
             cmd.extend(["--output-last-message", str(last_msg_file)])
 
         try:
-            proc = subprocess.Popen(
-                cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                cwd=cwd,
+            streamer = DeadlineStreamer(
+                cmd, cwd=cwd, stdin_text=prompt, timeout=timeout,
             )
 
-            # Write prompt to stdin
-            if proc.stdin:
-                try:
-                    proc.stdin.write(prompt)
-                    proc.stdin.close()
-                except BrokenPipeError:
-                    pass
-
             # Stream output
-            if proc.stdout:
-                for line in proc.stdout:
-                    line = line.rstrip("\n")
-                    if line.strip():
-                        last_non_empty_line = line
-                    yield line
+            for line in streamer.lines():
+                if line.strip():
+                    last_non_empty_line = line
+                yield line
 
-            proc.wait()
+            if streamer.timed_out:
+                # Killed mid-run: the last-message file was likely never
+                # written; partial output is not a trustworthy final
+                # message, so leave it unset.
+                yield timeout_message(timeout)
+                return
+
+            streamer.finish()
 
             # Read final message
             if last_msg_file and last_msg_file.exists():
@@ -131,6 +127,7 @@ class CodexAgent:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                timeout=15,
             )
             cls._supports_output_last_message = "--output-last-message" in result.stdout
         except Exception:

--- a/ralph_py/agents/custom.py
+++ b/ralph_py/agents/custom.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import shutil
-import subprocess
 from collections.abc import Iterator
 from pathlib import Path
+
+from ralph_py.agents.proc import DeadlineStreamer, timeout_message
 
 
 class CustomAgent:
@@ -30,7 +31,9 @@ class CustomAgent:
     ) -> Iterator[str]:
         """Run command with prompt piped to stdin.
 
-        Yields output lines as they arrive.
+        Yields output lines as they arrive. When ``timeout`` is set and the
+        command hangs (with or without output), its process group is killed
+        and a timeout error line is yielded last.
         """
         self._final_message = None
 
@@ -41,33 +44,26 @@ class CustomAgent:
             # Fallback to /bin/sh when bash is unavailable.
             cmd = self._command
 
-        proc = subprocess.Popen(
+        streamer = DeadlineStreamer(
             cmd,
             shell=not use_bash,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
             cwd=cwd,
+            stdin_text=prompt,
+            timeout=timeout,
         )
 
-        # Write prompt to stdin
-        if proc.stdin:
-            try:
-                proc.stdin.write(prompt)
-                proc.stdin.close()
-            except BrokenPipeError:
-                pass
-
-        # Stream output
         output_lines: list[str] = []
-        if proc.stdout:
-            for line in proc.stdout:
-                line = line.rstrip("\n")
-                output_lines.append(line)
-                yield line
+        for line in streamer.lines():
+            output_lines.append(line)
+            yield line
 
-        proc.wait()
+        if streamer.timed_out:
+            # Killed mid-run: partial output is not a trustworthy final
+            # message, so leave it unset.
+            yield timeout_message(timeout)
+            return
+
+        streamer.finish()
 
         # Store last output as "final message" for consistency
         if output_lines:

--- a/ralph_py/agents/proc.py
+++ b/ralph_py/agents/proc.py
@@ -137,20 +137,36 @@ class DeadlineStreamer:
         self.kill()
 
     def _signal_group(self, sig: signal.Signals) -> None:
+        pid = self._proc.pid
         try:
-            pgid = os.getpgid(self._proc.pid)
-            os.killpg(pgid, sig)
-        except (ProcessLookupError, PermissionError, TypeError,
-                AttributeError, OSError):
-            # Group already gone, non-POSIX platform, or a mocked proc in
-            # tests: fall back to signalling the direct child only.
-            try:
-                if sig == signal.SIGKILL:
-                    self._proc.kill()
-                else:
-                    self._proc.terminate()
-            except (ProcessLookupError, OSError):
-                pass
+            # `isinstance(pid, int)` is load-bearing: a mocked Popen's pid
+            # coerces to 1 via MagicMock.__index__, and killpg(1, sig) is
+            # kill(-1, sig) - "signal every process this user can" - which
+            # kills the harness and its whole session. Same reason for the
+            # pgid > 1 and not-our-own-group guards: start_new_session=True
+            # makes the child its own group leader (pgid == child pid), so
+            # any pgid at or below 1, or equal to ours, means something is
+            # wrong and group-kill must not proceed.
+            if (
+                hasattr(os, "killpg")
+                and isinstance(pid, int)
+                and pid > 1
+            ):
+                pgid = os.getpgid(pid)
+                if pgid > 1 and pgid != os.getpgrp():
+                    os.killpg(pgid, sig)
+                    return
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+        # Group already gone, non-POSIX platform, unsafe pgid, or a mocked
+        # proc in tests: fall back to signalling the direct child only.
+        try:
+            if sig == signal.SIGKILL:
+                self._proc.kill()
+            else:
+                self._proc.terminate()
+        except (ProcessLookupError, OSError):
+            pass
 
     def _write_stdin(self, stdin_text: str | None) -> None:
         stdin = self._proc.stdin

--- a/ralph_py/agents/proc.py
+++ b/ralph_py/agents/proc.py
@@ -1,0 +1,175 @@
+"""Deadline-enforced subprocess streaming shared by all agent adapters.
+
+R0.1: every agent subprocess launches with ``start_new_session=True`` so it
+owns its process group, and stdout is consumed on a reader thread so a child
+that hangs WITHOUT emitting output still trips the wall-clock deadline (a
+plain ``for line in proc.stdout`` only notices time passing when a line
+arrives). On breach the whole group receives SIGTERM, then SIGKILL after a
+grace period, so grandchildren (e.g. ``sh -c 'sleep 1000 & wait'``) die with
+the direct child.
+
+POSIX-first like the rest of the codebase: on platforms without
+``os.killpg`` the kill degrades to signalling the direct child only.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import signal
+import subprocess
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+# Every adapter yields this line when its subprocess is killed on deadline
+# breach. loop.py matches on the prefix to count timed-out iterations; it is
+# a hint for error reporting, never a control-flow gate (a CustomAgent
+# command could print the same string).
+TIMEOUT_MESSAGE_PREFIX = "ERROR: agent timed out"
+
+DEFAULT_TERM_GRACE_SECONDS = 5.0
+DEFAULT_FINISH_WAIT_SECONDS = 10.0
+
+
+def timeout_message(timeout: float | None) -> str:
+    """Uniform timeout line yielded by every adapter."""
+    return f"{TIMEOUT_MESSAGE_PREFIX} after {timeout}s"
+
+
+class DeadlineStreamer:
+    """Stream stdout lines from a subprocess under a wall-clock deadline.
+
+    stdin is written on its own thread for the same reason stdout is read on
+    one: a child that never reads stdin must not block the harness once the
+    pipe buffer fills.
+
+    The deadline is absolute: a child that keeps emitting output past it is
+    still killed. ``timed_out`` records whether the deadline fired.
+    """
+
+    def __init__(
+        self,
+        cmd: list[str] | str,
+        *,
+        cwd: Path | None = None,
+        shell: bool = False,
+        stdin_text: str | None = None,
+        timeout: float | None = None,
+        term_grace: float = DEFAULT_TERM_GRACE_SECONDS,
+    ) -> None:
+        self.timed_out = False
+        self._term_grace = term_grace
+        self._deadline: float | None = (
+            time.monotonic() + timeout if timeout and timeout > 0 else None
+        )
+        self._queue: queue.Queue[str | None] = queue.Queue()
+        self._proc = subprocess.Popen(
+            cmd,
+            shell=shell,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            cwd=cwd,
+            start_new_session=True,
+        )
+        self._writer = threading.Thread(
+            target=self._write_stdin, args=(stdin_text,), daemon=True,
+        )
+        self._writer.start()
+        self._reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self._reader.start()
+
+    def lines(self) -> Iterator[str]:
+        """Yield stdout lines (newline-stripped) until EOF or breach.
+
+        On deadline breach the process group is killed, ``timed_out`` is set,
+        and iteration stops.
+        """
+        while True:
+            if self._deadline is None:
+                item = self._queue.get()
+            else:
+                remaining = self._deadline - time.monotonic()
+                if remaining <= 0:
+                    self._breach()
+                    return
+                try:
+                    item = self._queue.get(timeout=remaining)
+                except queue.Empty:
+                    self._breach()
+                    return
+            if item is None:
+                return
+            yield item
+
+    def finish(self, timeout: float = DEFAULT_FINISH_WAIT_SECONDS) -> None:
+        """Bounded wait for exit; escalate to a group kill on expiry.
+
+        Replaces the unbounded ``proc.wait()`` the adapters used to call.
+        """
+        try:
+            self._proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            self.kill()
+        self._reader.join(timeout=1.0)
+        self._writer.join(timeout=1.0)
+
+    def kill(self) -> None:
+        """SIGTERM the process group, wait a grace period, then SIGKILL."""
+        self._signal_group(signal.SIGTERM)
+        try:
+            self._proc.wait(timeout=self._term_grace)
+        except subprocess.TimeoutExpired:
+            self._signal_group(signal.SIGKILL)
+            try:
+                self._proc.wait(timeout=self._term_grace)
+            except subprocess.TimeoutExpired:
+                # Unreapable child (e.g. stuck in uninterruptible IO).
+                # Do not hang the harness on it; the leak is reported by
+                # the caller via the timeout error path.
+                pass
+
+    def _breach(self) -> None:
+        self.timed_out = True
+        self.kill()
+
+    def _signal_group(self, sig: signal.Signals) -> None:
+        try:
+            pgid = os.getpgid(self._proc.pid)
+            os.killpg(pgid, sig)
+        except (ProcessLookupError, PermissionError, TypeError,
+                AttributeError, OSError):
+            # Group already gone, non-POSIX platform, or a mocked proc in
+            # tests: fall back to signalling the direct child only.
+            try:
+                if sig == signal.SIGKILL:
+                    self._proc.kill()
+                else:
+                    self._proc.terminate()
+            except (ProcessLookupError, OSError):
+                pass
+
+    def _write_stdin(self, stdin_text: str | None) -> None:
+        stdin = self._proc.stdin
+        if stdin is None:
+            return
+        try:
+            if stdin_text:
+                stdin.write(stdin_text)
+            stdin.close()
+        except (BrokenPipeError, OSError, ValueError):
+            pass
+
+    def _read_stdout(self) -> None:
+        stdout = self._proc.stdout
+        try:
+            if stdout is not None:
+                for raw_line in stdout:
+                    self._queue.put(raw_line.rstrip("\n"))
+        except (OSError, ValueError):
+            pass
+        finally:
+            self._queue.put(None)

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -23,6 +23,7 @@ from ralph_py.init_cmd import DEFAULT_FEATURE_UNDERSTAND, run_init
 from ralph_py.loop import run_loop
 from ralph_py.manifest import Manifest
 from ralph_py.prd import PRD
+from ralph_py.timeout import TimeoutConfig
 from ralph_py.ui import get_ui
 
 
@@ -341,6 +342,7 @@ def run(
         review_mode="advisory",
         contract_config=None,
         feedforward_config=ff_config,
+        timeout_config=TimeoutConfig.load(root_dir),
     )
 
     factory_result = run_factory(manifest, factory_cfg, config, ui_impl, root_dir)
@@ -560,7 +562,10 @@ def understand(
 
     agent = get_agent(config.agent_cmd, config.model, config.model_reasoning_effort)
 
-    result = run_loop(config, ui_impl, agent, root_dir)
+    result = run_loop(
+        config, ui_impl, agent, root_dir,
+        timeouts=TimeoutConfig.load(root_dir),
+    )
     sys.exit(result.exit_code)
 
 
@@ -882,9 +887,13 @@ def feature(
         understand_config.ralph_branch = branch
         understand_config.ralph_branch_explicit = True
 
+    timeouts = TimeoutConfig.load(root_dir)
+
     understand_log = log_path("understand")
     understand_agent = LoggingAgent(agent, understand_log)
-    understand_result = run_loop(understand_config, ui_impl, understand_agent, root_dir)
+    understand_result = run_loop(
+        understand_config, ui_impl, understand_agent, root_dir, timeouts=timeouts,
+    )
     if understand_result.exit_code != 0:
         sys.exit(understand_result.exit_code)
 
@@ -925,7 +934,7 @@ def feature(
 
     run_log = log_path("run")
     run_agent = LoggingAgent(agent, run_log)
-    result = run_loop(run_config, ui_impl, run_agent, root_dir)
+    result = run_loop(run_config, ui_impl, run_agent, root_dir, timeouts=timeouts)
     if result.exit_code == 0 or repair_max_runs == 0 or result.iterations == 0:
         sys.exit(result.exit_code)
 
@@ -949,7 +958,9 @@ def feature(
             base_config.model_reasoning_effort,
         )
         repair_agent = LoggingAgent(repair_agent_base, repair_log)
-        repair_result = run_loop(repair_config, ui_impl, repair_agent, root_dir)
+        repair_result = run_loop(
+            repair_config, ui_impl, repair_agent, root_dir, timeouts=timeouts,
+        )
         if repair_result.exit_code == 0:
             sys.exit(0)
         last_log = repair_log
@@ -1215,13 +1226,17 @@ def decompose(
     "--agent-timeout",
     type=float,
     default=1800.0,
-    help="Timeout per agent iteration in seconds (default: 1800)",
+    help="Timeout per agent iteration in seconds; 0 disables "
+         "(default: 1800, or RALPH_TIMEOUT_AGENT_ITERATION / "
+         "[timeout].agent_iteration in ralph.toml)",
 )
 @click.option(
     "--component-timeout",
     type=float,
     default=7200.0,
-    help="Timeout per component total in seconds (default: 7200)",
+    help="Timeout per component total in seconds; 0 disables "
+         "(default: 7200, or RALPH_TIMEOUT_COMPONENT / "
+         "[timeout].component_total in ralph.toml)",
 )
 @click.option(
     "--progress-log",
@@ -1439,6 +1454,16 @@ def factory(
         fail_threshold=security_fail_threshold,
     )
 
+    # R0.1: TimeoutConfig is the single source for timeout values.
+    # Precedence: explicit CLI flag > env > ralph.toml > defaults (the
+    # click defaults on the two flags only document the dataclass
+    # defaults; they are applied solely when the flag is passed).
+    timeout_config = TimeoutConfig.load(root_dir)
+    if _use_cli_value(ctx, "agent_timeout"):
+        timeout_config.agent_iteration = agent_timeout
+    if _use_cli_value(ctx, "component_timeout"):
+        timeout_config.component_total = component_timeout
+
     factory_config = FactoryConfig(
         max_parallel=max_parallel,
         max_retries=max_retries,
@@ -1453,6 +1478,7 @@ def factory(
         security_config=s_config,
         contract_config=c_config,
         progress_log_path=progress_log,
+        timeout_config=timeout_config,
     )
 
     ralph_dir = root_dir / "scripts" / "ralph"

--- a/ralph_py/config.py
+++ b/ralph_py/config.py
@@ -58,10 +58,9 @@ class RalphConfig:
     model_reasoning_effort: str | None = None
     agent_type: str | None = None  # "claude-code", "codex", "auto", or None
 
-    # Timeout config
-    agent_iteration_timeout: float = 1800.0   # 30 min per agent.run() call
-    component_timeout: float = 7200.0         # 2 hours per component total
-    subprocess_timeout: float = 60.0          # general subprocess default
+    # Timeouts live in ralph_py.timeout.TimeoutConfig (the single source
+    # for agent_iteration / component_total; R0.1). RalphConfig used to
+    # duplicate them as dead fields - deliberately deleted, do not re-add.
 
     # UI config
     ui_mode: str = "auto"  # auto|rich|plain
@@ -272,14 +271,6 @@ def _apply_env_overrides(config: RalphConfig, root_dir: Path) -> None:
         config.model_reasoning_effort = os.environ["MODEL_REASONING_EFFORT"]
     if "RALPH_AGENT_TYPE" in os.environ:
         config.agent_type = os.environ["RALPH_AGENT_TYPE"]
-    if "RALPH_TIMEOUT_AGENT_ITERATION" in os.environ:
-        config.agent_iteration_timeout = float(
-            os.environ["RALPH_TIMEOUT_AGENT_ITERATION"]
-        )
-    if "RALPH_TIMEOUT_COMPONENT" in os.environ:
-        config.component_timeout = float(os.environ["RALPH_TIMEOUT_COMPONENT"])
-    if "RALPH_TIMEOUT_DEFAULT" in os.environ:
-        config.subprocess_timeout = float(os.environ["RALPH_TIMEOUT_DEFAULT"])
     if "RALPH_UI" in os.environ:
         config.ui_mode = os.environ["RALPH_UI"]
     if "NO_COLOR" in os.environ:

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import os
 import subprocess
 import time
-from concurrent.futures import Future, ProcessPoolExecutor, as_completed
+from collections.abc import Mapping
+from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -26,6 +27,7 @@ from ralph_py.pr import create_prs_in_order, create_single_pr
 from ralph_py.prd import PRD
 from ralph_py.review import ReviewMode, run_review
 from ralph_py.security import SecurityConfig, SecurityMode, run_security_review
+from ralph_py.timeout import TimeoutConfig
 from ralph_py.verify import VerifyConfig, run_mechanical_verification
 
 if TYPE_CHECKING:
@@ -67,6 +69,10 @@ class FactoryConfig:
     # E6: when True, pause and prompt the user before each component's
     # PR creation step. Off by default; opt-in for sensitive projects.
     pause_before_pr_merge: bool = False
+    # R0.1: timeout limits (agent iteration, component wall clock,
+    # scheduler backstop margin). None means run_factory loads
+    # TimeoutConfig.load(root_dir) - toml [timeout] section + env.
+    timeout_config: TimeoutConfig | None = None
 
     @classmethod
     def from_env(cls) -> FactoryConfig:
@@ -136,11 +142,29 @@ class FactoryResult:
     exit_code: int = 0
 
 
+def _remove_stale_index_lock(root_dir: Path, component_id: str) -> None:
+    """Remove a stale index.lock left behind by a killed git operation.
+
+    A timed-out agent is SIGKILLed and can die mid-git-op inside its
+    worktree; git then refuses every subsequent operation there. The lock
+    for a worktree lives under the MAIN repo's .git/worktrees/<name>/.
+    Only the component's own lock is touched - the main repo's
+    .git/index.lock may belong to a live operator process and is left
+    alone.
+    """
+    lock = root_dir / ".git" / "worktrees" / component_id / "index.lock"
+    try:
+        lock.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
 def _setup_worktree(
     component_id: str,
     branch_name: str,
     base_branch: str,
     root_dir: Path,
+    fresh_from_base: bool = False,
 ) -> Path:
     """Create a git worktree for a component.
 
@@ -148,6 +172,11 @@ def _setup_worktree(
     serializes setup across concurrent factory invocations on the same
     machine. Without it, two simultaneously-running factories could
     clobber each other's worktree at the same path.
+
+    ``fresh_from_base=True`` (used for retries after a timeout kill)
+    additionally deletes the component branch so the worktree is recreated
+    from ``base_branch`` instead of silently reusing possibly-dirty state
+    from the killed attempt (R0.1).
 
     POSIX only. On Windows the fcntl import fails; we degrade to the
     pre-lock behavior and document the limitation in the runbook.
@@ -171,9 +200,20 @@ def _setup_worktree(
             # caveat.
             lock_fp = None
 
+        # A killed prior attempt may have left git mid-operation.
+        _remove_stale_index_lock(root_dir, component_id)
+
         if worktree_path.exists():
             subprocess.run(
                 ["git", "worktree", "remove", "--force", str(worktree_path)],
+                cwd=root_dir, capture_output=True, timeout=30,
+            )
+
+        if fresh_from_base:
+            # Delete the branch from the killed attempt so the add below
+            # recreates it from base rather than reusing its commits.
+            subprocess.run(
+                ["git", "branch", "-D", branch_name],
                 cwd=root_dir, capture_output=True, timeout=30,
             )
 
@@ -233,6 +273,8 @@ def _run_component(
     knowledge_prefix: str = "",
     progress_file_str: str = "scripts/ralph/progress.txt",
     codebase_map_file_str: str = "scripts/ralph/codebase_map.md",
+    agent_iteration_timeout: float = 1800.0,
+    component_timeout: float = 7200.0,
 ) -> ComponentResult:
     """Run a single component's implementation loop.
 
@@ -343,13 +385,37 @@ def _run_component(
         no_color=True,
     )
 
+    timeouts = TimeoutConfig(
+        agent_iteration=agent_iteration_timeout,
+        component_total=component_timeout,
+    )
+
     try:
-        result = run_loop(config, ui, agent, worktree_path, context_prefix=context_prefix)
+        result = run_loop(
+            config, ui, agent, worktree_path,
+            context_prefix=context_prefix, timeouts=timeouts,
+        )
+        # Report which limit fired so the retry/fail path can act on it
+        # (timeout errors trigger the recreate-from-base retry hygiene).
+        if result.completed:
+            error = None
+        elif result.timeout_limit == "component":
+            error = (
+                f"component timeout: exceeded {component_timeout}s wall clock "
+                f"after {result.iterations} iteration(s)"
+            )
+        elif result.timed_out_iterations:
+            error = (
+                f"Did not complete ({result.timed_out_iterations} iteration(s) "
+                f"hit the {agent_iteration_timeout}s agent iteration timeout)"
+            )
+        else:
+            error = "Did not complete"
         return ComponentResult(
             component_id=component_id,
             success=result.completed,
             iterations=result.iterations,
-            error=None if result.completed else "Did not complete",
+            error=error,
             duration_seconds=time.monotonic() - start,
             context_json=previous_context_json,
         )
@@ -362,6 +428,32 @@ def _run_component(
             duration_seconds=time.monotonic() - start,
             context_json=previous_context_json,
         )
+
+
+def _next_backstop_wait(
+    running: Mapping[Future[ComponentResult], str],
+    deadlines: Mapping[Future[ComponentResult], float],
+    now: float,
+) -> float | None:
+    """Seconds until the nearest scheduler-backstop deadline among running
+    futures. None means no deadline is armed (wait indefinitely for the
+    next completion, the pre-R0.1 behavior)."""
+    pending = [deadlines[f] for f in running if f in deadlines]
+    if not pending:
+        return None
+    return max(0.0, min(pending) - now)
+
+
+def _expired_futures(
+    running: Mapping[Future[ComponentResult], str],
+    deadlines: Mapping[Future[ComponentResult], float],
+    now: float,
+) -> list[Future[ComponentResult]]:
+    """Running futures whose scheduler-backstop deadline has passed."""
+    return [
+        f for f in running
+        if not f.done() and f in deadlines and now >= deadlines[f]
+    ]
 
 
 def run_factory(
@@ -429,6 +521,17 @@ def run_factory(
         max_parallel = 1
         ui.info("Worktrees disabled: running sequentially")
 
+    # R0.1: TimeoutConfig is the single source for the agent-iteration and
+    # component wall-clock limits. Enforcement layers: the adapters kill
+    # their subprocess group, run_loop aborts on the component wall clock,
+    # and the scheduler backstop below catches a worker that hangs outside
+    # both (e.g. a stuck scaffold or feedforward step).
+    timeout_cfg = factory_config.timeout_config or TimeoutConfig.load(root_dir)
+    backstop_seconds = (
+        timeout_cfg.component_total + timeout_cfg.scheduler_backstop_margin
+        if timeout_cfg.component_total > 0 else 0.0
+    )
+
     ui.section("Factory: Execution")
     ui.kv("Max parallel", str(max_parallel))
     ui.kv("Max retries", str(factory_config.max_retries))
@@ -438,11 +541,27 @@ def run_factory(
         if factory_config.contract_config else "skip"
     )
     ui.kv("Contract check", contract_mode)
+    ui.kv(
+        "Agent timeout",
+        f"{timeout_cfg.agent_iteration}s"
+        if timeout_cfg.agent_iteration > 0 else "<disabled>",
+    )
+    ui.kv(
+        "Component timeout",
+        f"{timeout_cfg.component_total}s"
+        if timeout_cfg.component_total > 0 else "<disabled>",
+    )
 
     # Scheduling state
     running_futures: dict[Future[ComponentResult], str] = {}
     worktree_paths: dict[str, Path] = {}
     component_contexts: dict[str, str] = {}  # comp_id -> context JSON
+    # Components whose last failure was a timeout kill: their retry must
+    # not trust the surviving worktree/branch state (R0.1 requirement 5).
+    timeout_retry_ids: set[str] = set()
+    # Components abandoned by the scheduler backstop; their workers may
+    # still be alive, so their worktrees are never cleaned up here.
+    leaked_component_ids: set[str] = set()
 
     # E4: adversarial-call counter shared across review / security /
     # knowledge phases. When max_adversarial_calls is 0 the budget is
@@ -480,6 +599,17 @@ def run_factory(
     def _retry_or_fail(comp: Component, error: str, context_json: str | None) -> None:
         """Retry a component or mark it as failed."""
         if comp.retries < factory_config.max_retries:
+            # A timeout failure means the agent was killed mid-flight: the
+            # worktree/branch state cannot be trusted. Note the hygiene
+            # behavior in the error string so the audit trail explains why
+            # the retry does not resume from the killed attempt's commits.
+            if "timeout" in error.lower() and factory_config.use_worktrees:
+                timeout_retry_ids.add(comp.id)
+                error = (
+                    error
+                    + " [timeout retry: worktree recreated from base; "
+                    "stale index.lock removed]"
+                )
             comp.retries += 1
             comp.status = ComponentStatus.PENDING.value
             comp.error = error
@@ -918,8 +1048,11 @@ def run_factory(
         """Set up worktree for a component. Returns worktree path or None."""
         try:
             if factory_config.use_worktrees:
+                fresh_from_base = comp.id in timeout_retry_ids
+                timeout_retry_ids.discard(comp.id)
                 wt_path = _setup_worktree(
                     comp.id, comp.branch_name, manifest.base_branch, root_dir,
+                    fresh_from_base=fresh_from_base,
                 )
             else:
                 wt_path = root_dir
@@ -972,6 +1105,8 @@ def run_factory(
             knowledge_prefix,
             progress_file_rel,
             codebase_map_file_rel,
+            timeout_cfg.agent_iteration,
+            timeout_cfg.component_total,
         )
 
     # Main scheduling loop
@@ -1002,7 +1137,12 @@ def run_factory(
 
             _handle_result(comp.id, comp_result)
     else:
-        with ProcessPoolExecutor(max_workers=max_parallel) as executor:
+        # Manual executor lifecycle: on a backstop breach we must NOT wait
+        # for the (possibly hung) worker at shutdown, which the
+        # `with ProcessPoolExecutor(...)` form would do.
+        executor = ProcessPoolExecutor(max_workers=max_parallel)
+        future_deadlines: dict[Future[ComponentResult], float] = {}
+        try:
             while True:
                 ready = manifest.get_ready_components()
                 slots = max_parallel - len(running_futures)
@@ -1023,32 +1163,94 @@ def run_factory(
                     args = _submit_args(comp, wt_path)
                     future = executor.submit(_run_component, *args)
                     running_futures[future] = comp.id
+                    if backstop_seconds > 0:
+                        future_deadlines[future] = (
+                            time.monotonic() + backstop_seconds
+                        )
 
                 if not running_futures:
                     break
 
-                done_futures: set[Future[ComponentResult]] = set()
-                for future in as_completed(running_futures):
-                    done_futures.add(future)
-                    comp_id = running_futures[future]
+                # Wait for the next completion, bounded by the nearest
+                # backstop deadline. The worker enforces its own timeouts
+                # (adapter kill + loop wall clock); this scheduler-side
+                # deadline is the last line of defense when a worker hangs
+                # outside those layers.
+                wait_timeout = _next_backstop_wait(
+                    running_futures, future_deadlines, time.monotonic(),
+                )
+                done, _pending = wait(
+                    set(running_futures),
+                    timeout=wait_timeout,
+                    return_when=FIRST_COMPLETED,
+                )
 
+                if done:
+                    # Preserve pre-R0.1 semantics: process one completion
+                    # per pass so freed slots are refilled promptly.
+                    future = next(iter(done))
+                    comp_id = running_futures.pop(future)
+                    future_deadlines.pop(future, None)
                     try:
                         comp_result = future.result()
                     except Exception as exc:
                         comp_result = ComponentResult(
                             component_id=comp_id, success=False, error=str(exc),
                         )
-
                     _handle_result(comp_id, comp_result)
-                    break
+                    continue
 
-                for future in done_futures:
-                    del running_futures[future]
+                # Nothing completed inside the window: fail every
+                # component past its backstop deadline and keep going.
+                now = time.monotonic()
+                for future in _expired_futures(
+                    running_futures, future_deadlines, now,
+                ):
+                    comp_id = running_futures.pop(future)
+                    future_deadlines.pop(future, None)
+                    leaked_component_ids.add(comp_id)
+                    timed_out_comp = manifest.get_component(comp_id)
+                    if timed_out_comp is not None:
+                        timed_out_comp.status = ComponentStatus.FAILED.value
+                        timed_out_comp.error = "component timeout"
+                        skipped = manifest.cascade_skip(comp_id)
+                        factory_result.failed.append(comp_id)
+                        factory_result.skipped.extend(skipped)
+                        progress_log.component_failed(
+                            comp_id, "component timeout",
+                        )
+                    ui.err(
+                        f"  Failed: {comp_id}: component timeout "
+                        f"(scheduler backstop after {backstop_seconds:.0f}s)"
+                    )
+                    ui.warn(
+                        f"  A worker process for '{comp_id}' may be leaked; "
+                        f"its worktree is left in place"
+                    )
+                    manifest.save(manifest_path)
+        finally:
+            if leaked_component_ids:
+                ui.warn(
+                    "Shutting down worker pool without waiting: "
+                    f"{len(leaked_component_ids)} worker(s) may still be running"
+                )
+                executor.shutdown(wait=False, cancel_futures=True)
+            else:
+                executor.shutdown(wait=True)
 
     # Cleanup worktrees
     if factory_config.use_worktrees:
         ui.section("Factory: Cleanup")
         for comp_id in worktree_paths:
+            if comp_id in leaked_component_ids:
+                # A possibly-live worker still owns this worktree; removing
+                # it under the worker risks corrupting the main repo's
+                # worktree metadata.
+                ui.warn(
+                    f"  Keeping worktree for '{comp_id}' "
+                    f"(leaked worker may still be running)"
+                )
+                continue
             _cleanup_worktree(comp_id, root_dir)
         ui.ok("Worktrees cleaned up")
 

--- a/ralph_py/loop.py
+++ b/ralph_py/loop.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ralph_py import git, guards
+from ralph_py.agents.proc import TIMEOUT_MESSAGE_PREFIX
 from ralph_py.prd import PRD
+from ralph_py.timeout import TimeoutConfig
 
 if TYPE_CHECKING:
     from ralph_py.agents.base import Agent
@@ -27,6 +29,13 @@ class LoopResult:
     exit_code: int
     duration_seconds: float = 0.0
     iteration_durations: list[float] = field(default_factory=list)
+    # R0.1: which limit aborted the loop, if any. "component" means the
+    # component_total wall clock was exceeded across iterations.
+    timeout_limit: str | None = None
+    # How many iterations were killed by the per-iteration agent timeout.
+    # Derived from the adapters' timeout error line - a reporting hint,
+    # never a control-flow gate.
+    timed_out_iterations: int = 0
 
 
 def run_loop(
@@ -35,6 +44,7 @@ def run_loop(
     agent: Agent,
     cwd: Path | None = None,
     context_prefix: str | None = None,
+    timeouts: TimeoutConfig | None = None,
 ) -> LoopResult:
     """Run the main agentic loop.
 
@@ -43,12 +53,18 @@ def run_loop(
         ui: UI implementation for output
         agent: Agent to run
         cwd: Working directory (defaults to current)
+        context_prefix: Optional context prepended to the prompt
+        timeouts: Timeout limits (agent_iteration is passed into every
+            agent.run call; component_total is enforced as a wall clock
+            across iterations). Defaults to TimeoutConfig.from_env().
 
     Returns:
         LoopResult with completion status and exit code
     """
     if cwd is None:
         cwd = Path.cwd()
+    if timeouts is None:
+        timeouts = TimeoutConfig.from_env()
 
     ui.startup_art()
 
@@ -70,6 +86,14 @@ def run_loop(
     ui.kv("Allowed paths", allowed_paths)
     ui.kv("Reasoning", config.model_reasoning_effort or "<default>")
     ui.kv("UI", config.ui_mode)
+    ui.kv(
+        "Agent timeout",
+        f"{timeouts.agent_iteration}s" if timeouts.agent_iteration > 0 else "<disabled>",
+    )
+    ui.kv(
+        "Component timeout",
+        f"{timeouts.component_total}s" if timeouts.component_total > 0 else "<disabled>",
+    )
 
     # Resolve the prompt template. If the explicit prompt file does not
     # exist, fall back to the H3-protected DEFAULT_PROMPT from
@@ -144,16 +168,35 @@ def run_loop(
 
     loop_start = time.monotonic()
     iteration_durations: list[float] = []
+    timed_out_iterations = 0
+    component_budget = timeouts.component_total
 
     for iteration in range(1, config.max_iterations + 1):
         ui.section(f"Iteration {iteration} / {config.max_iterations}")
         iter_start = time.monotonic()
 
+        # Bound the iteration by the per-iteration limit AND the remaining
+        # component budget, so one iteration cannot blow far past the
+        # component wall clock (the adapters kill the agent's process
+        # group when the passed timeout expires).
+        iteration_timeout: float | None = (
+            timeouts.agent_iteration if timeouts.agent_iteration > 0 else None
+        )
+        if component_budget > 0:
+            remaining = component_budget - (iter_start - loop_start)
+            iteration_timeout = (
+                min(iteration_timeout, remaining)
+                if iteration_timeout is not None else remaining
+            )
+
         # Run agent
         completion_seen = False
-        for line in agent.run(prompt, cwd):
+        iteration_timed_out = False
+        for line in agent.run(prompt, cwd, timeout=iteration_timeout):
             if line.strip() == COMPLETION_MARKER:
                 completion_seen = True
+            if line.startswith(TIMEOUT_MESSAGE_PREFIX):
+                iteration_timed_out = True
             ui.stream_line("AI", line)
 
         final_message = agent.final_message
@@ -166,6 +209,13 @@ def run_loop(
         iter_duration = time.monotonic() - iter_start
         iteration_durations.append(iter_duration)
 
+        if iteration_timed_out:
+            timed_out_iterations += 1
+            ui.warn(
+                f"Iteration {iteration} hit the agent iteration timeout "
+                f"({iteration_timeout}s); the agent process group was killed"
+            )
+
         # Check for completion
         if completion_seen:
             ui.ok("Done")
@@ -176,6 +226,7 @@ def run_loop(
                 exit_code=0,
                 duration_seconds=total_duration,
                 iteration_durations=iteration_durations,
+                timed_out_iterations=timed_out_iterations,
             )
 
         # Enforce ALLOWED_PATHS
@@ -183,6 +234,25 @@ def run_loop(
             ok, _ = guards.enforce_allowed_paths(config, ui, cwd)
             if not ok:
                 return LoopResult(completed=False, iterations=iteration, exit_code=1)
+
+        # Component wall clock: abort cleanly rather than start work that
+        # is already past its budget. This is the "which limit fired"
+        # signal for the factory (timeout_limit="component").
+        elapsed = time.monotonic() - loop_start
+        if component_budget > 0 and elapsed >= component_budget:
+            ui.err(
+                f"Component timeout: {component_budget}s wall clock exceeded "
+                f"after {iteration} iteration(s); aborting loop"
+            )
+            return LoopResult(
+                completed=False,
+                iterations=iteration,
+                exit_code=1,
+                duration_seconds=elapsed,
+                iteration_durations=iteration_durations,
+                timeout_limit="component",
+                timed_out_iterations=timed_out_iterations,
+            )
 
         # Interactive pause
         if config.interactive and ui.can_prompt():
@@ -202,7 +272,13 @@ def run_loop(
             time.sleep(config.sleep_seconds)
 
     # Max iterations reached
-    ui.warn(f"Max iterations reached (no {COMPLETION_MARKER} seen)")
+    if timed_out_iterations:
+        ui.warn(
+            f"Max iterations reached (no {COMPLETION_MARKER} seen; "
+            f"{timed_out_iterations} iteration(s) hit the agent timeout)"
+        )
+    else:
+        ui.warn(f"Max iterations reached (no {COMPLETION_MARKER} seen)")
     total_duration = time.monotonic() - loop_start
     return LoopResult(
         completed=False,
@@ -210,6 +286,7 @@ def run_loop(
         exit_code=1,
         duration_seconds=total_duration,
         iteration_durations=iteration_durations,
+        timed_out_iterations=timed_out_iterations,
     )
 
 

--- a/ralph_py/timeout.py
+++ b/ralph_py/timeout.py
@@ -4,14 +4,32 @@ from __future__ import annotations
 
 import os
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
+
+# Field name -> environment variable, shared by from_env and load so the
+# two surfaces cannot drift.
+_ENV_VARS: dict[str, str] = {
+    "git_operation": "RALPH_TIMEOUT_GIT",
+    "agent_iteration": "RALPH_TIMEOUT_AGENT_ITERATION",
+    "component_total": "RALPH_TIMEOUT_COMPONENT",
+    "verification_check": "RALPH_TIMEOUT_VERIFY",
+    "review_agent": "RALPH_TIMEOUT_REVIEW",
+    "contract_test": "RALPH_TIMEOUT_CONTRACT",
+    "subprocess_default": "RALPH_TIMEOUT_DEFAULT",
+    "scheduler_backstop_margin": "RALPH_TIMEOUT_BACKSTOP_MARGIN",
+}
 
 
 @dataclass
 class TimeoutConfig:
-    """Timeout configuration for various operations."""
+    """Timeout configuration for various operations.
+
+    Single source of truth for the agent-iteration and component wall-clock
+    limits enforced by loop.py, the agent adapters, and the factory
+    scheduler (R0.1). A value of 0 or less disables that limit.
+    """
 
     git_operation: float = 30.0
     agent_iteration: float = 1800.0
@@ -20,19 +38,45 @@ class TimeoutConfig:
     review_agent: float = 600.0
     contract_test: float = 600.0
     subprocess_default: float = 60.0
+    # Extra slack the factory scheduler grants a worker past
+    # component_total before declaring the component dead: workers need
+    # time for worktree setup, phase hand-offs, and the SIGTERM->SIGKILL
+    # grace inside the adapters.
+    scheduler_backstop_margin: float = 60.0
 
     @classmethod
     def from_env(cls) -> TimeoutConfig:
         """Load timeout config from environment variables."""
-        return cls(
-            git_operation=float(os.environ.get("RALPH_TIMEOUT_GIT", "30")),
-            agent_iteration=float(os.environ.get("RALPH_TIMEOUT_AGENT_ITERATION", "1800")),
-            component_total=float(os.environ.get("RALPH_TIMEOUT_COMPONENT", "7200")),
-            verification_check=float(os.environ.get("RALPH_TIMEOUT_VERIFY", "300")),
-            review_agent=float(os.environ.get("RALPH_TIMEOUT_REVIEW", "600")),
-            contract_test=float(os.environ.get("RALPH_TIMEOUT_CONTRACT", "600")),
-            subprocess_default=float(os.environ.get("RALPH_TIMEOUT_DEFAULT", "60")),
-        )
+        config = cls()
+        _apply_env_overrides(config)
+        return config
+
+    @classmethod
+    def load(cls, root_dir: Path | None = None) -> TimeoutConfig:
+        """Load timeout config with precedence: env > toml > defaults.
+
+        Reads the ``[timeout]`` section from ``<root_dir>/ralph.toml`` if
+        present, then overlays any explicitly-set env vars on top.
+        """
+        from ralph_py.config import load_toml_section
+
+        if root_dir is None:
+            root_dir = Path.cwd()
+        config = cls()
+        section = load_toml_section(root_dir / "ralph.toml", "timeout")
+        for f in fields(cls):
+            if f.name in section:
+                setattr(config, f.name, float(section[f.name]))
+        _apply_env_overrides(config)
+        return config
+
+
+def _apply_env_overrides(config: TimeoutConfig) -> None:
+    """Overlay env vars that are explicitly set; unset vars leave the
+    existing value untouched (so toml values survive the overlay)."""
+    for field_name, env_var in _ENV_VARS.items():
+        if env_var in os.environ:
+            setattr(config, field_name, float(os.environ[env_var]))
 
 
 def run_with_timeout(

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -21,7 +21,9 @@ class MockAgent:
     def name(self) -> str:
         return "mock"
 
-    def run(self, prompt: str, cwd: Path | None = None) -> Iterator[str]:
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
         yield from self._output
         if self._output:
             self._final_message = self._output[-1]

--- a/tests/test_phase_c_coverage.py
+++ b/tests/test_phase_c_coverage.py
@@ -347,22 +347,25 @@ class TestC6ConcurrentFactory:
         def go(root: Path) -> None:
             try:
                 manifest = _make_manifest([_component("comp-a")])
-                with patch(
-                    "ralph_py.factory._run_component", return_value=success,
-                ):
-                    run_factory(
-                        manifest, config, _base_config(root),
-                        PlainUI(no_color=True), root,
-                    )
+                run_factory(
+                    manifest, config, _base_config(root),
+                    PlainUI(no_color=True), root,
+                )
             except Exception as e:  # noqa: BLE001
                 errors.append(e)
 
-        t1 = threading.Thread(target=go, args=(root_a,))
-        t2 = threading.Thread(target=go, args=(root_b,))
-        t1.start()
-        t2.start()
-        t1.join()
-        t2.join()
+        # Patch ONCE around both threads. Entering/exiting the same patch
+        # target concurrently from two threads is racy and leaked the mock
+        # into ralph_py.factory._run_component for the rest of the pytest
+        # process (t2 restored t1's mock as the "original"), breaking any
+        # later test that needs the real function.
+        with patch("ralph_py.factory._run_component", return_value=success):
+            t1 = threading.Thread(target=go, args=(root_a,))
+            t2 = threading.Thread(target=go, args=(root_b,))
+            t1.start()
+            t2.start()
+            t1.join()
+            t2.join()
         assert errors == []
 
 

--- a/tests/test_timeout_enforcement.py
+++ b/tests/test_timeout_enforcement.py
@@ -265,6 +265,87 @@ class TestCodexAgentDeadline:
         assert _wait_pid_dead(_read_pid(pidfile))
 
 
+class TestSignalGroupSafety:
+    """_signal_group must never group-kill a pathological pgid.
+
+    Regression: a mocked Popen's pid coerces to 1 via MagicMock.__index__,
+    so os.getpgid(pid) did NOT raise TypeError as assumed; killpg(1, sig)
+    is kill(-1, sig) ("signal everything this user can") and took down the
+    whole CI runner. The guard must fall back to signalling the direct
+    child for any non-int pid, pid <= 1, resolved pgid <= 1, or our own
+    process group.
+    """
+
+    def _streamer_with_fake_proc(self, pid: object) -> tuple[object, object]:
+        from unittest.mock import MagicMock, patch
+
+        from ralph_py.agents.proc import DeadlineStreamer
+
+        fake_proc = MagicMock()
+        fake_proc.pid = pid
+        fake_proc.stdout = iter([])
+        fake_proc.stdin = MagicMock()
+        with patch("subprocess.Popen", return_value=fake_proc):
+            streamer = DeadlineStreamer(["true"])
+        return streamer, fake_proc
+
+    @pytest.mark.parametrize("bad_pid", [None, 0, 1, -1])
+    def test_never_killpg_for_unsafe_pids(
+        self, bad_pid: object, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import signal as _signal
+
+        killpg_calls: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            os, "killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+        streamer, fake_proc = self._streamer_with_fake_proc(bad_pid)
+
+        streamer._signal_group(_signal.SIGTERM)
+
+        assert killpg_calls == []
+        fake_proc.terminate.assert_called_once()
+
+    def test_mock_pid_falls_back_to_terminate(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The exact CI-killer shape: MagicMock pid (coerces to 1)."""
+        import signal as _signal
+        from unittest.mock import MagicMock
+
+        killpg_calls: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            os, "killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+        streamer, fake_proc = self._streamer_with_fake_proc(MagicMock())
+
+        streamer._signal_group(_signal.SIGTERM)
+
+        assert killpg_calls == []
+        fake_proc.terminate.assert_called_once()
+
+    def test_own_process_group_is_never_group_killed(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A pid resolving to the harness's own pgid must not be killpg'd."""
+        import signal as _signal
+
+        killpg_calls: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            os, "killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+        monkeypatch.setattr(os, "getpgid", lambda pid: os.getpgrp())
+        streamer, fake_proc = self._streamer_with_fake_proc(os.getpid())
+
+        streamer._signal_group(_signal.SIGTERM)
+
+        assert killpg_calls == []
+        fake_proc.terminate.assert_called_once()
+
+
 class _RecordingAgent:
     """In-process fake that records the timeout passed by run_loop."""
 

--- a/tests/test_timeout_enforcement.py
+++ b/tests/test_timeout_enforcement.py
@@ -1,0 +1,771 @@
+"""R0.1: timeout enforcement tests with real subprocesses (no LLM).
+
+Covers the enforcement layers end to end:
+
+- Adapter level: a sleep-forever fake agent (silent, or silent AFTER one
+  output line) is killed within the deadline; a grandchild spawned via
+  ``sh -c 'sleep N & wait'`` dies with its parent (start_new_session +
+  killpg); all three adapters honor their ``timeout`` parameter.
+- Loop level: ``agent_iteration`` is passed into ``agent.run`` (capped by
+  the remaining component budget); ``component_total`` aborts the loop and
+  reports which limit fired.
+- Factory level: a timed-out component is FAILED; a timeout retry recreates
+  the worktree from base, removes the stale index.lock, and says so in the
+  retry error string; the scheduler backstop fails a hung worker's
+  component and the run continues.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from collections.abc import Iterator
+from concurrent.futures import Future
+from pathlib import Path
+
+import pytest
+
+from ralph_py.agents.claude_code import ClaudeCodeAgent
+from ralph_py.agents.codex import CodexAgent
+from ralph_py.agents.custom import CustomAgent
+from ralph_py.agents.proc import TIMEOUT_MESSAGE_PREFIX
+from ralph_py.config import RalphConfig
+from ralph_py.factory import (
+    ComponentResult,
+    FactoryConfig,
+    _expired_futures,
+    _next_backstop_wait,
+    _remove_stale_index_lock,
+    _setup_worktree,
+    run_factory,
+)
+from ralph_py.loop import run_loop
+from ralph_py.manifest import Component, Manifest
+from ralph_py.timeout import TimeoutConfig
+from ralph_py.ui.plain import PlainUI
+
+# Generous bound for "killed within the deadline": 1s deadline + 5s
+# SIGTERM grace + slack. A hang would previously block forever.
+KILL_BOUND_SECONDS = 12.0
+
+
+def _wait_pid_dead(pid: int, timeout: float = 8.0) -> bool:
+    """Poll until signal 0 reports the pid gone."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            return False
+        time.sleep(0.05)
+    return False
+
+
+def _read_pid(pidfile: Path, timeout: float = 5.0) -> int:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            text = pidfile.read_text().strip()
+            if text:
+                return int(text)
+        except (FileNotFoundError, ValueError):
+            pass
+        time.sleep(0.05)
+    raise AssertionError(f"pid file never appeared: {pidfile}")
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, timeout=30,
+    )
+
+
+def _init_repo(root: Path) -> None:
+    """Real git repo with the ralph scaffolding committed to main."""
+    _git("init", "-q", "-b", "main", cwd=root)
+    _git("config", "user.email", "t@t", cwd=root)
+    _git("config", "user.name", "t", cwd=root)
+    ralph_dir = root / "scripts" / "ralph"
+    ralph_dir.mkdir(parents=True)
+    (ralph_dir / "prompt.md").write_text("test prompt\n")
+    feature_dir = ralph_dir / "feature" / "a"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "prd.json").write_text(json.dumps({
+        "branchName": "ralph/factory/a",
+        "userStories": [{
+            "id": "US-001", "title": "Test",
+            "acceptanceCriteria": ["AC1"],
+            "priority": 1, "passes": True, "notes": "",
+        }],
+    }))
+    _git("add", "-A", cwd=root)
+    _git("commit", "-q", "-m", "init", cwd=root)
+
+
+class TestCustomAgentDeadline:
+    """CustomAgent runs a real subprocess; these are the canonical
+    fake-agent kill scenarios from R0.1."""
+
+    def test_silent_hang_is_killed_within_deadline(self, tmp_path: Path) -> None:
+        """A sleep-forever agent that emits NO output still trips the
+        deadline (reader-thread enforcement, not per-line clock checks)."""
+        pidfile = tmp_path / "agent.pid"
+        agent = CustomAgent(f"echo $$ > {pidfile}; exec sleep 300")
+
+        start = time.monotonic()
+        lines = list(agent.run("prompt", tmp_path, timeout=1.0))
+        elapsed = time.monotonic() - start
+
+        assert elapsed < KILL_BOUND_SECONDS
+        assert any(line.startswith(TIMEOUT_MESSAGE_PREFIX) for line in lines)
+        assert agent.final_message is None
+        pid = _read_pid(pidfile)
+        assert _wait_pid_dead(pid), f"agent process {pid} survived the kill"
+
+    def test_grandchild_is_killed_too(self, tmp_path: Path) -> None:
+        """`sh -c 'sleep 300 & wait'` spawns a grandchild; killpg on the
+        session started by start_new_session must take it down as well."""
+        child_pidfile = tmp_path / "child.pid"
+        grandchild_pidfile = tmp_path / "grandchild.pid"
+        agent = CustomAgent(
+            f"sh -c 'echo $$ > {child_pidfile}; "
+            f"sleep 300 & echo $! > {grandchild_pidfile}; wait'"
+        )
+
+        start = time.monotonic()
+        lines = list(agent.run("prompt", tmp_path, timeout=1.0))
+        elapsed = time.monotonic() - start
+
+        assert elapsed < KILL_BOUND_SECONDS
+        assert any(line.startswith(TIMEOUT_MESSAGE_PREFIX) for line in lines)
+        child = _read_pid(child_pidfile)
+        grandchild = _read_pid(grandchild_pidfile)
+        assert _wait_pid_dead(child), f"child {child} survived"
+        assert _wait_pid_dead(grandchild), f"grandchild {grandchild} survived"
+
+    def test_hang_after_one_line_is_killed(self, tmp_path: Path) -> None:
+        """An agent that emits one line then hangs silently must still be
+        killed: pre-R0.1 the clock was only checked when a line arrived."""
+        pidfile = tmp_path / "agent.pid"
+        agent = CustomAgent(f"echo hello; echo $$ > {pidfile}; exec sleep 300")
+
+        start = time.monotonic()
+        lines = list(agent.run("prompt", tmp_path, timeout=1.0))
+        elapsed = time.monotonic() - start
+
+        assert elapsed < KILL_BOUND_SECONDS
+        assert "hello" in lines
+        assert any(line.startswith(TIMEOUT_MESSAGE_PREFIX) for line in lines)
+        pid = _read_pid(pidfile)
+        assert _wait_pid_dead(pid), f"agent process {pid} survived the kill"
+
+    def test_no_timeout_still_completes_normally(self, tmp_path: Path) -> None:
+        agent = CustomAgent("echo done")
+        lines = list(agent.run("prompt", tmp_path, timeout=None))
+        assert "done" in lines
+        assert agent.final_message == "done"
+
+    def test_agent_ignoring_stdin_does_not_block_on_large_prompt(
+        self, tmp_path: Path,
+    ) -> None:
+        """A child that never reads stdin must not deadlock the harness on
+        a prompt bigger than the pipe buffer (stdin is written on its own
+        thread)."""
+        pidfile = tmp_path / "agent.pid"
+        agent = CustomAgent(f"echo $$ > {pidfile}; exec sleep 300")
+        big_prompt = "x" * 512 * 1024  # > 64KB pipe buffer
+
+        start = time.monotonic()
+        lines = list(agent.run(big_prompt, tmp_path, timeout=1.0))
+        elapsed = time.monotonic() - start
+
+        assert elapsed < KILL_BOUND_SECONDS
+        assert any(line.startswith(TIMEOUT_MESSAGE_PREFIX) for line in lines)
+        assert _wait_pid_dead(_read_pid(pidfile))
+
+
+class TestClaudeCodeAgentDeadline:
+    """Real-subprocess timeout coverage for the claude adapter via a fake
+    `claude` executable on PATH."""
+
+    def test_hang_after_stream_event_is_killed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        pidfile = tmp_path / "claude.pid"
+        event = (
+            '{"type":"assistant","message":'
+            '{"content":[{"type":"text","text":"working"}]}}'
+        )
+        script = (
+            "#!/bin/sh\n"
+            f"echo '{event}'\n"
+            f"echo $$ > {pidfile}\n"
+            "exec sleep 300\n"
+        )
+        fake = bindir / "claude"
+        fake.write_text(script)
+        fake.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{bindir}:{os.environ['PATH']}")
+
+        agent = ClaudeCodeAgent()
+        start = time.monotonic()
+        lines = list(agent.run("prompt", tmp_path, timeout=1.0))
+        elapsed = time.monotonic() - start
+
+        assert elapsed < KILL_BOUND_SECONDS
+        assert "working" in lines
+        assert any(line.startswith(TIMEOUT_MESSAGE_PREFIX) for line in lines)
+        assert _wait_pid_dead(_read_pid(pidfile))
+
+
+class TestCodexAgentDeadline:
+    """Real-subprocess timeout coverage for the codex adapter via a fake
+    `codex` executable on PATH."""
+
+    def test_silent_hang_is_killed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        bindir = tmp_path / "bin"
+        bindir.mkdir()
+        pidfile = tmp_path / "codex.pid"
+        script = (
+            "#!/bin/sh\n"
+            'for a in "$@"; do\n'
+            '  case "$a" in\n'
+            "    --help) exit 0 ;;\n"
+            "  esac\n"
+            "done\n"
+            "echo starting\n"
+            f"echo $$ > {pidfile}\n"
+            "exec sleep 300\n"
+        )
+        fake = bindir / "codex"
+        fake.write_text(script)
+        fake.chmod(0o755)
+        monkeypatch.setenv("PATH", f"{bindir}:{os.environ['PATH']}")
+        # Reset the memoized --output-last-message probe so it targets the
+        # fake CLI (monkeypatch restores the original value afterwards).
+        monkeypatch.setattr(CodexAgent, "_supports_output_last_message", None)
+
+        agent = CodexAgent()
+        start = time.monotonic()
+        lines = list(agent.run("prompt", tmp_path, timeout=1.0))
+        elapsed = time.monotonic() - start
+
+        assert elapsed < KILL_BOUND_SECONDS
+        assert "starting" in lines
+        assert any(line.startswith(TIMEOUT_MESSAGE_PREFIX) for line in lines)
+        assert agent.final_message is None
+        assert _wait_pid_dead(_read_pid(pidfile))
+
+
+class _RecordingAgent:
+    """In-process fake that records the timeout passed by run_loop."""
+
+    name = "recording"
+    final_message: str | None = None
+
+    def __init__(
+        self, sleep_seconds: float = 0.0, lines: list[str] | None = None,
+    ) -> None:
+        self.received_timeouts: list[float | None] = []
+        self._sleep_seconds = sleep_seconds
+        self._lines = lines if lines is not None else ["working"]
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        self.received_timeouts.append(timeout)
+        if self._sleep_seconds:
+            time.sleep(self._sleep_seconds)
+        yield from self._lines
+
+
+def _loop_config(tmp_path: Path, max_iterations: int) -> RalphConfig:
+    ralph_dir = tmp_path / "scripts" / "ralph"
+    ralph_dir.mkdir(parents=True, exist_ok=True)
+    (ralph_dir / "prompt.md").write_text("test prompt")
+    (ralph_dir / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    return RalphConfig(
+        max_iterations=max_iterations,
+        prompt_file=ralph_dir / "prompt.md",
+        prd_file=ralph_dir / "prd.json",
+        sleep_seconds=0,
+        ralph_branch="",
+        ralph_branch_explicit=True,
+    )
+
+
+class TestLoopTimeouts:
+    """run_loop passes agent_iteration into agent.run and enforces
+    component_total as a wall clock across iterations."""
+
+    def test_agent_iteration_timeout_reaches_agent(self, tmp_path: Path) -> None:
+        config = _loop_config(tmp_path, max_iterations=1)
+        agent = _RecordingAgent()
+        timeouts = TimeoutConfig(agent_iteration=123.0, component_total=0)
+
+        run_loop(config, PlainUI(no_color=True), agent, tmp_path, timeouts=timeouts)
+
+        assert agent.received_timeouts == [123.0]
+
+    def test_iteration_timeout_capped_by_component_budget(
+        self, tmp_path: Path,
+    ) -> None:
+        config = _loop_config(tmp_path, max_iterations=1)
+        agent = _RecordingAgent()
+        timeouts = TimeoutConfig(agent_iteration=500.0, component_total=5.0)
+
+        run_loop(config, PlainUI(no_color=True), agent, tmp_path, timeouts=timeouts)
+
+        assert len(agent.received_timeouts) == 1
+        received = agent.received_timeouts[0]
+        assert received is not None
+        assert 0 < received <= 5.0
+
+    def test_component_timeout_aborts_loop(self, tmp_path: Path) -> None:
+        config = _loop_config(tmp_path, max_iterations=100)
+        agent = _RecordingAgent(sleep_seconds=0.2)
+        timeouts = TimeoutConfig(agent_iteration=0, component_total=0.3)
+
+        result = run_loop(
+            config, PlainUI(no_color=True), agent, tmp_path, timeouts=timeouts,
+        )
+
+        assert result.completed is False
+        assert result.exit_code == 1
+        assert result.timeout_limit == "component"
+        assert result.iterations < 100
+
+    def test_disabled_timeouts_run_to_max_iterations(self, tmp_path: Path) -> None:
+        config = _loop_config(tmp_path, max_iterations=3)
+        agent = _RecordingAgent()
+        timeouts = TimeoutConfig(agent_iteration=0, component_total=0)
+
+        result = run_loop(
+            config, PlainUI(no_color=True), agent, tmp_path, timeouts=timeouts,
+        )
+
+        assert result.iterations == 3
+        assert result.timeout_limit is None
+        assert agent.received_timeouts == [None, None, None]
+
+    def test_timed_out_iterations_counted(self, tmp_path: Path) -> None:
+        config = _loop_config(tmp_path, max_iterations=2)
+        agent = _RecordingAgent(lines=[f"{TIMEOUT_MESSAGE_PREFIX} after 1.0s"])
+        timeouts = TimeoutConfig(agent_iteration=60.0, component_total=0)
+
+        result = run_loop(
+            config, PlainUI(no_color=True), agent, tmp_path, timeouts=timeouts,
+        )
+
+        assert result.timed_out_iterations == 2
+
+
+class TestFactoryComponentTimeout:
+    """A sleep-forever fake agent times out and the component is FAILED."""
+
+    def test_component_failed_on_timeout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        ralph_dir = tmp_path / "scripts" / "ralph"
+        ralph_dir.mkdir(parents=True)
+        (ralph_dir / "prompt.md").write_text("test prompt")
+        feature_dir = ralph_dir / "feature" / "a"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "prd.json").write_text(json.dumps({
+            "branchName": "test",
+            "userStories": [{
+                "id": "US-001", "title": "Test",
+                "acceptanceCriteria": ["AC1"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+        pidfile = tmp_path / "agent.pid"
+
+        manifest = Manifest(
+            version="1", spec_file="spec.md", project_name="t",
+            base_branch="main", single_pr=False,
+            components=[Component(
+                "a", "A", "", [], "scripts/ralph/feature/a/prd.json", "b/a",
+            )],
+        )
+        config = FactoryConfig(
+            use_worktrees=False, create_prs=False, max_parallel=1,
+            max_retries=0, retry_delay=0, review_mode="skip",
+            timeout_config=TimeoutConfig(
+                agent_iteration=0.5, component_total=1.0,
+            ),
+        )
+        base = RalphConfig(
+            prompt_file=ralph_dir / "prompt.md",
+            prd_file=ralph_dir / "prd.json",
+            sleep_seconds=0,
+            agent_cmd=f"echo $$ > {pidfile}; exec sleep 300",
+            ralph_branch="", ralph_branch_explicit=True,
+            ui_mode="plain", no_color=True,
+        )
+
+        start = time.monotonic()
+        result = run_factory(
+            manifest, config, base, PlainUI(no_color=True), tmp_path,
+        )
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 30.0
+        assert "a" in result.failed
+        assert result.exit_code == 1
+        comp = manifest.get_component("a")
+        assert comp is not None
+        assert comp.status == "failed"
+        assert "timeout" in comp.error.lower()
+        assert _wait_pid_dead(_read_pid(pidfile))
+
+    def test_timeout_retry_notes_recreate_from_base(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A timeout retry must say it recreates the worktree from base in
+        the retry error string (R0.1 requirement 5)."""
+        monkeypatch.chdir(tmp_path)
+        _init_repo(tmp_path)
+        log_path = tmp_path / "progress.jsonl"
+
+        manifest = Manifest(
+            version="1", spec_file="spec.md", project_name="t",
+            base_branch="main", single_pr=False,
+            components=[Component(
+                "a", "A", "", [], "scripts/ralph/feature/a/prd.json",
+                "ralph/factory/a",
+            )],
+        )
+        config = FactoryConfig(
+            use_worktrees=True, create_prs=False, max_parallel=1,
+            max_retries=1, retry_delay=0, review_mode="skip",
+            progress_log_path=log_path,
+            timeout_config=TimeoutConfig(
+                agent_iteration=0.3, component_total=0.5,
+            ),
+        )
+        base = RalphConfig(
+            prompt_file=tmp_path / "scripts" / "ralph" / "prompt.md",
+            prd_file=tmp_path / "scripts" / "ralph" / "prd.json",
+            sleep_seconds=0,
+            agent_cmd="exec sleep 300",
+            ralph_branch="", ralph_branch_explicit=True,
+            ui_mode="plain", no_color=True,
+        )
+
+        result = run_factory(
+            manifest, config, base, PlainUI(no_color=True), tmp_path,
+        )
+
+        assert "a" in result.failed
+        comp = manifest.get_component("a")
+        assert comp is not None
+        assert comp.retries == 1
+
+        events = [
+            json.loads(line) for line in log_path.read_text().splitlines()
+        ]
+        retry_events = [e for e in events if e["event"] == "component_retrying"]
+        assert retry_events, "expected a component_retrying event"
+        reason = retry_events[0]["data"]["reason"]
+        assert "timeout" in reason.lower()
+        assert "recreated from base" in reason
+        assert "index.lock" in reason
+
+
+class TestWorktreeTimeoutHygiene:
+    """_setup_worktree(fresh_from_base=True) resets the branch to base and
+    stale index locks are removed."""
+
+    def test_fresh_from_base_resets_branch(self, tmp_path: Path) -> None:
+        _init_repo(tmp_path)
+        wt = _setup_worktree("a", "b/a", "main", tmp_path)
+
+        # Simulate a killed attempt that left a commit on the branch.
+        (wt / "leftover.txt").write_text("dirty state from killed attempt")
+        _git("add", "-A", cwd=wt)
+        _git("commit", "-q", "-m", "partial work", cwd=wt)
+        branch_tip = subprocess.run(
+            ["git", "rev-parse", "b/a"], cwd=tmp_path,
+            capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+        main_tip = subprocess.run(
+            ["git", "rev-parse", "main"], cwd=tmp_path,
+            capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+        assert branch_tip != main_tip
+
+        # Plant a stale lock like a SIGKILLed git op would leave.
+        lock = tmp_path / ".git" / "worktrees" / "a" / "index.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.write_text("")
+
+        wt2 = _setup_worktree("a", "b/a", "main", tmp_path, fresh_from_base=True)
+
+        new_tip = subprocess.run(
+            ["git", "rev-parse", "b/a"], cwd=tmp_path,
+            capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+        assert new_tip == main_tip, "branch was not recreated from base"
+        assert not (wt2 / "leftover.txt").exists()
+        assert not lock.exists()
+
+    def test_default_retry_keeps_branch_commits(self, tmp_path: Path) -> None:
+        """Without fresh_from_base the existing branch is reused (the
+        pre-R0.1 retry behavior for non-timeout failures is preserved)."""
+        _init_repo(tmp_path)
+        wt = _setup_worktree("a", "b/a", "main", tmp_path)
+        (wt / "progress.txt").write_text("legit progress")
+        _git("add", "-A", cwd=wt)
+        _git("commit", "-q", "-m", "progress", cwd=wt)
+        branch_tip = subprocess.run(
+            ["git", "rev-parse", "b/a"], cwd=tmp_path,
+            capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+
+        _setup_worktree("a", "b/a", "main", tmp_path)
+
+        new_tip = subprocess.run(
+            ["git", "rev-parse", "b/a"], cwd=tmp_path,
+            capture_output=True, text=True, timeout=30,
+        ).stdout.strip()
+        assert new_tip == branch_tip
+
+    def test_remove_stale_index_lock(self, tmp_path: Path) -> None:
+        lock = tmp_path / ".git" / "worktrees" / "comp" / "index.lock"
+        lock.parent.mkdir(parents=True)
+        lock.write_text("")
+        _remove_stale_index_lock(tmp_path, "comp")
+        assert not lock.exists()
+        # Absent lock is a no-op, not an error.
+        _remove_stale_index_lock(tmp_path, "comp")
+
+
+class TestSchedulerBackstop:
+    """Per-future deadline of component_total + margin in the parallel
+    scheduler."""
+
+    def test_expired_futures_selection(self) -> None:
+        hung: Future[ComponentResult] = Future()
+        done: Future[ComponentResult] = Future()
+        done.set_result(ComponentResult("done", success=True))
+        fresh: Future[ComponentResult] = Future()
+
+        running = {hung: "hung", done: "done", fresh: "fresh"}
+        deadlines = {hung: 100.0, done: 100.0, fresh: 200.0}
+
+        expired = _expired_futures(running, deadlines, now=150.0)
+        assert expired == [hung]
+
+    def test_next_backstop_wait(self) -> None:
+        f1: Future[ComponentResult] = Future()
+        f2: Future[ComponentResult] = Future()
+
+        assert _next_backstop_wait({f1: "a"}, {}, now=0.0) is None
+        wait_s = _next_backstop_wait(
+            {f1: "a", f2: "b"}, {f1: 50.0, f2: 30.0}, now=10.0,
+        )
+        assert wait_s == 20.0
+        # A deadline already in the past floors at zero (poll immediately).
+        assert _next_backstop_wait({f1: "a"}, {f1: 5.0}, now=10.0) == 0.0
+
+    def test_backstop_fails_component_and_continues(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A worker hung OUTSIDE the loop/adapter enforcement (here: a
+        stuck scaffold command) is abandoned at component_total + margin:
+        the component is FAILED with error 'component timeout', the run
+        finishes without waiting for the worker, and the leaked worker's
+        worktree is left in place."""
+        monkeypatch.chdir(tmp_path)
+        _init_repo(tmp_path)
+
+        manifest = Manifest(
+            version="1", spec_file="spec.md", project_name="t",
+            base_branch="main", single_pr=False,
+            components=[Component(
+                "a", "A", "", [], "scripts/ralph/feature/a/prd.json",
+                "ralph/factory/a", scaffold="sleep 5",
+            )],
+        )
+        config = FactoryConfig(
+            use_worktrees=True, create_prs=False, max_parallel=2,
+            max_retries=0, retry_delay=0, review_mode="skip",
+            timeout_config=TimeoutConfig(
+                agent_iteration=5.0, component_total=0.5,
+                scheduler_backstop_margin=0.5,
+            ),
+        )
+        base = RalphConfig(
+            prompt_file=tmp_path / "scripts" / "ralph" / "prompt.md",
+            prd_file=tmp_path / "scripts" / "ralph" / "prd.json",
+            sleep_seconds=0,
+            agent_cmd="echo done",
+            ralph_branch="", ralph_branch_explicit=True,
+            ui_mode="plain", no_color=True,
+        )
+
+        start = time.monotonic()
+        result = run_factory(
+            manifest, config, base, PlainUI(no_color=True), tmp_path,
+        )
+        elapsed = time.monotonic() - start
+
+        # Returned without waiting out the 5s scaffold hang.
+        assert elapsed < 5.0, f"run waited for the hung worker ({elapsed:.1f}s)"
+        assert "a" in result.failed
+        assert result.exit_code == 1
+        comp = manifest.get_component("a")
+        assert comp is not None
+        assert comp.status == "failed"
+        assert comp.error == "component timeout"
+        # Leaked worker's worktree is kept, not ripped out from under it.
+        assert (tmp_path / ".ralph" / "worktrees" / "a").exists()
+
+
+class TestTimeoutConfigLoading:
+    """TimeoutConfig is the single source: toml [timeout] + env overlay."""
+
+    def test_load_reads_toml_section(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        for var in (
+            "RALPH_TIMEOUT_AGENT_ITERATION", "RALPH_TIMEOUT_COMPONENT",
+            "RALPH_TIMEOUT_BACKSTOP_MARGIN",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        (tmp_path / "ralph.toml").write_text(
+            "[timeout]\n"
+            "agent_iteration = 11\n"
+            "component_total = 22\n"
+            "scheduler_backstop_margin = 5\n"
+        )
+        config = TimeoutConfig.load(tmp_path)
+        assert config.agent_iteration == 11.0
+        assert config.component_total == 22.0
+        assert config.scheduler_backstop_margin == 5.0
+        # Untouched keys keep their defaults.
+        assert config.git_operation == 30.0
+
+    def test_env_beats_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[timeout]\nagent_iteration = 11\ncomponent_total = 22\n"
+        )
+        monkeypatch.setenv("RALPH_TIMEOUT_AGENT_ITERATION", "33")
+        config = TimeoutConfig.load(tmp_path)
+        assert config.agent_iteration == 33.0
+        assert config.component_total == 22.0
+
+    def test_missing_toml_uses_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        for var in (
+            "RALPH_TIMEOUT_AGENT_ITERATION", "RALPH_TIMEOUT_COMPONENT",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        config = TimeoutConfig.load(tmp_path)
+        assert config.agent_iteration == 1800.0
+        assert config.component_total == 7200.0
+        assert config.scheduler_backstop_margin == 60.0
+
+    def test_ralph_config_duplicate_fields_deleted(self) -> None:
+        """R0.1 requirement 4: the dead duplicate fields on RalphConfig are
+        gone; TimeoutConfig is the only source."""
+        config = RalphConfig()
+        assert not hasattr(config, "agent_iteration_timeout")
+        assert not hasattr(config, "component_timeout")
+        assert not hasattr(config, "subprocess_timeout")
+
+
+class TestCliTimeoutFlags:
+    """`ralph factory --agent-timeout/--component-timeout` reach the
+    resolved TimeoutConfig (previously bound and never used)."""
+
+    def _write_manifest(self, tmp_path: Path) -> Path:
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps({
+            "version": "1",
+            "specFile": "spec.md",
+            "projectName": "t",
+            "baseBranch": "main",
+            "singlePr": False,
+            "components": [],
+        }))
+        return manifest_path
+
+    def _invoke_factory(
+        self, tmp_path: Path, extra_args: list[str],
+    ) -> FactoryConfig:
+        from unittest.mock import patch
+
+        from click.testing import CliRunner
+
+        from ralph_py.cli import cli
+        from ralph_py.factory import FactoryResult
+
+        manifest_path = self._write_manifest(tmp_path)
+        runner = CliRunner()
+        with patch("ralph_py.cli.run_factory") as mock_run:
+            mock_run.return_value = FactoryResult()
+            result = runner.invoke(cli, [
+                "factory",
+                "--manifest", str(manifest_path),
+                "--root", str(tmp_path),
+                "--agent-cmd", "echo hi",
+                "--yes",
+                *extra_args,
+            ])
+            assert result.exit_code == 0, result.output
+            factory_config = mock_run.call_args[0][1]
+        assert isinstance(factory_config, FactoryConfig)
+        return factory_config
+
+    def test_flags_reach_timeout_config(self, tmp_path: Path) -> None:
+        factory_config = self._invoke_factory(
+            tmp_path,
+            ["--agent-timeout", "111", "--component-timeout", "222"],
+        )
+        assert factory_config.timeout_config is not None
+        assert factory_config.timeout_config.agent_iteration == 111.0
+        assert factory_config.timeout_config.component_total == 222.0
+
+    def test_toml_used_when_flags_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        for var in (
+            "RALPH_TIMEOUT_AGENT_ITERATION", "RALPH_TIMEOUT_COMPONENT",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        (tmp_path / "ralph.toml").write_text(
+            "[timeout]\nagent_iteration = 44\ncomponent_total = 55\n"
+        )
+        factory_config = self._invoke_factory(tmp_path, [])
+        assert factory_config.timeout_config is not None
+        assert factory_config.timeout_config.agent_iteration == 44.0
+        assert factory_config.timeout_config.component_total == 55.0
+
+    def test_flag_beats_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("RALPH_TIMEOUT_AGENT_ITERATION", raising=False)
+        (tmp_path / "ralph.toml").write_text(
+            "[timeout]\nagent_iteration = 44\n"
+        )
+        factory_config = self._invoke_factory(
+            tmp_path, ["--agent-timeout", "111"],
+        )
+        assert factory_config.timeout_config is not None
+        assert factory_config.timeout_config.agent_iteration == 111.0


### PR DESCRIPTION
## Roadmap item

R0.1 (CRIT-1): agent timeouts were configured everywhere and enforced nowhere. This PR flips the R0.1 checkbox in `docs/remediation-roadmap.md` (the tracker file is newly tracked here; PRs #57/#58/#59 also add it with their own flips, so expect a trivial one-line conflict on whichever merges after the first).

## What changed

- **`ralph_py/agents/proc.py` (new)**: shared `DeadlineStreamer` used by all three adapters. `Popen(..., start_new_session=True)`; stdout is read on a reader thread against an absolute deadline, so a hang with NO output is detected; stdin is written on its own thread so a child that never reads a large prompt cannot deadlock the harness; on breach `killpg(SIGTERM)`, 5s grace, then `SIGKILL`, so grandchildren die with the child. Group-kill is hard-guarded: it only fires for a real int pid > 1 whose resolved pgid is > 1 and is not the harness's own process group (`killpg(1, sig)` is `kill(-1, sig)` and killed the CI runner via a MagicMock pid coercing to 1 - second commit).
- **Adapters**: `claude_code` (previously only checked the clock when a line arrived), `codex` (previously ignored `timeout` entirely; `proc.wait()` and the `--help` probe are now bounded), and `custom` (same class of problem) all honor the `timeout` parameter and yield a uniform `ERROR: agent timed out after Ns` line.
- **`loop.py`**: passes `agent_iteration` into every `agent.run` call (capped by the remaining component budget) and enforces `component_total` as a wall clock across iterations; aborts cleanly with `LoopResult.timeout_limit="component"` so the factory reports which limit fired.
- **`factory.py`**: parallel scheduler arms a backstop deadline of `component_total + scheduler_backstop_margin` per future; on breach the component is FAILED with error `component timeout`, a leaked-worker warning is printed, the leaked worktree is preserved (never ripped out from under a live worker), and the run continues; pool shutdown does not wait on leaked workers. Timeout-failure retries recreate the worktree from base (branch deleted, stale `.git/worktrees/<id>/index.lock` removed) and the retry error string says so.
- **`timeout.py` / `config.py` / `cli.py`**: `TimeoutConfig` is now the single source (gains `load()` reading the `[timeout]` toml section with env overlay, and `scheduler_backstop_margin`). The duplicate dead `RalphConfig` fields (`agent_iteration_timeout`, `component_timeout`, `subprocess_timeout`) are deleted. The previously dead `--agent-timeout`/`--component-timeout` flags on `ralph factory` now feed the resolved config (flag > env > toml > default); `ralph run`/`understand`/`feature` load `TimeoutConfig` too.
- **`tests/test_phase_c_coverage.py`**: pre-existing bug (relates to R4.3's C6 finding) - two threads entered `patch("ralph_py.factory._run_component")` concurrently, permanently leaking a mock into the module for the rest of the pytest process; any later test needing the real function failed in full-suite runs only. The patch now wraps both threads once.

## Tested (named tests, all real subprocesses unless noted, no LLM)

- Sleep-forever agent emitting NO output is killed within the deadline: `TestCustomAgentDeadline::test_silent_hang_is_killed_within_deadline`, plus per-adapter fakes on PATH: `TestClaudeCodeAgentDeadline::test_hang_after_stream_event_is_killed`, `TestCodexAgentDeadline::test_silent_hang_is_killed`.
- Grandchild (`sh -c 'sleep 300 & wait'`) killed with the child: `test_grandchild_is_killed_too` (pid-liveness asserted for child AND grandchild).
- Hang AFTER emitting one line still killed: `test_hang_after_one_line_is_killed`.
- Oversized prompt to a stdin-ignoring child does not deadlock: `test_agent_ignoring_stdin_does_not_block_on_large_prompt`.
- Group-kill safety guard (regression for the CI runner kill): `TestSignalGroupSafety` - killpg never fires for pid in {None, 0, 1, -1}, for a MagicMock pid, or when the pgid resolves to the harness's own group; the direct-child fallback fires instead.
- `agent_iteration` reaches `agent.run` and is capped by remaining component budget; `component_total` aborts the loop with `timeout_limit="component"`; 0 disables: `TestLoopTimeouts` (5 tests).
- Timed-out component is FAILED with a timeout error and the agent process is dead: `TestFactoryComponentTimeout::test_component_failed_on_timeout`.
- Timeout retry recreates worktree from base, removes the stale index.lock, and the retry error string records it (asserted via the progress-log retry event): `test_timeout_retry_notes_recreate_from_base`, `TestWorktreeTimeoutHygiene::test_fresh_from_base_resets_branch` (branch tip reset to base, planted lock removed), `test_default_retry_keeps_branch_commits` (non-timeout retries unchanged).
- Scheduler backstop fails a worker hung OUTSIDE loop/adapter enforcement (stuck scaffold) with error exactly `component timeout`, keeps its worktree, and returns without waiting for the worker: `TestSchedulerBackstop::test_backstop_fails_component_and_continues`, plus unit tests for `_expired_futures`/`_next_backstop_wait`.
- `TimeoutConfig.load` toml/env precedence, `RalphConfig` duplicate fields gone, and the two CLI flags reach the resolved config with flag > toml precedence: `TestTimeoutConfigLoading`, `TestCliTimeoutFlags`.

## Assumed (claimed but not tested)

- Review/security/distill agent calls still run without a deadline (they pass no `timeout` to `agent.run`); wiring `TimeoutConfig.review_agent` into those call sites is not in R0.1's scope.
- If a leaked worker never terminates, interpreter exit can still block on the process-pool atexit join; the run itself completes and warns (the requirement accepts the leak).
- On a leaked worker, the agent subprocess group it owns is not killed by the backstop (only its own in-worker deadline can do that); assumed acceptable per the "worker may be leaked" wording.
- Windows degradation paths (`killpg` absent) compile but are untested; the codebase is documented POSIX-first.
- `run_loop` callers that pass no `timeouts` get `TimeoutConfig.from_env()` defaults (1800s/7200s): enforcement is now on by default where it previously never fired.

## Checks (final lines, after the guard-fix commit)

```
uv run pytest tests/ -q          -> 639 passed, 12 skipped in 277.20s (0:04:37)
uv run mypy ralph_py/ --strict   -> Success: no issues found in 37 source files
uv run ruff check ralph_py/ tests/ -> All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)