### PR TITLE
fix: R0.5 instance and state safety (H-7, H-8, H-15)

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -119,7 +119,7 @@ item here is one of those three.
     prompt; unit test asserting the diff-scope failure message names the base
     branch and allowed paths.
 
-- [ ] R0.5 (M) **Instance and state safety** [H-7, H-8, H-15]
+- [x] R0.5 (M) **Instance and state safety** [H-7, H-8, H-15]
   - Run-level flock on `.ralph/factory.lock`: a second invocation on the same
     root refuses to start (override flag for intentional use).
   - Worktrees keyed `.ralph/worktrees/<run_id>/<component_id>`; stale branch

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -185,6 +185,12 @@ def cli() -> None:
     is_flag=True,
     help="Skip mechanical verification (raw loop, no post-checks)",
 )
+@click.option(
+    "--force-lock",
+    is_flag=True,
+    help="Proceed even if another ralph invocation holds "
+         ".ralph/factory.lock (may corrupt the other run's state)",
+)
 def run(
     max_iterations: int,
     root: Path | None,
@@ -201,6 +207,7 @@ def run(
     no_color: bool,
     ascii: bool,
     no_verify: bool,
+    force_lock: bool,
 ) -> None:
     """Run the agentic loop as a single-component factory invocation.
 
@@ -343,9 +350,15 @@ def run(
         contract_config=None,
         feedforward_config=ff_config,
         timeout_config=TimeoutConfig.load(root_dir),
+        force_lock=force_lock,
     )
 
-    factory_result = run_factory(manifest, factory_cfg, config, ui_impl, root_dir)
+    # R0.5 (H-15): `ralph run` persists to its own run-manifest.json so
+    # it can never clobber a factory run's resumable manifest.json.
+    factory_result = run_factory(
+        manifest, factory_cfg, config, ui_impl, root_dir,
+        manifest_path=root_dir / "scripts" / "ralph" / "run-manifest.json",
+    )
     sys.exit(factory_result.exit_code)
 
 
@@ -1249,6 +1262,12 @@ def decompose(
     help="Disable git worktrees (forces sequential execution)",
 )
 @click.option(
+    "--force-lock",
+    is_flag=True,
+    help="Proceed even if another ralph invocation holds "
+         ".ralph/factory.lock (may corrupt the other run's state)",
+)
+@click.option(
     "--yes", "-y",
     is_flag=True,
     help="Skip confirmation prompt",
@@ -1320,6 +1339,7 @@ def factory(
     component_timeout: float,
     progress_log: Path | None,
     no_worktrees: bool,
+    force_lock: bool,
     yes: bool,
     agent_cmd: str | None,
     model: str | None,
@@ -1479,6 +1499,7 @@ def factory(
         contract_config=c_config,
         progress_log_path=progress_log,
         timeout_config=timeout_config,
+        force_lock=force_lock,
     )
 
     ralph_dir = root_dir / "scripts" / "ralph"
@@ -1502,7 +1523,13 @@ def factory(
         if default_prompt.exists():
             base_config.prompt_file = default_prompt
 
-    result = run_factory(manifest, factory_config, base_config, ui_impl, root_dir)
+    # R0.5 (H-15): state saves back to the file it was loaded from.
+    # --manifest /custom.json persists to /custom.json; --spec runs keep
+    # the default scripts/ralph/manifest.json that decompose wrote.
+    result = run_factory(
+        manifest, factory_config, base_config, ui_impl, root_dir,
+        manifest_path=manifest_path,
+    )
     sys.exit(result.exit_code)
 
 

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import time
 from collections.abc import Mapping
 from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any
 
 from ralph_py.config import RalphConfig
 from ralph_py.context import IterationContext
@@ -85,6 +86,11 @@ class FactoryConfig:
     # R0.2: how long push_create_and_merge_pr waits for merge
     # confirmation before the component is parked as MERGE_PENDING.
     merge_timeout: float = 300.0
+    # R0.5: proceed even when another invocation holds the run-level
+    # .ralph/factory.lock. Deliberately CLI-only (no toml/env source):
+    # forcing past the lock can corrupt a live run's worktrees and
+    # manifest, so it must be an explicit per-invocation decision.
+    force_lock: bool = False
 
     @classmethod
     def from_env(cls) -> FactoryConfig:
@@ -167,6 +173,100 @@ class FactoryResult:
     exit_code: int = 0
 
 
+class FactoryLockHeldError(RuntimeError):
+    """Another factory invocation holds the run-level lock on this root."""
+
+
+@dataclass
+class _RunLock:
+    """Handle for the run-level factory lock.
+
+    ``held=True`` means we hold an exclusive flock for the whole run and
+    may safely prune state left by previous runs. ``held=False`` means we
+    are running WITHOUT exclusion (Windows/no-fcntl degrade, or
+    ``--force-lock``): stale-state cleanup must be skipped because another
+    live invocation may own it.
+    """
+
+    fp: IO[str] | None
+    held: bool
+
+    def release(self) -> None:
+        if self.fp is None:
+            return
+        try:
+            import fcntl
+            fcntl.flock(self.fp.fileno(), fcntl.LOCK_UN)
+        except (ImportError, OSError):
+            pass
+        self.fp.close()
+        self.fp = None
+
+
+def _acquire_run_lock(root_dir: Path, ui: UI, force: bool) -> _RunLock:
+    """Take the run-level flock on ``.ralph/factory.lock`` (R0.5, H-7).
+
+    Held for the entire run so a second ``ralph factory`` / ``ralph run``
+    on the same root refuses to start instead of destroying the first
+    invocation's in-flight worktrees and clobbering its manifest. flock
+    releases automatically if the holder dies, so a crashed run never
+    wedges the root.
+
+    POSIX only, like the A4 per-component lock: without fcntl we degrade
+    to no exclusion with a warning. ``force=True`` proceeds past a held
+    lock with a warning instead of raising FactoryLockHeldError.
+    """
+    lock_path = root_dir / ".ralph" / "factory.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import fcntl
+    except ImportError:
+        ui.warn(
+            "Run-level factory lock unavailable on this platform (no "
+            "fcntl); concurrent invocations on this root are not excluded"
+        )
+        return _RunLock(fp=None, held=False)
+
+    # "a+" so a refused attempt can read the holder's pid without
+    # truncating it.
+    fp = open(lock_path, "a+")
+    try:
+        fcntl.flock(fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        holder = ""
+        try:
+            fp.seek(0)
+            holder = fp.read(64).strip()
+        except OSError:
+            pass
+        fp.close()
+        holder_note = f" (pid {holder})" if holder else ""
+        if force:
+            ui.warn(
+                f"--force-lock: proceeding while {lock_path} is held"
+                f"{holder_note}; concurrent runs can corrupt each "
+                f"other's worktrees and manifest"
+            )
+            return _RunLock(fp=None, held=False)
+        raise FactoryLockHeldError(
+            f"Another ralph invocation{holder_note} holds {lock_path}; "
+            f"refusing to start a second factory run on this root. "
+            f"Wait for it to finish, or re-run with --force-lock to "
+            f"override."
+        ) from None
+
+    # Holder pid is diagnostic only (shown in the refusal message of a
+    # contending invocation); the flock itself is the exclusion.
+    try:
+        fp.seek(0)
+        fp.truncate()
+        fp.write(f"{os.getpid()}\n")
+        fp.flush()
+    except OSError:
+        pass
+    return _RunLock(fp=fp, held=True)
+
+
 def _remove_stale_index_lock(root_dir: Path, component_id: str) -> None:
     """Remove a stale index.lock left behind by a killed git operation.
 
@@ -189,14 +289,22 @@ def _setup_worktree(
     branch_name: str,
     base_branch: str,
     root_dir: Path,
+    run_id: str,
     fresh_from_base: bool = False,
 ) -> Path:
     """Create a git worktree for a component.
 
+    Worktrees are keyed ``.ralph/worktrees/<run_id>/<component_id>``
+    (R0.5, H-7): two invocations never share a worktree path, so setup
+    can only ever remove a leftover from an earlier attempt of THIS run
+    (a retry), never another invocation's in-flight worktree. Run-level
+    exclusion itself is the ``.ralph/factory.lock`` flock in run_factory.
+
     A per-host fcntl flock on ``.ralph/worktrees/<component_id>.lock``
-    serializes setup across concurrent factory invocations on the same
-    machine. Without it, two simultaneously-running factories could
-    clobber each other's worktree at the same path.
+    (run-agnostic on purpose) still serializes the git commands here for
+    the degraded modes that run without the run-level lock (Windows,
+    ``--force-lock``), where two invocations could otherwise race on the
+    shared branch and .git metadata.
 
     ``fresh_from_base=True`` (used for retries after a timeout kill)
     additionally deletes the component branch so the worktree is recreated
@@ -206,10 +314,10 @@ def _setup_worktree(
     POSIX only. On Windows the fcntl import fails; we degrade to the
     pre-lock behavior and document the limitation in the runbook.
     """
-    worktree_base = root_dir / ".ralph" / "worktrees"
+    worktree_base = root_dir / ".ralph" / "worktrees" / run_id
     worktree_base.mkdir(parents=True, exist_ok=True)
     worktree_path = worktree_base / component_id
-    lock_path = worktree_base / f"{component_id}.lock"
+    lock_path = root_dir / ".ralph" / "worktrees" / f"{component_id}.lock"
 
     lock_fp = None
     try:
@@ -256,6 +364,13 @@ def _setup_worktree(
         )
 
         if result.returncode != 0:
+            # Branch already exists: reuse it WITH its commits. After the
+            # run-start preflight (_preflight_component_branches) this can
+            # only be a branch created during THIS run - a non-timeout
+            # retry resuming its own progress, or single_pr components
+            # stacking on the shared branch. Stale branches from previous
+            # runs were deleted (fully merged) or refused at preflight,
+            # never silently reused here (R0.5).
             result = subprocess.run(
                 ["git", "worktree", "add", str(worktree_path), branch_name],
                 cwd=root_dir, capture_output=True, text=True, timeout=30,
@@ -278,15 +393,126 @@ def _setup_worktree(
             lock_fp.close()
 
 
-def _cleanup_worktree(component_id: str, root_dir: Path) -> None:
-    """Remove a git worktree for a component."""
-    worktree_path = root_dir / ".ralph" / "worktrees" / component_id
+def _cleanup_worktree(component_id: str, root_dir: Path, run_id: str) -> None:
+    """Remove a git worktree for a component of the current run."""
+    worktree_path = root_dir / ".ralph" / "worktrees" / run_id / component_id
     if not worktree_path.exists():
         return
     subprocess.run(
         ["git", "worktree", "remove", "--force", str(worktree_path)],
         cwd=root_dir, capture_output=True, timeout=30,
     )
+
+
+def _prune_stale_worktrees(root_dir: Path, run_id: str, ui: UI) -> None:
+    """Remove worktrees left behind by previous (crashed/aborted) runs.
+
+    Only called when the run-level flock is genuinely held: any prior
+    holder has exited (flock dies with its process), so everything under
+    ``.ralph/worktrees/`` that is not ours - other runs' ``<run_id>/``
+    dirs, and pre-R0.5 flat-layout ``<component_id>/`` worktrees - is
+    orphaned and safe to remove. Includes worktrees kept for leaked
+    workers (R0.1): their owning run is gone, so by the next invocation
+    they are stale state, matching the pre-R0.5 force-remove behavior.
+    """
+    worktree_root = root_dir / ".ralph" / "worktrees"
+    if not worktree_root.exists():
+        return
+    removed = 0
+    for entry in sorted(worktree_root.iterdir()):
+        if entry.name == run_id or not entry.is_dir():
+            continue  # our own run dir, or a per-component .lock file
+        if (entry / ".git").exists():
+            # Pre-R0.5 flat layout: the entry itself is a worktree.
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", str(entry)],
+                cwd=root_dir, capture_output=True, timeout=30,
+            )
+            removed += 1
+        else:
+            # <run_id>/ dir from a previous run: remove each component
+            # worktree inside it.
+            for wt in sorted(entry.iterdir()):
+                if wt.is_dir():
+                    subprocess.run(
+                        ["git", "worktree", "remove", "--force", str(wt)],
+                        cwd=root_dir, capture_output=True, timeout=30,
+                    )
+                    removed += 1
+        # Whatever git could not remove (or non-worktree debris) goes
+        # with the dir; `git worktree prune` below drops any metadata
+        # orphaned by this.
+        shutil.rmtree(entry, ignore_errors=True)
+    if removed:
+        subprocess.run(
+            ["git", "worktree", "prune"],
+            cwd=root_dir, capture_output=True, timeout=30,
+        )
+        ui.info(f"  Pruned {removed} stale worktree(s) from previous runs")
+
+
+def _preflight_component_branches(
+    manifest: Manifest, root_dir: Path, ui: UI,
+) -> list[str]:
+    """Refuse to silently reuse component branches from previous runs.
+
+    For every branch a PENDING component would be provisioned on: if it
+    already exists and is fully merged into the base branch, delete it
+    (setup recreates it from base); if it exists with unmerged commits,
+    return an error naming it - the caller refuses the run and the
+    operator decides (merge or ``git branch -D``). Previously such
+    branches were silently reused with their old commits via the
+    worktree-add fallback (R0.5, H-7).
+
+    Note: a squash-merged branch is NOT an ancestor of base (the squash
+    rewrites history), so leftovers from squash-merge flows are refused
+    rather than auto-deleted. Loud beats lossy.
+    """
+    errors: list[str] = []
+    fetch_base_branch(manifest.base_branch, root_dir, timeout=60.0)
+    base_ref = resolve_base_ref(manifest.base_branch, root_dir)
+    seen: set[str] = set()
+    for comp in manifest.components:
+        if comp.status != ComponentStatus.PENDING.value:
+            continue
+        branch = comp.branch_name
+        if branch in seen:
+            continue  # single_pr: all components share one branch
+        seen.add(branch)
+        exists = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+            cwd=root_dir, capture_output=True, timeout=30,
+        )
+        if exists.returncode != 0:
+            continue
+        merged = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", branch, base_ref],
+            cwd=root_dir, capture_output=True, timeout=30,
+        )
+        if merged.returncode == 0:
+            deleted = subprocess.run(
+                ["git", "branch", "-D", branch],
+                cwd=root_dir, capture_output=True, text=True, timeout=30,
+            )
+            if deleted.returncode == 0:
+                ui.info(
+                    f"  Deleted stale branch '{branch}' from a previous "
+                    f"run (fully merged into {manifest.base_branch})"
+                )
+            else:
+                errors.append(
+                    f"stale branch '{branch}' (component '{comp.id}') is "
+                    f"fully merged but could not be deleted: "
+                    f"{deleted.stderr.strip()}"
+                )
+        else:
+            errors.append(
+                f"branch '{branch}' (component '{comp.id}') already exists "
+                f"with commits not merged into '{manifest.base_branch}'; "
+                f"refusing to silently reuse it. Merge it or delete it "
+                f"(git branch -D {branch}) and re-run."
+            )
+    return errors
 
 
 def _run_component(
@@ -501,13 +727,53 @@ def run_factory(
     base_config: RalphConfig,
     ui: UI,
     root_dir: Path,
+    manifest_path: Path | None = None,
 ) -> FactoryResult:
     """Run the factory orchestrator with 3-phase verification.
 
     Phase 1: Mechanical verification (tests, typecheck, lint, PRD, diff scope)
     Phase 2: Second-opinion review (separate agent reviews diff against spec)
     Phase 3: Contract testing (merge tier branches, run integration tests)
+
+    ``manifest_path`` is where run state is SAVED as well as where it was
+    loaded from (R0.5, H-15): ``--manifest /custom.json`` must persist to
+    /custom.json and ``ralph run`` to its own run-manifest.json, never to
+    another invocation's resumable ``scripts/ralph/manifest.json``. None
+    keeps the historical default of ``<root>/scripts/ralph/manifest.json``.
+
+    Holds the run-level ``.ralph/factory.lock`` flock for the whole run
+    (R0.5, H-7); a contending invocation is refused with exit code 2
+    unless it passes ``--force-lock``.
     """
+    try:
+        run_lock = _acquire_run_lock(
+            root_dir, ui, force=factory_config.force_lock,
+        )
+    except FactoryLockHeldError as exc:
+        ui.err(str(exc))
+        refused = FactoryResult()
+        refused.exit_code = 2
+        return refused
+    try:
+        return _run_factory_locked(
+            manifest, factory_config, base_config, ui, root_dir,
+            manifest_path=manifest_path, lock_held=run_lock.held,
+        )
+    finally:
+        run_lock.release()
+
+
+def _run_factory_locked(
+    manifest: Manifest,
+    factory_config: FactoryConfig,
+    base_config: RalphConfig,
+    ui: UI,
+    root_dir: Path,
+    manifest_path: Path | None,
+    lock_held: bool,
+) -> FactoryResult:
+    """run_factory body; runs with the run-level lock resolved (held, or
+    explicitly degraded via --force-lock / no-fcntl platforms)."""
     from ralph_py.agents import get_agent
 
     factory_start = time.monotonic()
@@ -549,7 +815,8 @@ def run_factory(
             ui.info(f"  Resetting '{comp.id}' from {comp.status} to PENDING")
             comp.status = ComponentStatus.PENDING.value
 
-    manifest_path = root_dir / "scripts" / "ralph" / "manifest.json"
+    if manifest_path is None:
+        manifest_path = root_dir / "scripts" / "ralph" / "manifest.json"
 
     # R0.2 crash recovery: MERGE_PENDING is re-pollable, not failed. A
     # prior run initiated the merge but could not confirm it; check the
@@ -612,6 +879,16 @@ def run_factory(
     if not factory_config.use_worktrees:
         max_parallel = 1
         ui.info("Worktrees disabled: running sequentially")
+    if factory_config.single_pr and max_parallel > 1:
+        # R0.5 (H-8): single_pr components all live on ONE branch, and a
+        # branch can only be checked out in one worktree at a time -
+        # parallel same-tier components would hard-fail on "already
+        # checked out". Sequential is the only layout that works.
+        max_parallel = 1
+        ui.info(
+            "single_pr mode: components share one branch; "
+            "forcing max_parallel=1"
+        )
 
     # R0.1: TimeoutConfig is the single source for the agent-iteration and
     # component wall-clock limits. Enforcement layers: the adapters kill
@@ -623,6 +900,25 @@ def run_factory(
         timeout_cfg.component_total + timeout_cfg.scheduler_backstop_margin
         if timeout_cfg.component_total > 0 else 0.0
     )
+
+    # R0.5 worktree crash recovery + stale-branch policy. Both only
+    # apply to worktree mode: without worktrees the factory neither
+    # creates branches nor worktree dirs.
+    if factory_config.use_worktrees:
+        if lock_held:
+            _prune_stale_worktrees(root_dir, run_id, ui)
+        else:
+            ui.warn(
+                "  Run lock not held; skipping stale-worktree cleanup "
+                "(another live invocation may own them)"
+            )
+        branch_errors = _preflight_component_branches(manifest, root_dir, ui)
+        if branch_errors:
+            ui.err("Refusing to run: stale component branches found")
+            for line in branch_errors:
+                ui.err(f"  {line}")
+            factory_result.exit_code = 2
+            return factory_result
 
     ui.section("Factory: Execution")
     ui.kv("Max parallel", str(max_parallel))
@@ -1155,7 +1451,7 @@ def run_factory(
 
         # Clean up worktree now that code is merged
         if factory_config.use_worktrees and comp_id in worktree_paths:
-            _cleanup_worktree(comp_id, root_dir)
+            _cleanup_worktree(comp_id, root_dir, run_id)
             del worktree_paths[comp_id]
 
         # Mark completed
@@ -1180,7 +1476,7 @@ def run_factory(
                 timeout_retry_ids.discard(comp.id)
                 wt_path = _setup_worktree(
                     comp.id, comp.branch_name, manifest.base_branch, root_dir,
-                    fresh_from_base=fresh_from_base,
+                    run_id, fresh_from_base=fresh_from_base,
                 )
             else:
                 wt_path = root_dir
@@ -1393,7 +1689,14 @@ def run_factory(
                     f"(leaked worker may still be running)"
                 )
                 continue
-            _cleanup_worktree(comp_id, root_dir)
+            _cleanup_worktree(comp_id, root_dir, run_id)
+        # Drop the run's now-empty worktree dir; leaked workers' kept
+        # worktrees leave it non-empty and it stays for the next run's
+        # prune pass.
+        try:
+            os.rmdir(root_dir / ".ralph" / "worktrees" / run_id)
+        except OSError:
+            pass
         ui.ok("Worktrees cleaned up")
 
     def _record_contract_event(cr: ContractResult) -> None:

--- a/tests/test_instance_safety.py
+++ b/tests/test_instance_safety.py
@@ -1,0 +1,493 @@
+"""R0.5: instance and state safety (H-7, H-8, H-15).
+
+- Run-level flock on ``.ralph/factory.lock``: a second invocation on the
+  same root refuses to start while the first holds the lock (real
+  two-process contention), with ``--force-lock`` as the explicit
+  override.
+- Manifest save path == manifest load path: a custom ``--manifest``
+  round-trips to the custom file, and ``ralph run`` persists to its own
+  ``run-manifest.json`` instead of clobbering a factory's resumable
+  ``manifest.json``.
+- ``single_pr=True`` forces ``max_parallel=1`` with a printed notice
+  (all components share one branch; parallel worktrees hard-fail).
+- Stale branches from previous runs are deleted when fully merged and
+  refused (naming the branch) otherwise - never silently reused.
+- Stale worktrees from crashed runs (run-scoped and pre-R0.5 flat
+  layout) are pruned at start when the run lock is genuinely held.
+
+Real git repos and real fake-agent subprocesses; no LLM involved.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from ralph_py.cli import cli
+from ralph_py.config import RalphConfig
+from ralph_py.factory import FactoryConfig, FactoryResult, run_factory
+from ralph_py.manifest import Component, Manifest
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+COMPLETE_LINE = "echo '<promise>COMPLETE</promise>'"
+
+# Child process that takes the run-level flock and holds it until killed,
+# standing in for a live first factory invocation.
+_LOCK_HOLDER_SCRIPT = """
+import fcntl, sys, time
+fp = open(sys.argv[1], "a+")
+try:
+    fcntl.flock(fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+except OSError:
+    print("FAIL", flush=True)
+    sys.exit(1)
+print("locked", flush=True)
+time.sleep(60)
+"""
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, timeout=30,
+    )
+
+
+def _git_out(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True,
+        text=True, timeout=30,
+    ).stdout.strip()
+
+
+def _init_repo(root: Path, comp_ids: tuple[str, ...] = ("comp-a",)) -> None:
+    """Real git repo shaped like a ralph project (scripts/ralph/ is
+    gitignored, so provisioning must copy prompt + PRD into worktrees)."""
+    root.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", "-b", "main", cwd=root)
+    _git("config", "user.email", "t@t", cwd=root)
+    _git("config", "user.name", "t", cwd=root)
+    (root / ".gitignore").write_text("scripts/ralph/\n")
+    (root / "README.md").write_text("seed\n")
+    _git("add", ".gitignore", "README.md", cwd=root)
+    _git("commit", "-q", "-m", "init", cwd=root)
+
+    ralph_dir = root / "scripts" / "ralph"
+    (ralph_dir / "feature").mkdir(parents=True)
+    (ralph_dir / "prompt.md").write_text(
+        "Read the PRD at $prd_path and implement one story.\n"
+    )
+    for comp_id in comp_ids:
+        feature_dir = ralph_dir / "feature" / comp_id
+        feature_dir.mkdir(parents=True)
+        prd: dict[str, object] = {
+            "branchName": f"ralph/factory/{comp_id}",
+            "userStories": [{
+                "id": "US-001", "title": "Test",
+                "acceptanceCriteria": ["AC1"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }
+        (feature_dir / "prd.json").write_text(json.dumps(prd))
+
+
+def _component(comp_id: str, branch: str | None = None) -> Component:
+    return Component(
+        id=comp_id, title=comp_id.upper(), description="", dependencies=[],
+        prd_path=f"scripts/ralph/feature/{comp_id}/prd.json",
+        branch_name=branch or f"ralph/factory/{comp_id}",
+    )
+
+
+def _manifest(
+    components: list[Component] | None = None, single_pr: bool = False,
+) -> Manifest:
+    return Manifest(
+        version="1", spec_file="spec.md", project_name="t",
+        base_branch="main", single_pr=single_pr,
+        components=components if components is not None
+        else [_component("comp-a")],
+    )
+
+
+def _factory_config(**overrides: Any) -> FactoryConfig:
+    kwargs: dict[str, Any] = dict(
+        use_worktrees=True, create_prs=False, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_bad_patterns=False,
+            subprocess_timeout=30.0,
+        ),
+    )
+    kwargs.update(overrides)
+    return FactoryConfig(**kwargs)
+
+
+def _base_config(root: Path, agent_cmd: str = COMPLETE_LINE) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root / "scripts" / "ralph" / "prompt.md",
+        prd_file=root / "scripts" / "ralph" / "prd.json",
+        sleep_seconds=0, agent_cmd=agent_cmd,
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    )
+
+
+def _run(
+    root: Path,
+    manifest: Manifest | None = None,
+    config: FactoryConfig | None = None,
+    manifest_path: Path | None = None,
+    agent_cmd: str = COMPLETE_LINE,
+) -> FactoryResult:
+    return run_factory(
+        manifest if manifest is not None else _manifest(),
+        config if config is not None else _factory_config(),
+        _base_config(root, agent_cmd),
+        PlainUI(no_color=True),
+        root,
+        manifest_path=manifest_path,
+    )
+
+
+class _HeldLock:
+    """Context manager: a real second process holding .ralph/factory.lock."""
+
+    def __init__(self, root: Path) -> None:
+        self.lock_path = root / ".ralph" / "factory.lock"
+
+    def __enter__(self) -> _HeldLock:
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self.proc = subprocess.Popen(
+            [sys.executable, "-c", _LOCK_HOLDER_SCRIPT, str(self.lock_path)],
+            stdout=subprocess.PIPE, text=True,
+        )
+        assert self.proc.stdout is not None
+        line = self.proc.stdout.readline().strip()
+        assert line == "locked", f"lock-holder child failed: {line!r}"
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.proc.kill()
+        self.proc.wait(timeout=10)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="flock is POSIX-only (documented degrade)",
+)
+class TestRunLockContention:
+    def test_second_invocation_refused_while_lock_held(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """While a real second process holds the flock, run_factory
+        refuses to start: exit code 2, nothing scheduled, no state
+        written."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        manifest = _manifest()
+        with _HeldLock(root):
+            result = _run(root, manifest=manifest)
+
+        assert result.exit_code == 2
+        assert result.completed == []
+        # Nothing was scheduled or persisted.
+        assert manifest.components[0].status == "pending"
+        assert not (root / "scripts" / "ralph" / "manifest.json").exists()
+        assert not (root / ".ralph" / "worktrees").exists()
+        text = capsys.readouterr().err
+        assert "factory.lock" in text
+        assert "--force-lock" in text
+
+    def test_force_lock_overrides_held_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        with _HeldLock(root):
+            result = _run(root, config=_factory_config(force_lock=True))
+
+        assert result.exit_code == 0
+        assert result.completed == ["comp-a"]
+        text = capsys.readouterr().err
+        assert "--force-lock" in text
+
+    def test_lock_released_after_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A completed run releases the flock so the next invocation can
+        acquire it."""
+        import fcntl
+
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        result = _run(root)
+        assert result.completed == ["comp-a"]
+
+        with open(root / ".ralph" / "factory.lock", "a+") as fp:
+            # Raises BlockingIOError if the run leaked its lock.
+            fcntl.flock(fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+
+
+class TestManifestPathFidelity:
+    def test_custom_manifest_path_round_trip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """State saves to the same custom path the manifest was loaded
+        from, not the hardcoded scripts/ralph/manifest.json (H-15)."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        custom = tmp_path / "custom-manifest.json"
+        _manifest().save(custom)
+        manifest = Manifest.load(custom)
+
+        result = _run(root, manifest=manifest, manifest_path=custom)
+
+        assert result.completed == ["comp-a"]
+        saved = json.loads(custom.read_text())
+        assert saved["components"][0]["status"] == "completed"
+        assert not (root / "scripts" / "ralph" / "manifest.json").exists(), (
+            "custom-manifest run leaked state into the default path"
+        )
+
+    def test_default_manifest_path_preserved(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        result = _run(root)
+
+        assert result.completed == ["comp-a"]
+        default_path = root / "scripts" / "ralph" / "manifest.json"
+        saved = json.loads(default_path.read_text())
+        assert saved["components"][0]["status"] == "completed"
+
+    def test_cli_run_uses_run_manifest_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`ralph run` wires its own run-manifest.json into run_factory
+        so it cannot clobber a factory's resumable manifest.json."""
+        project = tmp_path / "project"
+        ralph_dir = project / "scripts" / "ralph"
+        ralph_dir.mkdir(parents=True)
+        (ralph_dir / "prompt.md").write_text("test prompt")
+        (ralph_dir / "prd.json").write_text(
+            '{"branchName": "test", "userStories": []}'
+        )
+
+        captured: dict[str, Any] = {}
+
+        def fake_run_factory(*args: Any, **kwargs: Any) -> FactoryResult:
+            captured["manifest_path"] = kwargs.get("manifest_path")
+            captured["factory_config"] = args[1]
+            return FactoryResult()
+
+        monkeypatch.setattr("ralph_py.cli.run_factory", fake_run_factory)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "run", "0",
+                "--agent-cmd", COMPLETE_LINE,
+                "--sleep", "0",
+                "--no-verify",
+                "--force-lock",
+            ],
+            env={
+                "PROMPT_FILE": str(ralph_dir / "prompt.md"),
+                "PRD_FILE": str(ralph_dir / "prd.json"),
+            },
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["manifest_path"] == (
+            ralph_dir / "run-manifest.json"
+        )
+        assert captured["factory_config"].force_lock is True
+
+    def test_cli_factory_passes_custom_manifest_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`ralph factory --manifest /x.json` hands that exact path to
+        run_factory as the save path."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        custom = tmp_path / "custom-manifest.json"
+        _manifest().save(custom)
+
+        captured: dict[str, Any] = {}
+
+        def fake_run_factory(*args: Any, **kwargs: Any) -> FactoryResult:
+            captured["manifest_path"] = kwargs.get("manifest_path")
+            captured["factory_config"] = args[1]
+            return FactoryResult()
+
+        monkeypatch.setattr("ralph_py.cli.run_factory", fake_run_factory)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "factory",
+                "--manifest", str(custom),
+                "--root", str(root),
+                "--agent-cmd", COMPLETE_LINE,
+                "--yes",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["manifest_path"] == custom
+        assert captured["factory_config"].force_lock is False
+
+
+class TestSinglePrParallelism:
+    def test_single_pr_forces_sequential(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """single_pr with max_parallel>1 downgrades to sequential with a
+        notice, and same-tier components complete instead of hard-failing
+        on 'branch already checked out' (H-8)."""
+        root = tmp_path / "repo"
+        _init_repo(root, comp_ids=("comp-a", "comp-b"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        shared_branch = "ralph/factory/shared"
+        manifest = _manifest(
+            components=[
+                _component("comp-a", branch=shared_branch),
+                _component("comp-b", branch=shared_branch),
+            ],
+            single_pr=True,
+        )
+        config = _factory_config(single_pr=True, max_parallel=4)
+
+        result = _run(root, manifest=manifest, config=config)
+
+        assert result.exit_code == 0
+        assert sorted(result.completed) == ["comp-a", "comp-b"]
+        text = capsys.readouterr().err
+        assert "forcing max_parallel=1" in text
+
+
+class TestStaleBranchPolicy:
+    def test_unmerged_stale_branch_refuses_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A leftover component branch with commits not merged into base
+        refuses the run with an error naming the branch (H-7): never
+        silently reused."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        # Aborted-run leftover: branch with a commit main does not have.
+        _git("branch", "ralph/factory/comp-a", cwd=root)
+        _git("checkout", "-q", "ralph/factory/comp-a", cwd=root)
+        (root / "stale.txt").write_text("from an aborted run\n")
+        _git("add", "stale.txt", cwd=root)
+        _git("commit", "-q", "-m", "stale work", cwd=root)
+        _git("checkout", "-q", "main", cwd=root)
+        stale_tip = _git_out("rev-parse", "ralph/factory/comp-a", cwd=root)
+
+        manifest = _manifest()
+        result = _run(root, manifest=manifest)
+
+        assert result.exit_code == 2
+        assert result.completed == []
+        assert manifest.components[0].status == "pending"
+        # The branch is untouched, not deleted and not built upon.
+        assert _git_out(
+            "rev-parse", "ralph/factory/comp-a", cwd=root,
+        ) == stale_tip
+        text = capsys.readouterr().err
+        assert "ralph/factory/comp-a" in text
+        assert "not merged" in text
+
+    def test_merged_stale_branch_deleted_and_run_proceeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A leftover branch fully merged into base is deleted at
+        preflight and the component is provisioned fresh from base."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        # Leftover branch pointing at main's tip: fully merged.
+        _git("branch", "ralph/factory/comp-a", "main", cwd=root)
+
+        result = _run(root)
+
+        assert result.exit_code == 0
+        assert result.completed == ["comp-a"]
+        text = capsys.readouterr().err
+        assert "Deleted stale branch 'ralph/factory/comp-a'" in text
+
+
+class TestStaleWorktreePrune:
+    def test_stale_worktrees_pruned_at_start(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Worktrees from crashed runs - run-scoped dirs from other run
+        ids AND pre-R0.5 flat-layout dirs - are removed when the run lock
+        is held; the completed run leaves no worktree dirs behind."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        worktree_root = root / ".ralph" / "worktrees"
+        old_run_wt = worktree_root / "20250101-000000-000000-dead" / "comp-x"
+        legacy_wt = worktree_root / "legacy-comp"
+        _git(
+            "worktree", "add", str(old_run_wt), "-b", "tmp/old-run", "main",
+            cwd=root,
+        )
+        _git(
+            "worktree", "add", str(legacy_wt), "-b", "tmp/legacy", "main",
+            cwd=root,
+        )
+
+        result = _run(root)
+
+        assert result.completed == ["comp-a"]
+        assert not old_run_wt.exists()
+        assert not legacy_wt.exists()
+        # The completed run's own worktree dir is gone too; only lock
+        # files may remain at the top level.
+        leftovers = [
+            p for p in worktree_root.iterdir() if not p.name.endswith(".lock")
+        ] if worktree_root.exists() else []
+        assert leftovers == []
+        # git's worktree bookkeeping agrees (no stale registrations).
+        listed = _git_out("worktree", "list", "--porcelain", cwd=root)
+        assert "worktrees/" not in listed.replace(str(root), "")

--- a/tests/test_timeout_enforcement.py
+++ b/tests/test_timeout_enforcement.py
@@ -571,7 +571,7 @@ class TestWorktreeTimeoutHygiene:
 
     def test_fresh_from_base_resets_branch(self, tmp_path: Path) -> None:
         _init_repo(tmp_path)
-        wt = _setup_worktree("a", "b/a", "main", tmp_path)
+        wt = _setup_worktree("a", "b/a", "main", tmp_path, "run1")
 
         # Simulate a killed attempt that left a commit on the branch.
         (wt / "leftover.txt").write_text("dirty state from killed attempt")
@@ -592,7 +592,9 @@ class TestWorktreeTimeoutHygiene:
         lock.parent.mkdir(parents=True, exist_ok=True)
         lock.write_text("")
 
-        wt2 = _setup_worktree("a", "b/a", "main", tmp_path, fresh_from_base=True)
+        wt2 = _setup_worktree(
+            "a", "b/a", "main", tmp_path, "run1", fresh_from_base=True,
+        )
 
         new_tip = subprocess.run(
             ["git", "rev-parse", "b/a"], cwd=tmp_path,
@@ -606,7 +608,7 @@ class TestWorktreeTimeoutHygiene:
         """Without fresh_from_base the existing branch is reused (the
         pre-R0.1 retry behavior for non-timeout failures is preserved)."""
         _init_repo(tmp_path)
-        wt = _setup_worktree("a", "b/a", "main", tmp_path)
+        wt = _setup_worktree("a", "b/a", "main", tmp_path, "run1")
         (wt / "progress.txt").write_text("legit progress")
         _git("add", "-A", cwd=wt)
         _git("commit", "-q", "-m", "progress", cwd=wt)
@@ -615,7 +617,7 @@ class TestWorktreeTimeoutHygiene:
             capture_output=True, text=True, timeout=30,
         ).stdout.strip()
 
-        _setup_worktree("a", "b/a", "main", tmp_path)
+        _setup_worktree("a", "b/a", "main", tmp_path, "run1")
 
         new_tip = subprocess.run(
             ["git", "rev-parse", "b/a"], cwd=tmp_path,
@@ -712,7 +714,9 @@ class TestSchedulerBackstop:
         assert comp.status == "failed"
         assert comp.error == "component timeout"
         # Leaked worker's worktree is kept, not ripped out from under it.
-        assert (tmp_path / ".ralph" / "worktrees" / "a").exists()
+        # R0.5: worktrees are keyed .ralph/worktrees/<run_id>/<component_id>
+        leaked = list((tmp_path / ".ralph" / "worktrees").glob("*/a"))
+        assert leaked, "leaked worker's worktree was removed"
 
 
 class TestTimeoutConfigLoading:


### PR DESCRIPTION
## Roadmap items

R0.5 (docs/remediation-roadmap.md) - findings H-7, H-8, H-15. Flips the R0.5 checkbox in the tracker.

## What changed

- **Run-level exclusion (H-7)**: `run_factory` now takes an fcntl flock on `.ralph/factory.lock` and holds it for the entire run. A second `ralph factory` / `ralph run` on the same root refuses to start with exit code 2 and a message naming the lock and the holder pid. New `--force-lock` flag on both commands overrides with a warning. Platforms without fcntl degrade to no exclusion with a warning (POSIX-only, same as the A4 lock).
- **Run-scoped worktrees (H-7)**: worktrees are now keyed `.ralph/worktrees/<run_id>/<component_id>`, so `_setup_worktree` can only ever remove a leftover from a retry of the current run, never another invocation's in-flight worktree. Stale worktrees from crashed runs (other run-id dirs and pre-R0.5 flat-layout dirs) are pruned at start, but only when the lock is genuinely held.
- **Stale-branch policy (H-7)**: a preflight pass checks every PENDING component's branch. Exists and fully merged into base: deleted (recreated fresh at setup). Exists with unmerged commits: the run refuses with exit code 2 and an error naming the branch. The worktree-add fallback that silently reused old commits can now only fire for branches created during the current run (retries, single_pr stacking).
- **Manifest path fidelity (H-15)**: `run_factory` takes a `manifest_path` parameter; state saves back to the file it was loaded from. `ralph factory --manifest /x.json` persists to /x.json; `ralph run` uses its own `scripts/ralph/run-manifest.json`; default unchanged.
- **single_pr parallelism (H-8)**: `single_pr=true` forces `max_parallel=1` with a printed notice, since all components share one branch and a branch can only be checked out in one worktree.

## Checks (final lines)

```
uv run pytest tests/ -q            -> 818 passed, 12 skipped, 1 warning in 302.05s (0:05:02)
uv run mypy ralph_py/ --strict     -> Success: no issues found in 37 source files
uv run ruff check ralph_py/ tests/ -> All checks passed!
```

Run in a detached scratch worktree at the PR head commit, so results reflect exactly the committed tree.

## Tested

- `test_second_invocation_refused_while_lock_held`: a real second process holds the flock; `run_factory` exits 2, schedules nothing, writes no manifest, and the message names `factory.lock` and `--force-lock` (two-process contention, real flock).
- `test_force_lock_overrides_held_lock`: with the lock held by another process, `force_lock=True` proceeds and completes the component, with a warning.
- `test_lock_released_after_run`: after a completed run, a fresh `LOCK_EX | LOCK_NB` flock on the lock file succeeds.
- `test_custom_manifest_path_round_trip`: a run loaded from a custom manifest path saves completed state to that path and does NOT create `scripts/ralph/manifest.json`.
- `test_default_manifest_path_preserved`: without `manifest_path` the historical default location still receives state.
- `test_cli_run_uses_run_manifest_path`: `ralph run` passes `scripts/ralph/run-manifest.json` and wires `--force-lock` into `FactoryConfig`.
- `test_cli_factory_passes_custom_manifest_path`: `ralph factory --manifest /x.json` hands exactly that path to `run_factory`.
- `test_single_pr_forces_sequential`: `single_pr=True, max_parallel=4` with two same-tier components prints "forcing max_parallel=1" and both components complete (previously the second hard-failed on "branch already checked out").
- `test_unmerged_stale_branch_refuses_run`: a leftover branch with unmerged commits refuses the run (exit 2), names the branch, and leaves the branch untouched.
- `test_merged_stale_branch_deleted_and_run_proceeds`: a leftover branch at the base tip is deleted at preflight and the run completes.
- `test_stale_worktrees_pruned_at_start`: stale run-scoped and pre-R0.5 flat-layout worktrees are removed at start; the completed run leaves no worktree dirs and no stale `git worktree list` registrations.
- Updated `test_timeout_enforcement.py` for the new `_setup_worktree(run_id)` signature and run-scoped leaked-worktree path; R0.1 fresh-from-base and keep-branch retry semantics re-verified unchanged.

## Assumed (not tested)

- Windows/no-fcntl degrade paths (run-level lock warning, per-component lock skip): guarded by `ImportError` handling, not executed on this POSIX host.
- Squash-merged leftover branches are refused rather than auto-deleted (a squash rewrite is not an ancestor of base); the error message's remediation hint covers it, but no test plants a squash-merge leftover.
- On Linux (fork start method), pool workers inherit the lock fd, so a leaked worker keeps the lock held after the parent exits; treated as intended (a live worker still owns its worktree) but only reasoned about, not tested. macOS uses spawn, where this does not arise.
- Contention behavior when two invocations race the flock in the same microsecond: flock atomicity is assumed from the OS, not stress-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)