### PR TITLE
fix: R1.7 persist architect red-team output, R1.8 decompose validation ordering

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -210,15 +210,23 @@ reviewers' output as much as it distrusts the engineer's.
     id to `knowledge.current_run_id()`, removing the last nonce-order
     edge; wiring proven by
     `test_factory_passes_microsecond_run_id_to_distill`.
-- [ ] R1.7 (S) **Persist the architect's red-team output** [MED spec-issues-lost]
+- [x] R1.7 (S) **Persist the architect's red-team output** [MED spec-issues-lost]
   - Write `spec_issues` (all severities) to `scripts/ralph/spec-issues.json`
     and a journal event; on SpecBlockerError, print the file path so the user
     iterates against a durable artifact, not scrollback.
-- [ ] R1.8 (S) **Decompose validation ordering** [MED prd-validate-late, LOW vacuous-prd]
+  - Note (2026-07-18, session 3D): `decompose.persist_spec_issues` writes the
+    artifact atomically on halt, success, and clean audit; `spec_issues`
+    journal event added; `SpecBlockerError.artifact_path` printed by both CLI
+    call sites.
+- [x] R1.8 (S) **Decompose validation ordering** [MED prd-validate-late, LOW vacuous-prd]
   - Run PRD schema validation inside the decompose retry loop (before files are
     written) so the LLM gets the error; clean up partial files on failure.
   - Reject empty `userStories`, empty `acceptanceCriteria`, and `passes: true`
     at decompose time.
