### PR TITLE
fix: R0.4 worktree provisioning, diff-scope retry context, guard ordering

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -106,7 +106,7 @@ item here is one of those three.
   - Verify: real-git tests: conflicted tier leaves user checkout untouched and
     recovers; breaker re-runs; exit code nonzero on unresolved contract failure.
 
-- [ ] R0.4 (S) **Fix the e2e-evidenced pair: provisioning + blind retries** [CRIT-10, MED cwd-paths, MED repo-root-heuristic, MED loop-guard]
+- [x] R0.4 (S) **Fix the e2e-evidenced pair: provisioning + blind retries** [CRIT-10, MED cwd-paths, MED repo-root-heuristic, MED loop-guard]
   - `factory._run_component`: copy `prompt.md` (and CLAUDE.md/AGENTS.md) into
     the worktree alongside the PRD; fix the inverted repo-root heuristic
     (`factory.py:274-280`); resolve all root-relative paths against `root_dir`,

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -261,6 +261,7 @@ def _run_component(
     component_id: str,
     prd_path_str: str,
     worktree_path_str: str,
+    root_dir_str: str,
     prompt_file_str: str,
     agent_cmd: str | None,
     model: str | None,
@@ -288,16 +289,23 @@ def _run_component(
 
     start = time.monotonic()
     worktree_path = Path(worktree_path_str)
-    prd_path = Path(prd_path_str)
+    # R0.4: every copy source below resolves against root_dir, never the
+    # worker's inherited CWD. prompt.md and the PRD live under gitignored
+    # scripts/ralph/, so a fresh worktree NEVER contains them via git; if
+    # a CWD-relative lookup missed them (e.g. --root from another
+    # directory) the copies silently no-op'd and the engineer fell back
+    # to the harness DEFAULT_PROMPT (phase-f e2e validation, line 38).
+    root_dir = Path(root_dir_str)
 
     ui = PlainUI(no_color=True)
     agent = get_agent(agent_cmd, model, reasoning, agent_type)
 
     # Copy PRD into worktree if needed
     worktree_prd = worktree_path / prd_path_str
-    if not worktree_prd.exists() and prd_path.exists():
+    prd_source = root_dir / prd_path_str
+    if not worktree_prd.exists() and prd_source.exists():
         worktree_prd.parent.mkdir(parents=True, exist_ok=True)
-        worktree_prd.write_text(prd_path.read_text())
+        worktree_prd.write_text(prd_source.read_text())
 
     # Note: the prompt template uses $prd_path which is substituted at runtime
     # by loop.py with config.prd_file, so the agent reads the correct component
@@ -305,30 +313,28 @@ def _run_component(
 
     # Copy prompt into worktree if needed
     worktree_prompt = worktree_path / prompt_file_str
-    prompt_source = Path(prompt_file_str)
+    prompt_source = root_dir / prompt_file_str
     if not worktree_prompt.exists() and prompt_source.exists():
         worktree_prompt.parent.mkdir(parents=True, exist_ok=True)
         worktree_prompt.write_text(prompt_source.read_text())
 
-    # Copy CLAUDE.md into worktree. AGENTS.md is a symlink to CLAUDE.md,
-    # so copying CLAUDE.md and recreating the symlink gives the agent both.
-    # When use_worktrees=False, worktree_path IS the repo root so CLAUDE.md
-    # is already in place - the .exists() guards handle this correctly.
-    worktree_base = worktree_path / ".ralph" / "worktrees"
-    if worktree_base.exists() and worktree_path.name != worktree_path.parent.name:
-        # This is a real worktree: .ralph/worktrees/<id> -> root is 3 levels up
-        repo_root = worktree_path.parent.parent.parent
-    else:
-        # No worktree (use_worktrees=False) - worktree_path is the repo root
-        repo_root = worktree_path
+    # Copy CLAUDE.md / AGENTS.md into the worktree from root_dir. When
+    # use_worktrees=False, worktree_path IS the repo root so the files are
+    # already in place - the .exists() guards handle this correctly.
     claude_dest = worktree_path / "CLAUDE.md"
-    if not claude_dest.exists():
-        claude_src = repo_root / "CLAUDE.md"
-        if claude_src.exists():
-            claude_dest.write_text(claude_src.read_text())
+    claude_src = root_dir / "CLAUDE.md"
+    if not claude_dest.exists() and claude_src.exists():
+        claude_dest.write_text(claude_src.read_text())
     agents_dest = worktree_path / "AGENTS.md"
-    if not agents_dest.exists() and claude_dest.exists():
-        agents_dest.symlink_to("CLAUDE.md")
+    agents_src = root_dir / "AGENTS.md"
+    if not agents_dest.exists():
+        if agents_src.is_symlink() and claude_dest.exists():
+            # Preserve the AGENTS.md -> CLAUDE.md symlink convention.
+            agents_dest.symlink_to("CLAUDE.md")
+        elif agents_src.exists():
+            agents_dest.write_text(agents_src.read_text())
+        elif claude_dest.exists():
+            agents_dest.symlink_to("CLAUDE.md")
 
     # Run scaffold script if configured
     if scaffold_cmd:
@@ -1093,7 +1099,7 @@ def run_factory(
             except Exception:
                 pass  # knowledge retrieval is non-fatal
         return (
-            comp.id, comp.prd_path, str(wt_path),
+            comp.id, comp.prd_path, str(wt_path), str(root_dir),
             prompt_file_rel, base_config.agent_cmd, base_config.model,
             base_config.model_reasoning_effort, base_config.agent_type,
             base_config.sleep_seconds, ctx_json,

--- a/ralph_py/loop.py
+++ b/ralph_py/loop.py
@@ -216,6 +216,23 @@ def run_loop(
                 f"({iteration_timeout}s); the agent process group was killed"
             )
 
+        # Enforce ALLOWED_PATHS BEFORE honoring the completion marker
+        # (R0.4): an agent that edits out-of-scope files and emits
+        # COMPLETE in the same iteration must not bypass enforcement.
+        # When enforcement fails the iteration is treated as failed even
+        # if the marker was seen.
+        if config.allowed_paths and is_repo:
+            ok, _ = guards.enforce_allowed_paths(config, ui, cwd)
+            if not ok:
+                return LoopResult(
+                    completed=False,
+                    iterations=iteration,
+                    exit_code=1,
+                    duration_seconds=time.monotonic() - loop_start,
+                    iteration_durations=iteration_durations,
+                    timed_out_iterations=timed_out_iterations,
+                )
+
         # Check for completion
         if completion_seen:
             ui.ok("Done")
@@ -228,12 +245,6 @@ def run_loop(
                 iteration_durations=iteration_durations,
                 timed_out_iterations=timed_out_iterations,
             )
-
-        # Enforce ALLOWED_PATHS
-        if config.allowed_paths and is_repo:
-            ok, _ = guards.enforce_allowed_paths(config, ui, cwd)
-            if not ok:
-                return LoopResult(completed=False, iterations=iteration, exit_code=1)
 
         # Component wall clock: abort cleanly rather than start work that
         # is already past its budget. This is the "which limit fired"

--- a/ralph_py/verify.py
+++ b/ralph_py/verify.py
@@ -503,11 +503,37 @@ def check_diff_scope(
     violations = [f for f in changed if not path_is_allowed(f, allowed_paths)]
 
     if violations:
+        # R0.4: name the base branch and the FULL allowed-paths list in the
+        # failure details. Without them the retry agent has to guess both;
+        # the recorded e2e run guessed `main` as base and reverted
+        # base-branch content with `git checkout main -- ...`, failing
+        # again. Base branch and allowed paths are single detail entries at
+        # the head of the list so VerificationResult.as_context()'s
+        # details[:10] slice carries them into the retry prompt verbatim.
+        shown = violations[:15]
+        violation_lines = [f"  - {v}" for v in shown]
+        if len(violations) > len(shown):
+            violation_lines.append(
+                f"  ... and {len(violations) - len(shown)} more"
+            )
+        details = [
+            f"Base branch: {base_branch} "
+            f"(scope is judged on `git diff {base_branch}...HEAD`; "
+            f"do NOT `git checkout {base_branch} -- <path>`, revert only "
+            "your own out-of-scope commits/edits)",
+            f"Allowed paths (complete list): {', '.join(allowed_paths)}",
+            # One multi-line entry so as_context()'s details[:10] slice
+            # cannot drop violations or the truncation marker.
+            "Files outside allowed scope:\n" + "\n".join(violation_lines),
+        ]
         return CheckResult(
             name="diff_scope",
             passed=False,
-            message=f"{len(violations)} files outside allowed scope",
-            details=violations[:20],
+            message=(
+                f"{len(violations)} files outside allowed scope "
+                f"(diff vs base branch '{base_branch}')"
+            ),
+            details=details,
             duration_seconds=time.monotonic() - start,
         )
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -257,3 +257,117 @@ class TestRunLoop:
         assert result.completed is False
         assert result.exit_code == 1
         assert result.iterations == 1
+
+
+class _RogueWriterAgent:
+    """Agent that writes an out-of-scope file and emits COMPLETE in the
+    SAME iteration -- the R0.4 enforcement-bypass scenario."""
+
+    def __init__(self, rogue_file: Path):
+        self._rogue_file = rogue_file
+        self._final_message: str | None = None
+
+    @property
+    def name(self) -> str:
+        return "rogue"
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        self._rogue_file.write_text("rogue = True\n")
+        yield COMPLETION_MARKER
+        self._final_message = COMPLETION_MARKER
+
+    @property
+    def final_message(self) -> str | None:
+        return self._final_message
+
+
+class TestGuardsRunBeforeCompletion:
+    """R0.4: guards.enforce_allowed_paths must run BEFORE the completion
+    early-return, so an out-of-scope edit plus same-iteration COMPLETE
+    cannot bypass enforcement (pre-fix, the marker returned first and the
+    guard never saw the violation)."""
+
+    def _git_repo(self, tmp_path: Path) -> RalphConfig:
+        import subprocess
+
+        subprocess.run(
+            ["git", "init", "-q", "-b", "main", str(tmp_path)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.email", "t@t"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "config", "user.name", "t"],
+            check=True, capture_output=True,
+        )
+        ralph_dir = tmp_path / "scripts" / "ralph"
+        ralph_dir.mkdir(parents=True)
+        (ralph_dir / "prompt.md").write_text("test prompt")
+        (ralph_dir / "prd.json").write_text(
+            '{"branchName": "test", "userStories": []}'
+        )
+        # Commit the scaffolding so the rogue file is the ONLY change.
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "add", "-A"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "commit", "-q", "-m", "init"],
+            check=True, capture_output=True,
+        )
+        return RalphConfig(
+            max_iterations=3,
+            prompt_file=ralph_dir / "prompt.md",
+            prd_file=ralph_dir / "prd.json",
+            sleep_seconds=0,
+            ralph_branch="",
+            ralph_branch_explicit=True,
+            allowed_paths=["src/"],
+        )
+
+    def test_out_of_scope_edit_plus_complete_fails_noninteractive(
+        self, tmp_path: Path,
+    ) -> None:
+        """Non-interactive: enforcement fires and the COMPLETE marker is
+        NOT honored -- the loop reports failure, not success."""
+        config = self._git_repo(tmp_path)
+        agent = _RogueWriterAgent(tmp_path / "rogue.py")
+
+        result = run_loop(config, PlainUI(no_color=True), agent, tmp_path)
+
+        assert result.completed is False
+        assert result.exit_code == 1
+        assert result.iterations == 1
+
+    def test_out_of_scope_edit_plus_complete_is_reverted_interactive(
+        self, tmp_path: Path,
+    ) -> None:
+        """Interactive revert path: the guard runs first, reverts the
+        out-of-scope edit, and only then is the completion marker honored
+        -- proving the guard executed before the early-return."""
+
+        class _ChooseRevertUI(PlainUI):
+            def can_prompt(self) -> bool:
+                return True
+
+            def choose(
+                self, header: str, options: list[str], default: int = 0,
+            ) -> int:
+                return options.index("Revert and continue")
+
+        config = self._git_repo(tmp_path)
+        config.interactive = True
+        rogue = tmp_path / "rogue.py"
+        agent = _RogueWriterAgent(rogue)
+
+        result = run_loop(
+            config, _ChooseRevertUI(no_color=True), agent, tmp_path,
+        )
+
+        assert not rogue.exists(), "out-of-scope edit was not reverted"
+        assert result.completed is True
+        assert result.exit_code == 0

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -1,0 +1,209 @@
+"""R0.4: worktree provisioning + diff-scope retry context (integration).
+
+Acceptance scenario is docs/phase-f-e2e-validation-v12.log:
+
+- ``scripts/ralph/`` is gitignored, so a fresh worktree never contains the
+  customized prompt.md or the component PRD via git. ``_run_component``
+  must copy them (plus CLAUDE.md/AGENTS.md) from ``root_dir`` -- resolved
+  against ``root_dir`` explicitly, never the worker's inherited CWD (the
+  logged run fell back to the harness DEFAULT_PROMPT, log line 38).
+- A diff-scope failure's retry prompt must name the base branch and the
+  full allowed-paths list. In the logged run the retry agent guessed
+  ``main`` as base, ran ``git checkout main -- ralph_py/...`` reverting
+  base-branch content, and failed again.
+
+These tests use real git repos and a real fake-agent subprocess
+(CustomAgent via ``agent_cmd``); no LLM is involved.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ralph_py.config import RalphConfig
+from ralph_py.factory import FactoryConfig, run_factory
+from ralph_py.manifest import Component, Manifest
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+CUSTOM_PROMPT = (
+    "CUSTOMIZED-PROMPT-MARKER-7f3a\n"
+    "\n"
+    "Read the PRD at $prd_path and implement one story.\n"
+)
+CLAUDE_MD_MARKER = "PROJECT-CONTEXT-MARKER-2b9c"
+COMPLETE_LINE = "echo '<promise>COMPLETE</promise>'"
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, timeout=30,
+    )
+
+
+def _init_repo(root: Path, allowed_paths: list[str] | None = None) -> None:
+    """Real git repo shaped like a ralph project: scripts/ralph/ (prompt +
+    PRD), CLAUDE.md, and AGENTS.md are all gitignored, so none of them
+    reach a fresh worktree through git -- provisioning must copy them."""
+    root.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", "-b", "main", cwd=root)
+    _git("config", "user.email", "t@t", cwd=root)
+    _git("config", "user.name", "t", cwd=root)
+    (root / ".gitignore").write_text(
+        "scripts/ralph/\nCLAUDE.md\nAGENTS.md\n"
+    )
+    (root / "README.md").write_text("seed\n")
+    _git("add", ".gitignore", "README.md", cwd=root)
+    _git("commit", "-q", "-m", "init", cwd=root)
+
+    ralph_dir = root / "scripts" / "ralph"
+    feature_dir = ralph_dir / "feature" / "comp-a"
+    feature_dir.mkdir(parents=True)
+    (ralph_dir / "prompt.md").write_text(CUSTOM_PROMPT)
+    prd: dict[str, object] = {
+        "branchName": "ralph/factory/comp-a",
+        "userStories": [{
+            "id": "US-001", "title": "Test",
+            "acceptanceCriteria": ["AC1"],
+            "priority": 1, "passes": True, "notes": "",
+        }],
+    }
+    if allowed_paths is not None:
+        prd["allowedPaths"] = allowed_paths
+    (feature_dir / "prd.json").write_text(json.dumps(prd))
+    (root / "CLAUDE.md").write_text(f"# {CLAUDE_MD_MARKER}\n")
+
+
+def _manifest() -> Manifest:
+    return Manifest(
+        version="1", spec_file="spec.md", project_name="t",
+        base_branch="main", single_pr=False,
+        components=[Component(
+            id="comp-a", title="A", description="", dependencies=[],
+            prd_path="scripts/ralph/feature/comp-a/prd.json",
+            branch_name="ralph/factory/comp-a",
+        )],
+    )
+
+
+def _factory_config(max_retries: int = 0) -> FactoryConfig:
+    return FactoryConfig(
+        use_worktrees=True, create_prs=False, max_parallel=1,
+        max_retries=max_retries, retry_delay=0, review_mode="skip",
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_bad_patterns=False,
+            subprocess_timeout=30.0,
+        ),
+    )
+
+
+def _base_config(root: Path, agent_cmd: str) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root / "scripts" / "ralph" / "prompt.md",
+        prd_file=root / "scripts" / "ralph" / "prd.json",
+        sleep_seconds=0, agent_cmd=agent_cmd,
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    )
+
+
+class TestWorktreeProvisioning:
+    def test_worktree_run_provisions_prompt_and_context_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A real worktree run has the customized prompt.md, CLAUDE.md, and
+        AGENTS.md present, and the engineer runs on the customized prompt
+        (not the DEFAULT_PROMPT fallback) -- with the worker's CWD pointed
+        somewhere else entirely, proving copies resolve against root_dir."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        dump = tmp_path / "dump"
+        dump.mkdir()
+        # The fake agent captures, from INSIDE the worktree: the rendered
+        # prompt it received (stdin) and the provisioned files.
+        agent_cmd = (
+            f"cat > {dump}/prompt-received.txt; "
+            f"cp scripts/ralph/prompt.md {dump}/prompt-in-worktree.md; "
+            f"cp CLAUDE.md {dump}/claude-in-worktree.md; "
+            f"[ -e AGENTS.md ] && echo present > {dump}/agents-present.txt; "
+            + COMPLETE_LINE
+        )
+
+        result = run_factory(
+            _manifest(), _factory_config(), _base_config(root, agent_cmd),
+            PlainUI(no_color=True), root,
+        )
+
+        assert result.completed == ["comp-a"]
+        assert (
+            (dump / "prompt-in-worktree.md").read_text() == CUSTOM_PROMPT
+        ), "customized prompt.md was not provisioned into the worktree"
+        assert CLAUDE_MD_MARKER in (dump / "claude-in-worktree.md").read_text()
+        assert (dump / "agents-present.txt").exists()
+
+        received = (dump / "prompt-received.txt").read_text()
+        assert "CUSTOMIZED-PROMPT-MARKER-7f3a" in received, (
+            "engineer did not run on the customized prompt"
+        )
+        assert CLAUDE_MD_MARKER in received, (
+            "CLAUDE.md project context was not prepended to the prompt"
+        )
+        out = capsys.readouterr().out
+        assert "falling back to harness DEFAULT_PROMPT" not in out
+
+
+class TestDiffScopeRetryContext:
+    def test_retry_prompt_names_base_branch_and_allowed_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Attempt 1 commits an out-of-scope file and emits COMPLETE;
+        Phase 1 diff_scope fails; attempt 2's prompt must carry the base
+        branch name and the full allowed-paths list verbatim, so the retry
+        agent never has to guess the base (the logged run guessed wrong)."""
+        root = tmp_path / "repo"
+        _init_repo(root, allowed_paths=["src/", "tests/"])
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        stamp = tmp_path / "attempt1.stamp"
+        dump = tmp_path / "retry-prompt.txt"
+        agent_cmd = (
+            f"if [ ! -f {stamp} ]; then "
+            f"touch {stamp}; "
+            "echo 'x = 1' > out_of_scope.py; "
+            "git add out_of_scope.py; "
+            "git commit -q -m oops; "
+            "else "
+            f"cat > {dump}; "
+            "fi; "
+            + COMPLETE_LINE
+        )
+
+        result = run_factory(
+            _manifest(), _factory_config(max_retries=1),
+            _base_config(root, agent_cmd),
+            PlainUI(no_color=True), root,
+        )
+
+        # The retry reuses the component branch, which still carries the
+        # out-of-scope commit, so the component ultimately fails -- the
+        # assertion under test is the CONTENT of the retry prompt.
+        assert "comp-a" in result.failed
+        retry_prompt = dump.read_text()
+        assert "Verification Failures" in retry_prompt
+        assert "Base branch: main" in retry_prompt
+        assert "Allowed paths (complete list): src/, tests/" in retry_prompt
+        assert "out_of_scope.py" in retry_prompt

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -175,7 +175,59 @@ class TestCheckDiffScope:
         ):
             result = check_diff_scope(tmp_path, "main", allowed_paths=["src/"])
         assert result.passed is False
-        assert "config/secret.py" in result.details
+        assert any("config/secret.py" in d for d in result.details)
+        # In-scope files are not listed as violations
+        assert not any("src/main.py" in d for d in result.details)
+
+    def test_failure_names_base_branch_and_allowed_paths(
+        self, tmp_path: Path,
+    ) -> None:
+        """R0.4: the failure details must name the base branch and the
+        allowed paths -- without them the retry agent guesses both (the
+        recorded e2e run guessed `main`, checked out base-branch content,
+        and failed again)."""
+        with patch(
+            "ralph_py.verify.git.get_diff_names",
+            return_value=["evil.py"],
+        ):
+            result = check_diff_scope(
+                tmp_path, "feat/retrospective-cleanup-2",
+                allowed_paths=["src/", "tests/"],
+            )
+        assert result.passed is False
+        assert "feat/retrospective-cleanup-2" in result.message
+        joined = "\n".join(result.details)
+        assert "Base branch: feat/retrospective-cleanup-2" in joined
+        assert "Allowed paths (complete list): src/, tests/" in joined
+
+    def test_retry_context_carries_base_and_full_allowed_paths(
+        self, tmp_path: Path,
+    ) -> None:
+        """The retry prompt is built via VerificationResult.as_context()
+        (which slices details[:10]) and IterationContext.format_for_prompt.
+        The base branch, EVERY allowed path, EVERY shown violation, and the
+        truncation marker must survive that pipeline verbatim."""
+        from ralph_py.context import IterationContext
+        from ralph_py.verify import VerificationResult
+
+        allowed = [f"pkg{i}/" for i in range(12)]
+        violations = [f"rogue{i}.py" for i in range(20)]
+        with patch(
+            "ralph_py.verify.git.get_diff_names", return_value=violations,
+        ):
+            result = check_diff_scope(tmp_path, "main", allowed_paths=allowed)
+
+        verification = VerificationResult(passed=False, checks=[result])
+        ctx = IterationContext()
+        ctx.add_verification_failure(verification.as_context())
+        prompt_text = ctx.format_for_prompt()
+
+        assert "Base branch: main" in prompt_text
+        for path in allowed:
+            assert path in prompt_text
+        for shown in violations[:15]:
+            assert shown in prompt_text
+        assert "and 5 more" in prompt_text
 
 
 class TestCheckBadPatterns:


### PR DESCRIPTION
Implements **R0.4** (Session 2C): the pair of defects behind the recorded e2e validation failure (`docs/phase-f-e2e-validation-v12.log`).

## Changes

- `factory._run_component` now receives `root_dir` explicitly (plumbed through `_submit_args`) and resolves every copy source - PRD, `scripts/ralph/prompt.md`, `CLAUDE.md`, `AGENTS.md` - against it instead of the worker's inherited CWD. All four files are copied into fresh worktrees (they live under gitignored paths, so git never provides them). The inverted `.ralph/worktrees` repo-root heuristic is deleted.
- `verify.check_diff_scope` failures now name the base branch and the full allowed-paths list, packed into the leading `details` entries (violations collapsed into one multi-line entry) so `VerificationResult.as_context()`'s `details[:10]` slice carries everything into the retry prompt verbatim. The message warns against `git checkout <base> -- <path>`, which is exactly how the logged run destroyed base-branch content.
- `loop.py` runs `guards.enforce_allowed_paths` BEFORE the completion-marker early return, so an out-of-scope edit plus same-iteration COMPLETE can no longer bypass enforcement.
- `context.py` needed no changes: the multi-line details flow through `as_context()` -> `add_verification_failure()` -> `format_for_prompt()` unchanged.

## Tested (all behaviors proven by named tests; each new test fails against pre-fix code, verified by stashing the source changes)

- `test_provisioning.py::TestWorktreeProvisioning::test_worktree_run_provisions_prompt_and_context_files`: real `run_factory` worktree run with a fake-agent subprocess and CWD pointed OUTSIDE the repo; the customized `prompt.md`, `CLAUDE.md`, and `AGENTS.md` are present inside the worktree, the rendered prompt the agent received contains the customized marker plus the CLAUDE.md context, and no DEFAULT_PROMPT fallback warning is emitted.
- `test_provisioning.py::TestDiffScopeRetryContext::test_retry_prompt_names_base_branch_and_allowed_paths`: attempt 1 commits an out-of-scope file and emits COMPLETE; the retry attempt's actual prompt (captured by the fake agent) contains `Base branch: main`, `Allowed paths (complete list): src/, tests/`, and the violating filename.
- `test_verify.py::TestCheckDiffScope::test_failure_names_base_branch_and_allowed_paths`: failure message and details name the base branch and allowed paths.
- `test_verify.py::TestCheckDiffScope::test_retry_context_carries_base_and_full_allowed_paths`: 12 allowed paths, all 15 shown violations, and the `... and 5 more` truncation marker survive the `details[:10]` slice into `IterationContext.format_for_prompt()`.
- `test_loop.py::TestGuardsRunBeforeCompletion::test_out_of_scope_edit_plus_complete_fails_noninteractive`: enforcement fires and COMPLETE is not honored (loop returns failure).
- `test_loop.py::TestGuardsRunBeforeCompletion::test_out_of_scope_edit_plus_complete_is_reverted_interactive`: the guard's revert path deletes the out-of-scope file before the completion marker is honored, proving guard-before-return ordering.

## Assumed (claimed but not tested)

- Non-interactive guard semantics are unchanged: violations fail the loop but files are NOT auto-reverted (`guards.py` was out of scope for this session). The "reverted" acceptance is covered via the guard's existing interactive revert path; in the factory pipeline the failed loop plus worktree recreation on retry serves the same end.
- AGENTS.md propagation when the root `AGENTS.md` is a regular file (copy) is implemented but only the symlink-recreation path is exercised by tests.
- Absolute prompt/PRD paths that cannot be relativized to root keep the previous absolute-path fallback behavior (code path unchanged, not tested).
- Checks below were run in a pristine worktree at this branch's tip; the local shared checkout currently carries unrelated in-flight R0.2 modifications that are not part of this PR.

## Checks

```
uv run pytest tests/ -q        -> 779 passed, 12 skipped, 1 warning in 288.35s (0:04:48)
uv run mypy ralph_py/ --strict -> Success: no issues found in 37 source files
uv run ruff check ralph_py/ tests/ -> All checks passed!
```

Roadmap: flips the R0.4 checkbox in `docs/remediation-roadmap.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
