### PR TITLE
feat: R3.1 cost meter - per-component per-phase usage accounting (H-17)

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -378,7 +378,7 @@ tests (enforced by the guard fixture).
 First principles: walking away requires knowing (a) is it stuck, (b) what is it
 spending, (c) what do I do when I come back to a partial failure.
 
-- [ ] R3.1 (M) **Cost meter** [H-17, P-3]
+- [x] R3.1 (M) **Cost meter** [H-17, P-3]
   - Parse token usage from the claude CLI stream-json result events; measure
     what codex exposes (this needs to be measured, not assumed: spike first);
     fall back to call counts + wall time where usage is unavailable.
@@ -387,6 +387,17 @@ spending, (c) what do I do when I come back to a partial failure.
     synthetic finding per R1.2's pattern).
   - Failure mode: usage formats drift with CLI versions: parse defensively,
     never gate correctness on the meter.
+  - Landed: measured claude CLI 2.1.214 (result-event `usage` +
+    `total_cost_usd`) and codex CLI 0.134.0 (plain "tokens used" trailer,
+    total only; `codex exec --json` exposes an in/out split but needs a
+    streaming-display rework - noted as follow-up). Adapters append one
+    UsageRecord per run; the factory rolls up
+    engineer/review/security/distill per component; journal entries gain
+    `usage`, experiments.tsv gains
+    total_tokens/total_cost_usd/unreported_calls; `max_total_tokens`
+    (toml/env/`--max-total-tokens`) fails the current component with a
+    synthetic finding and gates scheduling. Enforcement granularity is
+    the phase boundary; unreported calls make totals lower bounds.
 - [ ] R3.2 (M) **Status + notification** [P-4, D-status]
   - ProgressLog defaults on; `ralph status` renders manifest + log (per
     component: phase, attempt, last event age, evidence paths).

--- a/ralph_py/agents/base.py
+++ b/ralph_py/agents/base.py
@@ -1,10 +1,176 @@
-"""Base agent protocol for Ralph."""
+"""Base agent protocol and usage metering types for Ralph."""
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class UsageRecord:
+    """Token/cost usage for ONE agent invocation (one ``run`` call).
+
+    R3.1 cost meter. Every field except ``duration_seconds`` and
+    ``source`` is a CLI self-report parsed from agent output; ``None``
+    means "the CLI did not report it", never zero. These are hints for
+    accounting - they must never gate correctness (a parse failure
+    produces an all-``None`` record, not an exception).
+
+    Measured emission formats (2026-07-18, see R3.1 PR):
+    - claude CLI 2.1.214 stream-json ``result`` event: ``usage``
+      (``input_tokens``, ``output_tokens``, ``cache_read_input_tokens``,
+      ``cache_creation_input_tokens``), ``total_cost_usd``,
+      ``duration_ms``.
+    - codex CLI 0.134.0 plain output: a trailing ``tokens used`` /
+      ``14,511`` line pair - TOTAL tokens only, no in/out split, no cost.
+    """
+
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_read_tokens: int | None = None
+    cache_creation_tokens: int | None = None
+    # CLI-reported total where only a total exists (codex); for claude
+    # the adapter derives it as the sum of the four component fields.
+    total_tokens: int | None = None
+    cost_usd: float | None = None
+    duration_seconds: float = 0.0
+    # Provenance: "claude-stream-json", "codex-text", "unavailable",
+    # "timeout", or "parse-error".
+    source: str = "unavailable"
+
+
+@dataclass
+class UsageTotals:
+    """Aggregate of UsageRecords (per phase, per component, or per run).
+
+    ``known_calls`` counts invocations that reported at least one token
+    or cost figure; ``calls - known_calls`` invocations contributed only
+    wall time, so every token/cost total is a LOWER BOUND whenever
+    ``unreported_calls > 0`` (H4: totals are only as honest as their
+    coverage, and the rollup renders that gap explicitly).
+    """
+
+    calls: int = 0
+    known_calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    total_tokens: int = 0
+    cost_usd: float = 0.0
+    duration_seconds: float = 0.0
+
+    @property
+    def unreported_calls(self) -> int:
+        """Invocations that reported no token/cost data at all."""
+        return self.calls - self.known_calls
+
+    def add_record(self, record: object) -> None:
+        """Fold one usage record into the totals.
+
+        Defensive by design (R3.1 requirement 4): ``record`` is read
+        via ``getattr`` with per-field type checks so a malformed or
+        foreign object degrades to "one call, nothing reported" instead
+        of raising.
+        """
+        self.calls += 1
+        known = False
+        token_fields = (
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_creation_tokens",
+        )
+        part_sum = 0
+        parts_seen = False
+        for name in token_fields:
+            value = _as_int(getattr(record, name, None))
+            if value is not None:
+                setattr(self, name, getattr(self, name) + value)
+                part_sum += value
+                parts_seen = True
+                known = True
+        total = _as_int(getattr(record, "total_tokens", None))
+        if total is not None:
+            self.total_tokens += total
+            known = True
+        elif parts_seen:
+            self.total_tokens += part_sum
+        cost = _as_float(getattr(record, "cost_usd", None))
+        if cost is not None:
+            self.cost_usd += cost
+            known = True
+        duration = _as_float(getattr(record, "duration_seconds", None))
+        if duration is not None:
+            self.duration_seconds += duration
+        if known:
+            self.known_calls += 1
+
+    def merge(self, other: UsageTotals) -> None:
+        """Fold another totals object into this one."""
+        self.calls += other.calls
+        self.known_calls += other.known_calls
+        self.input_tokens += other.input_tokens
+        self.output_tokens += other.output_tokens
+        self.cache_read_tokens += other.cache_read_tokens
+        self.cache_creation_tokens += other.cache_creation_tokens
+        self.total_tokens += other.total_tokens
+        self.cost_usd += other.cost_usd
+        self.duration_seconds += other.duration_seconds
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serializable form for the progress log / journal / TSV."""
+        return {
+            "calls": self.calls,
+            "known_calls": self.known_calls,
+            "unreported_calls": self.unreported_calls,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "total_tokens": self.total_tokens,
+            "cost_usd": round(self.cost_usd, 6),
+            "duration_seconds": round(self.duration_seconds, 2),
+        }
+
+
+def _as_int(value: object) -> int | None:
+    """Non-negative int or None. bool is rejected (it is an int subclass
+    and a malformed ``usage`` dict could carry flags where counts go)."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value >= 0 else None
+
+
+def _as_float(value: object) -> float | None:
+    """Non-negative float or None (accepts ints, rejects bools)."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value) if value >= 0 else None
+
+
+def collect_usage(agent: object) -> UsageTotals:
+    """Aggregate an agent's accumulated ``usage_records`` defensively.
+
+    Works on ANY object: an agent without the attribute (a third-party
+    Agent implementation predating R3.1, or a test fake) yields empty
+    totals rather than an error - the meter must never gate correctness.
+    """
+    totals = UsageTotals()
+    try:
+        records = getattr(agent, "usage_records", None)
+        if records is None:
+            return totals
+        for record in list(records):
+            totals.add_record(record)
+    except Exception as exc:  # noqa: BLE001 - meter must never crash a run
+        logger.warning("Failed to collect agent usage records: %s", exc)
+    return totals
 
 
 class Agent(Protocol):
@@ -33,4 +199,17 @@ class Agent(Protocol):
     @property
     def final_message(self) -> str | None:
         """Return final message if available (for codex --output-last-message)."""
+        ...
+
+    @property
+    def usage_records(self) -> list[UsageRecord]:
+        """Usage records accumulated across ``run`` calls (R3.1).
+
+        One record per ``run`` invocation, appended on every exit path
+        (success, timeout, CLI-missing). Consumers must read this via
+        :func:`collect_usage`, which tolerates implementations that
+        predate the property - the protocol addition is backward-
+        compatible at runtime for CustomAgent-style adapters and
+        third-party fakes.
+        """
         ...

--- a/ralph_py/agents/claude_code.py
+++ b/ralph_py/agents/claude_code.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import json
+import logging
 import shutil
+import time
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from ralph_py.agents.base import UsageRecord
 from ralph_py.agents.proc import DeadlineStreamer, timeout_message
+
+logger = logging.getLogger(__name__)
 
 COMPLETION_MARKER = "<promise>COMPLETE</promise>"
 
@@ -32,6 +37,7 @@ class ClaudeCodeAgent:
         self._effort = effort
         self._final_message: str | None = None
         self._saw_result: bool = False
+        self._usage_records: list[UsageRecord] = []
 
     @property
     def name(self) -> str:
@@ -58,6 +64,8 @@ class ClaudeCodeAgent:
         self._final_message = None
         self._saw_result = False
         accumulated_text: list[str] = []
+        started = time.monotonic()
+        result_event_line: str | None = None
 
         cmd = [
             "claude", "--print",
@@ -75,6 +83,7 @@ class ClaudeCodeAgent:
                 cmd, cwd=cwd, stdin_text=prompt, timeout=timeout,
             )
         except FileNotFoundError:
+            self._usage_records.append(UsageRecord(source="unavailable"))
             yield "ERROR: claude CLI not found in PATH"
             return
 
@@ -87,6 +96,9 @@ class ClaudeCodeAgent:
             if result_text is not None:
                 self._saw_result = True
                 self._final_message = result_text
+                # The same event carries the usage/cost self-report
+                # (measured against claude CLI 2.1.214; see base.py).
+                result_event_line = raw_line
                 break
 
             # Parse stream-json events
@@ -96,11 +108,19 @@ class ClaudeCodeAgent:
                 yield display_line
 
         if streamer.timed_out:
+            self._usage_records.append(UsageRecord(
+                duration_seconds=time.monotonic() - started,
+                source="timeout",
+            ))
             yield timeout_message(timeout)
             return
 
         # Wait for process to exit, but don't hang forever
         streamer.finish(timeout=10)
+
+        self._usage_records.append(_usage_from_result_event(
+            result_event_line, time.monotonic() - started,
+        ))
 
         # Set final_message from accumulated text if not already set by result event
         if self._final_message is None and accumulated_text:
@@ -110,6 +130,90 @@ class ClaudeCodeAgent:
     def final_message(self) -> str | None:
         """Return last non-empty output line."""
         return self._final_message
+
+    @property
+    def usage_records(self) -> list[UsageRecord]:
+        """One usage record per ``run`` call, accumulated (R3.1)."""
+        return list(self._usage_records)
+
+
+def _usage_from_result_event(
+    raw_line: str | None, fallback_duration: float,
+) -> UsageRecord:
+    """Build a UsageRecord from the stream-json ``result`` event.
+
+    Measured shape (claude CLI 2.1.214): the event carries a ``usage``
+    dict (``input_tokens``, ``output_tokens``, ``cache_read_input_tokens``,
+    ``cache_creation_input_tokens``), a ``total_cost_usd`` float, and
+    ``duration_ms``. Formats drift across CLI versions, so every field
+    is optional: a parse failure logs a warning and records unknown -
+    the meter never gates correctness (R3.1 requirement 4).
+    """
+    duration = fallback_duration
+    if raw_line is None:
+        # Stream ended without a result event (e.g. CLI died early or a
+        # non-stream-json fake in tests): calls + wall time only.
+        return UsageRecord(duration_seconds=duration, source="unavailable")
+    try:
+        evt = json.loads(raw_line)
+        duration_ms = evt.get("duration_ms")
+        if (
+            isinstance(duration_ms, (int, float))
+            and not isinstance(duration_ms, bool)
+            and duration_ms >= 0
+        ):
+            duration = float(duration_ms) / 1000.0
+
+        usage = evt.get("usage")
+        if not isinstance(usage, dict):
+            usage = {}
+
+        def _tok(key: str) -> int | None:
+            value = usage.get(key)
+            if isinstance(value, bool) or not isinstance(value, int):
+                return None
+            return value if value >= 0 else None
+
+        input_tokens = _tok("input_tokens")
+        output_tokens = _tok("output_tokens")
+        cache_read = _tok("cache_read_input_tokens")
+        cache_creation = _tok("cache_creation_input_tokens")
+
+        cost_raw = evt.get("total_cost_usd")
+        cost: float | None = None
+        if (
+            isinstance(cost_raw, (int, float))
+            and not isinstance(cost_raw, bool)
+            and cost_raw >= 0
+        ):
+            cost = float(cost_raw)
+
+        parts = [
+            p for p in (input_tokens, output_tokens, cache_read, cache_creation)
+            if p is not None
+        ]
+        if not parts and cost is None:
+            logger.warning(
+                "claude result event carried no parsable usage fields; "
+                "recording unknown usage for this call"
+            )
+            return UsageRecord(duration_seconds=duration, source="parse-error")
+
+        return UsageRecord(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_creation,
+            total_tokens=sum(parts) if parts else None,
+            cost_usd=cost,
+            duration_seconds=duration,
+            source="claude-stream-json",
+        )
+    except Exception as exc:  # noqa: BLE001 - meter must never crash a run
+        logger.warning("Failed to parse claude usage: %s", exc)
+        return UsageRecord(
+            duration_seconds=fallback_duration, source="parse-error",
+        )
 
 
 def _extract_result_text(raw_line: str) -> str | None:

--- a/ralph_py/agents/codex.py
+++ b/ralph_py/agents/codex.py
@@ -2,13 +2,34 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import tempfile
+import time
 from collections.abc import Iterator
 from pathlib import Path
 
+from ralph_py.agents.base import UsageRecord
 from ralph_py.agents.proc import DeadlineStreamer, timeout_message
+
+# Measured against codex CLI 0.134.0 (R3.1): plain `codex exec` output
+# ends with a two-line trailer - a line reading "tokens used" followed by
+# a comma-formatted integer line ("14,511"). That is the ONLY usage data
+# codex emits with the flags this adapter uses: a TOTAL, no in/out split,
+# no cost. (`codex exec --json` exposes a structured turn.completed
+# usage event, but switching to it would rework streaming display and
+# the plain-text COMPLETION_MARKER detection - noted as follow-up.)
+_TOKENS_USED_LINE = re.compile(r"^tokens used:?\s*(?P<total>[\d,]+)?$", re.IGNORECASE)
+_TOKENS_COUNT_LINE = re.compile(r"^[\d,]{1,20}$")
+
+
+def _parse_token_count(text: str) -> int | None:
+    """Parse a comma-formatted token count; None on any mismatch."""
+    try:
+        return int(text.replace(",", ""))
+    except ValueError:
+        return None
 
 
 class CodexAgent:
@@ -30,6 +51,7 @@ class CodexAgent:
         self._model = model
         self._reasoning_effort = reasoning_effort
         self._final_message: str | None = None
+        self._usage_records: list[UsageRecord] = []
 
     @property
     def name(self) -> str:
@@ -54,6 +76,9 @@ class CodexAgent:
         """
         self._final_message = None
         last_non_empty_line: str | None = None
