### PR TITLE
fix: R1.1-R1.3 reviewer gate integrity - empty/partial/oversized/crashed reviews fail closed

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -153,12 +153,12 @@ First principles: a gate that can be passed by silence, case drift, or absence
 of data is not a gate. Every fix here makes the harness distrust its own
 reviewers' output as much as it distrusts the engineer's.
 
-- [ ] R1.1 (S) **Empty or partial reviews cannot pass hard mode** [CRIT-5]
+- [x] R1.1 (S) **Empty or partial reviews cannot pass hard mode** [CRIT-5]
   - `review.py`: criterion-coverage check: every PRD story id must receive a
     verdict or the result is `infrastructure_error=True` (id-based matching,
     not criterion-text string equality); verdict whitelist `{pass, fail}`
     case-insensitively, anything else is a parse failure, not an advisory.
-- [ ] R1.2 (S) **Close the E9 holes** [H-13, MED review-nondict, MED sec-pr-body]
+- [x] R1.2 (S) **Close the E9 holes** [H-13, MED review-nondict, MED sec-pr-body]
   - `review.py:518-527`: `AgentOutputTooLarge` sets `infrastructure_error=True`
     (mirror security.py).
   - Skipped and budget-exhausted phases emit a synthetic
@@ -170,7 +170,7 @@ reviewers' output as much as it distrusts the engineer's.
   - `pr.py` body: render an explicit "security review did not run
     (infrastructure error)" section when applicable (use
     `render_findings_markdown`'s existing callout).
-- [ ] R1.3 (S) **Empty diff from git error is an infrastructure failure** [H-14]
+- [x] R1.3 (S) **Empty diff from git error is an infrastructure failure** [H-14]
   - `git.get_diff_content` returns a result object (content | error) or raises;
     `factory.py:593` maps error to `infrastructure_error` for all three
     consumers instead of reviewing an empty string.

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -23,7 +23,8 @@ from ralph_py.contract import (
     run_contract_testing,
 )
 from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
