### PR TITLE
fix: R0.2 PR/merge outcome gates completion

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -73,7 +73,7 @@ item here is one of those three.
     worktree. Mitigation: timeout-failure retry path recreates the worktree
     from base instead of reusing it, and removes stale index locks.
 
-- [ ] R0.2 (M) **PR/merge outcome gates completion** [CRIT-2, H-1, MED pr-timeouts]
+- [x] R0.2 (M) **PR/merge outcome gates completion** [CRIT-2, H-1, MED pr-timeouts]
   - `pr.py`: return a typed `PrOutcome` (pushed / pr_url / merged /
     merge_pending / error) instead of a lossy tuple; add explicit timeouts to
     every `gh`/`git` subprocess call in the module.

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -22,6 +22,7 @@ from ralph_py.contract import (
     run_contract_testing,
 )
 from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
+from ralph_py.git import fetch_base_branch, resolve_base_ref
 from ralph_py.knowledge import (
     KnowledgeConfig,
     build_knowledge_context,
@@ -81,6 +82,9 @@ class FactoryConfig:
     # scheduler backstop margin). None means run_factory loads
     # TimeoutConfig.load(root_dir) - toml [timeout] section + env.
     timeout_config: TimeoutConfig | None = None
+    # R0.2: how long push_create_and_merge_pr waits for merge
+    # confirmation before the component is parked as MERGE_PENDING.
+    merge_timeout: float = 300.0
 
     @classmethod
     def from_env(cls) -> FactoryConfig:
@@ -89,6 +93,7 @@ class FactoryConfig:
             max_parallel=int(os.environ.get("FACTORY_MAX_PARALLEL", "4")),
             max_retries=int(os.environ.get("FACTORY_MAX_RETRIES", "3")),
             retry_delay=float(os.environ.get("FACTORY_RETRY_DELAY", "5.0")),
+            merge_timeout=float(os.environ.get("FACTORY_MERGE_TIMEOUT", "300.0")),
         )
 
     @classmethod
@@ -117,6 +122,8 @@ class FactoryConfig:
             config.create_prs = bool(section["create_prs"])
         if "review_mode" in section:
             config.review_mode = str(section["review_mode"])
+        if "merge_timeout" in section:
+            config.merge_timeout = float(section["merge_timeout"])
         # Env overrides (consistent with from_env)
         if "FACTORY_MAX_PARALLEL" in os.environ:
             config.max_parallel = int(os.environ["FACTORY_MAX_PARALLEL"])
@@ -124,6 +131,8 @@ class FactoryConfig:
             config.max_retries = int(os.environ["FACTORY_MAX_RETRIES"])
         if "FACTORY_RETRY_DELAY" in os.environ:
             config.retry_delay = float(os.environ["FACTORY_RETRY_DELAY"])
+        if "FACTORY_MERGE_TIMEOUT" in os.environ:
+            config.merge_timeout = float(os.environ["FACTORY_MERGE_TIMEOUT"])
         return config
 
 
@@ -146,6 +155,10 @@ class FactoryResult:
     completed: list[str] = field(default_factory=list)
     failed: list[str] = field(default_factory=list)
     skipped: list[str] = field(default_factory=list)
+    # R0.2: components whose PR merge was initiated but not confirmed.
+    # Not failed - a factory re-run re-polls them - but their dependents
+    # were not scheduled, so the run is incomplete (nonzero exit code).
+    merge_pending: list[str] = field(default_factory=list)
     pr_urls: list[str] = field(default_factory=list)
     # R0.3: unresolved contract failures (one human-readable line per
     # failed check). Non-empty forces a nonzero exit code even when no
@@ -229,8 +242,16 @@ def _setup_worktree(
                 cwd=root_dir, capture_output=True, timeout=30,
             )
 
+        # R0.2: cut from origin/<base> when a remote exists so this
+        # component builds on the squash-merged history of its
+        # dependencies, not a stale local base ref. The fetch is
+        # freshness-only and non-fatal: offline runs fall back to the
+        # current tracking ref, local-only repos to the local base.
+        fetch_base_branch(base_branch, root_dir, timeout=60.0)
+        base_ref = resolve_base_ref(base_branch, root_dir)
+
         result = subprocess.run(
-            ["git", "worktree", "add", str(worktree_path), "-b", branch_name, base_branch],
+            ["git", "worktree", "add", str(worktree_path), "-b", branch_name, base_ref],
             cwd=root_dir, capture_output=True, text=True, timeout=30,
         )
 
