### PR TITLE
fix: R1.4 truncated-diff policy + security strip parity (H-16)

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -174,11 +174,24 @@ reviewers' output as much as it distrusts the engineer's.
   - `git.get_diff_content` returns a result object (content | error) or raises;
     `factory.py:593` maps error to `infrastructure_error` for all three
     consumers instead of reviewing an empty string.
-- [ ] R1.4 (M) **Truncated-diff policy + security parity** [H-16]
+- [x] R1.4 (M) **Truncated-diff policy + security parity** [H-16]
   - Hard mode: a truncated diff is not silently reviewable. Chunk the diff and
     run multiple review passes (bounded by budget), or fail with an infra
     finding. Advisory mode: annotate PASS as partial.
   - Strip the Self-Critique block for the security reviewer too (`security.py:377`).
+  - Note (2026-07-18, session 4A): `git.split_diff_for_prompt` chunks on file
+    boundaries (reassembly-lossless; single file over the cap raises
+    `DiffUnsplittableError` and fails the component closed). Hard mode runs
+    `run_chunked_review` / `run_chunked_security_review`: one budget call per
+    chunk, any chunk failure fails, budget-insufficient chunking is a direct
+    infra-fail with zero passes run (no retries: budget only shrinks).
+    Advisory results carry `partial=True` + an injected finding + a PARTIAL
+    PR-body banner. Factory strips Self-Critique once into a shared reviewer
+    diff for Phase 2 AND 2.5; both phase entrypoints strip on their
+    fetch-fallback path and fail closed (backstop) if handed an unchunked
+    oversized diff in hard mode. Knowledge distiller input (still head-
+    truncated, unstripped) stays out of scope per the session prompt.
+    Reviewer-facing chunk/truncation DIRECTIVE remains Session 8C's.
 - [x] R1.5 (M) **Scope-guard hardening** [H-4, H-5, MED scope-none-fallthrough]
   - `git.get_diff_names`: use `--name-status -M`; rename/copy sources count as
     changed paths for scope purposes.

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -36,11 +36,17 @@ from ralph_py.manifest import Component, ComponentStatus, Manifest
 from ralph_py.observability import NullProgressLog, ProgressLog
 from ralph_py.pr import create_prs_in_order, create_single_pr
 from ralph_py.prd import PRD
-from ralph_py.review import ReviewMode, ReviewResult, run_review
+from ralph_py.review import (
+    ReviewMode,
+    ReviewResult,
+    run_chunked_review,
+    run_review,
+)
 from ralph_py.security import (
     SecurityConfig,
     SecurityMode,
     SecurityResult,
+    run_chunked_security_review,
     run_security_review,
 )
 from ralph_py.timeout import TimeoutConfig
