### PR TITLE
fix: R1.5 scope-guard hardening (rename-aware diffs, allowedPaths content validation, fail-closed PRD load)

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -179,7 +179,7 @@ reviewers' output as much as it distrusts the engineer's.
     run multiple review passes (bounded by budget), or fail with an infra
     finding. Advisory mode: annotate PASS as partial.
   - Strip the Self-Critique block for the security reviewer too (`security.py:377`).
-- [ ] R1.5 (M) **Scope-guard hardening** [H-4, H-5, MED scope-none-fallthrough]
+- [x] R1.5 (M) **Scope-guard hardening** [H-4, H-5, MED scope-none-fallthrough]
   - `git.get_diff_names`: use `--name-status -M`; rename/copy sources count as
     changed paths for scope purposes.
   - `decompose._validate_decompose_output`: validate allowedPaths CONTENT
@@ -188,6 +188,12 @@ reviewers' output as much as it distrusts the engineer's.
     reject and retry-with-error like other validation failures.
   - `factory.py:554-558`: PRD load failure fails the diff-scope check closed
     (infra failure) instead of silently disabling scope.
+  - Note (2026-07-18, session 3C): `get_diff_names` now runs
+    `--name-status -z -M -C` and returns both sides of renames/copies;
+    the validator enforces the prompt's EXCLUDE list verbatim plus
+    absolute/`..`/whole-repo entries; the factory forwards PRD load
+    failures as `allowed_paths_error`, which `check_diff_scope` fails
+    closed. Covered by `tests/test_scope_hardening.py`.
 - [x] R1.6 (M) **Knowledge retention + read-side defense** [CRIT-4, H-3, MED knowledge-trust, LOW nonce-order]
   - Retrieval: union across run dirs with per-fact-id latest-wins (supersede by
     fact id, not by directory). The DISTILL rule "do not duplicate existing

