### PR TITLE
fix: R0.3 contract phase cannot corrupt the repo; failures are loud

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -89,7 +89,7 @@ item here is one of those three.
     refs shows phantom diffs; using `origin/<base>` everywhere removes the
     class. MERGE_PENDING needs the R3.3 resume story to be ergonomic.
 
-- [ ] R0.3 (M) **Contract phase cannot corrupt the repo; failures are loud** [CRIT-6]
+- [x] R0.3 (M) **Contract phase cannot corrupt the repo; failures are loud** [CRIT-6]
   - `contract.py`: perform tier merges in a detached temp worktree, never the
     user's checkout; `git merge --abort` in the recovery path; assert cleanup
     succeeded (fail loudly if not).

--- a/ralph_py/contract.py
+++ b/ralph_py/contract.py
@@ -1,8 +1,33 @@
-"""Phase 3: Cross-component contract testing via temp merge branches."""
+"""Phase 3: Cross-component contract testing in detached temp worktrees.
+
+All tier merging happens in a throwaway worktree created with
+``git worktree add --detach`` under ``.ralph/contract/`` - never in the
+user's checkout (R0.3 / CRIT-6). The recovery path on any failure is
+``git merge --abort`` in the temp worktree followed by
+``git worktree remove --force``; if the worktree survives removal a
+:class:`ContractCleanupError` is raised so the run fails loudly instead
+of silently leaving stale state behind.
+
+Blame attribution (bisection) honesty:
+
+- Merge-order bisection only runs in deferred-merge mode (PRs not yet
+  merged to base). When components were already squash-merged to base
+  (``create_prs`` per-component mode), re-merging their branches is a
+  content no-op and bisection would blame the first component
+  unconditionally; in that mode a single integrated check of the base
+  branch runs instead, reporting pass/fail with the failing test output
+  and NO breaker attribution.
+- Known limitation of merge-order bisection: a failure caused by the
+  interaction of two components attributes to whichever component merges
+  later in topological order - the earlier component is never blamed
+  even if it contributed the incompatibility. Within a tier the merge
+  order follows the manifest's component order.
+"""
 
 from __future__ import annotations
 
 import os
+import secrets
 import subprocess
 import time
 from dataclasses import dataclass
@@ -21,6 +46,16 @@ class ContractMode(StrEnum):
     TIER = "tier"
     FINAL = "final"
     SKIP = "skip"
+
+
+class ContractCleanupError(RuntimeError):
+    """A contract temp worktree could not be removed.
+
+    Raised so the factory fails loudly: a surviving temp worktree means
+    ``.ralph/contract/`` holds stale state and git's worktree metadata
+    still references it, which would make every later contract pass
+    (and possibly component worktree setup) fail in confusing ways.
+    """
 
 
 @dataclass
@@ -97,25 +132,94 @@ def compute_tiers(manifest: Manifest) -> list[list[str]]:
     return manifest.compute_tiers()
 
 