-from ralph_py.git import fetch_base_branch, resolve_base_ref
+from ralph_py.findings import Finding
+from ralph_py.git import GitDiffError, fetch_base_branch, resolve_base_ref
 from ralph_py.knowledge import (
     KnowledgeConfig,
     build_knowledge_context,
@@ -35,8 +36,13 @@ from ralph_py.manifest import Component, ComponentStatus, Manifest
 from ralph_py.observability import NullProgressLog, ProgressLog
 from ralph_py.pr import create_prs_in_order, create_single_pr
 from ralph_py.prd import PRD
-from ralph_py.review import ReviewMode, run_review
-from ralph_py.security import SecurityConfig, SecurityMode, run_security_review
+from ralph_py.review import ReviewMode, ReviewResult, run_review
+from ralph_py.security import (
+    SecurityConfig,
+    SecurityMode,
+    SecurityResult,
+    run_security_review,
+)
 from ralph_py.timeout import TimeoutConfig
 from ralph_py.verify import VerifyConfig, run_mechanical_verification
 
@@ -1108,39 +1114,102 @@ def _run_factory_locked(
         # Phase 2.5, and knowledge distillation. Without this each phase
         # would shell out to `git diff` independently, redundantly
         # rebuilding the same patch on every component.
+        #
+        # R1.3 (H-14): a git failure here used to yield "" and all three
+        # consumers silently reviewed an empty diff and passed. Now it
+        # is an infrastructure failure for the component: record the
+        # infra finding, journal it, and retry/fail closed.
         from ralph_py import git as _git_for_diff
-        shared_diff = _git_for_diff.get_diff_content(
-            manifest.base_branch, wt_path,
+        try:
+            shared_diff = _git_for_diff.get_diff_content(
+                manifest.base_branch, wt_path,
+            )
+        except GitDiffError as exc:
+            ui.err(f"  Diff fetch FAILED for {comp_id}: {exc}")
+            comp.findings.append(Finding.infrastructure_error(
+                phase="diff",
+                explanation=(
+                    f"git diff against {manifest.base_branch} failed; "
+                    f"review/security/knowledge cannot run: {exc}"
+                ),
+            ))
+            progress_log.emit(
+                "diff_fetch_failed", comp_id, {"error": str(exc)},
+            )
+            ctx = IterationContext.from_json(comp_result.context_json or "{}")
+            ctx.add_verification_failure(
+                f"git diff against {manifest.base_branch} failed: {exc}"
+            )
+            _retry_or_fail(
+                comp, f"Diff fetch failed (infrastructure): {exc}",
+                ctx.to_json(),
+            )
+            return
+
+        # Forensic home for full raw reviewer output on parse failures
+        # (R1.2; mirrors knowledge.py's _debug/<run_id>/ layout).
+        adversarial_debug_dir = (
+            root_dir / ".ralph" / "debug" / run_id / comp_id
         )
+
+        def _record_phase_skip(phase: str, reason: str) -> None:
+            """R1.2: a phase that never ran must leave a trace in both
+            the findings stream and the journal, so "ran clean" and
+            "never ran" are distinguishable downstream."""
+            comp.findings.append(Finding.phase_skipped(phase, reason))
+            progress_log.emit(
+                "phase_skipped", comp_id,
+                {"phase": phase, "reason": reason},
+            )
 
         # PHASE 2: Second-opinion review
         review_mode = ReviewMode(factory_config.review_mode)
-        if review_mode != ReviewMode.SKIP and not _adversarial_budget_ok():
+        review_skip_reason: str | None = None
+        if review_mode == ReviewMode.SKIP:
+            review_skip_reason = "review disabled (mode=skip)"
+        elif not _adversarial_budget_ok():
             ui.warn(
                 f"  Phase 2 SKIPPED for {comp_id}: "
                 f"adversarial LLM budget ({factory_config.max_adversarial_calls}) exhausted"
+            )
+            review_skip_reason = (
+                f"adversarial LLM budget "
+                f"({factory_config.max_adversarial_calls}) exhausted"
             )
             review_mode = ReviewMode.SKIP
         if review_mode != ReviewMode.SKIP:
             _adversarial_budget_consume()
             ui.info(f"  Phase 2: review ({review_mode.value}) for {comp_id}...")
 
-            review_agent = get_agent(
-                factory_config.review_agent_cmd,
-                factory_config.review_model,
-                None,
-                factory_config.review_agent_type or base_config.agent_type,
-            )
-            review_result = run_review(
-                review_agent,
-                wt_path / comp.prd_path,
-                wt_path,
-                manifest.base_branch,
-                verification,
-                review_mode,
-                ui,
-                diff_content=shared_diff,
-            )
+            # R1.2: wrap the agent-driven work like Phase 2.5 does. A
+            # reviewer crash degrades to a per-component infrastructure
+            # failure; it must never abort the whole factory run.
+            try:
+                review_agent = get_agent(
+                    factory_config.review_agent_cmd,
+                    factory_config.review_model,
+                    None,
+                    factory_config.review_agent_type or base_config.agent_type,
+                )
+                review_result = run_review(
+                    review_agent,
+                    wt_path / comp.prd_path,
+                    wt_path,
+                    manifest.base_branch,
+                    verification,
+                    review_mode,
+                    ui,
+                    diff_content=shared_diff,
+                    debug_dir=adversarial_debug_dir,
+                )
+            except Exception as exc:  # noqa: BLE001
+                ui.warn(f"  Review crashed: {exc}")
+                review_result = ReviewResult(
+                    passed=review_mode != ReviewMode.HARD,
+                    mode=review_mode.value,
+                    overall_notes=f"Review agent crashed: {exc}",
+                    infrastructure_error=True,
+                )
             comp.review_passed = review_result.passed
             # E3: typed findings are the source of truth; the rendered
             # string is a derived view kept for backward-compat consumers.
@@ -1159,18 +1228,26 @@ def _run_factory_locked(
             )
 
             if not review_result.passed:
+                reason = (
+                    "Review infrastructure error"
+                    if review_result.infrastructure_error
+                    else "Review failed"
+                )
                 ui.warn(
                     f"  Phase 2 FAILED for {comp_id}: "
                     f"{review_result.fail_count} failures"
                 )
                 ctx = IterationContext.from_json(comp_result.context_json or "{}")
                 ctx.add_review_finding(review_result.as_retry_context())
-                _retry_or_fail(comp, "Review failed", ctx.to_json())
+                _retry_or_fail(comp, reason, ctx.to_json())
                 return
 
             ui.ok(f"  Phase 2 passed for {comp_id}")
         else:
             comp.review_passed = None
+            _record_phase_skip(
+                "review", review_skip_reason or "review skipped",
+            )
 
         # PHASE 2.5: Security review (adversarial pass focused on vulns).
         # Runs as a separate LLM call with its own threat-model framing so
@@ -1178,13 +1255,21 @@ def _run_factory_locked(
         # fails the component on findings at or above
         # SecurityConfig.fail_threshold OR on infrastructure errors.
         sec_config = factory_config.security_config
-        if (
-            sec_config and sec_config.mode != SecurityMode.SKIP.value
-            and not _adversarial_budget_ok()
-        ):
+        if sec_config is None:
+            _record_phase_skip(
+                "security", "security review not configured",
+            )
+        elif sec_config.mode == SecurityMode.SKIP.value:
+            _record_phase_skip(
+                "security", "security review disabled (mode=skip)",
+            )
+        elif not _adversarial_budget_ok():
             ui.warn(
                 f"  Phase 2.5 SKIPPED for {comp_id}: "
                 f"adversarial LLM budget exhausted"
+            )
+            _record_phase_skip(
+                "security", "adversarial LLM budget exhausted",
             )
             sec_config = None
         if sec_config and sec_config.mode != SecurityMode.SKIP.value:
@@ -1216,25 +1301,25 @@ def _run_factory_locked(
                     sec_config,
                     ui,
                     diff_content=shared_diff,
+                    debug_dir=adversarial_debug_dir,
                 )
             except Exception as exc:  # noqa: BLE001
                 # Agent infrastructure failed before run_security_review
-                # could classify the outcome. Hard mode must block;
-                # advisory passes through.
+                # could classify the outcome. Synthesize an infra result
+                # and fall through to the shared recording block below:
+                # hard mode blocks via passed=False, advisory continues
+                # but the infra finding stays in the findings stream and
+                # the PR body instead of vanishing (R1.2, sec-pr-body).
                 ui.warn(f"  Security review crashed: {exc}")
-                if sec_config.mode == SecurityMode.HARD.value:
-                    ctx = IterationContext.from_json(
-                        comp_result.context_json or "{}",
-                    )
-                    ctx.add_review_finding(
-                        f"Security review infrastructure error: {exc}",
-                    )
-                    _retry_or_fail(
-                        comp,
-                        f"Security review crashed: {exc}",
-                        ctx.to_json(),
-                    )
-                    return
+                sec_result = SecurityResult(
+                    passed=sec_config.mode != SecurityMode.HARD.value,
+                    mode=sec_config.mode,
+                    overall_notes=(
+                        f"Security review agent failed before "
+                        f"completion: {exc}"
+                    ),
+                    infrastructure_error=True,
+                )
 
             if sec_result is not None:
                 progress_log.review_result(
@@ -1271,7 +1356,14 @@ def _run_factory_locked(
                     ctx = IterationContext.from_json(
                         comp_result.context_json or "{}",
                     )
-                    ctx.add_review_finding(sec_result.as_retry_context())
+                    # as_retry_context is empty for infra results (no
+                    # findings list); fall back to the notes so the
+                    # retry prompt still says what went wrong.
+                    ctx.add_review_finding(
+                        sec_result.as_retry_context()
+                        or "Security review infrastructure error: "
+                        + sec_result.overall_notes
+                    )
                     _retry_or_fail(comp, reason, ctx.to_json())
                     return
 
@@ -1290,10 +1382,17 @@ def _run_factory_locked(
                 f"  Knowledge: skipped for {comp_id} "
                 f"(single_pr mode produces a polluted per-component diff)"
             )
+            _record_phase_skip(
+                "knowledge",
+                "single_pr mode produces a polluted per-component diff",
+            )
         elif knowledge_config.enabled and not _adversarial_budget_ok():
             ui.info(
                 f"  Knowledge: skipped for {comp_id} "
                 f"(adversarial budget exhausted)"
+            )
+            _record_phase_skip(
+                "knowledge", "adversarial LLM budget exhausted",
             )
         elif knowledge_config.enabled:
             _adversarial_budget_consume()

--- a/ralph_py/findings.py
+++ b/ralph_py/findings.py
@@ -19,9 +19,11 @@ Phase tag examples: ``"review"`` (Phase 2 reviewer), ``"security"`` (Phase
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 _INFRASTRUCTURE_CATEGORY = "infrastructure_error"
+_PHASE_SKIPPED_CATEGORY = "phase_skipped"
 
 
 @dataclass(frozen=True)
@@ -50,6 +52,16 @@ class Finding:
         cleanly"; ``[f for f in findings if not f.is_infrastructure_error]``
         gives the verified-clean subset (E3-infra)."""
         return self.category == _INFRASTRUCTURE_CATEGORY
+
+    @property
+    def is_phase_skip(self) -> bool:
+        """True when this finding records that a phase never executed
+        (mode=skip, budget exhausted). Deliberately NOT an
+        infrastructure error: nothing broke, the phase was skipped on
+        purpose. But like infra errors it marks non-execution, so
+        ``len(findings) == 0`` keeps meaning "every phase ran and found
+        nothing" (R1.2)."""
+        return self.category == _PHASE_SKIPPED_CATEGORY
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -96,6 +108,22 @@ class Finding:
             location="",
             explanation=explanation,
             tags=("infrastructure",),
+        )
+
+    @classmethod
+    def phase_skipped(cls, phase: str, reason: str) -> Finding:
+        """Build a synthetic Finding recording that the given phase was
+        deliberately not executed (mode=skip or adversarial budget
+        exhausted). Severity "skipped" keeps it out of every real
+        severity bucket; the ``non_execution`` tag is the machine-
+        readable marker (R1.2)."""
+        return cls(
+            phase=phase,
+            category=_PHASE_SKIPPED_CATEGORY,
+            severity="skipped",
+            location="",
+            explanation=reason,
+            tags=("non_execution", f"phase:{phase}"),
         )
 
     @classmethod
@@ -154,6 +182,34 @@ class Finding:
         )
 
 
+def dump_raw_debug(
+    debug_dir: Path | None,
+    phase: str,
+    raw_output: str,
+    label: str,
+) -> str | None:
+    """Persist the FULL raw agent output of a failed parse so the
+    forensic tail survives (R1.2; mirrors knowledge.py's
+    ``_distill_raw.txt`` pattern). The in-memory result keeps only a
+    2000-char sample to bound manifest/journal size; this dump is where
+    the rest lives.
+
+    Best-effort: returns the written path as a string, or None when
+    ``debug_dir`` is None or the write failed. Never raises."""
+    if debug_dir is None:
+        return None
+    try:
+        debug_dir.mkdir(parents=True, exist_ok=True)
+        raw_path = debug_dir / f"_{phase}_raw.txt"
+        raw_path.write_text(raw_output, encoding="utf-8")
+        (debug_dir / f"_{phase}_status.txt").write_text(
+            label, encoding="utf-8",
+        )
+        return str(raw_path)
+    except OSError:
+        return None
+
+
 def render_findings_markdown(findings: list[Finding]) -> str:
     """Render a list[Finding] as a markdown section. Returns empty
     string for empty input.
@@ -179,7 +235,11 @@ def render_findings_markdown(findings: list[Finding]) -> str:
     for phase in sorted(by_phase):
         items = by_phase[phase]
         infra = [f for f in items if f.is_infrastructure_error]
-        real = [f for f in items if not f.is_infrastructure_error]
+        skipped = [f for f in items if f.is_phase_skip]
+        real = [
+            f for f in items
+            if not f.is_infrastructure_error and not f.is_phase_skip
+        ]
 
         lines.append(f"### {phase.capitalize()} ({len(real)} findings)")
         lines.append("")
@@ -188,6 +248,13 @@ def render_findings_markdown(findings: list[Finding]) -> str:
                 lines.append(
                     f"- **INFRASTRUCTURE ERROR**: {f.explanation} "
                     "(this role did not actually run -- the PR is unverified for this phase)"
+                )
+            lines.append("")
+        if skipped:
+            for f in skipped:
+                lines.append(
+                    f"- **PHASE SKIPPED**: {f.explanation} "
+                    "(this role did not run for this PR)"
                 )
             lines.append("")
         for f in real:

--- a/ralph_py/git.py
+++ b/ralph_py/git.py
@@ -345,6 +345,14 @@ def _parse_name_status_z(output: str) -> list[str]:
     return unique
 
 
+class GitDiffError(RuntimeError):
+    """Raised when ``git diff`` cannot produce a diff (nonzero exit,
+    e.g. bad ref or not a repository, or a timeout). Callers must treat
+    this as an infrastructure failure: before R1.3 (H-14) these errors
+    returned an empty string, and review/security/knowledge silently
+    "reviewed" a diff of nothing and passed."""
+
+
 def get_diff_content(
     base_branch: str,
     cwd: Path | None = None,
@@ -354,6 +362,10 @@ def get_diff_content(
 
     The base is resolved through :func:`resolve_base_ref` so diffs
     measure against ``origin/<base>`` whenever a remote exists (R0.2).
+
+    Raises :class:`GitDiffError` on git failure or timeout (R1.3). An
+    empty return string therefore always means a genuinely empty diff,
+    never a swallowed error.
     """
     base_ref = resolve_base_ref(base_branch, cwd, timeout)
     try:
@@ -364,11 +376,16 @@ def get_diff_content(
             text=True,
             timeout=timeout,
         )
-        if result.returncode == 0:
-            return result.stdout
-    except subprocess.TimeoutExpired:
-        pass
-    return ""
+    except subprocess.TimeoutExpired as exc:
+        raise GitDiffError(
+            f"git diff against {base_ref} timed out after {timeout}s"
+        ) from exc
+    if result.returncode != 0:
+        raise GitDiffError(
+            f"git diff against {base_ref} exited "
+            f"{result.returncode}: {result.stderr.strip()[:500]}"
+        )
+    return result.stdout
 
 
 # Shared budget for diff content injected into LLM prompts. Centralized

--- a/ralph_py/pr.py
+++ b/ralph_py/pr.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from ralph_py.findings import render_findings_markdown
 from ralph_py.git import fetch_base_branch
 
 if TYPE_CHECKING:
@@ -359,6 +360,21 @@ def _generate_pr_body(
     # render_findings_markdown remains available for ad-hoc dumping.
     if component.review_findings:
         lines.append(component.review_findings)
+        lines.append("")
+
+    # R1.2 (sec-pr-body): phases that never executed must be visible in
+    # the PR body. In advisory mode a security infrastructure error used
+    # to produce NO security section at all - "did not run" was
+    # indistinguishable from "ran clean". Render the existing
+    # render_findings_markdown callouts for exactly the non-execution
+    # subset (infra errors + deliberate skips); real findings stay with
+    # the richer review_findings string above.
+    non_execution = [
+        f for f in component.findings
+        if f.is_infrastructure_error or f.is_phase_skip
+    ]
+    if non_execution:
+        lines.append(render_findings_markdown(non_execution).rstrip())
         lines.append("")
 
     # PRD reference

--- a/ralph_py/review.py
+++ b/ralph_py/review.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -15,7 +16,7 @@ from ralph_py.decompose import (
     _select_agent_output,
     collect_agent_output,
 )
-from ralph_py.findings import Finding
+from ralph_py.findings import Finding, dump_raw_debug
 from ralph_py.prd import PRD
 from ralph_py.verify import VerificationResult
 
@@ -45,6 +46,17 @@ VALID_CONCERN_CATEGORIES = frozenset({
     "error_handling",
     "copy_paste",
     "other",
+})
+
+# R1.1: whitelist of criterion verdicts accepted from the reviewer,
+# compared case-insensitively after stripping. The prompt schema
+# promises pass|fail|advisory; anything else ("Blocked", "n/a", a
+# missing key) is a parse failure - infrastructure error, never a
+# silently non-blocking advisory.
+VALID_CRITERION_VERDICTS = frozenset({
+    ReviewVerdict.PASS.value,
+    ReviewVerdict.FAIL.value,
+    ReviewVerdict.ADVISORY.value,
 })
 
 
@@ -403,43 +415,113 @@ def build_review_prompt(
     )
 
 
-def parse_review_output(raw_output: str) -> ReviewResult:
-    """Parse structured JSON from reviewer agent output."""
-    try:
-        data = _extract_json(raw_output)
-    except ValueError:
+def parse_review_output(
+    raw_output: str,
+    expected_story_ids: Sequence[str] | None = None,
+    *,
+    debug_dir: Path | None = None,
+) -> ReviewResult:
+    """Parse structured JSON from reviewer agent output.
+
+    ``expected_story_ids`` enables the R1.1 criterion-coverage gate:
+    every PRD story id must receive at least one criterion verdict or
+    the result is an infrastructure error - a partial or empty review
+    (``{"stories": [], "concerns": []}``) is a review that did not
+    happen, not a clean pass (CRIT-5). Matching is by story id
+    (case-insensitive, whitespace-stripped), never by criterion text.
+    ``None`` skips the check for callers that have no PRD.
+
+    ``debug_dir`` enables a full raw-output dump on parse failure via
+    :func:`ralph_py.findings.dump_raw_debug`; the result's
+    ``raw_output`` field stays truncated to 2000 chars to bound
+    manifest/journal size.
+    """
+
+    def _infra(notes: str, label: str) -> ReviewResult:
+        dump_path = dump_raw_debug(debug_dir, "review", raw_output, label)
+        if dump_path:
+            notes = f"{notes} [full raw output: {dump_path}]"
         return ReviewResult(
             passed=False,
             mode="",
-            overall_notes="Failed to parse reviewer output as JSON",
+            overall_notes=notes,
             raw_output=raw_output[:2000],
             infrastructure_error=True,
+        )
+
+    try:
+        data = _extract_json(raw_output)
+    except ValueError:
+        return _infra("Failed to parse reviewer output as JSON", "no_json")
+
+    # R1.2: _extract_json returns whatever json.loads produced - null,
+    # a list, a bare string. Anything but an object would crash the
+    # .get() calls below with AttributeError.
+    if not isinstance(data, dict):
+        return _infra(
+            f"Review output was not a JSON object (got {type(data).__name__})",
+            "non_dict_json",
         )
 
     criteria: list[CriterionReview] = []
 
     stories = data.get("stories", [])
     if not isinstance(stories, list):
-        return ReviewResult(
-            passed=False,
-            mode="",
-            overall_notes="Invalid review output: 'stories' is not an array",
-            raw_output=raw_output[:2000],
-            infrastructure_error=True,
+        return _infra(
+            "Invalid review output: 'stories' is not an array",
+            "stories_not_array",
         )
 
+    covered_story_ids: set[str] = set()
+    invalid_verdicts: list[str] = []
     for story in stories:
         if not isinstance(story, dict):
             continue
-        for crit_data in story.get("criteria", []):
+        story_id = str(story.get("storyId", "")).strip()
+        raw_criteria = story.get("criteria", [])
+        if not isinstance(raw_criteria, list):
+            continue
+        for crit_data in raw_criteria:
             if not isinstance(crit_data, dict):
+                continue
+            # R1.1: normalize then whitelist. Verbatim storage meant
+            # "FAIL" matched neither the fail gate nor the pass gate
+            # and became a non-blocking advisory-alike.
+            verdict = str(crit_data.get("verdict", "")).strip().lower()
+            if verdict not in VALID_CRITERION_VERDICTS:
+                invalid_verdicts.append(
+                    str(crit_data.get("verdict", ""))[:40] or "<missing>"
+                )
                 continue
             criteria.append(CriterionReview(
                 criterion=str(crit_data.get("criterion", "")),
-                verdict=str(crit_data.get("verdict", "fail")),
+                verdict=verdict,
                 explanation=str(crit_data.get("explanation", "")),
                 suggestion=str(crit_data.get("suggestion", "")),
             ))
+            if story_id:
+                covered_story_ids.add(story_id.lower())
+
+    if invalid_verdicts:
+        return _infra(
+            "Review output contained unrecognized verdicts: "
+            + ", ".join(repr(v) for v in invalid_verdicts)
+            + " (valid: pass/fail/advisory)",
+            "invalid_verdict",
+        )
+
+    if expected_story_ids:
+        missing = [
+            sid for sid in expected_story_ids
+            if sid.strip().lower() not in covered_story_ids
+        ]
+        if missing:
+            return _infra(
+                "Review coverage incomplete: no verdict for story ids "
+                + ", ".join(missing)
+                + " (CRIT-5: a partial or empty review cannot pass)",
+                "coverage_gap",
+            )
 
     concerns: list[ReviewConcern] = []
     raw_concerns = data.get("concerns", [])
@@ -495,10 +577,17 @@ def run_review(
     ui: UI,
     timeout: float = 600.0,
     diff_content: str | None = None,
+    *,
+    debug_dir: Path | None = None,
 ) -> ReviewResult:
     """Run the full review: build prompt, run agent, parse output.
 
     In advisory mode, all FAILs are downgraded and passed=True is returned.
+
+    Never raises: any agent/prompt failure degrades to a ReviewResult
+    with ``infrastructure_error=True`` so one broken reviewer fails one
+    component instead of aborting the whole factory run (R1.2, mirrors
+    ``run_security_review``).
     """
     if mode == ReviewMode.SKIP:
         return ReviewResult(passed=True, mode=mode.value)
@@ -506,28 +595,50 @@ def run_review(
     ui.info("  Running second-opinion review...")
     start = time.monotonic()
 
-    prompt = build_review_prompt(
-        prd_path, worktree_path, base_branch, verification_result,
-        diff_content=diff_content,
-    )
-
     try:
+        prompt = build_review_prompt(
+            prd_path, worktree_path, base_branch, verification_result,
+            diff_content=diff_content,
+        )
+        # R1.1: the coverage gate needs the ground-truth story ids from
+        # the PRD, not whatever ids the reviewer chose to mention.
+        expected_story_ids = [
+            story.id for story in PRD.load(prd_path).user_stories
+        ]
         output_lines = collect_agent_output(
             agent, prompt, cwd=worktree_path, timeout=timeout,
         )
     except AgentOutputTooLarge as exc:
-        # Hostile/buggy agent flooding output. In hard mode this needs
-        # to surface as a review failure; advisory passes but logs.
+        # Hostile/buggy agent flooding output. The review never
+        # happened: infrastructure error (H-13), which hard mode blocks
+        # on; advisory passes but the infra finding stays visible.
+        ui.warn(f"  Reviewer agent output too large: {exc}")
         result = ReviewResult(
             passed=mode != ReviewMode.HARD,
             mode=mode.value,
             overall_notes=f"Reviewer agent output too large: {exc}",
+            infrastructure_error=True,
+        )
+        result.duration_seconds = time.monotonic() - start
+        return result
+    except Exception as exc:  # noqa: BLE001
+        # Reviewer agent crashed (or the PRD/diff could not be read).
+        # Degrade to a per-component infrastructure failure - never
+        # propagate and abort the run (R1.2).
+        ui.warn(f"  Reviewer agent failed: {exc}")
+        result = ReviewResult(
+            passed=mode != ReviewMode.HARD,
+            mode=mode.value,
+            overall_notes=f"Reviewer agent failed: {exc}",
+            infrastructure_error=True,
         )
         result.duration_seconds = time.monotonic() - start
         return result
 
     raw_output = _select_agent_output(agent, output_lines)
-    result = parse_review_output(raw_output)
+    result = parse_review_output(
+        raw_output, expected_story_ids, debug_dir=debug_dir,
+    )
     result.mode = mode.value
     result.duration_seconds = time.monotonic() - start
 

--- a/ralph_py/security.py
+++ b/ralph_py/security.py
@@ -29,7 +29,7 @@ from ralph_py.decompose import (
     _select_agent_output,
     collect_agent_output,
 )
-from ralph_py.findings import Finding
+from ralph_py.findings import Finding, dump_raw_debug
 
 if TYPE_CHECKING:
     from ralph_py.agents.base import Agent
@@ -378,26 +378,42 @@ def _build_security_prompt(prd_text: str, diff_content: str) -> str:
     )
 
 
-def parse_security_output(raw_output: str, mode: str) -> SecurityResult:
-    """Parse structured JSON from the security reviewer agent."""
-    try:
-        data = _extract_json(raw_output)
-    except ValueError:
+def parse_security_output(
+    raw_output: str,
+    mode: str,
+    *,
+    debug_dir: Path | None = None,
+) -> SecurityResult:
+    """Parse structured JSON from the security reviewer agent.
+
+    ``debug_dir`` enables a full raw-output dump on parse failure via
+    :func:`ralph_py.findings.dump_raw_debug` (R1.2); the result's
+    ``raw_output`` field stays truncated to 2000 chars.
+    """
+
+    def _infra(notes: str, label: str) -> SecurityResult:
+        dump_path = dump_raw_debug(debug_dir, "security", raw_output, label)
+        if dump_path:
+            notes = f"{notes} [full raw output: {dump_path}]"
         return SecurityResult(
             passed=False,
             mode=mode,
-            overall_notes="Failed to parse security reviewer output as JSON",
+            overall_notes=notes,
             raw_output=raw_output[:2000],
             infrastructure_error=True,
         )
 
+    try:
+        data = _extract_json(raw_output)
+    except ValueError:
+        return _infra(
+            "Failed to parse security reviewer output as JSON", "no_json",
+        )
+
     if not isinstance(data, dict):
-        return SecurityResult(
-            passed=False,
-            mode=mode,
-            overall_notes="Security output was not a JSON object",
-            raw_output=raw_output[:2000],
-            infrastructure_error=True,
+        return _infra(
+            f"Security output was not a JSON object (got {type(data).__name__})",
+            "non_dict_json",
         )
 
     findings: list[SecurityFinding] = []
@@ -465,6 +481,8 @@ def run_security_review(
     config: SecurityConfig,
     ui: UI,
     diff_content: str | None = None,
+    *,
+    debug_dir: Path | None = None,
 ) -> SecurityResult:
     """Run the security review phase. Always non-fatal: on any
     infrastructure error returns a SecurityResult with empty findings
@@ -505,7 +523,7 @@ def run_security_review(
         )
 
     raw_output = _select_agent_output(agent, output_lines)
-    result = parse_security_output(raw_output, mode)
+    result = parse_security_output(raw_output, mode, debug_dir=debug_dir)
     if result.infrastructure_error:
         # Parsing failed - we have no usable findings list, so don't
         # let _passes_threshold overwrite passed=False with True. In

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -165,7 +165,9 @@ class TestRunFactoryExecution:
 
         success_result = ComponentResult("comp-a", success=True, iterations=3)
 
-        with patch("ralph_py.factory._run_component", return_value=success_result):
+        with patch(
+            "ralph_py.factory._run_component", return_value=success_result,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
             result = run_factory(manifest, config, base, ui, root)
 
         assert "comp-a" in result.completed
@@ -228,7 +230,9 @@ class TestRunFactoryExecution:
 
         success_result = ComponentResult("a", success=True, iterations=1)
 
-        with patch("ralph_py.factory._run_component", return_value=success_result):
+        with patch(
+            "ralph_py.factory._run_component", return_value=success_result,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
             result = run_factory(manifest, config, base, ui, root)
 
         assert "a" in result.completed
@@ -268,7 +272,9 @@ class TestRunFactoryExecution:
 
         success_result = ComponentResult("a", success=True, iterations=1)
 
-        with patch("ralph_py.factory._run_component", return_value=success_result):
+        with patch(
+            "ralph_py.factory._run_component", return_value=success_result,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
             result = run_factory(manifest, config, base, ui, root)
 
         assert "a" in result.completed
@@ -307,7 +313,9 @@ class TestRunFactoryExecution:
         success_result = ComponentResult("a", success=True, iterations=1)
         manifest_path = root / "scripts" / "ralph" / "manifest.json"
 
-        with patch("ralph_py.factory._run_component", return_value=success_result):
+        with patch(
+            "ralph_py.factory._run_component", return_value=success_result,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
             run_factory(manifest, config, base, ui, root)
 
         assert manifest_path.exists()
@@ -350,7 +358,9 @@ class TestRunFactoryExecution:
 
         success_result = ComponentResult("a", success=True, iterations=1)
 
-        with patch("ralph_py.factory._run_component", return_value=success_result):
+        with patch(
+            "ralph_py.factory._run_component", return_value=success_result,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
             result = run_factory(manifest, config, base, ui, root)
 
         # Should fail because tests fail, and retries are exhausted

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1724,7 +1724,9 @@ class TestFactoryDistillIntegration:
             "ralph_py.factory._run_component", return_value=success,
         ), patch(
             "ralph_py.factory.distill_facts", return_value=(2, "ok"),
-        ) as mock_distill:
+        ) as mock_distill, patch(
+            "ralph_py.git.get_diff_content", return_value="",
+        ):
             result = run_factory(manifest, config, base, ui, root)
 
         assert "comp-a" in result.completed
@@ -1782,7 +1784,9 @@ class TestFactoryDistillIntegration:
             "ralph_py.factory._run_component", return_value=success,
         ), patch(
             "ralph_py.factory.distill_facts", return_value=(0, "disabled"),
-        ) as mock_distill:
+        ) as mock_distill, patch(
+            "ralph_py.git.get_diff_content", return_value="",
+        ):
             run_factory(manifest, config, base, ui, root)
 
         mock_distill.assert_not_called()
@@ -1816,7 +1820,9 @@ class TestFactoryDistillIntegration:
             "ralph_py.factory._run_component", return_value=success,
         ), patch(
             "ralph_py.factory.distill_facts", return_value=(0, "ok"),
-        ) as mock_distill:
+        ) as mock_distill, patch(
+            "ralph_py.git.get_diff_content", return_value="",
+        ):
             run_factory(manifest, config, base, ui, root)
 
         mock_distill.assert_not_called()
@@ -1852,7 +1858,9 @@ class TestFactoryDistillIntegration:
             "ralph_py.factory._run_component", return_value=success,
         ), patch(
             "ralph_py.factory.distill_facts", return_value=(1, "ok"),
-        ) as mock_distill:
+        ) as mock_distill, patch(
+            "ralph_py.git.get_diff_content", return_value="",
+        ):
             run_factory(manifest, config, base, ui, root)
 
         run_id = mock_distill.call_args.args[5]

--- a/tests/test_phase_c_coverage.py
+++ b/tests/test_phase_c_coverage.py
@@ -144,7 +144,7 @@ class TestC1ParallelExecution:
         success = ComponentResult("comp-a", success=True, iterations=1)
         with patch(
             "ralph_py.factory._run_component", return_value=success,
-        ):
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
             result = run_factory(
                 manifest, config, _base_config(root),
                 PlainUI(no_color=True), root,
@@ -182,7 +182,7 @@ class TestC2ReviewRetry:
             "ralph_py.factory._run_component", return_value=success,
         ), patch(
             "ralph_py.factory.run_review", side_effect=fake_run_review,
-        ):
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
             result = run_factory(
                 manifest, config, _base_config(root),
                 PlainUI(no_color=True), root,
@@ -223,7 +223,7 @@ class TestC3SecurityRetry:
             "ralph_py.factory._run_component", return_value=success,
         ), patch(
             "ralph_py.factory.run_security_review", side_effect=fake_run_security,
-        ):
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
             result = run_factory(
                 manifest, config, _base_config(root),
                 PlainUI(no_color=True), root,
@@ -279,7 +279,7 @@ class TestC4ContractBreaker:
             side_effect=[success_a, success_b, success_a],
         ) as mock_run, patch(
             "ralph_py.factory.run_contract_testing", side_effect=fake_contract,
-        ):
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
             result = run_factory(
                 manifest, config, _base_config(root),
                 PlainUI(no_color=True), root,
@@ -315,7 +315,9 @@ class TestC5SinglePrMode:
             "ralph_py.factory._run_component", return_value=success,
         ), patch(
             "ralph_py.factory.distill_facts", return_value=(0, "skipped"),
-        ) as mock_distill:
+        ) as mock_distill, patch(
+            "ralph_py.git.get_diff_content", return_value="",
+        ):
             result = run_factory(
                 manifest, config, _base_config(root),
                 PlainUI(no_color=True), root,

--- a/tests/test_phase_e.py
+++ b/tests/test_phase_e.py
@@ -127,7 +127,9 @@ class TestE4BudgetCap:
             "ralph_py.factory._run_component", return_value=success,
         ), patch(
             "ralph_py.factory.run_review", return_value=passing_review,
-        ) as mock_review:
+        ) as mock_review, patch(
+            "ralph_py.git.get_diff_content", return_value="",
+        ):
             run_factory(
                 manifest, config, self._base_config(root),
                 PlainUI(no_color=True), root,
@@ -164,7 +166,9 @@ class TestE4BudgetCap:
             "ralph_py.factory._run_component", return_value=success,
         ), patch(
             "ralph_py.factory.run_review", return_value=passing_review,
-        ) as mock_review:
+        ) as mock_review, patch(
+            "ralph_py.git.get_diff_content", return_value="",
+        ):
             run_factory(
                 manifest, config, self._base_config(root),
                 PlainUI(no_color=True), root,
@@ -228,7 +232,9 @@ class TestE6HitlCheckpoint:
         success = ComponentResult("comp-a", success=True, iterations=1)
         with patch(
             "ralph_py.factory._run_component", return_value=success,
-        ), patch("ralph_py.pr.is_gh_available", return_value=False):
+        ), patch(
+            "ralph_py.pr.is_gh_available", return_value=False,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
             result = run_factory(
                 manifest, config, base, PlainUI(no_color=True), tmp_path,
             )

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -321,6 +321,7 @@ class TestConcerns:
         result = run_review(
             agent, prd_path, tmp_path, "main",
             verification, ReviewMode.ADVISORY, ui,
+            diff_content="+change\n",
         )
         # Concern was downgraded; review passes; concern survives as advisory
         assert result.passed is True
@@ -362,6 +363,7 @@ class TestRunReview:
         result = run_review(
             agent, prd_path, tmp_path, "main",
             verification, ReviewMode.HARD, ui,
+            diff_content="+change\n",
         )
         assert result.passed is False
         assert result.mode == "hard"
@@ -387,6 +389,7 @@ class TestRunReview:
         result = run_review(
             agent, prd_path, tmp_path, "main",
             verification, ReviewMode.ADVISORY, ui,
+            diff_content="+change\n",
         )
         assert result.passed is True
         assert result.mode == "advisory"

--- a/tests/test_review_gates.py
+++ b/tests/test_review_gates.py
@@ -1,0 +1,703 @@
+"""R1.1-R1.3 reviewer-gate integrity tests.
+
+A gate that can be passed by silence, case drift, or absence of data is
+not a gate. These tests prove the parser-side fixes:
+
+- R1.1: empty/partial reviews and unrecognized verdicts are
+  infrastructure errors, never silent passes or advisories.
+- R1.2: AgentOutputTooLarge / reviewer crashes / non-dict JSON degrade
+  to per-component infrastructure failures; skipped phases leave a
+  synthetic Finding + journal event; PR bodies show "did not run";
+  parse failures dump the FULL raw output to disk.
+- R1.3: a git error during diff fetch is an infrastructure failure,
+  not an empty diff that reviews cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ralph_py.config import RalphConfig
+from ralph_py.factory import ComponentResult, FactoryConfig, run_factory
+from ralph_py.findings import Finding, render_findings_markdown
+from ralph_py.git import GitDiffError, get_diff_content
+from ralph_py.manifest import Component, Manifest
+from ralph_py.review import (
+    ReviewMode,
+    ReviewResult,
+    parse_review_output,
+    run_review,
+)
+from ralph_py.security import SecurityConfig, SecurityMode, parse_security_output
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import CheckResult, VerificationResult, VerifyConfig
+
+
+class MockReviewAgent:
+    """Mock agent that returns predetermined review JSON."""
+
+    def __init__(self, output: str):
+        self._output = output
+        self._final_message: str | None = None
+
+    @property
+    def name(self) -> str:
+        return "mock-reviewer"
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        yield from self._output.splitlines()
+
+    @property
+    def final_message(self) -> str | None:
+        return self._final_message
+
+
+class CrashingAgent:
+    """Agent whose run() raises mid-stream."""
+
+    @property
+    def name(self) -> str:
+        return "crashing-reviewer"
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        raise RuntimeError("agent process exploded")
+        yield  # pragma: no cover
+
+    @property
+    def final_message(self) -> str | None:
+        return None
+
+
+def _write_prd(path: Path, story_ids: list[str]) -> None:
+    path.write_text(json.dumps({
+        "branchName": "test",
+        "userStories": [
+            {
+                "id": sid, "title": f"Story {sid}",
+                "acceptanceCriteria": ["AC1"], "priority": 1,
+                "passes": True, "notes": "",
+            }
+            for sid in story_ids
+        ],
+    }))
+
+
+def _story(story_id: str, verdict: str) -> dict[str, object]:
+    return {
+        "storyId": story_id,
+        "storyTitle": f"Story {story_id}",
+        "criteria": [{
+            "criterion": "AC1",
+            "verdict": verdict,
+            "explanation": "checked",
+            "suggestion": "",
+        }],
+    }
+
+
+_VERIFICATION = VerificationResult(
+    passed=True, checks=[CheckResult("test_suite", True, "ok")],
+)
+
+
+# ---------------------------------------------------------------------------
+# R1.1 - criterion coverage: empty/partial reviews cannot pass
+# ---------------------------------------------------------------------------
+
+
+class TestR11Coverage:
+    def test_empty_review_fails_hard_mode(self, tmp_path: Path) -> None:
+        """{"stories":[],"concerns":[]} used to parse to passed=True
+        (CRIT-5). With a PRD story expecting a verdict it is now an
+        infrastructure error and hard mode blocks."""
+        prd_path = tmp_path / "prd.json"
+        _write_prd(prd_path, ["US-001"])
+        agent = MockReviewAgent(json.dumps({"stories": [], "concerns": []}))
+        result = run_review(
+            agent, prd_path, tmp_path, "main", _VERIFICATION,
+            ReviewMode.HARD, PlainUI(no_color=True),
+            diff_content="+change\n",
+        )
+        assert result.passed is False
+        assert result.infrastructure_error is True
+        assert "US-001" in result.overall_notes
+
+    def test_partial_review_is_infrastructure_error(self) -> None:
+        output = json.dumps({"stories": [_story("US-001", "pass")]})
+        result = parse_review_output(output, ["US-001", "US-002"])
+        assert result.infrastructure_error is True
+        assert result.passed is False
+        # Only the uncovered id is reported as missing
+        assert "story ids US-002" in result.overall_notes
+
+    def test_full_coverage_passes(self) -> None:
+        output = json.dumps({
+            "stories": [_story("US-001", "pass"), _story("US-002", "pass")],
+        })
+        result = parse_review_output(output, ["US-001", "US-002"])
+        assert result.infrastructure_error is False
+        assert result.passed is True
+
+    def test_story_id_match_is_case_insensitive(self) -> None:
+        output = json.dumps({"stories": [_story("us-001 ", "pass")]})
+        result = parse_review_output(output, ["US-001"])
+        assert result.infrastructure_error is False
+
+    def test_story_without_criteria_does_not_count_as_covered(self) -> None:
+        output = json.dumps({
+            "stories": [{"storyId": "US-001", "criteria": []}],
+        })
+        result = parse_review_output(output, ["US-001"])
+        assert result.infrastructure_error is True
+
+    def test_no_expected_ids_skips_coverage_check(self) -> None:
+        """Direct callers without a PRD keep the old lenient behavior."""
+        result = parse_review_output(
+            json.dumps({"stories": [], "concerns": []}),
+        )
+        assert result.infrastructure_error is False
+        assert result.passed is True
+
+
+# ---------------------------------------------------------------------------
+# R1.1 - verdict whitelist
+# ---------------------------------------------------------------------------
+
+
+class TestR11VerdictWhitelist:
+    def test_uppercase_fail_blocks(self) -> None:
+        """"FAIL" was stored verbatim and matched neither gate,
+        becoming a non-blocking advisory-alike."""
+        output = json.dumps({"stories": [_story("US-001", "FAIL")]})
+        result = parse_review_output(output, ["US-001"])
+        assert result.infrastructure_error is False
+        assert result.passed is False
+        assert result.criteria[0].verdict == "fail"
+
+    def test_pass_with_whitespace_passes(self) -> None:
+        output = json.dumps({"stories": [_story("US-001", "PASS ")]})
+        result = parse_review_output(output, ["US-001"])
+        assert result.infrastructure_error is False
+        assert result.passed is True
+        assert result.criteria[0].verdict == "pass"
+
+    def test_unknown_verdict_is_infrastructure_error(self) -> None:
+        output = json.dumps({"stories": [_story("US-001", "Blocked")]})
+        result = parse_review_output(output, ["US-001"])
+        assert result.infrastructure_error is True
+        assert result.passed is False
+        assert "Blocked" in result.overall_notes
+
+    def test_missing_verdict_is_infrastructure_error(self) -> None:
+        output = json.dumps({
+            "stories": [{
+                "storyId": "US-001",
+                "criteria": [{"criterion": "AC1", "explanation": "x"}],
+            }],
+        })
+        result = parse_review_output(output, ["US-001"])
+        assert result.infrastructure_error is True
+
+    def test_advisory_verdict_stays_valid(self) -> None:
+        """The prompt schema promises pass|fail|advisory; a legitimate
+        advisory verdict must not be treated as a parse failure."""
+        output = json.dumps({"stories": [_story("US-001", "Advisory")]})
+        result = parse_review_output(output, ["US-001"])
+        assert result.infrastructure_error is False
+        assert result.passed is True
+        assert result.criteria[0].verdict == "advisory"
+
+
+# ---------------------------------------------------------------------------
+# R1.2 - oversized output, crashes, non-dict JSON
+# ---------------------------------------------------------------------------
+
+
+class TestR12InfrastructurePaths:
+    def _run(self, mode: ReviewMode, tmp_path: Path) -> ReviewResult:
+        from ralph_py.decompose import AgentOutputTooLarge
+
+        prd_path = tmp_path / "prd.json"
+        _write_prd(prd_path, ["US-001"])
+        agent = MockReviewAgent("irrelevant")
+        with patch(
+            "ralph_py.review.collect_agent_output",
+            side_effect=AgentOutputTooLarge("output exceeded cap"),
+        ):
+            return run_review(
+                agent, prd_path, tmp_path, "main", _VERIFICATION,
+                mode, PlainUI(no_color=True), diff_content="+x\n",
+            )
+
+    def test_oversized_output_is_infra_and_blocks_hard_mode(
+        self, tmp_path: Path,
+    ) -> None:
+        result = self._run(ReviewMode.HARD, tmp_path)
+        assert result.infrastructure_error is True
+        assert result.passed is False
+        findings = result.as_findings()
+        assert len(findings) == 1
+        assert findings[0].is_infrastructure_error
+
+    def test_oversized_output_in_advisory_passes_but_leaves_trace(
+        self, tmp_path: Path,
+    ) -> None:
+        result = self._run(ReviewMode.ADVISORY, tmp_path)
+        assert result.infrastructure_error is True
+        assert result.passed is True
+        assert result.as_findings()[0].is_infrastructure_error
+
+    def test_agent_crash_never_raises(self, tmp_path: Path) -> None:
+        prd_path = tmp_path / "prd.json"
+        _write_prd(prd_path, ["US-001"])
+        result = run_review(
+            CrashingAgent(), prd_path, tmp_path, "main", _VERIFICATION,
+            ReviewMode.HARD, PlainUI(no_color=True), diff_content="+x\n",
+        )
+        assert result.infrastructure_error is True
+        assert result.passed is False
+        assert "exploded" in result.overall_notes
+
+    @pytest.mark.parametrize("raw", ["null", "[1, 2]", '"just a string"'])
+    def test_non_dict_json_is_infra_not_crash(self, raw: str) -> None:
+        result = parse_review_output(raw, ["US-001"])
+        assert result.infrastructure_error is True
+        assert result.passed is False
+
+
+# ---------------------------------------------------------------------------
+# R1.2 - full raw-output debug dumps
+# ---------------------------------------------------------------------------
+
+
+class TestR12DebugDumps:
+    def test_review_parse_failure_dumps_full_output(
+        self, tmp_path: Path,
+    ) -> None:
+        raw = "not json " * 1000  # far beyond the 2000-char field cap
+        result = parse_review_output(raw, ["US-001"], debug_dir=tmp_path)
+        assert result.infrastructure_error is True
+        dumped = (tmp_path / "_review_raw.txt").read_text(encoding="utf-8")
+        assert dumped == raw  # FULL output, forensic tail intact
+        assert len(result.raw_output) <= 2000
+        assert str(tmp_path / "_review_raw.txt") in result.overall_notes
+
+    def test_security_parse_failure_dumps_full_output(
+        self, tmp_path: Path,
+    ) -> None:
+        raw = "garbage " * 1000
+        result = parse_security_output(raw, "hard", debug_dir=tmp_path)
+        assert result.infrastructure_error is True
+        dumped = (tmp_path / "_security_raw.txt").read_text(encoding="utf-8")
+        assert dumped == raw
+        assert len(result.raw_output) <= 2000
+
+    def test_clean_parse_writes_no_dump(self, tmp_path: Path) -> None:
+        output = json.dumps({"stories": [_story("US-001", "pass")]})
+        parse_review_output(output, ["US-001"], debug_dir=tmp_path)
+        assert not (tmp_path / "_review_raw.txt").exists()
+
+    def test_missing_debug_dir_is_not_an_error(self) -> None:
+        result = parse_review_output("not json", ["US-001"], debug_dir=None)
+        assert result.infrastructure_error is True
+
+
+# ---------------------------------------------------------------------------
+# R1.2 - phase_skipped Finding semantics
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseSkippedFinding:
+    def test_flags(self) -> None:
+        f = Finding.phase_skipped("security", "budget exhausted")
+        assert f.is_phase_skip is True
+        assert f.is_infrastructure_error is False
+        assert f.category == "phase_skipped"
+        assert "non_execution" in f.tags
+
+    def test_render_callout(self) -> None:
+        md = render_findings_markdown(
+            [Finding.phase_skipped("security", "budget exhausted")],
+        )
+        assert "PHASE SKIPPED" in md
+        assert "budget exhausted" in md
+        assert "### Security (0 findings)" in md
+
+
+# ---------------------------------------------------------------------------
+# R1.2 - PR body shows non-execution
+# ---------------------------------------------------------------------------
+
+
+class TestPrBodyDidNotRun:
+    def _component(self, findings: list[Finding]) -> tuple[Component, Manifest]:
+        comp = Component(
+            "comp-a", "Component A", "Desc", [],
+            "scripts/ralph/feature/comp-a/prd.json", "ralph/comp-a",
+        )
+        comp.findings = findings
+        manifest = Manifest(
+            version="1", spec_file="s", project_name="t",
+            base_branch="main", single_pr=False, components=[comp],
+        )
+        return comp, manifest
+
+    def test_security_infra_error_is_visible(self) -> None:
+        from ralph_py.pr import _generate_pr_body
+
+        comp, manifest = self._component([
+            Finding.infrastructure_error(
+                phase="security", explanation="agent crashed",
+            ),
+        ])
+        body = _generate_pr_body(comp, manifest)
+        assert "INFRASTRUCTURE ERROR" in body
+        assert "### Security" in body
+        assert "did not actually run" in body
+
+    def test_skipped_phase_is_visible(self) -> None:
+        from ralph_py.pr import _generate_pr_body
+
+        comp, manifest = self._component([
+            Finding.phase_skipped("review", "mode=skip"),
+        ])
+        body = _generate_pr_body(comp, manifest)
+        assert "PHASE SKIPPED" in body
+
+    def test_real_findings_do_not_duplicate_into_status_section(self) -> None:
+        from ralph_py.pr import _generate_pr_body
+
+        comp, manifest = self._component([
+            Finding.from_review_concern(
+                category="dead_code", severity="advisory",
+                location="x.py:1", explanation="unused helper",
+            ),
+        ])
+        body = _generate_pr_body(comp, manifest)
+        assert "Adversarial Findings" not in body
+
+
+# ---------------------------------------------------------------------------
+# R1.2/R1.3 - factory integration: skips, crashes, diff errors
+# ---------------------------------------------------------------------------
+
+
+def _scaffold(tmp_path: Path, comp_ids: list[str]) -> Path:
+    (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+    (tmp_path / "scripts" / "ralph" / "prompt.md").write_text("p")
+    (tmp_path / "scripts" / "ralph" / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    for comp_id in comp_ids:
+        feature_dir = tmp_path / "scripts" / "ralph" / "feature" / comp_id
+        feature_dir.mkdir(parents=True)
+        _write_prd(feature_dir / "prd.json", ["US-001"])
+    return tmp_path
+
+
+def _make_manifest(ids: list[str]) -> Manifest:
+    return Manifest(
+        version="1", spec_file="s", project_name="t",
+        base_branch="main", single_pr=False,
+        components=[
+            Component(
+                id=i, title=i, description="", dependencies=[],
+                prd_path=f"scripts/ralph/feature/{i}/prd.json",
+                branch_name=f"ralph/{i}",
+            )
+            for i in ids
+        ],
+    )
+
+
+def _base_config(root: Path) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root / "scripts/ralph/prompt.md",
+        prd_file=root / "scripts/ralph/prd.json",
+        sleep_seconds=0, agent_cmd="echo test",
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    )
+
+
+def _factory_config(**overrides: object) -> FactoryConfig:
+    defaults: dict[str, object] = dict(
+        use_worktrees=False, create_prs=False, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_diff_scope=False,
+            check_bad_patterns=False, subprocess_timeout=5.0,
+        ),
+    )
+    defaults.update(overrides)
+    return FactoryConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _read_events(log_path: Path) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+class TestFactorySkipTraces:
+    def test_mode_skip_emits_finding_and_journal_event(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        log_path = tmp_path / "progress.jsonl"
+        config = _factory_config(
+            review_mode="skip", progress_log_path=log_path,
+        )
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert "comp-a" in result.completed
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        skips = [f for f in comp.findings if f.is_phase_skip]
+        skip_phases = {f.phase for f in skips}
+        # review skipped by mode, security not configured
+        assert "review" in skip_phases
+        assert "security" in skip_phases
+        events = _read_events(log_path)
+        skip_events = [e for e in events if e["event"] == "phase_skipped"]
+        assert {
+            e["data"]["phase"]  # type: ignore[index]
+            for e in skip_events
+        } >= {"review", "security"}
+
+    def test_budget_exhaustion_emits_finding_and_journal_event(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _scaffold(tmp_path, ["comp-a", "comp-b"])
+        manifest = _make_manifest(["comp-a", "comp-b"])
+        log_path = tmp_path / "progress.jsonl"
+        config = _factory_config(
+            review_mode="hard", max_adversarial_calls=1,
+            progress_log_path=log_path,
+        )
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        passing = ReviewResult(passed=True, mode="hard")
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.factory.run_review", return_value=passing,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        # comp-a consumed the budget; comp-b's review was budget-skipped
+        comp_b = manifest.get_component("comp-b")
+        assert comp_b is not None
+        review_skips = [
+            f for f in comp_b.findings
+            if f.is_phase_skip and f.phase == "review"
+        ]
+        assert len(review_skips) == 1
+        assert "budget" in review_skips[0].explanation
+        events = _read_events(log_path)
+        assert any(
+            e["event"] == "phase_skipped"
+            and e.get("component") == "comp-b"
+            and e["data"]["phase"] == "review"  # type: ignore[index]
+            for e in events
+        )
+
+    def test_single_pr_knowledge_skip_leaves_trace(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        manifest.single_pr = True
+        config = _factory_config(review_mode="skip")
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert any(
+            f.is_phase_skip and f.phase == "knowledge"
+            for f in comp.findings
+        )
+
+
+class TestFactoryReviewerCrash:
+    def test_hard_mode_crash_fails_one_component_not_the_run(
+        self, tmp_path: Path,
+    ) -> None:
+        """comp-a's reviewer crashes; comp-b (independent) must still
+        complete and run_factory must return, not raise."""
+        root = _scaffold(tmp_path, ["comp-a", "comp-b"])
+        manifest = _make_manifest(["comp-a", "comp-b"])
+        config = _factory_config(review_mode="hard")
+
+        def fake_run_review(*args: object, **kwargs: object) -> ReviewResult:
+            if "comp-a" in str(args[1]):
+                raise RuntimeError("reviewer exploded")
+            return ReviewResult(passed=True, mode="hard")
+
+        def fake_run_component(comp_id: str, *a: object, **k: object) -> ComponentResult:
+            return ComponentResult(comp_id, success=True, iterations=1)
+
+        with patch(
+            "ralph_py.factory._run_component", side_effect=fake_run_component,
+        ), patch(
+            "ralph_py.factory.run_review", side_effect=fake_run_review,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert "comp-a" in result.failed
+        assert "comp-b" in result.completed
+        assert result.exit_code == 1
+        comp_a = manifest.get_component("comp-a")
+        assert comp_a is not None
+        assert any(
+            f.is_infrastructure_error and f.phase == "review"
+            for f in comp_a.findings
+        )
+
+    def test_advisory_mode_crash_completes_with_infra_finding(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        config = _factory_config(review_mode="advisory")
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.factory.run_review",
+            side_effect=RuntimeError("reviewer exploded"),
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert "comp-a" in result.completed
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert any(
+            f.is_infrastructure_error and f.phase == "review"
+            for f in comp.findings
+        )
+
+    def test_advisory_security_crash_leaves_infra_finding(
+        self, tmp_path: Path,
+    ) -> None:
+        """The sec-pr-body hole: an advisory-mode security crash used to
+        vanish entirely (no finding, no PR-body section)."""
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        config = _factory_config(
+            review_mode="skip",
+            security_config=SecurityConfig(
+                mode=SecurityMode.ADVISORY.value,
+            ),
+        )
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.factory.run_security_review",
+            side_effect=RuntimeError("security agent exploded"),
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert "comp-a" in result.completed
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        infra = [
+            f for f in comp.findings
+            if f.is_infrastructure_error and f.phase == "security"
+        ]
+        assert len(infra) == 1
+        # and the PR body renders the did-not-run callout from it
+        from ralph_py.pr import _generate_pr_body
+
+        body = _generate_pr_body(comp, manifest)
+        assert "INFRASTRUCTURE ERROR" in body
+
+
+class TestR13DiffErrors:
+    def test_get_diff_content_raises_outside_repo(
+        self, tmp_path: Path,
+    ) -> None:
+        with pytest.raises(GitDiffError):
+            get_diff_content("main", tmp_path)
+
+    def test_get_diff_content_empty_diff_is_not_an_error(
+        self, tmp_path: Path,
+    ) -> None:
+        subprocess.run(
+            ["git", "init", "-b", "main"], cwd=tmp_path,
+            capture_output=True, check=True,
+        )
+        subprocess.run(
+            ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+             "commit", "--allow-empty", "-m", "init"],
+            cwd=tmp_path, capture_output=True, check=True,
+        )
+        assert get_diff_content("main", tmp_path) == ""
+
+    def test_factory_maps_diff_error_to_infrastructure_failure(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        log_path = tmp_path / "progress.jsonl"
+        config = _factory_config(
+            review_mode="hard", progress_log_path=log_path,
+        )
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.git.get_diff_content",
+            side_effect=GitDiffError("git diff exited 129"),
+        ), patch("ralph_py.factory.run_review") as mock_review:
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        # No phase consumed the empty string: review never ran
+        mock_review.assert_not_called()
+        assert "comp-a" in result.failed
+        assert result.exit_code == 1
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert "Diff fetch failed" in comp.error
+        assert any(
+            f.is_infrastructure_error and f.phase == "diff"
+            for f in comp.findings
+        )
+        events = _read_events(log_path)
+        assert any(e["event"] == "diff_fetch_failed" for e in events)


### PR DESCRIPTION
## Roadmap items

R1.1 (CRIT-5), R1.2 (H-13, MED review-nondict, MED sec-pr-body, LOW raw-output-truncation), R1.3 (H-14). Session 3B of docs/remediation-sessions.md. Checkboxes flipped in docs/remediation-roadmap.md in this PR. No prompt body, `*_PROMPT_VERSION`, or snapshot was touched (the snapshot test passing proves it).

## What changed

- **R1.1** `review.py`: `parse_review_output` takes the PRD story ids; any story with no criterion verdict makes the result `infrastructure_error=True` (id-based, case-insensitive matching - never criterion text). Verdicts are normalized (strip + lower) and whitelisted `{pass, fail, advisory}`; anything else ("Blocked", missing key) is a parse failure, never a silent advisory. Note: "advisory" stays in the whitelist because the reviewer prompt schema promises `pass|fail|advisory`; the roadmap's `{pass, fail}` shorthand is read as the blocking-decision whitelist, not as outlawing the schema's third value.
- **R1.2** `review.py`: `AgentOutputTooLarge` and generic agent crashes set `infrastructure_error=True` (mirror of security.py); `run_review` never raises. `factory.py` additionally wraps the get_agent+run_review call like security's, so a reviewer crash fails one component, not the run. Non-dict `_extract_json` results (null/list/string) are guarded in both parsers.
- **R1.2** `findings.py` + `factory.py`: skipped and budget-exhausted phases (review, security, knowledge) emit `Finding.phase_skipped(phase, reason)` (`is_infrastructure_error` stays False; `non_execution` tag + `is_phase_skip` property mark non-execution) plus a `phase_skipped` journal event.
- **R1.2** `pr.py`: PR bodies render `render_findings_markdown`'s existing INFRASTRUCTURE ERROR / new PHASE SKIPPED callouts for the non-execution subset of `component.findings`, so an advisory-mode security infra error is no longer invisible.
- **R1.2** `findings.dump_raw_debug` + both parsers: parse failures dump the FULL raw agent output to `.ralph/debug/<run_id>/<comp_id>/_{review,security}_raw.txt` (knowledge.py's `_distill_raw` pattern); the in-memory `raw_output` field stays capped at 2000 chars and the notes name the dump path.
- **R1.3** `git.py`: `get_diff_content` raises `GitDiffError` on nonzero exit or timeout instead of returning `""`; empty string now always means a genuinely empty diff. `factory.py` maps the error to a per-component infrastructure failure (infra finding phase="diff", `diff_fetch_failed` journal event, retry/fail closed) before any of the three consumers can review an empty string.

**Scope note:** the session prompt's scope list omits `git.py`, but roadmap item R1.3 explicitly prescribes the `git.get_diff_content` change; I treated the roadmap item (which the prompt directs to and whose checkbox it orders flipped) as naming the file. The `git.py` diff is minimal: one exception class + fail-loud behavior in `get_diff_content` only.

## Checks (final lines)

```
uv run pytest tests/ -q
909 passed, 12 skipped, 1 warning in 308.30s (0:05:08)

uv run mypy ralph_py/ --strict
Success: no issues found in 37 source files

uv run ruff check ralph_py/ tests/
All checks passed!
```

Run after rebasing onto origin/main @ b8c96b5 (rebase had one textual conflict in git.py with R1.5's `_parse_name_status_z`; both hunks kept).

## Tested

- Empty review (`{"stories":[],"concerns":[]}`) fails hard mode as infra: `test_empty_review_fails_hard_mode`, `test_partial_review_is_infrastructure_error`, `test_story_without_criteria_does_not_count_as_covered`
- Verdict handling: `test_uppercase_fail_blocks` ("FAIL" blocks), `test_pass_with_whitespace_passes` ("PASS "), `test_unknown_verdict_is_infrastructure_error` ("Blocked"), `test_missing_verdict_is_infrastructure_error`, `test_advisory_verdict_stays_valid`
- Story-id matching case-insensitive + coverage check off without a PRD: `test_story_id_match_is_case_insensitive`, `test_no_expected_ids_skips_coverage_check`
- Oversized output is infra in both modes with the infra Finding emitted: `test_oversized_output_is_infra_and_blocks_hard_mode`, `test_oversized_output_in_advisory_passes_but_leaves_trace`
- Reviewer crash fails one component, not the run (and advisory completes with the infra finding): `test_hard_mode_crash_fails_one_component_not_the_run`, `test_advisory_mode_crash_completes_with_infra_finding`, `test_agent_crash_never_raises`
- Advisory security crash leaves an infra finding and the PR body callout: `test_advisory_security_crash_leaves_infra_finding`
- Non-dict JSON (null / list / string) is infra, not AttributeError: `test_non_dict_json_is_infra_not_crash`
- Skip/budget paths produce the synthetic finding + journal event for review, security, and knowledge: `TestFactorySkipTraces` (3 tests)
- PR body shows did-not-run / skipped sections and does not duplicate real findings: `TestPrBodyDidNotRun` (3 tests)
- Full raw dumps on parse failure (forensic tail intact, field still capped, clean parses write nothing): `TestR12DebugDumps` (4 tests)
- `get_diff_content` raises outside a repo, returns "" for a genuinely empty diff in a real repo, and the factory maps the error to component failure + infra finding + journal event with review never called: `TestR13DiffErrors` (3 tests)
- No regression: full suite green; pre-existing factory/knowledge/review tests that reached the diff fetch in non-git tmp dirs now stub `get_diff_content` explicitly (they previously depended on the exact H-14 silent-empty-diff hole; four of them had begun passing accidentally through the new error path and were fixed to keep testing what they claim)

## Assumed (not tested)

- `GitDiffError` on `git diff` *timeout* (only the nonzero-exit path is exercised; the timeout branch is the same raise pattern)
- `dump_raw_debug` disk-error swallowing (OSError branch is best-effort by design, not simulated)
- Journal `phase_skipped`/`diff_fetch_failed` events through `NullProgressLog` (no-op by construction)
- Concurrency: parallel-executor path exercises `_handle_result` identically to max_parallel=1 (existing suite convention)
- Calibration suite not re-run: no prompt body changed (H2 applies to prompt edits; this PR is parser/harness-side only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)