--- a/ralph_py/decompose.py
+++ b/ralph_py/decompose.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from ralph_py.manifest import (
@@ -336,6 +336,68 @@ def _extract_agent_json(agent: Any, output_lines: list[str]) -> Any:
     raise last_error
 
 
+# R1.5 / H-4: DECOMPOSE_PROMPT rule #12 promises the harness rejects
+# allowedPaths entries that would reopen its own guardrails. This is
+# that enforcement -- exactly the prompt's EXCLUDE list. Entries are
+# compared after normalization (leading `./` and trailing `/` removed)
+# so `.ralph`, `.ralph/` and `./.ralph/` all match. Keep this set in
+# sync with the prompt body (which only Session 8C may edit).
+_ALLOWED_PATHS_EXCLUDE: frozenset[str] = frozenset({
+    ".ralph",          # harness runtime state
+    ".github",         # CI configuration
+    "ralph_py",        # harness package
+    "src/ralph",       # legacy harness package
+    "scripts/ralph",   # bare prefix exposes the manifest + sibling features
+    "pyproject.toml",  # repo-root build manifests
+    "package.json",
+    "Cargo.toml",
+})
+
+
+def _validate_allowed_path_entry(entry: str) -> str | None:
+    """Return an error message if an allowedPaths entry is unacceptable.
+
+    Enforces the DECOMPOSE_PROMPT rule #12 EXCLUDE list plus structural
+    hazards: absolute paths, `..` traversal, and whole-repo scopes.
+    Returns None for acceptable entries. Errors feed the decompose
+    retry-with-error loop, so they address the architect directly.
+    """
+    stripped = entry.strip()
+    if stripped.startswith("/"):
+        if stripped.rstrip("/") == "":
+            return (
+                f"entry '{entry}' grants whole-repo scope; list specific "
+                "source/test/feature path prefixes instead"
+            )
+        return (
+            f"entry '{entry}' is an absolute path; entries must be "
+            "repo-relative prefixes"
+        )
+    if ".." in PurePosixPath(stripped).parts:
+        return (
+            f"entry '{entry}' contains '..'; path traversal outside the "
+            "worktree is not allowed"
+        )
+    normalized = stripped
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    normalized = normalized.rstrip("/")
+    if normalized in ("", "."):
+        return (
+            f"entry '{entry}' grants whole-repo scope; list specific "
+            "source/test/feature path prefixes instead"
+        )
+    if normalized in _ALLOWED_PATHS_EXCLUDE:
+        return (
+            f"entry '{entry}' is on the DECOMPOSE_PROMPT EXCLUDE list "
+            "(harness state, CI config, repo-root build manifests, and "
+            "the harness's own packages are never in scope; for "
+            "scripts/ralph list only this component's own "
+            "scripts/ralph/feature/<id>/ subtree)"
+        )
+    return None
+
+
 def _validate_decompose_output(data: Any) -> list[str]:
     """Validate the decomposition output structure.
 
@@ -447,6 +509,15 @@ def _validate_decompose_output(data: Any) -> list[str]:
                 errors.append(
                     f"{prefix}.allowedPaths: all items must be non-empty strings"
                 )
+            else:
+                # R1.5 / H-4: content validation. Without this, only
+                # the SHAPE was checked and the architect could emit
+                # `.ralph/` or `ralph_py/`, reopening the guardrail
+                # the prompt claims the harness enforces.
+                for p in ap:
+                    entry_error = _validate_allowed_path_entry(p)
+                    if entry_error:
+                        errors.append(f"{prefix}.allowedPaths: {entry_error}")
 
         stories = comp.get("userStories")
         if not isinstance(stories, list):

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -763,26 +763,28 @@ def run_factory(
         # prior "no constraint" behavior; v1.2.0+ architect outputs are
         # gated upstream in decompose._validate_decompose_output.
         #
-        # Acknowledged limitation: the try/except below briefly masks
-        # real PRD problems by falling through to allowed_paths=None.
-        # The verifier surfaces real PRD problems on its own checks
-        # (check_prd_stories) so this is a one-iteration grace period,
-        # not silent forever -- but a downstream consumer reading
-        # comp.findings should not assume allowed_paths=None means
-        # "intentionally unconstrained" without cross-referencing the
-        # verifier's PRD check status.
+        # R1.5: a PRD that fails to LOAD is not the same as a PRD with
+        # no allowedPaths. Swallowing the load error into
+        # allowed_paths=None silently disabled the scope check -- an
+        # agent that corrupts or deletes its own PRD would unbind its
+        # write scope. Load failure now flows into check_diff_scope as
+        # allowed_paths_error, which fails the check closed.
         component_allowed_paths: list[str] | None = None
+        allowed_paths_error: str | None = None
         try:
             prd_for_scope = PRD.load(wt_path / comp.prd_path)
             component_allowed_paths = prd_for_scope.allowed_paths
-        except (FileNotFoundError, ValueError):
-            pass
+        except FileNotFoundError as exc:
+            allowed_paths_error = f"PRD not found: {exc}"
+        except ValueError as exc:
+            allowed_paths_error = f"PRD failed to parse: {exc}"
         verification = run_mechanical_verification(
             wt_path,
             wt_path / comp.prd_path,
             manifest.base_branch,
             component_allowed_paths,
             verify_config,
+            allowed_paths_error=allowed_paths_error,
         )
         verify_duration = time.monotonic() - verify_start
         comp.verification_passed = verification.passed

--- a/ralph_py/git.py
+++ b/ralph_py/git.py
@@ -285,25 +285,64 @@ def get_diff_names(
 
     The base is resolved through :func:`resolve_base_ref` so diffs
     measure against ``origin/<base>`` whenever a remote exists (R0.2).
+
+    Rename/copy detection is explicit (`-M -C`) and BOTH sides of a
+    rename or copy count as changed paths. With `--name-only`, git's
+    rename detection reports only the destination, so
+    `git mv protected/gate.py allowed/gate.py` looked like a change
+    confined to `allowed/` and defeated the diff-scope guard
+    (R1.5 / H-5). For scope purposes the source changed too: content
+    left it.
     """
     base_ref = resolve_base_ref(base_branch, cwd, timeout)
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", f"{base_ref}...HEAD", "--"],
+            [
+                "git", "diff", "--name-status", "-z", "-M", "-C",
+                f"{base_ref}...HEAD", "--",
+            ],
             cwd=cwd,
             capture_output=True,
             text=True,
             timeout=timeout,
         )
         if result.returncode == 0:
-            return [
-                line.strip()
-                for line in result.stdout.splitlines()
-                if line.strip()
-            ]
+            return _parse_name_status_z(result.stdout)
     except subprocess.TimeoutExpired:
         pass
     return []