-def _create_temp_branch(
-    branch_name: str,
+def _create_temp_worktree(
     base: str,
-    cwd: Path,
-    timeout: float = 30.0,
-) -> bool:
-    """Create and checkout a temporary branch from base."""
-    return git.create_branch_from(branch_name, base, cwd, timeout)
+    root_dir: Path,
+    label: str,
+    timeout: float = 60.0,
+) -> tuple[Path | None, str]:
+    """Create a detached throwaway worktree at ``base``.
+
+    Returns ``(path, "")`` on success or ``(None, error)`` on failure.
+    Detached HEAD means merges move only the temp worktree's HEAD; no
+    branch is created and the user's checkout is never touched.
+    """
+    contract_base = root_dir / ".ralph" / "contract"
+    contract_base.mkdir(parents=True, exist_ok=True)
+    worktree_path = contract_base / f"{label}-{secrets.token_hex(4)}"
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "add", "--detach", str(worktree_path), base],
+            cwd=root_dir,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return None, f"git worktree add timed out after {timeout}s"
+    if result.returncode != 0:
+        return None, result.stderr.strip() or result.stdout.strip()
+    return worktree_path, ""
 
 
-def _cleanup_temp_branch(
-    branch_name: str,
-    base_branch: str,
-    cwd: Path,
-    timeout: float = 30.0,
+def _abort_merge(worktree_path: Path, timeout: float = 30.0) -> None:
+    """Abort any in-flight merge in the temp worktree.
+
+    Safe to call unconditionally: with no merge in progress git exits
+    nonzero and that is fine - the goal is only that no conflicted
+    index survives into worktree removal.
+    """
+    try:
+        subprocess.run(
+            ["git", "merge", "--abort"],
+            cwd=worktree_path,
+            capture_output=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        pass  # removal below is forced; a hung abort must not block it
+
+
+def _remove_temp_worktree(
+    worktree_path: Path,
+    root_dir: Path,
+    timeout: float = 60.0,
 ) -> None:
-    """Return to base branch and delete the temporary branch."""
-    git.checkout_existing(base_branch, cwd, timeout)
-    git.delete_branch(branch_name, cwd, force=True, timeout=timeout)
+    """Remove a contract temp worktree, asserting the removal succeeded.
+
+    Raises :class:`ContractCleanupError` when the worktree directory
+    survives the forced removal - the one case where silent continuation
+    would leave the repo's worktree metadata pointing at stale state.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree_path)],
+            cwd=root_dir,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ContractCleanupError(
+            f"git worktree remove timed out after {timeout}s for "
+            f"{worktree_path}; remove it manually with "
+            f"'git worktree remove --force {worktree_path}'"
+        ) from exc
+    if worktree_path.exists():
+        raise ContractCleanupError(
+            f"Contract temp worktree {worktree_path} survived removal "
+            f"(git: {result.stderr.strip() or result.stdout.strip()}); "
+            f"remove it manually with "
+            f"'git worktree remove --force {worktree_path}'"
+        )
+    if result.returncode != 0:
+        # Directory is gone but git may still track it; prune metadata.
+        subprocess.run(
+            ["git", "worktree", "prune"],
+            cwd=root_dir,
+            capture_output=True,
+            timeout=timeout,
+        )
 
 
 def _run_tests(
@@ -147,6 +251,11 @@ def bisect_breaker(
 ) -> str | None:
     """Linear bisection to identify which component broke integration.
 
+    Deferred-merge mode only: merges tier branches one at a time in
+    topological order inside a detached temp worktree, testing after
+    each. See the module docstring for the two-component-interaction
+    attribution limitation.
+
     Args:
         base_branch: Base branch to merge from
         prior_branches: Already-tested branches from prior tiers
@@ -158,30 +267,31 @@ def bisect_breaker(
     Returns:
         Component ID of the breaker, or None if unclear.
     """
-    ts = int(time.time())
-    bisect_branch = f"ralph/bisect-{ts}"
-
-    if not _create_temp_branch(bisect_branch, base_branch, root_dir):
+    worktree_path, _error = _create_temp_worktree(
+        base_branch, root_dir, "bisect",
+    )
+    if worktree_path is None:
         return None
 
     try:
         # Merge prior tier branches (should be clean)
         for branch in prior_branches:
-            if not git.merge_branch(branch, root_dir):
+            if not git.merge_branch(branch, worktree_path):
                 return None
 
         # Merge tier branches one at a time, test after each
         for comp_id, branch in tier_branches:
-            if not git.merge_branch(branch, root_dir):
+            if not git.merge_branch(branch, worktree_path):
                 return comp_id
 
-            passed, _ = _run_tests(root_dir, test_command, timeout)
+            passed, _ = _run_tests(worktree_path, test_command, timeout)
             if not passed:
                 return comp_id
 
         return None
     finally:
-        _cleanup_temp_branch(bisect_branch, base_branch, root_dir)
+        _abort_merge(worktree_path)
+        _remove_temp_worktree(worktree_path, root_dir)
 
 
 def run_tier_check(
@@ -193,14 +303,14 @@ def run_tier_check(
     ui: UI,
     tier_index: int = 0,
 ) -> ContractResult:
-    """Run contract test for one DAG tier.
+    """Run contract test for one DAG tier (deferred-merge mode).
 
-    Merges all prior + current tier branches, runs tests.
-    On failure, bisects to find the breaker.
+    Merges all prior + current tier branches into a detached temp
+    worktree, runs tests there. On failure, bisects to find the breaker.
+    The user's checkout is never touched; any merge conflict is aborted
+    in the temp worktree before it is removed.
     """
     start = time.monotonic()
-    ts = int(time.time())
-    merge_branch = f"ralph/contract-{tier_index}-{ts}"
 
     tier_branches: list[tuple[str, str]] = []
     for comp_id in tier_component_ids:
@@ -214,20 +324,23 @@ def run_tier_check(
         f"({', '.join(c for c, _ in tier_branches)})"
     )
 
-    # Create temp merge branch
-    if not _create_temp_branch(merge_branch, manifest.base_branch, root_dir):
+    worktree_path, error = _create_temp_worktree(
+        manifest.base_branch, root_dir, f"tier{tier_index}",
+    )
+    if worktree_path is None:
         return ContractResult(
             passed=False,
             tier=tier_index,
             components_tested=[c for c, _ in tier_branches],
-            test_output="Failed to create merge branch",
+            test_output=f"Failed to create contract worktree: {error}",
             duration_seconds=time.monotonic() - start,
         )
 
+    output = ""
     try:
         # Merge prior tiers
         for branch in prior_branches:
-            if not git.merge_branch(branch, root_dir):
+            if not git.merge_branch(branch, worktree_path):
                 return ContractResult(
                     passed=False,
                     tier=tier_index,
@@ -238,7 +351,7 @@ def run_tier_check(
 
         # Merge current tier
         for comp_id, branch in tier_branches:
-            if not git.merge_branch(branch, root_dir):
+            if not git.merge_branch(branch, worktree_path):
                 return ContractResult(
                     passed=False,
                     tier=tier_index,
@@ -249,7 +362,9 @@ def run_tier_check(
                 )
 
         # Run tests
-        passed, output = _run_tests(root_dir, config.test_command, config.timeout)
+        passed, output = _run_tests(
+            worktree_path, config.test_command, config.timeout,
+        )
 
         if passed:
             ui.ok(f"  Tier {tier_index}: contract tests passed")
@@ -264,9 +379,14 @@ def run_tier_check(
         ui.warn(f"  Tier {tier_index}: contract tests FAILED, bisecting...")
 
     finally:
-        _cleanup_temp_branch(merge_branch, manifest.base_branch, root_dir)
+        # Recovery path: abort any in-flight merge, then remove the temp
+        # worktree. _remove_temp_worktree raises ContractCleanupError if
+        # the worktree survives - fail loudly, never leave a conflicted
+        # checkout behind.
+        _abort_merge(worktree_path)
+        _remove_temp_worktree(worktree_path, root_dir)
 
-    # Bisect to find breaker
+    # Bisect to find breaker (fresh temp worktree of its own)
     breaker = bisect_breaker(
         manifest.base_branch, prior_branches, tier_branches,
         root_dir, config.test_command, config.timeout,
@@ -287,14 +407,80 @@ def run_tier_check(
     )
 
 
+def run_integrated_base_check(
+    manifest: Manifest,
+    component_ids: list[str],
+    root_dir: Path,
+    config: ContractConfig,
+    ui: UI,
+) -> ContractResult:
+    """Contract check for already-merged components (create_prs mode).
+
+    Per-component PRs were squash-merged into the base branch as each
+    component completed, so the integrated state IS the base branch:
+    re-merging component branches would be content no-ops and bisection
+    would blame the first component unconditionally. Instead, run the
+    test suite once against the base branch in a detached temp worktree
+    and report pass/fail with NO breaker attribution.
+    """
+    start = time.monotonic()
+    ui.info(
+        f"  Integrated check: testing '{manifest.base_branch}' with "
+        f"{len(component_ids)} merged components "
+        f"({', '.join(component_ids)})"
+    )
+
+    worktree_path, error = _create_temp_worktree(
+        manifest.base_branch, root_dir, "integrated",
+    )
+    if worktree_path is None:
+        return ContractResult(
+            passed=False,
+            tier=0,
+            components_tested=list(component_ids),
+            test_output=f"Failed to create contract worktree: {error}",
+            duration_seconds=time.monotonic() - start,
+        )
+
+    try:
+        passed, output = _run_tests(
+            worktree_path, config.test_command, config.timeout,
+        )
+    finally:
+        _remove_temp_worktree(worktree_path, root_dir)
+
+    if passed:
+        ui.ok("  Integrated check: contract tests passed")
+    else:
+        ui.err(
+            "  Integrated check: tier failed (components already merged "
+            "to base; no blame attribution)"
+        )
+
+    return ContractResult(
+        passed=passed,
+        tier=0,
+        components_tested=list(component_ids),
+        breaker=None,
+        test_output=output[:2000],
+        duration_seconds=time.monotonic() - start,
+    )
+
+
 def run_contract_testing(
     manifest: Manifest,
     root_dir: Path,
     config: ContractConfig,
     ui: UI,
+    components_merged: bool = False,
 ) -> list[ContractResult]:
     """Run contract testing across DAG tiers.
 
+    ``components_merged=True`` (create_prs per-component mode) runs a
+    single integrated check of the base branch with no blame
+    attribution - see :func:`run_integrated_base_check`.
+
+    Otherwise (deferred-merge mode):
     In TIER mode: tests each tier incrementally.
     In FINAL mode: tests all completed components at once.
     In SKIP mode: returns empty list.
@@ -313,6 +499,18 @@ def run_contract_testing(
         return []
 
     tiers = compute_tiers(manifest)
+
+    if components_merged:
+        ordered_ids = [
+            comp_id for tier in tiers for comp_id in tier
+            if comp_id in completed_ids
+        ]
+        return [
+            run_integrated_base_check(
+                manifest, ordered_ids, root_dir, config, ui,
+            )
+        ]
+
     results: list[ContractResult] = []
 
     if config.mode == ContractMode.FINAL.value:

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import time
@@ -13,7 +14,13 @@ from typing import TYPE_CHECKING, Any
 
 from ralph_py.config import RalphConfig
 from ralph_py.context import IterationContext
-from ralph_py.contract import ContractConfig, ContractMode, run_contract_testing
+from ralph_py.contract import (
+    ContractCleanupError,
+    ContractConfig,
+    ContractMode,
+    ContractResult,
+    run_contract_testing,
+)
 from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
 from ralph_py.knowledge import (
     KnowledgeConfig,
@@ -140,6 +147,10 @@ class FactoryResult:
     failed: list[str] = field(default_factory=list)
     skipped: list[str] = field(default_factory=list)
     pr_urls: list[str] = field(default_factory=list)
+    # R0.3: unresolved contract failures (one human-readable line per
+    # failed check). Non-empty forces a nonzero exit code even when no
+    # single component could be blamed.
+    contract_failures: list[str] = field(default_factory=list)
     exit_code: int = 0
 
 
@@ -551,7 +562,6 @@ def run_factory(
     )
 
     # Scheduling state
-    running_futures: dict[Future[ComponentResult], str] = {}
     worktree_paths: dict[str, Path] = {}
     component_contexts: dict[str, str] = {}  # comp_id -> context JSON
     # Components whose last failure was a timeout kill: their retry must
@@ -1107,38 +1117,50 @@ def run_factory(
             timeout_cfg.component_total,
         )
 
-    # Main scheduling loop
-    if max_parallel <= 1:
-        while True:
-            ready = manifest.get_ready_components()
-            if not ready:
-                break
+    def _run_scheduling_pass() -> None:
+        """Run ready components until nothing is PENDING-and-ready.
 
-            comp = ready[0]
-            comp.status = ComponentStatus.RUNNING.value
-            comp.started_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-            manifest.save(manifest_path)
-            progress_log.component_started(comp.id)
-            ui.info(f"  Starting: {comp.id}")
+        Called once per contract pass: a contract breaker reset to
+        PENDING after a failed contract phase re-enters scheduling via
+        the outer loop in run_factory (R0.3) - previously the reset
+        happened after the only scheduling loop had exited, so the
+        promised retry never ran.
+        """
+        if max_parallel <= 1:
+            while True:
+                ready = manifest.get_ready_components()
+                if not ready:
+                    break
 
-            wt_path = _launch_component(comp)
-            if wt_path is None:
-                continue
-
-            args = _submit_args(comp, wt_path)
-            try:
-                comp_result = _run_component(*args)
-            except Exception as exc:
-                comp_result = ComponentResult(
-                    component_id=comp.id, success=False, error=str(exc),
+                comp = ready[0]
+                comp.status = ComponentStatus.RUNNING.value
+                comp.started_at = time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
                 )
+                manifest.save(manifest_path)
+                progress_log.component_started(comp.id)
+                ui.info(f"  Starting: {comp.id}")
 
-            _handle_result(comp.id, comp_result)
-    else:
+                wt_path = _launch_component(comp)
+                if wt_path is None:
+                    continue
+
+                args = _submit_args(comp, wt_path)
+                try:
+                    comp_result = _run_component(*args)
+                except Exception as exc:
+                    comp_result = ComponentResult(
+                        component_id=comp.id, success=False, error=str(exc),
+                    )
+
+                _handle_result(comp.id, comp_result)
+            return
+
         # Manual executor lifecycle: on a backstop breach we must NOT wait
         # for the (possibly hung) worker at shutdown, which the
         # `with ProcessPoolExecutor(...)` form would do.
         executor = ProcessPoolExecutor(max_workers=max_parallel)
+        running_futures: dict[Future[ComponentResult], str] = {}
         future_deadlines: dict[Future[ComponentResult], float] = {}
         try:
             while True:
@@ -1236,8 +1258,10 @@ def run_factory(
             else:
                 executor.shutdown(wait=True)
 
-    # Cleanup worktrees
-    if factory_config.use_worktrees:
+    def _cleanup_pass_worktrees() -> None:
+        """Remove component worktrees left behind by a scheduling pass."""
+        if not factory_config.use_worktrees:
+            return
         ui.section("Factory: Cleanup")
         for comp_id in worktree_paths:
             if comp_id in leaked_component_ids:
@@ -1252,34 +1276,156 @@ def run_factory(
             _cleanup_worktree(comp_id, root_dir)
         ui.ok("Worktrees cleaned up")
 
-    # PHASE 3: Contract testing
-    contract_config = factory_config.contract_config
-    if contract_config and contract_config.mode != ContractMode.SKIP.value:
-        contract_results = run_contract_testing(
-            manifest, root_dir, contract_config, ui,
-        )
+    def _record_contract_event(cr: ContractResult) -> None:
+        """Append a contract_result event to the evolution journal.
+
+        Written for pass AND fail (R0.3): the journal is the audit trail
+        for every contract phase outcome, including intermediate failures
+        that a breaker retry later resolves. Non-fatal on I/O errors,
+        matching EvolutionJournal.record_run.
+        """
+        from ralph_py.evolution import EvolutionConfig
+
+        evo_config = EvolutionConfig()
+        if not evo_config.enabled:
+            return
+        entry = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "run_id": run_id,
+            "project": manifest.project_name,
+            "component_id": cr.breaker or "",
+            "event_type": "contract_result",
+            "tier": cr.tier,
+            "passed": cr.passed,
+            "breaker": cr.breaker,
+            "components_tested": cr.components_tested,
+            "test_output": cr.test_output[:2000],
+            "duration_seconds": round(cr.duration_seconds, 2),
+        }
+        try:
+            evo_config.journal_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(evo_config.journal_path, "a") as f:
+                f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+        except OSError:
+            pass  # evolution recording is non-fatal
+
+    # Per-component PRs are squash-merged into base as each component
+    # completes, so at contract time tier re-merges would be content
+    # no-ops and blame attribution would be meaningless: the contract
+    # phase instead tests the integrated base branch (R0.3). single_pr
+    # defers its one PR until after the contract phase, so it stays in
+    # deferred-merge (tier merge + bisection) mode.
+    components_merged = factory_config.create_prs and not factory_config.single_pr
+
+    # R0.3: scheduling + contract testing form one outer loop so a
+    # contract breaker reset to PENDING actually re-enters scheduling.
+    # Termination: every reset consumes one of the breaker's bounded
+    # retries, and any pass without a reset breaks out.
+    while True:
+        _run_scheduling_pass()
+        _cleanup_pass_worktrees()
+
+        # PHASE 3: Contract testing
+        contract_config = factory_config.contract_config
+        if (
+            contract_config is None
+            or contract_config.mode == ContractMode.SKIP.value
+        ):
+            break
+
+        try:
+            contract_results = run_contract_testing(
+                manifest, root_dir, contract_config, ui,
+                components_merged=components_merged,
+            )
+        except ContractCleanupError as exc:
+            # A contract temp worktree survived removal. The user's
+            # checkout is untouched, but .ralph/contract holds stale
+            # state - fail the run loudly instead of continuing.
+            ui.err(f"  Contract cleanup FAILED: {exc}")
+            factory_result.contract_failures.append(
+                f"contract cleanup failed: {exc}"
+            )
+            break
+
         for cr in contract_results:
             progress_log.contract_result(
                 cr.tier, cr.passed, cr.breaker, cr.duration_seconds,
             )
-            if not cr.passed and cr.breaker:
+            _record_contract_event(cr)
+
+        failures = [cr for cr in contract_results if not cr.passed]
+        if not failures:
+            break
+
+        # Reset retryable breakers to PENDING; the outer loop then
+        # re-enters scheduling so the promised retry actually runs.
+        any_breaker_reset = False
+        for cr in failures:
+            if not cr.breaker:
+                continue
+            breaker = manifest.get_component(cr.breaker)
+            if breaker and breaker.retries < factory_config.max_retries:
+                breaker.retries += 1
+                breaker.status = ComponentStatus.PENDING.value
+                breaker.error = f"Contract test failed at tier {cr.tier}"
+                # Remove from completed list
+                if cr.breaker in factory_result.completed:
+                    factory_result.completed.remove(cr.breaker)
+                ctx = IterationContext.from_json(
+                    component_contexts.get(cr.breaker, "{}")
+                )
+                ctx.add_contract_failure(cr.test_output[:500])
+                component_contexts[cr.breaker] = ctx.to_json()
+                manifest.save(manifest_path)
+                any_breaker_reset = True
+                ui.warn(
+                    f"  Contract breaker '{cr.breaker}' sent back for retry"
+                )
+
+        if any_breaker_reset:
+            continue
+
+        # Terminal contract failure: nothing left to retry. Record it in
+        # the run result so the summary shows it and the exit code is
+        # nonzero (previously this fell through silently and the run
+        # exited 0 with broken integrated code).
+        for cr in failures:
+            detail = (cr.test_output or "").strip()
+            summary_line = detail.splitlines()[-1][:200] if detail else ""
+            if cr.breaker:
                 breaker = manifest.get_component(cr.breaker)
-                if breaker and breaker.retries < factory_config.max_retries:
-                    breaker.retries += 1
-                    breaker.status = ComponentStatus.PENDING.value
-                    breaker.error = f"Contract test failed at tier {cr.tier}"
-                    # Remove from completed list
-                    if cr.breaker in factory_result.completed:
-                        factory_result.completed.remove(cr.breaker)
-                    ctx = IterationContext.from_json(
-                        component_contexts.get(cr.breaker, "{}")
+                if breaker is not None:
+                    breaker.status = ComponentStatus.FAILED.value
+                    breaker.error = (
+                        f"Contract test failed at tier {cr.tier} "
+                        f"(retries exhausted)"
                     )
-                    ctx.add_contract_failure(cr.test_output[:500])
-                    component_contexts[cr.breaker] = ctx.to_json()
-                    manifest.save(manifest_path)
-                    ui.warn(
-                        f"  Contract breaker '{cr.breaker}' sent back for retry"
-                    )
+                if cr.breaker in factory_result.completed:
+                    factory_result.completed.remove(cr.breaker)
+                if cr.breaker not in factory_result.failed:
+                    factory_result.failed.append(cr.breaker)
+                progress_log.component_failed(
+                    cr.breaker,
+                    f"Contract test failed at tier {cr.tier} "
+                    f"(retries exhausted)",
+                )
+                factory_result.contract_failures.append(
+                    f"tier {cr.tier}: breaker '{cr.breaker}' "
+                    f"(retries exhausted): {summary_line}"
+                )
+            else:
+                factory_result.contract_failures.append(
+                    f"tier {cr.tier}: contract tests failed, no blame "
+                    f"attributed (components: "
+                    f"{', '.join(cr.components_tested)}): {summary_line}"
+                )
+            ui.err(
+                f"  Contract failure recorded for tier {cr.tier}; "
+                f"run will exit nonzero"
+            )
+        manifest.save(manifest_path)
+        break
 
     # Create PRs for any remaining components that weren't handled per-component
     # (e.g. single-pr mode, or stragglers from parallel execution)
@@ -1313,13 +1459,17 @@ def run_factory(
     ui.kv("Completed", str(len(factory_result.completed)))
     ui.kv("Failed", str(len(factory_result.failed)))
     ui.kv("Skipped", str(len(factory_result.skipped)))
+    if factory_result.contract_failures:
+        ui.kv("Contract failures", str(len(factory_result.contract_failures)))
+        for line in factory_result.contract_failures:
+            ui.err(f"  {line}")
     ui.kv("Duration", f"{factory_duration:.0f}s")
     if factory_result.pr_urls:
         ui.kv("PRs created", str(len(factory_result.pr_urls)))
         for url in factory_result.pr_urls:
             ui.info(f"  {url}")
 
-    if factory_result.failed:
+    if factory_result.failed or factory_result.contract_failures:
         factory_result.exit_code = 1
     elif factory_result.skipped and not factory_result.completed:
         factory_result.exit_code = 1

--- a/tests/test_contract_safety.py
+++ b/tests/test_contract_safety.py
@@ -1,0 +1,511 @@
+"""R0.3: the contract phase cannot corrupt the user's repo; failures are loud.
+
+Real-git tests (no LLM):
+
+- A conflicted tier merge happens in a detached temp worktree, is aborted
+  there, and leaves the user's checkout byte-identical; the next tier
+  check runs cleanly (previously the conflict landed in the user's
+  checkout and every subsequent tier failed - CRIT-6).
+- A failing contract with no retries left yields a nonzero exit code,
+  a run-summary entry, and contract_result evolution-journal events.
+- A contract breaker reset actually re-enters scheduling (real fake-agent
+  subprocess): the component re-runs, the second contract passes, and the
+  run completes with exit code 0.
+- Squash-merged (create_prs) mode reports the failure with the failing
+  test output and NO breaker attribution.
+- A temp worktree that survives removal raises ContractCleanupError
+  (fail loudly), which the factory converts into a nonzero exit.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ralph_py import contract as contract_mod
+from ralph_py.config import RalphConfig
+from ralph_py.contract import (
+    ContractCleanupError,
+    ContractConfig,
+    ContractMode,
+    run_contract_testing,
+    run_tier_check,
+)
+from ralph_py.factory import FactoryConfig, run_factory
+from ralph_py.manifest import Component, ComponentStatus, Manifest
+from ralph_py.timeout import TimeoutConfig
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+# Fails (with output) whenever bad_marker.txt exists in the tested tree.
+MARKER_TEST_CMD = (
+    "if [ -f bad_marker.txt ]; then echo INTEGRATION BROKEN; exit 1; fi"
+)
+
+
+def _git(*args: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True,
+        text=True, timeout=30,
+    )
+    return result.stdout
+
+
+def _init_repo(root: Path) -> None:
+    """Real git repo on main with the ralph scaffolding committed."""
+    root.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", "-b", "main", cwd=root)
+    _git("config", "user.email", "t@t", cwd=root)
+    _git("config", "user.name", "t", cwd=root)
+    (root / "conflict.txt").write_text("base\n")
+    ralph_dir = root / "scripts" / "ralph"
+    ralph_dir.mkdir(parents=True)
+    (ralph_dir / "prompt.md").write_text("test prompt\n")
+    feature_dir = ralph_dir / "feature" / "a"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "prd.json").write_text(json.dumps({
+        "branchName": "ralph/factory/a",
+        "userStories": [{
+            "id": "US-001", "title": "Test",
+            "acceptanceCriteria": ["AC1"],
+            "priority": 1, "passes": True, "notes": "",
+        }],
+    }))
+    _git("add", "-A", cwd=root)
+    _git("commit", "-q", "-m", "init", cwd=root)
+
+
+def _commit_on_branch(
+    root: Path, branch: str, files: dict[str, str], base: str = "main",
+) -> None:
+    """Create ``branch`` from ``base`` with ``files`` committed, without
+    moving the user's checkout (worktree-based, like the factory)."""
+    wt = root.parent / f"setup-{branch.replace('/', '-')}"
+    _git("worktree", "add", str(wt), "-b", branch, base, cwd=root)
+    for rel, content in files.items():
+        target = wt / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    _git("add", "-A", cwd=wt)
+    _git("commit", "-q", "-m", f"setup {branch}", cwd=wt)
+    _git("worktree", "remove", "--force", str(wt), cwd=root)
+
+
+def _snapshot_working_tree(root: Path) -> dict[str, bytes]:
+    """All file bytes in the working tree, excluding .git and .ralph."""
+    snapshot: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*")):
+        rel = path.relative_to(root)
+        if rel.parts and rel.parts[0] in (".git", ".ralph"):
+            continue
+        if path.is_file():
+            snapshot[str(rel)] = path.read_bytes()
+    return snapshot
+
+
+def _make_manifest(components: list[Component]) -> Manifest:
+    return Manifest(
+        version="1",
+        spec_file="spec.md",
+        project_name="t",
+        base_branch="main",
+        single_pr=False,
+        components=components,
+    )
+
+
+def _component(
+    comp_id: str,
+    branch: str,
+    deps: list[str] | None = None,
+    status: str = ComponentStatus.COMPLETED.value,
+) -> Component:
+    return Component(
+        id=comp_id,
+        title=comp_id.upper(),
+        description="",
+        dependencies=deps or [],
+        prd_path="scripts/ralph/feature/a/prd.json",
+        branch_name=branch,
+        status=status,
+    )
+
+
+def _worktree_count(root: Path) -> int:
+    porcelain = _git("worktree", "list", "--porcelain", cwd=root)
+    return sum(1 for line in porcelain.splitlines() if line.startswith("worktree "))
+
+
+def _tracked_changes(root: Path) -> list[str]:
+    """git status lines for tracked files only. run_factory writes
+    untracked persistence state (scripts/ralph/manifest.json, .ralph/)
+    by design; contract corruption would show up as tracked modifications
+    or staged merge state."""
+    return [
+        line
+        for line in _git("status", "--porcelain", cwd=root).splitlines()
+        if not line.startswith("??")
+    ]
+
+
+def _read_journal_events(event_type: str) -> list[dict[str, object]]:
+    """Read evolution-journal entries of one event type. The autouse
+    conftest fixture chdirs to tmp_path, so the default cwd-relative
+    journal path lands there."""
+    journal = Path(".ralph") / "evolution.jsonl"
+    if not journal.exists():
+        return []
+    entries = [
+        json.loads(line)
+        for line in journal.read_text().splitlines() if line.strip()
+    ]
+    return [e for e in entries if e.get("event_type") == event_type]
+
+
+class TestConflictedTierLeavesCheckoutUntouched:
+    def test_conflict_recovers_and_checkout_is_byte_identical(
+        self, tmp_path: Path,
+    ) -> None:
+        root = tmp_path / "repo"
+        _init_repo(root)
+        _commit_on_branch(root, "ralph/a", {"conflict.txt": "from a\n"})
+        _commit_on_branch(root, "ralph/b", {"conflict.txt": "from b\n"})
+        manifest = _make_manifest([
+            _component("a", "ralph/a"),
+            _component("b", "ralph/b"),
+        ])
+        config = ContractConfig(
+            mode=ContractMode.TIER.value, test_command="true", timeout=60,
+        )
+        ui = PlainUI(no_color=True)
+
+        before = _snapshot_working_tree(root)
+        head_before = _git("rev-parse", "HEAD", cwd=root).strip()
+
+        result = run_tier_check(manifest, ["a", "b"], [], root, config, ui, 0)
+
+        assert result.passed is False
+        assert "Merge conflict" in result.test_output
+        # Merge-order attribution (deferred-merge mode): the later merge
+        # is blamed - documented limitation.
+        assert result.breaker == "b"
+
+        # The user's checkout is byte-identical and NOT mid-merge.
+        assert _snapshot_working_tree(root) == before
+        assert _git("rev-parse", "HEAD", cwd=root).strip() == head_before
+        assert _git("status", "--porcelain", cwd=root) == ""
+        assert not (root / ".git" / "MERGE_HEAD").exists()
+
+        # The temp worktree is gone: nothing under .ralph/contract and
+        # git tracks only the main worktree.
+        contract_dir = root / ".ralph" / "contract"
+        assert not contract_dir.exists() or not any(contract_dir.iterdir())
+        assert _worktree_count(root) == 1
+
+        # Recovery is clean: the next check runs fine (previously the
+        # conflicted index made every subsequent tier fail).
+        result2 = run_tier_check(manifest, ["a"], [], root, config, ui, 0)
+        assert result2.passed is True
+
+    def test_failing_tests_bisect_leaves_checkout_untouched(
+        self, tmp_path: Path,
+    ) -> None:
+        """Test-failure path (merge ok, tests fail, bisection runs):
+        the user's checkout still never changes."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        _commit_on_branch(root, "ralph/a", {"bad_marker.txt": "boom\n"})
+        manifest = _make_manifest([_component("a", "ralph/a")])
+        config = ContractConfig(
+            mode=ContractMode.TIER.value,
+            test_command=MARKER_TEST_CMD,
+            timeout=60,
+        )
+        before = _snapshot_working_tree(root)
+
+        result = run_tier_check(
+            manifest, ["a"], [], root, config, PlainUI(no_color=True), 0,
+        )
+
+        assert result.passed is False
+        assert result.breaker == "a"
+        assert "INTEGRATION BROKEN" in result.test_output
+        assert _snapshot_working_tree(root) == before
+        assert _git("status", "--porcelain", cwd=root) == ""
+        assert _worktree_count(root) == 1
+
+
+class TestContractFailureExitsNonzero:
+    def test_failing_tier_sets_nonzero_exit_and_run_summary(
+        self, tmp_path: Path,
+    ) -> None:
+        """Deferred-merge mode, retries exhausted: the run must exit
+        nonzero with the failure recorded (previously it exited 0 with
+        broken integrated code)."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        _commit_on_branch(root, "ralph/factory/a", {"bad_marker.txt": "boom\n"})
+        manifest = _make_manifest([_component("a", "ralph/factory/a")])
+        factory_config = FactoryConfig(
+            use_worktrees=True, create_prs=False, max_parallel=1,
+            max_retries=0, retry_delay=0, review_mode="skip",
+            contract_config=ContractConfig(
+                mode=ContractMode.TIER.value,
+                test_command=MARKER_TEST_CMD,
+                timeout=60,
+            ),
+        )
+        base = RalphConfig(
+            prompt_file=root / "scripts" / "ralph" / "prompt.md",
+            prd_file=root / "scripts" / "ralph" / "prd.json",
+            sleep_seconds=0,
+            agent_cmd="echo unused",
+            ralph_branch="", ralph_branch_explicit=True,
+            ui_mode="plain", no_color=True,
+        )
+
+        result = run_factory(
+            manifest, factory_config, base, PlainUI(no_color=True), root,
+        )
+
+        assert result.exit_code == 1
+        assert result.contract_failures, "failure must land in the run summary"
+        assert "a" in result.failed
+        comp = manifest.get_component("a")
+        assert comp is not None
+        assert comp.status == ComponentStatus.FAILED.value
+        assert "retries exhausted" in comp.error
+
+        # contract_result journal event recorded for the failure.
+        events = _read_journal_events("contract_result")
+        assert events, "expected a contract_result journal event"
+        assert events[-1]["passed"] is False
+        assert events[-1]["breaker"] == "a"
+
+        # The user's checkout survived: no tracked changes, no merge state.
+        assert _tracked_changes(root) == []
+        assert not (root / ".git" / "MERGE_HEAD").exists()
+        assert not (root / "bad_marker.txt").exists()
+
+
+class TestBreakerRetryReentersScheduling:
+    def test_breaker_reruns_and_passing_contract_completes_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """End to end with a real fake-agent subprocess: run 1 commits a
+        marker that breaks the contract tests, the breaker is reset, the
+        scheduling loop re-runs it (run 2 removes the marker), and the
+        second contract pass completes the run with exit code 0."""
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+        root = tmp_path / "repo"
+        _init_repo(root)
+        log_path = tmp_path / "progress.jsonl"
+
+        # The fake engineer: first run plants bad_marker.txt, the retry
+        # (which sees the marker on the resumed branch) removes it.
+        agent_cmd = (
+            "if [ -f bad_marker.txt ]; then "
+            "git rm -q bad_marker.txt && git commit -qm fix; "
+            "else "
+            "echo boom > bad_marker.txt && git add bad_marker.txt "
+            "&& git commit -qm break; "
+            "fi; "
+            "echo '<promise>COMPLETE</promise>'"
+        )
+
+        manifest = _make_manifest([
+            _component(
+                "a", "ralph/factory/a",
+                status=ComponentStatus.PENDING.value,
+            ),
+        ])
+        factory_config = FactoryConfig(
+            use_worktrees=True, create_prs=False, max_parallel=1,
+            max_retries=1, retry_delay=0, review_mode="skip",
+            progress_log_path=log_path,
+            verify_config=VerifyConfig(
+                test_command="true", typecheck_command="true",
+                lint_command="true", check_diff_scope=False,
+                check_bad_patterns=False,
+            ),
+            contract_config=ContractConfig(
+                mode=ContractMode.TIER.value,
+                test_command=MARKER_TEST_CMD,
+                timeout=120,
+            ),
+            timeout_config=TimeoutConfig(
+                agent_iteration=60, component_total=120,
+            ),
+        )
+        base = RalphConfig(
+            prompt_file=root / "scripts" / "ralph" / "prompt.md",
+            prd_file=root / "scripts" / "ralph" / "prd.json",
+            sleep_seconds=0,
+            agent_cmd=agent_cmd,
+            ralph_branch="", ralph_branch_explicit=True,
+            ui_mode="plain", no_color=True,
+        )
+
+        result = run_factory(
+            manifest, factory_config, base, PlainUI(no_color=True), root,
+        )
+
+        assert result.exit_code == 0
+        assert result.completed == ["a"]
+        assert result.failed == []
+        assert result.contract_failures == []
+        comp = manifest.get_component("a")
+        assert comp is not None
+        assert comp.status == ComponentStatus.COMPLETED.value
+        assert comp.retries == 1
+
+        # Progress log shows the failed contract pass, then the passing one.
+        events = [
+            json.loads(line) for line in log_path.read_text().splitlines()
+        ]
+        contract_events = [e for e in events if e["event"] == "contract_result"]
+        assert [e["data"]["passed"] for e in contract_events] == [False, True]
+        # Journal mirrors both outcomes (recorded for pass AND fail).
+        journal_events = _read_journal_events("contract_result")
+        assert [e["passed"] for e in journal_events] == [False, True]
+
+        # The user's checkout never saw the marker or any merge state.
+        assert _tracked_changes(root) == []
+        assert not (root / ".git" / "MERGE_HEAD").exists()
+        assert not (root / "bad_marker.txt").exists()
+        assert _worktree_count(root) == 1
+
+
+class TestMergedModeNoBlame:
+    def test_squash_merged_mode_reports_failure_without_blame(
+        self, tmp_path: Path,
+    ) -> None:
+        """create_prs mode: components already merged to base. The check
+        tests the integrated base, reports the failing output, and must
+        NOT attribute blame (previously bisection blamed the first
+        component unconditionally)."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        # The broken integrated state lives on base, as it would after
+        # squash merges.
+        (root / "bad_marker.txt").write_text("boom\n")
+        _git("add", "-A", cwd=root)
+        _git("commit", "-q", "-m", "squash-merged components", cwd=root)
+        _commit_on_branch(root, "ralph/a", {"a.txt": "a\n"})
+        _commit_on_branch(root, "ralph/b", {"b.txt": "b\n"})
+        manifest = _make_manifest([
+            _component("a", "ralph/a"),
+            _component("b", "ralph/b", deps=["a"]),
+        ])
+        config = ContractConfig(
+            mode=ContractMode.TIER.value,
+            test_command=MARKER_TEST_CMD,
+            timeout=60,
+        )
+        before = _snapshot_working_tree(root)
+
+        results = run_contract_testing(
+            manifest, root, config, PlainUI(no_color=True),
+            components_merged=True,
+        )
+
+        assert len(results) == 1
+        result = results[0]
+        assert result.passed is False
+        assert result.breaker is None, "merged mode must not attribute blame"
+        assert "INTEGRATION BROKEN" in result.test_output
+        assert result.components_tested == ["a", "b"]
+        assert _snapshot_working_tree(root) == before
+        assert _worktree_count(root) == 1
+
+    def test_squash_merged_mode_passes_on_healthy_base(
+        self, tmp_path: Path,
+    ) -> None:
+        root = tmp_path / "repo"
+        _init_repo(root)
+        _commit_on_branch(root, "ralph/a", {"a.txt": "a\n"})
+        manifest = _make_manifest([_component("a", "ralph/a")])
+        config = ContractConfig(
+            mode=ContractMode.TIER.value,
+            test_command=MARKER_TEST_CMD,
+            timeout=60,
+        )
+
+        results = run_contract_testing(
+            manifest, root, config, PlainUI(no_color=True),
+            components_merged=True,
+        )
+
+        assert len(results) == 1
+        assert results[0].passed is True
+        assert results[0].breaker is None
+
+
+class TestCleanupFailsLoudly:
+    def test_surviving_temp_worktree_raises_cleanup_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        root = tmp_path / "repo"
+        _init_repo(root)
+        worktree_path, error = contract_mod._create_temp_worktree(
+            "main", root, "cleanup-test",
+        )
+        assert worktree_path is not None, error
+
+        real_run = subprocess.run
+
+        def failing_remove(cmd: list[str], **kwargs: object) -> object:
+            if cmd[:3] == ["git", "worktree", "remove"]:
+                return subprocess.CompletedProcess(
+                    cmd, returncode=1, stdout="", stderr="planted failure",
+                )
+            return real_run(cmd, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(contract_mod.subprocess, "run", failing_remove)
+        with pytest.raises(ContractCleanupError, match="survived removal"):
+            contract_mod._remove_temp_worktree(worktree_path, root)
+        monkeypatch.undo()
+
+        # Real removal still works afterwards.
+        contract_mod._remove_temp_worktree(worktree_path, root)
+        assert not worktree_path.exists()
+
+    def test_factory_converts_cleanup_error_to_nonzero_exit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from unittest.mock import patch
+
+        root = tmp_path / "repo"
+        _init_repo(root)
+        manifest = _make_manifest([_component("a", "ralph/factory/a")])
+        factory_config = FactoryConfig(
+            use_worktrees=True, create_prs=False, max_parallel=1,
+            max_retries=0, retry_delay=0, review_mode="skip",
+            contract_config=ContractConfig(
+                mode=ContractMode.TIER.value, test_command="true",
+            ),
+        )
+        base = RalphConfig(
+            prompt_file=root / "scripts" / "ralph" / "prompt.md",
+            prd_file=root / "scripts" / "ralph" / "prd.json",
+            sleep_seconds=0,
+            agent_cmd="echo unused",
+            ralph_branch="", ralph_branch_explicit=True,
+            ui_mode="plain", no_color=True,
+        )
+
+        with patch(
+            "ralph_py.factory.run_contract_testing",
+            side_effect=ContractCleanupError("worktree survived removal"),
+        ):
+            result = run_factory(
+                manifest, factory_config, base, PlainUI(no_color=True), root,
+            )
+
+        assert result.exit_code == 1
+        assert any(
+            "cleanup failed" in line for line in result.contract_failures
+        )

--- a/tests/test_phase_c_coverage.py
+++ b/tests/test_phase_c_coverage.py
@@ -256,11 +256,13 @@ class TestC4ContractBreaker:
         success_a = ComponentResult("comp-a", success=True, iterations=1)
         success_b = ComponentResult("comp-b", success=True, iterations=1)
 
-        # First contract call fails with breaker=comp-a; verify the
-        # status is reset to PENDING for re-run.
+        # First contract call fails with breaker=comp-a. R0.3: the
+        # breaker reset must actually re-enter scheduling (a third
+        # _run_component call) and the second, passing contract call
+        # completes the run cleanly.
         contract_calls = {"count": 0}
 
-        def fake_contract(manifest, root, cfg, ui):
+        def fake_contract(manifest, root, cfg, ui, components_merged=False):
             contract_calls["count"] += 1
             if contract_calls["count"] == 1:
                 return [ContractResult(
@@ -274,18 +276,22 @@ class TestC4ContractBreaker:
 
         with patch(
             "ralph_py.factory._run_component",
-            side_effect=[success_a, success_b],
-        ), patch(
+            side_effect=[success_a, success_b, success_a],
+        ) as mock_run, patch(
             "ralph_py.factory.run_contract_testing", side_effect=fake_contract,
         ):
-            run_factory(
+            result = run_factory(
                 manifest, config, _base_config(root),
                 PlainUI(no_color=True), root,
             )
-        # We don't assert on final completion (the manifest state is
-        # mutated mid-test); we only assert the contract phase fired
-        # and the breaker reset path was exercised.
-        assert contract_calls["count"] >= 1
+        assert contract_calls["count"] == 2
+        assert mock_run.call_count == 3
+        assert "comp-a" in result.completed
+        assert result.contract_failures == []
+        assert result.exit_code == 0
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.retries == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Roadmap items

R0.3 [CRIT-6] - contract phase safety. Flips the R0.3 checkbox in `docs/remediation-roadmap.md`.

## What changed

**`ralph_py/contract.py`**
- All tier merging now happens in a detached temp worktree (`git worktree add --detach` under `.ralph/contract/`), never the user's checkout. The old flow created the temp branch in the user's repo and left it mid-conflict on merge failure, breaking every subsequent tier.
- Recovery path: `git merge --abort` in the temp worktree (unconditional, in `finally`), then forced worktree removal. If the worktree survives removal, `ContractCleanupError` is raised - cleanup is asserted, not assumed.
- Bisection honesty: `run_contract_testing` takes `components_merged`. When per-component PRs were already squash-merged to base (`create_prs` mode), re-merges are content no-ops and bisection would blame the first component unconditionally - instead one integrated check of base runs with NO breaker attribution, reporting the failing test output. Merge-order bisection remains only for deferred-merge mode, in topological order; the two-component-interaction limitation (blame attributes to the later merge) is documented in the module docstring.

**`ralph_py/factory.py`**
- Scheduling + contract testing now form one outer loop (`_run_scheduling_pass` per pass). A contract breaker reset to PENDING re-enters scheduling, so the promised retry actually runs; previously the reset happened after the scheduling loop had exited and the retry never ran. Termination: each reset consumes one bounded retry; a pass with no reset breaks out. Cascade rules unchanged.
- Terminal contract failures land in `FactoryResult.contract_failures` (plus `failed` + component status FAILED for a blamed breaker with exhausted retries), are printed in the run summary, and force exit code 1. Previously the run exited 0 with broken integrated code.
- A `contract_result` event is appended to the evolution journal for pass AND fail on every contract pass (same non-fatal write style as `EvolutionJournal.record_run`).
- `ContractCleanupError` from the contract phase is caught, recorded as a contract failure, and forces exit 1.

## Verification

```
uv run pytest tests/ -q            -> 781 passed, 12 skipped
uv run mypy ralph_py/ --strict     -> Success: no issues found in 37 source files
uv run ruff check ralph_py/ tests/ -> All checks passed!
```

## Tested (named tests, all real git except where noted)

- `test_conflict_recovers_and_checkout_is_byte_identical`: a conflicted tier leaves the user's working tree byte-identical (full file-bytes snapshot compare), HEAD unmoved, `git status` clean, no `MERGE_HEAD`, no temp worktree left in `git worktree list`, and the next tier check runs cleanly.
- `test_failing_tests_bisect_leaves_checkout_untouched`: the test-failure + bisection path also leaves the checkout untouched.
- `test_failing_tier_sets_nonzero_exit_and_run_summary`: `run_factory` with a failing contract and `max_retries=0` exits 1, records the failure in `contract_failures` + `failed`, marks the breaker FAILED with "retries exhausted", and writes a failed `contract_result` journal event.
- `test_breaker_reruns_and_passing_contract_completes_run`: end-to-end with a real fake-agent subprocess and real worktrees - run 1 plants a marker that fails the contract, the breaker resets, scheduling re-runs the component (retry removes the marker), the second contract passes, run exits 0 with `retries == 1`; progress log and evolution journal both show `[failed, passed]` contract events.
- `test_squash_merged_mode_reports_failure_without_blame` / `test_squash_merged_mode_passes_on_healthy_base`: `components_merged=True` yields exactly one result testing base, `breaker is None`, failing output included.
- `test_surviving_temp_worktree_raises_cleanup_error`: a worktree-remove failure raises `ContractCleanupError`; real removal afterwards still works.
- `test_factory_converts_cleanup_error_to_nonzero_exit` (mocked contract): factory records the cleanup failure and exits 1.
- `test_contract_failure_sends_breaker_for_retry` (updated, mocked contract): breaker reset causes a third `_run_component` call and a second contract call; run completes exit 0.

## Assumed (not tested)

- `components_merged` is derived from config (`create_prs and not single_pr`), not from observed PR state: if `gh` was unavailable or a PR merge failed mid-run, some components may not actually be on base while the phase still runs in integrated mode. The config flag is the declared intent; observed-state detection is out of scope here.
- The new `contract_result` journal entries are counted by `EvolutionJournal.get_concern_hit_rate` / `get_cross_run_patterns` entry scans (they use `.get` so nothing breaks, but `components` counts in `get_concern_hit_rate` now include contract events). evolution.py is out of scope for this session; noting the minor metric skew rather than fixing it.
- `git worktree remove --force` succeeding implies git's worktree metadata is consistent; the `git worktree prune` fallback for rc!=0-but-directory-gone is untested.
- Behavior on Windows (POSIX-first codebase per CLAUDE.md).
- single_pr mode keeps its pre-existing deferred-merge bisection behavior (all components share one branch, so within-tier blame there remains order-dependent); unchanged by design, not newly tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)