@@ -980,6 +986,9 @@ def _run_factory_locked(
     # knowledge phases. When max_adversarial_calls is 0 the budget is
     # unbounded (current behavior); otherwise we skip the LLM phase
     # once the budget is exhausted, with an informational log line.
+    # R1.4 exception: hard-mode chunked reviews never skip-on-exhausted;
+    # they either cover every chunk (one call each) or fail the
+    # component as an infrastructure error.
     adversarial_calls: dict[str, int] = {"count": 0}
 
     def _adversarial_budget_ok() -> bool:
@@ -990,6 +999,15 @@ def _run_factory_locked(
 
     def _adversarial_budget_consume() -> None:
         adversarial_calls["count"] += 1
+
+    def _adversarial_budget_remaining() -> int | None:
+        """Calls left in the budget, or None when unbounded (R1.4:
+        chunked reviews need one call per chunk and must know whether
+        the whole diff can be covered before starting)."""
+        cap = factory_config.max_adversarial_calls
+        if cap <= 0:
+            return None
+        return max(0, cap - adversarial_calls["count"])
 
     def _path_relative_to_root(path: Path) -> str:
         """Render `path` relative to root_dir for use inside per-component
@@ -1035,14 +1053,23 @@ def _run_factory_locked(
                 f"{error[:80]}"
             )
             time.sleep(factory_config.retry_delay)
+            manifest.save(manifest_path)
         else:
-            comp.status = ComponentStatus.FAILED.value
-            comp.error = error
-            skipped = manifest.cascade_skip(comp.id)
-            factory_result.failed.append(comp.id)
-            factory_result.skipped.extend(skipped)
-            progress_log.component_failed(comp.id, error)
-            ui.err(f"  Failed: {comp.id}: {error[:80]}")
+            _fail_component(comp, error)
+
+    def _fail_component(comp: Component, error: str) -> None:
+        """Mark a component FAILED with no retry. Direct callers are
+        conditions a retry can never fix (R1.4: chunked-review budget
+        insufficiency - the adversarial budget only shrinks, so
+        re-running the engineer would burn LLM calls to hit the same
+        wall); _retry_or_fail routes here once retries are exhausted."""
+        comp.status = ComponentStatus.FAILED.value
+        comp.error = error
+        skipped = manifest.cascade_skip(comp.id)
+        factory_result.failed.append(comp.id)
+        factory_result.skipped.extend(skipped)
+        progress_log.component_failed(comp.id, error)
+        ui.err(f"  Failed: {comp.id}: {error[:80]}")
         manifest.save(manifest_path)
 
     def _handle_result(comp_id: str, comp_result: ComponentResult) -> None:
@@ -1206,12 +1233,90 @@ def _run_factory_locked(
             root_dir / ".ralph" / "debug" / run_id / comp_id
         )
 
-        # PHASE 2: Second-opinion review
+        # R1.4: strip the engineer's Self-Critique block ONCE and share
+        # the stripped diff with BOTH reviewers (E2 anti-anchoring now
+        # applies to Phase 2.5 too, not just Phase 2). The knowledge
+        # distiller keeps the unstripped shared_diff: the self-critique
+        # is the engineer's own account, and anti-anchoring targets
+        # adversarial reviewers, not the distiller.
+        review_diff = _git_for_diff.strip_self_critique_from_diff(shared_diff)
+
+        # R1.4 (H-16): a diff over the prompt cap must never be
+        # partially reviewed in hard mode - a rogue engineer could pad
+        # the first 50KB with benign churn and land a malicious hunk
+        # after the cut. Split once on file boundaries; both hard-mode
+        # phases reuse the same chunks (one budget call per chunk).
+        # Advisory phases keep the single truncated pass, which
+        # run_review/run_security_review annotate as PARTIAL.
         review_mode = ReviewMode(factory_config.review_mode)
+        sec_config = factory_config.security_config
+        oversized = (
+            len(review_diff) > _git_for_diff.DEFAULT_PROMPT_DIFF_CHAR_LIMIT
+        )
+        needs_chunks = oversized and (
+            review_mode == ReviewMode.HARD
+            or (
+                sec_config is not None
+                and sec_config.mode == SecurityMode.HARD.value
+            )
+        )
+        review_chunks: list[str] | None = None
+        if needs_chunks:
+            try:
+                review_chunks = _git_for_diff.split_diff_for_prompt(
+                    review_diff,
+                )
+            except _git_for_diff.DiffUnsplittableError as exc:
+                # Fail closed via the retry path: unlike budget
+                # exhaustion, the engineer CAN fix this by producing a
+                # smaller diff, so the retry context carries the signal.
+                ui.err(f"  Diff unsplittable for {comp_id}: {exc}")
+                comp.findings.append(Finding.infrastructure_error(
+                    phase="review",
+                    explanation=(
+                        "Hard-mode review requires chunking the "
+                        f"oversized diff, but it cannot be split: {exc} "
+                        "(R1.4: an unreviewable diff must not merge)"
+                    ),
+                ))
+                progress_log.emit(
+                    "diff_unsplittable", comp_id,
+                    {"error": str(exc), "diff_chars": len(review_diff)},
+                )
+                ctx = IterationContext.from_json(
+                    comp_result.context_json or "{}",
+                )
+                ctx.add_review_finding(
+                    f"The diff is too large to review ({exc}). Reduce "
+                    "the change so each file's diff fits the "
+                    f"{_git_for_diff.DEFAULT_PROMPT_DIFF_CHAR_LIMIT // 1000}"
+                    "KB review cap."
+                )
+                _retry_or_fail(
+                    comp,
+                    f"Review diff unsplittable at the prompt cap: {exc}",
+                    ctx.to_json(),
+                )
+                return
+            progress_log.emit(
+                "diff_chunked", comp_id,
+                {
+                    "chunks": len(review_chunks),
+                    "diff_chars": len(review_diff),
+                },
+            )
+
+        # PHASE 2: Second-opinion review
+        chunked_review = (
+            review_mode == ReviewMode.HARD and review_chunks is not None
+        )
         review_skip_reason: str | None = None
         if review_mode == ReviewMode.SKIP:
             review_skip_reason = "review disabled (mode=skip)"
-        elif not _adversarial_budget_ok():
+        elif not chunked_review and not _adversarial_budget_ok():
+            # Chunked hard-mode reviews never downgrade to SKIP on an
+            # exhausted budget: their budget rule is "cover every chunk
+            # or fail as infrastructure" (handled below).
             ui.warn(
                 f"  Phase 2 SKIPPED for {comp_id}: "
                 f"adversarial LLM budget ({factory_config.max_adversarial_calls}) exhausted"
@@ -1221,9 +1326,47 @@ def _run_factory_locked(
                 f"({factory_config.max_adversarial_calls}) exhausted"
             )
             review_mode = ReviewMode.SKIP
+        if review_mode == ReviewMode.HARD and review_chunks is not None:
+            remaining = _adversarial_budget_remaining()
+            if remaining is not None and remaining < len(review_chunks):
+                # R1.4: the budget cannot cover the chunks. Retrying
+                # cannot recover budget, so fail directly instead of
+                # burning engineer iterations on a deterministic wall.
+                error = (
+                    f"Chunked review needs {len(review_chunks)} "
+                    f"adversarial calls but only {remaining} remain in "
+                    f"max_adversarial_calls "
+                    f"({factory_config.max_adversarial_calls}); refusing "
+                    "a partial hard-mode review (R1.4)"
+                )
+                ui.err(f"  Phase 2 FAILED for {comp_id}: {error}")
+                comp.review_passed = False
+                comp.findings.append(Finding.infrastructure_error(
+                    phase="review", explanation=error,
+                ))
+                progress_log.emit(
+                    "chunk_budget_insufficient", comp_id,
+                    {
+                        "phase": "review",
+                        "chunks": len(review_chunks),
+                        "remaining": remaining,
+                    },
+                )
+                _fail_component(
+                    comp, f"Review infrastructure error: {error}",
+                )
+                return
         if review_mode != ReviewMode.SKIP:
-            _adversarial_budget_consume()
-            ui.info(f"  Phase 2: review ({review_mode.value}) for {comp_id}...")
+            if not chunked_review:
+                _adversarial_budget_consume()
+            chunk_note = (
+                f", {len(review_chunks)} chunks"
+                if chunked_review and review_chunks is not None else ""
+            )
+            ui.info(
+                f"  Phase 2: review ({review_mode.value}{chunk_note}) "
+                f"for {comp_id}..."
+            )
 
             # R1.2: wrap the agent-driven work like Phase 2.5 does. A
             # reviewer crash degrades to a per-component infrastructure
@@ -1235,17 +1378,34 @@ def _run_factory_locked(
                     None,
                     factory_config.review_agent_type or base_config.agent_type,
                 )
-                review_result = run_review(
-                    review_agent,
-                    wt_path / comp.prd_path,
-                    wt_path,
-                    manifest.base_branch,
-                    verification,
-                    review_mode,
-                    ui,
-                    diff_content=shared_diff,
-                    debug_dir=adversarial_debug_dir,
-                )
+                if review_mode == ReviewMode.HARD and review_chunks is not None:
+                    # R1.4: one pass per chunk, each consuming budget;
+                    # any chunk failure fails the merged result.
+                    review_result = run_chunked_review(
+                        review_agent,
+                        wt_path / comp.prd_path,
+                        wt_path,
+                        manifest.base_branch,
+                        verification,
+                        review_mode,
+                        ui,
+                        diff_chunks=review_chunks,
+                        budget_remaining=_adversarial_budget_remaining(),
+                        consume_budget=_adversarial_budget_consume,
+                        debug_dir=adversarial_debug_dir,
+                    )
+                else:
+                    review_result = run_review(
+                        review_agent,
+                        wt_path / comp.prd_path,
+                        wt_path,
+                        manifest.base_branch,
+                        verification,
+                        review_mode,
+                        ui,
+                        diff_content=review_diff,
+                        debug_dir=adversarial_debug_dir,
+                    )
             except Exception as exc:  # noqa: BLE001
                 ui.warn(f"  Review crashed: {exc}")
                 review_result = ReviewResult(
@@ -1298,7 +1458,13 @@ def _run_factory_locked(
         # it catches what the correctness reviewer misses. Hard-mode
         # fails the component on findings at or above
         # SecurityConfig.fail_threshold OR on infrastructure errors.
-        sec_config = factory_config.security_config
+        # (sec_config was resolved above, where the R1.4 chunking
+        # decision needed it.)
+        chunked_security = (
+            sec_config is not None
+            and sec_config.mode == SecurityMode.HARD.value
+            and review_chunks is not None
+        )
         if sec_config is None:
             _record_phase_skip(
                 "security", "security review not configured",
@@ -1307,7 +1473,10 @@ def _run_factory_locked(
             _record_phase_skip(
                 "security", "security review disabled (mode=skip)",
             )
-        elif not _adversarial_budget_ok():
+        elif not chunked_security and not _adversarial_budget_ok():
+            # As with Phase 2: chunked hard-mode security never
+            # downgrades to SKIP on an exhausted budget - it covers
+            # every chunk or fails as infrastructure below.
             ui.warn(
                 f"  Phase 2.5 SKIPPED for {comp_id}: "
                 f"adversarial LLM budget exhausted"
@@ -1316,12 +1485,52 @@ def _run_factory_locked(
                 "security", "adversarial LLM budget exhausted",
             )
             sec_config = None
+        if (
+            sec_config is not None
+            and sec_config.mode == SecurityMode.HARD.value
+            and review_chunks is not None
+        ):
+            remaining = _adversarial_budget_remaining()
+            if remaining is not None and remaining < len(review_chunks):
+                # R1.4: same rule as Phase 2 - budget cannot cover the
+                # chunks, and retrying cannot recover budget.
+                error = (
+                    f"Chunked security review needs {len(review_chunks)} "
+                    f"adversarial calls but only {remaining} remain in "
+                    f"max_adversarial_calls "
+                    f"({factory_config.max_adversarial_calls}); refusing "
+                    "a partial hard-mode security review (R1.4)"
+                )
+                ui.err(f"  Phase 2.5 FAILED for {comp_id}: {error}")
+                comp.findings.append(Finding.infrastructure_error(
+                    phase="security", explanation=error,
+                ))
+                progress_log.emit(
+                    "chunk_budget_insufficient", comp_id,
+                    {
+                        "phase": "security",
+                        "chunks": len(review_chunks),
+                        "remaining": remaining,
+                    },
+                )
+                _fail_component(
+                    comp, f"Security review infrastructure error: {error}",
+                )
+                return
         if sec_config and sec_config.mode != SecurityMode.SKIP.value:
-            _adversarial_budget_consume()
+            if not chunked_security:
+                # Chunked passes consume per-chunk inside
+                # run_chunked_security_review instead.
+                _adversarial_budget_consume()
             from ralph_py.agents import get_agent as _get_sec_agent
 
+            chunk_note = (
+                f", {len(review_chunks)} chunks"
+                if chunked_security and review_chunks is not None else ""
+            )
             ui.info(
-                f"  Phase 2.5: security review ({sec_config.mode}) for {comp_id}..."
+                f"  Phase 2.5: security review "
+                f"({sec_config.mode}{chunk_note}) for {comp_id}..."
             )
             sec_result = None
             # The try/except deliberately wraps ONLY the agent-driven
@@ -1337,16 +1546,36 @@ def _run_factory_locked(
                     base_config.model_reasoning_effort,
                     sec_config.agent_type or base_config.agent_type,
                 )
-                sec_result = run_security_review(
-                    sec_agent,
-                    wt_path / comp.prd_path,
-                    wt_path,
-                    manifest.base_branch,
-                    sec_config,
-                    ui,
-                    diff_content=shared_diff,
-                    debug_dir=adversarial_debug_dir,
-                )
+                if (
+                    sec_config.mode == SecurityMode.HARD.value
+                    and review_chunks is not None
+                ):
+                    # R1.4: one pass per chunk, each consuming budget
+                    # via consume_budget; any chunk failure fails the
+                    # merged result.
+                    sec_result = run_chunked_security_review(
+                        sec_agent,
+                        wt_path / comp.prd_path,
+                        wt_path,
+                        manifest.base_branch,
+                        sec_config,
+                        ui,
+                        diff_chunks=review_chunks,
+                        budget_remaining=_adversarial_budget_remaining(),
+                        consume_budget=_adversarial_budget_consume,
+                        debug_dir=adversarial_debug_dir,
+                    )
+                else:
+                    sec_result = run_security_review(
+                        sec_agent,
+                        wt_path / comp.prd_path,
+                        wt_path,
+                        manifest.base_branch,
+                        sec_config,
+                        ui,
+                        diff_content=review_diff,
+                        debug_dir=adversarial_debug_dir,
+                    )
             except Exception as exc:  # noqa: BLE001
                 # Agent infrastructure failed before run_security_review
                 # could classify the outcome. Synthesize an infra result

--- a/ralph_py/git.py
+++ b/ralph_py/git.py
@@ -407,6 +407,112 @@ def truncate_diff_for_prompt(
     return diff_content[:limit] + f"\n... (diff truncated at {limit // 1000}KB)"
 
 
+class DiffUnsplittableError(ValueError):
+    """An oversized diff cannot be split into <=limit chunks on file
+    boundaries: a single file's diff alone exceeds the limit (or the
+    diff has no ``diff --git`` boundaries at all).
+
+    R1.4 (H-16): hard-mode callers must treat this as fail-closed - the
+    diff cannot be fully reviewed, so it must not merge."""
+
+
+# Start of a per-file segment in `git diff` output. Anchored to line
+# start so a "diff --git" string INSIDE a hunk (e.g. a diff quoted in a
+# test fixture) only splits when it begins a line - the worst case of a
+# crafted in-hunk marker is a smaller-than-necessary chunk, never
+# dropped content, because chunks are contiguous slices of the input.
+_DIFF_FILE_BOUNDARY_RE = _re.compile(r"^diff --git ", _re.MULTILINE)
+
+# Headroom reserved inside each chunk for the one-line provenance
+# header split_diff_for_prompt prepends, so header + content <= limit.
+_CHUNK_HEADER_RESERVE = 120
+
+
+def split_diff_for_prompt(
+    diff_content: str, limit: int = DEFAULT_PROMPT_DIFF_CHAR_LIMIT,
+) -> list[str]:
+    """R1.4 (H-16): split an oversized diff into chunks on ``diff --git``
+    file boundaries, each at most ``limit`` chars including a one-line
+    provenance header, so every byte of the diff can be reviewed across
+    multiple passes instead of head-truncating (which lets a rogue
+    engineer pad the first 50KB with benign churn and land a malicious
+    hunk after the cut).
+
+    Returns ``[diff_content]`` unchanged when it already fits. Raises
+    :class:`DiffUnsplittableError` when file-boundary splitting cannot
+    produce compliant chunks (single file over the limit, or no file
+    boundaries found).
+
+    Invariant: concatenating the chunks with their header lines removed
+    reproduces the input exactly - chunking never drops content.
+    """
+    if limit <= _CHUNK_HEADER_RESERVE:
+        raise ValueError(
+            f"limit must exceed the {_CHUNK_HEADER_RESERVE}-char header "
+            f"reserve, got {limit}"
+        )
+    if len(diff_content) <= limit:
+        return [diff_content]
+
+    boundaries = [
+        m.start() for m in _DIFF_FILE_BOUNDARY_RE.finditer(diff_content)
+    ]
+    if not boundaries:
+        raise DiffUnsplittableError(
+            f"diff is {len(diff_content)} chars (limit {limit}) but "
+            "contains no 'diff --git' file boundaries to split on"
+        )
+
+    # Per-file segments; any preamble before the first boundary becomes
+    # its own leading segment so no content is lost.
+    starts = [0] if boundaries[0] != 0 else []
+    starts.extend(boundaries)
+    segments = [
+        diff_content[start:end]
+        for start, end in zip(
+            starts, starts[1:] + [len(diff_content)], strict=True,
+        )
+    ]
+
+    budget = limit - _CHUNK_HEADER_RESERVE
+    for seg in segments:
+        if len(seg) > budget:
+            first_line = seg.split("\n", 1)[0][:200]
+            raise DiffUnsplittableError(
+                f"single-file diff segment is {len(seg)} chars, over the "
+                f"{budget}-char per-chunk budget; cannot split on file "
+                f"boundaries ({first_line})"
+            )
+
+    # Greedy packing preserves segment order, so contiguity (and the
+    # reassembly invariant) holds.
+    packed: list[list[str]] = [[]]
+    size = 0
+    for seg in segments:
+        if packed[-1] and size + len(seg) > budget:
+            packed.append([])
+            size = 0
+        packed[-1].append(seg)
+        size += len(seg)
+
+    total = len(packed)
+    chunks = []
+    for i, group in enumerate(packed, 1):
+        # Provenance only, no reviewer directives: prompt-body guidance
+        # about truncated/chunked diffs is Session 8C's calibrated change.
+        header = (
+            f"# [ralph R1.4] diff chunk {i} of {total}: oversized diff "
+            f"split on file boundaries; other files are in other chunks\n"
+        )
+        chunk = header + "".join(group)
+        if len(chunk) > limit:  # defensive: budget math above prevents this
+            raise DiffUnsplittableError(
+                f"chunk {i}/{total} is {len(chunk)} chars, over limit {limit}"
+            )
+        chunks.append(chunk)
+    return chunks
+
+
 # E2: regex matches a Self-Critique block in a diff. Used by the
 # reviewer-prep step to remove the engineer's self-reported failure
 # modes from what the reviewer sees, so the reviewer is not biased

--- a/ralph_py/review.py
+++ b/ralph_py/review.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -111,6 +111,13 @@ class ReviewResult:
     # downstream callers can distinguish "clean review found nothing"
     # from "review never actually happened".
     infrastructure_error: bool = False
+    # R1.4 (H-16): True when the reviewed diff was truncated at the
+    # prompt cap, i.e. the verdict covers only a prefix of the change.
+    # Advisory mode may pass a partial review, but the pass must be
+    # visibly partial (PR body annotation + an advisory concern);
+    # hard mode never accepts a partial review - the factory chunks
+    # the diff and runs one pass per chunk instead.
+    partial: bool = False
 
     def as_retry_context(self) -> str:
         """Format failing/advisory findings for injection into retry prompt."""
@@ -154,6 +161,12 @@ class ReviewResult:
             f"{criterion_adv} advisory; "
             f"{len(self.concerns)} additional concerns**"
         )
+        if self.partial:
+            lines.append("")
+            lines.append(
+                "**PARTIAL REVIEW (R1.4): the diff exceeded the prompt "
+                "size cap; only a truncated prefix was reviewed**"
+            )
         lines.append("")
 
         for cr in self.criteria:
@@ -383,9 +396,12 @@ def build_review_prompt(
     """Assemble the full reviewer prompt.
 
     ``diff_content`` may be pre-fetched by the caller (e.g. the factory
-    hoists git.get_diff_content to component scope and reuses the result
-    across Phase 2, 2.5, and knowledge distillation). When None, the
-    diff is fetched here for backward compatibility.
+    hoists git.get_diff_content to component scope, strips the
+    Self-Critique block ONCE, and shares the result with Phase 2 and
+    2.5). A provided diff is used as-is apart from the size cap: the
+    caller owns Self-Critique hygiene (R1.4 - one strip in the factory
+    instead of one per phase). When None, the diff is fetched AND
+    stripped here (E2).
     """
     prd = PRD.load(prd_path)
     prd_lines: list[str] = []
@@ -397,10 +413,10 @@ def build_review_prompt(
 
     if diff_content is None:
         diff_content = git.get_diff_content(base_branch, worktree_path)
-    # E2: hide the engineer's Self-Critique block from the reviewer.
-    # Otherwise the reviewer sees "Failure mode 1: X" inline and may
-    # uncritically conclude X is handled.
-    diff_content = git.strip_self_critique_from_diff(diff_content)
+        # E2: hide the engineer's Self-Critique block from the reviewer.
+        # Otherwise the reviewer sees "Failure mode 1: X" inline and may
+        # uncritically conclude X is handled.
+        diff_content = git.strip_self_critique_from_diff(diff_content)
     diff_content = git.truncate_diff_for_prompt(diff_content)
 
     verify_lines: list[str] = []
@@ -595,7 +611,16 @@ def run_review(
     ui.info("  Running second-opinion review...")
     start = time.monotonic()
 
+    truncated = False
     try:
+        if diff_content is None:
+            # Same fallback contract as build_review_prompt: fetch AND
+            # strip the Self-Critique block (E2) when the caller did
+            # not provide a pre-stripped diff.
+            diff_content = git.get_diff_content(base_branch, worktree_path)
+            diff_content = git.strip_self_critique_from_diff(diff_content)
+        # R1.4: anything past the cap is invisible to the reviewer.
+        truncated = len(diff_content) > git.DEFAULT_PROMPT_DIFF_CHAR_LIMIT
         prompt = build_review_prompt(
             prd_path, worktree_path, base_branch, verification_result,
             diff_content=diff_content,
@@ -642,6 +667,42 @@ def run_review(
     result.mode = mode.value
     result.duration_seconds = time.monotonic() - start
 
+    if truncated and not result.infrastructure_error:
+        # R1.4: the verdict covers only a prefix of the diff. Advisory
+        # mode may pass, but visibly: flag the result and inject an
+        # advisory concern so the PR body, findings stream, and retry
+        # context all say "partial".
+        result.partial = True
+        result.concerns.append(ReviewConcern(
+            category="other",
+            severity="advisory",
+            location="",
+            explanation=(
+                "Partial review (R1.4): the diff exceeded the "
+                f"{git.DEFAULT_PROMPT_DIFF_CHAR_LIMIT // 1000}KB prompt "
+                "cap and only the truncated prefix was reviewed; "
+                "anything past the cut is unreviewed."
+            ),
+            suggestion=(
+                "Split the component or reduce the diff so the full "
+                "change fits one review pass."
+            ),
+        ))
+        if mode == ReviewMode.HARD:
+            # Backstop, not the primary path: the factory chunks
+            # oversized diffs before calling us (run_chunked_review).
+            # Reaching this branch means a caller bypassed that policy,
+            # and hard mode must never approve a partially visible diff
+            # (H-16: the unreviewed tail would merge). Fail closed as
+            # infrastructure - the review did not fully happen.
+            result.passed = False
+            result.infrastructure_error = True
+            result.overall_notes = (
+                "Hard-mode review received an oversized diff without "
+                "chunking; the unreviewed tail cannot be approved "
+                "(R1.4). " + result.overall_notes
+            ).strip()
+
     # In advisory mode, downgrade all FAILs and force pass
     if mode == ReviewMode.ADVISORY:
         for cr in result.criteria:
@@ -653,9 +714,107 @@ def run_review(
         result.passed = True
 
     status = "passed" if result.passed else "FAILED"
+    partial_note = " (PARTIAL: diff truncated)" if result.partial else ""
     ui.info(
-        f"  Review {status}: "
+        f"  Review {status}{partial_note}: "
         f"{result.fail_count} fail, {result.advisory_count} advisory"
     )
 
     return result
+
+
+def merge_review_results(
+    results: list[ReviewResult], mode: str,
+) -> ReviewResult:
+    """R1.4: merge the per-chunk results of a chunked review into one.
+
+    Policy (H-16): any chunk failure fails the merged result; criteria
+    and concerns concatenate; any chunk infrastructure error marks the
+    merged result as an infrastructure error (the review did not fully
+    happen). ``exhaustively_searched`` survives only when every chunk
+    claimed it (hint, never a gate).
+
+    Known limitation, documented on purpose: when a chunk infra-errors,
+    ``as_findings()`` renders only the infrastructure finding (its
+    contract: an errored review has no trustworthy findings), while the
+    concatenated criteria/concerns stay visible in the PR body and
+    retry context via ``as_pr_body_section``/``as_retry_context``.
+    """
+    if not results:
+        raise ValueError("merge_review_results requires at least one result")
+    n = len(results)
+    merged = ReviewResult(
+        passed=all(r.passed for r in results),
+        mode=mode,
+        infrastructure_error=any(r.infrastructure_error for r in results),
+        exhaustively_searched=all(r.exhaustively_searched for r in results),
+        partial=any(r.partial for r in results),
+    )
+    notes = [f"Chunked review: {n} passes over an oversized diff (R1.4)."]
+    raw_parts: list[str] = []
+    for i, r in enumerate(results, 1):
+        merged.criteria.extend(r.criteria)
+        merged.concerns.extend(r.concerns)
+        merged.duration_seconds += r.duration_seconds
+        if r.overall_notes:
+            notes.append(f"[chunk {i}/{n}] {r.overall_notes}")
+        raw_parts.append(f"--- chunk {i}/{n} ---\n{r.raw_output}")
+    merged.overall_notes = "\n".join(notes)
+    merged.raw_output = "\n".join(raw_parts)
+    return merged
+
+
+def run_chunked_review(
+    agent: Agent,
+    prd_path: Path,
+    worktree_path: Path,
+    base_branch: str,
+    verification_result: VerificationResult,
+    mode: ReviewMode,
+    ui: UI,
+    diff_chunks: list[str],
+    timeout: float = 600.0,
+    *,
+    budget_remaining: int | None = None,
+    consume_budget: Callable[[], None] | None = None,
+    debug_dir: Path | None = None,
+) -> ReviewResult:
+    """R1.4 (H-16): review an oversized diff chunk by chunk, one agent
+    pass per chunk, and merge the verdicts.
+
+    Every pass counts against the adversarial budget via
+    ``consume_budget``. When ``budget_remaining`` cannot cover one pass
+    per chunk, NO pass runs and an infrastructure-error result is
+    returned: a diff that cannot be fully reviewed must fail loudly,
+    never pass partially. ``budget_remaining=None`` means unbounded.
+    """
+    n = len(diff_chunks)
+    if n == 0:
+        raise ValueError("run_chunked_review requires at least one chunk")
+    if budget_remaining is not None and budget_remaining < n:
+        return ReviewResult(
+            passed=False,
+            mode=mode.value,
+            overall_notes=(
+                f"Chunked review needs {n} adversarial calls for "
+                f"{n} diff chunks but only {budget_remaining} remain in "
+                "max_adversarial_calls; refusing to review the diff "
+                "partially (R1.4)"
+            ),
+            infrastructure_error=True,
+        )
+    results: list[ReviewResult] = []
+    for i, chunk in enumerate(diff_chunks, 1):
+        if consume_budget is not None:
+            consume_budget()
+        ui.info(f"    Review chunk {i}/{n}...")
+        results.append(run_review(
+            agent, prd_path, worktree_path, base_branch,
+            verification_result, mode, ui,
+            timeout=timeout,
+            diff_content=chunk,
+            # Per-chunk subdir: dump_raw_debug writes fixed filenames,
+            # so sharing one dir would overwrite earlier chunks' dumps.
+            debug_dir=debug_dir / f"chunk-{i}" if debug_dir else None,
+        ))
+    return merge_review_results(results, mode.value)

--- a/ralph_py/security.py
+++ b/ralph_py/security.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -113,6 +114,12 @@ class SecurityResult:
     # never actually happened" so hard-mode can fail loudly instead of
     # accidentally passing on infrastructure errors.
     infrastructure_error: bool = False
+    # R1.4 (H-16): True when the reviewed diff was truncated at the
+    # prompt cap - the verdict covers only a prefix of the change.
+    # Advisory mode may pass a partial review, but visibly (PR body
+    # annotation + a low-severity marker finding); hard mode never
+    # accepts one - the factory chunks the diff instead.
+    partial: bool = False
 
     def as_retry_context(self) -> str:
         """Format failing findings for injection into the implementer's