+
+
+def _parse_name_status_z(output: str) -> list[str]:
+    """Parse `git diff --name-status -z` output into a flat path list.
+
+    Records are NUL-separated: a status token followed by one path,
+    except rename/copy statuses (`R<score>`/`C<score>`) which carry
+    source AND destination. Both are included. Order is preserved and
+    duplicates (e.g. a copy source that was also modified) collapse.
+    """
+    tokens = output.split("\0")
+    paths: list[str] = []
+    i = 0
+    while i < len(tokens):
+        status = tokens[i]
+        if not status:
+            i += 1
+            continue
+        if status[0] in ("R", "C"):
+            paths.extend(tokens[i + 1:i + 3])
+            i += 3
+        else:
+            if i + 1 < len(tokens):
+                paths.append(tokens[i + 1])
+            i += 2
+    seen: set[str] = set()
+    unique: list[str] = []
+    for path in paths:
+        if path and path not in seen:
+            seen.add(path)
+            unique.append(path)
+    return unique
 
 
 def get_diff_content(

--- a/ralph_py/verify.py
+++ b/ralph_py/verify.py
@@ -487,9 +487,36 @@ def check_diff_scope(
     cwd: Path,
     base_branch: str,
     allowed_paths: list[str] | None = None,
+    allowed_paths_error: str | None = None,
 ) -> CheckResult:
-    """Check that git diff is within expected scope."""
+    """Check that git diff is within expected scope.
+
+    ``allowed_paths_error`` marks an infrastructure failure loading the
+    scope configuration (the PRD carrying allowedPaths was missing or
+    unparseable). The check then fails CLOSED: the diff cannot be
+    proven in-scope, and silently skipping the guard is exactly the
+    hole R1.5 closes. This is distinct from ``allowed_paths=None``,
+    which means no scope was configured -- a legitimate pass.
+    """
     start = time.monotonic()
+
+    if allowed_paths_error:
+        return CheckResult(
+            name="diff_scope",
+            passed=False,
+            message=(
+                "Scope configuration could not be loaded; failing closed "
+                "(infrastructure error, not a diff violation)"
+            ),
+            details=[
+                f"Error: {allowed_paths_error}",
+                "The PRD carrying allowedPaths failed to load, so the "
+                "diff cannot be proven in-scope. Restore a valid PRD "
+                "file; do not treat this as permission to widen the "
+                "diff.",
+            ],
+            duration_seconds=time.monotonic() - start,
+        )
 
     if not allowed_paths:
         return CheckResult(
@@ -859,6 +886,7 @@ def run_mechanical_verification(
     base_branch: str,
     allowed_paths: list[str] | None,
     config: VerifyConfig,
+    allowed_paths_error: str | None = None,
 ) -> VerificationResult:
     """Run all 6 mechanical checks. All checks run even if earlier ones fail."""
     checks: list[CheckResult] = []
@@ -880,6 +908,7 @@ def run_mechanical_verification(
     if config.check_diff_scope:
         checks.append(check_diff_scope(
             worktree_path, base_branch, allowed_paths,
+            allowed_paths_error=allowed_paths_error,
         ))
 
     if config.check_bad_patterns:

--- a/tests/test_scope_hardening.py
+++ b/tests/test_scope_hardening.py
@@ -1,0 +1,518 @@
+"""R1.5 scope-guard hardening tests (H-4, H-5, scope-none-fallthrough).
+
+Three defect classes are covered:
+
+1. Rename-move scope escape (H-5): `git diff --name-only` with git's
+   rename detection lists only the DESTINATION of a rename, so
+   `git mv protected/gate.py allowed/gate.py` looked in-scope.
+   `git.get_diff_names` now reports both sides of renames/copies.
+2. allowedPaths content (H-4): DECOMPOSE_PROMPT rule #12 promises the
+   harness rejects entries like `.ralph/`; the validator now enforces
+   exactly that EXCLUDE list plus structural hazards, and the error
+   flows through the decompose retry-with-error loop.
+3. PRD-load fail-closed: a PRD that fails to load at the factory's
+   scope site fails the diff_scope check (infrastructure error)
+   instead of silently disabling it; a PRD legitimately WITHOUT
+   allowedPaths still passes with the existing message.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from ralph_py.config import RalphConfig
+from ralph_py.decompose import (
+    _validate_allowed_path_entry,
+    _validate_decompose_output,
+    decompose_spec,
+)
+from ralph_py.factory import ComponentResult, FactoryConfig, run_factory
+from ralph_py.git import _parse_name_status_z, get_diff_names
+from ralph_py.manifest import Component, Manifest
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import (
+    CheckResult,
+    VerificationResult,
+    VerifyConfig,
+    check_diff_scope,
+    run_mechanical_verification,
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo_with_protected_file(tmp_path: Path) -> Path:
+    """Real repo whose base commit (mirrored to origin) contains a
+    protected file, so a branch-side `git mv` is a true rename against
+    the merge base."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "protected").mkdir()
+    (repo / "allowed").mkdir()
+    (repo / "protected" / "gate.py").write_text(
+        "def gate() -> bool:\n"
+        "    # deliberately long, distinctive content so git's rename\n"
+        "    # detection scores this file as a clean R100 move\n"
+        "    return check_signature() and check_scope() and check_budget()\n"
+    )
+    (repo / "allowed" / "app.py").write_text("APP = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "clone", "-q", "--bare", str(repo), str(origin)],
+        cwd=tmp_path, check=True, capture_output=True,
+    )
+    _git(repo, "remote", "add", "origin", str(origin))
+    return repo
+
+
+class TestRenameAwareDiffNames:
+    """H-5: rename/copy SOURCES count as changed paths."""
+
+    def test_rename_move_reports_both_sides(
+        self, repo_with_protected_file: Path,
+    ) -> None:
+        repo = repo_with_protected_file
+        _git(repo, "checkout", "-qb", "feat")
+        _git(repo, "mv", "protected/gate.py", "allowed/gate.py")
+        _git(repo, "commit", "-qm", "move gate")
+
+        names = get_diff_names("main", cwd=repo)
+        assert "protected/gate.py" in names
+        assert "allowed/gate.py" in names
+
+    def test_rename_move_fails_diff_scope(
+        self, repo_with_protected_file: Path,
+    ) -> None:
+        """The empirical H-5 repro: `git mv protected/gate.py
+        allowed/gate.py` must no longer pass a scope of allowed/."""
+        repo = repo_with_protected_file
+        _git(repo, "checkout", "-qb", "feat")
+        _git(repo, "mv", "protected/gate.py", "allowed/gate.py")
+        _git(repo, "commit", "-qm", "move gate")
+
+        result = check_diff_scope(repo, "main", allowed_paths=["allowed/"])
+        assert result.passed is False
+        details = "\n".join(result.details)
+        assert "protected/gate.py" in details
+
+    def test_plain_changes_still_reported(
+        self, repo_with_protected_file: Path,
+    ) -> None:
+        """Modify/add/delete statuses keep working under --name-status."""
+        repo = repo_with_protected_file
+        _git(repo, "checkout", "-qb", "feat")
+        (repo / "allowed" / "app.py").write_text("APP = 2\n")
+        (repo / "allowed" / "new.py").write_text("NEW = 1\n")
+        _git(repo, "rm", "-q", "protected/gate.py")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-qm", "edits")
+
+        names = get_diff_names("main", cwd=repo)
+        assert sorted(names) == [
+            "allowed/app.py", "allowed/new.py", "protected/gate.py",
+        ]
+
+
+class TestParseNameStatusZ:
+    """Unit coverage for the -z record parser, including copy records
+    (C status is heuristic-dependent in real repos, so it is pinned
+    here rather than via git)."""
+
+    def test_rename_record_yields_source_and_destination(self) -> None:
+        raw = "R100\0protected/gate.py\0allowed/gate.py\0"
+        assert _parse_name_status_z(raw) == [
+            "protected/gate.py", "allowed/gate.py",
+        ]
+
+    def test_copy_record_yields_source_and_destination(self) -> None:
+        raw = "C087\0protected/gate.py\0allowed/copy.py\0"
+        assert _parse_name_status_z(raw) == [
+            "protected/gate.py", "allowed/copy.py",
+        ]
+
+    def test_mixed_records_dedupe_and_preserve_order(self) -> None:
+        raw = (
+            "M\0a.py\0"
+            "R100\0old/x.py\0new/x.py\0"
+            "M\0a.py\0"
+            "A\0b.py\0"
+            "D\0gone.py\0"
+        )
+        assert _parse_name_status_z(raw) == [
+            "a.py", "old/x.py", "new/x.py", "b.py", "gone.py",
+        ]
+
+    def test_empty_output(self) -> None:
+        assert _parse_name_status_z("") == []
+
+
+def _decompose_payload(allowed_paths: list[str]) -> dict[str, Any]:
+    return {
+        "components": [
+            {
+                "id": "comp-a",
+                "title": "Component",
+                "description": "A component",
+                "dependencies": [],
+                "allowedPaths": allowed_paths,
+                "userStories": [
+                    {
+                        "id": "US-001",
+                        "title": "Story",
+                        "acceptanceCriteria": ["Works", "Tests pass"],
+                        "priority": 1,
+                        "passes": False,
+                        "notes": "",
+                    }
+                ],
+            }
+        ]
+    }
+
+
+class TestAllowedPathsContentValidation:
+    """H-4: the validator enforces the EXCLUDE list DECOMPOSE_PROMPT
+    rule #12 promises, plus structural hazards."""
+
+    @pytest.mark.parametrize("entry", [
+        ".ralph/",
+        ".github/",
+        "ralph_py/",
+        "src/ralph/",
+        "scripts/ralph/",
+        "pyproject.toml",
+        "package.json",
+        "Cargo.toml",
+    ])
+    def test_each_prompt_exclude_entry_rejected(self, entry: str) -> None:
+        errors = _validate_decompose_output(_decompose_payload([entry]))
+        assert any("allowedPaths" in e and entry in e for e in errors), errors
+
+    @pytest.mark.parametrize("entry", [
+        ".ralph",           # no trailing slash
+        "./ralph_py/",      # leading ./
+        "./.ralph",         # both
+        "scripts/ralph",    # bare prefix, no slash
+    ])
+    def test_normalized_variants_rejected(self, entry: str) -> None:
+        errors = _validate_decompose_output(_decompose_payload([entry]))
+        assert any("allowedPaths" in e for e in errors), errors
+
+    @pytest.mark.parametrize("entry", [
+        "/etc/passwd",
+        "/src/",
+        "..",
+        "../sibling/",
+        "src/../../escape/",
+        "/",
+        ".",
+        "./",
+    ])
+    def test_structural_hazards_rejected(self, entry: str) -> None:
+        errors = _validate_decompose_output(_decompose_payload([entry]))
+        assert any("allowedPaths" in e for e in errors), errors
+
+    @pytest.mark.parametrize("entry", [
+        "src/",
+        "tests/",
+        "lib/",
+        "scripts/ralph/feature/comp-a/",
+        "docs/pyproject.toml",   # manifest NOT at repo root
+        "packages/",             # prefix-similar to an excluded name
+        "ralph_py_docs/",
+    ])
+    def test_legitimate_entries_accepted(self, entry: str) -> None:
+        assert _validate_allowed_path_entry(entry) is None
+        assert _validate_decompose_output(_decompose_payload([entry])) == []
+
+    def test_error_message_names_offending_entry(self) -> None:
+        """The error feeds the retry prompt, so the architect must be
+        told which entry to drop."""
+        error = _validate_allowed_path_entry(".ralph/")
+        assert error is not None
+        assert ".ralph/" in error
+        assert "EXCLUDE" in error
+
+
+class _SequenceAgent:
+    """Agent returning one canned output per invocation."""
+
+    def __init__(self, outputs: list[str]):
+        self._outputs = outputs
+        self._calls = 0
+        self._final_message: str | None = None
+        self.prompts: list[str] = []
+
+    @property
+    def name(self) -> str:
+        return "sequence-agent"
+
+    def run(self, prompt: str, cwd: Path | None = None) -> Iterator[str]:
+        self.prompts.append(prompt)
+        output = self._outputs[min(self._calls, len(self._outputs) - 1)]
+        self._calls += 1
+        self._final_message = output
+        yield from output.splitlines()
+
+    def get_final_message(self) -> str | None:
+        return self._final_message
+
+
+class TestExcludeRejectionFlowsThroughRetryLoop:
+    def test_retry_prompt_carries_entry_error(self, tmp_path: Path) -> None:
+        """First attempt lists `.ralph/`; the retry prompt must contain
+        the rejection so the architect can fix it, and the corrected
+        second attempt must succeed."""
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Feature")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+
+        bad = json.dumps(_decompose_payload([".ralph/", "src/"]))
+        good = json.dumps(_decompose_payload(["src/", "tests/"]))
+        agent = _SequenceAgent([bad, good])
+
+        manifest = decompose_spec(
+            spec_path=spec_file,
+            project_name="test",
+            base_branch="main",
+            single_pr=True,
+            agent=agent,
+            ui=PlainUI(no_color=True),
+            root_dir=tmp_path,
+        )
+
+        assert len(agent.prompts) == 2
+        assert "PREVIOUS ATTEMPT FAILED" in agent.prompts[1]
+        assert ".ralph/" in agent.prompts[1]
+        assert [c.id for c in manifest.components] == ["comp-a"]
+
+
+class TestDiffScopeFailsClosed:
+    """PRD-load failure fails the check; unconfigured scope still
+    passes with the existing message."""
+
+    def test_allowed_paths_error_fails_check(self, tmp_path: Path) -> None:
+        result = check_diff_scope(
+            tmp_path, "main",
+            allowed_paths=None,
+            allowed_paths_error="PRD failed to parse: bad JSON",
+        )
+        assert result.passed is False
+        assert result.name == "diff_scope"
+        assert "failing closed" in result.message
+        assert any("PRD failed to parse" in d for d in result.details)
+
+    def test_error_wins_even_with_allowed_paths(self, tmp_path: Path) -> None:
+        """A half-loaded state (paths recovered but an error was
+        recorded) must still fail closed rather than judge scope on
+        possibly-stale paths."""
+        result = check_diff_scope(
+            tmp_path, "main",
+            allowed_paths=["src/"],
+            allowed_paths_error="PRD not found: prd.json",
+        )
+        assert result.passed is False
+
+    def test_unconfigured_scope_still_passes(self, tmp_path: Path) -> None:
+        result = check_diff_scope(tmp_path, "main", allowed_paths=None)
+        assert result.passed is True
+        assert result.message == "No scope constraints (allowed_paths not set)"
+
+    def test_run_mechanical_verification_forwards_error(
+        self, tmp_path: Path,
+    ) -> None:
+        prd_path = tmp_path / "prd.json"
+        prd_path.write_text(json.dumps({
+            "branchName": "test",
+            "userStories": [{
+                "id": "US-001", "title": "T",
+                "acceptanceCriteria": ["AC"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+        config = VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_bad_patterns=False,
+            subprocess_timeout=5.0,
+        )
+        verification = run_mechanical_verification(
+            tmp_path, prd_path, "main", None, config,
+            allowed_paths_error="PRD failed to parse: bad JSON",
+        )
+        diff_scope = next(
+            c for c in verification.checks if c.name == "diff_scope"
+        )
+        assert diff_scope.passed is False
+        assert verification.passed is False
+
+
+def _factory_fixtures(tmp_path: Path) -> tuple[Manifest, FactoryConfig, RalphConfig]:
+    ralph_dir = tmp_path / "scripts" / "ralph"
+    ralph_dir.mkdir(parents=True)
+    (ralph_dir / "prompt.md").write_text("test prompt")
+    manifest = Manifest(
+        version="1",
+        spec_file="spec.md",
+        project_name="test",
+        base_branch="main",
+        single_pr=False,
+        components=[
+            Component(
+                "comp-a", "Component A", "Desc",
+                [], "scripts/ralph/feature/comp-a/prd.json",
+                "ralph/factory/comp-a",
+            ),
+        ],
+    )
+    config = FactoryConfig(
+        use_worktrees=False, create_prs=False, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_bad_patterns=False,
+            subprocess_timeout=5.0,
+        ),
+    )
+    base = RalphConfig(
+        prompt_file=ralph_dir / "prompt.md",
+        prd_file=ralph_dir / "prd.json",
+        sleep_seconds=0,
+        agent_cmd="echo test",
+        ralph_branch="",
+        ralph_branch_explicit=True,
+        ui_mode="plain",
+        no_color=True,
+    )
+    return manifest, config, base
+
+
+class TestFactoryScopeSiteFailsClosed:
+    """The factory's PRD-load site forwards load failures into the
+    diff_scope check instead of swallowing them into None."""
+
+    def test_corrupt_prd_forwards_error(self, tmp_path: Path) -> None:
+        manifest, config, base = _factory_fixtures(tmp_path)
+        feature_dir = tmp_path / "scripts" / "ralph" / "feature" / "comp-a"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "prd.json").write_text("{not valid json")
+
+        captured: dict[str, Any] = {}
+
+        def spy_rmv(
+            worktree_path: Path,
+            prd_path: Path,
+            base_branch: str,
+            allowed_paths: list[str] | None,
+            verify_config: VerifyConfig,
+            allowed_paths_error: str | None = None,
+        ) -> VerificationResult:
+            captured["allowed_paths"] = allowed_paths
+            captured["allowed_paths_error"] = allowed_paths_error
+            return VerificationResult(
+                passed=True, checks=[CheckResult("diff_scope", True, "ok")],
+            )
+
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with (
+            patch("ralph_py.factory._run_component", return_value=success),
+            patch(
+                "ralph_py.factory.run_mechanical_verification",
+                side_effect=spy_rmv,
+            ),
+        ):
+            run_factory(manifest, config, base, PlainUI(no_color=True), tmp_path)
+
+        assert captured["allowed_paths"] is None
+        assert captured["allowed_paths_error"] is not None
+        assert "PRD failed to parse" in str(captured["allowed_paths_error"])
+
+    def test_missing_prd_forwards_error(self, tmp_path: Path) -> None:
+        manifest, config, base = _factory_fixtures(tmp_path)
+        # No PRD file written at all.
+        captured: dict[str, Any] = {}
+
+        def spy_rmv(
+            worktree_path: Path,
+            prd_path: Path,
+            base_branch: str,
+            allowed_paths: list[str] | None,
+            verify_config: VerifyConfig,
+            allowed_paths_error: str | None = None,
+        ) -> VerificationResult:
+            captured["allowed_paths_error"] = allowed_paths_error
+            return VerificationResult(
+                passed=True, checks=[CheckResult("diff_scope", True, "ok")],
+            )
+
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with (
+            patch("ralph_py.factory._run_component", return_value=success),
+            patch(
+                "ralph_py.factory.run_mechanical_verification",
+                side_effect=spy_rmv,
+            ),
+        ):
+            run_factory(manifest, config, base, PlainUI(no_color=True), tmp_path)
+
+        assert "PRD not found" in str(captured["allowed_paths_error"])
+
+    def test_legacy_prd_without_allowed_paths_stays_unconstrained(
+        self, tmp_path: Path,
+    ) -> None:
+        """The legitimate-disable case: a PRD that loads fine but has
+        no allowedPaths field must NOT produce an error."""
+        manifest, config, base = _factory_fixtures(tmp_path)
+        feature_dir = tmp_path / "scripts" / "ralph" / "feature" / "comp-a"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "prd.json").write_text(json.dumps({
+            "branchName": "test",
+            "userStories": [{
+                "id": "US-001", "title": "T",
+                "acceptanceCriteria": ["AC"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+
+        captured: dict[str, Any] = {}
+
+        def spy_rmv(
+            worktree_path: Path,
+            prd_path: Path,
+            base_branch: str,
+            allowed_paths: list[str] | None,
+            verify_config: VerifyConfig,
+            allowed_paths_error: str | None = None,
+        ) -> VerificationResult:
+            captured["allowed_paths"] = allowed_paths
+            captured["allowed_paths_error"] = allowed_paths_error
+            return VerificationResult(
+                passed=True, checks=[CheckResult("diff_scope", True, "ok")],
+            )
+
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with (
+            patch("ralph_py.factory._run_component", return_value=success),
+            patch(
+                "ralph_py.factory.run_mechanical_verification",
+                side_effect=spy_rmv,
+            ),
+        ):
+            run_factory(manifest, config, base, PlainUI(no_color=True), tmp_path)
+
+        assert captured["allowed_paths"] is None
+        assert captured["allowed_paths_error"] is None


### PR DESCRIPTION
## Roadmap item

R1.5 (session 3C) - closes H-4, H-5, and MED scope-none-fallthrough from the review.

## What changed

1. **Rename-move scope escape (H-5)**: `git.get_diff_names` now runs `git diff --name-status -z -M -C` and returns BOTH sides of rename/copy records, deduped and order-preserving. Previously `--name-only` with git's default rename detection listed only the destination, so `git mv protected/gate.py allowed/gate.py` looked like a change confined to `allowed/` and passed the scope check. All callers consume the same `list[str]` signature; no caller changes were needed.
2. **allowedPaths content validation (H-4)**: `decompose._validate_allowed_path_entry` enforces exactly the EXCLUDE list DECOMPOSE_PROMPT rule #12 already promises (`.ralph/`, `.github/`, `ralph_py/`, `src/ralph/`, bare `scripts/ralph/`, repo-root `pyproject.toml`/`package.json`/`Cargo.toml`) plus structural hazards: absolute paths, `..` traversal, and whole-repo entries (`/`, `.`, empty). Matching is on the normalized entry (leading `./`, trailing `/` stripped). Rejections append to the existing validation-errors list, so they flow through the decompose retry-with-error loop and name the offending entry. No prompt body was modified.
3. **Fail-closed PRD load**: the factory's scope site no longer swallows `PRD.load` failures into `allowed_paths=None`. Load failures become `allowed_paths_error`, forwarded through `run_mechanical_verification` into `check_diff_scope`, which fails with an infrastructure-flavored message. A PRD that loads fine but has no `allowedPaths` field still passes with the existing "No scope constraints (allowed_paths not set)" message, so legacy unconstrained PRDs keep working.

The wave-2 failure-message content (base branch + complete allowed-paths list in the violation details) is untouched, and `tests/test_verify.py::test_failure_names_base_branch_and_allowed_paths` / `test_retry_context_carries_base_and_full_allowed_paths` still pass.

## Tested

All in `tests/test_scope_hardening.py` (43 tests) unless noted:

- Real-git-repo repro of the H-5 attack: `git mv protected/gate.py allowed/gate.py` on a branch; `get_diff_names` reports both sides (`test_rename_move_reports_both_sides`) and `check_diff_scope` with `allowed_paths=["allowed/"]` fails naming `protected/gate.py` (`test_rename_move_fails_diff_scope`).
- Plain modify/add/delete still reported under `--name-status` in a real repo (`test_plain_changes_still_reported`); the pre-existing real-repo test `test_input_hygiene.py::test_get_diff_names_with_range` also still passes.
- `-z` record parser: rename and copy records yield source+destination, mixed records dedupe and preserve order, empty output (`TestParseNameStatusZ`).
- Every prompt EXCLUDE entry rejected verbatim, plus normalized variants (`.ralph`, `./ralph_py/`, `scripts/ralph`), absolute paths, `..` traversal, and whole-repo entries; error message names the offending entry (`TestAllowedPathsContentValidation`).
- Legitimate entries accepted: `src/`, `tests/`, `scripts/ralph/feature/<id>/`, non-root `docs/pyproject.toml`, prefix-similar names like `packages/` and `ralph_py_docs/`.
- Rejection flows through the decompose retry loop end-to-end: first agent attempt lists `.ralph/`, retry prompt carries "PREVIOUS ATTEMPT FAILED" plus the entry error, corrected second attempt succeeds (`TestExcludeRejectionFlowsThroughRetryLoop`).
- `check_diff_scope` fails closed on `allowed_paths_error` (also when allowed_paths are simultaneously present); `run_mechanical_verification` forwards the error; unconfigured scope still passes with the exact existing message (`TestDiffScopeFailsClosed`).
- Factory wiring via spy on `run_mechanical_verification`: corrupt PRD forwards "PRD failed to parse", missing PRD forwards "PRD not found", valid legacy PRD without allowedPaths forwards no error (`TestFactoryScopeSiteFailsClosed`).

## Assumed (not tested)

- Copy detection (`C` status) is exercised only at the parser level; producing a `C` record from a real repo depends on git's copy heuristics, so no real-repo copy test exists.
- `check_diff_scope` still returns `passed=True` with 0 files when `git diff` itself fails (pre-existing behavior of `get_diff_names` returning `[]` on subprocess failure); unchanged and out of R1.5's stated scope.
- The EXCLUDE match is exact-entry, not prefix-cover: `src/` remains accepted (it is in the prompt's INCLUDE examples) even though it contains `src/ralph/`. The diff-scope check itself is the second layer for files actually written there.
- POSIX path semantics only (no Windows drive-letter absolute-path check), consistent with the codebase's POSIX-first stance.

## Checks (final lines)

- `uv run pytest tests/ -q`: `850 passed, 12 skipped, 1 warning in 291.25s (0:04:51)`
- `uv run mypy ralph_py/ --strict`: `Success: no issues found in 37 source files`
- `uv run ruff check ralph_py/ tests/`: `All checks passed!`

## Tracker

- Flipped R1.5 to `[x]` in `docs/remediation-roadmap.md` with a session note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)