### PR TITLE
feat: R3.2 status + notification - default-on progress log, status join, notify hooks (P-4)

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -398,7 +398,7 @@ spending, (c) what do I do when I come back to a partial failure.
     (toml/env/`--max-total-tokens`) fails the current component with a
     synthetic finding and gates scheduling. Enforcement granularity is
     the phase boundary; unreported calls make totals lower bounds.
-- [ ] R3.2 (M) **Status + notification** [P-4, D-status]
+- [x] R3.2 (M) **Status + notification** [P-4, D-status]
   - ProgressLog defaults on; `ralph status` renders manifest + log (per
     component: phase, attempt, last event age, evidence paths).
   - Notification hook: configurable shell command (`[notify] on_complete /

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -25,6 +25,14 @@ from ralph_py.factory import FactoryConfig, run_factory
 from ralph_py.init_cmd import DEFAULT_FEATURE_UNDERSTAND, run_init
 from ralph_py.loop import run_loop
 from ralph_py.manifest import Manifest
+from ralph_py.observability import (
+    RunActivity,
+    event_age_seconds,
+    format_age,
+    latest_run_id,
+    read_progress_events,
+    summarize_events,
+)
 from ralph_py.prd import PRD
 from ralph_py.timeout import TimeoutConfig
 from ralph_py.ui import get_ui
@@ -1521,7 +1529,10 @@ def decompose(
 @click.option(
     "--progress-log",
     type=click.Path(path_type=Path),
-    help="Path for JSONL progress log",
+    help="Path for the JSONL progress log (default: .ralph/progress.jsonl; "
+         "the log is on by default, disable via "
+         "[factory].progress_log_enabled = false or "
+         "RALPH_FACTORY_PROGRESS_LOG_ENABLED=0)",
 )
 @click.option(
     "--no-worktrees",
@@ -1743,6 +1754,10 @@ def factory(
     factory_config.review_agent_cmd = review_agent_cmd
     factory_config.review_model = review_model
     factory_config.progress_log_path = progress_log
+    if progress_log is not None:
+        # An explicit --progress-log path is an explicit opt-in; it wins
+        # over a toml/env progress_log_enabled = false.
+        factory_config.progress_log_enabled = True
     factory_config.force_lock = force_lock
     # R2.3: --no-verify is an explicit skip sentinel that run_factory
     # honors; verify_config=None alone would substitute default checks.
@@ -2044,6 +2059,7 @@ def config_show(
     from ralph_py.evolution import EvolutionConfig
     from ralph_py.feedforward import FeedforwardConfig
     from ralph_py.knowledge import KnowledgeConfig
+    from ralph_py.observability import NotifyConfig
     from ralph_py.security import SecurityConfig
     from ralph_py.verify import VerifyConfig
 
@@ -2053,7 +2069,7 @@ def config_show(
             "max_parallel", "max_retries", "retry_delay", "use_worktrees",
             "single_pr", "create_prs", "review_mode", "merge_timeout",
             "max_adversarial_calls", "max_total_tokens",
-            "pause_before_pr_merge",
+            "pause_before_pr_merge", "progress_log_enabled",
         ]),
         ("verify", VerifyConfig.load, [
             "test_command", "typecheck_command", "lint_command",
@@ -2083,6 +2099,9 @@ def config_show(
         ]),
         ("timeout", TimeoutConfig.load, [
             f.name for f in dataclass_fields(TimeoutConfig)
+        ]),
+        ("notify", NotifyConfig.load, [
+            "on_complete", "on_first_failure", "hook_timeout",
         ]),
     ]
 
@@ -2158,17 +2177,44 @@ def config_show(
     sys.exit(0)
 
 
-def _render_status(manifest: Manifest, manifest_file: Path, ui_impl: UI) -> None:
+def _age_label(ts: str) -> str:
+    """"5m ago" for an event timestamp, or "" when unparseable."""
+    age = event_age_seconds(ts)
+    if age is None:
+        return ""
+    return f"{format_age(age)} ago"
+
+
+def _render_status(
+    manifest: Manifest,
+    manifest_file: Path,
+    ui_impl: UI,
+    activity: RunActivity | None = None,
+    log_path: Path | None = None,
+    root_dir: Path | None = None,
+) -> None:
     """Render the per-component status view from a manifest.
 
-    Deliberately a standalone helper: Session 7B (R3.2) extends this to
-    join ProgressLog events (phase, attempt, last-event age, cost totals)
-    onto the same per-component skeleton.
+    ``activity`` is an observability.RunActivity joined onto the same
+    per-component skeleton (R3.2): phase, attempt, last-event age, cost
+    totals and evidence paths ride along when a progress log exists.
     """
     ui_impl.section("Ralph status")
     ui_impl.kv("Project", manifest.project_name)
     ui_impl.kv("Manifest", str(manifest_file))
     ui_impl.kv("Base branch", manifest.base_branch)
+
+    if activity is not None and log_path is not None:
+        ui_impl.kv("Progress log", str(log_path))
+        if activity.run_id:
+            ui_impl.kv("Run id", activity.run_id)
+        if activity.last_event_ts:
+            age = _age_label(activity.last_event_ts)
+            state = "finished" if activity.finished else "in flight"
+            ui_impl.kv(
+                "Run state",
+                f"{state} (last event {age})" if age else state,
+            )
 
     counts: dict[str, int] = {}
     for comp in manifest.components:
@@ -2190,6 +2236,47 @@ def _render_status(manifest: Manifest, manifest_file: Path, ui_impl: UI) -> None
         if comp.error:
             ui_impl.kv("  error", comp.error)
 
+        comp_activity = (
+            activity.components.get(comp.id) if activity is not None else None
+        )
+        if comp_activity is not None:
+            if comp_activity.phase:
+                ui_impl.kv("  phase", comp_activity.phase)
+            attempt = comp_activity.attempt or comp.retries + 1
+            ui_impl.kv("  attempt", str(attempt))
+            if comp_activity.last_event:
+                age = _age_label(comp_activity.last_event_ts)
+                ui_impl.kv(
+                    "  last event",
+                    f"{comp_activity.last_event} ({age})"
+                    if age else comp_activity.last_event,
+                )
+            if comp_activity.usage_calls:
+                note = (
+                    f" (lower bound: {comp_activity.unreported_calls} "
+                    f"call(s) unreported)"
+                    if comp_activity.unreported_calls else ""
+                )
+                ui_impl.kv(
+                    "  usage",
+                    f"{comp_activity.total_tokens} tokens, "
+                    f"${comp_activity.cost_usd:.4f}, "
+                    f"{comp_activity.usage_calls} calls{note}",
+                )
+        # Evidence paths: whatever this run left on disk for the
+        # component (worktree kept after a failure, adversarial raw
+        # outputs under .ralph/debug/).
+        if root_dir is not None and activity is not None and activity.run_id:
+            evidence = [
+                path for path in (
+                    root_dir / ".ralph" / "worktrees" / activity.run_id / comp.id,
+                    root_dir / ".ralph" / "debug" / activity.run_id / comp.id,
+                )
+                if path.exists()
+            ]
+            for path in evidence:
+                ui_impl.kv("  evidence", str(path))
+
 
 @cli.command()
 @click.option(
@@ -2205,6 +2292,24 @@ def _render_status(manifest: Manifest, manifest_file: Path, ui_impl: UI) -> None
          "back to scripts/ralph/run-manifest.json)",
 )
 @click.option(
+    "--progress-log",
+    "progress_log_path",
+    type=click.Path(path_type=Path),
+    help="Progress log to join onto the manifest "
+         "(default: <root>/.ralph/progress.jsonl)",
+)
+@click.option(
+    "--watch",
+    is_flag=True,
+    help="Re-render on an interval until interrupted",
+)
+@click.option(
+    "--interval",
+    type=float,
+    default=5.0,
+    help="Polling interval in seconds for --watch (default: 5)",
+)
+@click.option(
     "--ui",
     type=click.Choice(["auto", "rich", "plain", "gum"]),
     default="auto",
@@ -2218,15 +2323,22 @@ def _render_status(manifest: Manifest, manifest_file: Path, ui_impl: UI) -> None
 def status(
     root: Path | None,
     manifest_path: Path | None,
+    progress_log_path: Path | None,
+    watch: bool,
+    interval: float,
     ui: str,
     no_color: bool,
 ) -> None:
-    """Show per-component status from the factory manifest.
+    """Show per-component status from the manifest + progress log.
 
-    Minimal manifest-backed view (R2.4): status, retries, branch, and
-    timestamps per component. The ProgressLog-backed detail view lands
-    with R3.2.
+    R3.2: joins the factory manifest with the ProgressLog (default
+    .ralph/progress.jsonl): per component status, retries, branch,
+    timestamps, plus phase, attempt, last-event age, usage totals and
+    evidence paths for the latest run found in the log. Works
+    manifest-only when no log exists.
     """
+    import time as _time
+
     root_dir = root.resolve() if root else Path.cwd()
     force_rich = os.environ.get("GUM_FORCE") == "1"
     ui_impl = get_ui(_normalize_ui_mode(ui), no_color, force_rich=force_rich)
@@ -2241,23 +2353,48 @@ def status(
             root_dir / "scripts" / "ralph" / "run-manifest.json",
         ]
 
-    manifest_file = next((p for p in candidates if p.exists()), None)
-    if manifest_file is None:
-        looked = ", ".join(str(p) for p in candidates)
-        ui_impl.err(f"No manifest found (looked for: {looked})")
-        ui_impl.info(
-            "Run `ralph factory` or `ralph run` first, or pass --manifest."
+    log_path = progress_log_path or root_dir / ".ralph" / "progress.jsonl"
+
+    def _load_and_render() -> int:
+        manifest_file = next((p for p in candidates if p.exists()), None)
+        if manifest_file is None:
+            looked = ", ".join(str(p) for p in candidates)
+            ui_impl.err(f"No manifest found (looked for: {looked})")
+            ui_impl.info(
+                "Run `ralph factory` or `ralph run` first, or pass --manifest."
+            )
+            return 1
+
+        try:
+            manifest = Manifest.load(manifest_file)
+        except (OSError, ValueError) as exc:
+            ui_impl.err(f"Failed to load manifest {manifest_file}: {exc}")
+            return 1
+
+        events = read_progress_events(log_path)
+        activity: RunActivity | None = None
+        if events:
+            activity = summarize_events(events, latest_run_id(events))
+
+        _render_status(
+            manifest, manifest_file, ui_impl,
+            activity=activity, log_path=log_path if events else None,
+            root_dir=root_dir,
         )
-        sys.exit(1)
+        return 0
+
+    if not watch:
+        sys.exit(_load_and_render())
 
     try:
-        manifest = Manifest.load(manifest_file)
-    except (OSError, ValueError) as exc:
-        ui_impl.err(f"Failed to load manifest {manifest_file}: {exc}")
-        sys.exit(1)
-
-    _render_status(manifest, manifest_file, ui_impl)
-    sys.exit(0)
+        while True:
+            click.clear()
+            exit_code = _load_and_render()
+            if exit_code != 0:
+                sys.exit(exit_code)
+            _time.sleep(max(0.5, interval))
+    except KeyboardInterrupt:
+        sys.exit(0)
 
 
 @cli.command()

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -34,7 +34,12 @@ from ralph_py.knowledge import (
     measure_fact_utilization,
 )
 from ralph_py.manifest import Component, ComponentStatus, Manifest
-from ralph_py.observability import NullProgressLog, ProgressLog
+from ralph_py.observability import (
+    NotifyConfig,
+    NotifyHooks,
+    NullProgressLog,
+    ProgressLog,
+)
 from ralph_py.pr import create_prs_in_order, create_single_pr
 from ralph_py.prd import PRD
 from ralph_py.review import (
@@ -91,8 +96,15 @@ class FactoryConfig:
     contract_config: ContractConfig | None = None
     # Phase 0: feedforward
     feedforward_config: FeedforwardConfig | None = None
-    # Observability
+    # Observability. R3.2: the progress log defaults ON so a walk-away
+    # run always leaves a consumable event trail; progress_log_enabled
+    # = false (toml/env) turns it off. progress_log_path=None means the
+    # default <root>/.ralph/progress.jsonl.
     progress_log_path: Path | None = None
+    progress_log_enabled: bool = True
+    # R3.2: [notify] hooks (on_complete / on_first_failure shell
+    # commands). None means run_factory loads NotifyConfig.load(root_dir).
+    notify_config: NotifyConfig | None = None
     # E4: per-run hard cap on adversarial LLM calls (review + security
     # + knowledge distill). 0 means unbounded. Once exceeded the
     # remaining components skip those phases with an informational log
@@ -143,6 +155,9 @@ class FactoryConfig:
             pause_before_pr_merge=_parse_bool(
                 os.environ.get("RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE")
             ),
+            progress_log_enabled=_parse_bool(
+                os.environ.get("RALPH_FACTORY_PROGRESS_LOG_ENABLED", "1")
+            ),
         )
 
     @classmethod
@@ -181,6 +196,8 @@ class FactoryConfig:
             config.max_total_tokens = int(section["max_total_tokens"])
         if "pause_before_pr_merge" in section:
             config.pause_before_pr_merge = bool(section["pause_before_pr_merge"])
+        if "progress_log_enabled" in section:
+            config.progress_log_enabled = bool(section["progress_log_enabled"])
         # Env overrides (consistent with from_env)
         if "FACTORY_MAX_PARALLEL" in os.environ:
             config.max_parallel = int(os.environ["FACTORY_MAX_PARALLEL"])
@@ -201,6 +218,10 @@ class FactoryConfig:
         if "RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE" in os.environ:
             config.pause_before_pr_merge = _parse_bool(
                 os.environ["RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE"]
+            )
+        if "RALPH_FACTORY_PROGRESS_LOG_ENABLED" in os.environ:
+            config.progress_log_enabled = _parse_bool(
+                os.environ["RALPH_FACTORY_PROGRESS_LOG_ENABLED"]
             )
         return config
 
@@ -924,11 +945,29 @@ def _run_factory_locked(
     # by creation time, not by nonce).
     run_id = current_run_id()
 
-    # Set up progress log
-    if factory_config.progress_log_path:
-        progress_log = ProgressLog(factory_config.progress_log_path)
-    else:
+    # Set up progress log. R3.2: defaults ON under .ralph/ so a
+    # walk-away run always leaves an event trail `ralph status` can
+    # join; [factory] progress_log_enabled = false (or env) opts out.
+    # Every event carries run_id so runs sharing the default file stay
+    # distinguishable.
+    progress_log: ProgressLog
+    if not factory_config.progress_log_enabled:
         progress_log = NullProgressLog()
+    else:
+        log_path = (
+            factory_config.progress_log_path
+            or root_dir / ".ralph" / "progress.jsonl"
+        )
+        progress_log = ProgressLog(log_path, run_id=run_id)
+
+    # R3.2: notification hooks - each condition fires at most once per
+    # run, and hook failures only ever warn.
+    notify = NotifyHooks(
+        factory_config.notify_config or NotifyConfig.load(root_dir),
+        run_id=run_id,
+        project=manifest.project_name,
+        warn=ui.warn,
+    )
 
     progress_log.factory_started(manifest.project_name, len(manifest.components))
 
@@ -1004,6 +1043,7 @@ def _run_factory_locked(
                     factory_result.failed.append(comp.id)
                     factory_result.skipped.extend(skipped)
                     progress_log.component_failed(comp.id, comp.error)
+                    notify.fire_first_failure(comp.id, comp.error)
                     ui.err(f"  Failed: {comp.id}: {comp.error}")
                 else:
                     ui.warn(
@@ -1220,6 +1260,7 @@ def _run_factory_locked(
         factory_result.failed.append(comp.id)
         factory_result.skipped.extend(skipped)
         progress_log.component_failed(comp.id, error)
+        notify.fire_first_failure(comp.id, error)
         ui.err(f"  Failed: {comp.id}: {error[:80]}")
         manifest.save(manifest_path)
 
@@ -2021,6 +2062,11 @@ def _run_factory_locked(
                         comp.error = (
                             outcome.error or "PR merge not confirmed"
                         )
+                        progress_log.emit(
+                            "merge_pending", comp_id,
+                            {"pr_url": comp.pr_url, "error": comp.error},
+                        )
+                        notify.fire_merge_pending(comp_id, comp.error)
                         ui.warn(
                             f"  MERGE PENDING: {comp_id}: {comp.error}; "
                             f"dependents stay blocked; a factory re-run "
@@ -2033,6 +2079,7 @@ def _run_factory_locked(
                         factory_result.failed.append(comp_id)
                         factory_result.skipped.extend(skipped)
                         progress_log.component_failed(comp_id, comp.error)
+                        notify.fire_first_failure(comp_id, comp.error)
                         ui.err(f"  Failed: {comp_id}: {comp.error[:120]}")
                     manifest.save(manifest_path)
                     return
@@ -2085,6 +2132,8 @@ def _run_factory_locked(
             skipped = manifest.cascade_skip(comp.id)
             factory_result.failed.append(comp.id)
             factory_result.skipped.extend(skipped)
+            progress_log.component_failed(comp.id, comp.error)
+            notify.fire_first_failure(comp.id, comp.error)
             manifest.save(manifest_path)
             return None
 
@@ -2267,6 +2316,7 @@ def _run_factory_locked(
                         progress_log.component_failed(
                             comp_id, "component timeout",
                         )
+                        notify.fire_first_failure(comp_id, "component timeout")
                     ui.err(
                         f"  Failed: {comp_id}: component timeout "
                         f"(scheduler backstop after {backstop_seconds:.0f}s)"
@@ -2447,6 +2497,11 @@ def _run_factory_locked(
                     f"Contract test failed at tier {cr.tier} "
                     f"(retries exhausted)",
                 )
+                notify.fire_first_failure(
+                    cr.breaker,
+                    f"Contract test failed at tier {cr.tier} "
+                    f"(retries exhausted)",
+                )
                 factory_result.contract_failures.append(
                     f"tier {cr.tier}: breaker '{cr.breaker}' "
                     f"(retries exhausted): {summary_line}"
@@ -2539,6 +2594,17 @@ def _run_factory_locked(
         factory_result.exit_code = 1
     elif factory_result.skipped and not factory_result.completed:
         factory_result.exit_code = 1
+
+    # R3.2: run-end notification. Fires on every run that reached the
+    # summary, whatever the outcome; early refusals (invalid DAG, held
+    # lock, stale branches) never notify because no work was started.
+    notify.fire_complete(
+        f"completed={len(factory_result.completed)} "
+        f"failed={len(factory_result.failed)} "
+        f"skipped={len(factory_result.skipped)} "
+        f"merge_pending={len(factory_result.merge_pending)} "
+        f"exit_code={factory_result.exit_code}"
+    )
 
     # Record run to evolution journal
     try:

--- a/ralph_py/observability.py
+++ b/ralph_py/observability.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 import time
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +16,38 @@ from typing import Any
 def _iso_now() -> str:
     """Return current time as ISO 8601 string."""
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def parse_event_ts(ts: str) -> datetime | None:
+    """Parse a progress-log ``ts`` field. None on malformed input."""
+    try:
+        return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=UTC,
+        )
+    except ValueError:
+        return None
+
+
+def event_age_seconds(ts: str, now: datetime | None = None) -> float | None:
+    """Seconds between an event ``ts`` and ``now``. None on bad input."""
+    parsed = parse_event_ts(ts)
+    if parsed is None:
+        return None
+    if now is None:
+        now = datetime.now(UTC)
+    return (now - parsed).total_seconds()
+
+
+def format_age(seconds: float) -> str:
+    """Render an age in seconds as a compact human string."""
+    seconds = max(0.0, seconds)
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m"
+    if seconds < 86400:
+        return f"{int(seconds // 3600)}h{int(seconds % 3600 // 60):02d}m"
+    return f"{seconds / 86400:.1f}d"
 
 
 @dataclass
@@ -32,10 +68,15 @@ class ProgressLog:
 
     Each event is a single JSON line. JSONL is crash-safe since each line
     is a complete object - partial writes only lose the last event.
+
+    R3.2: ``run_id`` is stamped on every event so multiple runs appending
+    to the same default log stay distinguishable; consumers pick the
+    latest run via :func:`latest_run_id`.
     """
 
-    def __init__(self, log_path: Path) -> None:
+    def __init__(self, log_path: Path, run_id: str = "") -> None:
         self._path = log_path
+        self._run_id = run_id
         self._path.parent.mkdir(parents=True, exist_ok=True)
 
     @property
@@ -53,6 +94,8 @@ class ProgressLog:
             "ts": _iso_now(),
             "event": event_type,
         }
+        if self._run_id:
+            event["run_id"] = self._run_id
         if component_id is not None:
             event["component"] = component_id
         if data:
@@ -179,15 +222,7 @@ class ProgressLog:
 
     def read_events(self) -> list[dict[str, Any]]:
         """Read all events from the log. Useful for testing."""
-        if not self._path.exists():
-            return []
-        events: list[dict[str, Any]] = []
-        with open(self._path) as f:
-            for line in f:
-                line = line.strip()
-                if line:
-                    events.append(json.loads(line))
-        return events
+        return read_progress_events(self._path)
 
 
 class NullProgressLog(ProgressLog):
@@ -196,6 +231,7 @@ class NullProgressLog(ProgressLog):
     def __init__(self) -> None:
         # Do not call super().__init__() since we have no path
         self._path = Path("/dev/null")
+        self._run_id = ""
 
     def emit(
         self,
@@ -204,3 +240,284 @@ class NullProgressLog(ProgressLog):
         data: dict[str, Any] | None = None,
     ) -> None:
         pass
+
+
+def read_progress_events(path: Path) -> list[dict[str, Any]]:
+    """Read all events from a JSONL progress log.
+
+    Malformed lines (a crash mid-write leaves at most one) are skipped
+    rather than raised: the log is an observability surface and a torn
+    tail line must not make `ralph status` unusable.
+    """
+    if not path.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    parsed = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed, dict):
+                    events.append(parsed)
+    except OSError:
+        return []
+    return events
+
+
+def latest_run_id(events: list[dict[str, Any]]) -> str:
+    """run_id of the most recent event that carries one, else ""."""
+    for event in reversed(events):
+        run_id = event.get("run_id")
+        if isinstance(run_id, str) and run_id:
+            return run_id
+    return ""
+
+
+def _phase_for_event(event: dict[str, Any]) -> str | None:
+    """Map an event to the phase it implies; None keeps the prior phase."""
+    etype = event.get("event")
+    data = event.get("data") or {}
+    if etype == "component_started":
+        return "engineer"
+    if etype == "component_usage":
+        phase = data.get("phase")
+        return str(phase) if phase else None
+    if etype == "verification_result":
+        return "verify"
+    if etype == "review_result":
+        mode = str(data.get("mode") or "")
+        return "security" if mode.startswith("security") else "review"
+    if etype == "component_retrying":
+        return "retrying"
+    if etype == "component_failed":
+        return "failed"
+    if etype == "component_completed":
+        return "done"
+    if etype == "budget_exceeded":
+        return "budget-halt"
+    return None
+
+
+@dataclass
+class ComponentActivity:
+    """Per-component view derived from one run's progress-log events."""
+
+    component_id: str
+    phase: str = ""
+    attempt: int = 0
+    last_event: str = ""
+    last_event_ts: str = ""
+    usage_calls: int = 0
+    unreported_calls: int = 0
+    total_tokens: int = 0
+    cost_usd: float = 0.0
+
+
+@dataclass
+class RunActivity:
+    """One factory run's progress-log events, joined per component."""
+
+    run_id: str = ""
+    started_ts: str = ""
+    last_event_ts: str = ""
+    finished: bool = False
+    components: dict[str, ComponentActivity] = field(default_factory=dict)
+
+
+def _as_int_field(data: dict[str, Any], key: str) -> int:
+    value = data.get(key)
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def summarize_events(
+    events: list[dict[str, Any]], run_id: str = "",
+) -> RunActivity:
+    """Fold progress-log events into a per-component activity summary.
+
+    ``run_id`` non-empty filters to that run's events; empty includes
+    everything (pre-R3.2 logs have no run_id to filter on).
+    """
+    activity = RunActivity(run_id=run_id)
+    for event in events:
+        if run_id and event.get("run_id") != run_id:
+            continue
+        ts = str(event.get("ts") or "")
+        etype = str(event.get("event") or "")
+        if not activity.started_ts:
+            activity.started_ts = ts
+        activity.last_event_ts = ts
+        if etype == "factory_completed":
+            activity.finished = True
+        comp_id = event.get("component")
+        if not isinstance(comp_id, str) or not comp_id:
+            continue
+        comp = activity.components.setdefault(
+            comp_id, ComponentActivity(component_id=comp_id),
+        )
+        comp.last_event = etype
+        comp.last_event_ts = ts
+        phase = _phase_for_event(event)
+        if phase:
+            comp.phase = phase
+        data = event.get("data") or {}
+        if not isinstance(data, dict):
+            continue
+        if etype == "component_retrying":
+            comp.attempt = max(comp.attempt, _as_int_field(data, "attempt"))
+        elif etype == "component_usage":
+            comp.usage_calls += _as_int_field(data, "calls")
+            comp.unreported_calls += _as_int_field(data, "unreported_calls")
+            comp.total_tokens += _as_int_field(data, "total_tokens")
+            cost = data.get("cost_usd")
+            if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+                comp.cost_usd += float(cost)
+    return activity
+
+
+@dataclass
+class NotifyConfig:
+    """R3.2 ``[notify]`` section: shell commands fired on run milestones.
+
+    Example one-liners for ralph.toml::
+
+        [notify]
+        # Terminal bell when the run finishes:
+        on_complete = "printf '\\a'"
+        # Webhook ping the moment something needs attention:
+        on_first_failure = "curl -fsS -X POST -d \\"$RALPH_NOTIFY_EVENT $RALPH_NOTIFY_COMPONENT\\" https://example.com/hook"
+
+    The commands run via the shell with these context variables set:
+    ``RALPH_NOTIFY_EVENT`` (run_complete | first_failure | merge_pending),
+    ``RALPH_NOTIFY_RUN_ID``, ``RALPH_NOTIFY_PROJECT``,
+    ``RALPH_NOTIFY_COMPONENT`` and ``RALPH_NOTIFY_DETAIL``.
+    """
+
+    on_complete: str = ""
+    on_first_failure: str = ""
+    hook_timeout: float = 30.0
+
+    @classmethod
+    def from_env(cls) -> NotifyConfig:
+        """Load notify config from environment variables only."""
+        config = cls()
+        _apply_notify_env(config)
+        return config
+
+    @classmethod
+    def load(cls, root_dir: Path | None = None) -> NotifyConfig:
+        """Load notify config with precedence: env > toml > defaults."""
+        from ralph_py.config import load_toml_section
+
+        if root_dir is None:
+            root_dir = Path.cwd()
+        config = cls()
+        section = load_toml_section(root_dir / "ralph.toml", "notify")
+        if isinstance(section.get("on_complete"), str):
+            config.on_complete = section["on_complete"]
+        if isinstance(section.get("on_first_failure"), str):
+            config.on_first_failure = section["on_first_failure"]
+        if "hook_timeout" in section:
+            config.hook_timeout = float(section["hook_timeout"])
+        _apply_notify_env(config)
+        return config
+
+
+def _apply_notify_env(config: NotifyConfig) -> None:
+    if "RALPH_NOTIFY_ON_COMPLETE" in os.environ:
+        config.on_complete = os.environ["RALPH_NOTIFY_ON_COMPLETE"]
+    if "RALPH_NOTIFY_ON_FIRST_FAILURE" in os.environ:
+        config.on_first_failure = os.environ["RALPH_NOTIFY_ON_FIRST_FAILURE"]
+    if "RALPH_NOTIFY_HOOK_TIMEOUT" in os.environ:
+        config.hook_timeout = float(os.environ["RALPH_NOTIFY_HOOK_TIMEOUT"])
+
+
+class NotifyHooks:
+    """Fires user-configured shell commands on factory-run milestones.
+
+    Three conditions, each fired at most once per run (R3.2):
+
+    - run completion -> ``on_complete``
+    - first component failure -> ``on_first_failure``
+    - first MERGE_PENDING park -> ``on_first_failure`` (the attention
+      channel: the run is blocked on a human confirming a merge). The
+      hook can tell the conditions apart via ``RALPH_NOTIFY_EVENT``.
+
+    Hooks are observability, never control flow: a hook that fails to
+    launch, exits nonzero, or times out produces a warning and nothing
+    else. Output is NOT captured - a terminal bell must reach the tty.
+    """
+
+    def __init__(
+        self,
+        config: NotifyConfig,
+        run_id: str = "",
+        project: str = "",
+        warn: Callable[[str], None] | None = None,
+    ) -> None:
+        self._config = config
+        self._run_id = run_id
+        self._project = project
+        self._warn = warn or (lambda _msg: None)
+        self._fired: set[str] = set()
+
+    def fire_complete(self, detail: str = "") -> None:
+        self._fire("run_complete", self._config.on_complete, detail=detail)
+
+    def fire_first_failure(self, component_id: str, error: str) -> None:
+        self._fire(
+            "first_failure", self._config.on_first_failure,
+            component_id=component_id, detail=error,
+        )
+
+    def fire_merge_pending(self, component_id: str, detail: str = "") -> None:
+        self._fire(
+            "merge_pending", self._config.on_first_failure,
+            component_id=component_id, detail=detail,
+        )
+
+    def _fire(
+        self,
+        condition: str,
+        command: str,
+        component_id: str = "",
+        detail: str = "",
+    ) -> None:
+        if not command or condition in self._fired:
+            return
+        # Marked before launching: a hook that crashes must not get a
+        # second chance on the next failure - once means once.
+        self._fired.add(condition)
+        env = dict(os.environ)
+        env.update({
+            "RALPH_NOTIFY_EVENT": condition,
+            "RALPH_NOTIFY_RUN_ID": self._run_id,
+            "RALPH_NOTIFY_PROJECT": self._project,
+            "RALPH_NOTIFY_COMPONENT": component_id,
+            "RALPH_NOTIFY_DETAIL": detail,
+        })
+        try:
+            proc = subprocess.run(
+                command, shell=True, env=env,
+                stdin=subprocess.DEVNULL,
+                timeout=self._config.hook_timeout,
+            )
+            if proc.returncode != 0:
+                self._warn(
+                    f"notify hook '{condition}' exited "
+                    f"{proc.returncode} (non-fatal)"
+                )
+        except subprocess.TimeoutExpired:
+            self._warn(
+                f"notify hook '{condition}' timed out after "
+                f"{self._config.hook_timeout}s (non-fatal)"
+            )
+        except OSError as exc:
+            self._warn(
+                f"notify hook '{condition}' failed to launch: {exc} "
+                f"(non-fatal)"
+            )

--- a/tests/test_config_show.py
+++ b/tests/test_config_show.py
@@ -18,6 +18,7 @@ ALL_SECTIONS = [
     "[agent]", "[run]", "[paths]", "[git]", "[ui]",
     "[factory]", "[verify]", "[security]", "[contract]",
     "[feedforward]", "[knowledge]", "[evolution]", "[timeout]",
+    "[notify]",
 ]
 
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,471 @@
+"""R3.2 notification hooks + default-on progress log.
+
+Covers:
+- NotifyConfig toml/env resolution ([notify] section).
+- NotifyHooks once-per-condition semantics via a counting stub command,
+  context env vars, and non-fatal failure modes (nonzero exit, missing
+  binary, timeout).
+- Factory wiring: default-on progress log written under .ralph/ with
+  run_id on events; configurable off; on_first_failure and on_complete
+  fired exactly once per run through real run_factory calls; a
+  MERGE_PENDING park fires the attention hook (real git + stub gh).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ralph_py.config import RalphConfig
+from ralph_py.factory import ComponentResult, FactoryConfig, run_factory
+from ralph_py.manifest import Component, ComponentStatus, Manifest
+from ralph_py.observability import (
+    NotifyConfig,
+    NotifyHooks,
+    latest_run_id,
+    read_progress_events,
+)
+from ralph_py.ui.plain import PlainUI
+from tests.spine_utils import (
+    base_config,
+    component,
+    factory_config,
+    git,
+    make_manifest,
+    write_stub_gh,
+)
+
+
+def _count_cmd(count_file: Path) -> str:
+    """Shell command that appends one line per invocation."""
+    return f"echo \"$RALPH_NOTIFY_EVENT $RALPH_NOTIFY_COMPONENT\" >> '{count_file}'"
+
+
+def _lines(count_file: Path) -> list[str]:
+    if not count_file.exists():
+        return []
+    return [
+        line for line in count_file.read_text().splitlines() if line.strip()
+    ]
+
+
+class TestNotifyConfig:
+    def test_defaults(self) -> None:
+        config = NotifyConfig()
+        assert config.on_complete == ""
+        assert config.on_first_failure == ""
+        assert config.hook_timeout == 30.0
+
+    def test_load_reads_notify_section(self, tmp_path: Path) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[notify]\n"
+            "on_complete = \"printf 'a'\"\n"
+            'on_first_failure = "curl example.com"\n'
+            "hook_timeout = 5.0\n"
+        )
+        config = NotifyConfig.load(tmp_path)
+        assert config.on_complete == "printf 'a'"
+        assert config.on_first_failure == "curl example.com"
+        assert config.hook_timeout == 5.0
+
+    def test_env_overrides_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            '[notify]\non_complete = "from-toml"\n'
+        )
+        monkeypatch.setenv("RALPH_NOTIFY_ON_COMPLETE", "from-env")
+        monkeypatch.setenv("RALPH_NOTIFY_ON_FIRST_FAILURE", "fail-env")
+        config = NotifyConfig.load(tmp_path)
+        assert config.on_complete == "from-env"
+        assert config.on_first_failure == "fail-env"
+
+    def test_missing_section_is_defaults(self, tmp_path: Path) -> None:
+        config = NotifyConfig.load(tmp_path)
+        assert config == NotifyConfig()
+
+
+class TestNotifyHooksOnce:
+    """Each condition fires its command at most once per run."""
+
+    def test_first_failure_fires_once(self, tmp_path: Path) -> None:
+        count = tmp_path / "count.txt"
+        hooks = NotifyHooks(
+            NotifyConfig(on_first_failure=_count_cmd(count)),
+            run_id="r1", project="demo",
+        )
+        hooks.fire_first_failure("comp-a", "boom")
+        hooks.fire_first_failure("comp-b", "boom again")
+        assert _lines(count) == ["first_failure comp-a"]
+
+    def test_complete_fires_once(self, tmp_path: Path) -> None:
+        count = tmp_path / "count.txt"
+        hooks = NotifyHooks(NotifyConfig(on_complete=_count_cmd(count)))
+        hooks.fire_complete("done")
+        hooks.fire_complete("done again")
+        assert _lines(count) == ["run_complete "]
+
+    def test_merge_pending_fires_once_and_is_distinct(
+        self, tmp_path: Path,
+    ) -> None:
+        """merge_pending uses the on_first_failure command but is its own
+        once-per-run condition: a later real failure still notifies."""
+        count = tmp_path / "count.txt"
+        hooks = NotifyHooks(
+            NotifyConfig(on_first_failure=_count_cmd(count)),
+        )
+        hooks.fire_merge_pending("comp-a", "awaiting merge")
+        hooks.fire_merge_pending("comp-b", "awaiting merge")
+        hooks.fire_first_failure("comp-c", "boom")
+        assert _lines(count) == [
+            "merge_pending comp-a",
+            "first_failure comp-c",
+        ]
+
+    def test_context_env_vars_reach_command(self, tmp_path: Path) -> None:
+        out = tmp_path / "env.txt"
+        cmd = (
+            'echo "$RALPH_NOTIFY_EVENT|$RALPH_NOTIFY_RUN_ID'
+            '|$RALPH_NOTIFY_PROJECT|$RALPH_NOTIFY_COMPONENT'
+            f"|$RALPH_NOTIFY_DETAIL\" > '{out}'"
+        )
+        hooks = NotifyHooks(
+            NotifyConfig(on_first_failure=cmd), run_id="r9", project="demo",
+        )
+        hooks.fire_first_failure("comp-a", "tests failed")
+        assert out.read_text().strip() == (
+            "first_failure|r9|demo|comp-a|tests failed"
+        )
+
+    def test_empty_command_is_noop(self, tmp_path: Path) -> None:
+        hooks = NotifyHooks(NotifyConfig())
+        hooks.fire_complete()
+        hooks.fire_first_failure("comp-a", "boom")
+        hooks.fire_merge_pending("comp-a")
+        # Nothing to assert beyond "no exception, no file writes".
+
+
+class TestNotifyHooksNonFatal:
+    """Hook failures warn and never raise."""
+
+    def test_nonzero_exit_warns(self) -> None:
+        warnings: list[str] = []
+        hooks = NotifyHooks(
+            NotifyConfig(on_complete="exit 3"), warn=warnings.append,
+        )
+        hooks.fire_complete()
+        assert len(warnings) == 1
+        assert "exited 3" in warnings[0]
+
+    def test_missing_binary_warns(self) -> None:
+        warnings: list[str] = []
+        hooks = NotifyHooks(
+            NotifyConfig(
+                on_complete="/nonexistent/ralph-notify-binary-xyz",
+            ),
+            warn=warnings.append,
+        )
+        hooks.fire_complete()
+        # shell=True: the shell itself launches and exits 127.
+        assert len(warnings) == 1
+
+    def test_timeout_warns_and_does_not_raise(self) -> None:
+        warnings: list[str] = []
+        hooks = NotifyHooks(
+            NotifyConfig(on_complete="sleep 30", hook_timeout=0.2),
+            warn=warnings.append,
+        )
+        hooks.fire_complete()
+        assert len(warnings) == 1
+        assert "timed out" in warnings[0]
+
+    def test_crashing_hook_never_retries(self, tmp_path: Path) -> None:
+        count = tmp_path / "count.txt"
+        cmd = f"echo x >> '{count}'; exit 1"
+        warnings: list[str] = []
+        hooks = NotifyHooks(
+            NotifyConfig(on_first_failure=cmd), warn=warnings.append,
+        )
+        hooks.fire_first_failure("comp-a", "boom")
+        hooks.fire_first_failure("comp-b", "boom")
+        assert len(_lines(count)) == 1
+
+
+def _plain_factory_config(**overrides: object) -> FactoryConfig:
+    config = FactoryConfig(
+        use_worktrees=False, create_prs=False, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        skip_verification=True,
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _setup_plain_project(tmp_path: Path) -> Path:
+    ralph_dir = tmp_path / "scripts" / "ralph"
+    ralph_dir.mkdir(parents=True)
+    (ralph_dir / "prompt.md").write_text("test prompt")
+    (ralph_dir / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    return tmp_path
+
+
+def _plain_base_config(root: Path) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root / "scripts" / "ralph" / "prompt.md",
+        prd_file=root / "scripts" / "ralph" / "prd.json",
+        sleep_seconds=0, agent_cmd="echo test",
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    )
+
+
+def _two_component_manifest() -> Manifest:
+    return Manifest(
+        version="1", spec_file="spec.md", project_name="demo",
+        base_branch="main", single_pr=False,
+        components=[
+            Component("a", "A", "", [], "a.json", "b/a"),
+            Component("b", "B", "", [], "b.json", "b/b"),
+        ],
+    )
+
+
+class TestFactoryProgressLogDefaultOn:
+    """R3.2 requirement 1: the log defaults on under .ralph/."""
+
+    def test_default_on_writes_log_with_run_id(self, tmp_path: Path) -> None:
+        root = _setup_plain_project(tmp_path)
+        manifest = make_manifest([])
+        result = run_factory(
+            manifest, _plain_factory_config(), _plain_base_config(root),
+            PlainUI(no_color=True), root,
+        )
+        assert result.exit_code == 0
+
+        log_path = root / ".ralph" / "progress.jsonl"
+        assert log_path.exists()
+        events = read_progress_events(log_path)
+        assert [e["event"] for e in events] == [
+            "factory_started", "factory_completed",
+        ]
+        assert latest_run_id(events) != ""
+
+    def test_disabled_writes_nothing(self, tmp_path: Path) -> None:
+        root = _setup_plain_project(tmp_path)
+        result = run_factory(
+            make_manifest([]),
+            _plain_factory_config(progress_log_enabled=False),
+            _plain_base_config(root), PlainUI(no_color=True), root,
+        )
+        assert result.exit_code == 0
+        assert not (root / ".ralph" / "progress.jsonl").exists()
+
+    def test_explicit_path_overrides_default(self, tmp_path: Path) -> None:
+        root = _setup_plain_project(tmp_path)
+        custom = root / "custom-progress.jsonl"
+        run_factory(
+            make_manifest([]),
+            _plain_factory_config(progress_log_path=custom),
+            _plain_base_config(root), PlainUI(no_color=True), root,
+        )
+        assert custom.exists()
+        assert not (root / ".ralph" / "progress.jsonl").exists()
+
+    def test_two_runs_share_log_distinguishably(self, tmp_path: Path) -> None:
+        root = _setup_plain_project(tmp_path)
+        for _ in range(2):
+            run_factory(
+                make_manifest([]), _plain_factory_config(),
+                _plain_base_config(root), PlainUI(no_color=True), root,
+            )
+        events = read_progress_events(root / ".ralph" / "progress.jsonl")
+        run_ids = {e["run_id"] for e in events}
+        assert len(run_ids) == 2
+
+
+class TestFactoryFiresHooks:
+    """R3.2 requirement 3 through real run_factory calls."""
+
+    def test_failing_run_fires_first_failure_and_complete_once(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _setup_plain_project(tmp_path)
+        fail_count = tmp_path / "fail-count.txt"
+        complete_count = tmp_path / "complete-count.txt"
+        config = _plain_factory_config(notify_config=NotifyConfig(
+            on_first_failure=_count_cmd(fail_count),
+            on_complete=_count_cmd(complete_count),
+        ))
+
+        def fake_run(
+            component_id: str, *args: object, **kwargs: object,
+        ) -> ComponentResult:
+            return ComponentResult(component_id, success=False, error="boom")
+
+        with patch("ralph_py.factory._run_component", side_effect=fake_run):
+            result = run_factory(
+                _two_component_manifest(), config, _plain_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        # Two independent components both failed; the hook fired once.
+        assert len(result.failed) == 2
+        assert _lines(fail_count) == ["first_failure a"]
+        assert _lines(complete_count) == ["run_complete "]
+
+    def test_clean_run_fires_only_complete(self, tmp_path: Path) -> None:
+        root = _setup_plain_project(tmp_path)
+        fail_count = tmp_path / "fail-count.txt"
+        complete_count = tmp_path / "complete-count.txt"
+        config = _plain_factory_config(notify_config=NotifyConfig(
+            on_first_failure=_count_cmd(fail_count),
+            on_complete=_count_cmd(complete_count),
+        ))
+
+        result = run_factory(
+            make_manifest([]), config, _plain_base_config(root),
+            PlainUI(no_color=True), root,
+        )
+        assert result.exit_code == 0
+        assert _lines(fail_count) == []
+        assert _lines(complete_count) == ["run_complete "]
+
+    def test_hook_failure_never_affects_the_run(self, tmp_path: Path) -> None:
+        root = _setup_plain_project(tmp_path)
+        config = _plain_factory_config(notify_config=NotifyConfig(
+            on_complete="/nonexistent/ralph-hook-xyz",
+            on_first_failure="exit 7",
+        ))
+
+        def fake_run(
+            component_id: str, *args: object, **kwargs: object,
+        ) -> ComponentResult:
+            return ComponentResult(component_id, success=False, error="boom")
+
+        with patch("ralph_py.factory._run_component", side_effect=fake_run):
+            result = run_factory(
+                _two_component_manifest(), config, _plain_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        # Failure exit code comes from the failed components, not hooks.
+        assert result.exit_code == 1
+        assert len(result.failed) == 2
+
+
+def _make_pr_repo(tmp_path: Path, comp_ids: tuple[str, ...]) -> Path:
+    """Real git repo with COMMITTED ralph scaffolding plus a bare origin,
+    so worktrees contain the PRDs without the (mocked-out) engineer's
+    provisioning step (mirrors tests/test_pr_outcomes.py)."""
+    root = tmp_path / "repo"
+    ralph_dir = root / "scripts" / "ralph"
+    ralph_dir.mkdir(parents=True)
+    (ralph_dir / "prompt.md").write_text("test prompt")
+    (ralph_dir / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    for cid in comp_ids:
+        feature = ralph_dir / "feature" / cid
+        feature.mkdir(parents=True)
+        (feature / "prd.json").write_text(json.dumps({
+            "branchName": f"ralph/factory/{cid}",
+            "userStories": [{
+                "id": "US-001", "title": "Test",
+                "acceptanceCriteria": ["AC1"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+    (root / ".gitignore").write_text(
+        ".ralph/\nscripts/ralph/manifest.json\n"
+    )
+    git("init", "-q", "-b", "main", cwd=root)
+    git("config", "user.email", "notify@test", cwd=root)
+    git("config", "user.name", "Notify Test", cwd=root)
+    git("add", "-A", cwd=root)
+    git("commit", "-q", "-m", "init", cwd=root)
+    origin = tmp_path / "origin.git"
+    git("init", "-q", "--bare", str(origin), cwd=tmp_path)
+    git("remote", "add", "origin", str(origin), cwd=root)
+    git("push", "-q", "-u", "origin", "main", cwd=root)
+    return root
+
+
+class TestMergePendingFiresHook:
+    """A MERGE_PENDING park pings the attention hook (real git + stub
+    gh whose `pr view` never reports MERGED)."""
+
+    def test_merge_pending_park_fires_hook(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        root = _make_pr_repo(tmp_path, ("alpha",))
+        bin_dir = tmp_path / "stub-bin"
+        bin_dir.mkdir()
+        write_stub_gh(bin_dir)
+        monkeypatch.setenv(
+            "PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        )
+        monkeypatch.setenv("GH_SPINE_VIEW_STATE", "OPEN")
+        monkeypatch.setenv("RALPH_KNOWLEDGE_ENABLED", "0")
+
+        count = tmp_path / "count.txt"
+        config = factory_config(
+            create_prs=True, merge_timeout=1.0,
+            notify_config=NotifyConfig(on_first_failure=_count_cmd(count)),
+        )
+        manifest = make_manifest([component("alpha")])
+
+        def fake_run(
+            component_id: str, *args: object, **kwargs: object,
+        ) -> ComponentResult:
+            return ComponentResult(component_id, success=True, iterations=1)
+
+        with patch("ralph_py.factory._run_component", side_effect=fake_run):
+            result = run_factory(
+                manifest, config, base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        alpha = manifest.get_component("alpha")
+        assert alpha is not None
+        assert alpha.status == ComponentStatus.MERGE_PENDING.value
+        assert result.merge_pending == ["alpha"]
+        assert _lines(count) == ["merge_pending alpha"]
+        # The park is also visible in the progress log for `ralph status`.
+        events = read_progress_events(root / ".ralph" / "progress.jsonl")
+        assert "merge_pending" in [e["event"] for e in events]
+
+
+class TestNotifyStubIsCounted:
+    """Meta-check: the counting stub counts every invocation, so the
+    exactly-once assertions above are behavior tests, not vacuous."""
+
+    def test_stub_counts_each_call(self, tmp_path: Path) -> None:
+        count = tmp_path / "count.txt"
+        for _ in range(3):
+            subprocess.run(
+                _count_cmd(count), shell=True, check=True,
+                env={**os.environ, "RALPH_NOTIFY_EVENT": "e",
+                     "RALPH_NOTIFY_COMPONENT": "c"},
+            )
+        assert len(_lines(count)) == 3
+
+
+def test_progress_log_survives_manifest_json_shape(tmp_path: Path) -> None:
+    """Regression guard: events written by a real run parse back as
+    dicts (json round-trip, one object per line)."""
+    root = _setup_plain_project(tmp_path)
+    run_factory(
+        make_manifest([]), _plain_factory_config(),
+        _plain_base_config(root), PlainUI(no_color=True), root,
+    )
+    raw = (root / ".ralph" / "progress.jsonl").read_text().splitlines()
+    for line in raw:
+        assert isinstance(json.loads(line), dict)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ralph_py.observability import NullProgressLog, ProgressLog
+from ralph_py.observability import (
+    NullProgressLog,
+    ProgressLog,
+    format_age,
+    latest_run_id,
+    parse_event_ts,
+    read_progress_events,
+    summarize_events,
+)
 
 
 class TestProgressLog:
@@ -74,3 +82,137 @@ class TestNullProgressLog:
         log.factory_started("demo", 5)
         log.component_started("comp-a")
         log.component_completed("comp-a", duration=10.0, iterations=3)
+
+
+class TestRunId:
+    """R3.2 requirement 4: events carry the run_id."""
+
+    def test_run_id_stamped_on_every_event(self, tmp_path: Path) -> None:
+        log = ProgressLog(tmp_path / "test.jsonl", run_id="run-123")
+        log.factory_started("demo", 1)
+        log.component_started("comp-a")
+        log.emit("custom_event")
+
+        events = log.read_events()
+        assert len(events) == 3
+        assert all(e["run_id"] == "run-123" for e in events)
+
+    def test_no_run_id_omits_field(self, tmp_path: Path) -> None:
+        log = ProgressLog(tmp_path / "test.jsonl")
+        log.emit("test")
+        assert "run_id" not in log.read_events()[0]
+
+    def test_latest_run_id_picks_last(self, tmp_path: Path) -> None:
+        path = tmp_path / "test.jsonl"
+        ProgressLog(path, run_id="run-1").factory_started("demo", 1)
+        ProgressLog(path, run_id="run-2").factory_started("demo", 1)
+
+        events = read_progress_events(path)
+        assert latest_run_id(events) == "run-2"
+
+    def test_latest_run_id_empty_for_legacy_log(self, tmp_path: Path) -> None:
+        path = tmp_path / "test.jsonl"
+        ProgressLog(path).emit("test")
+        assert latest_run_id(read_progress_events(path)) == ""
+
+
+class TestReadProgressEvents:
+    def test_skips_malformed_tail_line(self, tmp_path: Path) -> None:
+        """A torn line from a crash mid-write must not break consumers."""
+        path = tmp_path / "test.jsonl"
+        ProgressLog(path).emit("good_event")
+        with open(path, "a") as f:
+            f.write('{"ts": "2026-07-18T10:0')  # torn write
+
+        events = read_progress_events(path)
+        assert len(events) == 1
+        assert events[0]["event"] == "good_event"
+
+
+class TestSummarizeEvents:
+    """R3.2: fold one run's events into per-component activity."""
+
+    def _two_run_log(self, tmp_path: Path) -> Path:
+        path = tmp_path / "progress.jsonl"
+        old = ProgressLog(path, run_id="run-old")
+        old.factory_started("demo", 1)
+        old.component_started("comp-a")
+        old.component_failed("comp-a", "old failure")
+        new = ProgressLog(path, run_id="run-new")
+        new.factory_started("demo", 2)
+        new.component_started("comp-a")
+        new.component_usage("comp-a", "engineer", {
+            "calls": 3, "known_calls": 2, "unreported_calls": 1,
+            "total_tokens": 1200, "cost_usd": 0.25,
+        })
+        new.verification_result("comp-a", passed=True)
+        new.review_result("comp-a", passed=True, mode="hard")
+        new.component_usage("comp-a", "review", {
+            "calls": 1, "known_calls": 1, "unreported_calls": 0,
+            "total_tokens": 300, "cost_usd": 0.05,
+        })
+        new.component_retrying("comp-b", attempt=2, reason="tests failed")
+        return path
+
+    def test_filters_to_named_run(self, tmp_path: Path) -> None:
+        events = read_progress_events(self._two_run_log(tmp_path))
+        activity = summarize_events(events, latest_run_id(events))
+
+        assert activity.run_id == "run-new"
+        # The old run's failure must not leak into comp-a's activity.
+        comp_a = activity.components["comp-a"]
+        assert comp_a.phase != "failed"
+        assert comp_a.last_event == "component_usage"
+
+    def test_usage_totals_accumulate_across_phases(
+        self, tmp_path: Path,
+    ) -> None:
+        events = read_progress_events(self._two_run_log(tmp_path))
+        comp_a = summarize_events(events, "run-new").components["comp-a"]
+
+        assert comp_a.total_tokens == 1500
+        assert comp_a.usage_calls == 4
+        assert comp_a.unreported_calls == 1
+        assert abs(comp_a.cost_usd - 0.30) < 1e-9
+
+    def test_phase_and_attempt_derivation(self, tmp_path: Path) -> None:
+        events = read_progress_events(self._two_run_log(tmp_path))
+        activity = summarize_events(events, "run-new")
+
+        # Last phase-bearing event for comp-a is the review usage record.
+        assert activity.components["comp-a"].phase == "review"
+        assert activity.components["comp-b"].attempt == 2
+        assert activity.components["comp-b"].phase == "retrying"
+
+    def test_finished_flag(self, tmp_path: Path) -> None:
+        path = tmp_path / "progress.jsonl"
+        log = ProgressLog(path, run_id="r1")
+        log.factory_started("demo", 0)
+        events = read_progress_events(path)
+        assert summarize_events(events, "r1").finished is False
+
+        log.factory_completed(completed=1, failed=0, skipped=0)
+        events = read_progress_events(path)
+        assert summarize_events(events, "r1").finished is True
+
+    def test_empty_run_id_includes_legacy_events(self, tmp_path: Path) -> None:
+        path = tmp_path / "progress.jsonl"
+        ProgressLog(path).component_started("comp-a")
+        activity = summarize_events(read_progress_events(path), "")
+        assert "comp-a" in activity.components
+
+
+class TestTimeHelpers:
+    def test_parse_event_ts_roundtrip(self) -> None:
+        parsed = parse_event_ts("2026-07-18T10:00:00Z")
+        assert parsed is not None
+        assert parsed.year == 2026
+
+    def test_parse_event_ts_malformed(self) -> None:
+        assert parse_event_ts("not-a-timestamp") is None
+
+    def test_format_age_bands(self) -> None:
+        assert format_age(5) == "5s"
+        assert format_age(300) == "5m"
+        assert format_age(7500) == "2h05m"
+        assert format_age(200000) == "2.3d"

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -1,18 +1,21 @@
-"""R2.4 `ralph status`: minimal manifest-backed component status view.
+"""`ralph status`: manifest + ProgressLog component status view.
 
-Session 7B (R3.2) extends the same skeleton with ProgressLog detail;
-these tests pin the minimal contract: per component id, print status,
-retries, branch, and timestamps when present.
+R2.4 pinned the minimal manifest contract (per component id: status,
+retries, branch, timestamps). R3.2 joins the ProgressLog onto the same
+skeleton: phase, attempt, last-event age, usage totals and evidence
+paths for the latest run in the log.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from ralph_py.cli import cli
 from ralph_py.manifest import Component, Manifest
+from ralph_py.observability import ProgressLog
 
 
 def _synthetic_manifest() -> Manifest:
@@ -130,3 +133,122 @@ class TestStatusCommand:
 
         assert exit_code == 1
         assert "Failed to load manifest" in output
+
+
+def _write_progress_log(root: Path, run_id: str = "run-2") -> Path:
+    """Synthetic two-run log: the stale run must not leak into output."""
+    log_path = root / ".ralph" / "progress.jsonl"
+    old = ProgressLog(log_path, run_id="run-1")
+    old.factory_started("demo", 2)
+    old.component_failed("comp-a", "stale failure from run-1")
+    log = ProgressLog(log_path, run_id=run_id)
+    log.factory_started("demo", 2)
+    log.component_started("comp-a")
+    log.component_usage("comp-a", "engineer", {
+        "calls": 4, "known_calls": 4, "unreported_calls": 0,
+        "total_tokens": 5000, "cost_usd": 1.25,
+    })
+    log.verification_result("comp-a", passed=True)
+    log.review_result("comp-a", passed=True, mode="hard")
+    log.component_started("comp-b")
+    log.component_retrying("comp-b", attempt=2, reason="tests failed")
+    return log_path
+
+
+class TestStatusProgressLogJoin:
+    """R3.2: the log's phase / attempt / age / usage / evidence render."""
+
+    def test_joins_log_detail_onto_components(self, tmp_path: Path) -> None:
+        _synthetic_manifest().save(
+            tmp_path / "scripts" / "ralph" / "manifest.json",
+        )
+        _write_progress_log(tmp_path)
+
+        exit_code, output = _invoke_status("--root", str(tmp_path))
+
+        assert exit_code == 0
+        assert "run-2" in output
+        assert "progress.jsonl" in output
+        # comp-a: last phase-bearing event is the hard review.
+        assert re.search(r"phase:\s+review", output)
+        assert "5000 tokens" in output
+        assert "$1.2500" in output
+        assert "4 calls" in output
+        # comp-b: retrying on attempt 2.
+        assert re.search(r"phase:\s+retrying", output)
+        assert re.search(r"attempt:\s+2", output)
+        # Last-event ages render (events were just written).
+        assert "ago" in output
+
+    def test_latest_run_wins(self, tmp_path: Path) -> None:
+        _synthetic_manifest().save(
+            tmp_path / "scripts" / "ralph" / "manifest.json",
+        )
+        _write_progress_log(tmp_path)
+
+        _, output = _invoke_status("--root", str(tmp_path))
+
+        assert "run-1" not in output
+        assert "stale failure from run-1" not in output
+
+    def test_evidence_paths_listed_when_present(self, tmp_path: Path) -> None:
+        _synthetic_manifest().save(
+            tmp_path / "scripts" / "ralph" / "manifest.json",
+        )
+        _write_progress_log(tmp_path)
+        worktree = tmp_path / ".ralph" / "worktrees" / "run-2" / "comp-a"
+        debug_dir = tmp_path / ".ralph" / "debug" / "run-2" / "comp-b"
+        worktree.mkdir(parents=True)
+        debug_dir.mkdir(parents=True)
+
+        _, output = _invoke_status("--root", str(tmp_path))
+
+        assert str(worktree) in output
+        assert str(debug_dir) in output
+        # No evidence line for paths that do not exist.
+        assert str(
+            tmp_path / ".ralph" / "debug" / "run-2" / "comp-a",
+        ) not in output
+
+    def test_run_state_line(self, tmp_path: Path) -> None:
+        _synthetic_manifest().save(
+            tmp_path / "scripts" / "ralph" / "manifest.json",
+        )
+        log_path = _write_progress_log(tmp_path)
+
+        _, output = _invoke_status("--root", str(tmp_path))
+        assert "in flight" in output
+
+        ProgressLog(log_path, run_id="run-2").factory_completed(
+            completed=2, failed=0, skipped=0,
+        )
+        _, output = _invoke_status("--root", str(tmp_path))
+        assert "finished" in output
+
+    def test_explicit_progress_log_flag(self, tmp_path: Path) -> None:
+        _synthetic_manifest().save(
+            tmp_path / "scripts" / "ralph" / "manifest.json",
+        )
+        custom = tmp_path / "elsewhere.jsonl"
+        ProgressLog(custom, run_id="run-x").component_started("comp-a")
+
+        exit_code, output = _invoke_status(
+            "--root", str(tmp_path), "--progress-log", str(custom),
+        )
+
+        assert exit_code == 0
+        assert "run-x" in output
+        assert re.search(r"phase:\s+engineer", output)
+
+    def test_manifest_only_when_no_log(self, tmp_path: Path) -> None:
+        """Without a log the R2.4 manifest-only view still renders."""
+        _synthetic_manifest().save(
+            tmp_path / "scripts" / "ralph" / "manifest.json",
+        )
+
+        exit_code, output = _invoke_status("--root", str(tmp_path))
+
+        assert exit_code == 0
+        assert "comp-a: completed" in output
+        assert "phase:" not in output
+        assert "Run state" not in output


### PR DESCRIPTION
Implements **R3.2 (Status + notification)** [P-4, D-status] per Session 7B of `docs/remediation-sessions.md`. Flips the R3.2 checkbox in `docs/remediation-roadmap.md`.

## What changed

1. **ProgressLog defaults ON** at `.ralph/progress.jsonl`. Disable via `[factory] progress_log_enabled = false` or `RALPH_FACTORY_PROGRESS_LOG_ENABLED=0`; an explicit `--progress-log <path>` overrides the path and force-enables. Every event now carries the `run_id`, so multiple runs appending to the shared default file stay distinguishable.
2. **`ralph status` joins manifest + ProgressLog**: per component - phase, attempt, last-event age, usage totals (from the R3.1 `component_usage` events, rendered as a lower bound when calls went unreported), and evidence paths (`.ralph/worktrees/<run>/<id>`, `.ralph/debug/<run>/<id>` when they exist). The latest run in the log wins; manifest-only rendering is unchanged when no log exists. A `--watch` flag polls on `--interval` seconds.
3. **`[notify]` config** (`NotifyConfig` in observability.py, `from_env()` + `load()` per convention): `on_complete` / `on_first_failure` shell commands + `hook_timeout` (default 30s). Documented one-liners: terminal bell `printf '\a'`, webhook `curl -fsS -X POST -d "$RALPH_NOTIFY_EVENT $RALPH_NOTIFY_COMPONENT" <url>`. Hooks receive `RALPH_NOTIFY_EVENT / RUN_ID / PROJECT / COMPONENT / DETAIL`. Hook output is NOT captured so a bell reaches the tty. Failures/timeouts/nonzero exits warn and never affect the run.
4. **Firing semantics** (each condition at most once per run): run end -> `on_complete` (any outcome); first component failure -> `on_first_failure` (wired at every FAILED site: retry exhaustion, PR-flow failure, worktree-setup failure, scheduler backstop, contract terminal failure, crash-recovery closed PR); first MERGE_PENDING park -> the `on_first_failure` command as its own once-condition, distinguished via `RALPH_NOTIFY_EVENT=merge_pending`. The spec defines exactly two commands, so MERGE_PENDING (run blocked on a human) maps to the attention channel.
5. `ralph config show` gains the `[notify]` section and the `progress_log_enabled` knob. MERGE_PENDING parks also emit a `merge_pending` progress event; worktree-setup failures now emit `component_failed` (previously absent from the log).

## Checks

```
uv run pytest tests/ -q          -> 1133 passed, 14 skipped, 1 xfailed in 57.34s
uv run mypy ralph_py/ --strict   -> Success: no issues found in 37 source files
uv run ruff check ralph_py/ tests/ -> All checks passed!
```

## Tested

- `test_notify.py::TestFactoryProgressLogDefaultOn`: default-on `run_factory` writes `.ralph/progress.jsonl` with run_id; `progress_log_enabled=False` writes nothing; explicit path override; two runs share the file with distinct run_ids.
- `test_observability.py::TestRunId`: run_id stamped on every event, omitted when unset, `latest_run_id` picks the newest run, legacy logs return "".
- `test_observability.py::TestSummarizeEvents`: run filtering (stale run's failure does not leak), usage accumulation across phases (tokens/cost/calls/unreported), phase + attempt derivation, finished flag, legacy no-run_id logs.
- `test_status_cmd.py::TestStatusProgressLogJoin`: phase/attempt/age/usage/evidence render from a synthetic manifest + two-run log; latest run wins; evidence lines only for existing dirs; in-flight vs finished run state; `--progress-log` flag; manifest-only fallback. All six pre-existing R2.4 status tests still pass unchanged.
- `test_notify.py::TestNotifyHooksOnce`: counting stub proves exactly-once per condition (first_failure, run_complete, merge_pending as an independent condition - a later real failure still notifies); context env vars reach the command; empty command is a no-op. `TestNotifyStubIsCounted` meta-checks the stub counts every invocation (H4: the exactly-once assertions are behavior tests).
- `test_notify.py::TestNotifyHooksNonFatal`: nonzero exit warns, missing binary warns, `sleep 30` vs 0.2s hook_timeout warns; a crashing hook never retries. `TestFactoryFiresHooks::test_hook_failure_never_affects_the_run`: broken hooks leave exit code and component statuses untouched.
- `test_notify.py::TestFactoryFiresHooks`: through real `run_factory` calls - a run with two failing components fires `on_first_failure` exactly once (for the first) and `on_complete` exactly once; a clean run fires only `on_complete`.
- `test_notify.py::TestMergePendingFiresHook`: real git repo + bare origin + stub `gh` whose `pr view` reports OPEN -> component parks MERGE_PENDING, the hook fires `merge_pending alpha` exactly once, and the `merge_pending` event is in the progress log.
- `test_notify.py::TestNotifyConfig`: `[notify]` toml parsing, env-over-toml precedence, defaults on missing section.
- `test_observability.py::TestReadProgressEvents`: a torn tail line (crash mid-write) is skipped, not raised.
- `test_config_show.py::test_all_sections_present`: `[notify]` appears in `ralph config show`.

## Assumed (not tested)

- `--watch` loop behavior (clear + re-render + KeyboardInterrupt exit) is untested; it reuses the tested single-render path per iteration.
- `on_complete` is NOT fired on early refusals (invalid DAG, held lock, stale branch preflight) - deliberate: no work started. Stated in a code comment; no test pins it.
- The MERGE_PENDING->`on_first_failure` mapping is a design decision, not a spec-verbatim behavior: the session prompt defines only two commands and says "also fire on MERGE_PENDING"; the attention channel was chosen and the event var distinguishes the conditions.
- Hook subprocesses inherit the full parent environment (unlike R2.6-scrubbed verification): notify commands come from the user's own ralph.toml and a webhook one-liner may legitimately need a token env var.
- A timed-out hook's shell is killed but grandchildren it spawned may linger (subprocess.run timeout semantics); accepted for a 30s-default observability hook.
- `format_age` day rendering (`2.3d`) is tested; leap/second-boundary formatting beyond the four bands is not.

Roadmap item: R3.2 checkbox flipped in `docs/remediation-roadmap.md` in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