+        started = time.monotonic()
+        trailer_total: int | None = None
+        expect_token_count = False
 
         # Build command (non-interactive)
         cmd = ["codex", "exec"]
@@ -80,18 +105,44 @@ class CodexAgent:
 
             # Stream output
             for line in streamer.lines():
-                if line.strip():
+                stripped = line.strip()
+                if stripped:
                     last_non_empty_line = line
+                # Track the "tokens used" trailer (last match wins - the
+                # real trailer is at end-of-stream; an agent echoing the
+                # same text earlier is overwritten). This is a hint for
+                # the cost meter, never a gate.
+                if expect_token_count:
+                    expect_token_count = False
+                    if _TOKENS_COUNT_LINE.match(stripped):
+                        trailer_total = _parse_token_count(stripped)
+                match = _TOKENS_USED_LINE.match(stripped)
+                if match:
+                    if match.group("total"):
+                        trailer_total = _parse_token_count(match.group("total"))
+                    else:
+                        expect_token_count = True
                 yield line
 
             if streamer.timed_out:
                 # Killed mid-run: the last-message file was likely never
                 # written; partial output is not a trustworthy final
-                # message, so leave it unset.
+                # message, so leave it unset. The trailer never printed
+                # either, so only wall time is recorded.
+                self._usage_records.append(UsageRecord(
+                    duration_seconds=time.monotonic() - started,
+                    source="timeout",
+                ))
                 yield timeout_message(timeout)
                 return
 
             streamer.finish()
+
+            self._usage_records.append(UsageRecord(
+                total_tokens=trailer_total,
+                duration_seconds=time.monotonic() - started,
+                source="codex-text" if trailer_total is not None else "unavailable",
+            ))
 
             # Read final message
             if last_msg_file and last_msg_file.exists():
@@ -113,6 +164,11 @@ class CodexAgent:
     def final_message(self) -> str | None:
         """Return final message from --output-last-message."""
         return self._final_message
+
+    @property
+    def usage_records(self) -> list[UsageRecord]:
+        """One usage record per ``run`` call, accumulated (R3.1)."""
+        return list(self._usage_records)
 
     @classmethod
     def _codex_supports_output_last_message(cls) -> bool:

--- a/ralph_py/agents/custom.py
+++ b/ralph_py/agents/custom.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import shutil
+import time
 from collections.abc import Iterator
 from pathlib import Path
 
+from ralph_py.agents.base import UsageRecord
 from ralph_py.agents.proc import DeadlineStreamer, timeout_message
 
 
@@ -20,6 +22,7 @@ class CustomAgent:
         """
         self._command = command
         self._final_message: str | None = None
+        self._usage_records: list[UsageRecord] = []
 
     @property
     def name(self) -> str:
@@ -36,6 +39,7 @@ class CustomAgent:
         and a timeout error line is yielded last.
         """
         self._final_message = None
+        started = time.monotonic()
 
         use_bash = shutil.which("bash") is not None
         if use_bash:
@@ -60,10 +64,21 @@ class CustomAgent:
         if streamer.timed_out:
             # Killed mid-run: partial output is not a trustworthy final
             # message, so leave it unset.
+            self._usage_records.append(UsageRecord(
+                duration_seconds=time.monotonic() - started,
+                source="timeout",
+            ))
             yield timeout_message(timeout)
             return
 
         streamer.finish()
+
+        # R3.1: an arbitrary shell command exposes no token accounting;
+        # the fallback the roadmap mandates is call counts + wall time.
+        self._usage_records.append(UsageRecord(
+            duration_seconds=time.monotonic() - started,
+            source="unavailable",
+        ))
 
         # Store last output as "final message" for consistency
         if output_lines:
@@ -73,3 +88,8 @@ class CustomAgent:
     def final_message(self) -> str | None:
         """Return last output line."""
         return self._final_message
+
+    @property
+    def usage_records(self) -> list[UsageRecord]:
+        """One usage record per ``run`` call, accumulated (R3.1)."""
+        return list(self._usage_records)

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -18,7 +18,7 @@ from click.core import ParameterSource
 
 from ralph_py import __version__
 from ralph_py.agents import ClaudeCodeAgent, CodexAgent, get_agent
-from ralph_py.agents.base import Agent
+from ralph_py.agents.base import Agent, UsageRecord
 from ralph_py.config import RalphConfig, _parse_paths, load_toml_section
 from ralph_py.decompose import SpecBlockerError, decompose_spec
 from ralph_py.factory import FactoryConfig, run_factory
@@ -351,6 +351,12 @@ class LoggingAgent:
     @property
     def final_message(self) -> str | None:
         return self._agent.final_message
+
+    @property
+    def usage_records(self) -> list[UsageRecord]:
+        """R3.1: forward the wrapped agent's usage records."""
+        records = getattr(self._agent, "usage_records", None)
+        return list(records) if records is not None else []
 
 
 def _timestamp() -> str:
@@ -1495,6 +1501,16 @@ def decompose(
          "[factory].max_adversarial_calls in ralph.toml)",
 )
 @click.option(
+    "--max-total-tokens",
+    type=int,
+    default=None,
+    help="Run-level token budget across ALL phases (engineer + review "
+         "+ security + distill); 0 = unbounded. On breach the current "
+         "component fails with a synthetic budget finding and pending "
+         "components halt (default: 0, or RALPH_FACTORY_MAX_TOTAL_TOKENS "
+         "/ [factory].max_total_tokens in ralph.toml)",
+)
+@click.option(
     "--pause-before-pr-merge/--no-pause-before-pr-merge",
     default=None,
     help="Pause for human approval before each component's PR "
@@ -1589,6 +1605,7 @@ def factory(
     agent_timeout: float | None,
     component_timeout: float | None,
     max_adversarial_calls: int | None,
+    max_total_tokens: int | None,
     pause_before_pr_merge: bool | None,
     progress_log: Path | None,
     no_worktrees: bool,
@@ -1695,6 +1712,7 @@ def factory(
                 ("create_prs", create_prs is not None),
                 ("review_mode", review_mode is not None),
                 ("max_adversarial_calls", max_adversarial_calls is not None),
+                ("max_total_tokens", max_total_tokens is not None),
                 ("pause_before_pr_merge", pause_before_pr_merge is not None),
                 ("use_worktrees", no_worktrees),
                 # The manifest is authoritative for single_pr, so a toml
@@ -1714,6 +1732,8 @@ def factory(
         factory_config.review_mode = review_mode
     if max_adversarial_calls is not None:
         factory_config.max_adversarial_calls = max_adversarial_calls
+    if max_total_tokens is not None:
+        factory_config.max_total_tokens = max_total_tokens
     if pause_before_pr_merge is not None:
         factory_config.pause_before_pr_merge = pause_before_pr_merge
     if no_worktrees:
@@ -2032,7 +2052,8 @@ def config_show(
         ("factory", FactoryConfig.load, [
             "max_parallel", "max_retries", "retry_delay", "use_worktrees",
             "single_pr", "create_prs", "review_mode", "merge_timeout",
-            "max_adversarial_calls", "pause_before_pr_merge",
+            "max_adversarial_calls", "max_total_tokens",
+            "pause_before_pr_merge",
         ]),
         ("verify", VerifyConfig.load, [
             "test_command", "typecheck_command", "lint_command",

--- a/ralph_py/evolution.py
+++ b/ralph_py/evolution.py
@@ -263,15 +263,25 @@ class EvolutionJournal:
         run_id: str,
         manifest: Manifest,
         factory_result: FactoryResult,
+        usage_by_component: dict[str, dict[str, dict[str, Any]]] | None = None,
+        run_usage: dict[str, Any] | None = None,
     ) -> None:
         """Record a completed factory run to the journal.
 
         Writes individual component outcomes as JSONL entries.
         Also appends a summary line to experiments.tsv.
+
+        R3.1: ``usage_by_component`` maps component id -> phase ->
+        UsageTotals.to_dict() and lands on each component's journal
+        entry; ``run_usage`` is the run-level UsageTotals.to_dict() and
+        feeds the TSV totals columns. Both optional so pre-R3.1 callers
+        keep working; token/cost figures are CLI self-reports and are
+        lower bounds whenever ``unreported_calls`` > 0.
         """
         from ralph_py.manifest import ComponentStatus
 
         timestamp = _timestamp_now()
+        usage_by_component = usage_by_component or {}
 
         # --- JSONL entries per component ---
         entries: list[dict[str, Any]] = []
@@ -307,6 +317,7 @@ class EvolutionJournal:
                 "iteration_count": comp.iteration_count,
                 "findings": findings_serialized,
                 "findings_summary": findings_summary,
+                "usage": usage_by_component.get(comp.id, {}),
             }
             entries.append(entry)
 
@@ -343,14 +354,29 @@ class EvolutionJournal:
                 failure_sigs[sig] = failure_sigs.get(sig, 0) + 1
         common_failure = max(failure_sigs, key=failure_sigs.get, default="") if failure_sigs else ""  # type: ignore[arg-type]
 
+        # R3.1 totals columns. Empty string (not 0) when no usage was
+        # tracked for the run - zero would misread as "measured, free".
+        # unreported_calls > 0 marks the token/cost figures as lower
+        # bounds. Files written before R3.1 keep their shorter header;
+        # csv.DictReader in get_experiment_trends drops the extra values
+        # rather than crashing.
+        if run_usage:
+            total_tokens_col = str(run_usage.get("total_tokens", ""))
+            total_cost_col = str(run_usage.get("cost_usd", ""))
+            unreported_col = str(run_usage.get("unreported_calls", ""))
+        else:
+            total_tokens_col = total_cost_col = unreported_col = ""
+
         header = (
             "run_id\ttimestamp\tproject\tcomponents_total\tcompleted\tfailed\t"
-            "skipped\tavg_iterations\tavg_duration_s\tretry_rate\tcommon_failure"
+            "skipped\tavg_iterations\tavg_duration_s\tretry_rate\tcommon_failure\t"
+            "total_tokens\ttotal_cost_usd\tunreported_calls"
         )
         row = (
             f"{run_id}\t{timestamp}\t{manifest.project_name}\t{total}\t"
             f"{completed}\t{failed}\t{skipped}\t{avg_iterations:.2f}\t"
-            f"{avg_duration:.1f}\t{retry_rate:.2f}\t{common_failure}"
+            f"{avg_duration:.1f}\t{retry_rate:.2f}\t{common_failure}\t"
+            f"{total_tokens_col}\t{total_cost_col}\t{unreported_col}"
         )
 
         try:

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any
 
+from ralph_py.agents.base import UsageTotals, collect_usage
 from ralph_py.config import RalphConfig
 from ralph_py.context import IterationContext
 from ralph_py.contract import (
@@ -101,6 +102,15 @@ class FactoryConfig:
     # E6: when True, pause and prompt the user before each component's
     # PR creation step. Off by default; opt-in for sensitive projects.
     pause_before_pr_merge: bool = False
+    # R3.1: run-level token budget. 0 means unbounded. Compared against
+    # the run's aggregated total_tokens (a lower bound when some calls
+    # report no usage); on breach the factory halts LOUDLY - the current
+    # component fails with a synthetic budget finding and pending
+    # components fail at scheduling instead of burning more spend.
+    # Enforcement granularity is the phase boundary: an in-flight
+    # engineer loop or review call can overshoot before the parent sees
+    # its usage.
+    max_total_tokens: int = 0
     # R0.1: timeout limits (agent iteration, component wall clock,
     # scheduler backstop margin). None means run_factory loads
     # TimeoutConfig.load(root_dir) - toml [timeout] section + env.
@@ -126,6 +136,9 @@ class FactoryConfig:
             merge_timeout=float(os.environ.get("FACTORY_MERGE_TIMEOUT", "300.0")),
             max_adversarial_calls=int(
                 os.environ.get("RALPH_FACTORY_MAX_ADVERSARIAL_CALLS", "0")
+            ),
+            max_total_tokens=int(
+                os.environ.get("RALPH_FACTORY_MAX_TOTAL_TOKENS", "0")
             ),
             pause_before_pr_merge=_parse_bool(
                 os.environ.get("RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE")
@@ -164,6 +177,8 @@ class FactoryConfig:
         # (below) and CLI flags (cli.py factory command).
         if "max_adversarial_calls" in section:
             config.max_adversarial_calls = int(section["max_adversarial_calls"])
+        if "max_total_tokens" in section:
+            config.max_total_tokens = int(section["max_total_tokens"])
         if "pause_before_pr_merge" in section:
             config.pause_before_pr_merge = bool(section["pause_before_pr_merge"])
         # Env overrides (consistent with from_env)
@@ -178,6 +193,10 @@ class FactoryConfig:
         if "RALPH_FACTORY_MAX_ADVERSARIAL_CALLS" in os.environ:
             config.max_adversarial_calls = int(
                 os.environ["RALPH_FACTORY_MAX_ADVERSARIAL_CALLS"]
+            )
+        if "RALPH_FACTORY_MAX_TOTAL_TOKENS" in os.environ:
+            config.max_total_tokens = int(
+                os.environ["RALPH_FACTORY_MAX_TOTAL_TOKENS"]
             )
         if "RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE" in os.environ:
             config.pause_before_pr_merge = _parse_bool(
@@ -196,6 +215,10 @@ class ComponentResult:
     error: str | None = None
     duration_seconds: float = 0.0
     context_json: str | None = None
+    # R3.1: engineer-loop usage aggregated by the worker; pickled back
+    # across the ProcessPoolExecutor boundary. None means the worker
+    # predates the meter or crashed before the loop started.
+    usage: UsageTotals | None = None
 
 
 @dataclass
@@ -737,6 +760,7 @@ def _run_component(
             error=error,
             duration_seconds=time.monotonic() - start,
             context_json=previous_context_json,
+            usage=result.usage,
         )
     except Exception as exc:
         return ComponentResult(
@@ -746,6 +770,9 @@ def _run_component(
             error=str(exc),
             duration_seconds=time.monotonic() - start,
             context_json=previous_context_json,
+            # The loop crashed, but any iterations that did run still
+            # cost tokens; collect what the agent recorded (R3.1).
+            usage=collect_usage(agent),
         )
 
 
@@ -773,6 +800,63 @@ def _expired_futures(
         f for f in running
         if not f.done() and f in deadlines and now >= deadlines[f]
     ]
+
+
+# Rollup row order for the R3.1 usage table; phases outside this list
+# (future additions) sort after, alphabetically.
+_USAGE_PHASE_ORDER = ("engineer", "review", "security", "distill")
+
+
+def _format_usage_rollup(
+    usage_meter: Mapping[str, Mapping[str, UsageTotals]],
+    run_usage: UsageTotals,
+) -> list[str]:
+    """Render the per-component, per-phase usage table (R3.1).
+
+    Token and cost columns are sums of CLI self-reports: codex reports
+    only a total (in/out columns stay 0), CustomAgent reports nothing.
+    Whenever some calls reported no usage the footer says so explicitly -
+    the totals are then lower bounds, not measurements (H4).
+    """
+    header = (
+        f"{'component':<24} {'phase':<10} {'calls':>5} "
+        f"{'tokens_in':>11} {'tokens_out':>11} {'tokens_total':>13} "
+        f"{'cost_usd':>9} {'time_s':>8}"
+    )
+    lines = [header]
+
+    def _phase_sort_key(phase: str) -> tuple[int, str]:
+        try:
+            return (_USAGE_PHASE_ORDER.index(phase), phase)
+        except ValueError:
+            return (len(_USAGE_PHASE_ORDER), phase)
+
+    def _row(label: str, phase: str, totals: UsageTotals) -> str:
+        if totals.known_calls > 0:
+            tokens_in = f"{totals.input_tokens:,}"
+            tokens_out = f"{totals.output_tokens:,}"
+            tokens_total = f"{totals.total_tokens:,}"
+            cost = f"{totals.cost_usd:.4f}" if totals.cost_usd > 0 else "-"
+        else:
+            tokens_in = tokens_out = tokens_total = cost = "-"
+        return (
+            f"{label:<24} {phase:<10} {totals.calls:>5} "
+            f"{tokens_in:>11} {tokens_out:>11} {tokens_total:>13} "
+            f"{cost:>9} {totals.duration_seconds:>8.0f}"
+        )
+
+    for comp_id in sorted(usage_meter):
+        phases = usage_meter[comp_id]
+        for phase in sorted(phases, key=_phase_sort_key):
+            lines.append(_row(comp_id, phase, phases[phase]))
+    lines.append(_row("TOTAL", "", run_usage))
+    if run_usage.unreported_calls > 0:
+        lines.append(
+            f"note: {run_usage.unreported_calls} of {run_usage.calls} "
+            "call(s) reported no token/cost data; token and cost totals "
+            "are lower bounds"
+        )
+    return lines
 
 
 def run_factory(
@@ -1031,6 +1115,51 @@ def _run_factory_locked(
             return None
         return max(0, cap - adversarial_calls["count"])
 
+    # R3.1 cost meter: per-component, per-phase usage rollup plus a
+    # run-level total. Phases: "engineer" (loop iterations, reported by
+    # the worker), "review", "security", "distill" (fresh agent instance
+    # per phase, so an instance's accumulated usage_records ARE that
+    # phase's spend - chunked reviews reuse one instance for N calls and
+    # land here as N records). Retried attempts accumulate: every attempt
+    # cost real tokens, so the meter never forgets a failed attempt.
+    usage_meter: dict[str, dict[str, UsageTotals]] = {}
+    run_usage = UsageTotals()
+
+    def _record_usage(comp_id: str, phase: str, totals: UsageTotals) -> None:
+        if totals.calls == 0:
+            return
+        slot = usage_meter.setdefault(comp_id, {}).setdefault(
+            phase, UsageTotals(),
+        )
+        slot.merge(totals)
+        run_usage.merge(totals)
+        progress_log.component_usage(comp_id, phase, totals.to_dict())
+
+    def _token_budget_exceeded() -> bool:
+        cap = factory_config.max_total_tokens
+        return cap > 0 and run_usage.total_tokens >= cap
+
+    def _fail_component_for_budget(comp: Component, phase: str) -> None:
+        """R3.1: halt LOUDLY on a blown token budget. Mirrors the R1.2/
+        R1.4 synthetic-finding pattern (chunk_budget_insufficient): a
+        typed Finding in the stream, a progress-log event, and a FAILED
+        component - never a silent degrade. Retrying cannot un-spend
+        tokens, so this fails directly instead of burning retries."""
+        error = (
+            f"token budget exceeded: {run_usage.total_tokens} total tokens "
+            f"recorded >= max_total_tokens "
+            f"({factory_config.max_total_tokens}); halting instead of "
+            "spending further (R3.1)"
+        )
+        ui.err(f"  TOKEN BUDGET EXCEEDED for {comp.id}: {error}")
+        comp.findings.append(Finding.infrastructure_error(
+            phase=phase, explanation=error,
+        ))
+        progress_log.budget_exceeded(
+            comp.id, run_usage.total_tokens, factory_config.max_total_tokens,
+        )
+        _fail_component(comp, error)
+
     def _path_relative_to_root(path: Path) -> str:
         """Render `path` relative to root_dir for use inside per-component
         worktrees. Falls back to the absolute path string when relativization
@@ -1103,6 +1232,18 @@ def _run_factory_locked(
         # Record timing
         comp.duration_seconds = comp_result.duration_seconds
         comp.iteration_count = comp_result.iterations
+
+        # R3.1: engineer-loop spend counts BEFORE the success branch -
+        # failed attempts cost real tokens too.
+        if comp_result.usage is not None:
+            _record_usage(comp_id, "engineer", comp_result.usage)
+
+        # R3.1 budget checkpoint: the engineer loop just reported the
+        # dominant spend; halt before starting adversarial phases (or a
+        # retry) when the run-level cap is blown.
+        if _token_budget_exceeded():
+            _fail_component_for_budget(comp, "engineer")
+            return
 
         if not comp_result.success:
             from ralph_py.context import IterationRecord
@@ -1393,6 +1534,7 @@ def _run_factory_locked(
             # R1.2: wrap the agent-driven work like Phase 2.5 does. A
             # reviewer crash degrades to a per-component infrastructure
             # failure; it must never abort the whole factory run.
+            review_agent: Any = None
             try:
                 review_agent = get_agent(
                     factory_config.review_agent_cmd,
@@ -1436,6 +1578,15 @@ def _run_factory_locked(
                     overall_notes=f"Review agent crashed: {exc}",
                     infrastructure_error=True,
                 )
+            # R3.1: the instance is fresh per phase, so its accumulated
+            # records are exactly this review's spend (N records for a
+            # chunked review). Recorded before pass/fail handling so a
+            # failed or crashed review still counts.
+            if review_agent is not None:
+                _record_usage(comp_id, "review", collect_usage(review_agent))
+            if _token_budget_exceeded():
+                _fail_component_for_budget(comp, "review")
+                return
             comp.review_passed = review_result.passed
             # E3: typed findings are the source of truth; the rendered
             # string is a derived view kept for backward-compat consumers.
@@ -1555,6 +1706,7 @@ def _run_factory_locked(
                 f"({sec_config.mode}{chunk_note}) for {comp_id}..."
             )
             sec_result = None
+            sec_agent: Any = None
             # The try/except deliberately wraps ONLY the agent-driven
             # work (getting the agent + running the review). Errors in
             # the retry-or-fail path below must NOT be swallowed - if
@@ -1615,6 +1767,14 @@ def _run_factory_locked(
                     ),
                     infrastructure_error=True,
                 )
+
+            # R3.1: record security spend before pass/fail handling so
+            # failed and crashed passes still count toward the meter.
+            if sec_agent is not None:
+                _record_usage(comp_id, "security", collect_usage(sec_agent))
+            if _token_budget_exceeded():
+                _fail_component_for_budget(comp, "security")
+                return
 
             if sec_result is not None:
                 progress_log.review_result(
@@ -1689,8 +1849,22 @@ def _run_factory_locked(
             _record_phase_skip(
                 "knowledge", "adversarial LLM budget exhausted",
             )
+        elif knowledge_config.enabled and _token_budget_exceeded():
+            # R3.1: the gates all passed before the cap tripped, so the
+            # component proceeds to PR - but no further LLM spend. The
+            # skip is recorded, and the scheduling gate stops any
+            # remaining components loudly.
+            ui.warn(
+                f"  Knowledge: skipped for {comp_id} "
+                f"(token budget exceeded: {run_usage.total_tokens} >= "
+                f"{factory_config.max_total_tokens})"
+            )
+            _record_phase_skip(
+                "knowledge", "token budget (max_total_tokens) exceeded",
+            )
         elif knowledge_config.enabled:
             _adversarial_budget_consume()
+            distill_agent: Any = None
             try:
                 from ralph_py.agents import get_agent as _get_agent
 
@@ -1725,6 +1899,13 @@ def _run_factory_locked(
                     ui.info(f"  Knowledge: {status}")
             except Exception as exc:  # noqa: BLE001 - non-fatal
                 ui.warn(f"  Knowledge distillation failed: {exc}")
+
+            # R3.1: distillation spend (recorded even when the distill
+            # failed - the call still cost tokens). No fail-the-component
+            # checkpoint here: every gate already passed; the scheduling
+            # gate halts the run before any FURTHER spend.
+            if distill_agent is not None:
+                _record_usage(comp_id, "distill", collect_usage(distill_agent))
 
             # Fact-utilization metric: did the agent reference any of
             # the facts we injected at the top of the worker prompt?
@@ -1970,6 +2151,12 @@ def _run_factory_locked(
                     break
 
                 comp = ready[0]
+                # R3.1 scheduling gate: a blown token budget fails
+                # pending components loudly instead of launching an
+                # engineer loop that would only add spend.
+                if _token_budget_exceeded():
+                    _fail_component_for_budget(comp, "scheduling")
+                    continue
                 comp.status = ComponentStatus.RUNNING.value
                 comp.started_at = time.strftime(
                     "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
@@ -2005,6 +2192,10 @@ def _run_factory_locked(
                 slots = max_parallel - len(running_futures)
 
                 for comp in ready[:slots]:
+                    # R3.1 scheduling gate (see sequential path above).
+                    if _token_budget_exceeded():
+                        _fail_component_for_budget(comp, "scheduling")
+                        continue
                     comp.status = ComponentStatus.RUNNING.value
                     comp.started_at = time.strftime(
                         "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
@@ -2320,6 +2511,16 @@ def _run_factory_locked(
     if factory_result.merge_pending:
         ui.kv("Merge pending", str(len(factory_result.merge_pending)))
     ui.kv("Duration", f"{factory_duration:.0f}s")
+    # R3.1 usage rollup: per component, per phase, plus the run total.
+    if run_usage.calls > 0:
+        ui.subsection("Usage rollup")
+        for line in _format_usage_rollup(usage_meter, run_usage):
+            ui.info(f"  {line}")
+    if _token_budget_exceeded():
+        ui.err(
+            f"TOKEN BUDGET EXCEEDED: {run_usage.total_tokens} total tokens "
+            f"recorded >= max_total_tokens ({factory_config.max_total_tokens})"
+        )
     if factory_result.pr_urls:
         ui.kv("PRs created", str(len(factory_result.pr_urls)))
         for url in factory_result.pr_urls:
@@ -2346,7 +2547,17 @@ def _run_factory_locked(
         evo_config = EvolutionConfig.load(root_dir)
         if evo_config.enabled:
             journal = EvolutionJournal(evo_config)
-            journal.record_run(run_id, manifest, factory_result)
+            journal.record_run(
+                run_id, manifest, factory_result,
+                usage_by_component={
+                    comp_id: {
+                        phase: totals.to_dict()
+                        for phase, totals in phases.items()
+                    }
+                    for comp_id, phases in usage_meter.items()
+                },
+                run_usage=run_usage.to_dict(),
+            )
     except Exception:
         pass  # evolution recording is non-fatal
 

--- a/ralph_py/loop.py
+++ b/ralph_py/loop.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ralph_py import git, guards
+from ralph_py.agents.base import UsageTotals, collect_usage
 from ralph_py.agents.proc import TIMEOUT_MESSAGE_PREFIX
 from ralph_py.prd import PRD
 from ralph_py.timeout import TimeoutConfig
@@ -36,6 +37,10 @@ class LoopResult:
     # Derived from the adapters' timeout error line - a reporting hint,
     # never a control-flow gate.
     timed_out_iterations: int = 0
+    # R3.1: aggregated engineer-loop usage (one record per agent.run
+    # call, collected from the agent's usage_records). Token/cost fields
+    # are CLI self-reports - lower bounds whenever unreported_calls > 0.
+    usage: UsageTotals = field(default_factory=UsageTotals)
 
 
 def run_loop(
@@ -231,6 +236,7 @@ def run_loop(
                     duration_seconds=time.monotonic() - loop_start,
                     iteration_durations=iteration_durations,
                     timed_out_iterations=timed_out_iterations,
+                    usage=collect_usage(agent),
                 )
 
         # Check for completion
@@ -244,6 +250,7 @@ def run_loop(
                 duration_seconds=total_duration,
                 iteration_durations=iteration_durations,
                 timed_out_iterations=timed_out_iterations,
+                usage=collect_usage(agent),
             )
 
         # Component wall clock: abort cleanly rather than start work that
@@ -263,6 +270,7 @@ def run_loop(
                 iteration_durations=iteration_durations,
                 timeout_limit="component",
                 timed_out_iterations=timed_out_iterations,
+                usage=collect_usage(agent),
             )
 
         # Interactive pause
@@ -276,7 +284,10 @@ def run_loop(
                 # Disable interactive for remaining iterations
                 config.interactive = False
             elif choice == 2:
-                return LoopResult(completed=False, iterations=iteration, exit_code=0)
+                return LoopResult(
+                    completed=False, iterations=iteration, exit_code=0,
+                    usage=collect_usage(agent),
+                )
 
         # Sleep before next iteration (except on last)
         if iteration < config.max_iterations:
@@ -298,6 +309,7 @@ def run_loop(
         duration_seconds=total_duration,
         iteration_durations=iteration_durations,
         timed_out_iterations=timed_out_iterations,
+        usage=collect_usage(agent),
     )
 
 

--- a/ralph_py/observability.py
+++ b/ralph_py/observability.py
@@ -122,6 +122,33 @@ class ProgressLog:
             "duration_seconds": round(duration, 2),
         })
 
+    def component_usage(
+        self,
+        component_id: str,
+        phase: str,
+        usage: dict[str, Any],
+    ) -> None:
+        """R3.1: one event per (component, phase) usage capture. ``usage``
+        is a UsageTotals.to_dict() - token/cost values are CLI
+        self-reports and lower bounds when ``unreported_calls`` > 0."""
+        self.emit("component_usage", component_id=component_id, data={
+            "phase": phase,
+            **usage,
+        })
+
+    def budget_exceeded(
+        self,
+        component_id: str,
+        total_tokens: int,
+        max_total_tokens: int,
+    ) -> None:
+        """R3.1: the run-level token budget tripped; the named component
+        was failed with a synthetic budget finding."""
+        self.emit("budget_exceeded", component_id=component_id, data={
+            "total_tokens": total_tokens,
+            "max_total_tokens": max_total_tokens,
+        })
+
     def contract_result(
         self,
         tier: int,

--- a/tests/test_config_control_plane.py
+++ b/tests/test_config_control_plane.py
@@ -507,6 +507,29 @@ class TestSafetyKnobs:
         assert result.exit_code == 0, result.output
         assert captured["factory_config"].max_adversarial_calls == 1
 
+    def test_max_total_tokens_all_surfaces(
+        self,
+        tmp_path: Path,
+        captured: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """R3.1: the token budget is reachable via flag > env > toml."""
+        (tmp_path / "ralph.toml").write_text(
+            "[factory]\nmax_total_tokens = 100\n"
+        )
+        monkeypatch.setenv("RALPH_FACTORY_MAX_TOTAL_TOKENS", "200")
+        result = _invoke_factory(tmp_path, "--max-total-tokens", "300")
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].max_total_tokens == 300
+
+        result = _invoke_factory(tmp_path)
+        assert captured["factory_config"].max_total_tokens == 200
+
+        monkeypatch.delenv("RALPH_FACTORY_MAX_TOTAL_TOKENS")
+        result = _invoke_factory(tmp_path)
+        assert result.exit_code == 0, result.output
+        assert captured["factory_config"].max_total_tokens == 100
+
     def test_pause_before_pr_merge_all_surfaces(
         self,
         tmp_path: Path,

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -1,0 +1,942 @@
+"""R3.1 cost meter tests.
+
+Covers the four required behaviors:
+1. A fake agent emitting realistic usage events produces correct rollup
+   math (adapter extraction, loop aggregation, factory attribution).
+2. Missing usage degrades to call counts + wall time (CustomAgent /
+   codex-without-trailer fallback).
+3. The max_total_tokens budget halt fires LOUDLY and is recorded
+   (synthetic finding, progress-log event, FAILED component).
+4. Malformed usage never raises - the meter must not gate correctness.
+
+The "realistic" fixtures are verbatim from the R3.1 measurement probes:
+claude CLI 2.1.214 stream-json result event, codex CLI 0.134.0 plain
+"tokens used" trailer.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ralph_py.agents.base import UsageRecord, UsageTotals, collect_usage
+from ralph_py.agents.claude_code import ClaudeCodeAgent, _usage_from_result_event
+from ralph_py.agents.codex import CodexAgent
+from ralph_py.agents.custom import CustomAgent
+from ralph_py.config import RalphConfig
+from ralph_py.factory import (
+    ComponentResult,
+    FactoryConfig,
+    _format_usage_rollup,
+    run_factory,
+)
+from ralph_py.loop import COMPLETION_MARKER, run_loop
+from ralph_py.manifest import Component, ComponentStatus, Manifest
+from ralph_py.observability import ProgressLog
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+# Verbatim (trimmed to relevant fields) from the measurement probe:
+# `claude --print --output-format stream-json --verbose` on CLI 2.1.214.
+CLAUDE_RESULT_EVENT = {
+    "type": "result",
+    "subtype": "success",
+    "is_error": False,
+    "duration_ms": 1778,
+    "duration_api_ms": 1550,
+    "num_turns": 1,
+    "result": "hello",
+    "total_cost_usd": 0.0227028,
+    "usage": {
+        "input_tokens": 9,
+        "cache_creation_input_tokens": 10371,
+        "cache_read_input_tokens": 17418,
+        "output_tokens": 42,
+        "service_tier": "standard",
+    },
+}
+
+
+def _claude_record() -> UsageRecord:
+    return _usage_from_result_event(json.dumps(CLAUDE_RESULT_EVENT), 99.0)
+
+
+# ---------------------------------------------------------------------------
+# UsageTotals rollup math
+# ---------------------------------------------------------------------------
+
+
+class TestUsageTotalsMath:
+    def test_claude_style_record_rollup(self) -> None:
+        totals = UsageTotals()
+        totals.add_record(_claude_record())
+        totals.add_record(_claude_record())
+        assert totals.calls == 2
+        assert totals.known_calls == 2
+        assert totals.unreported_calls == 0
+        assert totals.input_tokens == 18
+        assert totals.output_tokens == 84
+        assert totals.cache_read_tokens == 2 * 17418
+        assert totals.cache_creation_tokens == 2 * 10371
+        assert totals.total_tokens == 2 * (9 + 42 + 17418 + 10371)
+        assert totals.cost_usd == pytest.approx(2 * 0.0227028)
+
+    def test_codex_style_total_only_record(self) -> None:
+        totals = UsageTotals()
+        totals.add_record(UsageRecord(
+            total_tokens=14511, duration_seconds=3.0, source="codex-text",
+        ))
+        assert totals.calls == 1
+        assert totals.known_calls == 1
+        assert totals.total_tokens == 14511
+        assert totals.input_tokens == 0  # not reported, stays zero
+        assert totals.cost_usd == 0.0
+
+    def test_unavailable_record_is_calls_plus_wall_time(self) -> None:
+        totals = UsageTotals()
+        totals.add_record(UsageRecord(duration_seconds=2.5))
+        assert totals.calls == 1
+        assert totals.known_calls == 0
+        assert totals.unreported_calls == 1
+        assert totals.total_tokens == 0
+        assert totals.duration_seconds == pytest.approx(2.5)
+
+    def test_partial_record_derives_total_from_parts(self) -> None:
+        totals = UsageTotals()
+        totals.add_record(UsageRecord(input_tokens=100, output_tokens=50))
+        assert totals.total_tokens == 150
+
+    def test_merge(self) -> None:
+        a = UsageTotals()
+        a.add_record(_claude_record())
+        b = UsageTotals()
+        b.add_record(UsageRecord(total_tokens=1000, duration_seconds=1.0))
+        a.merge(b)
+        assert a.calls == 2
+        assert a.total_tokens == (9 + 42 + 17418 + 10371) + 1000
+
+    def test_malformed_records_never_raise(self) -> None:
+        totals = UsageTotals()
+        for garbage in (None, "junk", 42, object(), {"input_tokens": 5}):
+            totals.add_record(garbage)
+        # Every entry still counted as a call; nothing reported.
+        assert totals.calls == 5
+        assert totals.known_calls == 0
+        assert totals.total_tokens == 0
+
+    def test_bool_and_negative_values_rejected(self) -> None:
+        totals = UsageTotals()
+        totals.add_record(UsageRecord(
+            input_tokens=True,  # type: ignore[arg-type]
+            output_tokens=-5,
+            cost_usd=-1.0,
+        ))
+        assert totals.known_calls == 0
+        assert totals.input_tokens == 0
+        assert totals.output_tokens == 0
+        assert totals.cost_usd == 0.0
+
+    def test_collect_usage_without_attribute(self) -> None:
+        totals = collect_usage(object())
+        assert totals.calls == 0
+
+    def test_collect_usage_with_non_iterable_attribute(self) -> None:
+        class Broken:
+            usage_records = 42
+
+        totals = collect_usage(Broken())
+        assert totals.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Claude adapter extraction (measured stream-json result event)
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeUsageExtraction:
+    def test_measured_result_event_parses(self) -> None:
+        record = _claude_record()
+        assert record.source == "claude-stream-json"
+        assert record.input_tokens == 9
+        assert record.output_tokens == 42
+        assert record.cache_read_tokens == 17418
+        assert record.cache_creation_tokens == 10371
+        assert record.total_tokens == 9 + 42 + 17418 + 10371
+        assert record.cost_usd == pytest.approx(0.0227028)
+        assert record.duration_seconds == pytest.approx(1.778)
+
+    def test_missing_event_records_unavailable(self) -> None:
+        record = _usage_from_result_event(None, 5.0)
+        assert record.source == "unavailable"
+        assert record.total_tokens is None
+        assert record.duration_seconds == pytest.approx(5.0)
+
+    def test_malformed_json_records_parse_error_and_warns(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level(logging.WARNING, "ralph_py.agents.claude_code"):
+            record = _usage_from_result_event("{not json", 5.0)
+        assert record.source == "parse-error"
+        assert record.total_tokens is None
+        assert any("usage" in r.message for r in caplog.records)
+
+    def test_event_without_usage_dict_warns_not_raises(
+        self, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level(logging.WARNING, "ralph_py.agents.claude_code"):
+            record = _usage_from_result_event(
+                json.dumps({"type": "result", "result": "hi"}), 5.0,
+            )
+        assert record.source == "parse-error"
+        assert caplog.records
+
+    def test_drifted_usage_types_record_unknown_fields(self) -> None:
+        evt = {
+            "type": "result",
+            "total_cost_usd": 0.5,
+            "usage": {"input_tokens": "many", "output_tokens": 10},
+        }
+        record = _usage_from_result_event(json.dumps(evt), 1.0)
+        assert record.input_tokens is None
+        assert record.output_tokens == 10
+        assert record.total_tokens == 10
+        assert record.cost_usd == pytest.approx(0.5)
+
+    def test_agent_run_appends_record_from_stream(self, tmp_path: Path) -> None:
+        mock_proc = MagicMock()
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = iter([
+            json.dumps({"type": "assistant", "message": {"content": [
+                {"type": "text", "text": "working"},
+            ]}}) + "\n",
+            json.dumps(CLAUDE_RESULT_EVENT) + "\n",
+        ])
+        mock_proc.wait.return_value = 0
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            agent = ClaudeCodeAgent()
+            list(agent.run("prompt", cwd=tmp_path))
+
+        assert len(agent.usage_records) == 1
+        assert agent.usage_records[0].source == "claude-stream-json"
+        assert agent.usage_records[0].total_tokens == 9 + 42 + 17418 + 10371
+
+    def test_agent_run_without_result_event_records_unavailable(
+        self, tmp_path: Path,
+    ) -> None:
+        mock_proc = MagicMock()
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = iter(["hello\n", "world\n"])
+        mock_proc.wait.return_value = 0
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            agent = ClaudeCodeAgent()
+            list(agent.run("prompt", cwd=tmp_path))
+
+        assert len(agent.usage_records) == 1
+        assert agent.usage_records[0].source == "unavailable"
+
+    def test_records_accumulate_across_runs(self, tmp_path: Path) -> None:
+        agent = ClaudeCodeAgent()
+        for _ in range(2):
+            mock_proc = MagicMock()
+            mock_proc.stdin = MagicMock()
+            mock_proc.stdout = iter([json.dumps(CLAUDE_RESULT_EVENT) + "\n"])
+            mock_proc.wait.return_value = 0
+            with patch("subprocess.Popen", return_value=mock_proc):
+                list(agent.run("prompt", cwd=tmp_path))
+        assert len(agent.usage_records) == 2
+
+
+# ---------------------------------------------------------------------------
+# Codex adapter extraction (measured plain-text trailer)
+# ---------------------------------------------------------------------------
+
+
+def _run_codex_with_stdout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, lines: list[str],
+) -> CodexAgent:
+    monkeypatch.setattr(CodexAgent, "_supports_output_last_message", False)
+    mock_proc = MagicMock()
+    mock_proc.stdin = MagicMock()
+    mock_proc.stdout = iter(lines)
+    mock_proc.wait.return_value = 0
+    with patch("subprocess.Popen", return_value=mock_proc):
+        agent = CodexAgent()
+        list(agent.run("prompt", cwd=tmp_path))
+    return agent
+
+
+class TestCodexUsageExtraction:
+    def test_measured_two_line_trailer(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        # Verbatim tail of the codex 0.134.0 probe output.
+        agent = _run_codex_with_stdout(monkeypatch, tmp_path, [
+            "codex\n", "hello\n", "tokens used\n", "14,511\n", "hello\n",
+        ])
+        assert len(agent.usage_records) == 1
+        record = agent.usage_records[0]
+        assert record.source == "codex-text"
+        assert record.total_tokens == 14511
+        assert record.input_tokens is None  # codex reports only a total
+
+    def test_single_line_trailer_variant(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        agent = _run_codex_with_stdout(monkeypatch, tmp_path, [
+            "hello\n", "tokens used: 1,234\n",
+        ])
+        assert agent.usage_records[0].total_tokens == 1234
+
+    def test_no_trailer_falls_back_to_calls_plus_wall_time(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        agent = _run_codex_with_stdout(monkeypatch, tmp_path, ["hello\n"])
+        assert len(agent.usage_records) == 1
+        record = agent.usage_records[0]
+        assert record.source == "unavailable"
+        assert record.total_tokens is None
+        assert record.duration_seconds >= 0.0
+
+    def test_non_numeric_after_tokens_used_never_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        agent = _run_codex_with_stdout(monkeypatch, tmp_path, [
+            "tokens used\n", "not a number\n",
+        ])
+        assert agent.usage_records[0].total_tokens is None
+
+    def test_last_trailer_wins_over_echoed_text(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        agent = _run_codex_with_stdout(monkeypatch, tmp_path, [
+            "tokens used\n", "111\n", "more output\n",
+            "tokens used\n", "222\n",
+        ])
+        assert agent.usage_records[0].total_tokens == 222
+
+
+# ---------------------------------------------------------------------------
+# CustomAgent fallback
+# ---------------------------------------------------------------------------
+
+
+class TestCustomAgentFallback:
+    def test_records_calls_and_wall_time_only(self, tmp_path: Path) -> None:
+        agent = CustomAgent("echo hi")
+        list(agent.run("prompt", cwd=tmp_path))
+        list(agent.run("prompt", cwd=tmp_path))
+        assert len(agent.usage_records) == 2
+        assert all(r.source == "unavailable" for r in agent.usage_records)
+        totals = collect_usage(agent)
+        assert totals.calls == 2
+        assert totals.known_calls == 0
+        assert totals.total_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# Engineer-loop aggregation (run_loop -> LoopResult.usage)
+# ---------------------------------------------------------------------------
+
+
+class FakeUsageAgent:
+    """Protocol-satisfying fake that emits one usage record per run."""
+
+    def __init__(
+        self,
+        outputs: list[list[str]],
+        record: UsageRecord | None = None,
+        records: Any = None,
+    ) -> None:
+        self._outputs = outputs
+        self._record = record
+        self._runs = 0
+        self._final_message: str | None = None
+        # `records` overrides accumulation for malformed-usage tests.
+        self._forced_records = records
+        self._usage_records: list[UsageRecord] = []
+
+    @property
+    def name(self) -> str:
+        return "fake-usage"
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        output = self._outputs[min(self._runs, len(self._outputs) - 1)]
+        self._runs += 1
+        if self._record is not None:
+            self._usage_records.append(self._record)
+        yield from output
+        self._final_message = output[-1] if output else None
+
+    @property
+    def final_message(self) -> str | None:
+        return self._final_message
+
+    @property
+    def usage_records(self) -> Any:
+        if self._forced_records is not None:
+            return self._forced_records
+        return list(self._usage_records)
+
+
+def _loop_config(tmp_path: Path, max_iterations: int) -> RalphConfig:
+    ralph_dir = tmp_path / "scripts" / "ralph"
+    ralph_dir.mkdir(parents=True, exist_ok=True)
+    (ralph_dir / "prompt.md").write_text("test prompt")
+    (ralph_dir / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    return RalphConfig(
+        max_iterations=max_iterations,
+        prompt_file=ralph_dir / "prompt.md",
+        prd_file=ralph_dir / "prd.json",
+        sleep_seconds=0,
+        ralph_branch="",
+        ralph_branch_explicit=True,
+    )
+
+
+class TestLoopUsageAggregation:
+    def test_two_iterations_sum_correctly(self, tmp_path: Path) -> None:
+        record = UsageRecord(
+            input_tokens=100, output_tokens=200, total_tokens=300,
+            cost_usd=0.01, duration_seconds=1.0, source="claude-stream-json",
+        )
+        agent = FakeUsageAgent(
+            outputs=[["working..."], [COMPLETION_MARKER]], record=record,
+        )
+        result = run_loop(
+            _loop_config(tmp_path, 5), PlainUI(no_color=True), agent, tmp_path,
+        )
+        assert result.completed is True
+        assert result.iterations == 2
+        assert result.usage.calls == 2
+        assert result.usage.input_tokens == 200
+        assert result.usage.output_tokens == 400
+        assert result.usage.total_tokens == 600
+        assert result.usage.cost_usd == pytest.approx(0.02)
+
+    def test_usage_present_on_max_iterations_failure(
+        self, tmp_path: Path,
+    ) -> None:
+        record = UsageRecord(total_tokens=50, source="codex-text")
+        agent = FakeUsageAgent(outputs=[["no marker"]], record=record)
+        result = run_loop(
+            _loop_config(tmp_path, 3), PlainUI(no_color=True), agent, tmp_path,
+        )
+        assert result.completed is False
+        assert result.usage.calls == 3
+        assert result.usage.total_tokens == 150
+
+    def test_agent_without_usage_records_yields_empty_totals(
+        self, tmp_path: Path,
+    ) -> None:
+        class BareAgent:
+            name = "bare"
+            final_message = None
+
+            def run(
+                self, prompt: str, cwd: Path | None = None,
+                timeout: float | None = None,
+            ) -> Iterator[str]:
+                yield COMPLETION_MARKER
+
+        result = run_loop(
+            _loop_config(tmp_path, 1), PlainUI(no_color=True),
+            BareAgent(), tmp_path,
+        )
+        assert result.completed is True
+        assert result.usage.calls == 0
+
+    def test_malformed_usage_records_never_crash_the_loop(
+        self, tmp_path: Path,
+    ) -> None:
+        agent = FakeUsageAgent(
+            outputs=[[COMPLETION_MARKER]],
+            records=[None, "garbage", 42],
+        )
+        result = run_loop(
+            _loop_config(tmp_path, 1), PlainUI(no_color=True), agent, tmp_path,
+        )
+        assert result.completed is True
+        assert result.usage.calls == 3
+        assert result.usage.known_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Factory aggregation + journal + experiments.tsv + rollup rendering
+# ---------------------------------------------------------------------------
+
+
+def _make_manifest(components: list[Component]) -> Manifest:
+    return Manifest(
+        version="1",
+        spec_file="spec.md",
+        project_name="test",
+        base_branch="main",
+        single_pr=False,
+        components=components,
+    )
+
+
+def _make_base_config(root_dir: Path) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root_dir / "scripts" / "ralph" / "prompt.md",
+        prd_file=root_dir / "scripts" / "ralph" / "prd.json",
+        sleep_seconds=0,
+        agent_cmd="echo test",
+        ralph_branch="",
+        ralph_branch_explicit=True,
+        ui_mode="plain",
+        no_color=True,
+    )
+
+
+def _setup_project(tmp_path: Path, component_ids: list[str]) -> Path:
+    ralph_dir = tmp_path / "scripts" / "ralph"
+    ralph_dir.mkdir(parents=True, exist_ok=True)
+    (ralph_dir / "prompt.md").write_text("test prompt")
+    (ralph_dir / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    # Knowledge distillation off by default in these tests: its agent
+    # call would add nondeterministic usage rows.
+    (tmp_path / "ralph.toml").write_text("[knowledge]\nenabled = false\n")
+    for comp_id in component_ids:
+        feature_dir = ralph_dir / "feature" / comp_id
+        feature_dir.mkdir(parents=True, exist_ok=True)
+        (feature_dir / "prd.json").write_text(json.dumps({
+            "branchName": "test",
+            "userStories": [{
+                "id": "US-001", "title": "Test",
+                "acceptanceCriteria": ["AC1"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+    return tmp_path
+
+
+def _component(comp_id: str, deps: list[str] | None = None) -> Component:
+    return Component(
+        comp_id, comp_id.title(), "Desc", deps or [],
+        f"scripts/ralph/feature/{comp_id}/prd.json",
+        f"ralph/factory/{comp_id}",
+    )
+
+
+def _factory_config(tmp_path: Path, **overrides: Any) -> FactoryConfig:
+    defaults: dict[str, Any] = dict(
+        use_worktrees=False, create_prs=False, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_diff_scope=False,
+            check_bad_patterns=False, subprocess_timeout=5.0,
+        ),
+        progress_log_path=tmp_path / "progress.jsonl",
+    )
+    defaults.update(overrides)
+    return FactoryConfig(**defaults)
+
+
+def _engineer_usage(total: int, cost: float = 0.0) -> UsageTotals:
+    totals = UsageTotals()
+    totals.add_record(UsageRecord(
+        input_tokens=total // 3,
+        output_tokens=total - total // 3,
+        total_tokens=total,
+        cost_usd=cost or None,
+        duration_seconds=1.0,
+        source="claude-stream-json",
+    ))
+    return totals
+
+
+def _read_journal(tmp_path: Path) -> list[dict[str, Any]]:
+    journal_path = tmp_path / ".ralph" / "evolution.jsonl"
+    entries = []
+    for line in journal_path.read_text().splitlines():
+        if line.strip():
+            entries.append(json.loads(line))
+    return entries
+
+
+class TestFactoryUsageAggregation:
+    def test_engineer_usage_lands_in_journal_tsv_and_log(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root)
+        success = ComponentResult(
+            "comp-a", success=True, iterations=2,
+            usage=_engineer_usage(1200, cost=0.05),
+        )
+        ui_buffer = io.StringIO()
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True, file=ui_buffer), root,
+            )
+
+        assert "comp-a" in result.completed
+
+        # Journal entry carries the per-phase usage dict.
+        entries = _read_journal(root)
+        comp_entry = next(e for e in entries if e["component_id"] == "comp-a")
+        assert comp_entry["usage"]["engineer"]["total_tokens"] == 1200
+        assert comp_entry["usage"]["engineer"]["calls"] == 1
+        assert comp_entry["usage"]["engineer"]["cost_usd"] == pytest.approx(0.05)
+
+        # experiments.tsv gains the totals columns.
+        tsv = (root / ".ralph" / "experiments.tsv").read_text().splitlines()
+        header = tsv[0].split("\t")
+        row = dict(zip(header, tsv[1].split("\t"), strict=True))
+        assert row["total_tokens"] == "1200"
+        assert float(row["total_cost_usd"]) == pytest.approx(0.05)
+        assert row["unreported_calls"] == "0"
+
+        # Progress log records the per-phase usage event.
+        events = ProgressLog(root / "progress.jsonl").read_events()
+        usage_events = [e for e in events if e["event"] == "component_usage"]
+        assert len(usage_events) == 1
+        assert usage_events[0]["component"] == "comp-a"
+        assert usage_events[0]["data"]["phase"] == "engineer"
+        assert usage_events[0]["data"]["total_tokens"] == 1200
+
+        # The run summary prints the rollup table.
+        out = ui_buffer.getvalue()
+        assert "Usage rollup" in out
+        assert "comp-a" in out
+        assert "1,200" in out
+
+    def test_review_phase_usage_attributed(self, tmp_path: Path) -> None:
+        from ralph_py.review import ReviewResult
+
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root, review_mode="advisory")
+        success = ComponentResult(
+            "comp-a", success=True, iterations=1,
+            usage=_engineer_usage(1000),
+        )
+        review_agent = FakeUsageAgent(outputs=[["ok"]])
+        review_agent._usage_records.append(UsageRecord(
+            input_tokens=10, output_tokens=20, total_tokens=30,
+            duration_seconds=0.5, source="claude-stream-json",
+        ))
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.git.get_diff_content", return_value="",
+        ), patch(
+            "ralph_py.agents.get_agent", return_value=review_agent,
+        ), patch(
+            "ralph_py.factory.run_review",
+            return_value=ReviewResult(passed=True, mode="advisory"),
+        ):
+            result = run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert "comp-a" in result.completed
+        entries = _read_journal(root)
+        comp_entry = next(e for e in entries if e["component_id"] == "comp-a")
+        assert comp_entry["usage"]["engineer"]["total_tokens"] == 1000
+        assert comp_entry["usage"]["review"]["total_tokens"] == 30
+
+    def test_all_four_phases_attributed(self, tmp_path: Path) -> None:
+        """Engineer, review, security, and distill spend each land under
+        their own phase key with the correct totals."""
+        from ralph_py.review import ReviewResult
+        from ralph_py.security import SecurityConfig, SecurityResult
+
+        root = _setup_project(tmp_path, ["comp-a"])
+        # Re-enable knowledge: distillation is one of the four phases.
+        (root / "ralph.toml").write_text("[knowledge]\nenabled = true\n")
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(
+            root,
+            review_mode="advisory",
+            security_config=SecurityConfig(mode="advisory"),
+        )
+        success = ComponentResult(
+            "comp-a", success=True, iterations=1,
+            usage=_engineer_usage(1000),
+        )
+
+        # Each phase's get_agent call yields a fresh fake preloaded with
+        # a distinct spend (review 30, security 40, distill 50).
+        phase_tokens = iter((30, 40, 50))
+
+        def make_agent(*args: Any, **kwargs: Any) -> FakeUsageAgent:
+            agent = FakeUsageAgent(outputs=[["ok"]])
+            agent._usage_records.append(UsageRecord(
+                total_tokens=next(phase_tokens),
+                duration_seconds=0.1, source="claude-stream-json",
+            ))
+            return agent
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.git.get_diff_content", return_value="",
+        ), patch(
+            "ralph_py.agents.get_agent", side_effect=make_agent,
+        ), patch(
+            "ralph_py.factory.run_review",
+            return_value=ReviewResult(passed=True, mode="advisory"),
+        ), patch(
+            "ralph_py.factory.run_security_review",
+            return_value=SecurityResult(passed=True, mode="advisory"),
+        ), patch(
+            "ralph_py.factory.distill_facts", return_value=(1, "ok"),
+        ):
+            result = run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert "comp-a" in result.completed
+        entries = _read_journal(root)
+        comp_entry = next(e for e in entries if e["component_id"] == "comp-a")
+        usage = comp_entry["usage"]
+        assert usage["engineer"]["total_tokens"] == 1000
+        assert usage["review"]["total_tokens"] == 30
+        assert usage["security"]["total_tokens"] == 40
+        assert usage["distill"]["total_tokens"] == 50
+
+    def test_missing_usage_still_completes_and_records_nothing(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root)
+        success = ComponentResult("comp-a", success=True, iterations=1)
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert "comp-a" in result.completed
+        entries = _read_journal(root)
+        comp_entry = next(e for e in entries if e["component_id"] == "comp-a")
+        assert comp_entry["usage"] == {}
+        tsv = (root / ".ralph" / "experiments.tsv").read_text().splitlines()
+        header = tsv[0].split("\t")
+        row = dict(zip(header, tsv[1].split("\t"), strict=True))
+        assert row["total_tokens"] == "0"
+
+    def test_unreported_calls_marked_as_lower_bound(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root)
+        fallback = UsageTotals()
+        fallback.add_record(UsageRecord(duration_seconds=4.0))
+        success = ComponentResult(
+            "comp-a", success=True, iterations=1, usage=fallback,
+        )
+        ui_buffer = io.StringIO()
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True, file=ui_buffer), root,
+            )
+
+        out = ui_buffer.getvalue()
+        assert "lower bounds" in out
+        tsv = (root / ".ralph" / "experiments.tsv").read_text().splitlines()
+        header = tsv[0].split("\t")
+        row = dict(zip(header, tsv[1].split("\t"), strict=True))
+        assert row["unreported_calls"] == "1"
+
+
+# ---------------------------------------------------------------------------
+# max_total_tokens budget halt
+# ---------------------------------------------------------------------------
+
+
+class TestTokenBudgetHalt:
+    def test_halt_fires_and_is_recorded(self, tmp_path: Path) -> None:
+        root = _setup_project(tmp_path, ["comp-a", "comp-b"])
+        manifest = _make_manifest([_component("comp-a"), _component("comp-b")])
+        config = _factory_config(root, max_total_tokens=500)
+
+        def fake_run_component(*args: Any, **kwargs: Any) -> ComponentResult:
+            comp_id = args[0]
+            return ComponentResult(
+                comp_id, success=True, iterations=1,
+                usage=_engineer_usage(600),
+            )
+
+        with patch(
+            "ralph_py.factory._run_component", side_effect=fake_run_component,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        # comp-a's engineer spend (600 >= 500) trips the cap at the
+        # phase boundary: comp-a fails with a synthetic budget finding.
+        assert "comp-a" in result.failed
+        assert result.exit_code == 1
+        comp_a = manifest.get_component("comp-a")
+        assert comp_a is not None
+        assert comp_a.status == ComponentStatus.FAILED.value
+        assert "max_total_tokens" in (comp_a.error or "")
+        budget_findings = [
+            f for f in comp_a.findings
+            if f.is_infrastructure_error and "token budget" in f.explanation
+        ]
+        assert len(budget_findings) == 1
+        assert budget_findings[0].phase == "engineer"
+
+        # comp-b never launches: the scheduling gate fails it loudly too.
+        assert "comp-b" in result.failed
+        comp_b = manifest.get_component("comp-b")
+        assert comp_b is not None
+        assert any(
+            f.is_infrastructure_error and f.phase == "scheduling"
+            for f in comp_b.findings
+        )
+
+        # Progress log carries the budget_exceeded events.
+        events = ProgressLog(root / "progress.jsonl").read_events()
+        breaches = [e for e in events if e["event"] == "budget_exceeded"]
+        assert len(breaches) == 2
+        assert breaches[0]["data"]["max_total_tokens"] == 500
+        assert breaches[0]["data"]["total_tokens"] >= 500
+
+        # The journal still recorded the spend that tripped the cap.
+        entries = _read_journal(root)
+        comp_entry = next(e for e in entries if e["component_id"] == "comp-a")
+        assert comp_entry["usage"]["engineer"]["total_tokens"] == 600
+
+    def test_unbounded_by_default(self, tmp_path: Path) -> None:
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root)  # max_total_tokens defaults to 0
+        success = ComponentResult(
+            "comp-a", success=True, iterations=1,
+            usage=_engineer_usage(10_000_000),
+        )
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert "comp-a" in result.completed
+        assert result.exit_code == 0
+
+    def test_unknown_usage_cannot_trip_the_cap(self, tmp_path: Path) -> None:
+        """Fallback-only usage (no tokens reported) must not halt: the
+        cap compares tokens, and unknown spend contributes none."""
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root, max_total_tokens=100)
+        fallback = UsageTotals()
+        fallback.add_record(UsageRecord(duration_seconds=60.0))
+        success = ComponentResult(
+            "comp-a", success=True, iterations=1, usage=fallback,
+        )
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert "comp-a" in result.completed
+
+
+# ---------------------------------------------------------------------------
+# Rollup rendering
+# ---------------------------------------------------------------------------
+
+
+class TestRollupRendering:
+    def test_rows_ordered_and_totalled(self) -> None:
+        engineer = UsageTotals()
+        engineer.add_record(UsageRecord(
+            input_tokens=100, output_tokens=200, total_tokens=300,
+            cost_usd=0.5, duration_seconds=10.0, source="claude-stream-json",
+        ))
+        review = UsageTotals()
+        review.add_record(UsageRecord(total_tokens=50, source="codex-text"))
+        run_usage = UsageTotals()
+        run_usage.merge(engineer)
+        run_usage.merge(review)
+
+        lines = _format_usage_rollup(
+            {"comp-a": {"review": review, "engineer": engineer}}, run_usage,
+        )
+        # Header, engineer row before review row (fixed phase order), TOTAL.
+        assert len(lines) == 4
+        assert "tokens_total" in lines[0]
+        assert "engineer" in lines[1]
+        assert "review" in lines[2]
+        assert lines[3].startswith("TOTAL")
+        assert "350" in lines[3]
+
+    def test_unknown_usage_rendered_as_dash_with_note(self) -> None:
+        unknown = UsageTotals()
+        unknown.add_record(UsageRecord(duration_seconds=3.0))
+        lines = _format_usage_rollup({"comp-a": {"engineer": unknown}}, unknown)
+        assert "-" in lines[1]
+        assert any("lower bounds" in line for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# Control plane: toml / env for max_total_tokens (flag surface is covered
+# in test_config_control_plane.py alongside its R2.2 siblings)
+# ---------------------------------------------------------------------------
+
+
+class TestMaxTotalTokensConfig:
+    def test_default_unbounded(self) -> None:
+        assert FactoryConfig().max_total_tokens == 0
+
+    def test_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RALPH_FACTORY_MAX_TOTAL_TOKENS", "250000")
+        assert FactoryConfig.from_env().max_total_tokens == 250000
+
+    def test_load_toml_and_env_precedence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[factory]\nmax_total_tokens = 111\n"
+        )
+        assert FactoryConfig.load(tmp_path).max_total_tokens == 111
+        monkeypatch.setenv("RALPH_FACTORY_MAX_TOTAL_TOKENS", "222")
+        assert FactoryConfig.load(tmp_path).max_total_tokens == 222


### PR DESCRIPTION
## Roadmap item

R3.1 (Cost meter) [H-17, P-3]. Checkbox flipped in docs/remediation-roadmap.md.

## Measured CLI emissions (spike-first, per R3.1)

Probes run 2026-07-18 on this machine before writing any meter code.

**claude CLI 2.1.214** (`claude --print --output-format stream-json --verbose`, the exact mode ClaudeCodeAgent uses): the final `result` event carries structured usage. Actual fields and sample values:

```json
{
  "type": "result", "duration_ms": 1778, "duration_api_ms": 1550,
  "num_turns": 1, "total_cost_usd": 0.0227028,
  "usage": {"input_tokens": 9, "cache_creation_input_tokens": 10371,
            "cache_read_input_tokens": 17418, "output_tokens": 42},
  "modelUsage": {"claude-haiku-4-5-20251001": {"inputTokens": 9,
      "outputTokens": 42, "cacheReadInputTokens": 17418,
      "cacheCreationInputTokens": 10371, "costUSD": 0.0227028}}
}
```

**codex CLI 0.134.0** with the exact flags CodexAgent uses (`codex exec -C <dir> --output-last-message <f>`, plain output): the only usage data is a two-line trailer at end of stream - a line `tokens used` followed by a comma-formatted integer line (`14,511`). TOTAL tokens only: no input/output split, no cost. The meter parses that trailer; when absent, codex falls back to call counts + wall time as the roadmap mandates.

Also measured: `codex exec --json` emits a structured final event `{"type": "turn.completed", "usage": {"input_tokens": 19050, "cached_input_tokens": 4480, "output_tokens": 26, "reasoning_output_tokens": 19}}`. NOT adopted here: switching CodexAgent to `--json` would rework streaming display and break the plain-text COMPLETION_MARKER detection in loop.py. Noted in the roadmap as a follow-up.

## What changed

- `agents/base.py`: `UsageRecord` (one per `run()` call, appended on every exit path incl. timeout), `UsageTotals` (rollup math), `collect_usage()` (defensive getattr reader). `Agent` protocol gains `usage_records`; runtime consumers read it via `collect_usage`, so third-party/CustomAgent-style implementations without the property keep working (backward-compatible per requirement 1).
- `agents/claude_code.py` / `codex.py` / `custom.py`: per-adapter extraction (stream-json result event / trailer / calls+wall-time fallback). All parsing wrapped: a failure logs a warning and records `parse-error`/`unavailable`, never raises (requirement 4).
- `loop.py`: `LoopResult.usage` aggregates engineer-loop spend across iterations.
- `factory.py`: per-component per-phase meter (engineer / review / security / distill; fresh agent instance per phase makes attribution exact, chunked reviews land as N records), rollup table in the run summary with a `lower bounds` note when calls went unreported, `max_total_tokens` on FactoryConfig (toml `[factory].max_total_tokens` / env `RALPH_FACTORY_MAX_TOTAL_TOKENS` / flag).
- Budget halt: on breach the current component FAILS with a synthetic `Finding.infrastructure_error` (the R1.2/R1.4 `chunk_budget_insufficient` pattern: typed finding + progress-log `budget_exceeded` event + FAILED status), and the scheduler fails still-pending components loudly instead of launching them. Enforcement granularity is the phase boundary - an in-flight engineer loop can overshoot before the parent sees its usage (documented in code).
- `observability.py`: `component_usage` and `budget_exceeded` ProgressLog events.
- `evolution.py`: journal entries gain a per-phase `usage` dict; experiments.tsv gains `total_tokens` / `total_cost_usd` / `unreported_calls` columns (empty when untracked - zero would misread as "measured, free"; pre-R3.1 TSV files keep their shorter header, csv.DictReader drops the extra values).
- `cli.py`: `--max-total-tokens` flag + toml-note wiring; `LoggingAgent` forwards the wrapped agent's usage records.

Scope note: `cli.py` is not in the session's file list, but requirement 3 mandates a flag via the control plane; the change is limited to the flag binding and the LoggingAgent protocol forward.

## Tested

- CLI emissions measured empirically (findings above; the claude result event and codex trailer in tests are verbatim from the probes).
- `TestClaudeUsageExtraction` (test_usage_meter.py): measured result event parses to the exact token/cost/duration values; missing event, malformed JSON, missing usage dict, and drifted field types record unknown + log a warning, never raise; records accumulate across runs; end-to-end through `ClaudeCodeAgent.run` with a mocked subprocess.
- `TestCodexUsageExtraction`: measured two-line trailer parses (14,511 -> 14511); single-line `tokens used: N` variant; no trailer -> calls+wall-time fallback; non-numeric count never raises; last trailer wins over echoed text.
- `TestCustomAgentFallback`: calls + wall time only, zero known tokens.
- `TestUsageTotalsMath`: rollup math for claude-style, codex-style, partial, and unavailable records; merge; bool/negative rejection; garbage records (None/str/int/dict) never raise; `collect_usage` on objects without/with-broken `usage_records`.
- `TestLoopUsageAggregation`: 2 iterations x (100 in / 200 out) -> LoopResult.usage 200/400/600 across 2 calls; usage present on max-iterations failure; protocol-less agent yields empty totals; malformed records never crash the loop.
- `TestFactoryUsageAggregation`: engineer usage lands in the journal entry, experiments.tsv columns, progress log event, and rendered rollup table; all four phases (engineer 1000 / review 30 / security 40 / distill 50) attributed under their own keys; missing usage completes cleanly with `usage: {}` and `total_tokens=0` in the TSV; unreported calls render the lower-bound note and TSV `unreported_calls=1`.
- `TestTokenBudgetHalt`: cap 500 vs 600-token component -> comp-a FAILED with an infrastructure finding at phase `engineer`, comp-b failed at the scheduling gate with its own finding, two `budget_exceeded` events, spend still journaled, exit code 1; default 0 is unbounded (10M tokens pass); unknown-usage-only spend cannot trip the token cap.
- `TestMaxTotalTokensConfig` + `test_max_total_tokens_all_surfaces` (test_config_control_plane.py): flag > env > toml precedence through the real `ralph factory` construction path.
- Full suite/typecheck/lint final lines:
  - `uv run pytest tests/ -q`: `1052 passed, 14 skipped, 1 xfailed, 1 warning in 67.67s (0:01:07)`
  - `uv run mypy ralph_py/ --strict`: `Success: no issues found in 37 source files`
  - `uv run ruff check ralph_py/ tests/`: `All checks passed!`

## Assumed (not tested)

- CLI emission formats hold across versions other than claude 2.1.214 / codex 0.134.0 - by design the meter degrades to unknown + warning on drift rather than failing.
- The codex trailer total's exact semantics (whether it counts cached tokens) - treated as the CLI's self-report, recorded as-is.
- `total_tokens` for claude sums input + output + cache_creation + cache_read at face value; the budget cap compares raw token throughput, not price-weighted tokens.
- Timeout-killed claude/codex runs record wall time but no tokens (the trailer/result event never prints); the spend that occurred before the kill is invisible to the meter - totals stay lower bounds.
- No live-LLM run of the full factory with the meter (unit/integration tests use fakes and the verbatim probe fixtures).