### PR TITLE
fix: R1.6 follow-up - factory adopts microsecond run ids

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -188,7 +188,7 @@ reviewers' output as much as it distrusts the engineer's.
     reject and retry-with-error like other validation failures.
   - `factory.py:554-558`: PRD load failure fails the diff-scope check closed
     (infra failure) instead of silently disabling scope.
-- [~] R1.6 (M) **Knowledge retention + read-side defense** [CRIT-4, H-3, MED knowledge-trust, LOW nonce-order]
+- [x] R1.6 (M) **Knowledge retention + read-side defense** [CRIT-4, H-3, MED knowledge-trust, LOW nonce-order]
   - Retrieval: union across run dirs with per-fact-id latest-wins (supersede by
     fact id, not by directory). The DISTILL rule "do not duplicate existing
     facts" becomes correct instead of corpus-destroying.
@@ -205,14 +205,11 @@ reviewers' output as much as it distrusts the engineer's.
   - Verify: regression tests for the exact decay scenario (fail distill, then
     read), the evidence-field injection bypass, and supersede-by-fact-id.
   - Note (2026-07-13, session 1C): all sub-items landed in
-    `ralph_py/knowledge.py` + tests. Marked `[~]` not `[x]` for one residual:
-    `knowledge.current_run_id()` now carries microseconds, but `factory.py`
-    still builds its own second-precision run id inline (out of 1C file
-    scope, and concurrently edited by session 1A). Follow-up is a one-line
-    change: have factory.py call `current_run_id()`. Until then the
-    nonce-order edge survives only for duplicate fact ids emitted by two
-    factory invocations started in the same second - union retrieval caps
-    the blast radius to that tie-break.
+    `ralph_py/knowledge.py` + tests (PR #58). Closed to `[x]` by the
+    follow-up PR that switched factory.py's inline second-precision run
+    id to `knowledge.current_run_id()`, removing the last nonce-order
+    edge; wiring proven by
+    `test_factory_passes_microsecond_run_id_to_distill`.
 - [ ] R1.7 (S) **Persist the architect's red-team output** [MED spec-issues-lost]
   - Write `spec_issues` (all severities) to `scripts/ralph/spec-issues.json`
     and a journal event; on SpecBlockerError, print the file path so the user

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -18,6 +18,7 @@ from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
 from ralph_py.knowledge import (
     KnowledgeConfig,
     build_knowledge_context,
+    current_run_id,
     distill_facts,
     measure_fact_utilization,
 )
@@ -469,20 +470,17 @@ def run_factory(
     Phase 2: Second-opinion review (separate agent reviews diff against spec)
     Phase 3: Contract testing (merge tier branches, run integration tests)
     """
-    import secrets
-
     from ralph_py.agents import get_agent
 
     factory_start = time.monotonic()
     factory_result = FactoryResult()
     # Stable run id shared by evolution journal and knowledge layer.
-    # Includes a random nonce so two factory invocations launched within
-    # the same UTC second do not collide on the run_id (and therefore on
-    # .ralph/knowledge/<comp>/<run_id>/ directories).
-    run_id = (
-        f"factory-{time.strftime('%Y%m%d-%H%M%S', time.gmtime())}"
-        f"-{secrets.token_hex(3)}"
-    )
+    # current_run_id() carries microseconds plus a random nonce, so two
+    # factory invocations launched within the same UTC second neither
+    # collide on .ralph/knowledge/<comp>/<run_id>/ directories nor
+    # order ambiguously (R1.6: same-second knowledge run dirs must sort
+    # by creation time, not by nonce).
+    run_id = current_run_id()
 
     # Set up progress log
     if factory_config.progress_log_path:

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1821,6 +1821,45 @@ class TestFactoryDistillIntegration:
 
         mock_distill.assert_not_called()
 
+    def test_factory_passes_microsecond_run_id_to_distill(
+        self, tmp_path: Path,
+    ) -> None:
+        """R1.6 follow-up: run_factory sources its run id from
+        knowledge.current_run_id(), so knowledge run dirs carry
+        microsecond precision and same-second factory invocations order
+        by creation time, not by random nonce."""
+        import re
+
+        root = _setup_factory_project(tmp_path, "comp-a")
+        manifest = _make_manifest([_make_component("comp-a", dependencies=[])])
+        manifest.components[0].prd_path = (
+            "scripts/ralph/feature/comp-a/prd.json"
+        )
+        config = FactoryConfig(
+            use_worktrees=False, create_prs=False, max_parallel=1,
+            review_mode="skip",
+            verify_config=VerifyConfig(
+                test_command="true", typecheck_command="true",
+                lint_command="true", check_diff_scope=False,
+                check_bad_patterns=False, subprocess_timeout=5.0,
+            ),
+        )
+        base = _factory_base_config(root)
+        ui = PlainUI(no_color=True)
+        success = ComponentResult("comp-a", success=True, iterations=2)
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.factory.distill_facts", return_value=(1, "ok"),
+        ) as mock_distill:
+            run_factory(manifest, config, base, ui, root)
+
+        run_id = mock_distill.call_args.args[5]
+        assert re.fullmatch(
+            r"factory-\d{8}-\d{6}\.\d{6}-[0-9a-f]{6}", run_id,
+        ), f"factory run id lacks microsecond precision: {run_id!r}"
+
 
 # ---------------------------------------------------------------------------
 # Per-fact-id supersede handles contract-breaker rollback scenario


### PR DESCRIPTION
## Roadmap item

R1.6 follow-up (closes the `[~]` residual from #58) - factory adopts microsecond run ids.

## What changed

- `ralph_py/factory.py`: `run_factory` now sources its run id from `knowledge.current_run_id()` instead of building a second-precision `factory-YYYYMMDD-HHMMSS-<nonce>` string inline. This removes the last nonce-order edge: two factory invocations started in the same UTC second now produce knowledge run dirs that sort by creation time. The function-local `import secrets` became dead and was removed.
- `tests/test_knowledge.py`: new `test_factory_passes_microsecond_run_id_to_distill` proves the wiring by capturing the `run_id` argument `run_factory` passes to `distill_facts` and asserting the `factory-\d{8}-\d{6}\.\d{6}-[0-9a-f]{6}` format.
- `docs/remediation-roadmap.md`: R1.6 flipped `[~]` -> `[x]`, note updated to record how the residual closed.

No prompt bodies, `*_PROMPT_VERSION` constants, or snapshots touched.

## Checks (final lines)

- `uv run pytest tests/ -q` -> `773 passed, 12 skipped, 1 warning in 296.13s (0:04:56)`
- `uv run mypy ralph_py/ --strict` -> `Success: no issues found in 37 source files`
- `uv run ruff check ralph_py/ tests/` -> `All checks passed!`

## Tested

- `run_factory` passes a microsecond-precision run id to the knowledge layer - `TestFactoryDistillIntegration::test_factory_passes_microsecond_run_id_to_distill`.
- Same-second ordering semantics of that id format - pre-existing `test_current_run_id_format_has_microseconds`, `test_current_run_ids_sort_chronologically`, `TestUnionRetrieval::test_same_second_runs_order_by_microsecond_not_nonce` (all landed in #58).
- No regressions: full suite green (773 passed / 12 skipped) including #60's timeout-enforcement tests against the modified `run_factory`.

## Assumed

- The evolution journal treats `run_id` as an opaque string (grouping key and TSV field); verified by reading `evolution.py`, not by a dedicated format test. Existing evolution tests pass.
- Old second-precision run ids already on disk keep ordering correctly against new ids (`-` < `.`), as established in #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
