### PR TITLE
fix: R2.1 config control plane + R2.2 safety knobs (CRIT-7)

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -36,8 +36,11 @@ Precedence: **CLI flag > env var > `ralph.toml` > dataclass default**.
 | `FACTORY_MAX_PARALLEL` | int | 4 |
 | `FACTORY_MAX_RETRIES` | int | 3 |
 | `FACTORY_RETRY_DELAY` | float | 5.0 |
+| `FACTORY_MERGE_TIMEOUT` | float | 300.0 |
+| `RALPH_FACTORY_MAX_ADVERSARIAL_CALLS` | int | 0 (unbounded) |
+| `RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE` | bool (`1`/`true`/`yes`) | false |
 
-Plus the new `max_adversarial_calls` (E4) and `pause_before_pr_merge` (E6) which are configured via CLI / programmatic construction; no env var today.
+The two safety knobs (E4 `max_adversarial_calls`, E6 `pause_before_pr_merge`) are reachable via all three surfaces since R2.2: the env vars above, `[factory]` keys in ralph.toml, and the `--max-adversarial-calls` / `--pause-before-pr-merge` CLI flags.
 
 ## VerifyConfig (`[verify]`)
 

--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -249,7 +249,7 @@ First principles: for a solo tool, the author-in-six-months is the primary
 user. Every knob must be reachable, every documented command must exist, and
 every flag must do what it says or fail loudly.
 
-- [ ] R2.1 (M) **Wire the six config loaders** [CRIT-7, D-precedence]
+- [x] R2.1 (M) **Wire the six config loaders** [CRIT-7, D-precedence]
   - CLI resolution order: explicit CLI flag > env > ralph.toml > dataclass
     default. Click flags get `default=None` sentinels so "not passed" is
     distinguishable from "passed the default value".
@@ -260,7 +260,7 @@ every flag must do what it says or fail loudly.
   - Failure mode: changed effective defaults for existing setups (e.g. a toml
     `review_mode` now taking effect). Mitigation: `ralph config show` (R2.4)
     prints the resolved config + source of each value; release note.
-- [ ] R2.2 (S) **Expose the safety knobs** [CRIT-7]
+- [x] R2.2 (S) **Expose the safety knobs** [CRIT-7]
   - `max_adversarial_calls` and `pause_before_pr_merge`: toml keys, env vars,
     CLI flags, documented. Budget exhaustion emits the R1.2 synthetic finding.
 - [x] R2.3 (M) **Make `ralph run` and factory flags honest** [CRIT-8, H-10, H-11]

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -7,8 +7,10 @@ import json
 import os
 import sys
 from collections.abc import Iterator
+from dataclasses import fields as dataclass_fields
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import click
 from click.core import ParameterSource
@@ -29,6 +31,37 @@ from ralph_py.ui import get_ui
 
 def _use_cli_value(ctx: click.Context, name: str) -> bool:
     return ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE
+
+
+def _collect_toml_notes(
+    notes: list[str],
+    section: str,
+    loaded: Any,
+    baseline: Any,
+    flag_overridden: set[str],
+) -> None:
+    """Record which effective values ralph.toml moved off the CLI default.
+
+    Before R2.1 six ralph.toml sections were silently ignored by the
+    factory command, so a value that now takes effect is a behavior
+    change for existing setups; the collected NOTE lines make that
+    visible at startup. Comparing the loaded config against an env-only
+    baseline isolates the toml contribution (env overlays are applied
+    identically on both sides, so they cancel out). Fields whose CLI
+    flag was explicitly passed are excluded: the flag wins, so the toml
+    value is not effective.
+    """
+    for f in dataclass_fields(loaded):
+        if f.name in flag_overridden:
+            continue
+        loaded_val = getattr(loaded, f.name)
+        baseline_val = getattr(baseline, f.name)
+        if loaded_val != baseline_val:
+            notes.append(
+                f"NOTE: [{section}] {f.name} = {loaded_val!r} from "
+                f"ralph.toml (built-in default: {baseline_val!r}; "
+                f"this section was ignored before R2.1)"
+            )
 
 
 def _resolve_root(root: Path | None, prompt: Path | None, prd: Path | None) -> Path:
@@ -292,8 +325,10 @@ def run(
         sys.exit(1)
 
     # Single-component factory invocation
+    from ralph_py.config import load_toml_section
     from ralph_py.feedforward import FeedforwardConfig
     from ralph_py.manifest import Manifest
+    from ralph_py.security import SecurityConfig
     from ralph_py.verify import VerifyConfig
 
     # Determine branch from config or PRD
@@ -335,25 +370,31 @@ def run(
         base_branch=detected_base,
     )
 
-    # Build factory config for single-component mode.
+    # Build factory config for single-component mode (R2.1): tunables
+    # resolve through the loaders (ralph.toml overlaid with env); the
+    # structural fields below are forced because `ralph run` is by
+    # definition a local, single-component, no-PR invocation.
     # R2.3: --no-verify sets the explicit skip sentinel; passing
     # verify_config=None meant "use defaults" in run_factory and Phase 1
-    # ran anyway. Feedforward is loaded from the toml/env control plane
-    # and is independent of --no-verify (it builds context, not checks).
-    factory_cfg = FactoryConfig(
-        max_parallel=1,
-        max_retries=3,
-        use_worktrees=False,
-        single_pr=False,
-        create_prs=False,
-        verify_config=None if no_verify else VerifyConfig(),
-        skip_verification=no_verify,
-        review_mode="advisory",
-        contract_config=None,
-        feedforward_config=FeedforwardConfig.load(root_dir),
-        timeout_config=TimeoutConfig.load(root_dir),
-        force_lock=force_lock,
-    )
+    # ran anyway. Feedforward is independent of --no-verify (it builds
+    # context, not checks).
+    factory_cfg = FactoryConfig.load(root_dir)
+    factory_cfg.max_parallel = 1
+    factory_cfg.use_worktrees = False
+    factory_cfg.single_pr = False
+    factory_cfg.create_prs = False
+    factory_cfg.verify_config = None if no_verify else VerifyConfig.load(root_dir)
+    factory_cfg.skip_verification = no_verify
+    factory_cfg.security_config = SecurityConfig.load(root_dir)
+    factory_cfg.contract_config = None
+    factory_cfg.feedforward_config = FeedforwardConfig.load(root_dir)
+    factory_cfg.timeout_config = TimeoutConfig.load(root_dir)
+    factory_cfg.force_lock = force_lock
+    # `ralph run` reviews in advisory mode unless the project's
+    # ralph.toml explicitly opts into a different review_mode (there is
+    # no review_mode env var, so the toml section check is exhaustive).
+    if "review_mode" not in load_toml_section(root_dir / "ralph.toml", "factory"):
+        factory_cfg.review_mode = "advisory"
 
     # R0.5 (H-15): `ralph run` persists to its own run-manifest.json so
     # it can never clobber a factory run's resumable manifest.json.
@@ -1135,19 +1176,19 @@ def decompose(
 @click.option(
     "--max-parallel",
     type=int,
-    default=4,
-    help="Maximum parallel components",
+    default=None,
+    help="Maximum parallel components (default: 4)",
 )
 @click.option(
     "--max-retries",
     type=int,
-    default=3,
-    help="Maximum retries per component",
+    default=None,
+    help="Maximum retries per component (default: 3)",
 )
 @click.option(
     "--create-prs/--no-prs",
-    default=True,
-    help="Create PRs for completed components",
+    default=None,
+    help="Create PRs for completed components (default: on)",
 )
 @click.option(
     "--verify-command",
@@ -1173,6 +1214,7 @@ def decompose(
 @click.option(
     "--dead-code-cleanup",
     is_flag=True,
+    default=None,
     help=(
         "Enable dead code cleanup: ruff auto-fixes unused "
         "imports/variables, vulture detects remaining dead code"
@@ -1185,19 +1227,21 @@ def decompose(
 @click.option(
     "--mutation-testing",
     is_flag=True,
+    default=None,
     help="Enable mutation testing (requires mutmut, off by default)",
 )
 @click.option(
     "--mutation-threshold",
     type=float,
-    default=50.0,
+    default=None,
     help="Mutation score threshold percent (default: 50)",
 )
 @click.option(
     "--review-mode",
     type=click.Choice(["hard", "advisory", "skip"]),
-    default="hard",
-    help="Phase 2 review: hard (block), advisory (warn), skip",
+    default=None,
+    help="Phase 2 review: hard (block), advisory (warn), skip "
+         "(default: hard)",
 )
 @click.option(
     "--review-agent-cmd",
@@ -1210,7 +1254,7 @@ def decompose(
 @click.option(
     "--security-mode",
     type=click.Choice(["hard", "advisory", "skip"]),
-    default="skip",
+    default=None,
     help="Phase 2.5 security review: hard (block on critical+high), "
          "advisory (warn only), skip (default - opt in explicitly)",
 )
@@ -1227,15 +1271,16 @@ def decompose(
 @click.option(
     "--security-fail-threshold",
     type=click.Choice(["critical", "high", "medium", "low"]),
-    default="high",
+    default=None,
     help="In hard mode, findings at or above this severity block "
          "(default: high - critical+high fail)",
 )
 @click.option(
     "--contract-check",
     type=click.Choice(["tier", "final", "skip"]),
-    default="tier",
-    help="Phase 3 contract testing: tier (per-tier), final (end-only), skip",
+    default=None,
+    help="Phase 3 contract testing: tier (per-tier), final (end-only), "
+         "skip (default: tier)",
 )
 @click.option(
     "--contract-test-cmd",
@@ -1244,7 +1289,7 @@ def decompose(
 @click.option(
     "--agent-timeout",
     type=float,
-    default=1800.0,
+    default=None,
     help="Timeout per agent iteration in seconds; 0 disables "
          "(default: 1800, or RALPH_TIMEOUT_AGENT_ITERATION / "
          "[timeout].agent_iteration in ralph.toml)",
@@ -1252,10 +1297,27 @@ def decompose(
 @click.option(
     "--component-timeout",
     type=float,
-    default=7200.0,
+    default=None,
     help="Timeout per component total in seconds; 0 disables "
          "(default: 7200, or RALPH_TIMEOUT_COMPONENT / "
          "[timeout].component_total in ralph.toml)",
+)
+@click.option(
+    "--max-adversarial-calls",
+    type=int,
+    default=None,
+    help="Hard cap on adversarial LLM calls (review + security + "
+         "distill) per run; 0 = unbounded (default: 0, or "
+         "RALPH_FACTORY_MAX_ADVERSARIAL_CALLS / "
+         "[factory].max_adversarial_calls in ralph.toml)",
+)
+@click.option(
+    "--pause-before-pr-merge/--no-pause-before-pr-merge",
+    default=None,
+    help="Pause for human approval before each component's PR "
+         "push+merge (default: off, or "
+         "RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE / "
+         "[factory].pause_before_pr_merge in ralph.toml)",
 )
 @click.option(
     "--progress-log",
@@ -1320,29 +1382,31 @@ def factory(
     project_name: str | None,
     base_branch: str,
     single_pr: bool,
-    max_parallel: int,
-    max_retries: int,
-    create_prs: bool,
+    max_parallel: int | None,
+    max_retries: int | None,
+    create_prs: bool | None,
     verify_command: str | None,
     test_command: str | None,
     typecheck_command: str | None,
     lint_command: str | None,
     no_verify: bool,
-    dead_code_cleanup: bool,
+    dead_code_cleanup: bool | None,
     dead_code_command: str | None,
-    mutation_testing: bool,
-    mutation_threshold: float,
-    review_mode: str,
+    mutation_testing: bool | None,
+    mutation_threshold: float | None,
+    review_mode: str | None,
     review_agent_cmd: str | None,
     review_model: str | None,
-    security_mode: str,
+    security_mode: str | None,
     security_agent_cmd: str | None,
     security_model: str | None,
-    security_fail_threshold: str,
-    contract_check: str,
+    security_fail_threshold: str | None,
+    contract_check: str | None,
     contract_test_cmd: str | None,
-    agent_timeout: float,
-    component_timeout: float,
+    agent_timeout: float | None,
+    component_timeout: float | None,
+    max_adversarial_calls: int | None,
+    pause_before_pr_merge: bool | None,
     progress_log: Path | None,
     no_worktrees: bool,
     force_lock: bool,
@@ -1424,14 +1488,196 @@ def factory(
             ui_impl.err(str(exc))
             sys.exit(1)
 
-    # Display summary and confirm
+    # Build configs (R2.1). Resolution order for every phase config:
+    # explicit CLI flag > env > ralph.toml > dataclass default. The
+    # loaders handle env-over-toml-over-default; flags use None
+    # sentinels so "not passed" is distinguishable from "passed the
+    # default value", and an explicitly-passed flag is applied on top.
+    from ralph_py.contract import ContractConfig
+    from ralph_py.evolution import EvolutionConfig
+    from ralph_py.feedforward import FeedforwardConfig
+    from ralph_py.security import SecurityConfig
+    from ralph_py.verify import VerifyConfig
+
+    toml_notes: list[str] = []
+
+    factory_config = FactoryConfig.load(root_dir)
+    _collect_toml_notes(
+        toml_notes, "factory", factory_config, FactoryConfig.from_env(),
+        flag_overridden={
+            name
+            for name, passed in (
+                ("max_parallel", max_parallel is not None),
+                ("max_retries", max_retries is not None),
+                ("create_prs", create_prs is not None),
+                ("review_mode", review_mode is not None),
+                ("max_adversarial_calls", max_adversarial_calls is not None),
+                ("pause_before_pr_merge", pause_before_pr_merge is not None),
+                ("use_worktrees", no_worktrees),
+                # The manifest is authoritative for single_pr, so a toml
+                # value never becomes effective in this command.
+                ("single_pr", True),
+            )
+            if passed
+        },
+    )
+    if max_parallel is not None:
+        factory_config.max_parallel = max_parallel
+    if max_retries is not None:
+        factory_config.max_retries = max_retries
+    if create_prs is not None:
+        factory_config.create_prs = create_prs
+    if review_mode is not None:
+        factory_config.review_mode = review_mode
+    if max_adversarial_calls is not None:
+        factory_config.max_adversarial_calls = max_adversarial_calls
+    if pause_before_pr_merge is not None:
+        factory_config.pause_before_pr_merge = pause_before_pr_merge
+    if no_worktrees:
+        factory_config.use_worktrees = False
+    factory_config.single_pr = manifest.single_pr
+    factory_config.verify_command = verify_command
+    factory_config.review_agent_cmd = review_agent_cmd
+    factory_config.review_model = review_model
+    factory_config.progress_log_path = progress_log
+    factory_config.force_lock = force_lock
+    # R2.3: --no-verify is an explicit skip sentinel that run_factory
+    # honors; verify_config=None alone would substitute default checks.
+    factory_config.skip_verification = no_verify
+
+    v_config: VerifyConfig | None = None
+    if not no_verify:
+        v_config = VerifyConfig.load(root_dir)
+        _collect_toml_notes(
+            toml_notes, "verify", v_config, VerifyConfig.from_env(),
+            flag_overridden={
+                name
+                for name, passed in (
+                    ("test_command", test_command is not None),
+                    ("typecheck_command", typecheck_command is not None),
+                    ("lint_command", lint_command is not None),
+                    ("dead_code_cleanup", dead_code_cleanup is not None),
+                    ("dead_code_command", dead_code_command is not None),
+                    ("mutation_testing", mutation_testing is not None),
+                    ("mutation_threshold", mutation_threshold is not None),
+                )
+                if passed
+            },
+        )
+        if test_command is not None:
+            v_config.test_command = test_command
+        if typecheck_command is not None:
+            v_config.typecheck_command = typecheck_command
+        if lint_command is not None:
+            v_config.lint_command = lint_command
+        if dead_code_cleanup is not None:
+            v_config.dead_code_cleanup = dead_code_cleanup
+        if dead_code_command is not None:
+            v_config.dead_code_command = dead_code_command
+        if mutation_testing is not None:
+            v_config.mutation_testing = mutation_testing
+        if mutation_threshold is not None:
+            v_config.mutation_threshold = mutation_threshold
+
+    s_config = SecurityConfig.load(root_dir)
+    _collect_toml_notes(
+        toml_notes, "security", s_config, SecurityConfig.from_env(),
+        flag_overridden={
+            name
+            for name, passed in (
+                ("mode", security_mode is not None),
+                ("agent_cmd", security_agent_cmd is not None),
+                ("model", security_model is not None),
+                ("fail_threshold", security_fail_threshold is not None),
+            )
+            if passed
+        },
+    )
+    if security_mode is not None:
+        s_config.mode = security_mode
+    if security_agent_cmd is not None:
+        s_config.agent_cmd = security_agent_cmd
+    if security_model is not None:
+        s_config.model = security_model
+    if security_fail_threshold is not None:
+        s_config.fail_threshold = security_fail_threshold
+
+    # --test-command historically flowed through to contract testing
+    # when --contract-test-cmd was absent; both are explicit CLI input,
+    # so either beats env/toml.
+    cli_contract_cmd = contract_test_cmd or test_command
+    contract_resolved = ContractConfig.load(root_dir)
+    _collect_toml_notes(
+        toml_notes, "contract", contract_resolved, ContractConfig.from_env(),
+        flag_overridden={
+            name
+            for name, passed in (
+                ("mode", contract_check is not None),
+                ("test_command", cli_contract_cmd is not None),
+            )
+            if passed
+        },
+    )
+    if contract_check is not None:
+        contract_resolved.mode = contract_check
+    if cli_contract_cmd is not None:
+        contract_resolved.test_command = cli_contract_cmd
+    # mode == "skip" keeps the historical contract of passing no config.
+    c_config: ContractConfig | None = (
+        contract_resolved if contract_resolved.mode != "skip" else None
+    )
+
+    ff_config = FeedforwardConfig.load(root_dir)
+    _collect_toml_notes(
+        toml_notes, "feedforward", ff_config, FeedforwardConfig.from_env(),
+        flag_overridden=set(),
+    )
+
+    # Evolution config is consumed inside run_factory via
+    # EvolutionConfig.load(root_dir); loaded here only for the NOTE sweep.
+    _collect_toml_notes(
+        toml_notes, "evolution", EvolutionConfig.load(root_dir),
+        EvolutionConfig.from_env(root_dir), flag_overridden=set(),
+    )
+
+    # R0.1: TimeoutConfig is the single source for timeout values.
+    timeout_config = TimeoutConfig.load(root_dir)
+    _collect_toml_notes(
+        toml_notes, "timeout", timeout_config, TimeoutConfig.from_env(),
+        flag_overridden={
+            name
+            for name, passed in (
+                ("agent_iteration", agent_timeout is not None),
+                ("component_total", component_timeout is not None),
+            )
+            if passed
+        },
+    )
+    if agent_timeout is not None:
+        timeout_config.agent_iteration = agent_timeout
+    if component_timeout is not None:
+        timeout_config.component_total = component_timeout
+
+    factory_config.verify_config = v_config
+    factory_config.security_config = s_config
+    factory_config.contract_config = c_config
+    factory_config.feedforward_config = ff_config
+    factory_config.timeout_config = timeout_config
+
+    # Display summary and confirm (resolved values, not raw flags)
     ui_impl.section("Factory Plan")
     ui_impl.kv("Project", manifest.project_name)
     ui_impl.kv("Components", str(len(manifest.components)))
     ui_impl.kv("Base branch", manifest.base_branch)
     ui_impl.kv("Single PR", "yes" if manifest.single_pr else "no")
-    ui_impl.kv("Max parallel", str(max_parallel))
-    ui_impl.kv("Create PRs", "yes" if create_prs else "no")
+    ui_impl.kv("Max parallel", str(factory_config.max_parallel))
+    ui_impl.kv("Create PRs", "yes" if factory_config.create_prs else "no")
+
+    # R2.1 behavior change: ralph.toml sections that used to be silently
+    # ignored now take effect. Surface every value a toml section moved
+    # away from the CLI default so existing setups see the change.
+    for note in toml_notes:
+        ui_impl.info(note)
 
     topo = manifest.topological_order()
     ui_impl.info("")
@@ -1451,73 +1697,6 @@ def factory(
         )
         if choice != 0:
             sys.exit(0)
-
-    # Build configs
-    from ralph_py.contract import ContractConfig
-    from ralph_py.feedforward import FeedforwardConfig
-    from ralph_py.verify import VerifyConfig
-
-    v_config: VerifyConfig | None = None
-    if not no_verify:
-        v_config = VerifyConfig(
-            test_command=test_command,
-            typecheck_command=typecheck_command,
-            lint_command=lint_command,
-            dead_code_cleanup=dead_code_cleanup,
-            dead_code_command=dead_code_command,
-            mutation_testing=mutation_testing,
-            mutation_threshold=mutation_threshold,
-        )
-
-    c_config: ContractConfig | None = None
-    if contract_check != "skip":
-        c_config = ContractConfig(
-            mode=contract_check,
-            test_command=contract_test_cmd or test_command or "uv run pytest",
-        )
-
-    from ralph_py.security import SecurityConfig as _SecurityConfig
-    s_config = _SecurityConfig(
-        mode=security_mode,
-        agent_cmd=security_agent_cmd,
-        model=security_model,
-        fail_threshold=security_fail_threshold,
-    )
-
-    # R0.1: TimeoutConfig is the single source for timeout values.
-    # Precedence: explicit CLI flag > env > ralph.toml > defaults (the
-    # click defaults on the two flags only document the dataclass
-    # defaults; they are applied solely when the flag is passed).
-    timeout_config = TimeoutConfig.load(root_dir)
-    if _use_cli_value(ctx, "agent_timeout"):
-        timeout_config.agent_iteration = agent_timeout
-    if _use_cli_value(ctx, "component_timeout"):
-        timeout_config.component_total = component_timeout
-
-    factory_config = FactoryConfig(
-        max_parallel=max_parallel,
-        max_retries=max_retries,
-        use_worktrees=not no_worktrees,
-        single_pr=manifest.single_pr,
-        create_prs=create_prs,
-        verify_command=verify_command,
-        verify_config=v_config,
-        # R2.3: --no-verify is an explicit skip sentinel that run_factory
-        # honors; v_config=None alone would substitute default checks.
-        skip_verification=no_verify,
-        review_mode=review_mode,
-        review_agent_cmd=review_agent_cmd,
-        review_model=review_model,
-        security_config=s_config,
-        contract_config=c_config,
-        # R2.3 (H-10): feedforward was never wired into this command, so
-        # ff_config_dict stayed None and Phase 0 silently never ran under
-        # `ralph factory`. Loaded via the toml/env control plane.
-        feedforward_config=FeedforwardConfig.load(root_dir),
-        progress_log_path=progress_log,
-        timeout_config=timeout_config,
-        force_lock=force_lock,
-    )
 
     ralph_dir = root_dir / "scripts" / "ralph"
     base_config = RalphConfig.load(root_dir)
@@ -1599,7 +1778,8 @@ def evolve(
     force_rich = os.environ.get("GUM_FORCE") == "1"
     ui_impl = get_ui(_normalize_ui_mode(ui), no_color, force_rich=force_rich)
 
-    evo_config = EvolutionConfig()
+    # R2.1: honor [evolution] in ralph.toml + env, anchored to --root.
+    evo_config = EvolutionConfig.load(root_dir)
 
     if not evo_config.enabled:
         ui_impl.err("Evolution is disabled in config")

--- a/ralph_py/evolution.py
+++ b/ralph_py/evolution.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -37,10 +38,22 @@ class EvolutionConfig:
     auto_apply_computational: bool = False
 
     @classmethod
+    def from_env(cls, root_dir: Path | None = None) -> EvolutionConfig:
+        """Load evolution config from environment variables only.
+
+        Relative journal/experiments paths resolve against ``root_dir``
+        (the project root), not the process CWD, matching :meth:`load`.
+        """
+        if root_dir is None:
+            root_dir = Path.cwd()
+        config = cls()
+        _apply_env_overrides(config, root_dir)
+        _resolve_relative_paths(config, root_dir)
+        return config
+
+    @classmethod
     def load(cls, root_dir: Path | None = None) -> EvolutionConfig:
         """Load evolution config with precedence: env > toml > defaults."""
-        import os
-
         from ralph_py.config import load_toml_section
         if root_dir is None:
             root_dir = Path.cwd()
@@ -68,19 +81,39 @@ class EvolutionConfig:
             config.auto_apply_computational = bool(
                 section["auto_apply_computational"]
             )
-        # Env overrides
-        if "RALPH_EVOLUTION_ENABLED" in os.environ:
-            config.enabled = os.environ["RALPH_EVOLUTION_ENABLED"].lower() in {
-                "1", "true", "yes",
-            }
-        if "RALPH_EVOLUTION_JOURNAL_PATH" in os.environ:
-            raw = os.environ["RALPH_EVOLUTION_JOURNAL_PATH"]
-            config.journal_path = (
-                Path(raw) if Path(raw).is_absolute() else root_dir / raw
-            )
-        if "RALPH_EVOLUTION_LOOKBACK_RUNS" in os.environ:
-            config.lookback_runs = int(os.environ["RALPH_EVOLUTION_LOOKBACK_RUNS"])
+        _apply_env_overrides(config, root_dir)
+        _resolve_relative_paths(config, root_dir)
         return config
+
+
+def _apply_env_overrides(config: EvolutionConfig, root_dir: Path) -> None:
+    """Overlay env vars that are explicitly set; unset vars leave the
+    existing value untouched (so toml values survive the overlay)."""
+    if "RALPH_EVOLUTION_ENABLED" in os.environ:
+        config.enabled = os.environ["RALPH_EVOLUTION_ENABLED"].lower() in {
+            "1", "true", "yes",
+        }
+    if "RALPH_EVOLUTION_JOURNAL_PATH" in os.environ:
+        raw = os.environ["RALPH_EVOLUTION_JOURNAL_PATH"]
+        config.journal_path = (
+            Path(raw) if Path(raw).is_absolute() else root_dir / raw
+        )
+    if "RALPH_EVOLUTION_LOOKBACK_RUNS" in os.environ:
+        config.lookback_runs = int(os.environ["RALPH_EVOLUTION_LOOKBACK_RUNS"])
+
+
+def _resolve_relative_paths(config: EvolutionConfig, root_dir: Path) -> None:
+    """Anchor relative journal/experiments paths to the project root.
+
+    The bare ``EvolutionConfig()`` constructor keeps its historical
+    CWD-relative defaults; the load/from_env paths always hand back
+    absolute paths so ``ralph factory --root X`` run from elsewhere
+    cannot scatter ``.ralph/`` state into the operator's CWD.
+    """
+    if not config.journal_path.is_absolute():
+        config.journal_path = root_dir / config.journal_path
+    if not config.experiments_path.is_absolute():
+        config.experiments_path = root_dir / config.experiments_path
 
 
 @dataclass

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -111,11 +111,19 @@ class FactoryConfig:
     @classmethod
     def from_env(cls) -> FactoryConfig:
         """Load factory config from environment variables."""
+        from ralph_py.config import _parse_bool
+
         return cls(
             max_parallel=int(os.environ.get("FACTORY_MAX_PARALLEL", "4")),
             max_retries=int(os.environ.get("FACTORY_MAX_RETRIES", "3")),
             retry_delay=float(os.environ.get("FACTORY_RETRY_DELAY", "5.0")),
             merge_timeout=float(os.environ.get("FACTORY_MERGE_TIMEOUT", "300.0")),
+            max_adversarial_calls=int(
+                os.environ.get("RALPH_FACTORY_MAX_ADVERSARIAL_CALLS", "0")
+            ),
+            pause_before_pr_merge=_parse_bool(
+                os.environ.get("RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE")
+            ),
         )
 
     @classmethod
@@ -125,7 +133,7 @@ class FactoryConfig:
         Reads the ``[factory]`` section from ``<root_dir>/ralph.toml`` if
         present, then overlays any matching env vars on top.
         """
-        from ralph_py.config import load_toml_section
+        from ralph_py.config import _parse_bool, load_toml_section
         if root_dir is None:
             root_dir = Path.cwd()
         config = cls()
@@ -146,6 +154,12 @@ class FactoryConfig:
             config.review_mode = str(section["review_mode"])
         if "merge_timeout" in section:
             config.merge_timeout = float(section["merge_timeout"])
+        # R2.2: the two safety knobs are reachable via toml (here), env
+        # (below) and CLI flags (cli.py factory command).
+        if "max_adversarial_calls" in section:
+            config.max_adversarial_calls = int(section["max_adversarial_calls"])
+        if "pause_before_pr_merge" in section:
+            config.pause_before_pr_merge = bool(section["pause_before_pr_merge"])
         # Env overrides (consistent with from_env)
         if "FACTORY_MAX_PARALLEL" in os.environ:
             config.max_parallel = int(os.environ["FACTORY_MAX_PARALLEL"])
@@ -155,6 +169,14 @@ class FactoryConfig:
             config.retry_delay = float(os.environ["FACTORY_RETRY_DELAY"])
         if "FACTORY_MERGE_TIMEOUT" in os.environ:
             config.merge_timeout = float(os.environ["FACTORY_MERGE_TIMEOUT"])
+        if "RALPH_FACTORY_MAX_ADVERSARIAL_CALLS" in os.environ:
+            config.max_adversarial_calls = int(
+                os.environ["RALPH_FACTORY_MAX_ADVERSARIAL_CALLS"]
+            )
+        if "RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE" in os.environ:
+            config.pause_before_pr_merge = _parse_bool(
+                os.environ["RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE"]
+            )
         return config
 
 
@@ -1860,7 +1882,9 @@ def _run_factory_locked(
         """
         from ralph_py.evolution import EvolutionConfig
 
-        evo_config = EvolutionConfig()
+        # R2.1: honor [evolution] in ralph.toml + env, resolved against
+        # the factory root rather than whatever the process CWD is.
+        evo_config = EvolutionConfig.load(root_dir)
         if not evo_config.enabled:
             return
         entry = {
@@ -2071,7 +2095,7 @@ def _run_factory_locked(
     try:
         from ralph_py.evolution import EvolutionConfig, EvolutionJournal
 
-        evo_config = EvolutionConfig()
+        evo_config = EvolutionConfig.load(root_dir)
         if evo_config.enabled:
             journal = EvolutionJournal(evo_config)
             journal.record_run(run_id, manifest, factory_result)

--- a/ralph_py/feedforward.py
+++ b/ralph_py/feedforward.py
@@ -41,10 +41,15 @@ class FeedforwardConfig:
     max_context_tokens: int = 4000   # rough cap (estimate 4 chars per token)
 
     @classmethod
+    def from_env(cls) -> FeedforwardConfig:
+        """Load feedforward config from environment variables only."""
+        config = cls()
+        _apply_env_overrides(config)
+        return config
+
+    @classmethod
     def load(cls, root_dir: Path | None = None) -> FeedforwardConfig:
         """Load feedforward config with precedence: env > toml > defaults."""
-        import os
-
         from ralph_py.config import load_toml_section
         if root_dir is None:
             root_dir = Path.cwd()
@@ -58,23 +63,32 @@ class FeedforwardConfig:
                 setattr(config, key, bool(section[key]))
         if "max_context_tokens" in section:
             config.max_context_tokens = int(section["max_context_tokens"])
-        # Env overrides
-        env_map = {
-            "RALPH_FEEDFORWARD_ENABLED": ("enabled", bool),
-            "RALPH_FEEDFORWARD_MODULE_MAP": ("module_map", bool),
-            "RALPH_FEEDFORWARD_PUBLIC_INTERFACES": ("public_interfaces", bool),
-            "RALPH_FEEDFORWARD_DEPENDENCY_GRAPH": ("dependency_graph", bool),
-            "RALPH_FEEDFORWARD_CONVENTIONS": ("conventions", bool),
-            "RALPH_FEEDFORWARD_MAX_TOKENS": ("max_context_tokens", int),
-        }
-        for env_key, (field_name, caster) in env_map.items():
-            if env_key in os.environ:
-                raw = os.environ[env_key]
-                if caster is bool:
-                    setattr(config, field_name, raw.lower() in {"1", "true", "yes"})
-                else:
-                    setattr(config, field_name, caster(raw))
+        _apply_env_overrides(config)
         return config
+
+
+_ENV_MAP: dict[str, tuple[str, type]] = {
+    "RALPH_FEEDFORWARD_ENABLED": ("enabled", bool),
+    "RALPH_FEEDFORWARD_MODULE_MAP": ("module_map", bool),
+    "RALPH_FEEDFORWARD_PUBLIC_INTERFACES": ("public_interfaces", bool),
+    "RALPH_FEEDFORWARD_DEPENDENCY_GRAPH": ("dependency_graph", bool),
+    "RALPH_FEEDFORWARD_CONVENTIONS": ("conventions", bool),
+    "RALPH_FEEDFORWARD_MAX_TOKENS": ("max_context_tokens", int),
+}
+
+
+def _apply_env_overrides(config: FeedforwardConfig) -> None:
+    """Overlay env vars that are explicitly set; unset vars leave the
+    existing value untouched (so toml values survive the overlay)."""
+    import os
+
+    for env_key, (field_name, caster) in _ENV_MAP.items():
+        if env_key in os.environ:
+            raw = os.environ[env_key]
+            if caster is bool:
+                setattr(config, field_name, raw.lower() in {"1", "true", "yes"})
+            else:
+                setattr(config, field_name, caster(raw))
 
 
 def _is_hidden(name: str) -> bool:

--- a/ralph_py/init_cmd.py
+++ b/ralph_py/init_cmd.py
@@ -363,6 +363,130 @@ Otherwise end normally.
 """
 
 
+# Scaffolded ralph.toml (R2.1): the project's discoverable config
+# surface. Every key is commented out and shows its built-in default, so
+# scaffolding changes no effective value; uncommenting a line is the
+# explicit opt-in. Content mirrors ralph.toml.example trimmed to keys the
+# loaders actually read, plus the [timeout] section wired in R0.1.
+DEFAULT_RALPH_TOML = """\
+# Ralph configuration (scaffolded by `ralph init`).
+# Every key is commented out and shows its built-in default: uncomment a
+# line to override it. Precedence: CLI flag > environment variable > this
+# file > built-in default. See docs/env-vars.md for the env-var mapping.
+
+[agent]
+# type = ""                        # "claude" | "codex" | "custom" (empty = auto-detect)
+# command = ""                     # shell command (only used when type = "custom")
+# model = ""                       # e.g. "sonnet" for claude, "o3" for codex (empty = agent default)
+# reasoning_effort = ""            # low|medium|high|max
+
+[run]
+# max_iterations = 10
+# sleep_seconds = 2
+# interactive = false
+
+[paths]
+# prompt = "scripts/ralph/prompt.md"
+# prd = "scripts/ralph/prd.json"
+# progress = "scripts/ralph/progress.txt"
+# codebase_map = "scripts/ralph/codebase_map.md"
+# allowed = []                     # e.g. ["scripts/ralph/", "src/"]
+
+[git]
+# branch = ""                      # override branch (empty = use PRD branchName)
+# auto_checkout = true
+
+[ui]
+# ascii = false
+
+# Factory orchestrator settings (Phase 0-3 pipeline coordination).
+[factory]
+# max_parallel = 4                 # concurrent component workers
+# max_retries = 3                  # per-component retry budget across all phases
+# retry_delay = 5.0                # seconds between retry attempts
+# use_worktrees = true             # branch each component into .ralph/worktrees/<id>
+# single_pr = false                # one PR for the whole factory vs per-component
+# create_prs = true                # call `gh` to push + merge per component
+# review_mode = "hard"             # hard | advisory | skip
+# merge_timeout = 300.0            # seconds to wait for PR merge confirmation
+# max_adversarial_calls = 0        # 0 = unbounded; caps review+security+distill LLM calls per run
+# pause_before_pr_merge = false    # opt-in HITL checkpoint before each PR push+merge
+
+# Phase 1 mechanical verification.
+[verify]
+# test_command = "uv run pytest"   # empty/omitted = project-type default
+# typecheck_command = "uv run mypy ."
+# lint_command = "uv run ruff check ."
+# check_diff_scope = true
+# check_bad_patterns = true
+# dead_code_cleanup = false
+# dead_code_command = ""           # custom dead-code detector (default: vulture)
+# mutation_testing = false
+# mutation_threshold = 50.0
+# mutation_timeout = 600.0
+# subprocess_timeout = 300.0
+# require_self_critique = false    # fail Phase 1 if the ## Self-Critique block is missing/sparse
+# self_critique_min_bullets = 3
+# progress_file_path = "scripts/ralph/progress.txt"
+
+# Phase 2.5 security review (independent adversarial pass focused on vulns).
+[security]
+# mode = "skip"                    # skip | advisory | hard (skip = default, opt in explicitly)
+# fail_threshold = "high"          # critical | high | medium | low (hard mode only)
+# timeout_seconds = 600.0
+# agent_cmd = ""                   # leave blank to inherit from [agent]
+# agent_type = ""
+# model = ""
+
+# Phase 3 cross-component contract testing.
+[contract]
+# mode = "tier"                    # tier | final | skip
+# test_command = "uv run pytest"
+# timeout = 600.0
+
+# Phase 0 feedforward (computational structural scan; no LLM).
+[feedforward]
+# enabled = true
+# module_map = true
+# public_interfaces = true
+# dependency_graph = true
+# conventions = true
+# max_context_tokens = 4000
+
+# Per-component semantic knowledge layer: durable facts about WHAT WAS
+# BUILT (interfaces, invariants, contracts, gotchas), written after the
+# review passes and read by downstream components automatically.
+[knowledge]
+# enabled = true
+# max_core_tokens = 2000           # current component's facts (full text)
+# max_dependency_tokens = 1000     # dependency facts (full text)
+# max_sibling_tokens = 500         # other components' facts (first sentence only)
+# distill_timeout_seconds = 300
+# distill_model = ""               # empty = falls back to [agent].model
+# max_facts_per_distill = 7
+# dependency_scope = "direct"      # direct | transitive
+
+# Continuous-learning journal.
+[evolution]
+# enabled = true
+# journal_path = ".ralph/evolution.jsonl"
+# experiments_path = ".ralph/experiments.tsv"
+# min_pattern_frequency = 2
+# lookback_runs = 10
+
+# Timeouts in seconds; 0 or less disables that limit.
+[timeout]
+# git_operation = 30.0
+# agent_iteration = 1800.0         # per agent iteration
+# component_total = 7200.0         # wall clock per component
+# verification_check = 300.0
+# review_agent = 600.0
+# contract_test = 600.0
+# subprocess_default = 60.0
+# scheduler_backstop_margin = 60.0
+"""
+
+
 def run_init(directory: Path, ui: UI) -> int:
     """Initialize Ralph harness in a project directory.
 
@@ -400,6 +524,7 @@ def run_init(directory: Path, ui: UI) -> int:
         ui.ok("scripts/ralph/ exists")
 
     ui.section("Create defaults")
+    _create_if_missing(root / "ralph.toml", DEFAULT_RALPH_TOML, ui)
     _create_if_missing(ralph_dir / "prompt.md", DEFAULT_PROMPT, ui)
     _create_if_missing(ralph_dir / "prd.json", json.dumps(DEFAULT_PRD, indent=2) + "\n", ui)
     _create_if_missing(ralph_dir / "progress.txt", DEFAULT_PROGRESS, ui)

--- a/ralph_py/knowledge.py
+++ b/ralph_py/knowledge.py
@@ -125,42 +125,62 @@ class KnowledgeConfig:
             if "dependency_scope" in section:
                 config.dependency_scope = str(section["dependency_scope"])
 
-        # Env overrides
-        if "RALPH_KNOWLEDGE_ENABLED" in os.environ:
-            config.enabled = _parse_bool(os.environ["RALPH_KNOWLEDGE_ENABLED"])
-        if "RALPH_KNOWLEDGE_MAX_CORE_TOKENS" in os.environ:
-            config.max_core_tokens = int(os.environ["RALPH_KNOWLEDGE_MAX_CORE_TOKENS"])
-        if "RALPH_KNOWLEDGE_MAX_DEPENDENCY_TOKENS" in os.environ:
-            config.max_dependency_tokens = int(
-                os.environ["RALPH_KNOWLEDGE_MAX_DEPENDENCY_TOKENS"]
-            )
-        if "RALPH_KNOWLEDGE_MAX_SIBLING_TOKENS" in os.environ:
-            config.max_sibling_tokens = int(
-                os.environ["RALPH_KNOWLEDGE_MAX_SIBLING_TOKENS"]
-            )
-        if "RALPH_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS" in os.environ:
-            config.distill_timeout_seconds = float(
-                os.environ["RALPH_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS"]
-            )
-        if "RALPH_KNOWLEDGE_DISTILL_MODEL" in os.environ:
-            config.distill_model = os.environ["RALPH_KNOWLEDGE_DISTILL_MODEL"]
-        if "RALPH_KNOWLEDGE_MAX_FACTS_PER_DISTILL" in os.environ:
-            config.max_facts_per_distill = int(
-                os.environ["RALPH_KNOWLEDGE_MAX_FACTS_PER_DISTILL"]
-            )
-        if "RALPH_KNOWLEDGE_DEPENDENCY_SCOPE" in os.environ:
-            config.dependency_scope = os.environ["RALPH_KNOWLEDGE_DEPENDENCY_SCOPE"]
-
-        # Re-run validation: env can supply a bad value that bypassed
-        # __post_init__ at construction time.
-        if config.dependency_scope not in _VALID_DEPENDENCY_SCOPES:
-            raise ValueError(
-                f"RALPH_KNOWLEDGE_DEPENDENCY_SCOPE must be one of "
-                f"{sorted(_VALID_DEPENDENCY_SCOPES)}, "
-                f"got {config.dependency_scope!r}"
-            )
-
+        _apply_knowledge_env_overrides(config)
         return config
+
+    @classmethod
+    def from_env(cls, root_dir: Path | None = None) -> KnowledgeConfig:
+        """Load knowledge config from environment variables only.
+
+        ``knowledge_root`` resolves against ``root_dir`` (the project
+        root), matching :meth:`load`; the toml file is not consulted.
+        """
+        if root_dir is None:
+            root_dir = Path.cwd()
+        config = cls()
+        config.knowledge_root = root_dir / ".ralph" / "knowledge"
+        _apply_knowledge_env_overrides(config)
+        return config
+
+
+def _apply_knowledge_env_overrides(config: KnowledgeConfig) -> None:
+    """Overlay env vars that are explicitly set; unset vars leave the
+    existing value untouched (so toml values survive the overlay).
+
+    Re-validates dependency_scope afterwards: env can supply a bad value
+    that bypassed ``__post_init__`` at construction time.
+    """
+    if "RALPH_KNOWLEDGE_ENABLED" in os.environ:
+        config.enabled = _parse_bool(os.environ["RALPH_KNOWLEDGE_ENABLED"])
+    if "RALPH_KNOWLEDGE_MAX_CORE_TOKENS" in os.environ:
+        config.max_core_tokens = int(os.environ["RALPH_KNOWLEDGE_MAX_CORE_TOKENS"])
+    if "RALPH_KNOWLEDGE_MAX_DEPENDENCY_TOKENS" in os.environ:
+        config.max_dependency_tokens = int(
+            os.environ["RALPH_KNOWLEDGE_MAX_DEPENDENCY_TOKENS"]
+        )
+    if "RALPH_KNOWLEDGE_MAX_SIBLING_TOKENS" in os.environ:
+        config.max_sibling_tokens = int(
+            os.environ["RALPH_KNOWLEDGE_MAX_SIBLING_TOKENS"]
+        )
+    if "RALPH_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS" in os.environ:
+        config.distill_timeout_seconds = float(
+            os.environ["RALPH_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS"]
+        )
+    if "RALPH_KNOWLEDGE_DISTILL_MODEL" in os.environ:
+        config.distill_model = os.environ["RALPH_KNOWLEDGE_DISTILL_MODEL"]
+    if "RALPH_KNOWLEDGE_MAX_FACTS_PER_DISTILL" in os.environ:
+        config.max_facts_per_distill = int(
+            os.environ["RALPH_KNOWLEDGE_MAX_FACTS_PER_DISTILL"]
+        )
+    if "RALPH_KNOWLEDGE_DEPENDENCY_SCOPE" in os.environ:
+        config.dependency_scope = os.environ["RALPH_KNOWLEDGE_DEPENDENCY_SCOPE"]
+
+    if config.dependency_scope not in _VALID_DEPENDENCY_SCOPES:
+        raise ValueError(
+            f"RALPH_KNOWLEDGE_DEPENDENCY_SCOPE must be one of "
+            f"{sorted(_VALID_DEPENDENCY_SCOPES)}, "
+            f"got {config.dependency_scope!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/ralph_py/security.py
+++ b/ralph_py/security.py
@@ -201,9 +201,18 @@ class SecurityResult:
 
 @dataclass
 class SecurityConfig:
-    """Configuration for the security review phase."""
+    """Configuration for the security review phase.
 
-    mode: str = SecurityMode.ADVISORY.value
+    The default mode is "skip": the security pass is an extra LLM call
+    per component and is opt-in everywhere it is documented (CLI
+    --security-mode default, ralph.toml.example, README). Before R2.1
+    the dataclass default was "advisory", but no product path consumed
+    it - the CLI always passed an explicit mode and run_factory treats
+    a missing config as skip - so aligning it with the documented
+    default cannot change a working setup.
+    """
+
+    mode: str = SecurityMode.SKIP.value
     agent_cmd: str | None = None
     agent_type: str | None = None
     model: str | None = None
@@ -231,7 +240,7 @@ class SecurityConfig:
     @classmethod
     def from_env(cls) -> SecurityConfig:
         return cls(
-            mode=os.environ.get("RALPH_SECURITY_MODE", SecurityMode.ADVISORY.value),
+            mode=os.environ.get("RALPH_SECURITY_MODE", SecurityMode.SKIP.value),
             agent_cmd=os.environ.get("RALPH_SECURITY_AGENT_CMD") or None,
             agent_type=os.environ.get("RALPH_SECURITY_AGENT_TYPE") or None,
             model=os.environ.get("RALPH_SECURITY_MODEL") or None,

--- a/ralph_py/verify.py
+++ b/ralph_py/verify.py
@@ -127,10 +127,14 @@ class VerifyConfig:
             config.check_bad_patterns = bool(section["check_bad_patterns"])
         if "dead_code_cleanup" in section:
             config.dead_code_cleanup = bool(section["dead_code_cleanup"])
+        if "dead_code_command" in section:
+            config.dead_code_command = str(section["dead_code_command"]) or None
         if "mutation_testing" in section:
             config.mutation_testing = bool(section["mutation_testing"])
         if "mutation_threshold" in section:
             config.mutation_threshold = float(section["mutation_threshold"])
+        if "mutation_timeout" in section:
+            config.mutation_timeout = float(section["mutation_timeout"])
         if "subprocess_timeout" in section:
             config.subprocess_timeout = float(section["subprocess_timeout"])
         if "require_self_critique" in section:
@@ -141,20 +145,30 @@ class VerifyConfig:
             )
         if "progress_file_path" in section:
             config.progress_file_path = str(section["progress_file_path"])
-        # Env overrides
+        # Env overrides. Each var is applied only when it is explicitly
+        # set in the environment: the previous compare-against-default
+        # heuristic silently dropped an env value that happened to equal
+        # the dataclass default (e.g. RALPH_MUTATION_THRESHOLD=50 could
+        # not override a toml mutation_threshold), breaking the
+        # env-beats-toml precedence contract (R2.1).
         env = cls.from_env()
-        for f in (
-            "test_command", "typecheck_command", "lint_command",
-            "dead_code_cleanup", "dead_code_command", "mutation_testing",
-            "mutation_threshold", "mutation_timeout", "subprocess_timeout",
-            "require_self_critique", "self_critique_min_bullets",
-            "progress_file_path",
-        ):
-            # only override when env-derived value differs from default()
-            env_val = getattr(env, f)
-            default_val = getattr(cls(), f)
-            if env_val != default_val:
-                setattr(config, f, env_val)
+        env_var_to_field = {
+            "RALPH_VERIFY_TEST_CMD": "test_command",
+            "RALPH_VERIFY_TYPECHECK_CMD": "typecheck_command",
+            "RALPH_VERIFY_LINT_CMD": "lint_command",
+            "RALPH_DEAD_CODE_CLEANUP": "dead_code_cleanup",
+            "RALPH_DEAD_CODE_CMD": "dead_code_command",
+            "RALPH_MUTATION_TESTING": "mutation_testing",
+            "RALPH_MUTATION_THRESHOLD": "mutation_threshold",
+            "RALPH_MUTATION_TIMEOUT": "mutation_timeout",
+            "RALPH_TIMEOUT_VERIFY": "subprocess_timeout",
+            "RALPH_VERIFY_REQUIRE_SELF_CRITIQUE": "require_self_critique",
+            "RALPH_VERIFY_SELF_CRITIQUE_MIN_BULLETS": "self_critique_min_bullets",
+            "RALPH_VERIFY_PROGRESS_FILE": "progress_file_path",
+        }
+        for env_var, field_name in env_var_to_field.items():
+            if env_var in os.environ:
+                setattr(config, field_name, getattr(env, field_name))
         return config
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # and so newly added vars in a family are covered without editing this list.
 RALPH_ENV_PREFIXES: tuple[str, ...] = (
     "FACTORY_",
+    "RALPH_FACTORY_",
     "RALPH_TIMEOUT_",
     "RALPH_CONTRACT_",
     "RALPH_SECURITY_",
@@ -39,6 +40,8 @@ RALPH_ENV_PREFIXES: tuple[str, ...] = (
     "RALPH_EVOLUTION_",
     "RALPH_KNOWLEDGE_",
     "RALPH_FEEDFORWARD_",
+    "RALPH_MUTATION_",
+    "RALPH_DEAD_CODE_",
 )
 
 # Legacy single-loop env vars (exact names, no shared prefix).
@@ -75,12 +78,13 @@ def isolate_ralph_state(
 ) -> Path:
     """Redirect every evolution/experiments/knowledge write path to tmp_path.
 
-    Why chdir is the mechanism: ``EvolutionConfig`` defaults
-    ``journal_path``/``experiments_path`` to relative ``.ralph/...`` paths
-    resolved against CWD at write time, and ``run_factory`` constructs
-    ``EvolutionConfig()`` directly (neither env nor toml is consulted at
-    that call site), so env vars cannot redirect the factory's journal
-    writes. ``KnowledgeConfig`` likewise defaults ``knowledge_root`` to a
+    Why chdir is the mechanism: the bare ``EvolutionConfig()``
+    constructor defaults ``journal_path``/``experiments_path`` to
+    relative ``.ralph/...`` paths resolved against CWD at write time
+    (since R2.1 ``run_factory`` uses ``EvolutionConfig.load(root_dir)``,
+    which anchors them to the factory root, but direct constructions in
+    tests and legacy call sites remain CWD-relative).
+    ``KnowledgeConfig`` likewise defaults ``knowledge_root`` to a
     relative ``.ralph/knowledge`` and ``KnowledgeConfig.load(None)``
     resolves it against ``Path.cwd()``; there is no env override for the
     root. Pointing CWD at ``tmp_path`` therefore redirects every relative

--- a/tests/test_config_control_plane.py
+++ b/tests/test_config_control_plane.py
@@ -1,0 +1,758 @@
+"""R2.1/R2.2 config control plane tests.
+
+Every phase config must resolve through the real CLI construction path
+with precedence: explicit CLI flag > env var > ralph.toml > dataclass
+default. The tests here invoke the actual click commands (``ralph
+factory`` / ``ralph run`` / ``ralph evolve`` / ``ralph init``) with
+``run_factory`` (or ``EvolutionJournal``) replaced by a capturing fake,
+so the assertion target is the exact config object the orchestrator
+would receive - not a loader called in isolation.
+
+Nine config surfaces map to ralph.toml sections:
+RalphConfig (agent/run/paths/git/ui), TimeoutConfig ([timeout]),
+KnowledgeConfig ([knowledge]), FactoryConfig ([factory]), VerifyConfig
+([verify]), SecurityConfig ([security]), ContractConfig ([contract]),
+FeedforwardConfig ([feedforward]), EvolutionConfig ([evolution]).
+KnowledgeConfig is consumed inside run_factory (factory.py calls
+``KnowledgeConfig.load(root_dir)``), so its CLI-path coverage here is
+the loader round-trip plus the new ``from_env``.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+import ralph_py.cli as cli_mod
+import ralph_py.evolution as evolution_mod
+from ralph_py.evolution import EvolutionConfig
+from ralph_py.factory import FactoryConfig, FactoryResult
+from ralph_py.feedforward import FeedforwardConfig
+from ralph_py.init_cmd import DEFAULT_RALPH_TOML
+from ralph_py.knowledge import KnowledgeConfig
+from ralph_py.manifest import Component, Manifest
+from ralph_py.verify import VerifyConfig
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace run_factory with a capturing fake; return the capture dict."""
+    box: dict[str, Any] = {}
+
+    def fake_run_factory(
+        manifest: Manifest,
+        factory_config: FactoryConfig,
+        base_config: Any,
+        ui: Any,
+        root_dir: Path,
+        manifest_path: Path | None = None,
+    ) -> FactoryResult:
+        box["manifest"] = manifest
+        box["factory_config"] = factory_config
+        box["base_config"] = base_config
+        box["root_dir"] = root_dir
+        return FactoryResult(exit_code=0)
+
+    monkeypatch.setattr(cli_mod, "run_factory", fake_run_factory)
+    return box
+
+
+def _write_manifest(tmp_path: Path) -> Path:
+    manifest = Manifest(
+        version="1",
+        spec_file="spec.md",
+        project_name="cp-test",
+        base_branch="main",
+        single_pr=False,
+        components=[
+            Component(
+                id="c1",
+                title="c1",
+                description="component one",
+                dependencies=[],
+                prd_path="scripts/ralph/prd.json",
+                branch_name="ralph/factory/c1",
+            ),
+        ],
+    )
+    path = tmp_path / "manifest.json"
+    manifest.save(path)
+    return path
+
+
+def _invoke_factory(
+    tmp_path: Path, *extra_args: str
+) -> Any:
+    manifest_path = _write_manifest(tmp_path)
+    runner = CliRunner()
+    return runner.invoke(
+        cli_mod.cli,
+        [
+            "factory",
+            "--manifest", str(manifest_path),
+            "--root", str(tmp_path),
+            "--yes",
+            "--agent-cmd", "true",
+            "--ui", "plain",
+            *extra_args,
+        ],
+    )
+
+
+def _invoke_run(tmp_path: Path, *extra_args: str) -> Any:
+    runner = CliRunner()
+    return runner.invoke(
+        cli_mod.cli,
+        [
+            "run", "1",
+            "--root", str(tmp_path),
+            "--agent-cmd", "true",
+            "--ui", "plain",
+            *extra_args,
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# TOML round-trips through the real `ralph factory` construction path
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryCommandTomlRoundTrip:
+    def test_factory_section(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[factory]\n"
+            "max_parallel = 7\n"
+            "max_retries = 9\n"
+            "review_mode = \"advisory\"\n"
+            "max_adversarial_calls = 5\n"
+            "pause_before_pr_merge = true\n"
+        )
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        fc = captured["factory_config"]
+        assert fc.max_parallel == 7
+        assert fc.max_retries == 9
+        assert fc.review_mode == "advisory"
+        assert fc.max_adversarial_calls == 5
+        assert fc.pause_before_pr_merge is True
+
+    def test_verify_section(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[verify]\n"
+            "test_command = \"echo verify-toml\"\n"
+            "mutation_threshold = 75.0\n"
+            "require_self_critique = true\n"
+        )
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        vc = captured["factory_config"].verify_config
+        assert vc is not None
+        assert vc.test_command == "echo verify-toml"
+        assert vc.mutation_threshold == 75.0
+        assert vc.require_self_critique is True
+
+    def test_security_section(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[security]\n"
+            "mode = \"hard\"\n"
+            "fail_threshold = \"critical\"\n"
+            "timeout_seconds = 123.0\n"
+        )
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        sc = captured["factory_config"].security_config
+        assert sc is not None
+        assert sc.mode == "hard"
+        assert sc.fail_threshold == "critical"
+        assert sc.timeout_seconds == 123.0
+
+    def test_contract_section(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[contract]\n"
+            "mode = \"final\"\n"
+            "test_command = \"echo contract-toml\"\n"
+            "timeout = 44.0\n"
+        )
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        cc = captured["factory_config"].contract_config
+        assert cc is not None
+        assert cc.mode == "final"
+        assert cc.test_command == "echo contract-toml"
+        assert cc.timeout == 44.0
+
+    def test_contract_toml_skip_disables_phase(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text("[contract]\nmode = \"skip\"\n")
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].contract_config is None
+
+    def test_feedforward_section(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[feedforward]\n"
+            "module_map = false\n"
+            "max_context_tokens = 1234\n"
+        )
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        ff = captured["factory_config"].feedforward_config
+        assert ff is not None
+        assert ff.module_map is False
+        assert ff.max_context_tokens == 1234
+
+    def test_timeout_section(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[timeout]\nagent_iteration = 42.0\ncomponent_total = 99.0\n"
+        )
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        tc = captured["factory_config"].timeout_config
+        assert tc is not None
+        assert tc.agent_iteration == 42.0
+        assert tc.component_total == 99.0
+
+    def test_base_config_sections(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        # RalphConfig covers the [agent]/[run]/[paths]/[git]/[ui] sections.
+        (tmp_path / "ralph.toml").write_text(
+            "[agent]\nmodel = \"model-from-toml\"\n"
+            "[run]\nsleep_seconds = 0.25\n"
+        )
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        base = captured["base_config"]
+        assert base.model == "model-from-toml"
+        assert base.sleep_seconds == 0.25
+
+
+# ---------------------------------------------------------------------------
+# TOML round-trips through the real `ralph run` construction path
+# ---------------------------------------------------------------------------
+
+
+class TestRunCommandTomlRoundTrip:
+    def test_verify_section(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[verify]\ntest_command = \"echo run-verify\"\n"
+        )
+        result = _invoke_run(tmp_path)
+        assert result.exit_code == 0, result.output
+        vc = captured["factory_config"].verify_config
+        assert vc is not None
+        assert vc.test_command == "echo run-verify"
+
+    def test_security_section(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text("[security]\nmode = \"advisory\"\n")
+        result = _invoke_run(tmp_path)
+        assert result.exit_code == 0, result.output
+        sc = captured["factory_config"].security_config
+        assert sc is not None
+        assert sc.mode == "advisory"
+
+    def test_feedforward_section(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[feedforward]\nmax_context_tokens = 555\n"
+        )
+        result = _invoke_run(tmp_path)
+        assert result.exit_code == 0, result.output
+        ff = captured["factory_config"].feedforward_config
+        assert ff is not None
+        assert ff.max_context_tokens == 555
+
+    def test_factory_tunables_honored(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[factory]\nmax_retries = 6\nmax_adversarial_calls = 2\n"
+        )
+        result = _invoke_run(tmp_path)
+        assert result.exit_code == 0, result.output
+        fc = captured["factory_config"]
+        assert fc.max_retries == 6
+        assert fc.max_adversarial_calls == 2
+
+    def test_single_component_structure_is_forced(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        # Structural fields cannot be overridden by toml: `ralph run` is
+        # by definition a local single-component no-PR invocation.
+        (tmp_path / "ralph.toml").write_text(
+            "[factory]\n"
+            "max_parallel = 8\n"
+            "use_worktrees = true\n"
+            "single_pr = true\n"
+            "create_prs = true\n"
+        )
+        result = _invoke_run(tmp_path)
+        assert result.exit_code == 0, result.output
+        fc = captured["factory_config"]
+        assert fc.max_parallel == 1
+        assert fc.use_worktrees is False
+        assert fc.single_pr is False
+        assert fc.create_prs is False
+
+    def test_review_mode_defaults_to_advisory(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        result = _invoke_run(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].review_mode == "advisory"
+
+    def test_review_mode_toml_optin_is_honored(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text("[factory]\nreview_mode = \"hard\"\n")
+        result = _invoke_run(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].review_mode == "hard"
+
+
+# ---------------------------------------------------------------------------
+# `ralph evolve` builds EvolutionConfig via load (the [evolution] section)
+# ---------------------------------------------------------------------------
+
+
+class TestEvolveCommandTomlRoundTrip:
+    def test_enabled_false_in_toml_stops_evolve(self, tmp_path: Path) -> None:
+        (tmp_path / "ralph.toml").write_text("[evolution]\nenabled = false\n")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_mod.cli,
+            ["evolve", "--status", "--root", str(tmp_path), "--ui", "plain"],
+        )
+        assert result.exit_code == 1
+        assert "disabled" in result.output
+
+    def test_journal_path_reaches_journal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[evolution]\njournal_path = \"custom/evo.jsonl\"\n"
+        )
+        box: dict[str, Any] = {}
+
+        class FakeJournal:
+            def __init__(self, config: EvolutionConfig) -> None:
+                box["config"] = config
+
+            def get_experiment_trends(self, last_n: int = 10) -> list[Any]:
+                return []
+
+        monkeypatch.setattr(evolution_mod, "EvolutionJournal", FakeJournal)
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_mod.cli,
+            ["evolve", "--status", "--root", str(tmp_path), "--ui", "plain"],
+        )
+        assert result.exit_code == 0, result.output
+        assert box["config"].journal_path == tmp_path / "custom/evo.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Precedence: explicit CLI flag > env > toml (factory / verify / security)
+# ---------------------------------------------------------------------------
+
+
+class TestPrecedence:
+    def test_factory_flag_beats_env_beats_toml(
+        self,
+        tmp_path: Path,
+        captured: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text("[factory]\nmax_parallel = 5\n")
+        monkeypatch.setenv("FACTORY_MAX_PARALLEL", "6")
+        result = _invoke_factory(tmp_path, "--max-parallel", "7")
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].max_parallel == 7
+
+        result = _invoke_factory(tmp_path)
+        assert captured["factory_config"].max_parallel == 6
+
+        monkeypatch.delenv("FACTORY_MAX_PARALLEL")
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].max_parallel == 5
+
+    def test_verify_flag_beats_env_beats_toml(
+        self,
+        tmp_path: Path,
+        captured: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[verify]\ntest_command = \"echo from-toml\"\n"
+        )
+        monkeypatch.setenv("RALPH_VERIFY_TEST_CMD", "echo from-env")
+        result = _invoke_factory(tmp_path, "--test-command", "echo from-flag")
+        assert result.exit_code == 0, result.output
+        assert (
+            captured["factory_config"].verify_config.test_command
+            == "echo from-flag"
+        )
+
+        result = _invoke_factory(tmp_path)
+        assert (
+            captured["factory_config"].verify_config.test_command
+            == "echo from-env"
+        )
+
+        monkeypatch.delenv("RALPH_VERIFY_TEST_CMD")
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert (
+            captured["factory_config"].verify_config.test_command
+            == "echo from-toml"
+        )
+
+    def test_security_flag_beats_env_beats_toml(
+        self,
+        tmp_path: Path,
+        captured: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text("[security]\nmode = \"advisory\"\n")
+        monkeypatch.setenv("RALPH_SECURITY_MODE", "skip")
+        result = _invoke_factory(tmp_path, "--security-mode", "hard")
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].security_config.mode == "hard"
+
+        result = _invoke_factory(tmp_path)
+        assert captured["factory_config"].security_config.mode == "skip"
+
+        monkeypatch.delenv("RALPH_SECURITY_MODE")
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].security_config.mode == "advisory"
+
+    def test_verify_env_equal_to_default_still_beats_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Regression: the old overlay compared the env-derived value to
+        # the dataclass default and skipped it on equality, so an env
+        # var explicitly set to the default value could not override a
+        # toml value.
+        (tmp_path / "ralph.toml").write_text(
+            "[verify]\nmutation_threshold = 75.0\n"
+        )
+        monkeypatch.setenv("RALPH_MUTATION_THRESHOLD", "50")
+        config = VerifyConfig.load(tmp_path)
+        assert config.mutation_threshold == 50.0
+
+
+# ---------------------------------------------------------------------------
+# R2.2: the two safety knobs are reachable via all three surfaces
+# ---------------------------------------------------------------------------
+
+
+class TestSafetyKnobs:
+    def test_max_adversarial_calls_all_surfaces(
+        self,
+        tmp_path: Path,
+        captured: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[factory]\nmax_adversarial_calls = 1\n"
+        )
+        monkeypatch.setenv("RALPH_FACTORY_MAX_ADVERSARIAL_CALLS", "2")
+        result = _invoke_factory(tmp_path, "--max-adversarial-calls", "3")
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].max_adversarial_calls == 3
+
+        result = _invoke_factory(tmp_path)
+        assert captured["factory_config"].max_adversarial_calls == 2
+
+        monkeypatch.delenv("RALPH_FACTORY_MAX_ADVERSARIAL_CALLS")
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].max_adversarial_calls == 1
+
+    def test_pause_before_pr_merge_all_surfaces(
+        self,
+        tmp_path: Path,
+        captured: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[factory]\npause_before_pr_merge = true\n"
+        )
+        # env (explicitly false) beats toml (true)
+        monkeypatch.setenv("RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE", "0")
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].pause_before_pr_merge is False
+
+        # flag beats env
+        result = _invoke_factory(tmp_path, "--pause-before-pr-merge")
+        assert captured["factory_config"].pause_before_pr_merge is True
+
+        # negated flag also wins
+        monkeypatch.setenv("RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE", "1")
+        result = _invoke_factory(tmp_path, "--no-pause-before-pr-merge")
+        assert captured["factory_config"].pause_before_pr_merge is False
+
+        # toml alone
+        monkeypatch.delenv("RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE")
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].pause_before_pr_merge is True
+
+
+# ---------------------------------------------------------------------------
+# NOTE lines: toml-driven changes are surfaced at factory startup
+# ---------------------------------------------------------------------------
+
+
+class TestTomlNotes:
+    def test_note_emitted_for_toml_value(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text("[factory]\nmax_parallel = 9\n")
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert "NOTE: [factory] max_parallel = 9" in result.output
+
+    def test_no_note_when_flag_overrides(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text("[factory]\nmax_parallel = 9\n")
+        result = _invoke_factory(tmp_path, "--max-parallel", "4")
+        assert result.exit_code == 0, result.output
+        assert "NOTE: [factory] max_parallel" not in result.output
+
+    def test_no_notes_without_toml(
+        self, tmp_path: Path, captured: dict[str, Any]
+    ) -> None:
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert "NOTE: [" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# from_env for the loaders that were missing it (R2.1)
+# ---------------------------------------------------------------------------
+
+
+class TestNewFromEnv:
+    def test_feedforward_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("RALPH_FEEDFORWARD_MAX_TOKENS", "123")
+        monkeypatch.setenv("RALPH_FEEDFORWARD_MODULE_MAP", "false")
+        config = FeedforwardConfig.from_env()
+        assert config.max_context_tokens == 123
+        assert config.module_map is False
+
+    def test_evolution_from_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("RALPH_EVOLUTION_LOOKBACK_RUNS", "3")
+        monkeypatch.setenv("RALPH_EVOLUTION_JOURNAL_PATH", "custom/j.jsonl")
+        config = EvolutionConfig.from_env(tmp_path)
+        assert config.lookback_runs == 3
+        assert config.journal_path == tmp_path / "custom/j.jsonl"
+        # defaults resolve against root_dir, not CWD
+        assert config.experiments_path == tmp_path / ".ralph/experiments.tsv"
+
+    def test_knowledge_from_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("RALPH_KNOWLEDGE_MAX_CORE_TOKENS", "99")
+        monkeypatch.setenv("RALPH_KNOWLEDGE_DEPENDENCY_SCOPE", "transitive")
+        config = KnowledgeConfig.from_env(tmp_path)
+        assert config.max_core_tokens == 99
+        assert config.dependency_scope == "transitive"
+        assert config.knowledge_root == tmp_path / ".ralph" / "knowledge"
+
+    def test_knowledge_from_env_rejects_bad_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("RALPH_KNOWLEDGE_DEPENDENCY_SCOPE", "everything")
+        with pytest.raises(ValueError, match="DEPENDENCY_SCOPE"):
+            KnowledgeConfig.from_env(tmp_path)
+
+    def test_factory_from_env_reads_safety_knobs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("RALPH_FACTORY_MAX_ADVERSARIAL_CALLS", "4")
+        monkeypatch.setenv("RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE", "true")
+        config = FactoryConfig.from_env()
+        assert config.max_adversarial_calls == 4
+        assert config.pause_before_pr_merge is True
+
+
+# ---------------------------------------------------------------------------
+# Knowledge section loader round-trip (consumed by run_factory internally)
+# ---------------------------------------------------------------------------
+
+
+class TestKnowledgeSectionRoundTrip:
+    def test_toml_reaches_loaded_config(self, tmp_path: Path) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[knowledge]\nmax_core_tokens = 777\ndistill_model = \"m\"\n"
+        )
+        config = KnowledgeConfig.load(tmp_path)
+        assert config.max_core_tokens == 777
+        assert config.distill_model == "m"
+
+
+# ---------------------------------------------------------------------------
+# ralph init scaffolds ralph.toml
+# ---------------------------------------------------------------------------
+
+
+EXPECTED_SCAFFOLD_SECTIONS = {
+    "agent", "run", "paths", "git", "ui",
+    "factory", "verify", "security", "contract",
+    "feedforward", "knowledge", "evolution", "timeout",
+}
+
+# Keys each loader actually consumes, mirrored by hand so a typo'd or
+# phantom key in the scaffold fails membership below.
+EXPECTED_SCAFFOLD_KEYS = {
+    "agent": {"type", "command", "model", "reasoning_effort"},
+    "run": {"max_iterations", "sleep_seconds", "interactive"},
+    "paths": {"prompt", "prd", "progress", "codebase_map", "allowed"},
+    "git": {"branch", "auto_checkout"},
+    "ui": {"ascii"},
+    "factory": {
+        "max_parallel", "max_retries", "retry_delay", "use_worktrees",
+        "single_pr", "create_prs", "review_mode", "merge_timeout",
+        "max_adversarial_calls", "pause_before_pr_merge",
+    },
+    "verify": {
+        "test_command", "typecheck_command", "lint_command",
+        "check_diff_scope", "check_bad_patterns", "dead_code_cleanup",
+        "dead_code_command", "mutation_testing", "mutation_threshold",
+        "mutation_timeout", "subprocess_timeout", "require_self_critique",
+        "self_critique_min_bullets", "progress_file_path",
+    },
+    "security": {
+        "mode", "fail_threshold", "timeout_seconds", "agent_cmd",
+        "agent_type", "model",
+    },
+    "contract": {"mode", "test_command", "timeout"},
+    "feedforward": {
+        "enabled", "module_map", "public_interfaces", "dependency_graph",
+        "conventions", "max_context_tokens",
+    },
+    "knowledge": {
+        "enabled", "max_core_tokens", "max_dependency_tokens",
+        "max_sibling_tokens", "distill_timeout_seconds", "distill_model",
+        "max_facts_per_distill", "dependency_scope",
+    },
+    "evolution": {
+        "enabled", "journal_path", "experiments_path",
+        "min_pattern_frequency", "lookback_runs",
+    },
+    "timeout": {
+        "git_operation", "agent_iteration", "component_total",
+        "verification_check", "review_agent", "contract_test",
+        "subprocess_default", "scheduler_backstop_margin",
+    },
+}
+
+
+def _uncomment_scaffold(text: str) -> str:
+    """Uncomment every `# key = value` line inside the scaffold."""
+    lines = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# ") and " = " in stripped and not (
+            stripped.startswith("# Ralph") or stripped[2:3].isupper()
+        ):
+            lines.append(stripped[2:])
+        else:
+            lines.append(line)
+    return "\n".join(lines) + "\n"
+
+
+class TestInitScaffold:
+    def test_init_creates_ralph_toml(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_mod.cli, ["init", str(tmp_path), "--ui", "plain"]
+        )
+        assert result.exit_code == 0, result.output
+        toml_path = tmp_path / "ralph.toml"
+        assert toml_path.exists()
+        data = tomllib.loads(toml_path.read_text())
+        assert set(data.keys()) == EXPECTED_SCAFFOLD_SECTIONS
+        # All keys commented out: scaffolding changes no effective value.
+        assert all(section == {} for section in data.values())
+
+    def test_init_does_not_overwrite_existing(self, tmp_path: Path) -> None:
+        (tmp_path / "ralph.toml").write_text("[factory]\nmax_parallel = 2\n")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli_mod.cli, ["init", str(tmp_path), "--ui", "plain"]
+        )
+        assert result.exit_code == 0, result.output
+        assert (
+            (tmp_path / "ralph.toml").read_text()
+            == "[factory]\nmax_parallel = 2\n"
+        )
+
+    def test_scaffold_keys_are_real(self) -> None:
+        # Uncomment every key and check each against the loader key sets;
+        # a scaffold key the loaders do not read fails here.
+        data = tomllib.loads(_uncomment_scaffold(DEFAULT_RALPH_TOML))
+        assert set(data.keys()) == EXPECTED_SCAFFOLD_SECTIONS
+        for section, keys in data.items():
+            unexpected = set(keys) - EXPECTED_SCAFFOLD_KEYS[section]
+            assert not unexpected, (
+                f"[{section}] scaffold keys not consumed by any loader: "
+                f"{sorted(unexpected)}"
+            )
+
+    def test_uncommented_scaffold_loads_through_every_loader(
+        self, tmp_path: Path
+    ) -> None:
+        from ralph_py.config import RalphConfig
+        from ralph_py.contract import ContractConfig
+        from ralph_py.security import SecurityConfig
+        from ralph_py.timeout import TimeoutConfig
+
+        (tmp_path / "ralph.toml").write_text(
+            _uncomment_scaffold(DEFAULT_RALPH_TOML)
+        )
+        RalphConfig.load(tmp_path)
+        FactoryConfig.load(tmp_path)
+        VerifyConfig.load(tmp_path)
+        SecurityConfig.load(tmp_path)
+        ContractConfig.load(tmp_path)
+        FeedforwardConfig.load(tmp_path)
+        EvolutionConfig.load(tmp_path)
+        KnowledgeConfig.load(tmp_path)
+        TimeoutConfig.load(tmp_path)

--- a/tests/test_contract_safety.py
+++ b/tests/test_contract_safety.py
@@ -151,11 +151,14 @@ def _tracked_changes(root: Path) -> list[str]:
     ]
 
 
-def _read_journal_events(event_type: str) -> list[dict[str, object]]:
-    """Read evolution-journal entries of one event type. The autouse
-    conftest fixture chdirs to tmp_path, so the default cwd-relative
-    journal path lands there."""
-    journal = Path(".ralph") / "evolution.jsonl"
+def _read_journal_events(
+    root: Path, event_type: str
+) -> list[dict[str, object]]:
+    """Read evolution-journal entries of one event type. Since R2.1
+    run_factory loads EvolutionConfig via ``load(root_dir)``, which
+    anchors the default journal path to the factory root (not the
+    process CWD)."""
+    journal = root / ".ralph" / "evolution.jsonl"
     if not journal.exists():
         return []
     entries = [
@@ -280,7 +283,7 @@ class TestContractFailureExitsNonzero:
         assert "retries exhausted" in comp.error
 
         # contract_result journal event recorded for the failure.
-        events = _read_journal_events("contract_result")
+        events = _read_journal_events(root, "contract_result")
         assert events, "expected a contract_result journal event"
         assert events[-1]["passed"] is False
         assert events[-1]["breaker"] == "a"
@@ -369,7 +372,7 @@ class TestBreakerRetryReentersScheduling:
         contract_events = [e for e in events if e["event"] == "contract_result"]
         assert [e["data"]["passed"] for e in contract_events] == [False, True]
         # Journal mirrors both outcomes (recorded for pass AND fail).
-        journal_events = _read_journal_events("contract_result")
+        journal_events = _read_journal_events(root, "contract_result")
         assert [e["passed"] for e in journal_events] == [False, True]
 
         # The user's checkout never saw the marker or any merge state.

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -69,8 +69,10 @@ VALID_SECURITY_OUTPUT = json.dumps({
 
 class TestSecurityConfigDefaults:
     def test_defaults(self) -> None:
+        # R2.1: default aligned with the documented product default -
+        # security review is an opt-in extra LLM call.
         c = SecurityConfig()
-        assert c.mode == "advisory"
+        assert c.mode == "skip"
         assert c.timeout_seconds == 600.0
         assert c.fail_threshold == "high"
 


### PR DESCRIPTION
Implements **R2.1 (wire the six config loaders)** and **R2.2 (expose the safety knobs)** from `docs/remediation-roadmap.md` (CRIT-7, D-precedence). Flips both checkboxes in the same PR.

## BEHAVIOR CHANGE - read before merging

ralph.toml sections that were previously **silently ignored** by `ralph factory` and `ralph run` now take effect: `[factory]`, `[verify]`, `[security]`, `[contract]`, `[feedforward]`, `[evolution]`. An existing checkout with a ralph.toml written back when those sections did nothing will now behave differently. Mitigations shipped in this PR:

- `ralph factory` prints a `NOTE:` line at startup for every value a toml section moved off the CLI default (suppressed when an explicit flag overrides it).
- `ralph init` scaffolds ralph.toml with **every key commented out**, so scaffolding changes no effective value.

Two smaller deliberate changes:

- `SecurityConfig` dataclass default `mode` changed `advisory` -> `skip`, matching the documented product default (CLI `--security-mode` default, ralph.toml.example, README). No product path consumed the old default: the CLI always passed an explicit mode and `run_factory` treats a missing config as skip. Grep-verified; the only call sites constructing a bare `SecurityConfig()` were tests.
- `EvolutionConfig.load`/`from_env` now anchor relative journal/experiments paths to the **project root** instead of the process CWD, and `run_factory` / `ralph evolve` use `EvolutionConfig.load(root_dir)`. Running with `--root X` from elsewhere no longer scatters `.ralph/` state into the operator's CWD.

## What changed

- **Resolution order everywhere**: explicit CLI flag > env > ralph.toml > dataclass default. Phase-config click options moved to `default=None` sentinels so "not passed" is distinguishable from "passed the default value"; explicitly-passed flags are applied on top of the loaded config.
- **`ralph factory` and `ralph run`** build every phase config via `.load(root)` (Factory/Verify/Security/Contract/Feedforward/Timeout; Evolution and Knowledge are loaded inside `run_factory` via `load(root_dir)`).
- **R2.2 safety knobs**: `FactoryConfig.load` reads `max_adversarial_calls` and `pause_before_pr_merge` from toml; new `RALPH_FACTORY_MAX_ADVERSARIAL_CALLS` / `RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE` env vars; new `--max-adversarial-calls` / `--pause-before-pr-merge/--no-pause-before-pr-merge` flags. Documented in `docs/env-vars.md`. (Budget exhaustion already emits the R1.2 synthetic finding: `test_review_gates.py::test_budget_exhaustion_emits_finding_and_journal_event`.)
- **`from_env` added** to `FeedforwardConfig`, `EvolutionConfig`, `KnowledgeConfig`.
- **VerifyConfig.load precedence bug fixed**: the env overlay compared env-derived values to dataclass defaults and dropped matches, so e.g. `RALPH_MUTATION_THRESHOLD=50` could not override a toml `mutation_threshold = 75`. Now each var applies iff explicitly set. Also reads `dead_code_command` / `mutation_timeout` toml keys.
- **`ralph run`**: structural fields stay forced (max_parallel=1, no worktrees, no PRs, no contract phase); tunables (max_retries, max_adversarial_calls, [verify]/[security]/[feedforward]) resolve via loaders; review stays advisory unless `[factory].review_mode` is explicitly set in toml. R2.3's `skip_verification` sentinel preserved through the rebase.
- **`ralph init`** scaffolds a fully commented ralph.toml mirroring ralph.toml.example trimmed to keys the loaders actually read, plus the `[timeout]` section (R0.1).

### Scope note

`factory.py` was touched beyond "FactoryConfig.load keys" in one way: the two `EvolutionConfig()` call sites inside `run_factory` became `EvolutionConfig.load(root_dir)`. Requirement 2 ("every phase config via .load(root)") is not satisfiable for evolution any other way, because evolution config is consumed inside `run_factory`, not built in the CLI. `docs/env-vars.md` was touched for R2.2's "documented" requirement.

## Checks (final lines)

```
uv run pytest tests/ -q        -> 957 passed, 12 skipped, 1 warning in 73.48s (0:01:13)
uv run mypy ralph_py/ --strict -> Success: no issues found in 37 source files
uv run ruff check ralph_py/ tests/ -> All checks passed!
```

## Tested (proven by named tests, all in tests/test_config_control_plane.py unless noted)

- Nine-section toml round-trips through the real CLI construction path (run_factory replaced by a capturing fake; assertions on the exact config object the orchestrator receives):
  - `[factory]`, `[verify]`, `[security]`, `[contract]`, `[feedforward]`, `[timeout]`, and RalphConfig's `[agent]`/`[run]` via `ralph factory`: `TestFactoryCommandTomlRoundTrip` (8 tests, incl. `[contract] mode="skip"` -> no contract config).
  - `[verify]`/`[security]`/`[feedforward]`/`[factory]` tunables via `ralph run`: `TestRunCommandTomlRoundTrip`, including forced single-component structure and review-mode advisory default vs toml opt-in.
  - `[evolution]` via `ralph evolve`: `TestEvolveCommandTomlRoundTrip` (enabled=false stops the command; journal_path reaches EvolutionJournal resolved against --root).
  - `[knowledge]`: loader round-trip `TestKnowledgeSectionRoundTrip` (consumed inside run_factory at its existing `KnowledgeConfig.load(root_dir)` call site).
- Precedence flag > env > toml for factory (`max_parallel`), verify (`test_command`), security (`mode`): `TestPrecedence`; regression `test_verify_env_equal_to_default_still_beats_toml`.
- Both safety knobs reachable via all three surfaces, including env-false-beats-toml-true and negated flag: `TestSafetyKnobs`.
- NOTE lines: emitted for toml-moved values, suppressed when the flag overrides, absent without toml: `TestTomlNotes`.
- New `from_env` for feedforward/evolution/knowledge (+ knowledge scope validation, factory knob env vars): `TestNewFromEnv`.
- Scaffold: created by `ralph init`, parses, sections exact, all keys commented (neutral), existing file never overwritten, every scaffold key checked against per-loader key sets, uncommented scaffold loads through all nine loaders: `TestInitScaffold`.
- Evolution journal anchored to factory root: `tests/test_contract_safety.py` journal helpers updated to read `<root>/.ralph/evolution.jsonl` and still see contract_result events for pass AND fail.
- SecurityConfig default: `tests/test_security.py::TestSecurityConfigDefaults` updated to `skip`.

## Assumed (claimed but not directly tested)

- run_factory's internal consumption of KnowledgeConfig/EvolutionConfig beyond loading (fact retrieval, journal writes) is unchanged apart from path anchoring; evidence is the existing test_knowledge/test_contract_safety/test_factory suites staying green, not new direct tests of run_factory reading a `[knowledge]` toml section.
- The NOTE sweep isolates toml contributions by comparing `load(root)` against an env-only `from_env()` baseline; this assumes each loader's env overlay is identical on both paths (true by inspection for all current loaders, not property-tested).
- No external consumer relied on `SecurityConfig()` defaulting to advisory (grep evidence only).
- ralph.toml.example was intentionally not modified (outside session scope); the scaffold mirrors it trimmed to real keys. R2.5 doc generation will reconcile the two.
- `--single-pr` continues to feed decompose only; the manifest stays authoritative for the factory config's single_pr (excluded from the NOTE sweep for that reason).

Roadmap: flips R2.1 and R2.2 to `[x]` in docs/remediation-roadmap.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