+  - Note (2026-07-18, session 3D): PRD schema validation is a retry-loop stage;
+    all writes (PRDs + manifest) happen post-validation inside a cleanup scope
+    that removes partial files on failure; the three vacuous shapes are
+    rejected with retryable messages.
 
 Done when: a new adversarial-parser test class proves each of: empty review
 fails hard mode; `"FAIL"`/`"Blocked"` verdicts block; oversized review output is

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -1076,6 +1076,10 @@ def decompose(
         ui_impl.ok(f"Decomposed into {len(manifest.components)} components")
     except SpecBlockerError as exc:
         ui_impl.err(str(exc))
+        # R1.7: point at the durable artifact so the user iterates
+        # against a file, not scrollback.
+        if exc.artifact_path is not None:
+            ui_impl.info(f"Spec issues written to: {exc.artifact_path}")
         sys.exit(2)
     except ValueError as exc:
         ui_impl.err(str(exc))
@@ -1388,8 +1392,11 @@ def factory(
             )
         except SpecBlockerError as exc:
             # Architect halted: spec has blocker-severity issues. Surface
-            # them and exit cleanly. The user fixes the spec and re-runs.
+            # them and exit cleanly. The user fixes the spec and re-runs,
+            # iterating against the persisted artifact (R1.7).
             ui_impl.err(str(exc))
+            if exc.artifact_path is not None:
+                ui_impl.info(f"Spec issues written to: {exc.artifact_path}")
             sys.exit(2)
         except ValueError as exc:
             ui_impl.err(str(exc))

--- a/ralph_py/decompose.py
+++ b/ralph_py/decompose.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import tempfile
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -38,11 +41,17 @@ class SpecBlockerError(Exception):
 
     The decompose pipeline halts until the human resolves the spec
     rather than letting a vague spec produce a brittle implementation.
-    The blocking issues are attached via ``issues``.
+    The blocking issues are attached via ``issues``; ``artifact_path``
+    points at the persisted spec-issues.json (R1.7) when the write
+    succeeded, so callers can direct the user at a durable record
+    instead of scrollback.
     """
 
-    def __init__(self, issues: list[SpecIssue]):
+    def __init__(
+        self, issues: list[SpecIssue], artifact_path: Path | None = None
+    ):
         self.issues = issues
+        self.artifact_path = artifact_path
         summary_lines = [f"- [{i.severity}/{i.kind}] {i.summary}" for i in issues]
         super().__init__(
             "Spec has blocker-severity issues; resolve before re-running:\n"
@@ -453,6 +462,16 @@ def _validate_decompose_output(data: Any) -> list[str]:
             errors.append(f"{prefix}.userStories: must be an array")
             continue
 
+        if not stories:
+            # R1.8: a component with zero stories has nothing for the
+            # engineer to implement and nothing for the reviewer to
+            # fail against - it auto-passes downstream. Vacuous, not
+            # minimal; reject with a retryable message.
+            errors.append(
+                f"{prefix}.userStories: must not be empty -- every "
+                "component needs at least one user story"
+            )
+
         for j, story in enumerate(stories):
             sp = f"{prefix}.userStories[{j}]"
             if not isinstance(story, dict):
@@ -464,6 +483,23 @@ def _validate_decompose_output(data: Any) -> list[str]:
                 if story_id in seen_story_ids:
                     errors.append(f"{sp}.id: duplicate story ID '{story_id}'")
                 seen_story_ids.add(story_id)
+
+            # R1.8 vacuous-PRD gates. Type errors (non-list criteria,
+            # non-bool passes) are caught by the PRD schema validation
+            # stage of the retry loop; these two checks reject shapes
+            # that are type-valid but semantically empty.
+            criteria = story.get("acceptanceCriteria")
+            if isinstance(criteria, list) and not criteria:
+                errors.append(
+                    f"{sp}.acceptanceCriteria: must not be empty -- a "
+                    "story with no criteria is vacuously satisfiable"
+                )
+            if story.get("passes") is True:
+                errors.append(
+                    f"{sp}.passes: must be false -- stories start "
+                    "unimplemented; passes:true would skip the story "
+                    "and auto-pass review"
+                )
 
     # Check dependency references
     for comp in components:
@@ -551,19 +587,135 @@ def _surface_spec_issues(issues: list[SpecIssue], ui: UI) -> None:
                 ui.info(f"    suggestion: {issue.suggestion}")
 
 
-def _generate_component_prd(
-    comp_data: dict[str, Any],
+# Relative location of the persisted red-team artifact (R1.7). Lives
+# next to manifest.json so one directory holds the decompose outputs.
+SPEC_ISSUES_REL_PATH = Path("scripts") / "ralph" / "spec-issues.json"
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Atomic JSON write: temp file in the same directory then
+    ``os.replace`` (same pattern as ``Manifest.save`` and
+    ``knowledge.write_facts``)."""
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), suffix=".tmp", prefix=f".{path.name}-"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(payload, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_name, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _issue_dicts(issues: list[SpecIssue]) -> list[dict[str, str]]:
+    return [
+        {
+            "severity": i.severity,
+            "kind": i.kind,
+            "summary": i.summary,
+            "location": i.location,
+            "suggestion": i.suggestion,
+        }
+        for i in issues
+    ]
+
+
+def _issue_counts(issues: list[SpecIssue]) -> dict[str, int]:
+    return {
+        sev: sum(1 for i in issues if i.severity == sev)
+        for sev in ("blocker", "major", "minor")
+    }
+
+
+def persist_spec_issues(
+    issues: list[SpecIssue],
     root_dir: Path,
-    branch_name: str,
+    project_name: str,
+    spec_file: str,
+    *,
+    halted: bool,
 ) -> Path:
-    """Generate a standard PRD file for one component.
+    """Persist the architect's red-team findings to a durable artifact (R1.7).
 
-    Returns the path to the generated prd.json.
+    Written on every decompose that produced parseable output, including
+    a clean audit: an empty ``issues`` array is the record that the
+    audit ran and found nothing, which is a different fact from "no
+    record". Returns the artifact path; raises ``OSError`` on write
+    failure so the caller can surface it loudly.
     """
-    comp_id: str = comp_data["id"]
-    feature_dir: Path = root_dir / "scripts" / "ralph" / "feature" / comp_id
-    feature_dir.mkdir(parents=True, exist_ok=True)
+    path = root_dir / SPEC_ISSUES_REL_PATH
+    payload: dict[str, Any] = {
+        "project": project_name,
+        "specFile": spec_file,
+        "generatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "halted": halted,
+        "counts": _issue_counts(issues),
+        "issues": _issue_dicts(issues),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_json(path, payload)
+    return path
 
+
+def _record_spec_issues_event(
+    issues: list[SpecIssue],
+    root_dir: Path,
+    project_name: str,
+    spec_file: str,
+    halted: bool,
+    ui: UI,
+) -> None:
+    """Append a spec_issues event to the evolution journal (R1.7).
+
+    Non-fatal on I/O errors, matching ``EvolutionJournal.record_run``,
+    but the failure is surfaced as a warning rather than swallowed:
+    the journal is an audit trail, so a silent skip would defeat it.
+    No ``run_id`` field: decompose runs before a factory run id exists.
+    """
+    from ralph_py.evolution import EvolutionConfig
+
+    evo_config = EvolutionConfig.load(root_dir)
+    if not evo_config.enabled:
+        return
+    journal_path = evo_config.journal_path
+    if not journal_path.is_absolute():
+        journal_path = root_dir / journal_path
+    entry: dict[str, Any] = {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "project": project_name,
+        "event_type": "spec_issues",
+        "spec_file": spec_file,
+        "halted": halted,
+        "counts": _issue_counts(issues),
+        "issues": _issue_dicts(issues),
+        "artifact": SPEC_ISSUES_REL_PATH.as_posix(),
+    }
+    try:
+        journal_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(journal_path, "a") as f:
+            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+    except OSError as exc:
+        ui.warn(f"Failed to record spec_issues journal event: {exc}")
+
+
+def _component_branch(comp_id: str, project_name: str, single_pr: bool) -> str:
+    """Branch a component's PRD will target."""
+    if single_pr:
+        return f"ralph/factory/{project_name}"
+    return f"ralph/factory/{comp_id}"
+
+
+def _build_prd_data(comp_data: dict[str, Any], branch_name: str) -> dict[str, Any]:
+    """Assemble the PRD payload for one component.
+
+    Shared by the retry-loop validation stage and the write phase so
+    what gets validated is byte-for-byte what gets written (R1.8).
+    """
     prd_data: dict[str, Any] = {
         "branchName": branch_name,
         "userStories": comp_data["userStories"],
@@ -576,19 +728,37 @@ def _generate_component_prd(
     # "scope unconstrained" (the previous global behavior).
     if "allowedPaths" in comp_data:
         prd_data["allowedPaths"] = comp_data["allowedPaths"]
+    return prd_data
 
-    prd_path = feature_dir / "prd.json"
-    with open(prd_path, "w") as f:
-        json.dump(prd_data, f, indent=2)
-        f.write("\n")
 
-    # Validate the generated PRD
+def _generate_component_prd(
+    comp_data: dict[str, Any],
+    root_dir: Path,
+    branch_name: str,
+) -> Path:
+    """Generate a standard PRD file for one component.
+
+    Validates BEFORE touching disk (R1.8): the retry loop has already
+    validated this payload, so a failure here indicates a harness bug,
+    but the guard preserves the write-only-validated invariant. The
+    write itself is atomic, so a crash mid-write never leaves a
+    truncated prd.json.
+
+    Returns the path to the generated prd.json.
+    """
+    comp_id: str = comp_data["id"]
+    prd_data = _build_prd_data(comp_data, branch_name)
+
     errors = PRD.validate_schema(prd_data)
     if errors:
         raise ValueError(
             f"Generated PRD for '{comp_id}' has schema errors: {'; '.join(errors)}"
         )
 
+    feature_dir: Path = root_dir / "scripts" / "ralph" / "feature" / comp_id
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    prd_path = feature_dir / "prd.json"
+    _atomic_write_json(prd_path, prd_data)
     return prd_path
 
 
@@ -675,82 +845,162 @@ def decompose_spec(
             data = None
             continue
 
+        # R1.8: PRD schema validation runs INSIDE the retry loop so a
+        # malformed story is a retryable error the LLM gets to fix,
+        # not a post-loop crash. Nothing is written to disk until every
+        # component's PRD payload validates.
+        prd_errors: list[str] = []
+        for comp_data in data["components"]:
+            branch = _component_branch(comp_data["id"], project_name, single_pr)
+            schema_errors = PRD.validate_schema(_build_prd_data(comp_data, branch))
+            if schema_errors:
+                prd_errors.append(
+                    f"component '{comp_data['id']}' PRD schema: "
+                    + "; ".join(schema_errors)
+                )
+        if prd_errors:
+            last_error = "; ".join(prd_errors)
+            ui.warn(f"PRD validation failed: {last_error}")
+            data = None
+            continue
+
         last_error = None
         break
 
     if data is None:
+        # No files were written in the retry loop, so terminal failure
+        # leaves no partial state behind (R1.8).
         raise ValueError(
             f"Failed to decompose spec after {max_retries} attempts. "
             f"Last error: {last_error}"
         )
 
-    # Surface red-team findings before doing any further work. If any
-    # are blockers, halt before generating PRDs - the architect
-    # explicitly judged the spec un-decomposable.
+    # Surface AND persist red-team findings before doing any further
+    # work (R1.7): the artifact and journal event are written for halt,
+    # success, and clean-audit outcomes alike. If any issue is a
+    # blocker, halt before generating PRDs - the architect explicitly
+    # judged the spec un-decomposable.
     spec_issues = _parse_spec_issues(data)
     _surface_spec_issues(spec_issues, ui)
     blockers = [i for i in spec_issues if i.severity == "blocker"]
+    artifact_path: Path | None = None
+    try:
+        artifact_path = persist_spec_issues(
+            spec_issues,
+            root_dir=root_dir,
+            project_name=project_name,
+            spec_file=spec_path.name,
+            halted=bool(blockers),
+        )
+        ui.ok(f"Spec audit written: {artifact_path}")
+    except OSError as exc:
+        # Loud but non-masking: the blocker halt (or the decompose
+        # result) matters more than the artifact write failing.
+        ui.err(f"Failed to persist spec issues to disk: {exc}")
+    _record_spec_issues_event(
+        spec_issues,
+        root_dir=root_dir,
+        project_name=project_name,
+        spec_file=spec_path.name,
+        halted=bool(blockers),
+        ui=ui,
+    )
     if blockers:
-        raise SpecBlockerError(blockers)
+        raise SpecBlockerError(blockers, artifact_path=artifact_path)
 
-    # Generate PRDs and build manifest components
-    ui.section("Generating PRDs")
-    manifest_components: list[Component] = []
-
+    # Pre-validate every branch name before any file is written.
+    # Component ids were validated in the retry loop; this can only
+    # fire for a project_name (user input) that is not branch-safe.
+    # Reject rather than sanitize so the caller sees exactly what
+    # was wrong (R0.6).
+    component_branches: dict[str, str] = {}
     for comp_data in data["components"]:
         comp_id = comp_data["id"]
-        if single_pr:
-            branch = f"ralph/factory/{project_name}"
-        else:
-            branch = f"ralph/factory/{comp_id}"
-
-        # Component ids were validated in the retry loop; this can only
-        # fire for a project_name (user input) that is not branch-safe.
-        # Reject rather than sanitize so the caller sees exactly what
-        # was wrong (R0.6).
+        branch = _component_branch(comp_id, project_name, single_pr)
         branch_error = validate_branch_name(branch)
         if branch_error:
             raise ValueError(
                 f"Cannot derive a git branch for component '{comp_id}': "
                 f"{branch_error}"
             )
+        component_branches[comp_id] = branch
 
-        prd_path = _generate_component_prd(comp_data, root_dir, branch)
-        rel_prd = prd_path.relative_to(root_dir).as_posix()
+    # Generate PRDs and build manifest components. Everything below has
+    # already validated, so a failure here is an I/O problem or a
+    # harness bug; either way, remove the files written so far rather
+    # than leaving partial decompose state for the next run to trip
+    # over (R1.8). The spec-issues artifact is deliberately NOT cleaned
+    # up - it is the audit record.
+    ui.section("Generating PRDs")
+    manifest_components: list[Component] = []
+    written_prds: list[Path] = []
+    created_dirs: list[Path] = []
+    try:
+        for comp_data in data["components"]:
+            comp_id = comp_data["id"]
+            branch = component_branches[comp_id]
 
-        manifest_components.append(
-            Component(
-                id=comp_id,
-                title=comp_data["title"],
-                description=comp_data["description"],
-                dependencies=comp_data.get("dependencies", []),
-                prd_path=rel_prd,
-                branch_name=branch,
-                status=ComponentStatus.PENDING.value,
+            # Track directories this run creates so cleanup can remove
+            # them; pre-existing directories are left alone.
+            probe = root_dir / "scripts" / "ralph" / "feature" / comp_id
+            while not probe.exists() and probe != root_dir:
+                created_dirs.append(probe)
+                probe = probe.parent
+
+            prd_path = _generate_component_prd(comp_data, root_dir, branch)
+            written_prds.append(prd_path)
+            rel_prd = prd_path.relative_to(root_dir).as_posix()
+
+            manifest_components.append(
+                Component(
+                    id=comp_id,
+                    title=comp_data["title"],
+                    description=comp_data["description"],
+                    dependencies=comp_data.get("dependencies", []),
+                    prd_path=rel_prd,
+                    branch_name=branch,
+                    status=ComponentStatus.PENDING.value,
+                )
             )
+            ui.ok(f"  {comp_id}: {len(comp_data['userStories'])} stories")
+
+        manifest = Manifest(
+            version="1",
+            spec_file=spec_path.name,
+            project_name=project_name,
+            base_branch=base_branch,
+            single_pr=single_pr,
+            components=manifest_components,
         )
-        ui.ok(f"  {comp_id}: {len(comp_data['userStories'])} stories")
 
-    manifest = Manifest(
-        version="1",
-        spec_file=spec_path.name,
-        project_name=project_name,
-        base_branch=base_branch,
-        single_pr=single_pr,
-        components=manifest_components,
-    )
+        # Validate DAG
+        dag_errors = manifest.validate_dag()
+        if dag_errors:
+            ui.warn("DAG validation warnings:")
+            for err in dag_errors:
+                ui.warn(f"  {err}")
 
-    # Validate DAG
-    dag_errors = manifest.validate_dag()
-    if dag_errors:
-        ui.warn("DAG validation warnings:")
-        for err in dag_errors:
-            ui.warn(f"  {err}")
-
-    # Save manifest
-    manifest_path = root_dir / "scripts" / "ralph" / "manifest.json"
-    manifest.save(manifest_path)
-    ui.ok(f"Manifest saved: {manifest_path}")
+        # Save manifest (atomic write; covered by the cleanup scope so
+        # a save failure does not strand PRDs without a manifest)
+        manifest_path = root_dir / "scripts" / "ralph" / "manifest.json"
+        manifest.save(manifest_path)
+        ui.ok(f"Manifest saved: {manifest_path}")
+    except BaseException:
+        for prd_file in written_prds:
+            try:
+                prd_file.unlink()
+            except OSError:
+                pass
+        # Deepest-first so children go before parents; rmdir refuses
+        # non-empty directories, which protects anything user-owned.
+        for created in sorted(
+            set(created_dirs), key=lambda p: len(p.parts), reverse=True
+        ):
+            try:
+                created.rmdir()
+            except OSError:
+                pass
+        raise
 
     ui.section("Decomposition Summary")
     ui.kv("Components", str(len(manifest.components)))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -171,3 +171,45 @@ class TestCliValidation:
         )
         assert result.exit_code == 0
         assert (feature_dir / "understand.md").exists()
+
+
+class TestDecomposeBlockerOutput:
+    """R1.7: the CLI points the user at the persisted spec-issues file."""
+
+    def test_prints_artifact_path_on_halt(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        import ralph_py.cli as cli_mod
+        from ralph_py.decompose import SpecBlockerError, SpecIssue
+
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Vague spec")
+        artifact = tmp_path / "scripts" / "ralph" / "spec-issues.json"
+
+        def fake_decompose(**kwargs: object) -> None:
+            raise SpecBlockerError(
+                [SpecIssue(
+                    severity="blocker",
+                    kind="ambiguity",
+                    summary="spec is too vague",
+                )],
+                artifact_path=artifact,
+            )
+
+        monkeypatch.setattr(cli_mod, "decompose_spec", fake_decompose)
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "decompose",
+                "--spec", str(spec_file),
+                "--project-name", "test",
+                "--agent-cmd", "true",
+                "--ui", "plain",
+                "--no-color",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "spec is too vague" in result.output
+        assert str(artifact) in result.output

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -258,6 +258,8 @@ class TestValidateDecomposeOutput:
         assert any("allowedPaths" in e for e in errors)
 
     def test_allowed_paths_valid(self) -> None:
+        # userStories must be non-empty since R1.8's vacuous-PRD gate,
+        # so this fixture carries one real story.
         data = {
             "components": [
                 {
@@ -270,7 +272,16 @@ class TestValidateDecomposeOutput:
                         "tests/",
                         "scripts/ralph/feature/comp-a/",
                     ],
-                    "userStories": [],
+                    "userStories": [
+                        {
+                            "id": "US-001",
+                            "title": "S1",
+                            "acceptanceCriteria": ["AC1", "AC2"],
+                            "priority": 1,
+                            "passes": False,
+                            "notes": "",
+                        }
+                    ],
                 }
             ]
         }
@@ -572,3 +583,368 @@ class TestDecomposeSpec:
                 root_dir=tmp_path,
                 max_retries=2,
             )
+
+
+class SequenceAgent:
+    """Agent returning one canned output per invocation, recording prompts."""
+
+    def __init__(self, outputs: list[str]):
+        self._outputs = outputs
+        self._final_message: str | None = None
+        self.prompts: list[str] = []
+
+    @property
+    def name(self) -> str:
+        return "sequence-agent"
+
+    def run(self, prompt: str, cwd: Path | None = None) -> Iterator[str]:
+        self.prompts.append(prompt)
+        output = self._outputs[min(len(self.prompts) - 1, len(self._outputs) - 1)]
+        self._final_message = output
+        yield from output.splitlines()
+
+    @property
+    def final_message(self) -> str | None:
+        return self._final_message
+
+
+def _story(**overrides: object) -> dict[str, object]:
+    story: dict[str, object] = {
+        "id": "US-001",
+        "title": "S1",
+        "acceptanceCriteria": ["AC1", "AC2"],
+        "priority": 1,
+        "passes": False,
+        "notes": "",
+    }
+    story.update(overrides)
+    return story
+
+
+def _single_component_output(
+    stories: list[dict[str, object]],
+    spec_issues: list[dict[str, object]] | None = None,
+) -> str:
+    payload: dict[str, object] = {
+        "components": [
+            {
+                "id": "comp-a",
+                "title": "A",
+                "description": "x",
+                "dependencies": [],
+                "allowedPaths": [
+                    "src/", "tests/", "scripts/ralph/feature/comp-a/",
+                ],
+                "userStories": stories,
+            }
+        ],
+    }
+    if spec_issues is not None:
+        payload["spec_issues"] = spec_issues
+    return json.dumps(payload)
+
+
+class TestVacuousPrdRejection:
+    """R1.8: vacuous shapes that previously sailed through validation."""
+
+    def test_empty_user_stories_rejected(self) -> None:
+        data = json.loads(_single_component_output([]))
+        errors = _validate_decompose_output(data)
+        assert any(
+            "userStories" in e and "must not be empty" in e for e in errors
+        )
+
+    def test_empty_acceptance_criteria_rejected(self) -> None:
+        data = json.loads(
+            _single_component_output([_story(acceptanceCriteria=[])])
+        )
+        errors = _validate_decompose_output(data)
+        assert any(
+            "acceptanceCriteria" in e and "must not be empty" in e
+            for e in errors
+        )
+
+    def test_passes_true_rejected(self) -> None:
+        data = json.loads(_single_component_output([_story(passes=True)]))
+        errors = _validate_decompose_output(data)
+        assert any("passes" in e and "must be false" in e for e in errors)
+
+    def test_vacuous_output_is_retryable(self, tmp_path: Path) -> None:
+        """passes:true fails attempt 1; the retry prompt carries the
+        error and attempt 2 succeeds."""
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Feature")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+
+        agent = SequenceAgent([
+            _single_component_output([_story(passes=True)]),
+            _single_component_output([_story()]),
+        ])
+        manifest = decompose_spec(
+            spec_path=spec_file,
+            project_name="test",
+            base_branch="main",
+            single_pr=False,
+            agent=agent,
+            ui=PlainUI(no_color=True),
+            root_dir=tmp_path,
+        )
+
+        assert len(agent.prompts) == 2
+        assert "PREVIOUS ATTEMPT FAILED" in agent.prompts[1]
+        assert "passes" in agent.prompts[1]
+        assert len(manifest.components) == 1
+
+
+BLOCKER_ISSUE: dict[str, object] = {
+    "severity": "blocker",
+    "kind": "ambiguity",
+    "summary": "What 'fast' means is not defined",
+    "location": "Performance section",
+    "suggestion": "Specify a P95 latency budget",
+}
+
+MINOR_ISSUE: dict[str, object] = {
+    "severity": "minor",
+    "kind": "missing_detail",
+    "summary": "Edge case unspecified",
+    "location": "API section",
+    "suggestion": "Document the empty-input path",
+}
+
+
+class TestSpecIssuesPersistence:
+    """R1.7: red-team output becomes a durable artifact + journal event."""
+
+    def _run(
+        self,
+        tmp_path: Path,
+        output: str,
+    ) -> Path:
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Spec\nBuild it.")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True, exist_ok=True)
+        decompose_spec(
+            spec_path=spec_file,
+            project_name="test",
+            base_branch="main",
+            single_pr=False,
+            agent=MockDecomposeAgent(output),
+            ui=PlainUI(no_color=True),
+            root_dir=tmp_path,
+        )
+        return tmp_path / "scripts" / "ralph" / "spec-issues.json"
+
+    def test_artifact_written_on_halt(self, tmp_path: Path) -> None:
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Vague spec")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+
+        output = json.dumps({"components": [], "spec_issues": [BLOCKER_ISSUE]})
+        with pytest.raises(SpecBlockerError) as exc_info:
+            decompose_spec(
+                spec_path=spec_file,
+                project_name="test",
+                base_branch="main",
+                single_pr=False,
+                agent=MockDecomposeAgent(output),
+                ui=PlainUI(no_color=True),
+                root_dir=tmp_path,
+            )
+
+        artifact = tmp_path / "scripts" / "ralph" / "spec-issues.json"
+        assert artifact.exists()
+        assert exc_info.value.artifact_path == artifact
+
+        content = json.loads(artifact.read_text())
+        assert content["project"] == "test"
+        assert content["specFile"] == "spec.md"
+        assert content["halted"] is True
+        assert content["counts"] == {"blocker": 1, "major": 0, "minor": 0}
+        assert content["issues"] == [
+            {
+                "severity": "blocker",
+                "kind": "ambiguity",
+                "summary": "What 'fast' means is not defined",
+                "location": "Performance section",
+                "suggestion": "Specify a P95 latency budget",
+            }
+        ]
+
+    def test_artifact_written_on_success(self, tmp_path: Path) -> None:
+        artifact = self._run(
+            tmp_path,
+            _single_component_output([_story()], spec_issues=[MINOR_ISSUE]),
+        )
+        assert artifact.exists()
+        content = json.loads(artifact.read_text())
+        assert content["halted"] is False
+        assert content["counts"] == {"blocker": 0, "major": 0, "minor": 1}
+        assert content["issues"][0]["summary"] == "Edge case unspecified"
+        assert content["issues"][0]["location"] == "API section"
+
+    def test_artifact_written_on_clean_audit(self, tmp_path: Path) -> None:
+        """An empty issues array is the record that the audit ran and
+        found nothing - distinct from no record at all."""
+        artifact = self._run(
+            tmp_path, _single_component_output([_story()], spec_issues=[]),
+        )
+        assert artifact.exists()
+        content = json.loads(artifact.read_text())
+        assert content["halted"] is False
+        assert content["issues"] == []
+
+    def _read_journal_events(self, tmp_path: Path) -> list[dict[str, object]]:
+        journal = tmp_path / ".ralph" / "evolution.jsonl"
+        assert journal.exists(), "journal event was not written"
+        entries = [
+            json.loads(line)
+            for line in journal.read_text().splitlines()
+            if line.strip()
+        ]
+        return [e for e in entries if e.get("event_type") == "spec_issues"]
+
+    def test_journal_event_on_halt(self, tmp_path: Path) -> None:
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Vague spec")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+
+        output = json.dumps({"components": [], "spec_issues": [BLOCKER_ISSUE]})
+        with pytest.raises(SpecBlockerError):
+            decompose_spec(
+                spec_path=spec_file,
+                project_name="test",
+                base_branch="main",
+                single_pr=False,
+                agent=MockDecomposeAgent(output),
+                ui=PlainUI(no_color=True),
+                root_dir=tmp_path,
+            )
+
+        events = self._read_journal_events(tmp_path)
+        assert len(events) == 1
+        assert events[0]["halted"] is True
+        assert events[0]["counts"] == {"blocker": 1, "major": 0, "minor": 0}
+        assert events[0]["artifact"] == "scripts/ralph/spec-issues.json"
+
+    def test_journal_event_on_success(self, tmp_path: Path) -> None:
+        self._run(
+            tmp_path,
+            _single_component_output([_story()], spec_issues=[MINOR_ISSUE]),
+        )
+        events = self._read_journal_events(tmp_path)
+        assert len(events) == 1
+        assert events[0]["halted"] is False
+        assert events[0]["counts"] == {"blocker": 0, "major": 0, "minor": 1}
+
+
+class TestPrdValidationInsideRetryLoop:
+    """R1.8: PRD schema errors are retryable and never leave partial files."""
+
+    def test_malformed_story_triggers_retry(self, tmp_path: Path) -> None:
+        """A story missing the 'notes' key passes decompose-output
+        validation but fails PRD schema validation; the error must feed
+        back through the retry loop instead of crashing after it."""
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Feature")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+
+        malformed = _story()
+        del malformed["notes"]
+        agent = SequenceAgent([
+            _single_component_output([malformed]),
+            _single_component_output([_story()]),
+        ])
+        manifest = decompose_spec(
+            spec_path=spec_file,
+            project_name="test",
+            base_branch="main",
+            single_pr=False,
+            agent=agent,
+            ui=PlainUI(no_color=True),
+            root_dir=tmp_path,
+        )
+
+        assert len(agent.prompts) == 2
+        assert "PREVIOUS ATTEMPT FAILED" in agent.prompts[1]
+        assert "notes" in agent.prompts[1]
+        assert len(manifest.components) == 1
+        prd_path = (
+            tmp_path / "scripts" / "ralph" / "feature" / "comp-a" / "prd.json"
+        )
+        assert prd_path.exists()
+        assert PRD.load(prd_path).user_stories[0].id == "US-001"
+
+    def test_no_partial_files_after_terminal_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """Terminal validation failure must not leave prd.json, feature
+        dirs, or a manifest behind."""
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Feature")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+
+        malformed = _story()
+        del malformed["notes"]
+        agent = MockDecomposeAgent(_single_component_output([malformed]))
+        with pytest.raises(ValueError, match="Failed to decompose"):
+            decompose_spec(
+                spec_path=spec_file,
+                project_name="test",
+                base_branch="main",
+                single_pr=False,
+                agent=agent,
+                ui=PlainUI(no_color=True),
+                root_dir=tmp_path,
+                max_retries=2,
+            )
+
+        assert not (tmp_path / "scripts" / "ralph" / "feature").exists()
+        assert not (tmp_path / "scripts" / "ralph" / "manifest.json").exists()
+        assert list(tmp_path.rglob("prd.json")) == []
+
+    def test_write_failure_cleans_up_partial_prds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If writing component 2's PRD fails, component 1's already
+        written PRD and the directories created for it are removed; the
+        spec-issues audit artifact survives."""
+        import ralph_py.decompose as decompose_mod
+
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Feature")
+        (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+
+        real_generate = decompose_mod._generate_component_prd
+        calls: list[str] = []
+
+        def flaky_generate(
+            comp_data: dict[str, object], root_dir: Path, branch_name: str
+        ) -> Path:
+            calls.append(str(comp_data["id"]))
+            if len(calls) == 2:
+                raise OSError("disk full")
+            return real_generate(comp_data, root_dir, branch_name)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(
+            decompose_mod, "_generate_component_prd", flaky_generate
+        )
+
+        agent = MockDecomposeAgent(VALID_DECOMPOSE_OUTPUT)
+        with pytest.raises(OSError, match="disk full"):
+            decompose_spec(
+                spec_path=spec_file,
+                project_name="test",
+                base_branch="main",
+                single_pr=False,
+                agent=agent,
+                ui=PlainUI(no_color=True),
+                root_dir=tmp_path,
+            )
+
+        assert calls == ["database", "api"]
+        assert list(tmp_path.rglob("prd.json")) == []
+        assert not (tmp_path / "scripts" / "ralph" / "feature").exists()
+        assert not (tmp_path / "scripts" / "ralph" / "manifest.json").exists()
+        # The audit artifact is deliberately kept.
+        assert (tmp_path / "scripts" / "ralph" / "spec-issues.json").exists()


### PR DESCRIPTION
## Roadmap items

- R1.7 (S) Persist the architect's red-team output [MED spec-issues-lost]
- R1.8 (S) Decompose validation ordering [MED prd-validate-late, LOW vacuous-prd]

Session 3D per docs/remediation-sessions.md. Checkboxes flipped in docs/remediation-roadmap.md in this PR.

## What changed

**R1.7** - `decompose.persist_spec_issues` writes ALL parsed spec_issues (severity, kind, summary, location, suggestion, plus counts and a halted flag) to `scripts/ralph/spec-issues.json` with an atomic mkstemp+os.replace write. It is written on halt, on success, and on a clean audit (an empty issues array is the record that the audit ran and found nothing). `_record_spec_issues_event` appends a `spec_issues` event to the evolution journal (non-fatal on OSError, but surfaced as a warning, not swallowed). `SpecBlockerError` gains `artifact_path`, and both CLI call sites (`ralph decompose`, `ralph factory --spec`) print the file path on halt.

**R1.8** - PRD schema validation is now a stage INSIDE the decompose retry loop: each component's PRD payload is built by the same `_build_prd_data` used at write time and run through `PRD.validate_schema`; failures feed back to the LLM as retryable errors. All disk writes (PRDs + manifest) happen only after every payload validates, inside a cleanup scope that removes the files and directories created by this run on terminal failure (the spec-issues artifact deliberately survives - it is the audit record). Decompose validation now rejects empty `userStories`, empty `acceptanceCriteria`, and `passes: true` with retryable messages. `PRD.validate_schema` itself is unchanged, so hand-authored PRDs consumed by `ralph run`/loop keep loading.

No prompt body, `*_PROMPT_VERSION`, or prompt snapshot was touched.

## Checks (final lines)

- `uv run pytest tests/ -q`: `820 passed, 12 skipped, 1 warning in 293.17s (0:04:53)`
- `uv run mypy ralph_py/ --strict`: `Success: no issues found in 37 source files`
- `uv run ruff check ralph_py/ tests/`: `All checks passed!`

## Tested

- spec-issues.json written with correct content (project, specFile, halted, counts, full issue fields) on halt: `test_artifact_written_on_halt`; on success: `test_artifact_written_on_success`; on clean audit: `test_artifact_written_on_clean_audit`.
- Journal `spec_issues` event appended on halt and success with counts/halted/artifact fields: `test_journal_event_on_halt`, `test_journal_event_on_success`.
- `SpecBlockerError.artifact_path` points at the artifact: `test_artifact_written_on_halt`; the CLI prints it on halt (exit 2): `test_prints_artifact_path_on_halt` (tests/test_cli.py).
- A malformed story (missing `notes`) triggers a retry with the PRD schema error in the retry prompt, and attempt 2 succeeds (fake agent fails once then succeeds): `test_malformed_story_triggers_retry`.
- No partial files (no feature dirs, no prd.json, no manifest.json) after terminal retry failure: `test_no_partial_files_after_terminal_failure`.
- A write failure on component 2 removes component 1's already-written prd.json and the dirs created by the run, while spec-issues.json survives: `test_write_failure_cleans_up_partial_prds`.
- The three vacuous-PRD cases are rejected with retryable messages: `test_empty_user_stories_rejected`, `test_empty_acceptance_criteria_rejected`, `test_passes_true_rejected`; retryability proven end to end by `test_vacuous_output_is_retryable`.
- End-to-end through the real CLI (manual, `uv run ralph decompose` with canned custom agents): halt path exits 2 and prints the artifact path, artifact + journal event content correct; success path writes PRD/manifest/artifact with halted=false and appends a second journal event; a static vacuous agent exhausts 3 attempts, exits 1, leaves zero files; a stateful agent that emits a malformed story once recovers on attempt 2 via the fed-back "missing keys: notes" error.

## Assumed

- Evolution journal consumers tolerate the new `spec_issues` event shape (it mirrors the R0.3 `contract_result` event pattern; `_read_journal_entries` groups by fields the event does not claim). Not exercised against `get_cross_run_patterns` directly, but the existing evolution tests stay green.
- Re-running decompose over an existing project overwrites prd.json atomically; cleanup-on-failure removes the new file rather than restoring the pre-run one. Backup/restore of prior PRDs is out of scope.
- `persist_spec_issues` write failure (disk full/permissions) degrades to a loud `ui.err` without masking the blocker halt; exercised only implicitly (the OSError branch is not unit-tested).
- No other parser paths regressed: guarded by the full suite (820 passed) rather than new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)