### PR TITLE
test: R4.2 spine tier II - contract execution, crash recovery, retry-context e2e

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -336,7 +336,7 @@ mock-only coverage.
   - Archive (do not delete) the polluted `.ralph/evolution.jsonl` +
     `experiments.tsv` to `.ralph/archive/` and start clean journals (R6.4
     re-baselines).
-- [~] R4.2 (L) **Real-git spine tier** [T-1..T-7, T-14]
+- [x] R4.2 (L) **Real-git spine tier** [T-1..T-7, T-14]
   - New marked tier (`-m spine`, in CI as a separate job): worktree lifecycle
     incl. two-process flock contention; PR failure paths against a stub `gh`
     binary on PATH; contract merge + conflict recovery; crash recovery with
@@ -346,8 +346,11 @@ mock-only coverage.
   - Spine I landed (marker + worktree lifecycle incl. two-process flock
     exclusion + PR failure paths with an unmocked engineer). The CI job
     split landed with R4.3/R4.4 (fast job `-m "not spine"`, spine job
-    `-m spine`). Spine II (session 6C: contract merge/conflict recovery,
-    crash recovery, retry-context propagation e2e) remains.
+    `-m spine`). Spine II landed (session 6C: contract passing/conflicted
+    tier + breaker re-run against real branches, SIGKILL-mid-verify crash
+    recovery incl. the loud refusal path for a crashed branch with
+    commits, diff-scope retry-context propagation e2e, and an unmocked
+    `_run_component` plumbing smoke). Spine complete.
 - [x] R4.3 (M) **Fix misleading tests** [T-5, T-6, T-8, T-9, T-10, T-11, T-15]
   - C1 becomes a true 2-worker worktree test; C6 uses the same root and proves
     serialization (fails if the flock is removed); C4 asserts the breaker was

