### PR TITLE
test: R4.2 spine tier I - real-git worktree lifecycle and PR failure paths

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -323,13 +323,17 @@ mock-only coverage.
   - Archive (do not delete) the polluted `.ralph/evolution.jsonl` +
     `experiments.tsv` to `.ralph/archive/` and start clean journals (R6.4
     re-baselines).
-- [ ] R4.2 (L) **Real-git spine tier** [T-1..T-7, T-14]
+- [~] R4.2 (L) **Real-git spine tier** [T-1..T-7, T-14]
   - New marked tier (`-m spine`, in CI as a separate job): worktree lifecycle
     incl. two-process flock contention; PR failure paths against a stub `gh`
     binary on PATH; contract merge + conflict recovery; crash recovery with
     stale worktrees and a mid-verify kill; retry-context propagation e2e (fake
     agent writes its received prompt to a file; assert the diff-scope failure
     details from attempt 1 appear in attempt 2's prompt).
+  - Spine I landed (marker + worktree lifecycle incl. two-process flock
+    exclusion + PR failure paths with an unmocked engineer). Spine II
+    (session 6C: contract merge/conflict recovery, crash recovery,
+    retry-context propagation e2e) remains, plus the CI job split.
 - [ ] R4.3 (M) **Fix misleading tests** [T-5, T-6, T-8, T-9, T-10, T-11, T-15]
   - C1 becomes a true 2-worker worktree test; C6 uses the same root and proves
     serialization (fails if the flock is removed); C4 asserts the breaker was

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ packages = ["ralph_py"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "spine: real-git spine tier (R4.2) - unmocked worktree/PR/lock paths; deselect with -m 'not spine' to keep the fast tier fast",
+]
 
 [tool.ruff]
 line-length = 100

--- a/tests/spine_utils.py
+++ b/tests/spine_utils.py
@@ -1,0 +1,176 @@
+"""Shared builders for the real-git spine tier (R4.2).
+
+The spine tier's contract is "unmocked at the boundary under test": repos
+are real ``git init`` repositories, origins are real bare repos, the
+engineer is a real ``bash -lc`` subprocess (no ``unittest.mock`` anywhere
+in a spine test), and ``gh`` is a real executable stub on PATH whose
+behavior is driven by ``GH_SPINE_*`` env vars.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+from ralph_py.config import RalphConfig
+from ralph_py.factory import FactoryConfig
+from ralph_py.manifest import Component, Manifest
+from ralph_py.verify import VerifyConfig
+
+STUB_PR_URL = "https://github.com/spine/repo/pull/41"
+STUB_PR_NUMBER = 41
+
+# One-iteration fake engineer: emits the completion promise and exits.
+COMPLETE_LINE = "echo '<promise>COMPLETE</promise>'"
+
+
+def logging_engineer(log_path: Path) -> str:
+    """Fake engineer that records the worktree it ran in, then completes.
+
+    The worktree path's basename is the component id, so the log is a
+    mock-free record of which components the scheduler actually ran.
+    """
+    return f"pwd >> '{log_path}' && {COMPLETE_LINE}"
+
+
+def ran_components(log_path: Path) -> list[str]:
+    """Component ids the logging engineer actually ran, in order."""
+    if not log_path.exists():
+        return []
+    return [
+        Path(line).name
+        for line in log_path.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+def git(*args: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"git {' '.join(args)} failed: {result.stderr}"
+    )
+    return result.stdout.strip()
+
+
+def init_ralph_repo(
+    root: Path, comp_ids: tuple[str, ...], with_origin: bool = False,
+) -> Path | None:
+    """Real git repo shaped like a ralph project.
+
+    ``scripts/ralph/`` is gitignored so worktree provisioning (R0.4) must
+    copy prompt and PRD files in. Returns the bare origin path when
+    ``with_origin`` is set, else None.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    git("init", "-q", "-b", "main", cwd=root)
+    git("config", "user.email", "spine@test", cwd=root)
+    git("config", "user.name", "Spine Test", cwd=root)
+    (root / ".gitignore").write_text("scripts/ralph/\n.ralph/\n")
+    (root / "README.md").write_text("seed\n")
+    git("add", ".gitignore", "README.md", cwd=root)
+    git("commit", "-q", "-m", "init", cwd=root)
+
+    ralph_dir = root / "scripts" / "ralph"
+    (ralph_dir / "prompt.md").parent.mkdir(parents=True, exist_ok=True)
+    (ralph_dir / "prompt.md").write_text(
+        "Read the PRD at $prd_path and implement one story.\n"
+    )
+    for comp_id in comp_ids:
+        feature_dir = ralph_dir / "feature" / comp_id
+        feature_dir.mkdir(parents=True)
+        prd: dict[str, object] = {
+            "branchName": f"ralph/factory/{comp_id}",
+            "userStories": [{
+                "id": "US-001", "title": "Test",
+                "acceptanceCriteria": ["AC1"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }
+        (feature_dir / "prd.json").write_text(json.dumps(prd))
+
+    if with_origin:
+        origin = root.parent / "origin.git"
+        git("init", "-q", "--bare", str(origin), cwd=root.parent)
+        git("remote", "add", "origin", str(origin), cwd=root)
+        git("push", "-q", "-u", "origin", "main", cwd=root)
+        return origin
+    return None
+
+
+def component(comp_id: str, dependencies: list[str] | None = None) -> Component:
+    return Component(
+        id=comp_id, title=comp_id.upper(), description="",
+        dependencies=dependencies or [],
+        prd_path=f"scripts/ralph/feature/{comp_id}/prd.json",
+        branch_name=f"ralph/factory/{comp_id}",
+    )
+
+
+def make_manifest(components: list[Component]) -> Manifest:
+    return Manifest(
+        version="1", spec_file="spec.md", project_name="spine",
+        base_branch="main", single_pr=False, components=components,
+    )
+
+
+def factory_config(**overrides: object) -> FactoryConfig:
+    config = FactoryConfig(
+        use_worktrees=True, create_prs=False, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        merge_timeout=2.0,
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_diff_scope=False,
+            check_bad_patterns=False, subprocess_timeout=10.0,
+        ),
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def base_config(root: Path, agent_cmd: str = COMPLETE_LINE) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root / "scripts" / "ralph" / "prompt.md",
+        prd_file=root / "scripts" / "ralph" / "prd.json",
+        sleep_seconds=0, agent_cmd=agent_cmd,
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    )
+
+
+def write_stub_gh(bin_dir: Path) -> Path:
+    """Executable ``gh`` stub; behavior driven by GH_SPINE_* env vars.
+
+    GH_SPINE_CREATE / GH_SPINE_MERGE: "ok" (default) or "fail".
+    GH_SPINE_VIEW_STATE: "MERGED" (default), "OPEN", or "CLOSED".
+    """
+    gh = bin_dir / "gh"
+    gh.write_text(textwrap.dedent(f"""\
+        #!/bin/sh
+        if [ "$1" = "auth" ]; then exit 0; fi
+        if [ "$1" = "pr" ]; then
+          case "$2" in
+            create)
+              if [ "${{GH_SPINE_CREATE:-ok}}" = "fail" ]; then
+                echo "spine stub: pr create failed" >&2; exit 1
+              fi
+              echo "{STUB_PR_URL}"; exit 0 ;;
+            merge)
+              if [ "${{GH_SPINE_MERGE:-ok}}" = "fail" ]; then
+                echo "spine stub: pr merge failed" >&2; exit 1
+              fi
+              exit 0 ;;
+            view)
+              printf '{{"state": "%s"}}\\n' "${{GH_SPINE_VIEW_STATE:-MERGED}}"
+              exit 0 ;;
+          esac
+        fi
+        exit 0
+    """))
+    gh.chmod(0o755)
+    return gh

--- a/tests/test_spine_pr_failures.py
+++ b/tests/test_spine_pr_failures.py
@@ -1,0 +1,236 @@
+"""Spine tier I (R4.2): PR failure paths, fully unmocked.
+
+tests/test_pr_outcomes.py already proves the wave-2 status semantics but
+patches ``_run_component`` (the engineer) with a mock. These spine tests
+close that last mocked boundary: the engineer is a real ``bash -lc``
+subprocess running in a real worktree, pushes go to a real bare origin,
+and only ``gh`` is a stub executable on PATH (tests/spine_utils.py,
+driven by GH_SPINE_* env vars). Which components actually ran is proven
+by the engineer's own side effect (it logs its worktree cwd), not by a
+mock's call list.
+
+Wave-2 semantics asserted per failure shape:
+- push-fail / pr-create-fail / merge-fail: component FAILED, dependents
+  cascade-SKIPPED and never run.
+- wait-timeout: component MERGE_PENDING (re-pollable, not failed),
+  dependents stay PENDING and never run.
+- resume: a MERGE_PENDING component whose PR merged is re-polled to
+  COMPLETED without re-running its engineer.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from ralph_py.factory import FactoryResult, run_factory
+from ralph_py.manifest import ComponentStatus, Manifest
+from ralph_py.ui.plain import PlainUI
+from tests.spine_utils import (
+    STUB_PR_NUMBER,
+    STUB_PR_URL,
+    base_config,
+    component,
+    factory_config,
+    git,
+    init_ralph_repo,
+    logging_engineer,
+    make_manifest,
+    ran_components,
+    write_stub_gh,
+)
+
+pytestmark = pytest.mark.spine
+
+
+@pytest.fixture
+def stub_gh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    bin_dir = tmp_path / "spine-bin"
+    bin_dir.mkdir()
+    write_stub_gh(bin_dir)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    for var in ("GH_SPINE_CREATE", "GH_SPINE_MERGE", "GH_SPINE_VIEW_STATE"):
+        monkeypatch.delenv(var, raising=False)
+    return bin_dir
+
+
+def _alpha_beta_manifest() -> Manifest:
+    return make_manifest([component("alpha"), component("beta", ["alpha"])])
+
+
+def _run_real(
+    root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    manifest: Manifest,
+) -> tuple[FactoryResult, list[str]]:
+    """run_factory with the real logging engineer; returns the result and
+    the component ids whose engineer subprocess actually ran."""
+    monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+    agent_log = tmp_path / "agent-calls.log"
+    result = run_factory(
+        manifest,
+        factory_config(create_prs=True),
+        base_config(root, logging_engineer(agent_log)),
+        PlainUI(no_color=True),
+        root,
+    )
+    return result, ran_components(agent_log)
+
+
+class TestSpinePrFailurePaths:
+    def test_merged_pr_completes_and_schedules_dependents(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Happy-path baseline for the harness itself: both engineers
+        run, both branches are REALLY pushed to the bare origin, both
+        components complete."""
+        root = tmp_path / "repo"
+        origin = init_ralph_repo(root, ("alpha", "beta"), with_origin=True)
+        assert origin is not None
+        manifest = _alpha_beta_manifest()
+
+        result, ran = _run_real(root, tmp_path, monkeypatch, manifest)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.COMPLETED.value
+        assert beta.status == ComponentStatus.COMPLETED.value
+        assert ran == ["alpha", "beta"]
+        assert result.completed == ["alpha", "beta"]
+        assert result.exit_code == 0
+        assert len(result.pr_urls) == 2
+        # The pushes were real: the bare origin has both branch refs.
+        for branch in ("ralph/factory/alpha", "ralph/factory/beta"):
+            assert git("rev-parse", f"refs/heads/{branch}", cwd=origin)
+
+    def test_push_failure_fails_component_and_skips_dependents(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        root = tmp_path / "repo"
+        init_ralph_repo(root, ("alpha", "beta"), with_origin=True)
+        # Break the push target AFTER the initial push so the
+        # origin/main tracking ref exists but every push fails.
+        git("remote", "set-url", "origin", str(tmp_path / "missing.git"),
+            cwd=root)
+        manifest = _alpha_beta_manifest()
+
+        result, ran = _run_real(root, tmp_path, monkeypatch, manifest)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.FAILED.value
+        assert "push" in alpha.error
+        assert beta.status == ComponentStatus.SKIPPED.value
+        assert ran == ["alpha"]  # beta's engineer never started
+        assert result.failed == ["alpha"]
+        assert "beta" in result.skipped
+        assert result.exit_code == 1
+
+    def test_pr_create_failure_fails_component_and_skips_dependents(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GH_SPINE_CREATE", "fail")
+        root = tmp_path / "repo"
+        origin = init_ralph_repo(root, ("alpha", "beta"), with_origin=True)
+        assert origin is not None
+        manifest = _alpha_beta_manifest()
+
+        result, ran = _run_real(root, tmp_path, monkeypatch, manifest)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.FAILED.value
+        assert "Failed to create PR" in alpha.error
+        assert beta.status == ComponentStatus.SKIPPED.value
+        assert ran == ["alpha"]
+        assert result.failed == ["alpha"]
+        assert "beta" in result.skipped
+        assert result.exit_code == 1
+        # The failure was after the real push: origin has alpha's branch.
+        assert git("rev-parse", "refs/heads/ralph/factory/alpha", cwd=origin)
+
+    def test_merge_failure_fails_component_and_skips_dependents(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GH_SPINE_MERGE", "fail")
+        root = tmp_path / "repo"
+        init_ralph_repo(root, ("alpha", "beta"), with_origin=True)
+        manifest = _alpha_beta_manifest()
+
+        result, ran = _run_real(root, tmp_path, monkeypatch, manifest)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.FAILED.value
+        assert "merge failed" in alpha.error
+        # The PR was created before the merge failed: recorded for audit.
+        assert alpha.pr_url == STUB_PR_URL
+        assert beta.status == ComponentStatus.SKIPPED.value
+        assert ran == ["alpha"]
+        assert result.exit_code == 1
+
+    def test_wait_timeout_marks_merge_pending_dependents_stay_pending(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GH_SPINE_VIEW_STATE", "OPEN")
+        root = tmp_path / "repo"
+        init_ralph_repo(root, ("alpha", "beta"), with_origin=True)
+        manifest = _alpha_beta_manifest()
+
+        result, ran = _run_real(root, tmp_path, monkeypatch, manifest)
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.MERGE_PENDING.value
+        assert alpha.pr_url == STUB_PR_URL  # recorded for the re-poll
+        assert "not merged within" in alpha.error
+        # Not a failure: beta stays PENDING (never SKIPPED) and its
+        # engineer never runs past an unconfirmed merge (CRIT-2).
+        assert beta.status == ComponentStatus.PENDING.value
+        assert ran == ["alpha"]
+        assert result.merge_pending == ["alpha"]
+        assert "alpha" not in result.completed
+        assert "alpha" not in result.failed
+        assert result.exit_code == 1
+
+    def test_merge_pending_resume_repolls_without_rerunning_engineer(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Crash-recovery semantics: a MERGE_PENDING component whose PR
+        has since merged is re-polled to COMPLETED on the next run; its
+        engineer does not re-run, and dependents then schedule."""
+        root = tmp_path / "repo"
+        init_ralph_repo(root, ("alpha", "beta"), with_origin=True)
+        manifest = _alpha_beta_manifest()
+        alpha = manifest.get_component("alpha")
+        assert alpha is not None
+        alpha.status = ComponentStatus.MERGE_PENDING.value
+        alpha.pr_number = STUB_PR_NUMBER
+        alpha.pr_url = STUB_PR_URL
+        # Stub default view state is MERGED: the PR landed while the
+        # factory was down.
+
+        result, ran = _run_real(root, tmp_path, monkeypatch, manifest)
+
+        beta = manifest.get_component("beta")
+        assert beta is not None
+        assert alpha.status == ComponentStatus.COMPLETED.value
+        assert beta.status == ComponentStatus.COMPLETED.value
+        assert ran == ["beta"]  # alpha was re-polled, never re-run
+        assert "alpha" in result.completed
+        assert result.merge_pending == []
+        assert result.exit_code == 0

--- a/tests/test_spine_worktree.py
+++ b/tests/test_spine_worktree.py
@@ -1,0 +1,358 @@
+"""Spine tier I (R4.2): worktree lifecycle against real git repos.
+
+No mocks at the boundary under test: ``_setup_worktree`` and
+``_cleanup_worktree`` run real git subprocesses against real repos, and
+the lock-exclusion tests use real second PROCESSES (flock exclusion is
+invisible to threads within one process's open file description).
+
+Covered:
+- create from the requested base branch (and from origin/<base> when a
+  remote exists, per R0.2 freshness semantics);
+- cleanup removes the worktree directory and its git registration;
+- recreate-after-crash: dirty dir + stale index.lock, branch-commit
+  resume, and ``fresh_from_base`` discard (R0.1 retry semantics);
+- the per-component flock and the run-level factory flock actually
+  exclude across processes, and the run lock dies with its holder.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from ralph_py.factory import _cleanup_worktree, _setup_worktree, run_factory
+from ralph_py.ui.plain import PlainUI
+from tests.spine_utils import (
+    base_config,
+    component,
+    factory_config,
+    git,
+    init_ralph_repo,
+    make_manifest,
+)
+
+pytestmark = pytest.mark.spine
+
+RUN_ID = "spine-run-1"
+COMP = "comp-a"
+BRANCH = "ralph/factory/comp-a"
+
+# Child that takes an exclusive flock on the given path and holds it
+# until killed, standing in for a live contending ralph process.
+_LOCK_HOLDER_SCRIPT = """
+import fcntl, sys, time
+fp = open(sys.argv[1], "a+")
+fcntl.flock(fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+print("locked", flush=True)
+time.sleep(120)
+"""
+
+# Child that runs the real _setup_worktree. Touches the ready file after
+# imports finish, immediately before the call, so the parent can time the
+# hold window against the call itself rather than interpreter startup.
+_SETUP_CHILD_SCRIPT = """
+import sys
+from pathlib import Path
+from ralph_py.factory import _setup_worktree
+root = Path(sys.argv[1])
+Path(sys.argv[2]).write_text("ready")
+wt = _setup_worktree("comp-a", "ralph/factory/comp-a", "main", root, sys.argv[3])
+print(wt, flush=True)
+"""
+
+
+def _init_plain_repo(root: Path) -> tuple[str, str]:
+    """Real repo with main plus a develop branch one commit ahead.
+
+    Returns (main_sha, develop_sha).
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    git("init", "-q", "-b", "main", cwd=root)
+    git("config", "user.email", "spine@test", cwd=root)
+    git("config", "user.name", "Spine Test", cwd=root)
+    (root / "README.md").write_text("seed\n")
+    git("add", "README.md", cwd=root)
+    git("commit", "-q", "-m", "init", cwd=root)
+    main_sha = git("rev-parse", "main", cwd=root)
+    git("checkout", "-q", "-b", "develop", cwd=root)
+    (root / "dev.txt").write_text("develop-only\n")
+    git("add", "dev.txt", cwd=root)
+    git("commit", "-q", "-m", "develop commit", cwd=root)
+    develop_sha = git("rev-parse", "develop", cwd=root)
+    git("checkout", "-q", "main", cwd=root)
+    return main_sha, develop_sha
+
+
+def _worktree_registered(root: Path, worktree_path: Path) -> bool:
+    listing = git("worktree", "list", "--porcelain", cwd=root)
+    return str(worktree_path) in listing
+
+
+class TestWorktreeLifecycle:
+    def test_setup_creates_worktree_from_requested_base(
+        self, tmp_path: Path,
+    ) -> None:
+        """The worktree is cut from the requested base branch (develop),
+        not the default branch, at the run-scoped path (R0.5 layout)."""
+        root = tmp_path / "repo"
+        main_sha, develop_sha = _init_plain_repo(root)
+
+        wt = _setup_worktree(COMP, BRANCH, "develop", root, RUN_ID)
+
+        assert wt == root / ".ralph" / "worktrees" / RUN_ID / COMP
+        assert wt.is_dir()
+        assert _worktree_registered(root, wt)
+        assert git("branch", "--show-current", cwd=wt) == BRANCH
+        head = git("rev-parse", "HEAD", cwd=wt)
+        assert head == develop_sha
+        assert head != main_sha
+        assert (wt / "dev.txt").exists()
+
+    def test_setup_cuts_from_origin_base_not_stale_local(
+        self, tmp_path: Path,
+    ) -> None:
+        """With a remote, the worktree is cut from origin/<base> even when
+        the local base ref is stale (R0.2: dependents must build on the
+        squash-merged remote history)."""
+        root = tmp_path / "repo"
+        _, local_develop_sha = _init_plain_repo(root)
+        origin = tmp_path / "origin.git"
+        git("init", "-q", "--bare", str(origin), cwd=tmp_path)
+        git("remote", "add", "origin", str(origin), cwd=root)
+        git("push", "-q", "-u", "origin", "main", "develop", cwd=root)
+
+        # Advance origin/develop from a second clone; local develop is
+        # now one commit behind the remote.
+        clone = tmp_path / "clone"
+        git("clone", "-q", "-b", "develop", str(origin), str(clone),
+            cwd=tmp_path)
+        git("config", "user.email", "other@test", cwd=clone)
+        git("config", "user.name", "Other", cwd=clone)
+        (clone / "remote.txt").write_text("landed remotely\n")
+        git("add", "remote.txt", cwd=clone)
+        git("commit", "-q", "-m", "remote-only commit", cwd=clone)
+        git("push", "-q", "origin", "develop", cwd=clone)
+        remote_develop_sha = git("rev-parse", "HEAD", cwd=clone)
+
+        wt = _setup_worktree(COMP, BRANCH, "develop", root, RUN_ID)
+
+        head = git("rev-parse", "HEAD", cwd=wt)
+        assert head == remote_develop_sha
+        assert head != local_develop_sha
+        assert (wt / "remote.txt").exists()
+
+    def test_cleanup_removes_worktree_and_registration(
+        self, tmp_path: Path,
+    ) -> None:
+        """Cleanup removes the directory and the git worktree entry; the
+        component branch survives (it is only deleted at merge time)."""
+        root = tmp_path / "repo"
+        _init_plain_repo(root)
+        wt = _setup_worktree(COMP, BRANCH, "develop", root, RUN_ID)
+
+        _cleanup_worktree(COMP, root, RUN_ID)
+
+        assert not wt.exists()
+        assert not _worktree_registered(root, wt)
+        assert git("branch", "--list", BRANCH, cwd=root).strip()
+
+    def test_recreate_after_crash_resumes_branch_commits(
+        self, tmp_path: Path,
+    ) -> None:
+        """A killed attempt leaves a dirty worktree and a stale
+        index.lock under .git/worktrees/<comp>/. Recreating for the same
+        run must clear both and resume the branch WITH its commits
+        (non-timeout retry semantics), dropping uncommitted dirt."""
+        root = tmp_path / "repo"
+        _init_plain_repo(root)
+        wt = _setup_worktree(COMP, BRANCH, "develop", root, RUN_ID)
+
+        # Simulate the crashed attempt: one committed step of progress,
+        # one uncommitted file, and git killed mid-operation.
+        (wt / "progress.txt").write_text("committed progress\n")
+        git("add", "progress.txt", cwd=wt)
+        git("commit", "-q", "-m", "crashed attempt progress", cwd=wt)
+        crashed_sha = git("rev-parse", "HEAD", cwd=wt)
+        (wt / "uncommitted.txt").write_text("dirty\n")
+        stale_lock = root / ".git" / "worktrees" / COMP / "index.lock"
+        stale_lock.parent.mkdir(parents=True, exist_ok=True)
+        stale_lock.write_text("")
+
+        wt2 = _setup_worktree(COMP, BRANCH, "develop", root, RUN_ID)
+
+        assert wt2 == wt
+        assert not stale_lock.exists()
+        assert git("rev-parse", "HEAD", cwd=wt2) == crashed_sha
+        assert (wt2 / "progress.txt").exists()
+        assert not (wt2 / "uncommitted.txt").exists()
+        assert git("status", "--porcelain", cwd=wt2) == ""
+
+    def test_recreate_fresh_from_base_discards_crashed_commits(
+        self, tmp_path: Path,
+    ) -> None:
+        """fresh_from_base=True (timeout retry, R0.1) deletes the branch
+        so the worktree is recut from the base, discarding the killed
+        attempt's possibly-poisoned commits."""
+        root = tmp_path / "repo"
+        _, develop_sha = _init_plain_repo(root)
+        wt = _setup_worktree(COMP, BRANCH, "develop", root, RUN_ID)
+        (wt / "poisoned.txt").write_text("from the killed attempt\n")
+        git("add", "poisoned.txt", cwd=wt)
+        git("commit", "-q", "-m", "poisoned progress", cwd=wt)
+        crashed_sha = git("rev-parse", "HEAD", cwd=wt)
+
+        wt2 = _setup_worktree(
+            COMP, BRANCH, "develop", root, RUN_ID, fresh_from_base=True,
+        )
+
+        head = git("rev-parse", "HEAD", cwd=wt2)
+        assert head == develop_sha
+        assert head != crashed_sha
+        assert not (wt2 / "poisoned.txt").exists()
+
+    # Product bug found by this spine test (report in the R4.2 PR body):
+    # when a crashed attempt's worktree DIRECTORY is gone (tmp cleaner,
+    # operator rm -rf) but its .git/worktrees/<comp>/ registration
+    # survives, _setup_worktree cannot recreate it: the exists() guard
+    # skips `git worktree remove`, and `git worktree add` then refuses
+    # with "missing but already registered worktree". Recovery needs a
+    # remove/prune of the registered-but-missing entry before the add
+    # (ralph_py/factory.py::_setup_worktree).
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "known product bug: _setup_worktree cannot recreate a "
+            "registered-but-missing worktree (dir deleted after crash)"
+        ),
+    )
+    def test_recreate_when_crashed_worktree_dir_was_deleted(
+        self, tmp_path: Path,
+    ) -> None:
+        root = tmp_path / "repo"
+        _init_plain_repo(root)
+        wt = _setup_worktree(COMP, BRANCH, "develop", root, RUN_ID)
+        shutil.rmtree(wt)  # dir gone, .git/worktrees/comp-a/ remains
+
+        wt2 = _setup_worktree(COMP, BRANCH, "develop", root, RUN_ID)
+
+        assert wt2.is_dir()
+        assert git("branch", "--show-current", cwd=wt2) == BRANCH
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="flock is POSIX-only (documented degrade)",
+)
+class TestComponentLockTwoProcessExclusion:
+    def test_component_lock_blocks_second_process_until_released(
+        self, tmp_path: Path,
+    ) -> None:
+        """While a real second process holds the per-component flock,
+        _setup_worktree in another process blocks; it completes only
+        after the holder dies. Unlocked setup takes ~0.03s (measured), so
+        a 1s hold with the child still running is exclusion, not noise."""
+        root = tmp_path / "repo"
+        _init_plain_repo(root)
+        lock_path = root / ".ralph" / "worktrees" / f"{COMP}.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        ready = tmp_path / "child-ready"
+        worktree_path = root / ".ralph" / "worktrees" / RUN_ID / COMP
+
+        holder = subprocess.Popen(
+            [sys.executable, "-c", _LOCK_HOLDER_SCRIPT, str(lock_path)],
+            stdout=subprocess.PIPE, text=True,
+        )
+        child: subprocess.Popen[str] | None = None
+        try:
+            assert holder.stdout is not None
+            assert holder.stdout.readline().strip() == "locked"
+
+            child = subprocess.Popen(
+                [sys.executable, "-c", _SETUP_CHILD_SCRIPT,
+                 str(root), str(ready), RUN_ID],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+            )
+            deadline = time.monotonic() + 30
+            while not ready.exists():
+                assert time.monotonic() < deadline, (
+                    "setup child never reached _setup_worktree"
+                )
+                assert child.poll() is None, (
+                    f"setup child died early: {child.communicate()}"
+                )
+                time.sleep(0.01)
+
+            time.sleep(1.0)  # hold window: ~30x unlocked setup time
+            assert child.poll() is None, (
+                "second process finished _setup_worktree while the "
+                "component lock was held: flock does not exclude"
+            )
+            assert not worktree_path.exists()
+
+            # Release the lock: the blocked child must now complete.
+            holder.kill()
+            holder.wait(timeout=10)
+            out, err = child.communicate(timeout=30)
+            assert child.returncode == 0, f"setup child failed: {err}"
+        finally:
+            if holder.poll() is None:
+                holder.kill()
+                holder.wait(timeout=10)
+            if child is not None and child.poll() is None:
+                child.kill()
+                child.wait(timeout=10)
+
+        assert worktree_path.is_dir()
+        assert str(worktree_path) in out
+        assert git("branch", "--show-current", cwd=worktree_path) == BRANCH
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="flock is POSIX-only (documented degrade)",
+)
+class TestRunLockTwoProcessExclusion:
+    def test_run_lock_refuses_second_invocation_until_holder_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """While a real process holds .ralph/factory.lock, run_factory
+        refuses to start (exit 2, nothing scheduled). Once the holder
+        dies the same invocation succeeds: the flock dies with its
+        process, so a stale lock FILE can never wedge the factory."""
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+        root = tmp_path / "repo"
+        init_ralph_repo(root, (COMP,))
+        lock_path = root / ".ralph" / "factory.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+        holder = subprocess.Popen(
+            [sys.executable, "-c", _LOCK_HOLDER_SCRIPT, str(lock_path)],
+            stdout=subprocess.PIPE, text=True,
+        )
+        try:
+            assert holder.stdout is not None
+            assert holder.stdout.readline().strip() == "locked"
+
+            manifest = make_manifest([component(COMP)])
+            refused = run_factory(
+                manifest, factory_config(), base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+            assert refused.exit_code == 2
+            assert refused.completed == []
+            assert manifest.components[0].status == "pending"
+            assert not (root / ".ralph" / "worktrees").exists()
+        finally:
+            holder.kill()
+            holder.wait(timeout=10)
+
+        rerun = run_factory(
+            make_manifest([component(COMP)]), factory_config(),
+            base_config(root), PlainUI(no_color=True), root,
+        )
+        assert rerun.exit_code == 0
+        assert rerun.completed == [COMP]


### PR DESCRIPTION
## Summary

R4.2 spine tier I (first half of the real-git spine): registers the `spine` pytest marker and adds unmocked tests for worktree lifecycle and PR failure paths. Tests only: no `ralph_py/` source changed. R4.2 flipped to `[~]` in `docs/remediation-roadmap.md` (spine II - contract merge/conflict recovery, crash recovery, retry-context propagation, CI job split - remains, session 6C).

The spine tier's contract is "unmocked at the boundary under test": real `git init` repos, real bare origins, the engineer is a real `bash -lc` subprocess, lock contention uses real second processes, and `gh` is a real executable stub on PATH driven by `GH_SPINE_*` env vars. No `unittest.mock` appears anywhere in a spine test. `tests/test_pr_outcomes.py` (wave 2A) already proved the PR-status semantics but patched `_run_component` (the engineer); these tests close that last mocked boundary, proving which components ran via the engineer's own side effect (it logs its worktree cwd) instead of a mock call list.

## Roadmap items

- R4.2 (spine I of II) -> `[~]`

## Files

- `pyproject.toml`: `spine` marker declaration only.
- `tests/spine_utils.py`: shared spine builders (real repo/origin/manifest/config factories, stub `gh` writer, logging engineer).
- `tests/test_spine_worktree.py`: worktree lifecycle + two-process lock exclusion (8 tests).
- `tests/test_spine_pr_failures.py`: PR failure paths with unmocked engineer (6 tests).
- `docs/remediation-roadmap.md`: R4.2 checkbox flip with spine II note.

Marker registration lives in `pyproject.toml` (`[tool.pytest.ini_options] markers`); `conftest.py` needed no change for registration (and is concurrently edited by a parallel wave-4 session, so it was deliberately left untouched).

## Product bug found (encoded as strict xfail)

`test_recreate_when_crashed_worktree_dir_was_deleted` (tests/test_spine_worktree.py): when a crashed attempt's worktree **directory** is gone (tmp cleaner, operator `rm -rf`) but its `.git/worktrees/<comp>/` registration survives, `_setup_worktree` cannot recreate it. The `worktree_path.exists()` guard skips `git worktree remove`, and `git worktree add` then refuses with `fatal: '<path>' is a missing but already registered worktree`. The component would fail its retry with no recovery path short of manual `git worktree prune`. Fix belongs in `ralph_py/factory.py::_setup_worktree` (remove/prune the registered-but-missing entry before the add); left as `xfail(strict=True)` so the fix must flip the test.

## Tested (all measured, none estimated)

Worktree lifecycle (`tests/test_spine_worktree.py`, real git subprocesses, no mocks):

- `test_setup_creates_worktree_from_requested_base`: worktree cut from the requested base branch (develop, not main) at the run-scoped `.ralph/worktrees/<run_id>/<comp>` path; registered in `git worktree list`; correct branch checked out.
- `test_setup_cuts_from_origin_base_not_stale_local`: with a remote, the worktree HEAD equals origin/develop advanced from a second clone, not the stale local develop (R0.2 freshness through `_setup_worktree` itself).
- `test_cleanup_removes_worktree_and_registration`: dir and git registration gone; component branch survives.
- `test_recreate_after_crash_resumes_branch_commits`: dirty worktree + stale `.git/worktrees/<comp>/index.lock` from a killed attempt; recreate clears both, resumes the branch WITH its commits, drops uncommitted dirt, leaves a clean status.
- `test_recreate_fresh_from_base_discards_crashed_commits`: `fresh_from_base=True` (R0.1 timeout retry) recuts from base; the killed attempt's commit is gone.
- `test_component_lock_blocks_second_process_until_released`: real second PROCESS holds the per-component flock; `_setup_worktree` in another real process is still blocked after a 1s hold window (~30x the measured 0.03s unlocked setup time) with no worktree created, then completes only after the holder is killed. Fails if the flock is removed from the product.
- `test_run_lock_refuses_second_invocation_until_holder_exits`: real process holds `.ralph/factory.lock`; `run_factory` refuses (exit 2, nothing scheduled); after the holder dies the same invocation succeeds, proving the flock dies with its process (a stale lock FILE cannot wedge the factory).

PR failure paths (`tests/test_spine_pr_failures.py`, real engineer subprocess + real bare origin + stub `gh`):

- `test_merged_pr_completes_and_schedules_dependents`: both components complete, exit 0, and both branch refs exist on the bare origin (the pushes were real).
- `test_push_failure_fails_component_and_skips_dependents`: push-fail -> alpha FAILED (error names push), beta cascade-SKIPPED, beta's engineer never ran (proven by the engineer's own cwd log), exit 1.
- `test_pr_create_failure_fails_component_and_skips_dependents`: create-fail -> FAILED / SKIPPED / engineer-not-run, and origin has alpha's branch (failure was after a real push).
- `test_merge_failure_fails_component_and_skips_dependents`: merge-fail -> FAILED with `pr_url` recorded for audit, beta SKIPPED.
- `test_wait_timeout_marks_merge_pending_dependents_stay_pending`: wait-timeout -> alpha MERGE_PENDING (not failed, not completed), `pr_url` recorded for the re-poll, beta stays PENDING (never SKIPPED) and never runs, `result.merge_pending == ["alpha"]`, exit 1 (wave-2 CRIT-2 semantics).
- `test_merge_pending_resume_repolls_without_rerunning_engineer`: MERGE_PENDING component whose PR merged while the factory was down is re-polled to COMPLETED; its engineer does not re-run (cwd log shows only beta); dependents then schedule; exit 0.

Marker mechanics: `-m spine` selects 14/935; `-m "not spine"` selects 921/935 (both measured via `--collect-only`).

## Measured timings (scratch worktree at this commit, macOS)

Spine tier total: **6.67s** pytest session, 6.81s wall (`/usr/bin/time uv run pytest tests/ -m spine -q`) - budget was <60s. Every test under the 5s per-test budget; slowest:

```
2.36s test_wait_timeout_marks_merge_pending_dependents_stay_pending
1.17s test_component_lock_blocks_second_process_until_released
0.53s test_merged_pr_completes_and_schedules_dependents
0.38s test_merge_pending_resume_repolls_without_rerunning_engineer
0.35s test_merge_failure_fails_component_and_skips_dependents
0.35s test_pr_create_failure_fails_component_and_skips_dependents
0.31s test_push_failure_fails_component_and_skips_dependents
(remaining 7 tests each <= 0.23s)
```

## Assumed

- The CI job split (fast job `-m "not spine"`, second job `-m spine`) is intentionally NOT added here; the session scope was tests + marker declaration only, and the roadmap note assigns the split to spine II.
- flock exclusion tests are skipped on Windows (`fcntl` is POSIX-only, matching the product's documented degrade); not run on Windows.
- Timings above are from one macOS machine; CI timings will differ (not measured on CI).
- The stub `gh` models only the subcommands the product calls (`auth status`, `pr create/merge/view`); real `gh` argument-level behavior (e.g. `--auto` fallback ordering) is exercised only insofar as the product invokes it against the stub.

## Green checks (run in a detached scratch worktree at this commit)

```
uv run pytest tests/ -q          -> 922 passed, 12 skipped, 1 xfailed, 1 warning in 325.04s (0:05:25)
uv run mypy ralph_py/ --strict   -> Success: no issues found in 37 source files
uv run ruff check ralph_py/ tests/ -> All checks passed!
```

(The 1 xfailed is this PR's strict-xfail product-bug test; the 12 skips and the warning are pre-existing.)

---
Generated with [Claude Code](https://claude.com/claude-code)
