### PR TITLE
feat: R3.3 resume + partial-failure ergonomics (P-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,9 @@ ralph evolve                       Analyze factory runs and propose harness impr
 ralph factory                      Run the software factory - decompose and execute a spec.
 ralph feature                      Run feature understanding, then implementation.
 ralph init [DIRECTORY]             Initialize Ralph in a project directory.
+ralph retry COMPONENT_ID           Retry a FAILED component from the factory manifest (R3.3).
 ralph run [MAX_ITERATIONS]         Run the agentic loop as a single-component factory invocation.
-ralph status                       Show per-component status from the factory manifest.
+ralph status                       Show per-component status from the manifest + progress log.
 ralph understand [MAX_ITERATIONS]  Run codebase understanding loop (read-only mode).
 ```
 
@@ -288,17 +289,19 @@ scheduler_backstop_margin = 60.0  # extra slack before the scheduler declares a 
 
 # Factory orchestration (Phase 0-3 pipeline)
 [factory]
-max_parallel = 4               # concurrent component workers
-max_retries = 3                # per-component retry budget across all phases
-retry_delay = 5.0              # seconds between retry attempts
-use_worktrees = true           # isolate each component in .ralph/worktrees/<id>
-single_pr = false              # one PR for the whole run instead of per-component
-create_prs = true              # push + merge PRs via gh
-review_mode = "hard"           # hard | advisory | skip (Phase 2)
-merge_timeout = 300.0          # seconds to wait for PR merge confirmation
-max_adversarial_calls = 0      # cap on review+security+distill LLM calls; 0 = unbounded
-max_total_tokens = 0           # run-level token budget; 0 = unbounded
-pause_before_pr_merge = false  # human checkpoint before each PR (E6)
+max_parallel = 4                   # concurrent component workers
+max_retries = 3                    # per-component retry budget across all phases
+retry_delay = 5.0                  # seconds between retry attempts
+use_worktrees = true               # isolate each component in .ralph/worktrees/<id>
+single_pr = false                  # one PR for the whole run instead of per-component
+create_prs = true                  # push + merge PRs via gh
+review_mode = "hard"               # hard | advisory | skip (Phase 2)
+merge_timeout = 300.0              # seconds to wait for PR merge confirmation
+max_adversarial_calls = 0          # cap on review+security+distill LLM calls; 0 = unbounded
+max_total_tokens = 0               # run-level token budget; 0 = unbounded
+pause_before_pr_merge = false      # human checkpoint before each PR (E6)
+progress_log_enabled = true        # JSONL event log at .ralph/progress.jsonl (R3.2)
+keep_worktrees_on_failure = false  # keep failed components' worktrees for post-mortem (R3.3)
 
 # Phase 1 mechanical verification
 [verify]

--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -404,7 +404,7 @@ spending, (c) what do I do when I come back to a partial failure.
   - Notification hook: configurable shell command (`[notify] on_complete /
     on_first_failure` in ralph.toml) so desktop/webhook/email are one liner
     configs. Fires on completion, first failure, and MERGE_PENDING.
-- [ ] R3.3 (M) **Resume + partial-failure ergonomics** [P-5, LOW completed_at, LOW findings-accumulate]
+- [x] R3.3 (M) **Resume + partial-failure ergonomics** [P-5, LOW completed_at, LOW findings-accumulate]
   - Persist `run_id` in the manifest; set `completed_at`; per-component event
     history refs (journal offsets).
   - `ralph retry <component-id>`: resets FAILED component + cascade-skipped
@@ -414,6 +414,10 @@ spending, (c) what do I do when I come back to a partial failure.
     journal distinguishes superseded findings from shipped ones.
   - Failure summary lists, per failed component: phase, check, evidence paths
     (worktree, raw outputs, journal offsets).
+  - Landed note: runbook wording is owned by Session 7A (R2.5) per its
+    coordination note; superseded findings are journaled as
+    `findings_superseded` events (attempt-tagged) while `component_result`
+    carries only the final attempt's stream.
 - [~] R3.4 (S) **Repo hygiene** [LOW hygiene]
   - `.gitignore` covers `.ralph/`; remove the 99MB stale worktree
     (`git worktree remove .claude/worktrees/tender-leakey` after confirming the

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -1540,6 +1540,14 @@ def decompose(
     help="Disable git worktrees (forces sequential execution)",
 )
 @click.option(
+    "--keep-worktrees-on-failure",
+    is_flag=True,
+    help="Keep a failed component's worktree for post-mortem instead of "
+         "removing it at cleanup; the failure summary points at it "
+         "(default: off, or RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE / "
+         "[factory].keep_worktrees_on_failure in ralph.toml)",
+)
+@click.option(
     "--force-lock",
     is_flag=True,
     help="Proceed even if another ralph invocation holds "
@@ -1620,6 +1628,7 @@ def factory(
     pause_before_pr_merge: bool | None,
     progress_log: Path | None,
     no_worktrees: bool,
+    keep_worktrees_on_failure: bool,
     force_lock: bool,
     yes: bool,
     agent_cmd: str | None,
@@ -1726,6 +1735,7 @@ def factory(
                 ("max_total_tokens", max_total_tokens is not None),
                 ("pause_before_pr_merge", pause_before_pr_merge is not None),
                 ("use_worktrees", no_worktrees),
+                ("keep_worktrees_on_failure", keep_worktrees_on_failure),
                 # The manifest is authoritative for single_pr, so a toml
                 # value never becomes effective in this command.
                 ("single_pr", True),
@@ -1749,6 +1759,8 @@ def factory(
         factory_config.pause_before_pr_merge = pause_before_pr_merge
     if no_worktrees:
         factory_config.use_worktrees = False
+    if keep_worktrees_on_failure:
+        factory_config.keep_worktrees_on_failure = True
     factory_config.single_pr = manifest.single_pr
     factory_config.verify_command = verify_command
     factory_config.review_agent_cmd = review_agent_cmd
@@ -2070,6 +2082,7 @@ def config_show(
             "single_pr", "create_prs", "review_mode", "merge_timeout",
             "max_adversarial_calls", "max_total_tokens",
             "pause_before_pr_merge", "progress_log_enabled",
+            "keep_worktrees_on_failure",
         ]),
         ("verify", VerifyConfig.load, [
             "test_command", "typecheck_command", "lint_command",
@@ -2395,6 +2408,216 @@ def status(
             _time.sleep(max(0.5, interval))
     except KeyboardInterrupt:
         sys.exit(0)
+
+
+@cli.command()
+@click.argument("component_id")
+@click.option(
+    "--root",
+    type=click.Path(path_type=Path),
+    help="Project root path (defaults to current directory)",
+)
+@click.option(
+    "--manifest",
+    "manifest_path",
+    type=click.Path(path_type=Path),
+    help="Manifest file (default: scripts/ralph/manifest.json)",
+)
+@click.option(
+    "--progress-log",
+    type=click.Path(path_type=Path),
+    help="Path for JSONL progress log",
+)
+@click.option(
+    "--keep-worktrees-on-failure",
+    is_flag=True,
+    help="Keep a failed component's worktree for post-mortem instead of "
+         "removing it at cleanup (also via "
+         "RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE / "
+         "[factory].keep_worktrees_on_failure in ralph.toml)",
+)
+@click.option(
+    "--force-lock",
+    is_flag=True,
+    help="Proceed even if another ralph invocation holds "
+         ".ralph/factory.lock (may corrupt the other run's state)",
+)
+@click.option(
+    "--yes", "-y",
+    is_flag=True,
+    help="Skip confirmation prompt",
+)
+@click.option(
+    "--ui",
+    type=click.Choice(["auto", "rich", "plain", "gum"]),
+    default="auto",
+    help="UI mode",
+)
+@click.option(
+    "--no-color",
+    is_flag=True,
+    help="Disable colors",
+)
+def retry(
+    component_id: str,
+    root: Path | None,
+    manifest_path: Path | None,
+    progress_log: Path | None,
+    keep_worktrees_on_failure: bool,
+    force_lock: bool,
+    yes: bool,
+    ui: str,
+    no_color: bool,
+) -> None:
+    """Retry a FAILED component from the factory manifest (R3.3).
+
+    Resets COMPONENT_ID and its cascade-skipped dependents to PENDING,
+    removes the failed attempt's kept worktree and branch (a retry
+    starts fresh from the base branch; the failed attempt's findings
+    stay in the evolution journal), then re-enters the factory with the
+    same manifest. Phase configs resolve env > ralph.toml > defaults,
+    exactly like `ralph factory` invoked without flags. The run-level
+    factory lock applies as usual.
+    """
+    import shutil as _shutil
+    import subprocess as _sp
+
+    root_dir = root.resolve() if root else Path.cwd()
+    force_rich = os.environ.get("GUM_FORCE") == "1"
+    ui_impl = get_ui(_normalize_ui_mode(ui), no_color, force_rich=force_rich)
+
+    manifest_file = (
+        manifest_path if manifest_path is not None
+        else root_dir / "scripts" / "ralph" / "manifest.json"
+    )
+    if not manifest_file.exists():
+        ui_impl.err(f"No manifest found at {manifest_file}")
+        ui_impl.info("Run `ralph factory` first, or pass --manifest.")
+        sys.exit(1)
+    try:
+        manifest = Manifest.load(manifest_file)
+    except (OSError, ValueError) as exc:
+        ui_impl.err(f"Failed to load manifest {manifest_file}: {exc}")
+        sys.exit(1)
+
+    comp = manifest.get_component(component_id)
+    evidence_worktree = comp.evidence_worktree if comp else ""
+    failed_branch = comp.branch_name if comp else ""
+
+    try:
+        reset_dependents = manifest.reset_for_retry(component_id)
+    except ValueError as exc:
+        ui_impl.err(str(exc))
+        sys.exit(2)
+
+    ui_impl.section("Retry plan")
+    ui_impl.kv("Component", component_id)
+    ui_impl.kv(
+        "Cascade-skipped dependents reset",
+        ", ".join(reset_dependents) if reset_dependents else "(none)",
+    )
+    ui_impl.kv("Manifest", str(manifest_file))
+
+    # The failed attempt's worktree and branch are superseded by the
+    # fresh attempt; remove them so provisioning and the stale-branch
+    # preflight start clean. In single_pr mode every component shares
+    # one branch carrying completed components' commits - never delete
+    # it here.
+    if evidence_worktree and Path(evidence_worktree).exists():
+        _sp.run(
+            ["git", "worktree", "remove", "--force", evidence_worktree],
+            cwd=root_dir, capture_output=True, timeout=30,
+        )
+        _shutil.rmtree(evidence_worktree, ignore_errors=True)
+        _sp.run(
+            ["git", "worktree", "prune"],
+            cwd=root_dir, capture_output=True, timeout=30,
+        )
+        ui_impl.info(
+            f"Removed the failed attempt's evidence worktree: "
+            f"{evidence_worktree}"
+        )
+    if failed_branch and not manifest.single_pr:
+        branch_exists = _sp.run(
+            ["git", "rev-parse", "--verify", "--quiet",
+             f"refs/heads/{failed_branch}"],
+            cwd=root_dir, capture_output=True, timeout=30,
+        )
+        if branch_exists.returncode == 0:
+            deleted = _sp.run(
+                ["git", "branch", "-D", failed_branch],
+                cwd=root_dir, capture_output=True, text=True, timeout=30,
+            )
+            if deleted.returncode == 0:
+                ui_impl.info(
+                    f"Deleted branch '{failed_branch}' from the failed "
+                    f"attempt; the retry recreates it from "
+                    f"'{manifest.base_branch}'"
+                )
+            else:
+                ui_impl.err(
+                    f"Could not delete branch '{failed_branch}': "
+                    f"{deleted.stderr.strip()}"
+                )
+                ui_impl.info(
+                    "Delete it manually (git branch -D "
+                    f"{failed_branch}) and re-run; the factory refuses "
+                    "to silently reuse stale branches (R0.5)."
+                )
+                sys.exit(1)
+    elif manifest.single_pr:
+        ui_impl.warn(
+            "single_pr mode: the shared branch is left in place; if the "
+            "run is refused at branch preflight, resolve it manually"
+        )
+
+    manifest.save(manifest_file)
+
+    if not yes and ui_impl.can_prompt():
+        choice = ui_impl.choose(
+            f"Re-enter the factory to retry '{component_id}'?",
+            ["Start", "Quit"],
+            default=0,
+        )
+        if choice != 0:
+            sys.exit(0)
+
+    # Config assembly mirrors `ralph factory` with no flags: every phase
+    # config resolves env > ralph.toml > defaults (R2.1 control plane).
+    from ralph_py.contract import ContractConfig
+    from ralph_py.feedforward import FeedforwardConfig
+    from ralph_py.security import SecurityConfig
+    from ralph_py.verify import VerifyConfig
+
+    base_config = RalphConfig.load(root_dir)
+    base_config.ui_mode = "plain"
+    base_config.no_color = True
+    if not base_config.prompt_file.exists():
+        default_prompt = root_dir / "scripts" / "ralph" / "prompt.md"
+        if default_prompt.exists():
+            base_config.prompt_file = default_prompt
+    _check_agent_preflight(base_config, ui_impl)
+
+    factory_config = FactoryConfig.load(root_dir)
+    factory_config.single_pr = manifest.single_pr
+    factory_config.verify_config = VerifyConfig.load(root_dir)
+    factory_config.security_config = SecurityConfig.load(root_dir)
+    contract_resolved = ContractConfig.load(root_dir)
+    factory_config.contract_config = (
+        contract_resolved if contract_resolved.mode != "skip" else None
+    )
+    factory_config.feedforward_config = FeedforwardConfig.load(root_dir)
+    factory_config.timeout_config = TimeoutConfig.load(root_dir)
+    factory_config.progress_log_path = progress_log
+    factory_config.force_lock = force_lock
+    if keep_worktrees_on_failure:
+        factory_config.keep_worktrees_on_failure = True
+
+    result = run_factory(
+        manifest, factory_config, base_config, ui_impl, root_dir,
+        manifest_path=manifest_file,
+    )
+    sys.exit(result.exit_code)
 
 
 @cli.command()

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -24,7 +24,7 @@ from ralph_py.contract import (
     run_contract_testing,
 )
 from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
-from ralph_py.findings import Finding
+from ralph_py.findings import Finding, tag_finding_with_attempt
 from ralph_py.git import GitDiffError, fetch_base_branch, resolve_base_ref
 from ralph_py.knowledge import (
     KnowledgeConfig,
@@ -64,6 +64,11 @@ from ralph_py.verify import (
 
 if TYPE_CHECKING:
     from ralph_py.ui.base import UI
+
+
+def _iso_now() -> str:
+    """Current UTC time as ISO 8601, matching the manifest timestamps."""
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
 @dataclass
@@ -135,6 +140,12 @@ class FactoryConfig:
     # forcing past the lock can corrupt a live run's worktrees and
     # manifest, so it must be an explicit per-invocation decision.
     force_lock: bool = False
+    # R3.3: keep a FAILED component's worktree at end-of-run cleanup so
+    # the operator can post-mortem it (the failure summary points at
+    # it). Kept worktrees are recorded as evidence pointers in the
+    # manifest and survive the next run's stale-worktree prune for as
+    # long as the component stays FAILED.
+    keep_worktrees_on_failure: bool = False
 
     @classmethod
     def from_env(cls) -> FactoryConfig:
@@ -157,6 +168,9 @@ class FactoryConfig:
             ),
             progress_log_enabled=_parse_bool(
                 os.environ.get("RALPH_FACTORY_PROGRESS_LOG_ENABLED", "1")
+            ),
+            keep_worktrees_on_failure=_parse_bool(
+                os.environ.get("RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE")
             ),
         )
 
@@ -198,6 +212,10 @@ class FactoryConfig:
             config.pause_before_pr_merge = bool(section["pause_before_pr_merge"])
         if "progress_log_enabled" in section:
             config.progress_log_enabled = bool(section["progress_log_enabled"])
+        if "keep_worktrees_on_failure" in section:
+            config.keep_worktrees_on_failure = bool(
+                section["keep_worktrees_on_failure"]
+            )
         # Env overrides (consistent with from_env)
         if "FACTORY_MAX_PARALLEL" in os.environ:
             config.max_parallel = int(os.environ["FACTORY_MAX_PARALLEL"])
@@ -222,6 +240,10 @@ class FactoryConfig:
         if "RALPH_FACTORY_PROGRESS_LOG_ENABLED" in os.environ:
             config.progress_log_enabled = _parse_bool(
                 os.environ["RALPH_FACTORY_PROGRESS_LOG_ENABLED"]
+            )
+        if "RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE" in os.environ:
+            config.keep_worktrees_on_failure = _parse_bool(
+                os.environ["RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE"]
             )
         return config
 
@@ -492,7 +514,32 @@ def _cleanup_worktree(component_id: str, root_dir: Path, run_id: str) -> None:
     )
 
 
-def _prune_stale_worktrees(root_dir: Path, run_id: str, ui: UI) -> None:
+def _evidence_worktrees_to_keep(manifest: Manifest) -> set[str]:
+    """Worktree paths the stale-prune pass must preserve (R3.3).
+
+    A worktree kept by ``keep_worktrees_on_failure`` stays referenced as
+    the FAILED component's evidence pointer; once the component leaves
+    FAILED (retried, or reset) the reference is cleared and the next
+    prune removes it. Both the recorded and resolved spellings are
+    included so path normalization differences cannot defeat the match.
+    """
+    keep: set[str] = set()
+    for comp in manifest.components:
+        if (
+            comp.status == ComponentStatus.FAILED.value
+            and comp.evidence_worktree
+        ):
+            keep.add(comp.evidence_worktree)
+            try:
+                keep.add(str(Path(comp.evidence_worktree).resolve()))
+            except OSError:
+                pass
+    return keep
+
+
+def _prune_stale_worktrees(
+    root_dir: Path, run_id: str, ui: UI, keep: set[str] | None = None,
+) -> None:
     """Remove worktrees left behind by previous (crashed/aborted) runs.
 
     Only called when the run-level flock is genuinely held: any prior
@@ -502,16 +549,34 @@ def _prune_stale_worktrees(root_dir: Path, run_id: str, ui: UI) -> None:
     orphaned and safe to remove. Includes worktrees kept for leaked
     workers (R0.1): their owning run is gone, so by the next invocation
     they are stale state, matching the pre-R0.5 force-remove behavior.
+
+    ``keep`` (R3.3) lists evidence worktrees of still-FAILED components
+    (kept via keep_worktrees_on_failure); those are preserved so a
+    resume does not destroy the post-mortem state it exists to protect.
     """
+    keep = keep or set()
+
+    def _kept(path: Path) -> bool:
+        if str(path) in keep:
+            return True
+        try:
+            return str(path.resolve()) in keep
+        except OSError:
+            return False
+
     worktree_root = root_dir / ".ralph" / "worktrees"
     if not worktree_root.exists():
         return
     removed = 0
+    kept = 0
     for entry in sorted(worktree_root.iterdir()):
         if entry.name == run_id or not entry.is_dir():
             continue  # our own run dir, or a per-component .lock file
         if (entry / ".git").exists():
             # Pre-R0.5 flat layout: the entry itself is a worktree.
+            if _kept(entry):
+                kept += 1
+                continue
             subprocess.run(
                 ["git", "worktree", "remove", "--force", str(entry)],
                 cwd=root_dir, capture_output=True, timeout=30,
@@ -520,13 +585,23 @@ def _prune_stale_worktrees(root_dir: Path, run_id: str, ui: UI) -> None:
         else:
             # <run_id>/ dir from a previous run: remove each component
             # worktree inside it.
+            entry_kept = 0
             for wt in sorted(entry.iterdir()):
                 if wt.is_dir():
+                    if _kept(wt):
+                        entry_kept += 1
+                        continue
                     subprocess.run(
                         ["git", "worktree", "remove", "--force", str(wt)],
                         cwd=root_dir, capture_output=True, timeout=30,
                     )
+                    # Whatever git could not remove goes with the dir.
+                    shutil.rmtree(wt, ignore_errors=True)
                     removed += 1
+            kept += entry_kept
+            if entry_kept:
+                # Evidence lives inside: keep the run dir itself.
+                continue
         # Whatever git could not remove (or non-worktree debris) goes
         # with the dir; `git worktree prune` below drops any metadata
         # orphaned by this.
@@ -537,6 +612,11 @@ def _prune_stale_worktrees(root_dir: Path, run_id: str, ui: UI) -> None:
             cwd=root_dir, capture_output=True, timeout=30,
         )
         ui.info(f"  Pruned {removed} stale worktree(s) from previous runs")
+    if kept:
+        ui.info(
+            f"  Preserved {kept} evidence worktree(s) of failed "
+            f"components (keep_worktrees_on_failure)"
+        )
 
 
 def _preflight_component_branches(
@@ -995,6 +1075,14 @@ def _run_factory_locked(
     if manifest_path is None:
         manifest_path = root_dir / "scripts" / "ralph" / "manifest.json"
 
+    # R3.3: persist which run owns this manifest state. completed_at is
+    # blanked while the run is in flight and stamped in the summary
+    # epilogue, so "did the last run finish?" is answerable from the
+    # manifest alone (and later, from Linear).
+    manifest.run_id = run_id
+    manifest.completed_at = ""
+    manifest.save(manifest_path)
+
     # R0.2 crash recovery: MERGE_PENDING is re-pollable, not failed. A
     # prior run initiated the merge but could not confirm it; check the
     # PR state again before scheduling so confirmed merges unblock their
@@ -1031,6 +1119,7 @@ def _run_factory_locked(
                     fetch_base_branch(manifest.base_branch, root_dir)
                     comp.status = ComponentStatus.COMPLETED.value
                     comp.error = ""
+                    comp.completed_at = _iso_now()
                     factory_result.completed.append(comp.id)
                     progress_log.component_completed(
                         comp.id, comp.duration_seconds, comp.iteration_count,
@@ -1039,6 +1128,9 @@ def _run_factory_locked(
                 elif merge_state == "closed":
                     comp.status = ComponentStatus.FAILED.value
                     comp.error = f"PR #{pr_number} closed without merge"
+                    comp.completed_at = _iso_now()
+                    comp.failed_phase = "pr"
+                    comp.failed_check = "pr_closed"
                     skipped = manifest.cascade_skip(comp.id)
                     factory_result.failed.append(comp.id)
                     factory_result.skipped.extend(skipped)
@@ -1084,7 +1176,10 @@ def _run_factory_locked(
     # creates branches nor worktree dirs.
     if factory_config.use_worktrees:
         if lock_held:
-            _prune_stale_worktrees(root_dir, run_id, ui)
+            _prune_stale_worktrees(
+                root_dir, run_id, ui,
+                keep=_evidence_worktrees_to_keep(manifest),
+            )
         else:
             ui.warn(
                 "  Run lock not held; skipping stale-worktree cleanup "
@@ -1179,6 +1274,90 @@ def _run_factory_locked(
         cap = factory_config.max_total_tokens
         return cap > 0 and run_usage.total_tokens >= cap
 
+    def _journal_offset() -> int:
+        """Current byte size of the progress log; used to bracket one
+        attempt's slice of events (R3.3). -1 when no real progress log
+        is configured for this run."""
+        if isinstance(progress_log, NullProgressLog):
+            return -1
+        try:
+            log_path = progress_log.path
+            return log_path.stat().st_size if log_path.exists() else 0
+        except OSError:
+            return -1
+
+    def _debug_dir_for(comp_id: str) -> Path:
+        """Forensic raw-output dir for this run's component (R1.2)."""
+        return root_dir / ".ralph" / "debug" / run_id / comp_id
+
+    def _add_findings(comp: Component, new_findings: list[Finding]) -> None:
+        """Append findings tagged ``attempt:<n>`` for the attempt in
+        flight (R3.3), so the journal can attribute every finding to the
+        attempt that produced it."""
+        attempt = comp.retries + 1
+        comp.findings.extend(
+            tag_finding_with_attempt(f, attempt) for f in new_findings
+        )
+
+    def _begin_attempt(comp: Component) -> None:
+        """PENDING -> RUNNING transition for one attempt (R3.3).
+
+        The prior attempt's findings were journaled when its retry was
+        scheduled (or by record_run when a previous run ended), so the
+        manifest carries only the current attempt's stream; the failure
+        and evidence pointers likewise describe only the attempt in
+        flight."""
+        comp.findings = []
+        comp.review_findings = ""
+        comp.failed_phase = ""
+        comp.failed_check = ""
+        comp.completed_at = ""
+        comp.evidence_worktree = ""
+        comp.evidence_debug_dir = ""
+        comp.journal_offset_start = _journal_offset()
+        comp.journal_offset_end = -1
+        comp.status = ComponentStatus.RUNNING.value
+        comp.started_at = _iso_now()
+
+    def _end_attempt(comp: Component) -> None:
+        """Stamp the attempt's evidence pointers when it stops running:
+        the progress-log slice end, and the debug dir when any phase
+        dumped raw output there (R3.3)."""
+        comp.journal_offset_end = _journal_offset()
+        debug_dir = _debug_dir_for(comp.id)
+        if debug_dir.exists():
+            comp.evidence_debug_dir = str(debug_dir)
+
+    def _journal_superseded_findings(comp: Component) -> None:
+        """A scheduled retry supersedes the current attempt's findings.
+        Record them in the evolution journal (attempt-tagged) before the
+        next attempt clears the manifest stream, so superseded and
+        shipped findings stay distinguishable (R3.3). The final
+        attempt's findings reach the journal via record_run instead.
+        Non-fatal on I/O errors, matching _record_contract_event."""
+        if not comp.findings:
+            return
+        from ralph_py.evolution import EvolutionConfig
+
+        evo_config = EvolutionConfig.load(root_dir)
+        if not evo_config.enabled:
+            return
+        entry = {
+            "timestamp": _iso_now(),
+            "run_id": run_id,
+            "project": manifest.project_name,
+            "component_id": comp.id,
+            "event_type": "findings_superseded",
+            "attempt": comp.retries + 1,
+            "findings": [f.to_dict() for f in comp.findings],
+        }
+        try:
+            evo_config.journal_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(evo_config.journal_path, "a") as f:
+                f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+        except OSError:
+            pass  # evolution recording is non-fatal
+
     def _fail_component_for_budget(comp: Component, phase: str) -> None:
         """R3.1: halt LOUDLY on a blown token budget. Mirrors the R1.2/
         R1.4 synthetic-finding pattern (chunk_budget_insufficient): a
@@ -1192,13 +1371,13 @@ def _run_factory_locked(
             "spending further (R3.1)"
         )
         ui.err(f"  TOKEN BUDGET EXCEEDED for {comp.id}: {error}")
-        comp.findings.append(Finding.infrastructure_error(
+        _add_findings(comp, [Finding.infrastructure_error(
             phase=phase, explanation=error,
-        ))
+        )])
         progress_log.budget_exceeded(
             comp.id, run_usage.total_tokens, factory_config.max_total_tokens,
         )
-        _fail_component(comp, error)
+        _fail_component(comp, error, phase=phase, check="token_budget")
 
     def _path_relative_to_root(path: Path) -> str:
         """Render `path` relative to root_dir for use inside per-component
@@ -1218,8 +1397,16 @@ def _run_factory_locked(
     progress_file_rel = _path_relative_to_root(base_config.progress_file)
     codebase_map_file_rel = _path_relative_to_root(base_config.codebase_map_file)
 
-    def _retry_or_fail(comp: Component, error: str, context_json: str | None) -> None:
-        """Retry a component or mark it as failed."""
+    def _retry_or_fail(
+        comp: Component,
+        error: str,
+        context_json: str | None,
+        phase: str = "",
+        check: str = "",
+    ) -> None:
+        """Retry a component or mark it as failed. ``phase``/``check``
+        name the gate that fired (R3.3); on a retry they describe the
+        superseded attempt until the next attempt clears them."""
         if comp.retries < factory_config.max_retries:
             # A timeout failure means the agent was killed mid-flight: the
             # worktree/branch state cannot be trusted. Note the hygiene
@@ -1232,6 +1419,14 @@ def _run_factory_locked(
                     + " [timeout retry: worktree recreated from base; "
                     "stale index.lock removed]"
                 )
+            # R3.3: journal this attempt's findings as superseded BEFORE
+            # the retry counter moves (the tag and the journal entry
+            # must agree on the attempt number), then stamp the
+            # attempt's evidence pointers.
+            _journal_superseded_findings(comp)
+            _end_attempt(comp)
+            comp.failed_phase = phase
+            comp.failed_check = check
             comp.retries += 1
             comp.status = ComponentStatus.PENDING.value
             comp.error = error
@@ -1246,9 +1441,11 @@ def _run_factory_locked(
             time.sleep(factory_config.retry_delay)
             manifest.save(manifest_path)
         else:
-            _fail_component(comp, error)
+            _fail_component(comp, error, phase=phase, check=check)
 
-    def _fail_component(comp: Component, error: str) -> None:
+    def _fail_component(
+        comp: Component, error: str, phase: str = "", check: str = "",
+    ) -> None:
         """Mark a component FAILED with no retry. Direct callers are
         conditions a retry can never fix (R1.4: chunked-review budget
         insufficiency - the adversarial budget only shrinks, so
@@ -1256,6 +1453,10 @@ def _run_factory_locked(
         wall); _retry_or_fail routes here once retries are exhausted."""
         comp.status = ComponentStatus.FAILED.value
         comp.error = error
+        comp.completed_at = _iso_now()
+        comp.failed_phase = phase
+        comp.failed_check = check
+        _end_attempt(comp)
         skipped = manifest.cascade_skip(comp.id)
         factory_result.failed.append(comp.id)
         factory_result.skipped.extend(skipped)
@@ -1294,7 +1495,10 @@ def _run_factory_locked(
                 success=False,
                 error=comp_result.error,
             ))
-            _retry_or_fail(comp, comp_result.error or "Unknown error", ctx.to_json())
+            _retry_or_fail(
+                comp, comp_result.error or "Unknown error", ctx.to_json(),
+                phase="engineer", check="loop",
+            )
             return
 
         wt_path = worktree_paths.get(comp_id, root_dir)
@@ -1303,7 +1507,7 @@ def _run_factory_locked(
             """R1.2: a phase that never ran must leave a trace in both
             the findings stream and the journal, so "ran clean" and
             "never ran" are distinguishable downstream."""
-            comp.findings.append(Finding.phase_skipped(phase, reason))
+            _add_findings(comp, [Finding.phase_skipped(phase, reason)])
             progress_log.emit(
                 "phase_skipped", comp_id,
                 {"phase": phase, "reason": reason},
@@ -1390,6 +1594,8 @@ def _run_factory_locked(
                 ctx.add_verification_failure(verification.as_context())
                 _retry_or_fail(
                     comp, "Mechanical verification failed", ctx.to_json(),
+                    phase="verify",
+                    check=", ".join(c.name for c in failing),
                 )
                 return
 
@@ -1411,13 +1617,13 @@ def _run_factory_locked(
             )
         except GitDiffError as exc:
             ui.err(f"  Diff fetch FAILED for {comp_id}: {exc}")
-            comp.findings.append(Finding.infrastructure_error(
+            _add_findings(comp, [Finding.infrastructure_error(
                 phase="diff",
                 explanation=(
                     f"git diff against {manifest.base_branch} failed; "
                     f"review/security/knowledge cannot run: {exc}"
                 ),
-            ))
+            )])
             progress_log.emit(
                 "diff_fetch_failed", comp_id, {"error": str(exc)},
             )
@@ -1427,7 +1633,7 @@ def _run_factory_locked(
             )
             _retry_or_fail(
                 comp, f"Diff fetch failed (infrastructure): {exc}",
-                ctx.to_json(),
+                ctx.to_json(), phase="diff", check="git_diff",
             )
             return
 
@@ -1475,14 +1681,14 @@ def _run_factory_locked(
                 # exhaustion, the engineer CAN fix this by producing a
                 # smaller diff, so the retry context carries the signal.
                 ui.err(f"  Diff unsplittable for {comp_id}: {exc}")
-                comp.findings.append(Finding.infrastructure_error(
+                _add_findings(comp, [Finding.infrastructure_error(
                     phase="review",
                     explanation=(
                         "Hard-mode review requires chunking the "
                         f"oversized diff, but it cannot be split: {exc} "
                         "(R1.4: an unreviewable diff must not merge)"
                     ),
-                ))
+                )])
                 progress_log.emit(
                     "diff_unsplittable", comp_id,
                     {"error": str(exc), "diff_chars": len(review_diff)},
@@ -1499,7 +1705,7 @@ def _run_factory_locked(
                 _retry_or_fail(
                     comp,
                     f"Review diff unsplittable at the prompt cap: {exc}",
-                    ctx.to_json(),
+                    ctx.to_json(), phase="review", check="diff_chunking",
                 )
                 return
             progress_log.emit(
@@ -1545,9 +1751,9 @@ def _run_factory_locked(
                 )
                 ui.err(f"  Phase 2 FAILED for {comp_id}: {error}")
                 comp.review_passed = False
-                comp.findings.append(Finding.infrastructure_error(
+                _add_findings(comp, [Finding.infrastructure_error(
                     phase="review", explanation=error,
-                ))
+                )])
                 progress_log.emit(
                     "chunk_budget_insufficient", comp_id,
                     {
@@ -1558,6 +1764,7 @@ def _run_factory_locked(
                 )
                 _fail_component(
                     comp, f"Review infrastructure error: {error}",
+                    phase="review", check="adversarial_budget",
                 )
                 return
         if review_mode != ReviewMode.SKIP:
@@ -1631,7 +1838,7 @@ def _run_factory_locked(
             comp.review_passed = review_result.passed
             # E3: typed findings are the source of truth; the rendered
             # string is a derived view kept for backward-compat consumers.
-            comp.findings.extend(review_result.as_findings())
+            _add_findings(comp, review_result.as_findings())
             comp.review_findings = review_result.as_pr_body_section()
             # Observability gets criterion-only counts to preserve the
             # historical meaning of fail_count = "failed PRD criteria".
@@ -1657,7 +1864,13 @@ def _run_factory_locked(
                 )
                 ctx = IterationContext.from_json(comp_result.context_json or "{}")
                 ctx.add_review_finding(review_result.as_retry_context())
-                _retry_or_fail(comp, reason, ctx.to_json())
+                _retry_or_fail(
+                    comp, reason, ctx.to_json(), phase="review",
+                    check=(
+                        "infrastructure"
+                        if review_result.infrastructure_error else "criteria"
+                    ),
+                )
                 return
 
             ui.ok(f"  Phase 2 passed for {comp_id}")
@@ -1716,9 +1929,9 @@ def _run_factory_locked(
                     "a partial hard-mode security review (R1.4)"
                 )
                 ui.err(f"  Phase 2.5 FAILED for {comp_id}: {error}")
-                comp.findings.append(Finding.infrastructure_error(
+                _add_findings(comp, [Finding.infrastructure_error(
                     phase="security", explanation=error,
-                ))
+                )])
                 progress_log.emit(
                     "chunk_budget_insufficient", comp_id,
                     {
@@ -1729,6 +1942,7 @@ def _run_factory_locked(
                 )
                 _fail_component(
                     comp, f"Security review infrastructure error: {error}",
+                    phase="security", check="adversarial_budget",
                 )
                 return
         if sec_config and sec_config.mode != SecurityMode.SKIP.value:
@@ -1828,7 +2042,7 @@ def _run_factory_locked(
 
                 # E3: source-of-truth typed findings list, plus the
                 # legacy rendered string for PR body / manifest readers.
-                comp.findings.extend(sec_result.as_findings())
+                _add_findings(comp, sec_result.as_findings())
                 if sec_result.findings:
                     if comp.review_findings:
                         comp.review_findings = (
@@ -1860,7 +2074,14 @@ def _run_factory_locked(
                         or "Security review infrastructure error: "
                         + sec_result.overall_notes
                     )
-                    _retry_or_fail(comp, reason, ctx.to_json())
+                    _retry_or_fail(
+                        comp, reason, ctx.to_json(), phase="security",
+                        check=(
+                            "infrastructure"
+                            if sec_result.infrastructure_error
+                            else "findings"
+                        ),
+                    )
                     return
 
         # Knowledge distillation (Voyager-style post-gate write).
@@ -2017,7 +2238,10 @@ def _run_factory_locked(
                         ui.warn(
                             f"  Human rejected {comp_id} at PR checkpoint"
                         )
-                        _fail_component(comp, "Rejected at HITL checkpoint")
+                        _fail_component(
+                            comp, "Rejected at HITL checkpoint",
+                            phase="pr", check="hitl_reject",
+                        )
                         return
                     if choice == 2:
                         ui.warn(
@@ -2033,7 +2257,7 @@ def _run_factory_locked(
                         _retry_or_fail(
                             comp,
                             "Retry requested at HITL checkpoint",
-                            ctx.to_json(),
+                            ctx.to_json(), phase="pr", check="hitl_retry",
                         )
                         return
                 else:
@@ -2067,6 +2291,11 @@ def _run_factory_locked(
                             {"pr_url": comp.pr_url, "error": comp.error},
                         )
                         notify.fire_merge_pending(comp_id, comp.error)
+                        # Parked, not terminal: no completed_at, but the
+                        # attempt's journal slice is closed (R3.3) -
+                        # after the merge_pending event so the slice
+                        # includes it.
+                        _end_attempt(comp)
                         ui.warn(
                             f"  MERGE PENDING: {comp_id}: {comp.error}; "
                             f"dependents stay blocked; a factory re-run "
@@ -2075,6 +2304,10 @@ def _run_factory_locked(
                     else:
                         comp.status = ComponentStatus.FAILED.value
                         comp.error = outcome.error or "PR flow failed"
+                        comp.completed_at = _iso_now()
+                        comp.failed_phase = "pr"
+                        comp.failed_check = "pr_flow"
+                        _end_attempt(comp)
                         skipped = manifest.cascade_skip(comp_id)
                         factory_result.failed.append(comp_id)
                         factory_result.skipped.extend(skipped)
@@ -2100,6 +2333,8 @@ def _run_factory_locked(
         # Mark completed
         comp.status = ComponentStatus.COMPLETED.value
         comp.error = ""
+        comp.completed_at = _iso_now()
+        _end_attempt(comp)
         factory_result.completed.append(comp_id)
         progress_log.component_completed(
             comp_id, comp_result.duration_seconds, comp_result.iterations,
@@ -2127,14 +2362,11 @@ def _run_factory_locked(
             return wt_path
         except RuntimeError as exc:
             ui.err(f"  Worktree setup failed for '{comp.id}': {exc}")
-            comp.status = ComponentStatus.FAILED.value
-            comp.error = str(exc)
-            skipped = manifest.cascade_skip(comp.id)
-            factory_result.failed.append(comp.id)
-            factory_result.skipped.extend(skipped)
-            progress_log.component_failed(comp.id, comp.error)
-            notify.fire_first_failure(comp.id, comp.error)
-            manifest.save(manifest_path)
+            # _fail_component covers the R3.2 notify + progress-log
+            # calls and stamps the R3.3 failure/evidence fields.
+            _fail_component(
+                comp, str(exc), phase="provisioning", check="worktree_setup",
+            )
             return None
 
     # Build feedforward config dict for serialization to worker processes
@@ -2206,10 +2438,7 @@ def _run_factory_locked(
                 if _token_budget_exceeded():
                     _fail_component_for_budget(comp, "scheduling")
                     continue
-                comp.status = ComponentStatus.RUNNING.value
-                comp.started_at = time.strftime(
-                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
-                )
+                _begin_attempt(comp)
                 manifest.save(manifest_path)
                 progress_log.component_started(comp.id)
                 ui.info(f"  Starting: {comp.id}")
@@ -2245,10 +2474,7 @@ def _run_factory_locked(
                     if _token_budget_exceeded():
                         _fail_component_for_budget(comp, "scheduling")
                         continue
-                    comp.status = ComponentStatus.RUNNING.value
-                    comp.started_at = time.strftime(
-                        "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
-                    )
+                    _begin_attempt(comp)
                     manifest.save(manifest_path)
                     progress_log.component_started(comp.id)
                     ui.info(f"  Starting: {comp.id}")
@@ -2310,6 +2536,16 @@ def _run_factory_locked(
                     if timed_out_comp is not None:
                         timed_out_comp.status = ComponentStatus.FAILED.value
                         timed_out_comp.error = "component timeout"
+                        timed_out_comp.completed_at = _iso_now()
+                        timed_out_comp.failed_phase = "engineer"
+                        timed_out_comp.failed_check = "scheduler_backstop"
+                        _end_attempt(timed_out_comp)
+                        # The worktree stays (leaked worker may own it);
+                        # point the evidence at it (R3.3).
+                        if comp_id in worktree_paths:
+                            timed_out_comp.evidence_worktree = str(
+                                worktree_paths[comp_id]
+                            )
                         skipped = manifest.cascade_skip(comp_id)
                         factory_result.failed.append(comp_id)
                         factory_result.skipped.extend(skipped)
@@ -2337,10 +2573,16 @@ def _run_factory_locked(
                 executor.shutdown(wait=True)
 
     def _cleanup_pass_worktrees() -> None:
-        """Remove component worktrees left behind by a scheduling pass."""
+        """Remove component worktrees left behind by a scheduling pass.
+
+        With ``keep_worktrees_on_failure`` (R3.3), a FAILED component's
+        worktree is kept and recorded as its evidence pointer instead of
+        removed, so the failure summary can point the operator at it.
+        """
         if not factory_config.use_worktrees:
             return
         ui.section("Factory: Cleanup")
+        kept_evidence = False
         for comp_id in worktree_paths:
             if comp_id in leaked_component_ids:
                 # A possibly-live worker still owns this worktree; removing
@@ -2351,10 +2593,26 @@ def _run_factory_locked(
                     f"(leaked worker may still be running)"
                 )
                 continue
+            comp = manifest.get_component(comp_id)
+            if (
+                factory_config.keep_worktrees_on_failure
+                and comp is not None
+                and comp.status == ComponentStatus.FAILED.value
+            ):
+                comp.evidence_worktree = str(worktree_paths[comp_id])
+                kept_evidence = True
+                ui.info(
+                    f"  Keeping failed worktree for post-mortem: "
+                    f"{worktree_paths[comp_id]}"
+                )
+                continue
             _cleanup_worktree(comp_id, root_dir, run_id)
-        # Drop the run's now-empty worktree dir; leaked workers' kept
-        # worktrees leave it non-empty and it stays for the next run's
-        # prune pass.
+        if kept_evidence:
+            manifest.save(manifest_path)
+        # Drop the run's now-empty worktree dir; leaked workers' and
+        # failed components' kept worktrees leave it non-empty and it
+        # stays for the next run's prune pass (which preserves recorded
+        # evidence worktrees of still-FAILED components).
         try:
             os.rmdir(root_dir / ".ralph" / "worktrees" / run_id)
         except OSError:
@@ -2453,6 +2711,10 @@ def _run_factory_locked(
                 continue
             breaker = manifest.get_component(cr.breaker)
             if breaker and breaker.retries < factory_config.max_retries:
+                # R3.3: the completed attempt's findings are superseded
+                # by the contract-triggered re-run; journal them before
+                # the retry increments the attempt counter.
+                _journal_superseded_findings(breaker)
                 breaker.retries += 1
                 breaker.status = ComponentStatus.PENDING.value
                 breaker.error = f"Contract test failed at tier {cr.tier}"
@@ -2488,6 +2750,9 @@ def _run_factory_locked(
                         f"Contract test failed at tier {cr.tier} "
                         f"(retries exhausted)"
                     )
+                    breaker.completed_at = _iso_now()
+                    breaker.failed_phase = "contract"
+                    breaker.failed_check = f"tier_{cr.tier}"
                 if cr.breaker in factory_result.completed:
                     factory_result.completed.remove(cr.breaker)
                 if cr.breaker not in factory_result.failed:
@@ -2559,6 +2824,49 @@ def _run_factory_locked(
     ui.kv("Completed", str(len(factory_result.completed)))
     ui.kv("Failed", str(len(factory_result.failed)))
     ui.kv("Skipped", str(len(factory_result.skipped)))
+    # R3.3 failure summary: per failed component, which gate fired and
+    # where the last attempt's evidence lives, so the run is diagnosable
+    # without reading raw JSON.
+    if factory_result.failed:
+        ui.subsection("Failure summary")
+        for failed_id in factory_result.failed:
+            failed_comp = manifest.get_component(failed_id)
+            if failed_comp is None:
+                continue
+            ui.err(
+                f"  {failed_id}: "
+                f"phase={failed_comp.failed_phase or 'unknown'} "
+                f"check={failed_comp.failed_check or 'unknown'} "
+                f"(attempt {failed_comp.retries + 1})"
+            )
+            if failed_comp.error:
+                ui.info(f"    error: {failed_comp.error[:160]}")
+            if failed_comp.evidence_worktree:
+                ui.info(
+                    f"    worktree: {failed_comp.evidence_worktree}"
+                )
+            elif factory_config.use_worktrees:
+                ui.info(
+                    "    worktree: removed (re-run with "
+                    "--keep-worktrees-on-failure to keep it)"
+                )
+            if failed_comp.evidence_debug_dir:
+                ui.info(
+                    f"    raw outputs: {failed_comp.evidence_debug_dir}"
+                )
+            if (
+                failed_comp.journal_offset_start >= 0
+                and not isinstance(progress_log, NullProgressLog)
+            ):
+                end = (
+                    str(failed_comp.journal_offset_end)
+                    if failed_comp.journal_offset_end >= 0 else "end"
+                )
+                ui.info(
+                    f"    journal: {progress_log.path} bytes "
+                    f"[{failed_comp.journal_offset_start}:{end}]"
+                )
+            ui.info(f"    retry with: ralph retry {failed_id}")
     if factory_result.contract_failures:
         ui.kv("Contract failures", str(len(factory_result.contract_failures)))
         for line in factory_result.contract_failures:
@@ -2594,6 +2902,13 @@ def _run_factory_locked(
         factory_result.exit_code = 1
     elif factory_result.skipped and not factory_result.completed:
         factory_result.exit_code = 1
+
+    # R3.3: the run reached its terminal state; stamp the manifest so a
+    # resume (and Linear, later) can tell a finished run from a crash.
+    # Stamped BEFORE the completion notification so a hook that reads
+    # the manifest sees the terminal state.
+    manifest.completed_at = _iso_now()
+    manifest.save(manifest_path)
 
     # R3.2: run-end notification. Fires on every run that reached the
     # summary, whatever the outcome; early refusals (invalid DAG, held

--- a/ralph_py/findings.py
+++ b/ralph_py/findings.py
@@ -18,12 +18,17 @@ Phase tag examples: ``"review"`` (Phase 2 reviewer), ``"security"`` (Phase
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
 _INFRASTRUCTURE_CATEGORY = "infrastructure_error"
 _PHASE_SKIPPED_CATEGORY = "phase_skipped"
+
+# R3.3: every finding the factory records is tagged with the attempt
+# that produced it, so the journal can distinguish superseded findings
+# (an attempt that was retried) from the shipped attempt's findings.
+ATTEMPT_TAG_PREFIX = "attempt:"
 
 
 @dataclass(frozen=True)
@@ -180,6 +185,31 @@ class Finding:
             cwe=cwe,
             tags=tuple(tags),
         )
+
+
+def tag_finding_with_attempt(finding: Finding, attempt: int) -> Finding:
+    """Return a copy of *finding* tagged ``attempt:<n>`` (R3.3).
+
+    Idempotent: a finding already carrying an attempt tag is returned
+    unchanged, so re-tagging on a resumed manifest cannot stack
+    conflicting attempt numbers."""
+    if any(t.startswith(ATTEMPT_TAG_PREFIX) for t in finding.tags):
+        return finding
+    return replace(
+        finding, tags=finding.tags + (f"{ATTEMPT_TAG_PREFIX}{attempt}",),
+    )
+
+
+def finding_attempt(finding: Finding) -> int | None:
+    """The attempt number a finding was recorded on, or None for
+    findings that predate the R3.3 attempt tagging."""
+    for tag in finding.tags:
+        if tag.startswith(ATTEMPT_TAG_PREFIX):
+            try:
+                return int(tag[len(ATTEMPT_TAG_PREFIX):])
+            except ValueError:
+                return None
+    return None
 
 
 def dump_raw_debug(

--- a/ralph_py/manifest.py
+++ b/ralph_py/manifest.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import tempfile
+import time
 from collections import deque
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -13,6 +14,11 @@ from pathlib import Path
 from typing import Any
 
 from ralph_py.findings import Finding
+
+
+def _iso_now() -> str:
+    """Current UTC time as ISO 8601, matching the factory's timestamps."""
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 # R0.6 input hygiene: component ids and branch names are LLM-emitted
 # (architect output) and flow into filesystem paths
@@ -157,6 +163,20 @@ class Component:
     review_findings: str = ""
     # Optional scaffold script to run before the agent
     scaffold: str = ""
+    # R3.3 post-mortem fields. failed_phase/failed_check name where the
+    # last failure happened (phase = engineer/verify/review/security/pr/
+    # contract/..., check = the specific gate within it). The evidence
+    # pointers say where the last attempt's artifacts live:
+    # evidence_worktree is the kept worktree path ("" when removed),
+    # evidence_debug_dir the .ralph/debug/<run>/<comp> raw-output dir,
+    # and the journal offsets bracket the attempt's slice of the
+    # progress log (byte offsets; -1 = not recorded).
+    failed_phase: str = ""
+    failed_check: str = ""
+    evidence_worktree: str = ""
+    evidence_debug_dir: str = ""
+    journal_offset_start: int = -1
+    journal_offset_end: int = -1
 
 
 @dataclass
@@ -169,6 +189,12 @@ class Manifest:
     base_branch: str
     single_pr: bool
     components: list[Component] = field(default_factory=list)
+    # R3.3: id of the factory run that last operated on this manifest,
+    # and when that run finished ("" while a run is in flight). Lets a
+    # resume - and later the Linear integration - correlate manifest
+    # state with the journals keyed by run_id.
+    run_id: str = ""
+    completed_at: str = ""
 
     @classmethod
     def from_prd(
@@ -257,6 +283,12 @@ class Manifest:
                 ],
                 review_findings=c.get("reviewFindings", ""),
                 scaffold=c.get("scaffold", ""),
+                failed_phase=c.get("failedPhase", ""),
+                failed_check=c.get("failedCheck", ""),
+                evidence_worktree=c.get("evidenceWorktree", ""),
+                evidence_debug_dir=c.get("evidenceDebugDir", ""),
+                journal_offset_start=c.get("journalOffsetStart", -1),
+                journal_offset_end=c.get("journalOffsetEnd", -1),
             )
             for c in data["components"]
         ]
@@ -268,6 +300,8 @@ class Manifest:
             base_branch=data["baseBranch"],
             single_pr=data["singlePr"],
             components=components,
+            run_id=data.get("runId", ""),
+            completed_at=data.get("completedAt", ""),
         )
 
     def save(self, path: Path) -> None:
@@ -278,6 +312,8 @@ class Manifest:
             "projectName": self.project_name,
             "baseBranch": self.base_branch,
             "singlePr": self.single_pr,
+            "runId": self.run_id,
+            "completedAt": self.completed_at,
             "components": [
                 {
                     "id": c.id,
@@ -300,6 +336,12 @@ class Manifest:
                     "findings": [f.to_dict() for f in c.findings],
                     "reviewFindings": c.review_findings,
                     "scaffold": c.scaffold,
+                    "failedPhase": c.failed_phase,
+                    "failedCheck": c.failed_check,
+                    "evidenceWorktree": c.evidence_worktree,
+                    "evidenceDebugDir": c.evidence_debug_dir,
+                    "journalOffsetStart": c.journal_offset_start,
+                    "journalOffsetEnd": c.journal_offset_end,
                 }
                 for c in self.components
             ],
@@ -358,6 +400,10 @@ class Manifest:
                 errors.append(f"baseBranch: {base_error}")
         if not isinstance(data.get("singlePr"), bool):
             errors.append("singlePr must be a boolean")
+        if "runId" in data and not isinstance(data["runId"], str):
+            errors.append("runId must be a string")
+        if "completedAt" in data and not isinstance(data["completedAt"], str):
+            errors.append("completedAt must be a string")
 
         components = data.get("components")
         if not isinstance(components, list):
@@ -370,6 +416,8 @@ class Manifest:
             "startedAt", "completedAt", "durationSeconds", "iterationCount",
             "verificationPassed", "reviewPassed", "reviewFindings",
             "findings", "scaffold",
+            "failedPhase", "failedCheck", "evidenceWorktree",
+            "evidenceDebugDir", "journalOffsetStart", "journalOffsetEnd",
         }
         component_all = component_required | component_optional
 
@@ -563,10 +611,105 @@ class Manifest:
                 ):
                     dep_comp.status = ComponentStatus.SKIPPED.value
                     dep_comp.error = f"Dependency '{failed_id}' failed"
+                    # R3.3: SKIPPED is terminal for this run.
+                    dep_comp.completed_at = _iso_now()
                     skipped.append(dependent_id)
                     bfs_queue.append(dependent_id)
 
         return skipped
+
+    def _transitive_dependents(self, component_id: str) -> set[str]:
+        """All components that transitively depend on *component_id*."""
+        dependents: dict[str, list[str]] = {c.id: [] for c in self.components}
+        for comp in self.components:
+            for dep in comp.dependencies:
+                if dep in dependents:
+                    dependents[dep].append(comp.id)
+        found: set[str] = set()
+        queue: deque[str] = deque([component_id])
+        while queue:
+            current = queue.popleft()
+            for dependent_id in dependents.get(current, []):
+                if dependent_id not in found:
+                    found.add(dependent_id)
+                    queue.append(dependent_id)
+        return found
+
+    def reset_for_retry(self, component_id: str) -> list[str]:
+        """Reset a FAILED component and its cascade-SKIPPED dependents to
+        PENDING so a factory re-run schedules them again (R3.3).
+
+        A SKIPPED dependent is only reset when every one of its
+        dependencies will be runnable afterwards: COMPLETED, PENDING, or
+        itself part of this reset. A dependent that was also skipped
+        because of a DIFFERENT still-failed component stays SKIPPED -
+        resetting it would leave it permanently unschedulable.
+
+        Returns the ids of the reset dependents. Raises ValueError when
+        the component does not exist or is not FAILED.
+        """
+        comp = self.get_component(component_id)
+        if comp is None:
+            raise ValueError(f"Unknown component '{component_id}'")
+        if comp.status != ComponentStatus.FAILED.value:
+            raise ValueError(
+                f"Component '{component_id}' is '{comp.status}', not "
+                f"'{ComponentStatus.FAILED.value}'; only failed components "
+                f"can be retried"
+            )
+
+        dependents = self._transitive_dependents(component_id)
+        reset_ids = {component_id}
+        runnable = {
+            ComponentStatus.COMPLETED.value,
+            ComponentStatus.PENDING.value,
+        }
+        reset_dependents: list[str] = []
+        for cid in self.topological_order():
+            if cid not in dependents:
+                continue
+            dep_comp = self.get_component(cid)
+            if dep_comp is None or dep_comp.status != ComponentStatus.SKIPPED.value:
+                continue
+            if all(
+                dep in reset_ids
+                or (
+                    (d := self.get_component(dep)) is not None
+                    and d.status in runnable
+                )
+                for dep in dep_comp.dependencies
+            ):
+                reset_ids.add(cid)
+                reset_dependents.append(cid)
+
+        for cid in [component_id, *reset_dependents]:
+            target = self.get_component(cid)
+            assert target is not None
+            target.status = ComponentStatus.PENDING.value
+            target.error = ""
+            target.retries = 0
+            target.started_at = ""
+            target.completed_at = ""
+            target.duration_seconds = 0.0
+            target.iteration_count = 0
+            target.pr_number = None
+            target.pr_url = ""
+            target.verification_passed = None
+            target.review_passed = None
+            # Findings from the failed attempt are already in the
+            # evolution journal (record_run wrote them, attempt-tagged,
+            # when the failed run finished); the fresh attempt starts
+            # with a clean stream.
+            target.findings = []
+            target.review_findings = ""
+            target.failed_phase = ""
+            target.failed_check = ""
+            target.evidence_worktree = ""
+            target.evidence_debug_dir = ""
+            target.journal_offset_start = -1
+            target.journal_offset_end = -1
+
+        return reset_dependents
 
     def compute_tiers(self) -> list[list[str]]:
         """Compute DAG tier levels using Kahn's algorithm with level tracking.

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -196,7 +196,8 @@ def _section_specs() -> list[SectionSpec]:
                 "max_parallel", "max_retries", "retry_delay", "use_worktrees",
                 "single_pr", "create_prs", "review_mode", "merge_timeout",
                 "max_adversarial_calls", "max_total_tokens",
-                "pause_before_pr_merge",
+                "pause_before_pr_merge", "progress_log_enabled",
+                "keep_worktrees_on_failure",
             ]),
             lambda root: FactoryConfig.load(root_dir=root),
             FactoryConfig(), probe_undocumented_fields=True,
@@ -286,6 +287,10 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("factory", "max_adversarial_calls"): "cap on review+security+distill LLM calls; 0 = unbounded",
     ("factory", "max_total_tokens"): "run-level token budget; 0 = unbounded",
     ("factory", "pause_before_pr_merge"): "human checkpoint before each PR (E6)",
+    ("factory", "progress_log_enabled"):
+        "JSONL event log at .ralph/progress.jsonl (R3.2)",
+    ("factory", "keep_worktrees_on_failure"):
+        "keep failed components' worktrees for post-mortem (R3.3)",
     ("verify", "test_command"): "empty = smart default (uv run pytest)",
     ("verify", "typecheck_command"): "empty = smart default (uv run mypy)",
     ("verify", "lint_command"): "empty = smart default (uv run ruff check)",

--- a/tests/test_resume_ergonomics.py
+++ b/tests/test_resume_ergonomics.py
@@ -1,0 +1,650 @@
+"""R3.3 - resume + partial-failure ergonomics.
+
+Covers: run_id/completed_at persistence in the manifest, per-attempt
+findings hygiene (cleared per attempt, superseded findings retained in
+the evolution journal tagged ``attempt:<n>``), keep-worktrees-on-failure
+evidence, the failure summary, and the ``ralph retry`` command.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from ralph_py.cli import cli
+from ralph_py.config import RalphConfig
+from ralph_py.evolution import EvolutionConfig
+from ralph_py.factory import (
+    ComponentResult,
+    FactoryConfig,
+    FactoryResult,
+    run_factory,
+)
+from ralph_py.findings import (
+    Finding,
+    finding_attempt,
+    tag_finding_with_attempt,
+)
+from ralph_py.manifest import Component, ComponentStatus, Manifest
+from ralph_py.review import ReviewConcern, ReviewResult
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+# ---------------------------------------------------------------------------
+# Shared builders (pattern follows tests/test_review_gates.py)
+# ---------------------------------------------------------------------------
+
+
+def _write_prd(path: Path, story_ids: list[str]) -> None:
+    path.write_text(json.dumps({
+        "branchName": "test",
+        "userStories": [
+            {
+                "id": sid, "title": f"Story {sid}",
+                "acceptanceCriteria": ["AC1"], "priority": 1,
+                "passes": True, "notes": "",
+            }
+            for sid in story_ids
+        ],
+    }))
+
+
+def _scaffold(tmp_path: Path, comp_ids: list[str]) -> Path:
+    (tmp_path / "scripts" / "ralph").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "scripts" / "ralph" / "prompt.md").write_text("p")
+    (tmp_path / "scripts" / "ralph" / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    for comp_id in comp_ids:
+        feature_dir = tmp_path / "scripts" / "ralph" / "feature" / comp_id
+        feature_dir.mkdir(parents=True, exist_ok=True)
+        _write_prd(feature_dir / "prd.json", ["US-001"])
+    return tmp_path
+
+
+def _make_manifest(ids: list[str]) -> Manifest:
+    return Manifest(
+        version="1", spec_file="s", project_name="t",
+        base_branch="main", single_pr=False,
+        components=[
+            Component(
+                id=i, title=i, description="", dependencies=[],
+                prd_path=f"scripts/ralph/feature/{i}/prd.json",
+                branch_name=f"ralph/{i}",
+            )
+            for i in ids
+        ],
+    )
+
+
+def _base_config(root: Path) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root / "scripts/ralph/prompt.md",
+        prd_file=root / "scripts/ralph/prd.json",
+        sleep_seconds=0, agent_cmd="echo test",
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    )
+
+
+def _factory_config(**overrides: object) -> FactoryConfig:
+    defaults: dict[str, object] = dict(
+        use_worktrees=False, create_prs=False, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_diff_scope=False,
+            check_bad_patterns=False, subprocess_timeout=5.0,
+        ),
+    )
+    defaults.update(overrides)
+    return FactoryConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args], cwd=root, capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"git {' '.join(args)} failed: {result.stderr}"
+    )
+    return result
+
+
+def _init_git_repo(root: Path) -> None:
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "r33@test")
+    _git(root, "config", "user.name", "R33 Test")
+    (root / ".gitignore").write_text("scripts/ralph/\n.ralph/\n")
+    (root / "README.md").write_text("seed\n")
+    _git(root, "add", ".gitignore", "README.md")
+    _git(root, "commit", "-q", "-m", "init")
+
+
+def _journal_events(root: Path) -> list[dict[str, object]]:
+    journal = EvolutionConfig.load(root).journal_path
+    if not journal.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in journal.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Attempt-tag helpers
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptTagging:
+    def test_tag_and_parse_round_trip(self) -> None:
+        f = Finding.phase_skipped("review", "skipped")
+        tagged = tag_finding_with_attempt(f, 3)
+        assert "attempt:3" in tagged.tags
+        assert finding_attempt(tagged) == 3
+
+    def test_tagging_is_idempotent(self) -> None:
+        f = tag_finding_with_attempt(
+            Finding.phase_skipped("review", "skipped"), 1,
+        )
+        retagged = tag_finding_with_attempt(f, 2)
+        assert retagged.tags == f.tags
+        assert finding_attempt(retagged) == 1
+
+    def test_untagged_finding_has_no_attempt(self) -> None:
+        assert finding_attempt(Finding.phase_skipped("x", "y")) is None
+
+
+# ---------------------------------------------------------------------------
+# Manifest: new fields + reset_for_retry
+# ---------------------------------------------------------------------------
+
+
+class TestManifestRunMetadata:
+    def test_run_id_and_completed_at_round_trip(self, tmp_path: Path) -> None:
+        manifest = _make_manifest(["comp-a"])
+        manifest.run_id = "20260718-abc"
+        manifest.completed_at = "2026-07-18T00:00:00Z"
+        comp = manifest.components[0]
+        comp.failed_phase = "review"
+        comp.failed_check = "criteria"
+        comp.evidence_worktree = "/tmp/wt"
+        comp.evidence_debug_dir = "/tmp/dbg"
+        comp.journal_offset_start = 10
+        comp.journal_offset_end = 250
+
+        path = tmp_path / "m.json"
+        manifest.save(path)
+        loaded = Manifest.load(path)
+
+        assert loaded.run_id == "20260718-abc"
+        assert loaded.completed_at == "2026-07-18T00:00:00Z"
+        loaded_comp = loaded.components[0]
+        assert loaded_comp.failed_phase == "review"
+        assert loaded_comp.failed_check == "criteria"
+        assert loaded_comp.evidence_worktree == "/tmp/wt"
+        assert loaded_comp.evidence_debug_dir == "/tmp/dbg"
+        assert loaded_comp.journal_offset_start == 10
+        assert loaded_comp.journal_offset_end == 250
+
+    def test_pre_r33_manifest_loads_with_defaults(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.json"
+        path.write_text(json.dumps({
+            "version": "1", "specFile": "s", "projectName": "t",
+            "baseBranch": "main", "singlePr": False,
+            "components": [{
+                "id": "comp-a", "title": "a", "description": "",
+                "dependencies": [], "prdPath": "p.json",
+                "branchName": "ralph/comp-a",
+            }],
+        }))
+        loaded = Manifest.load(path)
+        assert loaded.run_id == ""
+        assert loaded.completed_at == ""
+        comp = loaded.components[0]
+        assert comp.evidence_worktree == ""
+        assert comp.journal_offset_start == -1
+
+    def test_cascade_skip_sets_completed_at(self) -> None:
+        manifest = _make_manifest(["comp-a", "comp-b"])
+        manifest.components[1].dependencies = ["comp-a"]
+        manifest.components[0].status = ComponentStatus.FAILED.value
+        manifest.cascade_skip("comp-a")
+        skipped = manifest.get_component("comp-b")
+        assert skipped is not None
+        assert skipped.status == ComponentStatus.SKIPPED.value
+        assert skipped.completed_at != ""
+
+
+class TestResetForRetry:
+    def _failed_manifest(self) -> Manifest:
+        manifest = _make_manifest(["comp-a", "comp-b", "comp-c"])
+        a, b, c = manifest.components
+        b.dependencies = ["comp-a"]
+        a.status = ComponentStatus.FAILED.value
+        a.error = "boom"
+        a.retries = 3
+        a.completed_at = "2026-07-18T00:00:00Z"
+        a.failed_phase = "review"
+        a.failed_check = "criteria"
+        a.findings = [Finding.phase_skipped("security", "skipped")]
+        a.review_findings = "text"
+        b.status = ComponentStatus.SKIPPED.value
+        b.error = "Dependency 'comp-a' failed"
+        c.status = ComponentStatus.COMPLETED.value
+        return manifest
+
+    def test_resets_failed_component_and_cascade(self) -> None:
+        manifest = self._failed_manifest()
+        reset = manifest.reset_for_retry("comp-a")
+        assert reset == ["comp-b"]
+        a = manifest.get_component("comp-a")
+        b = manifest.get_component("comp-b")
+        c = manifest.get_component("comp-c")
+        assert a is not None and b is not None and c is not None
+        for comp in (a, b):
+            assert comp.status == ComponentStatus.PENDING.value
+            assert comp.error == ""
+            assert comp.retries == 0
+            assert comp.completed_at == ""
+            assert comp.findings == []
+            assert comp.failed_phase == ""
+            assert comp.journal_offset_start == -1
+        assert c.status == ComponentStatus.COMPLETED.value
+
+    def test_rejects_non_failed_component(self) -> None:
+        manifest = self._failed_manifest()
+        with pytest.raises(ValueError, match="not 'failed'"):
+            manifest.reset_for_retry("comp-c")
+        with pytest.raises(ValueError, match="Unknown component"):
+            manifest.reset_for_retry("nope")
+
+    def test_dependent_skipped_by_other_failure_stays_skipped(self) -> None:
+        manifest = self._failed_manifest()
+        manifest.components.append(Component(
+            id="comp-e", title="e", description="", dependencies=[],
+            prd_path="p.json", branch_name="ralph/comp-e",
+            status=ComponentStatus.FAILED.value, error="other failure",
+        ))
+        manifest.components.append(Component(
+            id="comp-f", title="f", description="",
+            dependencies=["comp-a", "comp-e"],
+            prd_path="p.json", branch_name="ralph/comp-f",
+            status=ComponentStatus.SKIPPED.value,
+            error="Dependency 'comp-e' failed",
+        ))
+        reset = manifest.reset_for_retry("comp-a")
+        assert reset == ["comp-b"]
+        f = manifest.get_component("comp-f")
+        assert f is not None
+        assert f.status == ComponentStatus.SKIPPED.value
+
+
+# ---------------------------------------------------------------------------
+# Factory: completed_at + run_id persistence
+# ---------------------------------------------------------------------------
+
+
+class TestRunMetadataPersistence:
+    def test_completed_at_and_run_id_set_on_success(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        config = _factory_config()
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert result.exit_code == 0
+        assert manifest.run_id != ""
+        assert manifest.completed_at != ""
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.completed_at != ""
+        saved = json.loads(
+            (root / "scripts" / "ralph" / "manifest.json").read_text()
+        )
+        assert saved["runId"] == manifest.run_id
+        assert saved["completedAt"] == manifest.completed_at
+
+    def test_completed_at_set_on_failure(self, tmp_path: Path) -> None:
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        config = _factory_config()
+        failure = ComponentResult(
+            "comp-a", success=False, iterations=1, error="agent died",
+        )
+        with patch(
+            "ralph_py.factory._run_component", return_value=failure,
+        ):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        assert result.exit_code == 1
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.status == ComponentStatus.FAILED.value
+        assert comp.completed_at != ""
+        assert comp.failed_phase == "engineer"
+        assert comp.failed_check == "loop"
+        assert manifest.completed_at != ""
+
+
+# ---------------------------------------------------------------------------
+# Factory: per-attempt findings + superseded journal entries
+# ---------------------------------------------------------------------------
+
+
+class TestPerAttemptFindings:
+    def test_attempt1_findings_cleared_but_journaled(
+        self, tmp_path: Path,
+    ) -> None:
+        """Attempt 1 fails hard review with a concern; attempt 2 passes.
+        The final component findings carry only attempt:2 tags; the
+        evolution journal keeps the attempt-1 findings in a
+        findings_superseded event tagged attempt:1."""
+        root = _scaffold(tmp_path, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        config = _factory_config(
+            review_mode="hard", max_retries=1,
+        )
+        success = ComponentResult("comp-a", success=True, iterations=1)
+        failing_review = ReviewResult(
+            passed=False, mode="hard",
+            concerns=[ReviewConcern(
+                category="test_quality", severity="fail",
+                location="x.py:1", explanation="tautological test",
+            )],
+        )
+        passing_review = ReviewResult(passed=True, mode="hard")
+        with patch(
+            "ralph_py.factory._run_component", return_value=success,
+        ), patch(
+            "ralph_py.factory.run_review",
+            side_effect=[failing_review, passing_review],
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert result.completed == ["comp-a"]
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.retries == 1
+
+        # Final stream: attempt-2 findings only, no attempt-1 leftovers.
+        assert comp.findings, "attempt 2 should record phase-skip findings"
+        attempts = {finding_attempt(f) for f in comp.findings}
+        assert attempts == {2}
+        assert not any(
+            f.category == "test_quality" for f in comp.findings
+        ), "the superseded review concern must not survive into attempt 2"
+
+        # Journal: superseded findings retained, tagged attempt:1.
+        events = _journal_events(root)
+        superseded = [
+            e for e in events if e["event_type"] == "findings_superseded"
+        ]
+        assert len(superseded) == 1
+        assert superseded[0]["component_id"] == "comp-a"
+        assert superseded[0]["attempt"] == 1
+        journaled = [
+            Finding.from_dict(d)
+            for d in superseded[0]["findings"]  # type: ignore[union-attr]
+        ]
+        assert any(f.category == "test_quality" for f in journaled)
+        assert all(finding_attempt(f) == 1 for f in journaled)
+
+        # record_run's component_result carries only the final stream.
+        component_results = [
+            e for e in events
+            if e["event_type"] == "component_result"
+            and e["component_id"] == "comp-a"
+        ]
+        assert component_results, "record_run must journal the component"
+        final_findings = [
+            Finding.from_dict(d)
+            for d in component_results[-1]["findings"]  # type: ignore[index]
+        ]
+        assert all(finding_attempt(f) == 2 for f in final_findings)
+        assert not any(
+            f.category == "test_quality" for f in final_findings
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory: keep-worktrees-on-failure + failure summary (real git)
+# ---------------------------------------------------------------------------
+
+
+class TestKeepWorktreesOnFailure:
+    def _run_failing_factory(
+        self, root: Path, keep: bool,
+    ) -> tuple[Manifest, FactoryResult]:
+        _init_git_repo(root)
+        _scaffold(root, ["comp-a"])
+        manifest = _make_manifest(["comp-a"])
+        config = _factory_config(
+            use_worktrees=True,
+            keep_worktrees_on_failure=keep,
+            progress_log_path=root / ".ralph" / "progress.jsonl",
+        )
+        failure = ComponentResult(
+            "comp-a", success=False, iterations=1, error="agent died",
+        )
+        with patch(
+            "ralph_py.factory._run_component", return_value=failure,
+        ):
+            result = run_factory(
+                manifest, config, _base_config(root),
+                PlainUI(no_color=True), root,
+            )
+        return manifest, result
+
+    def test_failed_worktree_kept_and_summary_points_at_it(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        manifest, result = self._run_failing_factory(tmp_path, keep=True)
+        assert result.exit_code == 1
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.evidence_worktree != ""
+        kept = Path(comp.evidence_worktree)
+        assert kept.exists(), "failed worktree must survive cleanup"
+        assert kept == tmp_path / ".ralph" / "worktrees" / manifest.run_id / "comp-a"
+
+        # Evidence pointers persisted to disk.
+        saved = json.loads(
+            (tmp_path / "scripts" / "ralph" / "manifest.json").read_text()
+        )
+        saved_comp = saved["components"][0]
+        assert saved_comp["evidenceWorktree"] == comp.evidence_worktree
+        assert saved_comp["failedPhase"] == "engineer"
+
+        # Journal offsets bracket the attempt in the progress log.
+        assert comp.journal_offset_start >= 0
+        assert comp.journal_offset_end >= comp.journal_offset_start
+
+        # The failure summary names phase, check, and evidence.
+        # PlainUI writes to stderr.
+        out = capsys.readouterr().err
+        assert "Failure summary" in out
+        assert "phase=engineer" in out
+        assert "check=loop" in out
+        assert comp.evidence_worktree in out
+        assert "ralph retry comp-a" in out
+
+    def test_failed_worktree_removed_without_flag(
+        self, tmp_path: Path,
+    ) -> None:
+        manifest, result = self._run_failing_factory(tmp_path, keep=False)
+        assert result.exit_code == 1
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.evidence_worktree == ""
+        run_dir = tmp_path / ".ralph" / "worktrees" / manifest.run_id
+        assert not (run_dir / "comp-a").exists()
+
+    def test_next_run_prune_preserves_kept_evidence(
+        self, tmp_path: Path,
+    ) -> None:
+        manifest, _ = self._run_failing_factory(tmp_path, keep=True)
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        kept = Path(comp.evidence_worktree)
+        assert kept.exists()
+
+        # A second run on the same manifest (comp-a still FAILED) must
+        # not prune the recorded evidence worktree.
+        config = _factory_config(use_worktrees=True)
+        with patch(
+            "ralph_py.factory._run_component",
+            side_effect=AssertionError("nothing should be scheduled"),
+        ):
+            run_factory(
+                manifest, config, _base_config(tmp_path),
+                PlainUI(no_color=True), tmp_path,
+            )
+        assert kept.exists(), "prune must preserve evidence worktrees"
+
+
+# ---------------------------------------------------------------------------
+# ralph retry CLI
+# ---------------------------------------------------------------------------
+
+
+class TestRetryCli:
+    def _failed_repo(self, root: Path) -> Path:
+        """Real git repo with a failed comp-a (branch + kept worktree)
+        and a cascade-skipped comp-b, persisted to manifest.json."""
+        _init_git_repo(root)
+        _scaffold(root, ["comp-a", "comp-b"])
+        # Branch from the failed attempt, with a commit not on main.
+        _git(root, "checkout", "-q", "-b", "ralph/comp-a")
+        (root / "half-done.txt").write_text("partial\n")
+        _git(root, "add", "half-done.txt")
+        _git(root, "commit", "-q", "-m", "failed attempt")
+        _git(root, "checkout", "-q", "main")
+        # Kept evidence worktree on that branch.
+        wt = root / ".ralph" / "worktrees" / "run-old" / "comp-a"
+        wt.parent.mkdir(parents=True, exist_ok=True)
+        _git(root, "worktree", "add", str(wt), "ralph/comp-a")
+
+        manifest = _make_manifest(["comp-a", "comp-b"])
+        a, b = manifest.components
+        b.dependencies = ["comp-a"]
+        a.status = ComponentStatus.FAILED.value
+        a.error = "review failed"
+        a.retries = 3
+        a.failed_phase = "review"
+        a.failed_check = "criteria"
+        a.evidence_worktree = str(wt)
+        b.status = ComponentStatus.SKIPPED.value
+        b.error = "Dependency 'comp-a' failed"
+        manifest_file = root / "scripts" / "ralph" / "manifest.json"
+        manifest.save(manifest_file)
+        return manifest_file
+
+    def test_retry_round_trip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manifest_file = self._failed_repo(tmp_path)
+        captured: dict[str, object] = {}
+
+        def fake_run_factory(
+            manifest: Manifest,
+            factory_config: FactoryConfig,
+            base_config: RalphConfig,
+            ui_impl: object,
+            root_dir: Path,
+            manifest_path: Path | None = None,
+        ) -> FactoryResult:
+            captured["manifest"] = manifest
+            captured["manifest_path"] = manifest_path
+            captured["config"] = factory_config
+            return FactoryResult(exit_code=0)
+
+        monkeypatch.setattr("ralph_py.cli.run_factory", fake_run_factory)
+        monkeypatch.setattr(
+            "ralph_py.cli._check_agent_preflight", lambda *a, **k: None,
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "retry", "comp-a", "--root", str(tmp_path), "--yes",
+        ])
+        assert result.exit_code == 0, result.output
+
+        # The factory re-entered with the SAME manifest file, components
+        # reset to PENDING.
+        assert captured["manifest_path"] == manifest_file
+        entered = captured["manifest"]
+        assert isinstance(entered, Manifest)
+        for cid in ("comp-a", "comp-b"):
+            comp = entered.get_component(cid)
+            assert comp is not None
+            assert comp.status == ComponentStatus.PENDING.value
+            assert comp.retries == 0
+            assert comp.error == ""
+
+        # Saved manifest matches the reset state.
+        saved = Manifest.load(manifest_file)
+        saved_a = saved.get_component("comp-a")
+        assert saved_a is not None
+        assert saved_a.status == ComponentStatus.PENDING.value
+        assert saved_a.evidence_worktree == ""
+
+        # Failed-attempt branch and evidence worktree are gone, so the
+        # stale-branch preflight cannot refuse the re-run.
+        branch = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet",
+             "refs/heads/ralph/comp-a"],
+            cwd=tmp_path, capture_output=True, timeout=30,
+        )
+        assert branch.returncode != 0, "failed-attempt branch must be deleted"
+        assert not (
+            tmp_path / ".ralph" / "worktrees" / "run-old" / "comp-a"
+        ).exists()
+
+    def test_retry_rejects_non_failed_component(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manifest_file = self._failed_repo(tmp_path)
+        manifest = Manifest.load(manifest_file)
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        comp.status = ComponentStatus.COMPLETED.value
+        manifest.save(manifest_file)
+
+        monkeypatch.setattr(
+            "ralph_py.cli._check_agent_preflight", lambda *a, **k: None,
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "retry", "comp-a", "--root", str(tmp_path), "--yes",
+        ])
+        assert result.exit_code == 2
+        assert "not 'failed'" in result.output
+
+    def test_retry_unknown_component(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._failed_repo(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "retry", "ghost", "--root", str(tmp_path), "--yes",
+        ])
+        assert result.exit_code == 2
+        assert "Unknown component" in result.output


### PR DESCRIPTION
## Roadmap item

R3.3 (M) **Resume + partial-failure ergonomics** [P-5, LOW completed_at, LOW findings-accumulate] - checkbox flipped in docs/remediation-roadmap.md in this PR.

## What changed

- **Run metadata**: `Manifest.run_id` / `Manifest.completed_at` persisted (blanked at run start, stamped in the summary epilogue). `Component.completed_at` is now set on every terminal transition (COMPLETED, FAILED including backstop/PR/contract/merge-closed paths, SKIPPED via `cascade_skip`); MERGE_PENDING deliberately stays unstamped (parked, not terminal).
- **Evidence pointers**: components record `failed_phase`/`failed_check`, `evidence_worktree` (kept worktree path), `evidence_debug_dir` (`.ralph/debug/<run>/<comp>` when a phase dumped raw output), and `journal_offset_start/end` (byte offsets bracketing the attempt's slice of the progress log).
- **`ralph retry <component-id>`**: `Manifest.reset_for_retry` resets the FAILED component plus cascade-SKIPPED dependents to PENDING (a dependent also skipped because of a *different* still-failed component stays SKIPPED). The CLI removes the failed attempt's evidence worktree and deletes its branch (never in single_pr mode), then re-enters `run_factory` with the same manifest file; phase configs resolve env > toml > defaults like flagless `ralph factory`, and the run-level flock applies as usual.
- **`--keep-worktrees-on-failure`**: CLI flag on `factory` and `retry`, `[factory].keep_worktrees_on_failure` toml key, `RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE` env (all via the R2.1 control plane; shown in `ralph config show`). Cleanup keeps FAILED components' worktrees and records them as evidence; `_prune_stale_worktrees` preserves recorded evidence worktrees of still-FAILED components across runs. The failure summary lists phase, check, error head, worktree, raw-output dir, journal byte range, and the `ralph retry` command per failed component.
- **Per-attempt findings**: `comp.findings` (and the derived `review_findings` string) cleared at each attempt start; every finding is tagged `attempt:<n>` (`findings.tag_finding_with_attempt`, idempotent). When a retry supersedes an attempt (including contract-breaker re-runs), its findings are journaled as a `findings_superseded` event before clearing; `record_run`'s `component_result` carries only the final attempt's stream, so superseded findings no longer inflate journal counts or get attributed to shipped code.

## Checks

```
1109 passed, 14 skipped, 1 xfailed, 1 warning in 55.79s
Success: no issues found in 37 source files
All checks passed!
```

## Tested (behaviors proven by named tests, tests/test_resume_ergonomics.py)

- `test_retry_round_trip`: `ralph retry` on a synthetic failed manifest in a real git repo resets comp-a and cascade-skipped comp-b to PENDING (retries 0, error cleared), deletes the failed attempt's branch and evidence worktree, saves the reset manifest, and re-enters the factory with the same manifest path.
- `test_retry_rejects_non_failed_component` / `test_retry_unknown_component`: exit 2 with an actionable message.
- `test_failed_worktree_kept_and_summary_points_at_it` (real git worktrees): with the flag, the failed worktree survives cleanup, `evidenceWorktree`/`failedPhase` are persisted, journal offsets bracket the attempt, and the failure summary names phase=engineer, check=loop, the worktree path, and the retry command.
- `test_failed_worktree_removed_without_flag`: default behavior unchanged.
- `test_next_run_prune_preserves_kept_evidence`: a second factory run on the same root does not prune the recorded evidence worktree.
- `test_attempt1_findings_cleared_but_journaled`: attempt 1 fails hard review with a concern, attempt 2 passes; final component findings carry only `attempt:2` tags (no attempt-1 concern), while the evolution journal holds a `findings_superseded` event with the attempt-1 findings tagged `attempt:1` and a `component_result` with only attempt-2 findings.
- `test_completed_at_and_run_id_set_on_success` / `test_completed_at_set_on_failure`: manifest `runId`/`completedAt` persisted to disk; component `completed_at`, `failed_phase=engineer`, `failed_check=loop` set on failure.
- `test_run_id_and_completed_at_round_trip` / `test_pre_r33_manifest_loads_with_defaults`: schema round-trip and backward compatibility with pre-R3.3 manifests.
- `test_cascade_skip_sets_completed_at`, `test_resets_failed_component_and_cascade`, `test_dependent_skipped_by_other_failure_stays_skipped`, attempt-tag helper tests.

## Assumed (claimed but not directly tested)

- `ralph retry` respects the run-level lock only via the shared `run_factory` path (R0.5 tests cover the lock; retry adds no lock handling of its own).
- Journal offsets are meaningful only when a progress log is configured; with `NullProgressLog` they stay -1 (asserted only implicitly via the keep-worktrees test which configures a log).
- The contract-breaker superseded-findings journaling and the HITL reject/retry phase tags follow the same code path as the tested review-retry case but have no dedicated test.
- Runbook wording for the new recovery flow is owned by Session 7A (R2.5) per its coordination note; not touched here.
- On resume, `Manifest.run_id` is overwritten with the new run's id; the prior run's id remains recoverable from the journals.
- mypy scope note: `tests/` is outside mypy's configured scope (`files = ["ralph_py"]`), matching CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)