@@ -131,11 +138,17 @@ class SecurityResult:
         return "\n".join(lines)
 
     def as_pr_body_section(self) -> str:
+        partial_note = (
+            "\n\n**PARTIAL SECURITY REVIEW (R1.4): the diff exceeded the "
+            "prompt size cap; only a truncated prefix was reviewed**"
+            if self.partial else ""
+        )
         if not self.findings:
             return (
                 "## Security Review\n\n"
                 f"**No findings ({self.mode} mode, "
                 f"{'exhaustively' if self.exhaustively_searched else 'briefly'} searched)**"
+                + partial_note
             )
         lines = ["## Security Review", ""]
         crit = sum(1 for f in self.findings if f.severity == "critical")
@@ -146,6 +159,12 @@ class SecurityResult:
             f"**{crit} critical, {high} high, {med} medium, {low} low "
             f"({self.mode} mode)**"
         )
+        if self.partial:
+            lines.append("")
+            lines.append(
+                "**PARTIAL SECURITY REVIEW (R1.4): the diff exceeded the "
+                "prompt size cap; only a truncated prefix was reviewed**"
+            )
         lines.append("")
         for f in self.findings:
             lines.append(
@@ -502,6 +521,13 @@ def run_security_review(
 
     if diff_content is None:
         diff_content = git.get_diff_content(base_branch, worktree_path)
+        # R1.4: parity with Phase 2 (E2 anti-anchoring) - the security
+        # reviewer must not see the engineer's Self-Critique block
+        # either. The factory strips once and passes diff_content in;
+        # this covers direct callers on the fetch-it-myself path.
+        diff_content = git.strip_self_critique_from_diff(diff_content)
+    # R1.4: anything past the cap is invisible to the reviewer.
+    truncated = len(diff_content) > git.DEFAULT_PROMPT_DIFF_CHAR_LIMIT
     prompt = _build_security_prompt(prd_text, diff_content)
 
     try:
@@ -535,12 +561,144 @@ def run_security_review(
         result.passed = _passes_threshold(
             result.findings, mode, config.fail_threshold,
         )
+
+    if truncated and not result.infrastructure_error:
+        # R1.4: the verdict covers only a prefix of the diff. Mark the
+        # result and inject a low-severity marker finding so the PR
+        # body, findings stream, and retry context all say "partial"
+        # (low never trips the hard-mode threshold on its own).
+        result.partial = True
+        result.findings.append(SecurityFinding(
+            category="other",
+            severity="low",
+            location="",
+            explanation=(
+                "Partial security review (R1.4): the diff exceeded the "
+                f"{git.DEFAULT_PROMPT_DIFF_CHAR_LIMIT // 1000}KB prompt "
+                "cap and only the truncated prefix was reviewed; "
+                "anything past the cut is unreviewed."
+            ),
+            suggestion=(
+                "Split the component or reduce the diff so the full "
+                "change fits one review pass."
+            ),
+        ))
+        if mode == SecurityMode.HARD.value:
+            # Backstop, not the primary path: the factory chunks
+            # oversized diffs before calling us
+            # (run_chunked_security_review). Hard mode must never
+            # approve a partially visible diff (H-16). Fail closed as
+            # infrastructure - the review did not fully happen.
+            result.passed = False
+            result.infrastructure_error = True
+            result.overall_notes = (
+                "Hard-mode security review received an oversized diff "
+                "without chunking; the unreviewed tail cannot be "
+                "approved (R1.4). " + result.overall_notes
+            ).strip()
     result.duration_seconds = time.monotonic() - start
 
     status = "passed" if result.passed else "FAILED"
+    partial_note = " (PARTIAL: diff truncated)" if result.partial else ""
     ui.info(
-        f"  Security review {status}: "
+        f"  Security review {status}{partial_note}: "
         f"{result.critical_count} critical, {result.high_count} high, "
         f"{len(result.findings)} total"
     )
     return result
+
+
+def merge_security_results(
+    results: list[SecurityResult], mode: str,
+) -> SecurityResult:
+    """R1.4: merge the per-chunk results of a chunked security review.
+
+    Policy (H-16): any chunk failure fails the merged result; findings
+    concatenate; any chunk infrastructure error marks the merged result
+    as an infrastructure error (the review did not fully happen).
+    ``exhaustively_searched`` survives only when every chunk claimed it
+    (hint, never a gate). Same ``as_findings()`` limitation as
+    ``review.merge_review_results``: an infra-errored merge renders
+    only the infrastructure finding in the typed stream, while the
+    concatenated findings stay visible via ``as_pr_body_section``.
+    """
+    if not results:
+        raise ValueError(
+            "merge_security_results requires at least one result"
+        )
+    n = len(results)
+    merged = SecurityResult(
+        passed=all(r.passed for r in results),
+        mode=mode,
+        infrastructure_error=any(r.infrastructure_error for r in results),
+        exhaustively_searched=all(r.exhaustively_searched for r in results),
+        partial=any(r.partial for r in results),
+    )
+    notes = [
+        f"Chunked security review: {n} passes over an oversized diff "
+        "(R1.4)."
+    ]
+    raw_parts: list[str] = []
+    for i, r in enumerate(results, 1):
+        merged.findings.extend(r.findings)
+        merged.duration_seconds += r.duration_seconds
+        if r.overall_notes:
+            notes.append(f"[chunk {i}/{n}] {r.overall_notes}")
+        raw_parts.append(f"--- chunk {i}/{n} ---\n{r.raw_output}")
+    merged.overall_notes = "\n".join(notes)
+    merged.raw_output = "\n".join(raw_parts)
+    return merged
+
+
+def run_chunked_security_review(
+    agent: Agent,
+    prd_path: Path,
+    worktree_path: Path,
+    base_branch: str,
+    config: SecurityConfig,
+    ui: UI,
+    diff_chunks: list[str],
+    *,
+    budget_remaining: int | None = None,
+    consume_budget: Callable[[], None] | None = None,
+    debug_dir: Path | None = None,
+) -> SecurityResult:
+    """R1.4 (H-16): security-review an oversized diff chunk by chunk,
+    one agent pass per chunk, and merge the verdicts.
+
+    Every pass counts against the adversarial budget via
+    ``consume_budget``. When ``budget_remaining`` cannot cover one pass
+    per chunk, NO pass runs and an infrastructure-error result is
+    returned: a diff that cannot be fully reviewed must fail loudly,
+    never pass partially. ``budget_remaining=None`` means unbounded.
+    """
+    n = len(diff_chunks)
+    if n == 0:
+        raise ValueError(
+            "run_chunked_security_review requires at least one chunk"
+        )
+    if budget_remaining is not None and budget_remaining < n:
+        return SecurityResult(
+            passed=False,
+            mode=config.mode,
+            overall_notes=(
+                f"Chunked security review needs {n} adversarial calls "
+                f"for {n} diff chunks but only {budget_remaining} remain "
+                "in max_adversarial_calls; refusing to review the diff "
+                "partially (R1.4)"
+            ),
+            infrastructure_error=True,
+        )
+    results: list[SecurityResult] = []
+    for i, chunk in enumerate(diff_chunks, 1):
+        if consume_budget is not None:
+            consume_budget()
+        ui.info(f"    Security review chunk {i}/{n}...")
+        results.append(run_security_review(
+            agent, prd_path, worktree_path, base_branch, config, ui,
+            diff_content=chunk,
+            # Per-chunk subdir: dump_raw_debug writes fixed filenames,
+            # so sharing one dir would overwrite earlier chunks' dumps.
+            debug_dir=debug_dir / f"chunk-{i}" if debug_dir else None,
+        ))
+    return merge_security_results(results, config.mode)

--- a/tests/test_truncation_policy.py
+++ b/tests/test_truncation_policy.py
@@ -1,0 +1,816 @@
+"""R1.4 truncated-diff policy tests (H-16) + security strip parity.
+
+Head-truncating a review diff at the prompt cap let a rogue engineer pad
+the first 50KB with benign churn and land a malicious hunk after the
+cut: both reviewers saw a truncation notice, but hard mode had no
+policy, so the unreviewed tail merged. These tests prove the mechanical
+policy:
+
+- Oversized diffs split on file boundaries into <=cap chunks; splitting
+  never drops content; a single file over the cap is unsplittable and
+  fails closed.
+- Hard mode runs one review pass per chunk (each pass consumes the
+  adversarial budget) and merges verdicts: any chunk failure fails.
+- Budget that cannot cover the chunks is an infrastructure failure with
+  ZERO passes run - never a partial review, never a silent skip.
+- Advisory mode keeps the single truncated pass but the result is
+  visibly PARTIAL (flag + injected finding + PR body annotation).
+- The security reviewer no longer sees the engineer's Self-Critique
+  block (E2 anti-anchoring parity), and the factory strips it once for
+  both reviewers.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ralph_py.config import RalphConfig
+from ralph_py.factory import ComponentResult, FactoryConfig, run_factory
+from ralph_py.git import (
+    DEFAULT_PROMPT_DIFF_CHAR_LIMIT,
+    DiffUnsplittableError,
+    split_diff_for_prompt,
+)
+from ralph_py.manifest import Component, Manifest
+from ralph_py.review import (
+    ReviewMode,
+    ReviewResult,
+    merge_review_results,
+    run_chunked_review,
+    run_review,
+)
+from ralph_py.security import (
+    SecurityConfig,
+    SecurityMode,
+    SecurityResult,
+    merge_security_results,
+    run_chunked_security_review,
+    run_security_review,
+)
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import CheckResult, VerificationResult, VerifyConfig
+
+UI = PlainUI(no_color=True)
+
+_VERIFICATION = VerificationResult(
+    passed=True, checks=[CheckResult("test_suite", True, "ok")],
+)
+
+
+class CountingAgent:
+    """Agent that counts invocations, captures prompts, and replies with
+    the output at the current call index (last output repeats)."""
+
+    def __init__(self, outputs: list[str]):
+        self._outputs = outputs
+        self.calls = 0
+        self.prompts: list[str] = []
+        self._final_message: str | None = None
+
+    @property
+    def name(self) -> str:
+        return "counting-agent"
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        idx = min(self.calls, len(self._outputs) - 1)
+        self.calls += 1
+        self.prompts.append(prompt)
+        yield from self._outputs[idx].splitlines()
+
+    @property
+    def final_message(self) -> str | None:
+        return self._final_message
+
+
+def _story(story_id: str, verdict: str) -> dict[str, object]:
+    return {
+        "storyId": story_id,
+        "storyTitle": f"Story {story_id}",
+        "criteria": [{
+            "criterion": "AC1",
+            "verdict": verdict,
+            "explanation": "checked",
+            "suggestion": "",
+        }],
+    }
+
+
+def _review_json(verdict: str = "pass") -> str:
+    return json.dumps({
+        "stories": [_story("US-001", verdict)],
+        "concerns": [],
+        "exhaustively_searched": True,
+        "overallNotes": "",
+    })
+
+
+_CLEAN_SECURITY_JSON = json.dumps({
+    "findings": [],
+    "exhaustively_searched": True,
+    "overallNotes": "",
+})
+
+
+def _write_prd(path: Path, story_ids: list[str]) -> None:
+    path.write_text(json.dumps({
+        "branchName": "test",
+        "userStories": [
+            {
+                "id": sid, "title": f"Story {sid}",
+                "acceptanceCriteria": ["AC1"], "priority": 1,
+                "passes": True, "notes": "",
+            }
+            for sid in story_ids
+        ],
+    }))
+
+
+def _file_segment(name: str, payload_chars: int) -> str:
+    """One per-file segment of a synthetic unified diff, ~payload_chars
+    long."""
+    header = (
+        f"diff --git a/{name} b/{name}\n"
+        f"--- a/{name}\n"
+        f"+++ b/{name}\n"
+        "@@ -0,0 +1 @@\n"
+    )
+    line = "+" + "x" * 98 + "\n"
+    n_lines = max(1, (payload_chars - len(header)) // 100)
+    return header + line * n_lines
+
+
+def _synthetic_diff(n_files: int, payload_chars: int) -> str:
+    return "".join(
+        _file_segment(f"src/f{i}.py", payload_chars) for i in range(n_files)
+    )
+
+
+_SELF_CRITIQUE_DIFF = """\
+diff --git a/scripts/ralph/progress.txt b/scripts/ralph/progress.txt
++## Iteration 1 - US-001
++- What I did: added the function
++## Self-Critique
++- Failure mode 1: empty input crashes the parser
++- Failure mode 2: concurrent writes race
++---
++
+diff --git a/src/x.py b/src/x.py
++def add(a, b): return a + b
+"""
+
+
+# ---------------------------------------------------------------------------
+# split_diff_for_prompt mechanics
+# ---------------------------------------------------------------------------
+
+
+class TestSplitDiffForPrompt:
+    def test_small_diff_returned_unchanged(self) -> None:
+        diff = _synthetic_diff(2, 300)
+        assert split_diff_for_prompt(diff, limit=5000) == [diff]
+
+    def test_oversized_diff_splits_on_file_boundaries(self) -> None:
+        diff = _synthetic_diff(10, 300)
+        chunks = split_diff_for_prompt(diff, limit=1000)
+        assert len(chunks) >= 2
+        for i, chunk in enumerate(chunks, 1):
+            assert len(chunk) <= 1000
+            assert chunk.startswith(
+                f"# [ralph R1.4] diff chunk {i} of {len(chunks)}"
+            )
+        # Reassembly invariant: dropping each chunk's header line
+        # reproduces the input exactly - chunking never loses content.
+        reassembled = "".join(c.split("\n", 1)[1] for c in chunks)
+        assert reassembled == diff
+        # Every file boundary survives exactly once.
+        for i in range(10):
+            assert reassembled.count(f"diff --git a/src/f{i}.py") == 1
+
+    def test_preamble_before_first_boundary_is_kept(self) -> None:
+        diff = "binary files differ notice\n" + _synthetic_diff(6, 300)
+        chunks = split_diff_for_prompt(diff, limit=1000)
+        reassembled = "".join(c.split("\n", 1)[1] for c in chunks)
+        assert reassembled == diff
+
+    def test_single_oversized_file_raises(self) -> None:
+        diff = _file_segment("src/big.py", 3000)
+        with pytest.raises(DiffUnsplittableError, match="single-file"):
+            split_diff_for_prompt(diff, limit=1000)
+
+    def test_no_file_boundaries_raises(self) -> None:
+        with pytest.raises(DiffUnsplittableError, match="no 'diff --git'"):
+            split_diff_for_prompt("x" * 2000, limit=1000)
+
+    def test_limit_must_exceed_header_reserve(self) -> None:
+        with pytest.raises(ValueError, match="header"):
+            split_diff_for_prompt("x", limit=100)
+
+
+# ---------------------------------------------------------------------------
+# merge semantics
+# ---------------------------------------------------------------------------
+
+
+class TestMergeResults:
+    def _result(self, passed: bool, **kwargs: object) -> ReviewResult:
+        return ReviewResult(passed=passed, mode="hard", **kwargs)  # type: ignore[arg-type]
+
+    def test_all_chunks_pass_merges_to_pass(self) -> None:
+        merged = merge_review_results(
+            [self._result(True), self._result(True)], "hard",
+        )
+        assert merged.passed is True
+        assert merged.infrastructure_error is False
+        assert "Chunked review: 2 passes" in merged.overall_notes
+
+    def test_any_chunk_failure_fails(self) -> None:
+        merged = merge_review_results(
+            [self._result(True), self._result(False)], "hard",
+        )
+        assert merged.passed is False
+
+    def test_findings_concatenate(self) -> None:
+        from ralph_py.review import CriterionReview, ReviewConcern
+        a = self._result(True)
+        a.criteria.append(CriterionReview("AC1", "pass", "ok"))
+        b = self._result(False)
+        b.concerns.append(ReviewConcern(
+            "dead_code", "fail", "x.py:1", "unused",
+        ))
+        merged = merge_review_results([a, b], "hard")
+        assert len(merged.criteria) == 1
+        assert len(merged.concerns) == 1
+
+    def test_chunk_infra_error_marks_merged_infra(self) -> None:
+        merged = merge_review_results(
+            [
+                self._result(True),
+                self._result(False, infrastructure_error=True),
+            ],
+            "hard",
+        )
+        assert merged.infrastructure_error is True
+        assert merged.passed is False
+
+    def test_exhaustive_hint_requires_all_chunks(self) -> None:
+        merged = merge_review_results(
+            [
+                self._result(True, exhaustively_searched=True),
+                self._result(True, exhaustively_searched=False),
+            ],
+            "hard",
+        )
+        assert merged.exhaustively_searched is False
+
+    def test_empty_input_raises(self) -> None:
+        with pytest.raises(ValueError):
+            merge_review_results([], "hard")
+        with pytest.raises(ValueError):
+            merge_security_results([], "hard")
+
+    def test_security_merge_mirrors_policy(self) -> None:
+        from ralph_py.security import SecurityFinding
+        a = SecurityResult(passed=True, mode="hard")
+        a.findings.append(SecurityFinding(
+            "injection", "low", "x.py:1", "meh",
+        ))
+        b = SecurityResult(
+            passed=False, mode="hard", infrastructure_error=True,
+        )
+        merged = merge_security_results([a, b], "hard")
+        assert merged.passed is False
+        assert merged.infrastructure_error is True
+        assert len(merged.findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# chunked runners: one pass per chunk, budget rules
+# ---------------------------------------------------------------------------
+
+
+class TestRunChunkedReview:
+    def _prd(self, tmp_path: Path) -> Path:
+        prd = tmp_path / "prd.json"
+        _write_prd(prd, ["US-001"])
+        return prd
+
+    def test_one_pass_per_chunk_and_merge(self, tmp_path: Path) -> None:
+        agent = CountingAgent([_review_json("pass")])
+        consumed = {"n": 0}
+
+        def consume() -> None:
+            consumed["n"] += 1
+
+        chunks = ["chunk-a", "chunk-b", "chunk-c"]
+        result = run_chunked_review(
+            agent, self._prd(tmp_path), tmp_path, "main",
+            _VERIFICATION, ReviewMode.HARD, UI,
+            diff_chunks=chunks,
+            budget_remaining=3,
+            consume_budget=consume,
+        )
+        assert agent.calls == 3
+        assert consumed["n"] == 3
+        assert result.passed is True
+        assert len(result.criteria) == 3  # US-001 verdict per chunk
+        # Each pass saw exactly its own chunk.
+        for chunk, prompt in zip(chunks, agent.prompts, strict=True):
+            assert chunk in prompt
+
+    def test_failing_chunk_fails_merged_verdict(self, tmp_path: Path) -> None:
+        agent = CountingAgent([
+            _review_json("pass"), _review_json("fail"), _review_json("pass"),
+        ])
+        result = run_chunked_review(
+            agent, self._prd(tmp_path), tmp_path, "main",
+            _VERIFICATION, ReviewMode.HARD, UI,
+            diff_chunks=["a", "b", "c"],
+        )
+        assert agent.calls == 3
+        assert result.passed is False
+        assert result.infrastructure_error is False
+
+    def test_insufficient_budget_is_infra_fail_with_zero_passes(
+        self, tmp_path: Path,
+    ) -> None:
+        agent = CountingAgent([_review_json("pass")])
+        result = run_chunked_review(
+            agent, self._prd(tmp_path), tmp_path, "main",
+            _VERIFICATION, ReviewMode.HARD, UI,
+            diff_chunks=["a", "b", "c"],
+            budget_remaining=2,
+        )
+        assert agent.calls == 0
+        assert result.passed is False
+        assert result.infrastructure_error is True
+        assert "refusing" in result.overall_notes
+
+    def test_security_chunked_runner_mirrors(self, tmp_path: Path) -> None:
+        prd = tmp_path / "prd.json"
+        prd.write_text("spec")
+        agent = CountingAgent([_CLEAN_SECURITY_JSON])
+        config = SecurityConfig(mode=SecurityMode.HARD.value)
+        result = run_chunked_security_review(
+            agent, prd, tmp_path, "main", config, UI,
+            diff_chunks=["a", "b"],
+            budget_remaining=2,
+        )
+        assert agent.calls == 2
+        assert result.passed is True
+
+        starved = CountingAgent([_CLEAN_SECURITY_JSON])
+        result = run_chunked_security_review(
+            starved, prd, tmp_path, "main", config, UI,
+            diff_chunks=["a", "b"],
+            budget_remaining=1,
+        )
+        assert starved.calls == 0
+        assert result.passed is False
+        assert result.infrastructure_error is True
+
+
+# ---------------------------------------------------------------------------
+# advisory mode: single truncated pass, visibly PARTIAL
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryPartial:
+    def _oversized(self) -> str:
+        return _synthetic_diff(3, DEFAULT_PROMPT_DIFF_CHAR_LIMIT // 2)
+
+    def test_advisory_review_is_marked_partial(self, tmp_path: Path) -> None:
+        prd = tmp_path / "prd.json"
+        _write_prd(prd, ["US-001"])
+        agent = CountingAgent([_review_json("pass")])
+        result = run_review(
+            agent, prd, tmp_path, "main", _VERIFICATION,
+            ReviewMode.ADVISORY, UI,
+            diff_content=self._oversized(),
+        )
+        assert result.passed is True
+        assert result.partial is True
+        partial_concerns = [
+            c for c in result.concerns if "Partial review" in c.explanation
+        ]
+        assert len(partial_concerns) == 1
+        assert partial_concerns[0].severity == "advisory"
+        assert "PARTIAL REVIEW" in result.as_pr_body_section()
+
+    def test_fitting_diff_is_not_partial(self, tmp_path: Path) -> None:
+        prd = tmp_path / "prd.json"
+        _write_prd(prd, ["US-001"])
+        agent = CountingAgent([_review_json("pass")])
+        result = run_review(
+            agent, prd, tmp_path, "main", _VERIFICATION,
+            ReviewMode.ADVISORY, UI,
+            diff_content="+small diff\n",
+        )
+        assert result.partial is False
+        assert "PARTIAL" not in result.as_pr_body_section()
+
+    def test_hard_review_backstop_fails_closed(self, tmp_path: Path) -> None:
+        """Direct hard-mode call with an unchunked oversized diff must
+        never pass (the factory chunks; this guards other callers)."""
+        prd = tmp_path / "prd.json"
+        _write_prd(prd, ["US-001"])
+        agent = CountingAgent([_review_json("pass")])
+        result = run_review(
+            agent, prd, tmp_path, "main", _VERIFICATION,
+            ReviewMode.HARD, UI,
+            diff_content=self._oversized(),
+        )
+        assert result.passed is False
+        assert result.infrastructure_error is True
+        assert "without chunking" in result.overall_notes
+
+    def test_advisory_security_is_marked_partial(self, tmp_path: Path) -> None:
+        prd = tmp_path / "prd.json"
+        prd.write_text("spec")
+        agent = CountingAgent([_CLEAN_SECURITY_JSON])
+        config = SecurityConfig(mode=SecurityMode.ADVISORY.value)
+        result = run_security_review(
+            agent, prd, tmp_path, "main", config, UI,
+            diff_content=self._oversized(),
+        )
+        assert result.passed is True
+        assert result.partial is True
+        markers = [
+            f for f in result.findings
+            if "Partial security review" in f.explanation
+        ]
+        assert len(markers) == 1
+        assert markers[0].severity == "low"
+        assert "PARTIAL SECURITY REVIEW" in result.as_pr_body_section()
+
+    def test_hard_security_backstop_fails_closed(self, tmp_path: Path) -> None:
+        prd = tmp_path / "prd.json"
+        prd.write_text("spec")
+        agent = CountingAgent([_CLEAN_SECURITY_JSON])
+        config = SecurityConfig(mode=SecurityMode.HARD.value)
+        result = run_security_review(
+            agent, prd, tmp_path, "main", config, UI,
+            diff_content=self._oversized(),
+        )
+        assert result.passed is False
+        assert result.infrastructure_error is True
+        assert "without chunking" in result.overall_notes
+
+
+# ---------------------------------------------------------------------------
+# security parity: the Self-Critique block never reaches either prompt
+# ---------------------------------------------------------------------------
+
+
+class TestSelfCritiqueStripParity:
+    def test_security_prompt_contains_no_self_critique(
+        self, tmp_path: Path,
+    ) -> None:
+        """String-level proof on the BUILT prompt via the fetch-fallback
+        path (diff_content=None)."""
+        prd = tmp_path / "prd.json"
+        prd.write_text("spec")
+        agent = CountingAgent([_CLEAN_SECURITY_JSON])
+        config = SecurityConfig(mode=SecurityMode.ADVISORY.value)
+        with patch(
+            "ralph_py.git.get_diff_content",
+            return_value=_SELF_CRITIQUE_DIFF,
+        ):
+            run_security_review(agent, prd, tmp_path, "main", config, UI)
+        assert len(agent.prompts) == 1
+        assert "Self-Critique" not in agent.prompts[0]
+        assert "Failure mode 1" not in agent.prompts[0]
+        # The actual code change still reaches the reviewer.
+        assert "def add(a, b)" in agent.prompts[0]
+
+    def test_review_prompt_fallback_still_strips(self, tmp_path: Path) -> None:
+        prd = tmp_path / "prd.json"
+        _write_prd(prd, ["US-001"])
+        agent = CountingAgent([_review_json("pass")])
+        with patch(
+            "ralph_py.git.get_diff_content",
+            return_value=_SELF_CRITIQUE_DIFF,
+        ):
+            run_review(
+                agent, prd, tmp_path, "main", _VERIFICATION,
+                ReviewMode.ADVISORY, UI,
+            )
+        assert len(agent.prompts) == 1
+        assert "Self-Critique" not in agent.prompts[0]
+        assert "def add(a, b)" in agent.prompts[0]
+
+
+# ---------------------------------------------------------------------------
+# factory wiring: chunk orchestration, budget accounting, strip-once
+# ---------------------------------------------------------------------------
+
+
+def _scaffold(tmp_path: Path, comp_ids: list[str]) -> Path:
+    (tmp_path / "scripts" / "ralph").mkdir(parents=True)
+    (tmp_path / "scripts" / "ralph" / "prompt.md").write_text("p")
+    (tmp_path / "scripts" / "ralph" / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    for comp_id in comp_ids:
+        feature_dir = tmp_path / "scripts" / "ralph" / "feature" / comp_id
+        feature_dir.mkdir(parents=True)
+        _write_prd(feature_dir / "prd.json", ["US-001"])
+    return tmp_path
+
+
+def _make_manifest(ids: list[str]) -> Manifest:
+    return Manifest(
+        version="1", spec_file="s", project_name="t",
+        base_branch="main", single_pr=False,
+        components=[
+            Component(
+                id=i, title=i, description="", dependencies=[],
+                prd_path=f"scripts/ralph/feature/{i}/prd.json",
+                branch_name=f"ralph/{i}",
+            )
+            for i in ids
+        ],
+    )
+
+
+def _base_config(root: Path) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root / "scripts/ralph/prompt.md",
+        prd_file=root / "scripts/ralph/prd.json",
+        sleep_seconds=0, agent_cmd="echo test",
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    )
+
+
+def _factory_config(**overrides: object) -> FactoryConfig:
+    defaults: dict[str, object] = dict(
+        use_worktrees=False, create_prs=False, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_diff_scope=False,
+            check_bad_patterns=False, subprocess_timeout=5.0,
+        ),
+    )
+    defaults.update(overrides)
+    return FactoryConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _read_events(log_path: Path) -> list[dict[str, object]]:
+    return [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+# Three ~40KB files: over the 50KB cap, and each file fits a chunk, so
+# greedy packing yields exactly 3 chunks of one file each.
+def _oversized_component_diff() -> str:
+    return _synthetic_diff(3, 40_000)
+
+
+class TestFactoryChunkedReview:
+    def test_hard_mode_oversized_diff_runs_one_pass_per_chunk(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        log_path = tmp_path / "progress.jsonl"
+        config = _factory_config(
+            review_mode="hard", max_adversarial_calls=3,
+            progress_log_path=log_path,
+        )
+        agent = CountingAgent([_review_json("pass")])
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.agents.get_agent", return_value=agent,
+        ), patch(
+            "ralph_py.git.get_diff_content",
+            return_value=_oversized_component_diff(),
+        ):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert "comp-a" in result.completed
+        assert agent.calls == 3
+        events = _read_events(log_path)
+        chunk_events = [e for e in events if e["event"] == "diff_chunked"]
+        assert len(chunk_events) == 1
+        assert chunk_events[0]["data"]["chunks"] == 3  # type: ignore[index]
+
+    def test_insufficient_budget_fails_component_without_retry(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        log_path = tmp_path / "progress.jsonl"
+        # 3 chunks needed, budget 2; retries available but must NOT be
+        # used - the budget can only shrink, so retrying is pure waste.
+        config = _factory_config(
+            review_mode="hard", max_adversarial_calls=2, max_retries=2,
+            progress_log_path=log_path,
+        )
+        agent = CountingAgent([_review_json("pass")])
+        run_component_calls = {"n": 0}
+
+        def fake_run_component(
+            comp_id: str, *a: object, **k: object,
+        ) -> ComponentResult:
+            run_component_calls["n"] += 1
+            return ComponentResult(comp_id, success=True, iterations=1)
+
+        with patch(
+            "ralph_py.factory._run_component", side_effect=fake_run_component,
+        ), patch(
+            "ralph_py.agents.get_agent", return_value=agent,
+        ), patch(
+            "ralph_py.git.get_diff_content",
+            return_value=_oversized_component_diff(),
+        ):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert "comp-a" in result.failed
+        assert agent.calls == 0
+        assert run_component_calls["n"] == 1
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.error is not None
+        assert "Review infrastructure error" in comp.error
+        infra = [
+            f for f in comp.findings
+            if f.is_infrastructure_error and f.phase == "review"
+        ]
+        assert len(infra) == 1
+        assert "refusing" in infra[0].explanation
+        events = _read_events(log_path)
+        assert any(
+            e["event"] == "chunk_budget_insufficient" for e in events
+        )
+
+    def test_security_hard_mode_chunks_too(self, tmp_path: Path) -> None:
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        config = _factory_config(
+            review_mode="skip", max_adversarial_calls=3,
+            security_config=SecurityConfig(mode=SecurityMode.HARD.value),
+        )
+        agent = CountingAgent([_CLEAN_SECURITY_JSON])
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.agents.get_agent", return_value=agent,
+        ), patch(
+            "ralph_py.git.get_diff_content",
+            return_value=_oversized_component_diff(),
+        ):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert "comp-a" in result.completed
+        assert agent.calls == 3
+
+    def test_unsplittable_diff_fails_closed(self, tmp_path: Path) -> None:
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        log_path = tmp_path / "progress.jsonl"
+        config = _factory_config(
+            review_mode="hard", progress_log_path=log_path,
+        )
+        # One file bigger than the cap: no file boundary to split on.
+        big_single_file = _file_segment(
+            "src/huge.py", DEFAULT_PROMPT_DIFF_CHAR_LIMIT + 10_000,
+        )
+        agent = CountingAgent([_review_json("pass")])
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.agents.get_agent", return_value=agent,
+        ), patch(
+            "ralph_py.git.get_diff_content", return_value=big_single_file,
+        ):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert "comp-a" in result.failed
+        assert agent.calls == 0
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.error is not None
+        assert "unsplittable" in comp.error
+        events = _read_events(log_path)
+        assert any(e["event"] == "diff_unsplittable" for e in events)
+
+
+class TestSinglePassSecurityBudget:
+    def test_single_pass_security_consumes_exactly_one_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Regression: the R1.4 refactor briefly double-consumed the
+        budget for non-chunked security passes, which would silently
+        halve the effective budget. Two components + budget 2 must both
+        get their security pass."""
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+        root = _scaffold(tmp_path, ["comp-a", "comp-b"])
+        manifest = _make_manifest(["comp-a", "comp-b"])
+        config = _factory_config(
+            review_mode="skip", max_adversarial_calls=2,
+            security_config=SecurityConfig(
+                mode=SecurityMode.ADVISORY.value,
+            ),
+        )
+        agent = CountingAgent([_CLEAN_SECURITY_JSON])
+
+        def fake_run_component(
+            comp_id: str, *a: object, **k: object,
+        ) -> ComponentResult:
+            return ComponentResult(comp_id, success=True, iterations=1)
+
+        with patch(
+            "ralph_py.factory._run_component", side_effect=fake_run_component,
+        ), patch(
+            "ralph_py.agents.get_agent", return_value=agent,
+        ), patch(
+            "ralph_py.git.get_diff_content", return_value="+small\n",
+        ):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert set(result.completed) == {"comp-a", "comp-b"}
+        assert agent.calls == 2
+        for comp_id in ("comp-a", "comp-b"):
+            comp = manifest.get_component(comp_id)
+            assert comp is not None
+            assert not any(
+                f.is_phase_skip and f.phase == "security"
+                for f in comp.findings
+            )
+
+
+class TestFactoryStripOnce:
+    def test_both_reviewers_receive_stripped_diff(
+        self, tmp_path: Path,
+    ) -> None:
+        """R1.4 requirement 3: the factory strips the Self-Critique
+        block once and shares the result with Phase 2 AND Phase 2.5."""
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        config = _factory_config(
+            review_mode="advisory", max_adversarial_calls=2,
+            security_config=SecurityConfig(
+                mode=SecurityMode.ADVISORY.value,
+            ),
+        )
+        captured: dict[str, str] = {}
+
+        def fake_run_review(
+            *args: object, **kwargs: object,
+        ) -> ReviewResult:
+            captured["review"] = str(kwargs.get("diff_content"))
+            return ReviewResult(passed=True, mode="advisory")
+
+        def fake_run_security(
+            *args: object, **kwargs: object,
+        ) -> SecurityResult:
+            captured["security"] = str(kwargs.get("diff_content"))
+            return SecurityResult(passed=True, mode="advisory")
+
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.factory.run_review", side_effect=fake_run_review,
+        ), patch(
+            "ralph_py.factory.run_security_review",
+            side_effect=fake_run_security,
+        ), patch(
+            "ralph_py.git.get_diff_content",
+            return_value=_SELF_CRITIQUE_DIFF,
+        ):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert "comp-a" in result.completed
+        assert "Self-Critique" not in captured["review"]
+        assert "Self-Critique" not in captured["security"]
+        # The real change survives the strip for both reviewers.
+        assert "def add(a, b)" in captured["review"]
+        assert "def add(a, b)" in captured["security"]


### PR DESCRIPTION
## Roadmap item

R1.4 (session 4A): **Truncated-diff policy + security parity** [H-16]. Flips the R1.4 checkbox in `docs/remediation-roadmap.md`.

## What changed

- `git.split_diff_for_prompt`: splits an oversized diff on `diff --git` file boundaries into chunks of at most the 50KB prompt cap, each with a one-line provenance header (no reviewer directives - the calibrated prompt-side DIRECTIVE stays with Session 8C). Reassembly-lossless by construction. `DiffUnsplittableError` when a single file alone exceeds the cap or there are no boundaries.
- Hard mode (`review` and `security`): the factory splits once and runs `run_chunked_review` / `run_chunked_security_review` - one agent pass per chunk, each pass consuming `max_adversarial_calls`. Merge policy: any chunk failure fails; criteria/findings concatenate; any chunk infrastructure error marks the merged result infrastructure. If the remaining budget cannot cover the chunks, ZERO passes run and the component fails directly as infrastructure (no retries: the budget only shrinks, so retrying burns engineer LLM calls to hit the same wall). An unsplittable diff fails via the normal retry path instead, because the engineer CAN fix that by producing a smaller diff.
- Advisory mode: single truncated pass as before, but the result now carries `partial=True`, an injected advisory (review) / low (security) marker finding, and a PARTIAL banner in the PR-body section - a PASS over a truncated diff is visibly partial everywhere it is rendered.
- Backstops: `run_review` / `run_security_review` in hard mode fail closed (infrastructure) if any caller hands them an unchunked oversized diff.
- Self-Critique parity (E2): the factory strips the engineer's Self-Critique block ONCE and shares the stripped diff with Phase 2 AND Phase 2.5; both entrypoints strip on their fetch-fallback (`diff_content=None`) path. `build_review_prompt` no longer re-strips caller-provided diffs (single-strip contract, documented in the docstrings).

## Checks (final lines)

- `uv run pytest tests/ -q` -> `964 passed, 12 skipped, 1 xfailed, 1 warning in 80.81s (0:01:20)`
- `uv run mypy ralph_py/ --strict` -> `Success: no issues found in 37 source files`
- `uv run ruff check ralph_py/ tests/` -> `All checks passed!`

## Tested

- `tests/test_truncation_policy.py::TestSplitDiffForPrompt`: chunks respect the limit, split only on file boundaries, header-stripped reassembly reproduces the input byte-for-byte (including a preamble before the first boundary); single-file-over-cap and no-boundary diffs raise `DiffUnsplittableError`.
- `TestRunChunkedReview::test_one_pass_per_chunk_and_merge`: a fake agent counts invocations - 3 chunks produce exactly 3 review passes, 3 budget consumptions, each prompt contains exactly its own chunk, and verdicts merge (all-pass -> pass).
- `TestRunChunkedReview::test_failing_chunk_fails_merged_verdict`: chunk 2 failing fails the merged result without marking it infrastructure.
- `TestRunChunkedReview::test_insufficient_budget_is_infra_fail_with_zero_passes` and the security mirror: budget 2 vs 3 chunks -> infrastructure error, agent never invoked.
- `TestFactoryChunkedReview::test_hard_mode_oversized_diff_runs_one_pass_per_chunk`: end-to-end factory run over a ~120KB synthetic diff -> 3 chunked agent calls, component completes, `diff_chunked` journal event with `chunks=3`.
- `TestFactoryChunkedReview::test_insufficient_budget_fails_component_without_retry`: budget 2 vs 3 chunks with retries available -> component FAILED, engineer ran exactly once (no retry), zero agent calls, infra finding with the refusal explanation, `chunk_budget_insufficient` journal event.
- `TestFactoryChunkedReview::test_security_hard_mode_chunks_too`: security-hard with review skipped also runs one pass per chunk.
- `TestFactoryChunkedReview::test_unsplittable_diff_fails_closed`: a single >50KB file fails the component with a `diff_unsplittable` journal event and zero agent calls.
- `TestAdvisoryPartial`: advisory review/security over an oversized diff pass but carry `partial=True`, the injected marker finding, and the PARTIAL banner in `as_pr_body_section`; fitting diffs carry none of it; hard-mode backstops fail closed as infrastructure.
- `TestSelfCritiqueStripParity::test_security_prompt_contains_no_self_critique`: string-level assertion on the BUILT security prompt via the fetch-fallback path - `Self-Critique` and the failure-mode bullets are absent while the real code change survives. Review fallback mirrored.
- `TestFactoryStripOnce`: factory-level capture of the `diff_content` handed to both `run_review` and `run_security_review` - neither contains the Self-Critique block.
- `TestSinglePassSecurityBudget`: regression for a bug caught during this session's own review pass - the refactor briefly double-consumed budget for non-chunked security passes; two components with budget 2 must both get their security pass.
- `TestMergeResults`: merge policy unit coverage (any-fail fails, infra propagates, `exhaustively_searched` requires all chunks, empty input raises) for both reviewers.

## Assumed (not tested)

- Real-LLM behavior on chunked prompts. Each chunk pass sees the FULL PRD plus a partial diff, and the R1.1 coverage gate still requires a verdict for every story id per pass - so a real hard-mode reviewer will plausibly mark criteria "fail: not implemented" in chunks that do not contain the relevant files, biasing chunked hard reviews toward failure. This is fail-closed by design ("any chunk failure fails" per the session spec), but expect friction on legitimately large multi-story components until Session 8C's reviewer-facing truncation/chunk DIRECTIVE lands (roadmap already pairs R5.3 with R1.4 for exactly this). No calibration run was done: no prompt body changed (snapshot test untouched).
- The 120-char chunk-header reserve is asserted structurally (chunks stay under the cap) but the header's effect on reviewer attention is unmeasured.
- Chunk packing is greedy in file order; a pathological ordering could produce more chunks (= more budget) than optimal bin-packing. Bounded and lossless, just not minimal.

## Out of scope, noted per session prompt

- The knowledge distiller still receives the UNSTRIPPED, head-truncated diff (`knowledge.py` truncates via the same `truncate_diff_for_prompt`). It matters less than the reviewers (distillation happens post-gate and its output is injection-filtered on write AND read since R1.6), but a padded oversized diff can still hide the tail from distilled facts - worth folding into a later knowledge item.
- The pre-existing behavior "hard-mode review skips entirely when the budget is already exhausted for a NORMAL-sized diff" is unchanged (it predates R1.4 and leaves a phase_skipped trace); only chunked reviews got the stricter cover-or-fail rule. Flagging in case the stricter rule should be universal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)