--- a/tests/test_spine_contract.py
+++ b/tests/test_spine_contract.py
@@ -1,0 +1,346 @@
+"""Spine tier II (R4.2): contract execution against real git.
+
+tests/test_contract_safety.py proves the temp-worktree mechanics with
+synthetic repos but drives ``run_tier_check`` directly; these tests close
+the factory-level boundary: ``run_factory`` in deferred-merge mode
+(``create_prs=False``), real ``bash -lc`` engineers committing on real
+branches, and the contract phase REALLY merging those branches in a
+detached temp worktree and running a real shell test command there.
+
+Covered, with wave-2 (R0.3) semantics asserted:
+- passing tiers: the per-tier contract test observes exactly the files
+  the merged branches contribute (tier 0 sees alpha only, tier 1 sees
+  alpha + beta), proving real incremental merges;
+- conflicted tier: the breaker is attributed, the failure is terminal
+  when retries are exhausted, and the user's checkout is BYTE-IDENTICAL
+  afterward (no merge debris, no contract temp worktrees left behind);
+- breaker re-run: a contract test failure bisects to the breaker, the
+  breaker re-enters scheduling, its retry context carries the contract
+  failure output into the next prompt, and the re-run completes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ralph_py.contract import ContractConfig
+from ralph_py.factory import FactoryResult, run_factory
+from ralph_py.manifest import ComponentStatus, Manifest
+from ralph_py.ui.plain import PlainUI
+from tests.spine_utils import (
+    base_config,
+    component,
+    factory_config,
+    git,
+    init_ralph_repo,
+    make_manifest,
+)
+
+pytestmark = pytest.mark.spine
+
+
+def _checkout_state(root: Path) -> dict[str, Any]:
+    """Byte-level fingerprint of the user's checkout.
+
+    Hashes every file under ``root`` except ``.git/`` and ``.ralph/``
+    (branches and run state legitimately change during a factory run;
+    the user's working tree must not), plus the git-visible state of the
+    checkout itself: HEAD, current branch, and porcelain status.
+    """
+    files: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        rel = path.relative_to(root)
+        if rel.parts[0] in (".git", ".ralph"):
+            continue
+        if path.is_file():
+            files[str(rel)] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return {
+        "files": files,
+        "head": git("rev-parse", "HEAD", cwd=root),
+        "branch": git("branch", "--show-current", cwd=root),
+        "status": git("status", "--porcelain", cwd=root),
+    }
+
+
+def _contract_events(progress_path: Path) -> list[tuple[int, bool, str | None]]:
+    """(tier, passed, breaker) for each contract_result progress event."""
+    events = [
+        json.loads(line)
+        for line in progress_path.read_text().splitlines()
+        if line.strip()
+    ]
+    return [
+        (e["data"]["tier"], e["data"]["passed"], e["data"]["breaker"])
+        for e in events
+        if e["event"] == "contract_result"
+    ]
+
+
+def _assert_no_contract_debris(root: Path) -> None:
+    """No temp worktree survived under .ralph/contract/ and git tracks
+    only the main checkout afterward."""
+    contract_dir = root / ".ralph" / "contract"
+    if contract_dir.exists():
+        assert list(contract_dir.iterdir()) == []
+    listing = git("worktree", "list", "--porcelain", cwd=root)
+    worktree_lines = [
+        line for line in listing.splitlines() if line.startswith("worktree ")
+    ]
+    assert worktree_lines == [f"worktree {root}"]
+
+
+def _run(
+    root: Path,
+    manifest: Manifest,
+    agent_cmd: str,
+    contract_test_cmd: str,
+    progress_path: Path,
+    max_retries: int = 0,
+) -> FactoryResult:
+    return run_factory(
+        manifest,
+        factory_config(
+            max_retries=max_retries,
+            contract_config=ContractConfig(
+                mode="tier", test_command=contract_test_cmd, timeout=30.0,
+            ),
+            progress_log_path=progress_path,
+        ),
+        base_config(root, agent_cmd),
+        PlainUI(no_color=True),
+        root,
+        # Outside the repo so the byte-identical checkout assertions
+        # cover everything except ralph's declared state dirs.
+        manifest_path=progress_path.parent / "manifest.json",
+    )
+
+
+# Engineer that commits one file named after its component. The worktree
+# basename is the component id, so one command string serves every
+# component without mocks.
+_FILE_PER_COMPONENT_ENGINEER = textwrap.dedent("""\
+    comp="$(basename "$PWD")"
+    echo "$comp" > "$comp.txt"
+    git add "$comp.txt"
+    git commit -q -m "add $comp.txt"
+    echo '<promise>COMPLETE</promise>'
+""")
+
+# Engineer that commits the SAME file with per-component content: any
+# two components in one tier conflict at contract merge time.
+_CONFLICTING_ENGINEER = textwrap.dedent("""\
+    comp="$(basename "$PWD")"
+    echo "content from $comp" > conflict.txt
+    git add conflict.txt
+    git commit -q -m "$comp writes conflict.txt"
+    echo '<promise>COMPLETE</promise>'
+""")
+
+
+class TestContractPassingTier:
+    def test_tier_checks_merge_real_branches_incrementally(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Two-tier manifest (beta depends on alpha): each tier's
+        contract test runs in a temp worktree that REALLY contains the
+        merged branches - tier 0 sees alpha.txt only, tier 1 sees
+        alpha.txt (prior branch) plus beta.txt - and the run exits 0."""
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+        root = tmp_path / "repo"
+        init_ralph_repo(root, ("alpha", "beta"))
+        manifest = make_manifest(
+            [component("alpha"), component("beta", ["alpha"])]
+        )
+        before = _checkout_state(root)
+        obs_log = tmp_path / "contract-observations.log"
+        # The contract command is a real check AND a real observer: it
+        # fails if no merged .txt exists, and records which ones each
+        # tier's merged temp worktree actually contains.
+        contract_cmd = f"ls *.txt >> '{obs_log}' && echo -- >> '{obs_log}'"
+        progress_path = tmp_path / "progress.jsonl"
+
+        result = _run(
+            root, manifest, _FILE_PER_COMPONENT_ENGINEER, contract_cmd,
+            progress_path,
+        )
+
+        assert result.exit_code == 0
+        assert result.completed == ["alpha", "beta"]
+        assert result.failed == []
+        assert result.contract_failures == []
+        for comp_id in ("alpha", "beta"):
+            comp = manifest.get_component(comp_id)
+            assert comp is not None
+            assert comp.status == ComponentStatus.COMPLETED.value
+
+        # Both tiers ran and passed, with no breaker.
+        assert _contract_events(progress_path) == [
+            (0, True, None), (1, True, None),
+        ]
+
+        # The merges were real: tier 0's temp worktree held alpha's file
+        # only; tier 1's held alpha's (prior branch) plus beta's.
+        blocks: list[list[str]] = [[]]
+        for line in obs_log.read_text().splitlines():
+            if line == "--":
+                blocks.append([])
+            else:
+                blocks[-1].append(line)
+        assert [b for b in blocks if b] == [
+            ["alpha.txt"], ["alpha.txt", "beta.txt"],
+        ]
+
+        assert _checkout_state(root) == before
+        _assert_no_contract_debris(root)
+
+
+class TestContractConflictedTier:
+    def test_merge_conflict_attributes_breaker_and_leaves_checkout_intact(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Same-tier components whose branches conflict: the later
+        merge (manifest order) is blamed, the failure is terminal with
+        max_retries=0 (wave-2: recorded loudly, nonzero exit), and the
+        user's checkout is byte-identical afterward - the conflict
+        happened ONLY in a temp worktree that no longer exists."""
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+        root = tmp_path / "repo"
+        init_ralph_repo(root, ("alpha", "beta"))
+        manifest = make_manifest([component("alpha"), component("beta")])
+        before = _checkout_state(root)
+        progress_path = tmp_path / "progress.jsonl"
+
+        result = _run(
+            root, manifest, _CONFLICTING_ENGINEER, "true", progress_path,
+        )
+
+        # Wave-2 recovery semantics: the run completes (no exception),
+        # fails loudly, and blames the conflicting merge.
+        assert result.exit_code == 1
+        assert result.completed == ["alpha"]
+        assert result.failed == ["beta"]
+        assert len(result.contract_failures) == 1
+        assert "tier 0" in result.contract_failures[0]
+        assert "beta" in result.contract_failures[0]
+
+        alpha = manifest.get_component("alpha")
+        beta = manifest.get_component("beta")
+        assert alpha is not None and beta is not None
+        assert alpha.status == ComponentStatus.COMPLETED.value
+        assert beta.status == ComponentStatus.FAILED.value
+        assert beta.error == "Contract test failed at tier 0 (retries exhausted)"
+
+        assert _contract_events(progress_path) == [(0, False, "beta")]
+
+        # The user's checkout is byte-identical: same file bytes, same
+        # HEAD, same branch, still clean. The conflicted merge never
+        # touched it and its temp worktree is gone.
+        assert _checkout_state(root) == before
+        _assert_no_contract_debris(root)
+        assert not (root / ".git" / "MERGE_HEAD").exists()
+        assert not (root / "conflict.txt").exists()
+
+
+class TestContractBreakerRerun:
+    def test_breaker_reenters_scheduling_and_completes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A contract TEST failure (clean merges, broken integration)
+        bisects to beta; beta is reset to PENDING, its retry prompt
+        carries the contract failure output, its engineer re-runs and
+        fixes the branch, and the second contract pass completes the
+        run (R0.3: the promised breaker retry actually runs)."""
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+        root = tmp_path / "repo"
+        init_ralph_repo(root, ("alpha", "beta"))
+        manifest = make_manifest([component("alpha"), component("beta")])
+        cap_dir = tmp_path / "prompts"
+        cap_dir.mkdir()
+        marker = tmp_path / "beta-first-attempt-done"
+        progress_path = tmp_path / "progress.jsonl"
+
+        # Stateful engineer: beta's first attempt commits broken.txt
+        # (integration-breaking); its second attempt - on the SAME
+        # branch, resumed with the broken commit - removes it and
+        # commits beta.txt instead. Every attempt captures the prompt
+        # it received on stdin, mock-free.
+        engineer = textwrap.dedent(f"""\
+            comp="$(basename "$PWD")"
+            if [ "$comp" = beta ] && [ -f '{marker}' ]; then
+              cat > '{cap_dir}/beta-attempt2.prompt'
+              git rm -q broken.txt
+              echo beta > beta.txt
+              git add beta.txt
+              git commit -q -m 'fix integration: replace broken.txt'
+            else
+              cat > '{cap_dir}'/"$comp"-attempt1.prompt
+              if [ "$comp" = beta ]; then
+                touch '{marker}'
+                echo broken > broken.txt
+                git add broken.txt
+                git commit -q -m 'beta adds broken.txt'
+              else
+                echo alpha > alpha.txt
+                git add alpha.txt
+                git commit -q -m 'alpha adds alpha.txt'
+              fi
+            fi
+            echo '<promise>COMPLETE</promise>'
+        """)
+        contract_cmd = (
+            "test ! -f broken.txt || "
+            "{ echo 'integration broken: broken.txt present'; exit 1; }"
+        )
+
+        result = _run(
+            root, manifest, engineer, contract_cmd, progress_path,
+            max_retries=1,
+        )
+
+        assert result.exit_code == 0
+        assert result.completed == ["alpha", "beta"]
+        assert result.failed == []
+        assert result.contract_failures == []
+
+        beta = manifest.get_component("beta")
+        assert beta is not None
+        assert beta.status == ComponentStatus.COMPLETED.value
+        assert beta.retries == 1
+
+        # First pass failed and bisected to beta; the re-run passed.
+        assert _contract_events(progress_path) == [
+            (0, False, "beta"), (0, True, None),
+        ]
+
+        # The breaker's engineer REALLY re-ran (exactly once), alpha's
+        # did not - proven by the engineers' own capture files.
+        assert sorted(p.name for p in cap_dir.iterdir()) == [
+            "alpha-attempt1.prompt",
+            "beta-attempt1.prompt",
+            "beta-attempt2.prompt",
+        ]
+
+        # Retry-context propagation for contract failures: attempt 2's
+        # prompt names the failing contract output.
+        attempt2 = (cap_dir / "beta-attempt2.prompt").read_text()
+        assert "## Contract Test Failures" in attempt2
+        assert "integration broken: broken.txt present" in attempt2
+        assert "PREVIOUS ATTEMPT CONTEXT" in attempt2
+        attempt1 = (cap_dir / "beta-attempt1.prompt").read_text()
+        assert "PREVIOUS ATTEMPT CONTEXT" not in attempt1
+
+        # The fix landed on beta's real branch: beta.txt in, broken.txt
+        # gone.
+        branch_files = git(
+            "ls-tree", "--name-only", "ralph/factory/beta", cwd=root,
+        ).splitlines()
+        assert "beta.txt" in branch_files
+        assert "broken.txt" not in branch_files
+
+        _assert_no_contract_debris(root)

--- a/tests/test_spine_crash_recovery.py
+++ b/tests/test_spine_crash_recovery.py
@@ -1,0 +1,281 @@
+"""Spine tier II (R4.2): crash recovery after a SIGKILL mid-run.
+
+A real factory run in a real second PROCESS is SIGKILLed while a
+component is mid-flight - either during the engineer iteration (status
+RUNNING on disk) or during Phase 1 verification (status VERIFYING); the
+in-flight command signals via a marker file, then sleeps, so the kill
+provably lands inside the phase under test. That leaves exactly the
+state crash recovery must handle: a manifest persisted with an
+intermediate status, a provisioned worktree under the run-scoped
+``.ralph/worktrees/<run_id>/`` layout, and the component branch checked
+out there.
+
+The restart then proves the R0.5 recovery contract end to end:
+- RUNNING/VERIFYING statuses are reset to PENDING;
+- the crashed run's ``<run_id>/`` worktree is pruned (run ids differ, so
+  the new run can never mistake it for its own);
+- the crashed attempt's branch is handled per the stale-branch policy:
+  auto-deleted when fully merged, loudly REFUSED (exit 2, operator
+  decides) when it carries unmerged commits - never silently reused;
+- the manifest ends consistent: the component re-runs to COMPLETED with
+  no stale error, and no worktree survives the run.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from ralph_py.factory import run_factory
+from ralph_py.manifest import ComponentStatus, Manifest
+from ralph_py.ui.plain import PlainUI
+from tests.spine_utils import (
+    COMPLETE_LINE,
+    base_config,
+    component,
+    factory_config,
+    git,
+    init_ralph_repo,
+    make_manifest,
+)
+
+pytestmark = pytest.mark.spine
+
+COMP = "comp-a"
+BRANCH = f"ralph/factory/{COMP}"
+
+# Real factory run in a child process. argv: root, manifest_path,
+# verify test command, engineer agent command.
+_DRIVER_SCRIPT = """
+import sys
+from pathlib import Path
+from ralph_py.config import RalphConfig
+from ralph_py.factory import FactoryConfig, run_factory
+from ralph_py.manifest import Manifest
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+root = Path(sys.argv[1])
+manifest_path = Path(sys.argv[2])
+result = run_factory(
+    Manifest.load(manifest_path),
+    FactoryConfig(
+        use_worktrees=True, create_prs=False, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        verify_config=VerifyConfig(
+            test_command=sys.argv[3], typecheck_command="true",
+            lint_command="true", check_diff_scope=False,
+            check_bad_patterns=False, subprocess_timeout=300.0,
+        ),
+    ),
+    RalphConfig(
+        prompt_file=root / "scripts" / "ralph" / "prompt.md",
+        prd_file=root / "scripts" / "ralph" / "prd.json",
+        sleep_seconds=0, agent_cmd=sys.argv[4],
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    ),
+    PlainUI(no_color=True),
+    root,
+    manifest_path=manifest_path,
+)
+sys.exit(result.exit_code)
+"""
+
+
+def _crash_factory(
+    root: Path,
+    manifest_path: Path,
+    marker: Path,
+    agent_cmd: str,
+    verify_cmd: str,
+) -> None:
+    """Run the driver until ``marker`` appears, then SIGKILL it.
+
+    The phase under test owns the marker: touch-then-sleep as the agent
+    command crashes mid-RUNNING, as the verify command mid-VERIFYING.
+    """
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-c", _DRIVER_SCRIPT,
+            str(root), str(manifest_path), verify_cmd, agent_cmd,
+        ],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 60
+        while not marker.exists():
+            assert time.monotonic() < deadline, (
+                "factory run never reached the phase under test"
+            )
+            assert proc.poll() is None, (
+                f"factory run died early: {proc.communicate()[0]}"
+            )
+            time.sleep(0.05)
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=10)
+    finally:
+        if proc.poll() is None:
+            os.killpg(proc.pid, signal.SIGKILL)
+            proc.wait(timeout=10)
+
+
+def _assert_crashed_state(
+    root: Path, manifest_path: Path, expected_status: str,
+) -> Path:
+    """The kill really landed inside the intended phase: the manifest
+    persisted the intermediate status and the run-scoped worktree
+    survived. Returns the stale worktree path."""
+    crashed = Manifest.load(manifest_path)
+    assert crashed.components[0].status == expected_status
+    stale_worktrees = sorted((root / ".ralph" / "worktrees").glob(f"*/{COMP}"))
+    assert len(stale_worktrees) == 1, (
+        f"expected exactly one crashed worktree, found {stale_worktrees}"
+    )
+    return stale_worktrees[0]
+
+
+def _no_worktree_dirs_left(root: Path) -> bool:
+    worktree_root = root / ".ralph" / "worktrees"
+    if not worktree_root.exists():
+        return True
+    return not any(p.is_dir() for p in worktree_root.iterdir())
+
+
+class TestCrashRecovery:
+    @pytest.mark.parametrize(
+        "crashed_status",
+        [ComponentStatus.RUNNING.value, ComponentStatus.VERIFYING.value],
+    )
+    def test_restart_resets_intermediate_status_prunes_worktree_completes(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        crashed_status: str,
+    ) -> None:
+        """Kill mid-engineer (RUNNING) or mid-verify (VERIFYING): the
+        crashed attempt committed nothing, so its branch equals base and
+        the restart auto-deletes it, prunes the stale run-dir worktree,
+        resets the intermediate status to PENDING, and re-runs to
+        COMPLETED."""
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+        root = tmp_path / "repo"
+        init_ralph_repo(root, (COMP,))
+        manifest_path = tmp_path / "manifest.json"
+        make_manifest([component(COMP)]).save(manifest_path)
+        marker = tmp_path / "phase-started"
+        hang = f"touch '{marker}' && sleep 45"
+        if crashed_status == ComponentStatus.RUNNING.value:
+            # The ENGINEER signals and hangs: verify is never reached.
+            agent_cmd, verify_cmd = hang, "true"
+        else:
+            # The engineer completes; Phase 1 VERIFY signals and hangs.
+            agent_cmd, verify_cmd = COMPLETE_LINE, hang
+
+        _crash_factory(root, manifest_path, marker, agent_cmd, verify_cmd)
+        stale_worktree = _assert_crashed_state(
+            root, manifest_path, crashed_status,
+        )
+
+        out = io.StringIO()
+        restarted = Manifest.load(manifest_path)
+        result = run_factory(
+            restarted, factory_config(), base_config(root),
+            PlainUI(no_color=True, file=out), root,
+            manifest_path=manifest_path,
+        )
+        ui_output = out.getvalue()
+
+        assert (
+            f"Resetting '{COMP}' from {crashed_status} to PENDING"
+            in ui_output
+        )
+        assert "Pruned 1 stale worktree(s) from previous runs" in ui_output
+        assert f"Deleted stale branch '{BRANCH}'" in ui_output
+
+        assert result.exit_code == 0
+        assert result.completed == [COMP]
+        assert not stale_worktree.exists()
+        assert _no_worktree_dirs_left(root)
+        listing = git("worktree", "list", "--porcelain", cwd=root)
+        assert [
+            line for line in listing.splitlines()
+            if line.startswith("worktree ")
+        ] == [f"worktree {root}"]
+
+        # The persisted manifest is consistent after recovery.
+        final = Manifest.load(manifest_path)
+        assert final.components[0].status == ComponentStatus.COMPLETED.value
+        assert final.components[0].error == ""
+
+    def test_restart_refuses_crashed_branch_with_commits_then_operator_recovers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Crashed attempt COMMITTED work before dying: the restart still
+        resets state and prunes the stale worktree, but refuses to run
+        (exit 2) rather than silently reuse or destroy the branch - loud
+        beats lossy (R0.5). Deleting the branch, as the refusal
+        instructs, lets the next run complete."""
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+        root = tmp_path / "repo"
+        init_ralph_repo(root, (COMP,))
+        manifest_path = tmp_path / "manifest.json"
+        make_manifest([component(COMP)]).save(manifest_path)
+        committing_agent = (
+            "echo progress > progress.txt && git add progress.txt && "
+            "git commit -q -m 'crashed attempt progress' && "
+            + COMPLETE_LINE
+        )
+
+        marker = tmp_path / "verify-started"
+        _crash_factory(
+            root, manifest_path, marker, committing_agent,
+            f"touch '{marker}' && sleep 45",
+        )
+        stale_worktree = _assert_crashed_state(
+            root, manifest_path, ComponentStatus.VERIFYING.value,
+        )
+
+        out = io.StringIO()
+        refused = run_factory(
+            Manifest.load(manifest_path), factory_config(),
+            base_config(root), PlainUI(no_color=True, file=out), root,
+            manifest_path=manifest_path,
+        )
+        ui_output = out.getvalue()
+
+        assert refused.exit_code == 2
+        assert refused.completed == []
+        assert "Refusing to run: stale component branches found" in ui_output
+        assert f"branch '{BRANCH}'" in ui_output
+        # Stale-worktree handling ran even though the run was refused.
+        assert "Pruned 1 stale worktree(s) from previous runs" in ui_output
+        assert not stale_worktree.exists()
+        # The crashed attempt's commits were preserved, not destroyed.
+        assert git("branch", "--list", BRANCH, cwd=root).strip()
+        assert "progress.txt" in git(
+            "ls-tree", "--name-only", BRANCH, cwd=root,
+        ).splitlines()
+
+        # Operator path from the refusal message: delete the branch and
+        # re-run; recovery then completes and the manifest is consistent.
+        git("branch", "-D", BRANCH, cwd=root)
+        rerun = run_factory(
+            Manifest.load(manifest_path), factory_config(),
+            base_config(root), PlainUI(no_color=True, file=io.StringIO()),
+            root, manifest_path=manifest_path,
+        )
+        assert rerun.exit_code == 0
+        assert rerun.completed == [COMP]
+        final = Manifest.load(manifest_path)
+        assert final.components[0].status == ComponentStatus.COMPLETED.value
+        assert final.components[0].error == ""
+        assert _no_worktree_dirs_left(root)

--- a/tests/test_spine_engineer_loop.py
+++ b/tests/test_spine_engineer_loop.py
@@ -1,0 +1,111 @@
+"""Spine tier II (R4.2): engineer-loop plumbing, fully unmocked.
+
+One direct ``_run_component`` execution - the exact function the factory
+scheduler submits to its worker pool - against a real worktree with a
+fake agent BINARY (an executable script on disk, run through the custom
+agent adapter as a real subprocess). No ``unittest.mock`` anywhere.
+
+Proven by the artifacts, not by call records:
+- worktree in: the agent's own ``pwd`` capture shows it ran inside the
+  provisioned worktree, on the component branch;
+- provisioning: the per-component PRD and the prompt template (both
+  gitignored, so absent from a fresh worktree) were copied in, and the
+  prompt the agent RECEIVED is the template with ``$prd_path``
+  substituted to the worktree's PRD copy;
+- result out: the agent's commit lands on the component branch and
+  ``_run_component`` reports success with the true iteration count.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ralph_py.factory import _run_component, _setup_worktree
+from tests.spine_utils import git, init_ralph_repo
+
+pytestmark = pytest.mark.spine
+
+COMP = "comp-a"
+BRANCH = f"ralph/factory/{COMP}"
+RUN_ID = "spine-run-engineer"
+PRD_REL = f"scripts/ralph/feature/{COMP}/prd.json"
+PROMPT_REL = "scripts/ralph/prompt.md"
+
+
+class TestEngineerLoopPlumbing:
+    def test_run_component_end_to_end_with_fake_agent_binary(
+        self, tmp_path: Path,
+    ) -> None:
+        root = tmp_path / "repo"
+        init_ralph_repo(root, (COMP,))
+        worktree = _setup_worktree(COMP, BRANCH, "main", root, RUN_ID)
+        # The gitignored inputs are NOT in the fresh worktree via git;
+        # only _run_component's provisioning can put them there.
+        assert not (worktree / PRD_REL).exists()
+        assert not (worktree / PROMPT_REL).exists()
+
+        cap_dir = tmp_path / "capture"
+        cap_dir.mkdir()
+        agent_bin = tmp_path / "bin" / "fake-agent"
+        agent_bin.parent.mkdir()
+        agent_bin.write_text(textwrap.dedent(f"""\
+            #!/bin/bash
+            cat > '{cap_dir}/prompt.txt'
+            pwd > '{cap_dir}/cwd.txt'
+            echo implemented > result.txt
+            git add result.txt
+            git commit -q -m 'engineer output'
+            echo '<promise>COMPLETE</promise>'
+        """))
+        agent_bin.chmod(0o755)
+
+        result = _run_component(
+            COMP,
+            PRD_REL,
+            str(worktree),
+            str(root),
+            PROMPT_REL,
+            str(agent_bin),  # agent_cmd: the fake agent binary
+            None,  # model
+            None,  # reasoning
+            None,  # agent_type
+            0.0,   # sleep_seconds
+        )
+
+        assert result.success is True
+        assert result.component_id == COMP
+        assert result.iterations == 1
+        assert result.error is None
+
+        # PRD copy present, byte-identical to the root's per-component
+        # PRD; prompt copy present likewise.
+        assert (worktree / PRD_REL).read_text() == (
+            (root / PRD_REL).read_text()
+        )
+        assert (worktree / PROMPT_REL).read_text() == (
+            (root / PROMPT_REL).read_text()
+        )
+
+        # Worktree in: the agent subprocess really ran inside the
+        # provisioned worktree, on the component branch.
+        agent_cwd = (cap_dir / "cwd.txt").read_text().strip()
+        assert Path(agent_cwd).resolve() == worktree.resolve()
+        assert git("branch", "--show-current", cwd=worktree) == BRANCH
+
+        # The prompt the agent received is the template with $prd_path
+        # substituted to the worktree's PRD copy (never the root's).
+        prompt = (cap_dir / "prompt.txt").read_text()
+        assert "Read the PRD at" in prompt
+        assert str(worktree / PRD_REL) in prompt
+        assert str(root / PRD_REL) not in prompt
+        assert "PREVIOUS ATTEMPT CONTEXT" not in prompt
+
+        # Result out: the engineer's commit is on the component branch.
+        assert (worktree / "result.txt").read_text() == "implemented\n"
+        assert git("log", "-1", "--format=%s", cwd=worktree) == (
+            "engineer output"
+        )
+        assert git("status", "--porcelain", cwd=worktree) == ""

--- a/tests/test_spine_retry_context.py
+++ b/tests/test_spine_retry_context.py
@@ -1,0 +1,144 @@
+"""Spine tier II (R4.2): retry-context propagation, end to end.
+
+tests/test_verify.py proves check_diff_scope's failure DETAILS carry the
+base branch and the full allowed-paths list (R0.4), and unit tests prove
+IterationContext formatting - but nothing proved the whole pipe: a real
+engineer failing Phase 1 in a real worktree, the factory rebuilding the
+retry prompt, and the NEXT engineer invocation actually receiving it.
+
+Here the engineer is a real ``bash -lc`` subprocess that writes the
+prompt it received on stdin to a file (mock-free capture at the exact
+boundary the retry context must cross). Attempt 1 commits an
+out-of-scope file and fails diff-scope; the test asserts attempt 2's
+prompt contains the failure details INCLUDING the base branch and the
+complete allowed-paths list (wave-2 behavior), then attempt 2 fixes the
+scope violation and the component completes.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ralph_py.factory import run_factory
+from ralph_py.manifest import ComponentStatus
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+from tests.spine_utils import (
+    base_config,
+    component,
+    factory_config,
+    init_ralph_repo,
+    make_manifest,
+)
+
+pytestmark = pytest.mark.spine
+
+COMP = "comp-a"
+
+
+class TestRetryContextPropagation:
+    def test_diff_scope_failure_details_reach_attempt_two_prompt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+        root = tmp_path / "repo"
+        init_ralph_repo(root, (COMP,))
+        # PRD with an allowedPaths scope: only src/ may change.
+        prd_path = root / "scripts" / "ralph" / "feature" / COMP / "prd.json"
+        prd_path.write_text(json.dumps({
+            "branchName": f"ralph/factory/{COMP}",
+            "userStories": [{
+                "id": "US-001", "title": "Test",
+                "acceptanceCriteria": ["AC1"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+            "allowedPaths": ["src/"],
+        }))
+
+        cap_dir = tmp_path / "prompts"
+        cap_dir.mkdir()
+        marker = tmp_path / "first-attempt-done"
+        # Attempt 1: capture the prompt, commit an in-scope file AND an
+        # out-of-scope one. Attempt 2: capture the prompt, then remove
+        # the out-of-scope file (the branch is resumed with attempt 1's
+        # commit, so the fix must revert it).
+        engineer = textwrap.dedent(f"""\
+            if [ -f '{marker}' ]; then
+              cat > '{cap_dir}/attempt2.prompt'
+              git rm -q evil.txt
+              git commit -q -m 'remove out-of-scope file'
+            else
+              touch '{marker}'
+              cat > '{cap_dir}/attempt1.prompt'
+              mkdir -p src
+              echo ok > src/ok.txt
+              echo evil > evil.txt
+              git add src/ok.txt evil.txt
+              git commit -q -m 'in-scope and out-of-scope files'
+            fi
+            echo '<promise>COMPLETE</promise>'
+        """)
+
+        manifest = make_manifest([component(COMP)])
+        progress_path = tmp_path / "progress.jsonl"
+        result = run_factory(
+            manifest,
+            factory_config(
+                max_retries=1,
+                progress_log_path=progress_path,
+                verify_config=VerifyConfig(
+                    test_command="true", typecheck_command="true",
+                    lint_command="true", check_diff_scope=True,
+                    check_bad_patterns=False, subprocess_timeout=10.0,
+                ),
+            ),
+            base_config(root, engineer),
+            PlainUI(no_color=True),
+            root,
+        )
+
+        # The retry recovered: attempt 2 fixed the scope violation.
+        assert result.exit_code == 0
+        assert result.completed == [COMP]
+        comp = manifest.get_component(COMP)
+        assert comp is not None
+        assert comp.status == ComponentStatus.COMPLETED.value
+        assert comp.retries == 1
+
+        # Attempt 1 ran with no inherited context.
+        attempt1 = (cap_dir / "attempt1.prompt").read_text()
+        assert "PREVIOUS ATTEMPT CONTEXT" not in attempt1
+
+        # Attempt 2's prompt carries the diff-scope failure verbatim,
+        # INCLUDING the base branch and the complete allowed-paths list
+        # (R0.4: without them the retry agent guessed the base and
+        # reverted base-branch content, failing again).
+        attempt2 = (cap_dir / "attempt2.prompt").read_text()
+        assert "PREVIOUS ATTEMPT CONTEXT" in attempt2
+        assert "## Verification Failures" in attempt2
+        assert "diff_scope: FAIL" in attempt2
+        assert "Base branch: main" in attempt2
+        assert "Allowed paths (complete list): src/" in attempt2
+        assert "evil.txt" in attempt2
+        # The anti-footgun instruction rides along with the base branch.
+        assert "do NOT `git checkout main -- <path>`" in attempt2
+
+        # The journal agrees with the prompts: one failed verification,
+        # one retry, one passing verification.
+        events = [
+            json.loads(line)
+            for line in progress_path.read_text().splitlines()
+            if line.strip()
+        ]
+        verifications = [
+            e["data"]["passed"] for e in events
+            if e["event"] == "verification_result"
+        ]
+        assert verifications == [False, True]
+        retries = [e for e in events if e["event"] == "component_retrying"]
+        assert len(retries) == 1
+        assert retries[0]["data"]["reason"] == "Mechanical verification failed"


### PR DESCRIPTION
## Roadmap items

R4.2 (real-git spine tier, second half - session 6C). Flips R4.2 to `[x]`: spine complete (spine I landed in #69; the CI fast/spine job split landed with R4.3/R4.4 in #74).

Four new spine-marked, mock-free test files (`tests/` only; no product code changed):

- `tests/test_spine_contract.py` - contract execution against real git in deferred-merge mode
- `tests/test_spine_retry_context.py` - retry-context propagation end to end
- `tests/test_spine_crash_recovery.py` - SIGKILL mid-verify + restart recovery
- `tests/test_spine_engineer_loop.py` - unmocked `_run_component` plumbing smoke

## Tested

Behaviors proven by named tests (real `git init` repos, real `bash -lc` engineer subprocesses, no `unittest.mock`):

- **Passing tiers merge real branches incrementally** (`test_tier_checks_merge_real_branches_incrementally`): two-tier manifest; the per-tier contract command records what the merged temp worktree actually contains - tier 0 sees `alpha.txt` only, tier 1 sees `alpha.txt` (prior branch) + `beta.txt`; both `contract_result` progress events pass; user checkout byte-identical afterward; no `.ralph/contract/` debris and `git worktree list` shows only the main checkout.
- **Conflicted tier recovers per wave-2 (R0.3) semantics** (`test_merge_conflict_attributes_breaker_and_leaves_checkout_intact`): same-tier branches conflict; breaker attributed to the later merge; terminal failure with retries exhausted (exit 1, `contract_failures` recorded, breaker FAILED, sibling stays COMPLETED); user checkout **byte-identical** (per-file sha256 over everything outside `.git`/`.ralph`, plus HEAD, branch, and clean porcelain status); no `MERGE_HEAD`, no conflict file, no surviving contract temp worktree.
- **Breaker re-runs to completion** (`test_breaker_reenters_scheduling_and_completes`): clean merges + broken integration bisects to beta; beta re-enters scheduling (proven by the engineers' own prompt-capture files: `alpha-attempt1`, `beta-attempt1`, `beta-attempt2` and nothing else); beta's attempt-2 prompt contains `## Contract Test Failures` with the real contract output; the fix lands on beta's actual branch; second contract pass passes; exit 0 with `beta.retries == 1`.
- **Retry-context propagation e2e** (`test_diff_scope_failure_details_reach_attempt_two_prompt`): attempt 1 commits an out-of-scope file and fails diff-scope; attempt 2's stdin-captured prompt contains the failure details **including** `Base branch: main`, `Allowed paths (complete list): src/`, the violating file, and the R0.4 anti-footgun instruction (`do NOT git checkout main -- <path>`); attempt 1's prompt carries no inherited context; the retry fixes scope and completes; progress-log verification events read `[False, True]` with exactly one retry event.
- **Crash recovery, clean path, both intermediate statuses** (`test_restart_resets_intermediate_status_prunes_worktree_completes`, parameterized over RUNNING and VERIFYING): a real second-process factory run (driver via `sys.executable`) is SIGKILLed only after the in-flight command proves the intended phase is executing - the engineer hangs for the RUNNING variant, the Phase 1 verify command for the VERIFYING variant; the on-disk manifest shows that exact intermediate status and the run-scoped `.ralph/worktrees/<run_id>/comp-a` worktree survives; restart resets it to PENDING (asserted on UI output), prunes exactly one stale worktree, auto-deletes the fully-merged crashed branch, completes the component, and leaves the persisted manifest consistent (COMPLETED, empty error) with zero worktree dirs left.
- **Crash recovery, loud-refusal path** (`test_restart_refuses_crashed_branch_with_commits_then_operator_recovers`): when the crashed attempt COMMITTED work, the restart still prunes the stale worktree but refuses to run (exit 2) naming the branch, preserving its commits (R0.5 loud-beats-lossy); after the operator deletes the branch as instructed, the next run completes and the manifest is consistent.
- **Engineer-loop plumbing smoke** (`test_run_component_end_to_end_with_fake_agent_binary`): one direct `_run_component` call with a fake agent **binary** (executable script) - the gitignored PRD and prompt template are proven absent from the fresh worktree, then present byte-identical after provisioning; the agent's own `pwd` capture shows it ran in the worktree on the component branch; the prompt it received is the template with `$prd_path` substituted to the worktree PRD copy (not the root's); its commit lands on the branch and the result reports success with 1 iteration.

## Measured timings (R4.2 requirement 5, budget ~90s)

Measured on this machine (`time uv run pytest ... -q`):

- Spine II files alone (8 tests): **2.96s** (slowest test 0.54s)
- Full spine tier `-m spine` (23 passed, 1 xfailed): **10.07s**
- Full suite: 1019 passed, 14 skipped, 1 xfailed in **71.10s**

## Assumed

- No new product bugs surfaced, so no new xfails were added (the one xfailed spine test is spine I's pre-existing registered-but-missing worktree bug from #69). One observation from the refusal-path crash test: a refused restart (exit 2) does not persist the in-memory VERIFYING-to-PENDING reset to disk; this is self-healing (every subsequent run re-resets on load, which the operator-recovery tail asserts) and is not treated as a defect.
- The `sleep 45` verify child orphaned by the SIGKILL is fully detached (own session via `run_scrubbed`) and expires on its own; assumed harmless to parallel test runs, not separately tested.
- Timings above are from one machine (Darwin, warm uv cache); CI numbers will differ but the ~36x headroom against the 90s budget is assumed to absorb that.

## Checks (final lines)

```
1019 passed, 14 skipped, 1 xfailed, 1 warning in 71.10s (0:01:11)
Success: no issues found in 37 source files
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
