### PR TITLE
fix: R2.3 honest run/factory flags (CRIT-8, H-10, H-11)

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -263,7 +263,7 @@ every flag must do what it says or fail loudly.
 - [ ] R2.2 (S) **Expose the safety knobs** [CRIT-7]
   - `max_adversarial_calls` and `pause_before_pr_merge`: toml keys, env vars,
     CLI flags, documented. Budget exhaustion emits the R1.2 synthetic finding.
-- [ ] R2.3 (M) **Make `ralph run` and factory flags honest** [CRIT-8, H-10, H-11]
+- [x] R2.3 (M) **Make `ralph run` and factory flags honest** [CRIT-8, H-10, H-11]
   - Forward `max_iterations` (N), `interactive`, and `allowed_paths` through
     `_submit_args` into `_run_component`; delete the hardcoded 30.
   - `--no-verify` actually skips Phase 1 (explicit `skip` sentinel instead of

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -335,20 +335,22 @@ def run(
         base_branch=detected_base,
     )
 
-    # Build factory config for single-component mode
-    v_config = None if no_verify else VerifyConfig()
-    ff_config = FeedforwardConfig() if not no_verify else None
-
+    # Build factory config for single-component mode.
+    # R2.3: --no-verify sets the explicit skip sentinel; passing
+    # verify_config=None meant "use defaults" in run_factory and Phase 1
+    # ran anyway. Feedforward is loaded from the toml/env control plane
+    # and is independent of --no-verify (it builds context, not checks).
     factory_cfg = FactoryConfig(
         max_parallel=1,
         max_retries=3,
         use_worktrees=False,
         single_pr=False,
         create_prs=False,
-        verify_config=v_config,
+        verify_config=None if no_verify else VerifyConfig(),
+        skip_verification=no_verify,
         review_mode="advisory",
         contract_config=None,
-        feedforward_config=ff_config,
+        feedforward_config=FeedforwardConfig.load(root_dir),
         timeout_config=TimeoutConfig.load(root_dir),
         force_lock=force_lock,
     )
@@ -1452,6 +1454,7 @@ def factory(
 
     # Build configs
     from ralph_py.contract import ContractConfig
+    from ralph_py.feedforward import FeedforwardConfig
     from ralph_py.verify import VerifyConfig
 
     v_config: VerifyConfig | None = None
@@ -1499,11 +1502,18 @@ def factory(
         create_prs=create_prs,
         verify_command=verify_command,
         verify_config=v_config,
+        # R2.3: --no-verify is an explicit skip sentinel that run_factory
+        # honors; v_config=None alone would substitute default checks.
+        skip_verification=no_verify,
         review_mode=review_mode,
         review_agent_cmd=review_agent_cmd,
         review_model=review_model,
         security_config=s_config,
         contract_config=c_config,
+        # R2.3 (H-10): feedforward was never wired into this command, so
+        # ff_config_dict stayed None and Phase 0 silently never ran under
+        # `ralph factory`. Loaded via the toml/env control plane.
+        feedforward_config=FeedforwardConfig.load(root_dir),
         progress_log_path=progress_log,
         timeout_config=timeout_config,
         force_lock=force_lock,

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -44,7 +44,11 @@ from ralph_py.security import (
     run_security_review,
 )
 from ralph_py.timeout import TimeoutConfig
-from ralph_py.verify import VerifyConfig, run_mechanical_verification
+from ralph_py.verify import (
+    VerificationResult,
+    VerifyConfig,
+    run_mechanical_verification,
+)
 
 if TYPE_CHECKING:
     from ralph_py.ui.base import UI
@@ -63,6 +67,12 @@ class FactoryConfig:
     verify_command: str | None = None
     # Phase 1: mechanical verification
     verify_config: VerifyConfig | None = None
+    # R2.3 (CRIT-8): explicit skip sentinel for Phase 1. verify_config=None
+    # keeps its historical meaning of "use the default checks"; only this
+    # flag (set by --no-verify) genuinely skips mechanical verification.
+    # The skip is stated in the run output and recorded as a phase_skipped
+    # finding so "ran clean" and "never ran" stay distinguishable.
+    skip_verification: bool = False
     # Phase 2: reviewer agent
     review_mode: str = ReviewMode.HARD.value
     review_agent_cmd: str | None = None
@@ -541,6 +551,9 @@ def _run_component(
     codebase_map_file_str: str = "scripts/ralph/codebase_map.md",
     agent_iteration_timeout: float = 1800.0,
     component_timeout: float = 7200.0,
+    max_iterations: int = 10,
+    interactive: bool = False,
+    allowed_paths: list[str] | None = None,
 ) -> ComponentResult:
     """Run a single component's implementation loop.
 
@@ -571,9 +584,11 @@ def _run_component(
         worktree_prd.parent.mkdir(parents=True, exist_ok=True)
         worktree_prd.write_text(prd_source.read_text())
 
-    # Note: the prompt template uses $prd_path which is substituted at runtime
-    # by loop.py with config.prd_file, so the agent reads the correct component
-    # PRD without needing to overwrite scripts/ralph/prd.json.
+    # The prompt template's $prd_path placeholder (shipped in
+    # DEFAULT_PROMPT >= 1.1.0 and the scaffolded prompt.md) is substituted
+    # at runtime by loop.py with config.prd_file, so the agent reads the
+    # SAME per-component PRD that check_prd_stories re-reads (R2.3, H-11)
+    # without overwriting scripts/ralph/prd.json.
 
     # Copy prompt into worktree if needed
     worktree_prompt = worktree_path / prompt_file_str
@@ -638,14 +653,19 @@ def _run_component(
     if parts:
         context_prefix = "\n\n".join(parts)
 
+    # R2.3 (CRIT-8): max_iterations, interactive, and allowed_paths come
+    # from the invoking config via _submit_args. They were previously
+    # hardcoded here (30 / False / unset), which made `ralph run N`, -i,
+    # and --allowed-paths silent no-ops under the factory pipeline.
     config = RalphConfig(
-        max_iterations=30,
+        max_iterations=max_iterations,
         prompt_file=worktree_prompt,
         prd_file=worktree_prd,
         progress_file=worktree_path / progress_file_str,
         codebase_map_file=worktree_path / codebase_map_file_str,
         sleep_seconds=sleep_seconds,
-        interactive=False,
+        interactive=interactive,
+        allowed_paths=list(allowed_paths) if allowed_paths else [],
         ralph_branch="",
         ralph_branch_explicit=True,
         agent_cmd=agent_cmd,
@@ -1048,67 +1068,101 @@ def _run_factory_locked(
 
         wt_path = worktree_paths.get(comp_id, root_dir)
 
+        def _record_phase_skip(phase: str, reason: str) -> None:
+            """R1.2: a phase that never ran must leave a trace in both
+            the findings stream and the journal, so "ran clean" and
+            "never ran" are distinguishable downstream."""
+            comp.findings.append(Finding.phase_skipped(phase, reason))
+            progress_log.emit(
+                "phase_skipped", comp_id,
+                {"phase": phase, "reason": reason},
+            )
+
         # PHASE 1: Mechanical verification
         comp.status = ComponentStatus.VERIFYING.value
         manifest.save(manifest_path)
 
-        verify_config = factory_config.verify_config or VerifyConfig()
-        ui.info(f"  Phase 1: mechanical verification for {comp_id}...")
-        verify_start = time.monotonic()
-        # Per-component allowed_paths comes from the PRD (architect-emitted
-        # via DECOMPOSE_PROMPT v1.1.0+, REQUIRED for v1.2.0+). Without
-        # this, the diff-scope check silently passes and a rogue agent
-        # can touch anything in the worktree -- the end-to-end validation
-        # run on 2026-05-27 caught an agent editing factory internals
-        # because allowed_paths was always None here. Legacy PRDs without
-        # the field load with allowed_paths=None which preserves the
-        # prior "no constraint" behavior; v1.2.0+ architect outputs are
-        # gated upstream in decompose._validate_decompose_output.
-        #
-        # R1.5: a PRD that fails to LOAD is not the same as a PRD with
-        # no allowedPaths. Swallowing the load error into
-        # allowed_paths=None silently disabled the scope check -- an
-        # agent that corrupts or deletes its own PRD would unbind its
-        # write scope. Load failure now flows into check_diff_scope as
-        # allowed_paths_error, which fails the check closed.
-        component_allowed_paths: list[str] | None = None
-        allowed_paths_error: str | None = None
-        try:
-            prd_for_scope = PRD.load(wt_path / comp.prd_path)
-            component_allowed_paths = prd_for_scope.allowed_paths
-        except FileNotFoundError as exc:
-            allowed_paths_error = f"PRD not found: {exc}"
-        except ValueError as exc:
-            allowed_paths_error = f"PRD failed to parse: {exc}"
-        verification = run_mechanical_verification(
-            wt_path,
-            wt_path / comp.prd_path,
-            manifest.base_branch,
-            component_allowed_paths,
-            verify_config,
-            allowed_paths_error=allowed_paths_error,
-        )
-        verify_duration = time.monotonic() - verify_start
-        comp.verification_passed = verification.passed
-        progress_log.verification_result(
-            comp_id, verification.passed,
-            check_names=[c.name for c in verification.checks],
-            failures=[c.message for c in verification.checks if not c.passed],
-            duration=verify_duration,
-        )
-
-        if not verification.passed:
-            failing = [c for c in verification.checks if not c.passed]
-            ui.warn(
-                f"  Phase 1 FAILED for {comp_id}: "
-                f"{', '.join(c.name for c in failing)}"
+        if factory_config.skip_verification:
+            # R2.3: --no-verify. Previously verify_config=None fell
+            # through to VerifyConfig() defaults here and Phase 1 ran
+            # anyway - on a non-Python repo that burned every retry
+            # against checks that could never pass. The empty
+            # VerificationResult below is what downstream reviewers see:
+            # no checks ran, none are claimed.
+            ui.info(
+                f"  Phase 1 SKIPPED for {comp_id}: mechanical "
+                f"verification disabled (--no-verify)"
             )
-            ctx = IterationContext.from_json(comp_result.context_json or "{}")
-            ctx.add_verification_failure(verification.as_context())
-            _retry_or_fail(comp, "Mechanical verification failed", ctx.to_json())
-            return
+            comp.verification_passed = None
+            _record_phase_skip(
+                "verify", "mechanical verification disabled (--no-verify)",
+            )
+            verification = VerificationResult(passed=True, checks=[])
+        else:
+            verify_config = factory_config.verify_config or VerifyConfig()
+            ui.info(f"  Phase 1: mechanical verification for {comp_id}...")
+            verify_start = time.monotonic()
+            # Per-component allowed_paths comes from the PRD (architect-
+            # emitted via DECOMPOSE_PROMPT v1.1.0+, REQUIRED for v1.2.0+).
+            # Without this, the diff-scope check silently passes and a
+            # rogue agent can touch anything in the worktree -- the
+            # end-to-end validation run on 2026-05-27 caught an agent
+            # editing factory internals because allowed_paths was always
+            # None here. Legacy PRDs without the field load with
+            # allowed_paths=None which preserves the prior "no constraint"
+            # behavior; v1.2.0+ architect outputs are gated upstream in
+            # decompose._validate_decompose_output.
+            #
+            # R1.5: a PRD that fails to LOAD is not the same as a PRD with
+            # no allowedPaths. Swallowing the load error into
+            # allowed_paths=None silently disabled the scope check -- an
+            # agent that corrupts or deletes its own PRD would unbind its
+            # write scope. Load failure now flows into check_diff_scope as
+            # allowed_paths_error, which fails the check closed.
+            component_allowed_paths: list[str] | None = None
+            allowed_paths_error: str | None = None
+            try:
+                prd_for_scope = PRD.load(wt_path / comp.prd_path)
+                component_allowed_paths = prd_for_scope.allowed_paths
+            except FileNotFoundError as exc:
+                allowed_paths_error = f"PRD not found: {exc}"
+            except ValueError as exc:
+                allowed_paths_error = f"PRD failed to parse: {exc}"
+            verification = run_mechanical_verification(
+                wt_path,
+                wt_path / comp.prd_path,
+                manifest.base_branch,
+                component_allowed_paths,
+                verify_config,
+                allowed_paths_error=allowed_paths_error,
+            )
+            verify_duration = time.monotonic() - verify_start
+            comp.verification_passed = verification.passed
+            progress_log.verification_result(
+                comp_id, verification.passed,
+                check_names=[c.name for c in verification.checks],
+                failures=[
+                    c.message for c in verification.checks if not c.passed
+                ],
+                duration=verify_duration,
+            )
 
-        ui.ok(f"  Phase 1 passed for {comp_id}")
+            if not verification.passed:
+                failing = [c for c in verification.checks if not c.passed]
+                ui.warn(
+                    f"  Phase 1 FAILED for {comp_id}: "
+                    f"{', '.join(c.name for c in failing)}"
+                )
+                ctx = IterationContext.from_json(
+                    comp_result.context_json or "{}",
+                )
+                ctx.add_verification_failure(verification.as_context())
+                _retry_or_fail(
+                    comp, "Mechanical verification failed", ctx.to_json(),
+                )
+                return
+
+            ui.ok(f"  Phase 1 passed for {comp_id}")
 
         # Fetch the component diff once and share it across Phase 2,
         # Phase 2.5, and knowledge distillation. Without this each phase
@@ -1151,16 +1205,6 @@ def _run_factory_locked(
         adversarial_debug_dir = (
             root_dir / ".ralph" / "debug" / run_id / comp_id
         )
-
-        def _record_phase_skip(phase: str, reason: str) -> None:
-            """R1.2: a phase that never ran must leave a trace in both
-            the findings stream and the journal, so "ran clean" and
-            "never ran" are distinguishable downstream."""
-            comp.findings.append(Finding.phase_skipped(phase, reason))
-            progress_log.emit(
-                "phase_skipped", comp_id,
-                {"phase": phase, "reason": reason},
-            )
 
         # PHASE 2: Second-opinion review
         review_mode = ReviewMode(factory_config.review_mode)
@@ -1632,6 +1676,12 @@ def _run_factory_locked(
             codebase_map_file_rel,
             timeout_cfg.agent_iteration,
             timeout_cfg.component_total,
+            # R2.3 (CRIT-8): forward the invoking config's loop settings;
+            # they were previously dropped here and _run_component ran a
+            # hardcoded 30 non-interactive iterations with no path guard.
+            base_config.max_iterations,
+            base_config.interactive,
+            base_config.allowed_paths or None,
         )
 
     def _run_scheduling_pass() -> None:

--- a/ralph_py/init_cmd.py
+++ b/ralph_py/init_cmd.py
@@ -18,8 +18,15 @@ DEFAULT_PRD = {
     "userStories": [],
 }
 
-DEFAULT_PROMPT_VERSION = "1.0.0"
+DEFAULT_PROMPT_VERSION = "1.1.0"
 
+# The $prd_path / $progress_path / $codebase_map_path placeholders are
+# substituted by loop.run_loop (string.Template.safe_substitute) with the
+# per-component paths, so a decomposed component's agent reads the SAME
+# PRD file that verify.check_prd_stories re-reads (R2.3, H-11). Before
+# v1.1.0 the body hardcoded scripts/ralph/prd.json while decomposed PRDs
+# live at scripts/ralph/feature/<id>/prd.json - the agent and the
+# verifier disagreed on which file mattered.
 DEFAULT_PROMPT = """# Ralph Agent Instructions
 
 You are the implementing engineer in a software factory. You will be
@@ -28,10 +35,10 @@ reviewer as already reading your diff while you write it.
 
 ## Your Task (one iteration)
 
-1. Read the PRD file for this run (default: `scripts/ralph/prd.json`)
-2. Read `scripts/ralph/progress.txt` (check `## Codebase Patterns` first)
+1. Read the PRD file for this run: `$prd_path`
+2. Read `$progress_path` (check `## Codebase Patterns` first)
 3. Derive a short list of keywords from the PRD intent, not just exact wording.
-4. If `scripts/ralph/codebase_map.md` exists, query it for sections relevant to your story
+4. If `$codebase_map_path` exists, query it for sections relevant to your story
    using those keywords.
    - Do not load the entire file.
    - Always check **Quick Facts** and any relevant **Iteration Notes**.
@@ -52,7 +59,7 @@ reviewer as already reading your diff while you write it.
    - Do NOT mark the story as done unless typecheck AND tests pass. If they fail, fix and rerun;
      only proceed when both are green.
 10. If you discover durable, reusable codebase facts, append a brief, evidence-based note to
-   `scripts/ralph/codebase_map.md` under **Iteration Notes** or update **Quick Facts**
+   `$codebase_map_path` under **Iteration Notes** or update **Quick Facts**
    (skip if nothing new).
 11. Update `AGENTS.md` files with reusable learnings
    (only if you discovered something worth preserving):
@@ -71,20 +78,20 @@ reviewer as already reading your diff while you write it.
     every new function and ask what could break it. Placeholders will
     fail the mechanical check.
 13. Commit with message: `feat: [ID] - [Title]`
-14. Update `scripts/ralph/prd.json`: set that story's `passes` to `true`
+14. Update `$prd_path`: set that story's `passes` to `true`
     (only after tests/typecheck pass AND the self-critique is written)
-15. Append learnings to `scripts/ralph/progress.txt`
+15. Append learnings to `$progress_path`
 
 ## PRD ambiguity
 
 If the PRD is too vague to implement responsibly, do NOT guess. Append an
-`## INTERPRETATION` block to `scripts/ralph/progress.txt` stating what
+`## INTERPRETATION` block to `$progress_path` stating what
 assumptions you are making and why. The reviewer will see this and can
 push back; silent guesses become silent bugs.
 
 ## Progress Format
 
-Append this to the END of `scripts/ralph/progress.txt`:
+Append this to the END of `$progress_path`:
 
 ## [YYYY-MM-DD] - [Story ID]
 - What was implemented
@@ -102,7 +109,7 @@ Append this to the END of `scripts/ralph/progress.txt`:
 
 ## Codebase Patterns
 
-Add reusable patterns to the TOP section in `scripts/ralph/progress.txt`
+Add reusable patterns to the TOP section in `$progress_path`
 under `## Codebase Patterns`.
 
 ## Stop Condition

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ RALPH_ENV_PREFIXES: tuple[str, ...] = (
     "RALPH_VERIFY_",
     "RALPH_EVOLUTION_",
     "RALPH_KNOWLEDGE_",
+    "RALPH_FEEDFORWARD_",
 )
 
 # Legacy single-loop env vars (exact names, no shared prefix).

--- a/tests/test_prompt_versions.py
+++ b/tests/test_prompt_versions.py
@@ -94,8 +94,8 @@ _EXPECTED_SNAPSHOTS: dict[str, tuple[str, str]] = {
         "1.0.0",
     ),
     "DEFAULT_PROMPT": (
-        "a4a3a090139c370d7eecd12e3ef98055352110722750bb7b4cbf9bc50b1b9125",
-        "1.0.0",
+        "aa7fa6acb045dc6105d1a4c4ce8b687e1e04289c7b751eb0373b7c59dca3f7ae",
+        "1.1.0",
     ),
 }
 

--- a/tests/test_run_honesty.py
+++ b/tests/test_run_honesty.py
@@ -1,0 +1,473 @@
+"""R2.3: `ralph run` and factory flags are honest (CRIT-8, H-10, H-11).
+
+- CRIT-8: max_iterations (N), interactive, and allowed_paths forward from
+  the invoking config through ``_submit_args`` into ``_run_component``;
+  the hardcoded 30-iteration non-interactive loop is gone.
+- --no-verify: ``FactoryConfig.skip_verification`` is an explicit skip
+  sentinel that ``run_factory`` honors - Phase 1 runs ZERO checks, states
+  the skip in output, and records a phase_skipped finding.
+- H-10: both ``ralph run`` and ``ralph factory`` wire FeedforwardConfig
+  (via the toml/env control plane), and the built Phase 0 context reaches
+  the engineer prompt.
+- H-11: the rendered engineer prompt names the SAME per-component PRD
+  file that ``verify.check_prd_stories`` re-reads for a decomposed
+  component (DEFAULT_PROMPT >= 1.1.0 ships the ``$prd_path`` placeholder
+  substituted by loop.py).
+
+Fake agents are real subprocesses (CustomAgent via ``agent_cmd``); no LLM
+is involved.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from string import Template
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+import ralph_py.cli as cli_mod
+import ralph_py.loop as loop_mod
+from ralph_py.config import RalphConfig
+from ralph_py.factory import FactoryConfig, FactoryResult, run_factory
+from ralph_py.init_cmd import DEFAULT_PROMPT
+from ralph_py.loop import LoopResult
+from ralph_py.manifest import Component, Manifest
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+COMPLETE_LINE = "echo '<promise>COMPLETE</promise>'"
+COMP_PRD_PATH = "scripts/ralph/feature/comp-a/prd.json"
+# Header emitted by feedforward.build_feedforward_context; asserting on it
+# proves Phase 0 context reached the engineer prompt.
+FEEDFORWARD_HEADER = "=== CODEBASE CONTEXT (auto-generated) ==="
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, timeout=30,
+    )
+
+
+def _init_repo(root: Path) -> None:
+    """Real git repo with a decomposed component PRD (passes=true) and a
+    small Python source file so feedforward has content to summarize."""
+    root.mkdir(parents=True, exist_ok=True)
+    _git("init", "-q", "-b", "main", cwd=root)
+    _git("config", "user.email", "t@t", cwd=root)
+    _git("config", "user.name", "t", cwd=root)
+    src = root / "src"
+    src.mkdir()
+    (src / "app.py").write_text(
+        "def greet(name: str) -> str:\n"
+        "    return f'hello {name}'\n"
+    )
+    _git("add", "src/app.py", cwd=root)
+    _git("commit", "-q", "-m", "init", cwd=root)
+
+    feature_dir = root / "scripts" / "ralph" / "feature" / "comp-a"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "prd.json").write_text(json.dumps({
+        "branchName": "ralph/factory/comp-a",
+        "userStories": [{
+            "id": "US-001", "title": "Test",
+            "acceptanceCriteria": ["AC1"],
+            "priority": 1, "passes": True, "notes": "",
+        }],
+    }))
+
+
+def _manifest() -> Manifest:
+    return Manifest(
+        version="1", spec_file="spec.md", project_name="t",
+        base_branch="main", single_pr=False,
+        components=[Component(
+            id="comp-a", title="A", description="", dependencies=[],
+            prd_path=COMP_PRD_PATH,
+            branch_name="ralph/factory/comp-a",
+        )],
+    )
+
+
+def _factory_config(**overrides: Any) -> FactoryConfig:
+    defaults: dict[str, Any] = dict(
+        max_parallel=1, max_retries=0, retry_delay=0,
+        use_worktrees=False, create_prs=False, review_mode="skip",
+        skip_verification=True,
+    )
+    defaults.update(overrides)
+    return FactoryConfig(**defaults)
+
+
+def _base_config(root: Path, agent_cmd: str, **overrides: Any) -> RalphConfig:
+    defaults: dict[str, Any] = dict(
+        prompt_file=root / "scripts" / "ralph" / "prompt.md",
+        prd_file=root / "scripts" / "ralph" / "prd.json",
+        sleep_seconds=0, agent_cmd=agent_cmd,
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    )
+    defaults.update(overrides)
+    return RalphConfig(**defaults)
+
+
+class TestIterationForwarding:
+    """CRIT-8: `ralph run N` runs at most N iterations, not 30."""
+
+    def test_n3_executes_exactly_three_iterations(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        count_file = tmp_path / "invocations.txt"
+        # Consumes the prompt, records the invocation, never completes.
+        agent_cmd = f"cat > /dev/null; echo x >> {count_file}"
+
+        result = run_factory(
+            _manifest(), _factory_config(),
+            _base_config(root, agent_cmd, max_iterations=3),
+            PlainUI(no_color=True), root,
+            manifest_path=tmp_path / "manifest.json",
+        )
+
+        assert result.failed == ["comp-a"]
+        invocations = len(count_file.read_text().splitlines())
+        assert invocations == 3, (
+            f"expected exactly 3 agent iterations for N=3, got {invocations}"
+        )
+
+    def test_loop_settings_forwarded_into_run_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """max_iterations, interactive, and allowed_paths all reach the
+        RalphConfig that _run_component hands to run_loop."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        captured: dict[str, RalphConfig] = {}
+
+        def fake_run_loop(
+            config: RalphConfig, ui: Any, agent: Any,
+            cwd: Path | None = None, context_prefix: str | None = None,
+            timeouts: Any = None,
+        ) -> LoopResult:
+            captured["config"] = config
+            return LoopResult(completed=True, iterations=1, exit_code=0)
+
+        monkeypatch.setattr(loop_mod, "run_loop", fake_run_loop)
+
+        result = run_factory(
+            _manifest(), _factory_config(),
+            _base_config(
+                root, COMPLETE_LINE, max_iterations=7,
+                interactive=True, allowed_paths=["src/", "docs/"],
+            ),
+            PlainUI(no_color=True), root,
+            manifest_path=tmp_path / "manifest.json",
+        )
+
+        assert result.completed == ["comp-a"]
+        config = captured["config"]
+        assert config.max_iterations == 7
+        assert config.interactive is True
+        assert config.allowed_paths == ["src/", "docs/"]
+
+
+class TestNoVerifySkipSentinel:
+    """--no-verify genuinely skips Phase 1 (zero checks, stated, recorded)."""
+
+    def test_skip_sentinel_runs_zero_checks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        marker = tmp_path / "check-ran.marker"
+        # Even with a verify_config PRESENT, the sentinel wins: none of
+        # these commands may execute.
+        verify_config = VerifyConfig(
+            test_command=f"touch {marker}",
+            typecheck_command=f"touch {marker}",
+            lint_command=f"touch {marker}",
+        )
+        manifest = _manifest()
+
+        result = run_factory(
+            manifest,
+            _factory_config(skip_verification=True, verify_config=verify_config),
+            _base_config(root, COMPLETE_LINE),
+            PlainUI(no_color=True), root,
+            manifest_path=tmp_path / "manifest.json",
+        )
+
+        assert result.completed == ["comp-a"]
+        assert not marker.exists(), (
+            "--no-verify still executed a mechanical check command"
+        )
+        # PlainUI info lines go to stderr.
+        assert "Phase 1 SKIPPED" in capsys.readouterr().err
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.verification_passed is None
+        assert any(
+            f.phase == "verify" and f.severity == "skipped"
+            for f in comp.findings
+        ), "skip must be recorded as a phase_skipped finding"
+
+    def test_checks_run_when_not_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Mirror: the same setup without the sentinel does run checks."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        marker = tmp_path / "check-ran.marker"
+        verify_config = VerifyConfig(
+            test_command=f"touch {marker}",
+            typecheck_command="true",
+            lint_command="true",
+            check_diff_scope=False,
+            check_bad_patterns=False,
+        )
+        manifest = _manifest()
+
+        result = run_factory(
+            manifest,
+            _factory_config(skip_verification=False, verify_config=verify_config),
+            _base_config(root, COMPLETE_LINE),
+            PlainUI(no_color=True), root,
+            manifest_path=tmp_path / "manifest.json",
+        )
+
+        assert result.completed == ["comp-a"]
+        assert marker.exists(), "verification did not run without the sentinel"
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.verification_passed is True
+
+
+class TestCliWiring:
+    """The CLI passes the sentinel + feedforward config into run_factory."""
+
+    def _capture_run_factory(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> dict[str, Any]:
+        captured: dict[str, Any] = {}
+
+        def fake_run_factory(
+            manifest: Manifest, factory_config: FactoryConfig,
+            base_config: RalphConfig, ui: Any, root_dir: Path,
+            manifest_path: Path | None = None,
+        ) -> FactoryResult:
+            captured["factory_config"] = factory_config
+            captured["base_config"] = base_config
+            return FactoryResult()
+
+        monkeypatch.setattr(cli_mod, "run_factory", fake_run_factory)
+        return captured
+
+    def test_run_no_verify_sets_skip_sentinel(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured = self._capture_run_factory(monkeypatch)
+        monkeypatch.setenv("AGENT_CMD", "echo hi")
+
+        result = CliRunner().invoke(
+            cli_mod.cli,
+            ["run", "2", "--root", str(tmp_path), "--no-verify"],
+        )
+
+        assert result.exit_code == 0, result.output
+        cfg = captured["factory_config"]
+        assert cfg.skip_verification is True
+        assert cfg.verify_config is None
+        assert cfg.feedforward_config is not None
+        assert captured["base_config"].max_iterations == 2
+
+    def test_run_default_does_not_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured = self._capture_run_factory(monkeypatch)
+        monkeypatch.setenv("AGENT_CMD", "echo hi")
+
+        result = CliRunner().invoke(
+            cli_mod.cli, ["run", "2", "--root", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        cfg = captured["factory_config"]
+        assert cfg.skip_verification is False
+        assert isinstance(cfg.verify_config, VerifyConfig)
+        assert cfg.feedforward_config is not None
+
+    def _write_manifest(self, root: Path) -> Path:
+        manifest_path = root / "m.json"
+        _manifest().save(manifest_path)
+        return manifest_path
+
+    def test_factory_wires_feedforward_from_control_plane(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """H-10: `ralph factory` passes a FeedforwardConfig loaded from
+        toml/env; previously feedforward_config was never set and Phase 0
+        silently never ran."""
+        captured = self._capture_run_factory(monkeypatch)
+        monkeypatch.setenv("AGENT_CMD", "echo hi")
+        manifest_path = self._write_manifest(tmp_path)
+        args = [
+            "factory", "--manifest", str(manifest_path),
+            "--root", str(tmp_path), "--yes",
+        ]
+
+        # Default: enabled.
+        result = CliRunner().invoke(cli_mod.cli, args)
+        assert result.exit_code == 0, result.output
+        ff = captured["factory_config"].feedforward_config
+        assert ff is not None and ff.enabled is True
+
+        # toml disables it.
+        (tmp_path / "ralph.toml").write_text("[feedforward]\nenabled = false\n")
+        result = CliRunner().invoke(cli_mod.cli, args)
+        assert result.exit_code == 0, result.output
+        ff = captured["factory_config"].feedforward_config
+        assert ff is not None and ff.enabled is False
+
+        # Env overrides toml.
+        monkeypatch.setenv("RALPH_FEEDFORWARD_ENABLED", "1")
+        result = CliRunner().invoke(cli_mod.cli, args)
+        assert result.exit_code == 0, result.output
+        ff = captured["factory_config"].feedforward_config
+        assert ff is not None and ff.enabled is True
+
+    def test_factory_no_verify_sets_skip_sentinel(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured = self._capture_run_factory(monkeypatch)
+        monkeypatch.setenv("AGENT_CMD", "echo hi")
+        manifest_path = self._write_manifest(tmp_path)
+
+        result = CliRunner().invoke(cli_mod.cli, [
+            "factory", "--manifest", str(manifest_path),
+            "--root", str(tmp_path), "--yes", "--no-verify",
+        ])
+
+        assert result.exit_code == 0, result.output
+        cfg = captured["factory_config"]
+        assert cfg.skip_verification is True
+        assert cfg.verify_config is None
+
+
+class TestFeedforwardAndPrdPathEndToEnd:
+    """Real `ralph factory` CLI run: Phase 0 context and the per-component
+    PRD path both land in the prompt the engineer receives."""
+
+    def test_factory_run_builds_feedforward_and_names_component_prd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        root = tmp_path / "repo"
+        _init_repo(root)
+        manifest_path = root / "m.json"
+        manifest = _manifest()
+        manifest.save(manifest_path)
+
+        dump = tmp_path / "prompt-received.txt"
+        monkeypatch.setenv("AGENT_CMD", f"cat > {dump}; " + COMPLETE_LINE)
+        monkeypatch.setenv("RALPH_BRANCH", "")
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        result = CliRunner().invoke(cli_mod.cli, [
+            "factory", "--manifest", str(manifest_path),
+            "--root", str(root), "--yes",
+            "--no-prs", "--no-worktrees",
+            "--review-mode", "skip", "--contract-check", "skip",
+            "--no-verify", "--ui", "plain", "--no-color",
+        ])
+
+        assert result.exit_code == 0, result.output
+        prompt = dump.read_text()
+
+        # H-10: Phase 0 feedforward context reached the built prompt.
+        assert FEEDFORWARD_HEADER in prompt
+
+        # H-11: the prompt names the decomposed component's PRD - the
+        # exact path check_prd_stories reads (wt_path / comp.prd_path;
+        # wt_path == root with --no-worktrees) - not the legacy default.
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert str(root / comp.prd_path) in prompt
+        assert "scripts/ralph/prd.json" not in prompt
+
+        # The skip sentinel flowed through the real CLI stack.
+        assert "Phase 1 SKIPPED" in result.output
+
+    def test_rendered_prompt_and_check_prd_stories_agree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With verification RUNNING, the component completes because
+        check_prd_stories reads the same feature PRD (passes=true) that
+        the rendered DEFAULT_PROMPT told the agent to use."""
+        root = tmp_path / "repo"
+        _init_repo(root)
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        dump = tmp_path / "prompt-received.txt"
+        manifest = _manifest()
+
+        result = run_factory(
+            manifest,
+            _factory_config(
+                skip_verification=False,
+                verify_config=VerifyConfig(
+                    test_command="true", typecheck_command="true",
+                    lint_command="true", check_diff_scope=False,
+                    check_bad_patterns=False,
+                ),
+            ),
+            # No prompt.md exists in the repo, so the run exercises the
+            # harness DEFAULT_PROMPT fallback and its $prd_path contract.
+            _base_config(root, f"cat > {dump}; " + COMPLETE_LINE),
+            PlainUI(no_color=True), root,
+            manifest_path=tmp_path / "manifest.json",
+        )
+
+        # Completion proves check_prd_stories PASSED on the feature PRD.
+        assert result.completed == ["comp-a"]
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.verification_passed is True
+
+        prompt = dump.read_text()
+        assert str(root / comp.prd_path) in prompt
+        assert "scripts/ralph/prd.json" not in prompt
+
+
+class TestDefaultPromptPlaceholderContract:
+    """H-11 unit level: DEFAULT_PROMPT carries the placeholders and
+    renders them exactly the way loop.run_loop substitutes."""
+
+    def test_placeholders_present_and_legacy_paths_absent(self) -> None:
+        assert "$prd_path" in DEFAULT_PROMPT
+        assert "$progress_path" in DEFAULT_PROMPT
+        assert "$codebase_map_path" in DEFAULT_PROMPT
+        assert "scripts/ralph/prd.json" not in DEFAULT_PROMPT
+        assert "scripts/ralph/progress.txt" not in DEFAULT_PROMPT
+
+    def test_rendering_matches_loop_substitution(self) -> None:
+        prd = "/w/scripts/ralph/feature/comp-a/prd.json"
+        rendered = Template(DEFAULT_PROMPT).safe_substitute(
+            prd_path=prd,
+            progress_path="/w/scripts/ralph/progress.txt",
+            codebase_map_path="/w/scripts/ralph/codebase_map.md",
+        )
+        assert prd in rendered
+        for leftover in ("$prd_path", "$progress_path", "$codebase_map_path"):
+            assert leftover not in rendered


### PR DESCRIPTION
## Roadmap

R2.3 (docs/remediation-roadmap.md) - checkbox flipped to [x] in this PR.

## What changed

1. **CRIT-8**: `_submit_args` now forwards `base_config.max_iterations`, `interactive`, and `allowed_paths` into `_run_component`; the hardcoded `max_iterations=30` / `interactive=False` RalphConfig is gone. `ralph run 5` runs at most 5 iterations per attempt; `-i` and `--allowed-paths` reach the loop.
2. **--no-verify**: new `FactoryConfig.skip_verification` is an explicit skip sentinel set by `--no-verify` on both `ralph run` and `ralph factory`. `verify_config=None` keeps meaning "default checks"; only the sentinel skips Phase 1 - zero check subprocesses, "Phase 1 SKIPPED" in output, `verification_passed=None`, and a `phase_skipped` finding (R1.2 convention). Downstream reviewers receive an empty VerificationResult (no checks claimed).
3. **H-10**: both command paths now pass `feedforward_config=FeedforwardConfig.load(root_dir)` (toml `[feedforward]` + `RALPH_FEEDFORWARD_*` env). Previously `ralph factory` never set it, so Phase 0 silently never ran. In `ralph run`, feedforward is no longer conflated with `--no-verify`.
4. **H-11 (prompt exception)**: `DEFAULT_PROMPT` now uses `$prd_path` / `$progress_path` / `$codebase_map_path` placeholders, substituted by the existing `loop.py` `Template.safe_substitute` with the per-component paths, so the agent reads the SAME PRD file `check_prd_stories` re-reads. **H3 compliance**: `DEFAULT_PROMPT_VERSION` bumped 1.0.0 -> 1.1.0 and the `(hash, version)` snapshot in `tests/test_prompt_versions.py` updated in the same commit. No other prompt touched.

## Checks (run in a clean worktree of this branch)

- `uv run pytest tests/ -q`: `921 passed, 12 skipped, 1 warning in 73.78s (0:01:13)`
- `uv run mypy ralph_py/ --strict`: `Success: no issues found in 37 source files`
- `uv run ruff check ralph_py/ tests/`: `All checks passed!`

## Tested (all in tests/test_run_honesty.py, fake-agent subprocesses, no LLM)

- N=3 executes exactly 3 agent iterations (invocation-counting fake agent) and the component fails after them: `test_n3_executes_exactly_three_iterations`.
- `max_iterations` / `interactive` / `allowed_paths` all arrive in the RalphConfig handed to `run_loop`: `test_loop_settings_forwarded_into_run_loop`.
- The sentinel runs ZERO check commands even when a populated `VerifyConfig` is present, states the skip, sets `verification_passed=None`, records the `phase_skipped` finding: `test_skip_sentinel_runs_zero_checks`; the mirror test proves the same configured check command DOES run without the sentinel: `test_checks_run_when_not_skipped`.
- CLI wiring: `ralph run --no-verify` and `ralph factory --no-verify` set the sentinel; both commands pass a FeedforwardConfig; `[feedforward] enabled=false` in ralph.toml and `RALPH_FEEDFORWARD_ENABLED` env are honored (env wins): `TestCliWiring` (4 tests).
- Real `ralph factory` CLI run end to end: the prompt the engineer received contains the feedforward header AND the exact per-component PRD path (`<root>/scripts/ralph/feature/comp-a/prd.json` == `wt_path / comp.prd_path`), with no `scripts/ralph/prd.json` reference; "Phase 1 SKIPPED" stated: `test_factory_run_builds_feedforward_and_names_component_prd`.
- With verification RUNNING, the component completes because `check_prd_stories` passes on the same feature PRD the rendered DEFAULT_PROMPT names: `test_rendered_prompt_and_check_prd_stories_agree`.
- Placeholder contract unit tests (placeholders present, legacy literals absent, rendering leaves no `$` placeholders): `TestDefaultPromptPlaceholderContract`.

## Assumed (not tested)

- **Calibration not re-run (H2 deviation, flagged)**: the DEFAULT_PROMPT edit is path-templating only (no behavioral instruction changed), and the engineer prompt is not one of the calibration-measured detection roles (suite measures architect/reviewer/security detection). The session prompt's exception required H3 only. Say the word and I'll run the calibration suite.
- `interactive=True` under parallel factory workers still cannot prompt (worker PlainUI `can_prompt` is stdin.isatty); forwarding is honest, prompting works in the in-process `max_parallel=1` path that `ralph run` uses.
- Behavior change: `ralph run --no-verify` previously ALSO disabled feedforward; they are now independent. Wiring tested; no test asserts the old conflation is gone beyond that.
- No CLI flag for feedforward was added (toml/env only); full six-loader CLI resolution is R2.1's scope.
- The skip sentinel lives on FactoryConfig (factory.py) rather than VerifyConfig because `ralph_py/verify.py` is outside this session's declared scope.
- Out of scope, reported per shared rule 2: the traceability appendix folds a "dep-graph-bounds" fix into "R2.3 feedforward wiring", but that fix lives in `ralph_py/feedforward.py`, which this session's scope excludes. Not done here; it should ride with R2.5's feedforward honesty work or a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)