### PR TITLE
fix: R2.6 HITL reject semantics, verification env scrub, process-group kill

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -306,7 +306,7 @@ every flag must do what it says or fail loudly.
     worktree note aligned with keep-worktree-on-failure (R3.3), test count,
     `[sensors]`/`[fixtures]` sections removed or implemented, `ralph evolve
     --apply` promise aligned with R6.3.
-- [ ] R2.6 (S) **HITL semantics + subprocess env hygiene** [MED hitl-abort, MED env-leak, MED process-group]
+- [x] R2.6 (S) **HITL semantics + subprocess env hygiene** [MED hitl-abort, MED env-leak, MED process-group]
   - E6 "Reject" marks the component FAILED immediately (no retry loop, no
     re-prompt); "Retry" is a separate choice.
   - Verification/contract/fixture subprocesses run with a scrubbed env

--- a/ralph_py/contract.py
+++ b/ralph_py/contract.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING
 
 from ralph_py import git
 from ralph_py.manifest import Manifest
+from ralph_py.verify import run_scrubbed
 
 if TYPE_CHECKING:
     from ralph_py.ui.base import UI
@@ -148,11 +149,9 @@ def _create_temp_worktree(
     contract_base.mkdir(parents=True, exist_ok=True)
     worktree_path = contract_base / f"{label}-{secrets.token_hex(4)}"
     try:
-        result = subprocess.run(
+        result = run_scrubbed(
             ["git", "worktree", "add", "--detach", str(worktree_path), base],
             cwd=root_dir,
-            capture_output=True,
-            text=True,
             timeout=timeout,
         )
     except subprocess.TimeoutExpired:
@@ -170,10 +169,9 @@ def _abort_merge(worktree_path: Path, timeout: float = 30.0) -> None:
     index survives into worktree removal.
     """
     try:
-        subprocess.run(
+        run_scrubbed(
             ["git", "merge", "--abort"],
             cwd=worktree_path,
-            capture_output=True,
             timeout=timeout,
         )
     except subprocess.TimeoutExpired:
@@ -192,11 +190,9 @@ def _remove_temp_worktree(
     would leave the repo's worktree metadata pointing at stale state.
     """
     try:
-        result = subprocess.run(
+        result = run_scrubbed(
             ["git", "worktree", "remove", "--force", str(worktree_path)],
             cwd=root_dir,
-            capture_output=True,
-            text=True,
             timeout=timeout,
         )
     except subprocess.TimeoutExpired as exc:
@@ -214,10 +210,9 @@ def _remove_temp_worktree(
         )
     if result.returncode != 0:
         # Directory is gone but git may still track it; prune metadata.
-        subprocess.run(
+        run_scrubbed(
             ["git", "worktree", "prune"],
             cwd=root_dir,
-            capture_output=True,
             timeout=timeout,
         )
 
@@ -227,14 +222,7 @@ def _run_tests(
 ) -> tuple[bool, str]:
     """Run test suite and return (passed, output)."""
     try:
-        result = subprocess.run(
-            test_command,
-            shell=True,
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
+        result = run_scrubbed(test_command, cwd=cwd, timeout=timeout)
         output = (result.stdout + result.stderr).strip()
         return result.returncode == 0, output
     except subprocess.TimeoutExpired:

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -1767,9 +1767,15 @@ def _run_factory_locked(
             # E6: human-in-the-loop checkpoint. When opt-in, prompt
             # before pushing+merging so a human can inspect the diff,
             # the review findings, and the security findings before
-            # the PR goes through. Skip the prompt when no UI is
-            # interactive - automation should fail loudly rather than
-            # block indefinitely.
+            # the PR goes through. Reject is terminal (R2.6): it marks
+            # the component FAILED and cascade-skips dependents with no
+            # retry and no re-prompt - routing it through the retry
+            # loop would re-run the full agent+review cycle and ask the
+            # human again, once per remaining retry. A human who wants
+            # a re-run says so explicitly via Retry, which consumes a
+            # retry like any other failure. Skip the prompt when no UI
+            # is interactive - automation should fail loudly rather
+            # than block indefinitely.
             proceed = True
             if factory_config.pause_before_pr_merge:
                 if ui.can_prompt():
@@ -1777,22 +1783,35 @@ def _run_factory_locked(
                     ui.info(comp.review_findings or "(no review findings)")
                     choice = ui.choose(
                         f"Approve PR creation and merge for {comp_id}?",
-                        ["Approve", "Reject and abort component"],
+                        [
+                            "Approve",
+                            "Reject (fail component, skip dependents)",
+                            "Retry (consume a retry, re-run component)",
+                        ],
                         default=0,
                     )
                     proceed = choice == 0
-                    if not proceed:
+                    if choice == 1:
                         ui.warn(
                             f"  Human rejected {comp_id} at PR checkpoint"
+                        )
+                        _fail_component(comp, "Rejected at HITL checkpoint")
+                        return
+                    if choice == 2:
+                        ui.warn(
+                            f"  Human requested retry for {comp_id} "
+                            f"at PR checkpoint"
                         )
                         ctx = IterationContext.from_json(
                             comp_result.context_json or "{}",
                         )
                         ctx.add_review_finding(
-                            "Human reviewer rejected at PR checkpoint",
+                            "Human reviewer requested changes at PR checkpoint",
                         )
                         _retry_or_fail(
-                            comp, "Rejected at HITL checkpoint", ctx.to_json(),
+                            comp,
+                            "Retry requested at HITL checkpoint",
+                            ctx.to_json(),
                         )
                         return
                 else:

--- a/ralph_py/fixtures.py
+++ b/ralph_py/fixtures.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     pass
 
-from ralph_py.verify import CheckResult
+from ralph_py.verify import CheckResult, run_scrubbed
 
 
 @dataclass
@@ -66,14 +66,7 @@ def run_cli_fixture(
         )
 
     try:
-        result = subprocess.run(
-            command,
-            shell=True,
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
+        result = run_scrubbed(command, cwd=cwd, timeout=timeout)
     except subprocess.TimeoutExpired:
         return FixtureResult(
             fixture=fixture,

--- a/ralph_py/verify.py
+++ b/ralph_py/verify.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import py_compile
 import re
+import signal
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -21,6 +22,136 @@ from ralph_py.parsers import (
     parse_ruff_output,
 )
 from ralph_py.prd import PRD
+
+# R2.6 env scrub: verification subprocesses execute agent-authored code
+# (the project's tests, linters run over agent files, CLI fixtures), so
+# they must never inherit the harness's secrets. Allowlist, not denylist:
+# only names below (or matching a prefix below) pass through, everything
+# else - ANTHROPIC_API_KEY, OPENAI_API_KEY, cloud credentials, gh tokens -
+# is dropped. The set was determined empirically: `uv run pytest` with a
+# fresh venv succeeds under env -i with only PATH/HOME/TMPDIR/TERM/LANG
+# (uv locates its cache via HOME); the rest are the locale, venv, uv, and
+# CPython knobs a project's own commands legitimately consume, plus the
+# XDG cache/data paths uv honors when set.
+SCRUB_ENV_ALLOWED_NAMES: frozenset[str] = frozenset({
+    "PATH",
+    "HOME",
+    "LANG",
+    "TMPDIR",
+    "TERM",
+    "VIRTUAL_ENV",
+    "CI",
+    "XDG_CACHE_HOME",
+    "XDG_DATA_HOME",
+})
+SCRUB_ENV_ALLOWED_PREFIXES: tuple[str, ...] = ("LC_", "UV_", "PYTHON")
+
+# Belt over the allowlist's braces: an allowed prefix must never smuggle a
+# secret through (UV_PUBLISH_TOKEN matches UV_*). Any name containing one
+# of these fragments is dropped even when the allowlist admits it.
+_SCRUB_ENV_SENSITIVE_FRAGMENTS: tuple[str, ...] = (
+    "API_KEY",
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "CREDENTIAL",
+)
+
+
+def scrubbed_subprocess_env() -> dict[str, str]:
+    """Allowlist-filtered copy of ``os.environ`` for verification subprocesses."""
+    env: dict[str, str] = {}
+    for name, value in os.environ.items():
+        if name not in SCRUB_ENV_ALLOWED_NAMES and not name.startswith(
+            SCRUB_ENV_ALLOWED_PREFIXES
+        ):
+            continue
+        if any(frag in name for frag in _SCRUB_ENV_SENSITIVE_FRAGMENTS):
+            continue
+        env[name] = value
+    return env
+
+
+_SCRUB_TERM_GRACE_SECONDS = 5.0
+
+
+def _signal_process_group(proc: subprocess.Popen[str], sig: signal.Signals) -> None:
+    """Signal the child's whole process group, direct-child fallback.
+
+    The pid/pgid guards are load-bearing: a mocked Popen's pid coerces to
+    1 via ``MagicMock.__index__`` and ``killpg(1, sig)`` is ``kill(-1,
+    sig)`` - signal every process this user owns. ``start_new_session=True``
+    makes the child its own group leader, so a pgid at or below 1 or equal
+    to ours means something is wrong and the group kill must not proceed.
+    """
+    pid = proc.pid
+    try:
+        if hasattr(os, "killpg") and isinstance(pid, int) and pid > 1:
+            pgid = os.getpgid(pid)
+            if pgid > 1 and pgid != os.getpgrp():
+                os.killpg(pgid, sig)
+                return
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+    try:
+        if sig == signal.SIGKILL:
+            proc.kill()
+        else:
+            proc.terminate()
+    except (ProcessLookupError, OSError):
+        pass
+
+
+def run_scrubbed(
+    cmd: str | list[str],
+    *,
+    cwd: Path,
+    timeout: float,
+    term_grace: float = _SCRUB_TERM_GRACE_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    """Run a verification subprocess: scrubbed env, own process group.
+
+    Drop-in for the ``subprocess.run(..., capture_output=True, text=True,
+    timeout=...)`` calls verification used to make, with two differences
+    (R2.6): the child gets :func:`scrubbed_subprocess_env` instead of the
+    harness environment, and on timeout the ENTIRE process group is
+    signalled (SIGTERM, grace, SIGKILL) so a test that backgrounds a
+    server cannot leak it past the deadline. A string ``cmd`` runs through
+    the shell exactly as before; a list does not.
+
+    Raises :class:`subprocess.TimeoutExpired` after the group is dead so
+    existing callers' timeout handling keeps working unchanged.
+    """
+    proc = subprocess.Popen(
+        cmd,
+        shell=isinstance(cmd, str),
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=scrubbed_subprocess_env(),
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _signal_process_group(proc, signal.SIGTERM)
+        try:
+            proc.wait(timeout=term_grace)
+        except subprocess.TimeoutExpired:
+            pass
+        # SIGKILL the group even when the direct child honored SIGTERM: a
+        # grandchild that ignored it can hold the pipes open and would
+        # otherwise block the drain below indefinitely.
+        _signal_process_group(proc, signal.SIGKILL)
+        try:
+            stdout, stderr = proc.communicate(timeout=term_grace)
+        except subprocess.TimeoutExpired:
+            stdout, stderr = "", ""
+        raise subprocess.TimeoutExpired(
+            cmd, timeout, output=stdout, stderr=stderr,
+        ) from None
+    return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
 
 
 @dataclass
@@ -333,10 +464,7 @@ def check_test_suite(
     cmd = command or "uv run pytest"
 
     try:
-        result = subprocess.run(
-            cmd, shell=True, cwd=cwd,
-            capture_output=True, text=True, timeout=timeout,
-        )
+        result = run_scrubbed(cmd, cwd=cwd, timeout=timeout)
     except subprocess.TimeoutExpired:
         return CheckResult(
             name="test_suite",
@@ -417,10 +545,7 @@ def check_typecheck(
     cmd = command or _default_typecheck_command(cwd)
 
     try:
-        result = subprocess.run(
-            cmd, shell=True, cwd=cwd,
-            capture_output=True, text=True, timeout=timeout,
-        )
+        result = run_scrubbed(cmd, cwd=cwd, timeout=timeout)
     except subprocess.TimeoutExpired:
         return CheckResult(
             name="typecheck",
@@ -461,10 +586,7 @@ def check_linter(
     cmd = command or "uv run ruff check ."
 
     try:
-        result = subprocess.run(
-            cmd, shell=True, cwd=cwd,
-            capture_output=True, text=True, timeout=timeout,
-        )
+        result = run_scrubbed(cmd, cwd=cwd, timeout=timeout)
     except subprocess.TimeoutExpired:
         return CheckResult(
             name="linter",
@@ -672,12 +794,9 @@ def check_mutation_score(
     # Run mutmut on changed files only
     paths_arg = " ".join(py_files)
     try:
-        result = subprocess.run(
+        result = run_scrubbed(
             f"mutmut run --paths-to-mutate={paths_arg} --no-progress",
-            shell=True,
             cwd=cwd,
-            capture_output=True,
-            text=True,
             timeout=timeout,
         )
     except subprocess.TimeoutExpired:
@@ -690,14 +809,7 @@ def check_mutation_score(
 
     # Parse mutmut results
     try:
-        results_proc = subprocess.run(
-            "mutmut results",
-            shell=True,
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
+        results_proc = run_scrubbed("mutmut results", cwd=cwd, timeout=30)
         output = results_proc.stdout
     except subprocess.TimeoutExpired:
         output = result.stdout
@@ -785,10 +897,7 @@ def check_dead_code(
 
     if shutil.which("ruff"):
         try:
-            ruff_result = subprocess.run(
-                ruff_cmd, shell=True, cwd=cwd,
-                capture_output=True, text=True, timeout=timeout,
-            )
+            ruff_result = run_scrubbed(ruff_cmd, cwd=cwd, timeout=timeout)
             # Count fixes from ruff output (lines like "Found X errors (Y fixed, ...)")
             for line in (ruff_result.stdout + ruff_result.stderr).splitlines():
                 if "fixed" in line.lower():
@@ -803,14 +912,10 @@ def check_dead_code(
         if ruff_fixed_count > 0:
             try:
                 # Stage all changes ruff made
-                subprocess.run(
-                    "git add -A", shell=True, cwd=cwd,
-                    capture_output=True, text=True, timeout=30,
-                )
-                subprocess.run(
+                run_scrubbed("git add -A", cwd=cwd, timeout=30)
+                run_scrubbed(
                     'git commit -m "chore: auto-remove dead code (ruff F401/F811/F841)"',
-                    shell=True, cwd=cwd,
-                    capture_output=True, text=True, timeout=30,
+                    cwd=cwd, timeout=30,
                 )
             except subprocess.TimeoutExpired:
                 pass  # Non-fatal
@@ -849,10 +954,7 @@ def check_dead_code(
         )
 
     try:
-        result = subprocess.run(
-            detect_cmd, shell=True, cwd=cwd,
-            capture_output=True, text=True, timeout=timeout,
-        )
+        result = run_scrubbed(detect_cmd, cwd=cwd, timeout=timeout)
     except subprocess.TimeoutExpired:
         return CheckResult(
             name="dead_code",

--- a/tests/test_contract_safety.py
+++ b/tests/test_contract_safety.py
@@ -458,7 +458,7 @@ class TestCleanupFailsLoudly:
         )
         assert worktree_path is not None, error
 
-        real_run = subprocess.run
+        real_run = contract_mod.run_scrubbed
 
         def failing_remove(cmd: list[str], **kwargs: object) -> object:
             if cmd[:3] == ["git", "worktree", "remove"]:
@@ -467,7 +467,7 @@ class TestCleanupFailsLoudly:
                 )
             return real_run(cmd, **kwargs)  # type: ignore[arg-type]
 
-        monkeypatch.setattr(contract_mod.subprocess, "run", failing_remove)
+        monkeypatch.setattr(contract_mod, "run_scrubbed", failing_remove)
         with pytest.raises(ContractCleanupError, match="survived removal"):
             contract_mod._remove_temp_worktree(worktree_path, root)
         monkeypatch.undo()

--- a/tests/test_hitl_env_scrub.py
+++ b/tests/test_hitl_env_scrub.py
@@ -1,0 +1,296 @@
+"""R2.6: HITL checkpoint semantics + verification subprocess hygiene.
+
+Three defect classes, three test groups:
+
+1. E6 checkpoint: Reject must mark the component FAILED immediately
+   (cascade-skipping dependents) with zero further agent calls and zero
+   re-prompts; Retry is a separate explicit choice that consumes a retry.
+2. Env scrub: every verification subprocess runs under an allowlist env,
+   so agent-authored test code can never read ANTHROPIC_API_KEY /
+   OPENAI_API_KEY / any other harness secret - while `uv run` still
+   functions under the scrub.
+3. Process groups: verification subprocesses launch with
+   ``start_new_session=True`` and a timeout kills the whole group, so a
+   test that backgrounds a server cannot leak it across iterations.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ralph_py.config import RalphConfig
+from ralph_py.factory import ComponentResult, FactoryConfig, run_factory
+from ralph_py.manifest import Component, ComponentStatus, Manifest
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import (
+    VerifyConfig,
+    check_test_suite,
+    run_scrubbed,
+    scrubbed_subprocess_env,
+)
+
+
+class ScriptedUI(PlainUI):
+    """PlainUI that reports as interactive and answers with scripted choices."""
+
+    def __init__(self, choices: list[int]) -> None:
+        super().__init__(no_color=True)
+        self._choices = choices
+        self.choose_calls: list[str] = []
+
+    def can_prompt(self) -> bool:
+        return True
+
+    def choose(self, header: str, options: list[str], default: int = 0) -> int:
+        self.choose_calls.append(header)
+        return self._choices.pop(0)
+
+
+def _scaffold(
+    tmp_path: Path, comp_ids: list[str], deps: dict[str, list[str]],
+) -> tuple[Manifest, RalphConfig]:
+    scaffold = tmp_path / "scripts" / "ralph"
+    scaffold.mkdir(parents=True)
+    (scaffold / "prompt.md").write_text("p")
+    (scaffold / "prd.json").write_text(
+        '{"branchName": "t", "userStories": []}'
+    )
+    components: list[Component] = []
+    for cid in comp_ids:
+        feature_dir = scaffold / "feature" / cid
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "prd.json").write_text(json.dumps({
+            "branchName": "t",
+            "userStories": [{
+                "id": "US-1", "title": "t", "acceptanceCriteria": ["AC"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+        components.append(Component(
+            id=cid, title=cid, description="",
+            dependencies=deps.get(cid, []),
+            prd_path=f"scripts/ralph/feature/{cid}/prd.json",
+            branch_name=f"ralph/{cid}",
+        ))
+    manifest = Manifest(
+        version="1", spec_file="s", project_name="t",
+        base_branch="main", single_pr=False, components=components,
+    )
+    base = RalphConfig(
+        prompt_file=scaffold / "prompt.md",
+        prd_file=scaffold / "prd.json",
+        sleep_seconds=0, agent_cmd="echo test",
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    )
+    return manifest, base
+
+
+def _checkpoint_config(max_retries: int = 3) -> FactoryConfig:
+    return FactoryConfig(
+        use_worktrees=False, create_prs=True, max_parallel=1,
+        review_mode="skip", pause_before_pr_merge=True,
+        max_retries=max_retries, retry_delay=0.0,
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_diff_scope=False,
+            check_bad_patterns=False, subprocess_timeout=10.0,
+        ),
+    )
+
+
+class TestHitlCheckpoint:
+    def test_reject_fails_immediately_zero_further_agent_calls(
+        self, tmp_path: Path,
+    ) -> None:
+        """Reject = FAILED now: one agent run total, one prompt total,
+        dependents cascade-skipped, no retry consumed."""
+        manifest, base = _scaffold(
+            tmp_path, ["comp-a", "comp-b"], {"comp-b": ["comp-a"]},
+        )
+        ui = ScriptedUI(choices=[1])
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ) as fake_agent, patch(
+            "ralph_py.pr.is_gh_available", return_value=False,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, _checkpoint_config(), base, ui, tmp_path,
+            )
+        assert fake_agent.call_count == 1
+        assert len(ui.choose_calls) == 1
+        assert result.failed == ["comp-a"]
+        assert "comp-b" in result.skipped
+        comp_a = manifest.get_component("comp-a")
+        assert comp_a is not None
+        assert comp_a.status == ComponentStatus.FAILED.value
+        assert comp_a.error == "Rejected at HITL checkpoint"
+        assert comp_a.retries == 0
+
+    def test_retry_choice_consumes_a_retry_and_reruns(
+        self, tmp_path: Path,
+    ) -> None:
+        """Retry is explicit: the agent runs again, one retry is spent,
+        and a second Approve completes the component."""
+        manifest, base = _scaffold(tmp_path, ["comp-a"], {})
+        ui = ScriptedUI(choices=[2, 0])
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ) as fake_agent, patch(
+            "ralph_py.pr.is_gh_available", return_value=False,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, _checkpoint_config(max_retries=1), base, ui,
+                tmp_path,
+            )
+        assert fake_agent.call_count == 2
+        assert len(ui.choose_calls) == 2
+        assert "comp-a" in result.completed
+        comp_a = manifest.get_component("comp-a")
+        assert comp_a is not None
+        assert comp_a.retries == 1
+
+    def test_approve_proceeds_without_retry_or_failure(
+        self, tmp_path: Path,
+    ) -> None:
+        manifest, base = _scaffold(tmp_path, ["comp-a"], {})
+        ui = ScriptedUI(choices=[0])
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ) as fake_agent, patch(
+            "ralph_py.pr.is_gh_available", return_value=False,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, _checkpoint_config(), base, ui, tmp_path,
+            )
+        assert fake_agent.call_count == 1
+        assert "comp-a" in result.completed
+        comp_a = manifest.get_component("comp-a")
+        assert comp_a is not None
+        assert comp_a.retries == 0
+
+
+class TestScrubbedEnv:
+    def test_allowlist_passes_and_secrets_drop(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-oai-secret")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "aws-secret")
+        monkeypatch.setenv("GITHUB_TOKEN", "gh-secret")
+        # Allowed prefix carrying a sensitive name must still be dropped.
+        monkeypatch.setenv("UV_PUBLISH_TOKEN", "uv-secret")
+        monkeypatch.setenv("LC_ALL", "C")
+        monkeypatch.setenv("UV_CACHE_DIR", "/tmp/uvcache")
+        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "1")
+        env = scrubbed_subprocess_env()
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "OPENAI_API_KEY" not in env
+        assert "AWS_SECRET_ACCESS_KEY" not in env
+        assert "GITHUB_TOKEN" not in env
+        assert "UV_PUBLISH_TOKEN" not in env
+        assert env["LC_ALL"] == "C"
+        assert env["UV_CACHE_DIR"] == "/tmp/uvcache"
+        assert env["PYTHONDONTWRITEBYTECODE"] == "1"
+        assert "PATH" in env
+        assert "HOME" in env
+        forbidden = ("API_KEY", "SECRET", "TOKEN", "PASSWORD", "CREDENTIAL")
+        assert not any(
+            frag in name for name in env for frag in forbidden
+        )
+
+    def test_subprocess_sees_no_api_keys(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-oai-secret")
+        result = run_scrubbed(
+            [
+                sys.executable, "-c",
+                "import os, json; print(json.dumps(dict(os.environ)))",
+            ],
+            cwd=tmp_path, timeout=30,
+        )
+        assert result.returncode == 0
+        child_env = json.loads(result.stdout)
+        assert "ANTHROPIC_API_KEY" not in child_env
+        assert "OPENAI_API_KEY" not in child_env
+        assert not any("API_KEY" in name for name in child_env)
+
+    @pytest.mark.skipif(shutil.which("uv") is None, reason="uv not on PATH")
+    def test_uv_run_functions_under_scrub(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """uv itself must keep working with only the allowlist env, and
+        the interpreter it launches must not see the harness's keys."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-oai-secret")
+        code = "import os, json; print(json.dumps(dict(os.environ)))"
+        result = run_scrubbed(
+            f'uv run --no-project python -c "{code}"',
+            cwd=tmp_path, timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        child_env = json.loads(result.stdout.strip().splitlines()[-1])
+        assert not any("API_KEY" in name for name in child_env)
+
+
+def _assert_process_dies(pid: int, deadline_seconds: float = 10.0) -> None:
+    deadline = time.monotonic() + deadline_seconds
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.1)
+    pytest.fail(f"process {pid} still alive after group kill")
+
+
+class TestProcessGroupKill:
+    def test_child_runs_in_its_own_process_group(
+        self, tmp_path: Path,
+    ) -> None:
+        result = run_scrubbed(
+            [
+                sys.executable, "-c",
+                "import os; print(os.getpgrp() == os.getpid())",
+            ],
+            cwd=tmp_path, timeout=30,
+        )
+        assert result.stdout.strip() == "True"
+
+    def test_timeout_kills_backgrounded_grandchild(
+        self, tmp_path: Path,
+    ) -> None:
+        """A backgrounded grandchild (the leaked-server shape) dies with
+        the group when the deadline fires."""
+        pid_file = tmp_path / "grandchild.pid"
+        cmd = f"sleep 300 & echo $! > {pid_file}; wait"
+        with pytest.raises(subprocess.TimeoutExpired):
+            run_scrubbed(cmd, cwd=tmp_path, timeout=1.0, term_grace=1.0)
+        pid = int(pid_file.read_text().strip())
+        _assert_process_dies(pid)
+
+    def test_check_test_suite_timeout_kills_grandchild(
+        self, tmp_path: Path,
+    ) -> None:
+        """Same guarantee through a real verification entry point."""
+        pid_file = tmp_path / "server.pid"
+        cmd = f"sleep 300 & echo $! > {pid_file}; wait"
+        result = check_test_suite(tmp_path, command=cmd, timeout=1.0)
+        assert result.passed is False
+        assert "timed out" in result.message
+        pid = int(pid_file.read_text().strip())
+        _assert_process_dies(pid)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -532,7 +532,7 @@ class TestCheckMutationScore:
                 return_value=["src/main.py"],
             ),
             patch(
-                "ralph_py.verify.subprocess.run",
+                "ralph_py.verify.run_scrubbed",
                 side_effect=sp.TimeoutExpired("mutmut", 600),
             ),
         ):
@@ -573,7 +573,7 @@ class TestCheckDeadCode:
 
         with (
             patch("shutil.which", side_effect=mock_which),
-            patch("ralph_py.verify.subprocess.run", side_effect=mock_run),
+            patch("ralph_py.verify.run_scrubbed", side_effect=mock_run),
             patch("ralph_py.verify.git.get_diff_names", return_value=["src/main.py"]),
         ):
             result = check_dead_code(tmp_path, "main")
@@ -604,7 +604,7 @@ class TestCheckDeadCode:
 
         with (
             patch("shutil.which", side_effect=mock_which),
-            patch("ralph_py.verify.subprocess.run", side_effect=mock_run),
+            patch("ralph_py.verify.run_scrubbed", side_effect=mock_run),
             patch("ralph_py.verify.git.get_diff_names", return_value=["src/main.py", "src/utils.py"]),
         ):
             result = check_dead_code(tmp_path, "main")
@@ -626,7 +626,7 @@ class TestCheckDeadCode:
 
         with (
             patch("shutil.which", return_value="/usr/bin/ruff"),
-            patch("ralph_py.verify.subprocess.run", side_effect=mock_run),
+            patch("ralph_py.verify.run_scrubbed", side_effect=mock_run),
         ):
             result = check_dead_code(tmp_path, "main", command="my-custom-checker src/")
 
@@ -646,7 +646,7 @@ class TestCheckDeadCode:
 
         with (
             patch("shutil.which", side_effect=mock_which),
-            patch("ralph_py.verify.subprocess.run", side_effect=mock_run),
+            patch("ralph_py.verify.run_scrubbed", side_effect=mock_run),
             patch("ralph_py.verify.git.get_diff_names", return_value=["README.md", "docs/spec.md"]),
         ):
             result = check_dead_code(tmp_path, "main")


### PR DESCRIPTION
## Roadmap item

R2.6 (Session 5B) - HITL semantics + subprocess env hygiene [MED hitl-abort, MED env-leak, MED process-group]. Flips the R2.6 checkbox in docs/remediation-roadmap.md.

## What changed

1. **E6 checkpoint (factory.py)**: choices are now Approve / Reject / Retry. Reject marks the component FAILED immediately via the existing `_fail_component` path (dependents cascade-skip, no retry consumed, no re-prompt). Retry is a separate explicit choice that consumes a retry via `_retry_or_fail` and feeds a review finding into the retry context. Previously Reject routed through `_retry_or_fail`, re-running the full agent+review cycle and re-prompting the human once per remaining retry. Non-interactive behavior unchanged: warn + proceed.
2. **Env scrub (verify.py, shared by contract.py and fixtures.py)**: new `scrubbed_subprocess_env()` - allowlist of PATH, HOME, LANG, TMPDIR, TERM, VIRTUAL_ENV, CI, XDG_CACHE_HOME, XDG_DATA_HOME plus the LC_*/UV_*/PYTHON* prefixes, with a sensitive-name denylist on top (API_KEY/SECRET/TOKEN/PASSWORD/CREDENTIAL fragments are dropped even when a prefix admits them, e.g. UV_PUBLISH_TOKEN). Applied to every subprocess in verify.py (9 sites), contract.py (5 sites), fixtures.py (1 site) via the new `run_scrubbed()` runner. The allowlist was determined empirically, not guessed: `uv run pytest` with a fresh venv succeeds under `env -i` with only PATH/HOME/TMPDIR/TERM/LANG (uv locates its cache via HOME).
3. **Process groups**: `run_scrubbed()` launches every verification subprocess with `start_new_session=True`; on timeout it signals the whole group (SIGTERM, grace period, SIGKILL - always escalating to group SIGKILL so a grandchild that ignores SIGTERM cannot hold the output pipes open), then re-raises `TimeoutExpired` so existing caller handling is unchanged. The pgid guards mirror the R0.1 `agents/proc.py` pattern (mocked-pid `killpg(1,...)` footgun).

Existing tests that mocked `ralph_py.verify.subprocess.run` / `contract.subprocess.run` were repointed at the new `run_scrubbed` seam (5 tests in test_verify.py, 1 in test_contract_safety.py); their assertions are unchanged.

## Tested

- `TestHitlCheckpoint::test_reject_fails_immediately_zero_further_agent_calls`: reject on comp-a with dependent comp-b -> fake agent (`_run_component` mock) called exactly once, human prompted exactly once, comp-a FAILED with retries==0, comp-b in skipped.
- `TestHitlCheckpoint::test_retry_choice_consumes_a_retry_and_reruns`: Retry then Approve -> agent called twice, retries==1, component completes.
- `TestHitlCheckpoint::test_approve_proceeds_without_retry_or_failure`: Approve -> one agent call, completed.
- Non-interactive warn+proceed: pre-existing `test_phase_e.py::TestE6HitlCheckpoint::test_non_interactive_ui_warns_and_proceeds` still passes unchanged.
- `TestScrubbedEnv::test_allowlist_passes_and_secrets_drop`: ANTHROPIC_API_KEY, OPENAI_API_KEY, AWS_SECRET_ACCESS_KEY, GITHUB_TOKEN, UV_PUBLISH_TOKEN all dropped; LC_ALL/UV_CACHE_DIR/PYTHONDONTWRITEBYTECODE/PATH/HOME pass; no name containing a sensitive fragment survives.
- `TestScrubbedEnv::test_subprocess_sees_no_api_keys`: a real child process printing os.environ shows no *_API_KEY.
- `TestScrubbedEnv::test_uv_run_functions_under_scrub`: `uv run --no-project python` exits 0 under the scrub and its env carries no API keys.
- Manual empirical check: `uv run pytest` on a fresh project with a deleted .venv (forcing venv creation + sync) under `env -i PATH HOME TMPDIR TERM LANG` -> 1 passed, exit 0.
- `TestProcessGroupKill::test_child_runs_in_its_own_process_group`: child observes pgid == pid.
- `TestProcessGroupKill::test_timeout_kills_backgrounded_grandchild` and `test_check_test_suite_timeout_kills_grandchild`: real `sleep 300 &` grandchild is dead (ProcessLookupError) after the deadline fires, both at the runner and through `check_test_suite`.
- Full gates: `uv run pytest tests/ -q` -> `1009 passed, 12 skipped, 1 xfailed, 1 warning in 82.40s`; `uv run mypy ralph_py/ --strict` -> `Success: no issues found in 37 source files`; `uv run ruff check ralph_py/ tests/` -> `All checks passed!`.

## Assumed (not tested)

- The scrub on contract.py's git subprocesses (worktree add/remove/prune, merge --abort) does not break exotic git setups that depend on GIT_* env vars; identity/config flows through HOME (~/.gitconfig), which the suite exercises only via repo-local config.
- The empirical uv-under-scrub check ran on macOS with a warm uv cache reachable via HOME; a host whose uv cache lives only behind a non-allowlisted env var would see a cold cache (re-download), not breakage.
- mutmut/vulture paths under the scrub are covered by mocked tests only (tools not exercised for real in the suite).
- POSIX-only group kill: on platforms without os.killpg the kill degrades to the direct child (same documented degradation as R0.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)