@@ -529,6 +550,62 @@ def run_factory(
             comp.status = ComponentStatus.PENDING.value
 
     manifest_path = root_dir / "scripts" / "ralph" / "manifest.json"
+
+    # R0.2 crash recovery: MERGE_PENDING is re-pollable, not failed. A
+    # prior run initiated the merge but could not confirm it; check the
+    # PR state again before scheduling so confirmed merges unblock their
+    # dependents. Local imports keep the late binding tests rely on.
+    merge_pending_comps = [
+        c for c in manifest.components
+        if c.status == ComponentStatus.MERGE_PENDING.value
+    ]
+    if merge_pending_comps:
+        from ralph_py.pr import is_gh_available, pr_number_from_url, wait_for_merge
+
+        if not factory_config.create_prs or not is_gh_available():
+            ui.warn(
+                f"  {len(merge_pending_comps)} component(s) are merge-pending "
+                f"but PR polling is unavailable (create_prs off or gh "
+                f"missing); their dependents stay blocked"
+            )
+        else:
+            for comp in merge_pending_comps:
+                pr_number = comp.pr_number or pr_number_from_url(comp.pr_url)
+                if not pr_number:
+                    ui.warn(
+                        f"  Cannot re-poll '{comp.id}': no PR number recorded"
+                    )
+                    continue
+                ui.info(
+                    f"  Re-polling merge state for '{comp.id}' "
+                    f"(PR #{pr_number})..."
+                )
+                merge_state = wait_for_merge(
+                    pr_number, root_dir, timeout=factory_config.merge_timeout,
+                )
+                if merge_state == "merged":
+                    fetch_base_branch(manifest.base_branch, root_dir)
+                    comp.status = ComponentStatus.COMPLETED.value
+                    comp.error = ""
+                    factory_result.completed.append(comp.id)
+                    progress_log.component_completed(
+                        comp.id, comp.duration_seconds, comp.iteration_count,
+                    )
+                    ui.ok(f"  PR #{pr_number} merged; '{comp.id}' completed")
+                elif merge_state == "closed":
+                    comp.status = ComponentStatus.FAILED.value
+                    comp.error = f"PR #{pr_number} closed without merge"
+                    skipped = manifest.cascade_skip(comp.id)
+                    factory_result.failed.append(comp.id)
+                    factory_result.skipped.extend(skipped)
+                    progress_log.component_failed(comp.id, comp.error)
+                    ui.err(f"  Failed: {comp.id}: {comp.error}")
+                else:
+                    ui.warn(
+                        f"  '{comp.id}' still awaiting merge of "
+                        f"PR #{pr_number}; dependents stay blocked"
+                    )
+        manifest.save(manifest_path)
 
     # Determine effective parallelism
     max_parallel = factory_config.max_parallel
@@ -987,8 +1064,12 @@ def run_factory(
             except Exception:  # noqa: BLE001
                 pass
 
-        # All verification phases passed - create PR and merge
-        if factory_config.create_prs:
+        # All verification phases passed - create PR and merge.
+        # single_pr mode is exempt: every component shares one branch,
+        # a single PR is created at end-of-run, and squash-merging the
+        # shared branch per component would destroy the history the
+        # remaining components build on.
+        if factory_config.create_prs and not factory_config.single_pr:
             from ralph_py.pr import is_gh_available, push_create_and_merge_pr
 
             # E6: human-in-the-loop checkpoint. When opt-in, prompt
@@ -1030,14 +1111,47 @@ def run_factory(
 
             if proceed and is_gh_available():
                 ui.info(f"  Creating and merging PR for {comp_id}...")
-                pr_result = push_create_and_merge_pr(
+                outcome = push_create_and_merge_pr(
                     comp, manifest, root_dir, ui,
                     merge_method="squash",
-                    merge_timeout=300,
+                    merge_timeout=factory_config.merge_timeout,
                 )
-                if pr_result:
-                    factory_result.pr_urls.append(pr_result[1])
+                if outcome.pr_url:
+                    factory_result.pr_urls.append(outcome.pr_url)
                 manifest.save(manifest_path)
+
+                # R0.2 (CRIT-2): COMPLETED requires a CONFIRMED merge.
+                # Anything less and dependents would cut worktrees from
+                # a base that lacks this component's code.
+                if not outcome.merged:
+                    if outcome.merge_pending:
+                        comp.status = ComponentStatus.MERGE_PENDING.value
+                        comp.error = (
+                            outcome.error or "PR merge not confirmed"
+                        )
+                        ui.warn(
+                            f"  MERGE PENDING: {comp_id}: {comp.error}; "
+                            f"dependents stay blocked; a factory re-run "
+                            f"re-polls the PR"
+                        )
+                    else:
+                        comp.status = ComponentStatus.FAILED.value
+                        comp.error = outcome.error or "PR flow failed"
+                        skipped = manifest.cascade_skip(comp_id)
+                        factory_result.failed.append(comp_id)
+                        factory_result.skipped.extend(skipped)
+                        progress_log.component_failed(comp_id, comp.error)
+                        ui.err(f"  Failed: {comp_id}: {comp.error[:120]}")
+                    manifest.save(manifest_path)
+                    return
+            elif proceed:
+                # No gh: the PR/merge gate cannot run. Completing anyway
+                # preserves local-only workflows, but say so loudly -
+                # this component's code exists only on its local branch.
+                ui.warn(
+                    f"  gh CLI not available: {comp_id} completes without "
+                    f"a PR; its code stays on branch {comp.branch_name}"
+                )
 
         # Clean up worktree now that code is merged
         if factory_config.use_worktrees and comp_id in worktree_paths:
@@ -1461,6 +1575,14 @@ def run_factory(
         factory_duration,
     )
 
+    # R0.2: collect components parked awaiting merge confirmation. Built
+    # from the manifest (not accumulated during the run) so it reflects
+    # the final state after any crash-recovery re-poll.
+    factory_result.merge_pending = [
+        c.id for c in manifest.components
+        if c.status == ComponentStatus.MERGE_PENDING.value
+    ]
+
     ui.section("Factory: Summary")
     ui.kv("Completed", str(len(factory_result.completed)))
     ui.kv("Failed", str(len(factory_result.failed)))
@@ -1469,13 +1591,24 @@ def run_factory(
         ui.kv("Contract failures", str(len(factory_result.contract_failures)))
         for line in factory_result.contract_failures:
             ui.err(f"  {line}")
+    if factory_result.merge_pending:
+        ui.kv("Merge pending", str(len(factory_result.merge_pending)))
     ui.kv("Duration", f"{factory_duration:.0f}s")
     if factory_result.pr_urls:
         ui.kv("PRs created", str(len(factory_result.pr_urls)))
         for url in factory_result.pr_urls:
             ui.info(f"  {url}")
+    if factory_result.merge_pending:
+        ui.warn(
+            "Some PR merges are unconfirmed; re-run the factory to "
+            "re-poll them: " + ", ".join(factory_result.merge_pending)
+        )
 
     if factory_result.failed or factory_result.contract_failures:
+        factory_result.exit_code = 1
+    elif factory_result.merge_pending:
+        # Incomplete, not failed: unconfirmed merges blocked their
+        # dependents. Nonzero so automation notices; a re-run re-polls.
         factory_result.exit_code = 1
     elif factory_result.skipped and not factory_result.completed:
         factory_result.exit_code = 1

--- a/ralph_py/git.py
+++ b/ralph_py/git.py
@@ -12,6 +12,72 @@ if TYPE_CHECKING:
 
 DEFAULT_TIMEOUT = 30.0
 
+# Network fetches get a longer budget than local plumbing calls.
+FETCH_TIMEOUT = 120.0
+
+
+def resolve_base_ref(
+    base_branch: str,
+    cwd: Path | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> str:
+    """Resolve the ref that worktree cuts and diffs measure against.
+
+    Returns ``origin/<base_branch>`` when that remote-tracking ref
+    exists, else ``base_branch`` unchanged (local-only repos). This is
+    the single place that decides the base ref (R0.2): squash merges
+    rewrite SHAs, so a stale local base produces phantom diffs via
+    ``base...HEAD``; cutting AND diffing against ``origin/<base>``
+    removes the class. Never mutates any ref or the checkout.
+    """
+    if base_branch.startswith("origin/"):
+        return base_branch
+    try:
+        result = subprocess.run(
+            [
+                "git", "rev-parse", "--verify", "--quiet",
+                f"refs/remotes/origin/{base_branch}",
+            ],
+            cwd=cwd,
+            capture_output=True,
+            timeout=timeout,
+        )
+        if result.returncode == 0:
+            return f"origin/{base_branch}"
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return base_branch
+
+
+def fetch_base_branch(
+    base_branch: str,
+    cwd: Path | None = None,
+    timeout: float = FETCH_TIMEOUT,
+) -> str | None:
+    """Update ``refs/remotes/origin/<base_branch>`` via ``git fetch``.
+
+    Replaces the old ``git pull`` (R0.2/H-1): fetch touches only the
+    remote-tracking ref, never the operator's checked-out branch or the
+    local base branch. Returns an error message, or None on success.
+    """
+    try:
+        # "--" keeps a crafted base branch out of option position (R0.6).
+        result = subprocess.run(
+            ["git", "fetch", "--", "origin", base_branch],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return f"git fetch origin {base_branch} timed out after {timeout}s"
+    if result.returncode != 0:
+        return (
+            result.stderr.strip()
+            or f"git fetch origin {base_branch} failed"
+        )
+    return None
+
 
 def is_git_repo(path: Path | None = None, timeout: float = DEFAULT_TIMEOUT) -> bool:
     """Check if path is inside a git repository."""
@@ -215,10 +281,15 @@ def get_diff_names(
     cwd: Path | None = None,
     timeout: float = DEFAULT_TIMEOUT,
 ) -> list[str]:
-    """Get list of changed file names compared to a base branch."""
+    """Get list of changed file names compared to a base branch.
+
+    The base is resolved through :func:`resolve_base_ref` so diffs
+    measure against ``origin/<base>`` whenever a remote exists (R0.2).
+    """
+    base_ref = resolve_base_ref(base_branch, cwd, timeout)
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", f"{base_branch}...HEAD", "--"],
+            ["git", "diff", "--name-only", f"{base_ref}...HEAD", "--"],
             cwd=cwd,
             capture_output=True,
             text=True,
@@ -240,10 +311,15 @@ def get_diff_content(
     cwd: Path | None = None,
     timeout: float = DEFAULT_TIMEOUT,
 ) -> str:
-    """Get full diff content compared to a base branch."""
+    """Get full diff content compared to a base branch.
+
+    The base is resolved through :func:`resolve_base_ref` so diffs
+    measure against ``origin/<base>`` whenever a remote exists (R0.2).
+    """
+    base_ref = resolve_base_ref(base_branch, cwd, timeout)
     try:
         result = subprocess.run(
-            ["git", "diff", f"{base_branch}...HEAD", "--"],
+            ["git", "diff", f"{base_ref}...HEAD", "--"],
             cwd=cwd,
             capture_output=True,
             text=True,

--- a/ralph_py/manifest.py
+++ b/ralph_py/manifest.py
@@ -114,6 +114,13 @@ class ComponentStatus(StrEnum):
     RUNNING = "running"
     VERIFYING = "verifying"
     COMPLETED = "completed"
+    # R0.2: the component's PR was created and a merge was initiated,
+    # but wait_for_merge could not confirm the merge within the timeout.
+    # Not a failure: crash recovery re-polls the PR state on the next
+    # run. Dependents are NOT scheduled past it (get_ready_components
+    # requires COMPLETED), because they would build without the
+    # dependency's merged code (CRIT-2).
+    MERGE_PENDING = "merge_pending"
     FAILED = "failed"
     SKIPPED = "skipped"
 

--- a/ralph_py/pr.py
+++ b/ralph_py/pr.py
@@ -6,97 +6,243 @@ import json
 import shutil
 import subprocess
 import time
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
+
+from ralph_py.git import fetch_base_branch
 
 if TYPE_CHECKING:
     from ralph_py.manifest import Component, Manifest
     from ralph_py.ui.base import UI
+
+# Explicit budgets for every subprocess in this module (R0.2): a hung
+# gh or git call previously blocked the factory scheduler forever.
+GH_TIMEOUT = 60.0
+GH_POLL_TIMEOUT = 30.0
+PUSH_TIMEOUT = 300.0
+
+MergeState = Literal["merged", "closed", "pending"]
+
+
+@dataclass(frozen=True)
+class PrOutcome:
+    """Typed result of the per-component PR lifecycle (R0.2).
+
+    Replaces the lossy ``tuple | None`` return: the factory gates
+    COMPLETED on ``merged`` and maps ``merge_pending`` to the
+    MERGE_PENDING manifest status, so no failure shape can fall through
+    to "completed" (CRIT-2).
+    """
+
+    pushed: bool = False
+    pr_number: int | None = None
+    pr_url: str = ""
+    merged: bool = False
+    # True when a merge was initiated but not confirmed within the
+    # timeout: re-pollable, unlike a push/create/merge failure.
+    merge_pending: bool = False
+    error: str | None = None
+
+
+def pr_number_from_url(pr_url: str) -> int:
+    """Extract the PR number from a GitHub PR URL, 0 if unparseable."""
+    if "/pull/" in pr_url:
+        try:
+            return int(pr_url.rstrip("/").rsplit("/", 1)[-1])
+        except ValueError:
+            pass
+    return 0
 
 
 def is_gh_available() -> bool:
     """Check if gh CLI is available and authenticated."""
     if shutil.which("gh") is None:
         return False
-    result = subprocess.run(
-        ["gh", "auth", "status"],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return False
     return result.returncode == 0
 
 
-def push_branch(branch: str, cwd: Path) -> bool:
-    """Push a branch to the remote with tracking."""
+def push_branch(branch: str, cwd: Path) -> str | None:
+    """Push a branch to the remote with tracking.
+
+    Returns an error message, or None on success.
+    """
     # "--" makes a crafted branch value an invalid refspec instead of a
     # git option (R0.6).
-    result = subprocess.run(
-        ["git", "push", "-u", "--", "origin", branch],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-    )
-    return result.returncode == 0
+    try:
+        result = subprocess.run(
+            ["git", "push", "-u", "--", "origin", branch],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=PUSH_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return f"git push of {branch} timed out after {PUSH_TIMEOUT}s"
+    if result.returncode != 0:
+        return result.stderr.strip() or f"git push of {branch} failed"
+    return None
 
 
-def merge_pr(pr_number: int, cwd: Path, method: str = "squash") -> bool:
+def merge_pr(pr_number: int, cwd: Path, method: str = "squash") -> str | None:
     """Merge a PR via gh CLI with auto-merge.
 
     Uses --auto so GitHub merges once status checks pass.
     Uses --delete-branch to clean up the feature branch.
+
+    Returns an error message, or None when a merge was initiated
+    (confirmation is wait_for_merge's job).
 
     Args:
         pr_number: PR number to merge.
         cwd: Working directory (must be in the git repo).
         method: Merge method - "squash", "merge", or "rebase".
     """
-    result = subprocess.run(
-        [
-            "gh", "pr", "merge", str(pr_number),
-            f"--{method}", "--delete-branch", "--auto",
-        ],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-    )
-    # If --auto fails (no required checks), try direct merge
-    if result.returncode != 0:
+    try:
         result = subprocess.run(
             [
                 "gh", "pr", "merge", str(pr_number),
-                f"--{method}", "--delete-branch",
+                f"--{method}", "--delete-branch", "--auto",
             ],
             cwd=cwd,
             capture_output=True,
             text=True,
+            timeout=GH_TIMEOUT,
         )
-    return result.returncode == 0
+        # If --auto fails (no required checks), try direct merge
+        if result.returncode != 0:
+            result = subprocess.run(
+                [
+                    "gh", "pr", "merge", str(pr_number),
+                    f"--{method}", "--delete-branch",
+                ],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=GH_TIMEOUT,
+            )
+    except subprocess.TimeoutExpired:
+        return f"gh pr merge #{pr_number} timed out after {GH_TIMEOUT}s"
+    if result.returncode != 0:
+        return (
+            result.stderr.strip()
+            or f"gh pr merge #{pr_number} failed"
+        )
+    return None
 
 
-def wait_for_merge(
-    pr_number: int, cwd: Path, timeout: int = 300, poll_interval: int = 10,
-) -> bool:
-    """Poll until a PR is merged or timeout.
-
-    Returns True if merged, False if timeout or closed without merge.
-    """
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
+def _pr_state(pr_number: int, cwd: Path) -> str | None:
+    """Fetch a PR's state via gh: "MERGED", "CLOSED", "OPEN", or None
+    when the state could not be determined (gh error, timeout, bad
+    JSON)."""
+    try:
         result = subprocess.run(
             ["gh", "pr", "view", str(pr_number), "--json", "state"],
             cwd=cwd,
             capture_output=True,
             text=True,
+            timeout=GH_POLL_TIMEOUT,
         )
-        if result.returncode == 0:
-            data = json.loads(result.stdout)
-            state = data.get("state", "")
-            if state == "MERGED":
-                return True
-            if state == "CLOSED":
-                return False
-        time.sleep(poll_interval)
-    return False
+    except subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except ValueError:
+        return None
+    state = data.get("state", "") if isinstance(data, dict) else ""
+    return str(state) or None
+
+
+def wait_for_merge(
+    pr_number: int,
+    cwd: Path,
+    timeout: float = 300,
+    poll_interval: float = 10,
+) -> MergeState:
+    """Poll until a PR is merged, closed, or the timeout elapses.
+
+    Returns "merged", "closed" (closed without merge), or "pending"
+    (timeout: state unknown, re-pollable). Each poll is individually
+    bounded so a hung gh cannot outlive the deadline by much.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        state = _pr_state(pr_number, cwd)
+        if state == "MERGED":
+            return "merged"
+        if state == "CLOSED":
+            return "closed"
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(poll_interval, remaining))
+    return "pending"
+
+
+def _merge_and_wait(
+    pr_number: int,
+    pr_url: str,
+    base_branch: str,
+    cwd: Path,
+    ui: UI,
+    merge_method: str,
+    merge_timeout: float,
+) -> PrOutcome:
+    """Shared merge-initiate + confirm + fetch tail of the PR lifecycle."""
+    merge_error = merge_pr(pr_number, cwd, merge_method)
+    if merge_error:
+        ui.warn(f"  Failed to merge #{pr_number}: {merge_error}")
+        return PrOutcome(
+            pushed=True, pr_number=pr_number, pr_url=pr_url,
+            error=f"merge failed for PR #{pr_number}: {merge_error}",
+        )
+
+    state = wait_for_merge(pr_number, cwd, timeout=merge_timeout)
+    if state == "merged":
+        ui.ok(f"  PR #{pr_number} merged")
+        # Fetch (never pull, H-1) so origin/<base> includes the merged
+        # code for downstream worktrees; the operator's checkout is
+        # untouched. A failed fetch does not un-merge the PR, but it
+        # leaves origin/<base> stale, so it is recorded loudly.
+        fetch_error = fetch_base_branch(base_branch, cwd)
+        if fetch_error:
+            ui.warn(
+                f"  Fetch of origin/{base_branch} after merge failed: "
+                f"{fetch_error}; downstream worktrees retry the fetch "
+                f"at setup"
+            )
+        return PrOutcome(
+            pushed=True, pr_number=pr_number, pr_url=pr_url,
+            merged=True, error=fetch_error,
+        )
+
+    if state == "closed":
+        ui.warn(f"  PR #{pr_number} was closed without merging")
+        return PrOutcome(
+            pushed=True, pr_number=pr_number, pr_url=pr_url,
+            error=f"PR #{pr_number} closed without merge",
+        )
+
+    ui.warn(
+        f"  PR #{pr_number} not merged within {merge_timeout}s - "
+        f"marked merge-pending; a factory re-run re-polls it"
+    )
+    return PrOutcome(
+        pushed=True, pr_number=pr_number, pr_url=pr_url,
+        merge_pending=True,
+        error=f"PR #{pr_number} not merged within {merge_timeout}s",
+    )
 
 
 def push_create_and_merge_pr(
@@ -105,58 +251,74 @@ def push_create_and_merge_pr(
     cwd: Path,
     ui: UI,
     merge_method: str = "squash",
-    merge_timeout: int = 300,
-) -> tuple[int, str] | None:
-    """Push branch, create PR, merge it, and pull main.
+    merge_timeout: float = 300,
+) -> PrOutcome:
+    """Push branch, create PR, merge it, and fetch the base branch.
 
     Full per-component PR lifecycle:
     1. Push branch to origin
     2. Create PR via gh
     3. Merge PR (auto-merge if checks required, direct otherwise)
     4. Wait for merge to complete
-    5. Pull main so downstream components get the merged code
+    5. Fetch origin/<base> so downstream worktrees get the merged code
+       (never ``git pull``: the operator's checkout is not ours to move)
 
-    Returns (pr_number, pr_url) on success, None on failure.
+    Returns a PrOutcome; the caller decides component status from it.
     """
     if component.pr_url:
+        # Resume/retry path: a PR already exists. Its state must be
+        # verified, not assumed - the pre-R0.2 code returned success
+        # here even when the PR was never merged.
+        pr_number = component.pr_number or pr_number_from_url(component.pr_url)
+        if not pr_number:
+            return PrOutcome(
+                pushed=True, pr_url=component.pr_url,
+                error=(
+                    f"existing PR {component.pr_url} has no usable PR "
+                    f"number; cannot verify merge state"
+                ),
+            )
         ui.info(f"  {component.id}: PR already exists ({component.pr_url})")
-        return (component.pr_number or 0, component.pr_url)
+        state = _pr_state(pr_number, cwd)
+        if state == "MERGED":
+            return PrOutcome(
+                pushed=True, pr_number=pr_number, pr_url=component.pr_url,
+                merged=True,
+            )
+        if state == "CLOSED":
+            return PrOutcome(
+                pushed=True, pr_number=pr_number, pr_url=component.pr_url,
+                error=f"PR #{pr_number} closed without merge",
+            )
+        return _merge_and_wait(
+            pr_number, component.pr_url, manifest.base_branch,
+            cwd, ui, merge_method, merge_timeout,
+        )
 
     # Push
     ui.info(f"  Pushing {component.branch_name}...")
-    if not push_branch(component.branch_name, cwd):
-        ui.warn(f"  Failed to push {component.branch_name}")
-        return None
+    push_error = push_branch(component.branch_name, cwd)
+    if push_error:
+        ui.warn(f"  Failed to push {component.branch_name}: {push_error}")
+        return PrOutcome(
+            error=f"push of {component.branch_name} failed: {push_error}",
+        )
 
     # Create PR
     try:
         pr_number, pr_url = create_component_pr(component, manifest, cwd)
     except RuntimeError as exc:
         ui.warn(f"  {exc}")
-        return None
+        return PrOutcome(pushed=True, error=str(exc))
 
     component.pr_number = pr_number
     component.pr_url = pr_url
     ui.ok(f"  PR created: {pr_url}")
 
-    # Merge
-    if not merge_pr(pr_number, cwd, merge_method):
-        ui.warn(f"  Failed to merge #{pr_number} - needs manual merge")
-        return (pr_number, pr_url)
-
-    # Wait for merge
-    if wait_for_merge(pr_number, cwd, timeout=merge_timeout):
-        ui.ok(f"  PR #{pr_number} merged")
-        # Pull main so downstream worktrees start from merged state.
-        # "--" keeps a crafted base branch out of option position (R0.6).
-        subprocess.run(
-            ["git", "pull", "--", "origin", manifest.base_branch],
-            cwd=cwd, capture_output=True,
-        )
-        return (pr_number, pr_url)
-
-    ui.warn(f"  PR #{pr_number} not merged within {merge_timeout}s - may need manual merge")
-    return (pr_number, pr_url)
+    return _merge_and_wait(
+        pr_number, pr_url, manifest.base_branch,
+        cwd, ui, merge_method, merge_timeout,
+    )
 
 
 def _generate_pr_body(
@@ -227,34 +389,32 @@ def create_component_pr(
 
     # --base=/--head= bind the branch values to their flags even if a
     # crafted value starts with "-" (R0.6).
-    result = subprocess.run(
-        [
-            "gh", "pr", "create",
-            "--title", title,
-            "--body", body,
-            f"--base={manifest.base_branch}",
-            f"--head={component.branch_name}",
-        ],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "gh", "pr", "create",
+                "--title", title,
+                "--body", body,
+                f"--base={manifest.base_branch}",
+                f"--head={component.branch_name}",
+            ],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(
+            f"Failed to create PR for '{component.id}': gh pr create "
+            f"timed out after {GH_TIMEOUT}s"
+        ) from None
 
     if result.returncode != 0:
         error = result.stderr.strip() or result.stdout.strip()
         raise RuntimeError(f"Failed to create PR for '{component.id}': {error}")
 
     pr_url = result.stdout.strip()
-
-    # Extract PR number from URL (e.g., https://github.com/owner/repo/pull/42)
-    pr_number = 0
-    if "/pull/" in pr_url:
-        try:
-            pr_number = int(pr_url.rstrip("/").rsplit("/", 1)[-1])
-        except ValueError:
-            pass
-
-    return pr_number, pr_url
+    return pr_number_from_url(pr_url), pr_url
 
 
 def create_prs_in_order(
@@ -297,8 +457,12 @@ def create_prs_in_order(
             continue
 
         ui.info(f"  {comp_id}: pushing branch {component.branch_name}...")
-        if not push_branch(component.branch_name, cwd):
-            ui.warn(f"  {comp_id}: failed to push branch, skipping PR")
+        push_error = push_branch(component.branch_name, cwd)
+        if push_error:
+            ui.warn(
+                f"  {comp_id}: failed to push branch ({push_error}), "
+                f"skipping PR"
+            )
             continue
 
         try:
@@ -339,8 +503,9 @@ def create_single_pr(
     branch = next(iter(branches))
 
     ui.info(f"  Pushing branch {branch}...")
-    if not push_branch(branch, cwd):
-        ui.warn("  Failed to push branch, skipping PR")
+    push_error = push_branch(branch, cwd)
+    if push_error:
+        ui.warn(f"  Failed to push branch ({push_error}), skipping PR")
         return None
 
     # Build combined body
@@ -367,18 +532,23 @@ def create_single_pr(
 
     # --base=/--head= bind the branch values to their flags even if a
     # crafted value starts with "-" (R0.6).
-    result = subprocess.run(
-        [
-            "gh", "pr", "create",
-            "--title", title,
-            "--body", body,
-            f"--base={manifest.base_branch}",
-            f"--head={branch}",
-        ],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "gh", "pr", "create",
+                "--title", title,
+                "--body", body,
+                f"--base={manifest.base_branch}",
+                f"--head={branch}",
+            ],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        ui.warn(f"  Failed to create PR: timed out after {GH_TIMEOUT}s")
+        return None
 
     if result.returncode != 0:
         error = result.stderr.strip() or result.stdout.strip()
@@ -386,12 +556,5 @@ def create_single_pr(
         return None
 
     pr_url = result.stdout.strip()
-    pr_number = 0
-    if "/pull/" in pr_url:
-        try:
-            pr_number = int(pr_url.rstrip("/").rsplit("/", 1)[-1])
-        except ValueError:
-            pass
-
     ui.ok(f"  PR created: {pr_url}")
-    return pr_number, pr_url
+    return pr_number_from_url(pr_url), pr_url

--- a/tests/test_input_hygiene.py
+++ b/tests/test_input_hygiene.py
@@ -377,13 +377,14 @@ class TestGitArgvSeparators:
             ["git", "checkout", "-qb", "ralph/factory/comp-a"],
             cwd=repo, check=True,
         )
-        assert push_branch("ralph/factory/comp-a", repo) is True
+        # R0.2: push_branch returns None on success, an error otherwise.
+        assert push_branch("ralph/factory/comp-a", repo) is None
 
     def test_push_branch_option_shape_fails_closed(
         self, git_repo_with_origin: Path,
     ) -> None:
         # With "--", "-evil" is an unknown refspec, not a push option.
-        assert push_branch("-evil", git_repo_with_origin) is False
+        assert push_branch("-evil", git_repo_with_origin) is not None
 
     def test_merge_branch_legitimate(self, git_repo_with_origin: Path) -> None:
         repo = git_repo_with_origin
@@ -490,6 +491,7 @@ class TestPrArgvShapes:
 
         monkeypatch.setattr(pr_module.subprocess, "run", fake_run)
 
-        assert push_branch("ralph/factory/comp-a", tmp_path) is True
+        # R0.2: push_branch returns None on success, an error otherwise.
+        assert push_branch("ralph/factory/comp-a", tmp_path) is None
         (argv,) = captured
         assert argv.index("--") < argv.index("ralph/factory/comp-a")

--- a/tests/test_pr_outcomes.py
+++ b/tests/test_pr_outcomes.py
@@ -1,0 +1,579 @@
+"""R0.2 tests: PR/merge outcome gates completion (CRIT-2, H-1).
+
+Real git repositories with a stub ``gh`` binary placed on PATH. Covers:
+
+- push-fail / create-fail / merge-fail -> component FAILED, dependents
+  do not schedule (cascade-skipped).
+- wait_for_merge timeout -> MERGE_PENDING, dependents stay PENDING
+  (re-pollable, not failed); crash recovery re-polls on the next run.
+- ``git fetch origin <base>`` updates only the remote-tracking ref: the
+  operator's checked-out branch, local base branch, and uncommitted
+  state are never touched.
+- origin/<base> resolution for worktree cuts and diffs, with a local
+  fallback when no remote exists.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ralph_py import git
+from ralph_py.config import RalphConfig
+from ralph_py.factory import (
+    ComponentResult,
+    FactoryConfig,
+    FactoryResult,
+    run_factory,
+)
+from ralph_py.manifest import Component, ComponentStatus, Manifest
+from ralph_py.pr import PrOutcome, push_create_and_merge_pr, wait_for_merge
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+STUB_PR_URL = "https://github.com/stub/repo/pull/7"
+
+
+def _git(*args: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"git {' '.join(args)} failed: {result.stderr}"
+    )
+    return result.stdout.strip()
+
+
+def _prd_json() -> str:
+    return json.dumps({
+        "branchName": "test",
+        "userStories": [{
+            "id": "US-001", "title": "Test",
+            "acceptanceCriteria": ["AC1"],
+            "priority": 1, "passes": True, "notes": "",
+        }],
+    })
+
+
+def _make_repo(
+    tmp_path: Path, comp_ids: list[str], with_origin: bool = True,
+) -> Path:
+    """Real git repo with committed ralph scaffolding and, optionally, a
+    bare origin. The operator is parked on a side branch with an
+    uncommitted file so H-1 violations (checkout mutation) are visible.
+    """
+    root = tmp_path / "repo"
+    ralph_dir = root / "scripts" / "ralph"
+    ralph_dir.mkdir(parents=True)
+    (ralph_dir / "prompt.md").write_text("test prompt")
+    (ralph_dir / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    for cid in comp_ids:
+        feature = ralph_dir / "feature" / cid
+        feature.mkdir(parents=True)
+        (feature / "prd.json").write_text(_prd_json())
+    (root / ".gitignore").write_text(
+        ".ralph/\nscripts/ralph/manifest.json\n"
+    )
+    _git("init", "-b", "main", cwd=root)
+    _git("config", "user.email", "ralph-test@example.com", cwd=root)
+    _git("config", "user.name", "Ralph Test", cwd=root)
+    _git("add", "-A", cwd=root)
+    _git("commit", "-m", "init", cwd=root)
+    if with_origin:
+        origin = tmp_path / "origin.git"
+        _git("init", "--bare", str(origin), cwd=tmp_path)
+        _git("remote", "add", "origin", str(origin), cwd=root)
+        _git("push", "-u", "origin", "main", cwd=root)
+    _git("checkout", "-b", "operator-branch", cwd=root)
+    (root / "OPERATOR_NOTES.txt").write_text("uncommitted operator state")
+    return root
+
+
+def _advance_origin(tmp_path: Path, filename: str = "file1.txt") -> str:
+    """Push a new commit to origin/main from a second clone, simulating a
+    squash merge landing remotely. Returns the new origin/main sha."""
+    clone = tmp_path / f"clone-{filename}"
+    _git("clone", "-b", "main", str(tmp_path / "origin.git"), str(clone),
+         cwd=tmp_path)
+    _git("config", "user.email", "other@example.com", cwd=clone)
+    _git("config", "user.name", "Other", cwd=clone)
+    (clone / filename).write_text("remote change")
+    _git("add", "-A", cwd=clone)
+    _git("commit", "-m", f"add {filename}", cwd=clone)
+    _git("push", "origin", "main", cwd=clone)
+    return _git("rev-parse", "HEAD", cwd=clone)
+
+
+@pytest.fixture
+def stub_gh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Executable ``gh`` stub on PATH, behavior driven by GH_STUB_* env
+    vars (inherited by subprocesses): GH_STUB_CREATE / GH_STUB_MERGE
+    ("ok"|"fail") and GH_STUB_VIEW_STATE ("MERGED"|"OPEN"|"CLOSED")."""
+    bin_dir = tmp_path / "stub-bin"
+    bin_dir.mkdir()
+    gh = bin_dir / "gh"
+    gh.write_text(textwrap.dedent(f"""\
+        #!/bin/sh
+        if [ "$1" = "auth" ]; then exit 0; fi
+        if [ "$1" = "pr" ]; then
+          case "$2" in
+            create)
+              if [ "${{GH_STUB_CREATE:-ok}}" = "fail" ]; then
+                echo "stub: pr create failed" >&2; exit 1
+              fi
+              echo "{STUB_PR_URL}"; exit 0 ;;
+            merge)
+              if [ "${{GH_STUB_MERGE:-ok}}" = "fail" ]; then
+                echo "stub: pr merge failed" >&2; exit 1
+              fi
+              exit 0 ;;
+            view)
+              printf '{{"state": "%s"}}\\n' "${{GH_STUB_VIEW_STATE:-MERGED}}"
+              exit 0 ;;
+          esac
+        fi
+        exit 0
+    """))
+    gh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    return bin_dir
+
+
+def _two_component_manifest() -> Manifest:
+    return Manifest(
+        version="1", spec_file="spec.md", project_name="test",
+        base_branch="main", single_pr=False,
+        components=[
+            Component(
+                "alpha", "Alpha", "First", [],
+                "scripts/ralph/feature/alpha/prd.json",
+                "ralph/factory/alpha",
+            ),
+            Component(
+                "beta", "Beta", "Depends on alpha", ["alpha"],
+                "scripts/ralph/feature/beta/prd.json",
+                "ralph/factory/beta",
+            ),
+        ],
+    )
+
+
+def _factory_config(**overrides: object) -> FactoryConfig:
+    config = FactoryConfig(
+        use_worktrees=True, create_prs=True, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        merge_timeout=2.0,
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_diff_scope=False,
+            check_bad_patterns=False, subprocess_timeout=5.0,
+        ),
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _base_config(root: Path) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root / "scripts" / "ralph" / "prompt.md",
+        prd_file=root / "scripts" / "ralph" / "prd.json",
+        sleep_seconds=0, agent_cmd="echo test",
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    )
+
+
+def _run(
+    manifest: Manifest, root: Path, config: FactoryConfig | None = None,
+) -> tuple[FactoryResult, list[str]]:
+    """run_factory with a fake always-succeeding engineer; returns the
+    result and the component ids the scheduler actually ran."""
+    calls: list[str] = []
+
+    def fake_run(
+        component_id: str, *args: object, **kwargs: object,
+    ) -> ComponentResult:
+        calls.append(component_id)
+        return ComponentResult(component_id, success=True, iterations=1)
+
+    with patch("ralph_py.factory._run_component", side_effect=fake_run):
+        result = run_factory(
+            manifest, config or _factory_config(), _base_config(root),
+            PlainUI(no_color=True), root,
+        )
+    return result, calls
+
+
+class TestPrFlowGatesCompletion:
+    """CRIT-2: each PR-flow failure shape produces the right status and
+    dependents do not schedule."""
+
+    def test_push_failure_fails_component_and_blocks_dependents(
+        self, tmp_path: Path, stub_gh: Path,
+    ) -> None:
+        root = _make_repo(tmp_path, ["alpha", "beta"])
+        # Break the push target AFTER the initial push, so the
+        # origin/main tracking ref exists but pushes fail.
+        _git("remote", "set-url", "origin", str(tmp_path / "missing.git"),
+             cwd=root)
+        manifest = _two_component_manifest()
+
+        result, calls = _run(manifest, root)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.FAILED.value
+        assert "push" in alpha.error
+        assert beta.status == ComponentStatus.SKIPPED.value
+        assert calls == ["alpha"]
+        assert result.failed == ["alpha"]
+        assert "beta" in result.skipped
+        assert result.exit_code == 1
+
+    def test_create_failure_fails_component_and_blocks_dependents(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GH_STUB_CREATE", "fail")
+        root = _make_repo(tmp_path, ["alpha", "beta"])
+        manifest = _two_component_manifest()
+
+        result, calls = _run(manifest, root)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.FAILED.value
+        assert "Failed to create PR" in alpha.error
+        assert beta.status == ComponentStatus.SKIPPED.value
+        assert calls == ["alpha"]
+        assert result.exit_code == 1
+
+    def test_merge_failure_fails_component_and_blocks_dependents(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GH_STUB_MERGE", "fail")
+        root = _make_repo(tmp_path, ["alpha", "beta"])
+        manifest = _two_component_manifest()
+
+        result, calls = _run(manifest, root)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.FAILED.value
+        assert "merge failed" in alpha.error
+        # The PR itself was created and is recorded for the audit trail.
+        assert alpha.pr_url == STUB_PR_URL
+        assert beta.status == ComponentStatus.SKIPPED.value
+        assert calls == ["alpha"]
+        assert result.exit_code == 1
+
+    def test_wait_timeout_marks_merge_pending_dependents_stay_pending(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GH_STUB_VIEW_STATE", "OPEN")
+        root = _make_repo(tmp_path, ["alpha", "beta"])
+        manifest = _two_component_manifest()
+
+        result, calls = _run(manifest, root)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.MERGE_PENDING.value
+        assert alpha.pr_url == STUB_PR_URL  # recorded for the re-poll
+        # NOT failed: dependents stay PENDING (re-pollable), never
+        # SKIPPED, and are not scheduled.
+        assert beta.status == ComponentStatus.PENDING.value
+        assert calls == ["alpha"]
+        assert result.merge_pending == ["alpha"]
+        assert "alpha" not in result.completed
+        assert "alpha" not in result.failed
+        assert result.exit_code == 1
+
+    def test_merged_pr_completes_and_schedules_dependents(
+        self, tmp_path: Path, stub_gh: Path,
+    ) -> None:
+        root = _make_repo(tmp_path, ["alpha", "beta"])
+        manifest = _two_component_manifest()
+        main_before = _git("rev-parse", "main", cwd=root)
+        head_before = _git("rev-parse", "HEAD", cwd=root)
+
+        result, calls = _run(manifest, root)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.COMPLETED.value
+        assert beta.status == ComponentStatus.COMPLETED.value
+        assert calls == ["alpha", "beta"]
+        assert result.completed == ["alpha", "beta"]
+        assert result.exit_code == 0
+        assert len(result.pr_urls) == 2
+
+        # H-1: the operator's checkout was never touched.
+        assert _git("branch", "--show-current", cwd=root) == "operator-branch"
+        assert _git("rev-parse", "main", cwd=root) == main_before
+        assert _git("rev-parse", "HEAD", cwd=root) == head_before
+        notes = root / "OPERATOR_NOTES.txt"
+        assert notes.read_text() == "uncommitted operator state"
+
+
+class TestMergePendingResume:
+    """Crash recovery treats MERGE_PENDING as re-pollable, not failed."""
+
+    def _manifest_with_pending_alpha(self) -> Manifest:
+        manifest = _two_component_manifest()
+        alpha = manifest.get_component("alpha")
+        assert alpha is not None
+        alpha.status = ComponentStatus.MERGE_PENDING.value
+        alpha.pr_number = 7
+        alpha.pr_url = STUB_PR_URL
+        return manifest
+
+    def test_resume_repolls_merged_pr_and_unblocks_dependents(
+        self, tmp_path: Path, stub_gh: Path,
+    ) -> None:
+        root = _make_repo(tmp_path, ["alpha", "beta"])
+        manifest = self._manifest_with_pending_alpha()
+
+        result, calls = _run(manifest, root)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.COMPLETED.value
+        assert beta.status == ComponentStatus.COMPLETED.value
+        # alpha's engineer never re-ran: only its PR state was polled.
+        assert calls == ["beta"]
+        assert "alpha" in result.completed
+        assert result.merge_pending == []
+        assert result.exit_code == 0
+
+    def test_resume_keeps_merge_pending_while_pr_still_open(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GH_STUB_VIEW_STATE", "OPEN")
+        root = _make_repo(tmp_path, ["alpha", "beta"])
+        manifest = self._manifest_with_pending_alpha()
+
+        result, calls = _run(manifest, root)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.MERGE_PENDING.value
+        assert beta.status == ComponentStatus.PENDING.value
+        assert calls == []
+        assert result.merge_pending == ["alpha"]
+        assert result.exit_code == 1
+
+    def test_resume_fails_component_when_pr_closed_without_merge(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GH_STUB_VIEW_STATE", "CLOSED")
+        root = _make_repo(tmp_path, ["alpha", "beta"])
+        manifest = self._manifest_with_pending_alpha()
+
+        result, calls = _run(manifest, root)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.FAILED.value
+        assert "closed without merge" in alpha.error
+        assert beta.status == ComponentStatus.SKIPPED.value
+        assert calls == []
+        assert result.exit_code == 1
+
+
+class TestPrOutcomeDataclass:
+    """push_create_and_merge_pr returns a typed PrOutcome per scenario."""
+
+    def _single_component(self, manifest: Manifest, root: Path) -> Component:
+        comp = manifest.get_component("alpha")
+        assert comp is not None
+        _git("branch", comp.branch_name, "main", cwd=root)
+        return comp
+
+    def test_merged_outcome(self, tmp_path: Path, stub_gh: Path) -> None:
+        root = _make_repo(tmp_path, ["alpha"])
+        manifest = _two_component_manifest()
+        comp = self._single_component(manifest, root)
+
+        outcome = push_create_and_merge_pr(
+            comp, manifest, root, PlainUI(no_color=True), merge_timeout=2.0,
+        )
+
+        assert outcome == PrOutcome(
+            pushed=True, pr_number=7, pr_url=STUB_PR_URL,
+            merged=True, merge_pending=False, error=None,
+        )
+
+    def test_wait_timeout_outcome(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GH_STUB_VIEW_STATE", "OPEN")
+        root = _make_repo(tmp_path, ["alpha"])
+        manifest = _two_component_manifest()
+        comp = self._single_component(manifest, root)
+
+        outcome = push_create_and_merge_pr(
+            comp, manifest, root, PlainUI(no_color=True), merge_timeout=1.0,
+        )
+
+        assert outcome.pushed is True
+        assert outcome.merged is False
+        assert outcome.merge_pending is True
+        assert outcome.pr_number == 7
+        assert outcome.error is not None and "not merged within" in outcome.error
+
+    def test_push_failure_outcome(
+        self, tmp_path: Path, stub_gh: Path,
+    ) -> None:
+        root = _make_repo(tmp_path, ["alpha"])
+        _git("remote", "set-url", "origin", str(tmp_path / "missing.git"),
+             cwd=root)
+        manifest = _two_component_manifest()
+        comp = self._single_component(manifest, root)
+
+        outcome = push_create_and_merge_pr(
+            comp, manifest, root, PlainUI(no_color=True), merge_timeout=1.0,
+        )
+
+        assert outcome.pushed is False
+        assert outcome.merged is False
+        assert outcome.merge_pending is False
+        assert outcome.error is not None
+
+    def test_existing_merged_pr_short_circuits(
+        self, tmp_path: Path, stub_gh: Path,
+    ) -> None:
+        root = _make_repo(tmp_path, ["alpha"])
+        manifest = _two_component_manifest()
+        comp = manifest.get_component("alpha")
+        assert comp is not None
+        comp.pr_number = 7
+        comp.pr_url = STUB_PR_URL
+
+        outcome = push_create_and_merge_pr(
+            comp, manifest, root, PlainUI(no_color=True), merge_timeout=1.0,
+        )
+
+        assert outcome.merged is True
+        assert outcome.pr_number == 7
+
+    def test_wait_for_merge_distinguishes_closed_from_timeout(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        root = _make_repo(tmp_path, ["alpha"])
+        monkeypatch.setenv("GH_STUB_VIEW_STATE", "CLOSED")
+        assert wait_for_merge(7, root, timeout=1.0) == "closed"
+        monkeypatch.setenv("GH_STUB_VIEW_STATE", "OPEN")
+        assert wait_for_merge(7, root, timeout=1.0) == "pending"
+        monkeypatch.setenv("GH_STUB_VIEW_STATE", "MERGED")
+        assert wait_for_merge(7, root, timeout=1.0) == "merged"
+
+
+class TestFetchNeverPull:
+    """H-1: base freshness comes from fetch; the checkout is never moved."""
+
+    def test_fetch_updates_tracking_ref_without_touching_checkout(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _make_repo(tmp_path, ["alpha"])
+        new_sha = _advance_origin(tmp_path)
+        main_before = _git("rev-parse", "main", cwd=root)
+        head_before = _git("rev-parse", "HEAD", cwd=root)
+        assert main_before != new_sha
+
+        assert git.fetch_base_branch("main", root) is None
+
+        assert _git("rev-parse", "refs/remotes/origin/main", cwd=root) == new_sha
+        assert _git("rev-parse", "main", cwd=root) == main_before
+        assert _git("rev-parse", "HEAD", cwd=root) == head_before
+        assert _git("branch", "--show-current", cwd=root) == "operator-branch"
+        notes = root / "OPERATOR_NOTES.txt"
+        assert notes.read_text() == "uncommitted operator state"
+
+    def test_fetch_reports_error_when_no_remote(self, tmp_path: Path) -> None:
+        root = _make_repo(tmp_path, ["alpha"], with_origin=False)
+        error = git.fetch_base_branch("main", root)
+        assert error is not None
+
+
+class TestBaseRefResolution:
+    """Worktrees and diffs use origin/<base> when a remote exists and
+    fall back to the local base ref otherwise."""
+
+    def test_resolves_to_origin_when_tracking_ref_exists(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _make_repo(tmp_path, ["alpha"])
+        assert git.resolve_base_ref("main", root) == "origin/main"
+
+    def test_falls_back_to_local_ref_without_remote(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _make_repo(tmp_path, ["alpha"], with_origin=False)
+        assert git.resolve_base_ref("main", root) == "main"
+
+    def test_origin_prefixed_ref_passes_through(self, tmp_path: Path) -> None:
+        root = _make_repo(tmp_path, ["alpha"])
+        assert git.resolve_base_ref("origin/main", root) == "origin/main"
+
+    def test_diff_against_origin_base_removes_phantom_diffs(
+        self, tmp_path: Path,
+    ) -> None:
+        """Squash merges rewrite SHAs: a branch cut from origin/<base>
+        diffed against a stale LOCAL base shows the already-merged files
+        as phantom changes. Resolving to origin/<base> removes them."""
+        root = _make_repo(tmp_path, ["alpha"])
+        # A "squash-merged PR" lands on origin only; local main is stale.
+        _advance_origin(tmp_path, filename="file1.txt")
+        assert git.fetch_base_branch("main", root) is None
+
+        wt = tmp_path / "wt-feat2"
+        _git("worktree", "add", str(wt), "-b", "feat2", "origin/main",
+             cwd=root)
+        (wt / "file2.txt").write_text("component change")
+        _git("add", "-A", cwd=wt)
+        _git("commit", "-m", "feat2 change", cwd=wt)
+
+        names = git.get_diff_names("main", cwd=wt)
+        assert names == ["file2.txt"]  # no phantom file1.txt
+        content = git.get_diff_content("main", cwd=wt)
+        assert "file2.txt" in content and "file1.txt" not in content
+
+    def test_factory_worktrees_fall_back_without_remote(
+        self, tmp_path: Path,
+    ) -> None:
+        """Local-only repos (and the test suite) keep working: worktrees
+        cut from the local base ref when there is no origin."""
+        root = _make_repo(tmp_path, ["alpha", "beta"], with_origin=False)
+        manifest = _two_component_manifest()
+        config = _factory_config(create_prs=False)
+
+        result, calls = _run(manifest, root, config)
+
+        assert result.completed == ["alpha", "beta"]
+        assert calls == ["alpha", "beta"]
+        assert result.exit_code == 0
+        assert _git("branch", "--show-current", cwd=root) == "operator-branch"


### PR DESCRIPTION
## Roadmap items

R0.2 (M) **PR/merge outcome gates completion** [CRIT-2, H-1, MED pr-timeouts]

## What changed

- **`pr.py`**: `push_create_and_merge_pr` returns a typed frozen `PrOutcome`
  (pushed / pr_number / pr_url / merged / merge_pending / error) instead of the
  lossy `tuple | None`. Every `gh`/`git` subprocess in the module now has an
  explicit timeout (`GH_TIMEOUT=60s`, `GH_POLL_TIMEOUT=30s`, `PUSH_TIMEOUT=300s`),
  including each poll inside `wait_for_merge`, whose sleep is clamped to the
  remaining deadline. `wait_for_merge` distinguishes `merged` / `closed` /
  `pending` instead of collapsing closed-without-merge and timeout into `False`.
  The existing-PR path verifies the PR state instead of assuming success.
- **`pr.py` (H-1)**: the post-merge `git pull origin <base>` on the operator's
  checkout is replaced with `git fetch origin <base>`, which updates only
  `refs/remotes/origin/<base>`. No code path in scope touches the checked-out
  branch, the local base branch, or uncommitted state.
- **`factory.py`**: a component is COMPLETED only when `PrOutcome.merged` is
  True (or PRs are disabled). Push/create/merge failures mark it FAILED and
  cascade-skip dependents. A `wait_for_merge` timeout parks it in the new
  `MERGE_PENDING` manifest status: dependents stay PENDING (never scheduled,
  never skipped), the run exits nonzero, and crash recovery re-polls the PR on
  the next run (merged -> COMPLETED and dependents unblock; closed -> FAILED;
  still open -> stays MERGE_PENDING). Merge wait time is `FactoryConfig.merge_timeout`
  (toml `merge_timeout` / env `FACTORY_MERGE_TIMEOUT`, default 300s).
- **`git.py`**: new `resolve_base_ref` (single place that decides
  `origin/<base>` vs local `<base>`) and `fetch_base_branch`. Worktrees are cut
  from the resolved ref (with a non-fatal freshness fetch at setup) and
  `get_diff_names` / `get_diff_content` diff against it, so squash-merge SHA
  rewrites no longer produce phantom diffs. Local-only repos (no origin) fall
  back to the local base ref.
- **`manifest.py`**: `ComponentStatus.MERGE_PENDING` added.
  `get_ready_components` requires COMPLETED deps, so MERGE_PENDING blocks
  dependents with no further changes.
- **single_pr exemption**: the per-component PR block now skips `single_pr`
  mode. All components share one branch there; squash-merging it after the
  first component would destroy the history the remaining components build on.
  The end-of-run `create_single_pr` path is unchanged.

## Tested

(behaviors proven by named tests in `tests/test_pr_outcomes.py`, real git repos + stub `gh` binary on PATH)

- push-fail -> component FAILED (error names the push), dependent SKIPPED, engineer ran once, exit 1: `test_push_failure_fails_component_and_blocks_dependents` (+ `test_push_failure_outcome` for the raw PrOutcome)
- create-fail -> FAILED / dependent SKIPPED / exit 1: `test_create_failure_fails_component_and_blocks_dependents`
- merge-fail -> FAILED with PR recorded for audit trail / dependent SKIPPED: `test_merge_failure_fails_component_and_blocks_dependents`
- wait-timeout -> MERGE_PENDING, dependent stays PENDING (not skipped, not scheduled), `result.merge_pending`, exit 1: `test_wait_timeout_marks_merge_pending_dependents_stay_pending` (+ `test_wait_timeout_outcome`)
- merged -> both components complete in dependency order, exit 0, operator branch/HEAD/local main/uncommitted file all untouched: `test_merged_pr_completes_and_schedules_dependents`
- crash recovery re-poll: merged PR completes the component without re-running its engineer and unblocks the dependent (`test_resume_repolls_merged_pr_and_unblocks_dependents`); still-open PR stays MERGE_PENDING with dependents unscheduled (`test_resume_keeps_merge_pending_while_pr_still_open`); closed PR fails and cascade-skips (`test_resume_fails_component_when_pr_closed_without_merge`)
- `wait_for_merge` distinguishes merged/closed/pending: `test_wait_for_merge_distinguishes_closed_from_timeout`
- existing-PR path verifies state instead of assuming success: `test_existing_merged_pr_short_circuits`
- fetch updates `refs/remotes/origin/main` only; checked-out branch, HEAD, local main, and uncommitted files untouched: `test_fetch_updates_tracking_ref_without_touching_checkout`
- squash-merge phantom-diff class removed (branch cut from origin/main diffed while local main is stale shows only its own files): `test_diff_against_origin_base_removes_phantom_diffs`
- no-remote fallback: `resolve_base_ref` returns the local ref (`test_falls_back_to_local_ref_without_remote`), full worktree factory run completes with `create_prs=False` (`test_factory_worktrees_fall_back_without_remote`), `fetch_base_branch` reports the error (`test_fetch_reports_error_when_no_remote`)
- `push_branch` new error-or-None contract keeps R0.6 separator behavior: updated `test_push_branch_legitimate`, `test_push_branch_option_shape_fails_closed`, `test_push_branch_uses_separator`

## Assumed

(claimed but not covered by a test)

- **gh unavailable with `create_prs=True` still completes components** (pre-R0.2
  behavior, now with a loud per-component warning). The strictest reading of
  "COMPLETED only when merged" would fail every component for local users
  without gh under the default config; kept the lenient behavior deliberately.
- **PR-flow failures do not consume agent retries**: push/create/merge failures
  FAIL the component directly rather than re-running the engineer, since
  re-running the agent cannot fix gh auth, permissions, or merge conflicts
  (halt over heroics). Manual remediation + re-run is the recovery path.
- **Timeout constants are chosen, not measured** (60s gh calls, 30s polls, 300s
  push). They bound hangs; they are not tuned latency budgets.
- A gh error/timeout during `wait_for_merge` polling counts as "not yet
  merged" and rides to the deadline -> MERGE_PENDING (re-pollable), assumed
  preferable to hard-failing on a transient gh outage.
- A failed `git fetch` after a CONFIRMED merge records the error on the
  (still merged=True) outcome and warns; the per-component setup fetch retries
  freshness before each worktree cut. Not separately tested.
- `FactoryConfig.load` reads `merge_timeout` from toml/env, but the
  `ralph factory` CLI constructs `FactoryConfig` directly and does not yet pass
  it; config plumbing is R2.1's scope.
- Behavior when `origin/<base>` exists but the remote is unreachable mid-run:
  setup fetch fails silently and the (possibly stale) tracking ref is used;
  loud failure then happens at push/PR time, not silently at diff time.

## Checks

```
uv run pytest tests/ -q
793 passed, 12 skipped, 1 warning in 299.42s (0:04:59)

uv run mypy ralph_py/ --strict
Success: no issues found in 37 source files

uv run ruff check ralph_py/ tests/
All checks passed!
```

R0.2 checkbox flipped in `docs/remediation-roadmap.md` in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
