### PR TITLE
fix: R5.4 self-critique check correctness (MED self-critique)

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -483,7 +483,7 @@ third, all in one measured cycle.
     add only if the R5.2 fixtures show they are detectable without FP cost.
   - Every edited prompt: version bump + snapshot + before/after calibration
     delta recorded in `docs/` (H2/H3 audit trail).
-- [ ] R5.4 (S) **Self-critique check correctness** [MED self-critique]
+- [x] R5.4 (S) **Self-critique check correctness** [MED self-critique]
   - Associate the block with the CURRENT iteration's entry; fix the dead
     boundary-break so unrelated bullets stop inflating the count; fuzz corpus
     extended with the regression cases. (Substance stays out of scope: shape

--- a/ralph_py/verify.py
+++ b/ralph_py/verify.py
@@ -335,17 +335,68 @@ _SELF_CRITIQUE_HEADING_RE = re.compile(
     re.IGNORECASE | re.VERBOSE,
 )
 
+# An iteration entry boundary in progress.txt. The engineer prompt's
+# documented format starts each appended entry with
+# `## [YYYY-MM-DD] - [Story ID]`; agents also commonly write
+# `## Iteration N`. Exactly two hashes: H3 sub-headings inside an
+# entry must not be mistaken for a new entry.
+_ITERATION_HEADING_RE = re.compile(
+    r"""^\#\#\s+
+    (?:
+        \[?\d{4}-\d{2}-\d{2}        # '## [YYYY-MM-DD] - ...' (documented form)
+      | Iteration\b                 # '## Iteration N' (loose variant)
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# An UNINDENTED bullet opening with a closed bold label, e.g.
+# `- **Learnings:**` or `- **Interpretations** (only if ...): ...`.
+# In the engineer prompt's entry format these are sibling sections of
+# `- **Self-Critique:**`, so one of them terminates the bullet count.
+# Applied to the raw line: the Self-Critique block's own nested bullets
+# are indented and therefore never match.
+_SECTION_BULLET_RE = re.compile(r"^[\-*]\s+\*{2}[^*]+\*{2}")
+
+# Thematic break: the engineer prompt's entry format ends each entry
+# with `---`.
+_ENTRY_SEPARATOR_RE = re.compile(r"^-{3,}$")
+
 
 def check_self_critique(
     progress_path: Path, min_bullets: int = 3,
 ) -> CheckResult:
-    """Confirm the latest progress.txt entry contains a Self-Critique
-    block with at least ``min_bullets`` bullet points.
+    """Confirm the CURRENT (latest) progress.txt entry contains a
+    Self-Critique block with at least ``min_bullets`` bullet points.
 
-    The check looks at the LAST occurrence of a Self-Critique heading
-    (line matching `_SELF_CRITIQUE_HEADING_RE`, e.g. `## Self-Critique`
-    or `- **Self-Critique:**`) and counts the bullet lines that follow
-    until the next heading or end-of-file.
+    Shape check only (H4): this verifies that a Self-Critique block of
+    the right shape exists in the right place. It does NOT verify the
+    substance of the bullets - vacuous-but-plausible failure modes
+    pass. Substance is the reviewer's job.
+
+    Format assumption (from the engineer prompt's Progress Format):
+    each iteration appends an entry starting with an H2 heading of the
+    form `## [YYYY-MM-DD] - [Story ID]` (the loose `## Iteration N`
+    variant is also recognized), containing `- **Self-Critique:**` (or
+    `## Self-Critique`) followed by bullets, sibling bold-label
+    sections such as `- **Interpretations:**`, and a closing `---`.
+
+    The check first locates the latest iteration boundary (the LAST
+    line matching ``_ITERATION_HEADING_RE``), then requires a
+    Self-Critique heading within that entry - a block written by an
+    EARLIER iteration does not satisfy the check for the current one.
+    If no iteration heading exists anywhere, the whole file is treated
+    as a single entry (fallback for free-form progress files; per-
+    iteration association is not possible there).
+
+    Bullet counting stops at the next `##` heading, a `---` entry
+    separator, or an unindented bold-label bullet (a sibling section
+    like `- **Interpretations:**`), so bullets belonging to later
+    sections do not inflate the count. Consequence of the format
+    assumption: critique bullets themselves must either be indented
+    under the `- **Self-Critique:**` bullet (the documented format) or
+    not open with a bold label, otherwise they read as a sibling
+    section and the check fails loudly rather than over-counting.
 
     Without this mechanical check, the engineer prompt's mandate to
     list >=3 failure modes can silently rot - the only enforcement
@@ -363,29 +414,46 @@ def check_self_critique(
         )
 
     lines = text.splitlines()
-    # Find the LAST self-critique heading. Walking from the end lets
-    # multiple iterations accumulate without earlier ones masking the
-    # current iteration's block.
-    heading_idx: int | None = None
+    # Locate the latest iteration entry: entries are appended, so the
+    # LAST iteration heading starts the current iteration's entry.
+    entry_start = 0
+    entry_found = False
     for i in range(len(lines) - 1, -1, -1):
+        if _ITERATION_HEADING_RE.match(lines[i]):
+            entry_start = i
+            entry_found = True
+            break
+
+    # Find the LAST self-critique heading WITHIN the latest entry, so
+    # an earlier iteration's block cannot satisfy the current one and
+    # repeated blocks inside one entry resolve to the newest.
+    heading_idx: int | None = None
+    for i in range(len(lines) - 1, entry_start - 1, -1):
         if _SELF_CRITIQUE_HEADING_RE.match(lines[i]):
             heading_idx = i
             break
 
     if heading_idx is None:
+        where = (
+            f"in the latest iteration entry (line {entry_start + 1}: "
+            f"{lines[entry_start].strip()[:60]!r})"
+            if entry_found
+            else "in progress file"
+        )
         return CheckResult(
             name="self_critique",
             passed=False,
             message=(
-                "No '## Self-Critique' block found in progress file. "
+                f"No '## Self-Critique' block found {where}. "
                 "Engineer prompt mandates >=3 failure-mode bullets "
                 "before declaring done."
             ),
             duration_seconds=time.monotonic() - start,
         )
 
-    # Count bullets after the heading until the next heading (^##) or
-    # the next list-style heading (e.g. - **Learnings:**).
+    # Count bullets after the heading until the entry's content ends:
+    # next `##` heading, `---` separator, or a sibling bold-label
+    # bullet section (e.g. `- **Interpretations:**`).
     bullet_count = 0
     bullet_lines: list[str] = []
     for line in lines[heading_idx + 1:]:
@@ -393,10 +461,13 @@ def check_self_critique(
         # Stop at next major heading
         if stripped.startswith("##"):
             break
-        # Stop at the next labeled bullet header (e.g. "- **Interpretations:**")
-        if stripped.startswith("- **") and stripped.rstrip(":*").lower().endswith(
-            ("**", "**:"),
-        ) and "self" not in stripped.lower():
+        # Stop at the entry separator
+        if _ENTRY_SEPARATOR_RE.match(stripped):
+            break
+        # Stop at the next sibling section: an UNINDENTED bold-label
+        # bullet (matched on the raw line so the block's own indented
+        # bullets never terminate the count).
+        if _SECTION_BULLET_RE.match(line):
             break
         # Count substantive bullets (require non-trivial content after the marker)
         if stripped.startswith("- ") or stripped.startswith("* "):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -495,6 +495,127 @@ class TestCheckSelfCritique:
                 f"line {line!r} should not be treated as heading"
             )
 
+    def test_missing_block_in_latest_iteration_fails(
+        self, tmp_path: Path,
+    ) -> None:
+        """R5.4 regression: an earlier iteration's Self-Critique block
+        must not satisfy the check when the LATEST entry omits it."""
+        earlier_entries = [
+            # Documented '## [YYYY-MM-DD] - [Story ID]' form
+            "## [2026-07-17] - US-001\n",
+            # Unbracketed date form
+            "## 2026-07-17 - US-001\n",
+            # Loose 'Iteration N' form
+            "## Iteration 1\n",
+        ]
+        for earlier in earlier_entries:
+            progress = tmp_path / "progress.txt"
+            progress.write_text(
+                f"{earlier}"
+                "- implemented the parser\n"
+                "- **Self-Critique:**\n"
+                "  - Failure mode 1: realistic detail\n"
+                "  - Failure mode 2: realistic detail\n"
+                "  - Failure mode 3: realistic detail\n"
+                "---\n"
+                "## [2026-07-18] - US-002\n"
+                "- implemented the serializer\n"
+                "- ran the tests\n"
+                "---\n"
+            )
+            result = check_self_critique(progress, min_bullets=3)
+            assert result.passed is False, (
+                f"earlier entry {earlier!r} must not mask the latest "
+                "entry's missing block"
+            )
+            assert "latest iteration entry" in result.message
+
+    def test_next_section_bullets_do_not_inflate_count(
+        self, tmp_path: Path,
+    ) -> None:
+        """R5.4 regression: bullets belonging to a FOLLOWING bold-label
+        section (e.g. Interpretations in the engineer prompt's format)
+        must not count toward min_bullets."""
+        progress = tmp_path / "progress.txt"
+        progress.write_text(
+            "## [2026-07-18] - US-002\n"
+            "- **Self-Critique:**\n"
+            "  - Failure mode 1: only one substantive failure mode\n"
+            "- **Interpretations** (PRD was ambiguous): assumed idempotency\n"
+            "- **Learnings:**\n"
+            "  - discovered a pattern\n"
+            "  - hit a gotcha\n"
+        )
+        result = check_self_critique(progress, min_bullets=3)
+        assert result.passed is False
+        assert "1 bullets" in result.message
+
+    def test_default_prompt_entry_format_counts_exact_bullets(
+        self, tmp_path: Path,
+    ) -> None:
+        """Positive control: a full entry in the engineer prompt's
+        documented Progress Format passes with EXACTLY the critique
+        bullets counted - surrounding sections contribute nothing."""
+        progress = tmp_path / "progress.txt"
+        progress.write_text(
+            "# Ralph Progress Log\n\n"
+            "## Codebase Patterns\n"
+            "- (add reusable patterns here)\n\n"
+            "## Iteration Notes\n"
+            "- (append entries below using the format in prompt.md)\n\n"
+            "---\n"
+            "## [2026-07-18] - US-002\n"
+            "- What was implemented: the serializer\n"
+            "- Files changed: serializer.py\n"
+            "- Verification run: uv run pytest -q\n"
+            "- **Learnings:**\n"
+            "  - Patterns discovered: registry pattern\n"
+            "  - Gotchas encountered: import cycle\n"
+            "- **Self-Critique:**\n"
+            "  - Failure mode 1: malformed input crashes the encoder\n"
+            "  - Failure mode 2: concurrent flushes interleave\n"
+            "  - Failure mode 3: timeout error swallowed silently\n"
+            "- **Interpretations** (only if PRD was ambiguous): assumed utf-8\n"
+            "---\n"
+        )
+        result = check_self_critique(progress, min_bullets=3)
+        assert result.passed is True
+        assert "3 failure modes" in result.message
+
+    def test_entry_separator_terminates_bullet_count(
+        self, tmp_path: Path,
+    ) -> None:
+        """Bullets after the closing `---` belong to no entry and must
+        not count."""
+        progress = tmp_path / "progress.txt"
+        progress.write_text(
+            "## [2026-07-18] - US-002\n"
+            "- **Self-Critique:**\n"
+            "  - Failure mode 1: realistic detail\n"
+            "---\n"
+            "- stray bullet after the separator\n"
+            "- another stray bullet\n"
+        )
+        result = check_self_critique(progress, min_bullets=3)
+        assert result.passed is False
+        assert "1 bullets" in result.message
+
+    def test_no_iteration_heading_falls_back_to_whole_file(
+        self, tmp_path: Path,
+    ) -> None:
+        """Free-form progress files without a recognized iteration
+        heading are treated as a single entry (documented fallback)."""
+        progress = tmp_path / "progress.txt"
+        progress.write_text(
+            "Free-form notes, no iteration headings anywhere.\n"
+            "- **Self-Critique:**\n"
+            "  - Failure mode 1: realistic detail\n"
+            "  - Failure mode 2: realistic detail\n"
+            "  - Failure mode 3: realistic detail\n"
+        )
+        result = check_self_critique(progress, min_bullets=3)
+        assert result.passed is True
+
 
 class TestCheckMutationScore:
     def test_skips_when_mutmut_not_installed(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Roadmap item

R5.4 (Session 8D): self-critique check correctness. Flips the R5.4 checkbox in `docs/remediation-roadmap.md`.

## Defects fixed (ralph_py/verify.py, check_self_critique)

1. **Latest-iteration association.** The check walked from EOF to the LAST Self-Critique heading anywhere in progress.txt, so an iteration that omitted the block passed if any earlier iteration had one. It now locates the latest iteration boundary first (last line matching `## [YYYY-MM-DD] - ...` or `## Iteration N`, new `_ITERATION_HEADING_RE`) and requires the heading within that entry. Files with no recognized iteration heading fall back to whole-file scan; the docstring states this and the format assumption honestly.
2. **Dead boundary break.** `stripped.rstrip(":*").lower().endswith(("**","**:"))` could never be true (the rstrip removes the asterisks first), so bullets from following sections (e.g. `- **Interpretations**` in DEFAULT_PROMPT's entry format) inflated the count toward min_bullets. Replaced with `_SECTION_BULLET_RE` (unindented bullet opening with a closed bold label) matched on the raw line so the block's own indented bullets never terminate the count; also breaks on the entry's closing `---` separator.

The check remains a shape check: the docstring now states per H4 that bullet substance is NOT verified (that is the reviewer's job). No prompt body, `*_PROMPT_VERSION`, or snapshot was touched.

## Tested (behaviors proven by named tests, tests/test_verify.py)

- `test_missing_block_in_latest_iteration_fails`: an earlier entry's block no longer masks a latest entry that omits it, across all three recognized heading forms (`## [date] - id`, `## date - id`, `## Iteration N`). **Empirically demonstrated as a regression test: this test and the next one both FAIL against origin/main's verify.py and pass against this branch.**
- `test_next_section_bullets_do_not_inflate_count`: 1 critique bullet + Interpretations/Learnings bullets after it now fails with "1 bullets" instead of passing at 3.
- `test_default_prompt_entry_format_counts_exact_bullets`: a full entry in DEFAULT_PROMPT's documented Progress Format passes with exactly 3 counted (message asserts "3 failure modes", proving no inflation from surrounding sections).
- `test_entry_separator_terminates_bullet_count`: bullets after the closing `---` do not count.
- `test_no_iteration_heading_falls_back_to_whole_file`: free-form files without iteration headings still work (documented fallback).
- All 10 pre-existing TestCheckSelfCritique tests pass unchanged, including both fuzz corpora (accepted headings / rejected prose lines).

## Assumed (claimed but not tested)

- Iteration entries in real runs start with `## [YYYY-MM-DD] - [Story ID]` or `## Iteration N` at column 0. Entries using other heading styles degrade to the whole-file fallback (old, weaker semantics), not to a false failure.
- Under an H2-form `## Self-Critique` heading, an unindented bullet that opens with a closed bold label (e.g. `- **Race condition**: ...`) is treated as a sibling section and stops the count. This trades a loud, retryable false failure for closing the silent-inflation hole; documented in the docstring.
- Bullet substance is not verified (H4): vacuous-but-plausible failure modes still pass the shape check.
- No calibration re-run: no prompt body changed (H2 does not trigger).

## Checks (final lines)

- `uv run pytest tests/ -q`: `1169 passed, 14 skipped, 1 xfailed, 1 warning in 58.74s`
- `uv run mypy ralph_py/ --strict`: `Success: no issues found in 37 source files`
- `uv run ruff check ralph_py/ tests/`: `All checks passed!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)