### PR TITLE
feat: R5.1 calibration tooling + R5.5 model-bump trigger

### DIFF
--- a/docs/adversarial-design.md
+++ b/docs/adversarial-design.md
@@ -96,9 +96,41 @@ To run:
 RALPH_RUN_CALIBRATION=1 RALPH_CALIBRATION_MODEL=haiku uv run pytest tests/test_calibration.py -v
 ```
 
-Each run writes `tests/adversarial_fixtures/_results/baseline-<UTC>.json` with per-role detection rates. Fixtures cover security (5), reviewer concerns (3), and vague specs (3).
+Each run executes every fixture `RALPH_CALIBRATION_RUNS` times (default 3, R5.1) and writes `tests/adversarial_fixtures/_results/baseline-<UTC>.json` in the v2 format defined by `ralph_py/calibration.py`: per-fixture *consistency* (fraction of completed runs that caught the planted issue; agent-infrastructure errors are excluded from the denominator, unparseable model output counts as a miss), per-role and per-category (per-CWE for security) detection rates, the run count, and the model id. Fixtures cover security (5), reviewer concerns (3), and vague specs (3), plus one non-halting allowedPaths fixture.
 
 The fixtures themselves live in `tests/adversarial_fixtures/{security,concerns,specs}/` with paired `.meta.json` files describing the planted bug and the must-detect category.
+
+### Threshold gates instead of hard asserts (R5.1)
+
+A truth signal that is expected to be red is not a signal, so the suite no longer hard-asserts each single run. A fixture test passes when a majority of its completed runs detect the planted issue (`FIXTURE_DETECTION_THRESHOLD = 0.5`, i.e. 2 of 3 at the default run count): one flaky miss is reported as reduced consistency, a fixture that misses most runs fails the suite. Set `RALPH_CALIBRATION_RUNS=1` for a cheap single-run smoke (it degrades to the old hard-assert behavior and is too coarse for baseline capture).
+
+### Comparing baselines (H2's "compare" step, concretely)
+
+```bash
+uv run python -m ralph_py.calibration compare \
+  tests/adversarial_fixtures/_results/baseline-<old>.json \
+  tests/adversarial_fixtures/_results/baseline-<new>.json
+```
+
+Exit code 0 = no regression, 1 = regression, 2 = usage/load error. Both v1 (pre-R5.1 single-run) and v2 files load. The codified thresholds live in one constants block at the top of `ralph_py/calibration.py` with sizing rationale inline:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `MAX_ROLE_DETECTION_DROP` | 0.15 | A role's mean detection rate may not drop more than this between baselines. Sized so one run flipping on a 3-fixture role (drop ~0.11) is variance, an entire fixture going dark (~0.33) is a regression. |
+| `MAX_CATEGORY_DETECTION_DROP` | 0.40 | Same per category (per-CWE categories usually hold one fixture: one run flip ~0.33 tolerated, two flips fail). Only meaningful at 3+ runs. |
+| `MIN_ROLE_DETECTION_RATE` | security 0.80, reviewer/architect 0.65, allowed_paths 0.50 | Absolute floors on the new baseline so successive comparisons cannot ratchet a role downward. |
+| `FIXTURE_DETECTION_THRESHOLD` | 0.5 | Majority-of-completed-runs gate used by the suite and by per-fixture `detected`. |
+| `DEFAULT_CALIBRATION_RUNS` | 3 | Default runs per fixture for baseline capture. |
+
+Partial runs (a role present in the old baseline but not exercised in the new one) and cross-model comparisons produce warnings, not failures - the latter because a cross-model delta measures the model change, not a prompt change.
+
+### Kind synonyms (matcher de-brittling, R5.1)
+
+The architect matcher's `must_include_kind` used to demand exact taxonomy labels, but every architect miss in the recorded 20260527 baselines was the planted issue reported under a sibling label (`missing_detail` instead of `undefined_failure_mode` / `unstated_assumption`) - a matcher artifact, not a detection failure. `calibration.KIND_SYNONYM_GROUPS` documents the one symmetric family that collapses: `{missing_detail, unstated_assumption, undefined_failure_mode}` ("the spec is silent about X"). `ambiguity`, `contradiction`, `out_of_scope_creep`, and `other` still require exact labels - ambiguity is about vague language that IS present, not absence. Exact-label matching is still recorded in run details (`exact_kind_match=`) as a non-gating signal so taxonomy drift stays visible.
+
+### Model drift (R5.5, H2-extended)
+
+Baselines record the model id, and an always-run structural test (`tests/test_calibration.py::TestFixtureStructure::test_warns_when_calibration_model_differs_from_newest_baseline`) warns - never fails - when `RALPH_CALIBRATION_MODEL` differs from the newest baseline's recorded model. H2 extended: calibration re-runs on model change, not just prompt change; a detection rate measured against an older model does not transfer.
 
 ## Feedforward vs knowledge (E7)
 
@@ -130,7 +162,7 @@ Healthy state: empty file. Persistent non-zero values per build are the signal t
 1. **Correlated failure.** The architect, engineer, reviewer, security reviewer, and distiller can all be the same model. They will fail on the same inputs in the same way. Multi-model rotation (roadmap E1) was deliberately deferred; until it lands, treat "all roles agree" as one data point, not several.
 2. **`exhaustively_searched` is self-reported.** Both reviewer and security results expose the flag, but it cannot be verified at runtime. The trustworthy signal is calibration rate, not the flag.
 3. **Fact-utilization is a lower bound.** `measure_fact_utilization` uses a 30-character case-insensitive substring match. LLMs paraphrase, so a false negative just means we under-count.
-4. **Calibration baseline is non-deterministic.** LLMs vary; a single calibration run is one data point. Aggregate across multiple runs before trusting a detection rate as a stable measurement.
+4. **Calibration baseline is non-deterministic.** LLMs vary; the suite now runs each fixture `RALPH_CALIBRATION_RUNS` times (default 3) and reports per-fixture consistency (R5.1), but 3 runs is still a small sample - treat a consistency of 2/3 as "flaky", not as a precise 0.67.
 5. **Windows is not supported for concurrent worktrees.** `fcntl.flock` is POSIX-only (Phase A4); on Windows the lock is silently skipped and concurrent factory invocations against the same worktree directory can clobber each other.
 6. **The fact-injection prompt is trusted code.** A future model that ignores the engineer prompt's "treat as ground truth" framing could be misled by injected facts. The Phase A1 sanitizer is a defense-in-depth pattern, not a guarantee.
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -121,7 +121,8 @@ Invalid mode or threshold raises ValueError (Phase B8). Note: the `ralph_py fact
 | Env var | Default | Notes |
 |---|---|---|
 | `RALPH_RUN_CALIBRATION` | unset | Set to `1` to enable real-LLM calibration tests under `tests/test_calibration.py` |
-| `RALPH_CALIBRATION_MODEL` | `haiku` | Fast model used by the calibration suite |
+| `RALPH_CALIBRATION_MODEL` | `haiku` | Fast model used by the calibration suite. Changing it triggers the R5.5 model-drift warning until a fresh baseline is captured (H2-extended) |
+| `RALPH_CALIBRATION_RUNS` | `3` | Runs per fixture (R5.1). The suite gates on majority-of-runs consistency; use `1` for a cheap smoke, keep `3` for baseline capture |
 
 ## Patterns
 

--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -447,7 +447,11 @@ First principles: calibration must be able to detect a regression before we
 change the prompts it guards. So: tooling first, fixtures second, prompt edits
 third, all in one measured cycle.
 
-- [ ] R5.1 (M) **Calibration tooling** [T-cal findings]
+- [~] R5.1 (M) **Calibration tooling** [T-cal findings]
+  (tooling + threshold gates + synonym matcher landed; stays partial until
+  the user captures a baseline in the new v2 format with
+  `RALPH_RUN_CALIBRATION=1` - the assistant cannot run the real-LLM suite,
+  so green-at-baseline is asserted from recorded runs, not re-measured)
   - Baseline diff tool: `python -m ralph_py.calibration compare <old> <new>`
     with codified per-role thresholds; N-run mode (default 3) reporting
     per-fixture consistency; per-category (per-CWE for security) rates in the
@@ -488,7 +492,7 @@ third, all in one measured cycle.
     boundary-break so unrelated bullets stop inflating the count; fuzz corpus
     extended with the regression cases. (Substance stays out of scope: shape
     checks are documented as shape checks, per H4.)
-- [ ] R5.5 (S) **Model-bump trigger** [research topic 4]
+- [x] R5.5 (S) **Model-bump trigger** [research topic 4]
   - Baselines record the model id; a structural test warns when the configured
     calibration model differs from the latest baseline's, prompting a re-run.
     H2 extended: calibration re-runs on model change, not just prompt change.

--- a/ralph_py/calibration.py
+++ b/ralph_py/calibration.py
@@ -1,0 +1,687 @@
+"""Calibration tooling: baseline report format, comparison, and thresholds (R5.1/R5.5).
+
+The calibration suite (``tests/test_calibration.py``) measures whether each
+adversarial role catches its planted bugs. This module is the non-LLM half of
+that loop:
+
+- **Report format (v2)**: N runs per fixture with per-fixture consistency
+  (fraction of runs that detected the planted issue), per-role and
+  per-category detection rates, and the model id. ``build_report`` /
+  ``save_report`` are the single source of the on-disk shape under
+  ``tests/adversarial_fixtures/_results/``.
+- **Comparison**: ``python -m ralph_py.calibration compare <old.json> <new.json>``
+  diffs two baseline files (v1 or v2) and applies the codified thresholds
+  below. Exit code 0 = no regression, 1 = regression, 2 = usage/load error.
+  This is what H2's "compare against the baseline" concretely means.
+- **Kind synonyms**: the architect matcher accepts documented paraphrases of
+  the spec-issue taxonomy (see ``KIND_SYNONYM_GROUPS``) so a planted issue
+  reported under a sibling label is a hit, not a miss.
+- **Model drift (R5.5, H2-extended)**: ``model_drift_message`` compares the
+  configured calibration model against the newest recorded baseline's model
+  so the always-run structural test can warn that a re-calibration is due.
+  H2 extended: calibration re-runs on model change, not just prompt change.
+
+Detection-rate semantics: a fixture's *consistency* is
+``runs_detected / runs_completed`` (agent-infrastructure errors are excluded
+from the denominator; unparseable model output counts as a completed miss).
+A fixture is *detected* when its consistency reaches
+``FIXTURE_DETECTION_THRESHOLD`` (majority of completed runs). A role's
+*detection_rate* is the mean consistency across its fixtures - the expected
+single-run detection probability, which is what the thresholds gate on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Codified thresholds (R5.1) - the single source of truth for what counts as
+# a calibration regression. Documented in docs/adversarial-design.md.
+#
+# Sizing rationale (fixture counts as of R5.1: security 5, reviewer 3,
+# architect 3, architect_allowed_paths 1; default 3 runs per fixture):
+#
+# - FIXTURE_DETECTION_THRESHOLD = 0.5: a fixture counts as detected when a
+#   majority of its completed runs caught the planted issue (2 of 3 at the
+#   default run count). One flaky miss does not fail the suite; a fixture
+#   that misses most runs does.
+# - MAX_ROLE_DETECTION_DROP = 0.15: for a 3-fixture role at 3 runs, one
+#   run flipping is a drop of 1/9 ~ 0.11 (allowed as run-to-run variance);
+#   an entire fixture going dark is 1/3 ~ 0.33 (fails). For the 5-fixture
+#   security role: run flip 0.07 allowed, fixture loss 0.20 fails.
+# - MAX_CATEGORY_DETECTION_DROP = 0.40: categories often hold a single
+#   fixture, so at 3 runs one run flip is 0.33 (allowed) and two flips are
+#   0.67 (fails). Single-run (v1) baselines make any category flip a 1.0
+#   drop - category gating is only meaningful at N >= 3, which is why
+#   DEFAULT_CALIBRATION_RUNS is 3.
+# - MIN_ROLE_DETECTION_RATE: absolute floors on the NEW baseline,
+#   independent of the old one, so a slow multi-comparison slide cannot
+#   ratchet a role to zero. security 0.80 = at most one of five fixtures
+#   lost; reviewer/architect 0.65 = at least two of three caught.
+# ---------------------------------------------------------------------------
+
+DEFAULT_CALIBRATION_RUNS = 3
+FIXTURE_DETECTION_THRESHOLD = 0.5
+MAX_ROLE_DETECTION_DROP = 0.15
+MAX_CATEGORY_DETECTION_DROP = 0.40
+MIN_ROLE_DETECTION_RATE: dict[str, float] = {
+    "security": 0.80,
+    "reviewer": 0.65,
+    "architect": 0.65,
+    "architect_allowed_paths": 0.50,
+}
+DEFAULT_MIN_ROLE_DETECTION_RATE = 0.50
+
+REPORT_FORMAT_VERSION = 2
+
+# ---------------------------------------------------------------------------
+# Spec-issue kind synonyms (R5.1 matcher fix).
+#
+# DECOMPOSE_PROMPT's taxonomy separates ambiguity / missing_detail /
+# contradiction / unstated_assumption / undefined_failure_mode /
+# out_of_scope_creep / other, but the boundary inside the "the spec is
+# silent about X" family is a judgment call the model makes differently
+# run to run: "no audit log requirement" is simultaneously a missing
+# detail, an unstated assumption that auditing is not needed, and an
+# undefined failure mode. Every architect miss in the recorded baselines
+# (baseline-20260527-161822 spec-01, baseline-20260527-191337 and
+# baseline-20260527-195157 spec-02) is exactly this artifact: the planted
+# issue WAS reported, under a sibling label (missing_detail instead of
+# undefined_failure_mode / unstated_assumption).
+#
+# Groups are symmetric: a required kind is satisfied by any member of its
+# group. Kinds outside any group (ambiguity, contradiction,
+# out_of_scope_creep, other) only match themselves - ambiguity is about
+# vague language that IS present, not absence, and stays distinct.
+# Exact-label matching is still reported (``exact_kinds_present``) as a
+# non-gating signal so taxonomy drift stays visible in run details.
+# ---------------------------------------------------------------------------
+
+KIND_SYNONYM_GROUPS: tuple[frozenset[str], ...] = (
+    frozenset({"missing_detail", "unstated_assumption", "undefined_failure_mode"}),
+)
+
+
+def acceptable_kinds(required_kind: str) -> frozenset[str]:
+    """Return the set of emitted kinds that satisfy ``required_kind``."""
+    for group in KIND_SYNONYM_GROUPS:
+        if required_kind in group:
+            return group
+    return frozenset({required_kind})
+
+
+def required_kinds_satisfied(
+    required: Iterable[str], actual: Iterable[str],
+) -> bool:
+    """True when every required kind is present in ``actual`` up to synonyms."""
+    actual_set = set(actual)
+    return all(acceptable_kinds(kind) & actual_set for kind in required)
+
+
+def exact_kinds_present(required: Iterable[str], actual: Iterable[str]) -> bool:
+    """True when every required kind is present under its exact label."""
+    return set(required).issubset(set(actual))
+
+
+# ---------------------------------------------------------------------------
+# Consistency math
+# ---------------------------------------------------------------------------
+
+
+def consistency(runs_detected: int, runs_completed: int) -> float:
+    """Fraction of completed runs that detected the planted issue.
+
+    Zero completed runs (every run hit an agent-infrastructure error)
+    yields 0.0 - the caller is expected to have skipped such fixtures
+    before they reach a gate.
+    """
+    if runs_completed <= 0:
+        return 0.0
+    return runs_detected / runs_completed
+
+
+@dataclass(frozen=True)
+class FixtureStats:
+    """Aggregated result of running one fixture N times."""
+
+    role: str
+    fixture_id: str
+    category: str | None
+    cwe: str | None
+    runs_total: int
+    runs_errored: int
+    runs_detected: int
+
+    @property
+    def runs_completed(self) -> int:
+        return self.runs_total - self.runs_errored
+
+    @property
+    def consistency(self) -> float:
+        return consistency(self.runs_detected, self.runs_completed)
+
+    @property
+    def detected(self) -> bool:
+        return (
+            self.runs_completed > 0
+            and self.consistency >= FIXTURE_DETECTION_THRESHOLD
+        )
+
+
+def _mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def role_detection_rate(fixtures: Sequence[FixtureStats]) -> float:
+    """Mean per-fixture consistency: expected single-run detection rate."""
+    return _mean([f.consistency for f in fixtures])
+
+
+# ---------------------------------------------------------------------------
+# Baseline report: build / save / load
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Baseline:
+    """A parsed baseline file, normalized across format versions."""
+
+    path: Path | None
+    model: str
+    timestamp: str
+    format_version: int
+    runs_per_fixture: int
+    fixtures: tuple[FixtureStats, ...]
+
+    def roles(self) -> dict[str, list[FixtureStats]]:
+        grouped: dict[str, list[FixtureStats]] = {}
+        for fixture in self.fixtures:
+            grouped.setdefault(fixture.role, []).append(fixture)
+        return grouped
+
+    def role_rates(self) -> dict[str, float]:
+        return {
+            role: role_detection_rate(fixtures)
+            for role, fixtures in self.roles().items()
+        }
+
+    def category_rates(self) -> dict[str, dict[str, float]]:
+        """Per-role, per-category mean consistency. Unknown (None)
+        categories - v1 baselines predate category recording - are skipped."""
+        rates: dict[str, dict[str, float]] = {}
+        for role, fixtures in self.roles().items():
+            by_category: dict[str, list[float]] = {}
+            for fixture in fixtures:
+                if fixture.category is None:
+                    continue
+                by_category.setdefault(fixture.category, []).append(
+                    fixture.consistency
+                )
+            if by_category:
+                rates[role] = {
+                    category: _mean(values)
+                    for category, values in by_category.items()
+                }
+        return rates
+
+
+def build_report(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    model: str,
+    timestamp: str,
+    runs_per_fixture: int,
+) -> dict[str, Any]:
+    """Assemble the v2 report JSON from per-run records.
+
+    Each record is one run of one fixture:
+    ``{"role", "fixture_id", "category", "cwe", "caught", "error", "detail"}``
+    where ``error=True`` marks an agent-infrastructure failure (excluded
+    from the consistency denominator; a parse failure of model output is
+    NOT an error - it is a completed miss).
+    """
+    grouped: dict[tuple[str, str], list[Mapping[str, Any]]] = {}
+    order: list[tuple[str, str]] = []
+    for record in records:
+        key = (str(record["role"]), str(record["fixture_id"]))
+        if key not in grouped:
+            order.append(key)
+        grouped.setdefault(key, []).append(record)
+
+    fixtures_json: list[dict[str, Any]] = []
+    stats: list[FixtureStats] = []
+    for role, fixture_id in order:
+        runs = grouped[(role, fixture_id)]
+        errored = sum(1 for r in runs if bool(r.get("error")))
+        detected = sum(
+            1 for r in runs if bool(r.get("caught")) and not bool(r.get("error"))
+        )
+        first = runs[0]
+        fixture = FixtureStats(
+            role=role,
+            fixture_id=fixture_id,
+            category=(
+                str(first["category"]) if first.get("category") is not None else None
+            ),
+            cwe=str(first["cwe"]) if first.get("cwe") is not None else None,
+            runs_total=len(runs),
+            runs_errored=errored,
+            runs_detected=detected,
+        )
+        stats.append(fixture)
+        fixtures_json.append({
+            "role": fixture.role,
+            "fixture_id": fixture.fixture_id,
+            "category": fixture.category,
+            "cwe": fixture.cwe,
+            "runs_total": fixture.runs_total,
+            "runs_errored": fixture.runs_errored,
+            "runs_detected": fixture.runs_detected,
+            "consistency": fixture.consistency,
+            "detected": fixture.detected,
+            "runs": [
+                {
+                    "caught": bool(r.get("caught")),
+                    "error": bool(r.get("error")),
+                    "detail": str(r.get("detail", "")),
+                }
+                for r in runs
+            ],
+        })
+
+    summary: dict[str, Any] = {}
+    by_role: dict[str, list[FixtureStats]] = {}
+    for fixture in stats:
+        by_role.setdefault(fixture.role, []).append(fixture)
+    for role, fixtures in by_role.items():
+        role_summary: dict[str, Any] = {
+            "fixtures_total": len(fixtures),
+            "fixtures_detected": sum(1 for f in fixtures if f.detected),
+            "detection_rate": role_detection_rate(fixtures),
+        }
+        by_category: dict[str, list[float]] = {}
+        by_cwe: dict[str, list[float]] = {}
+        for fixture in fixtures:
+            if fixture.category is not None:
+                by_category.setdefault(fixture.category, []).append(
+                    fixture.consistency
+                )
+            if fixture.cwe is not None:
+                by_cwe.setdefault(fixture.cwe, []).append(fixture.consistency)
+        if by_category:
+            role_summary["by_category"] = {
+                category: {
+                    "fixtures_total": len(values),
+                    "detection_rate": _mean(values),
+                }
+                for category, values in by_category.items()
+            }
+        if by_cwe:
+            role_summary["by_cwe"] = {
+                cwe: {
+                    "fixtures_total": len(values),
+                    "detection_rate": _mean(values),
+                }
+                for cwe, values in by_cwe.items()
+            }
+        summary[role] = role_summary
+
+    return {
+        "format_version": REPORT_FORMAT_VERSION,
+        "model": model,
+        "timestamp": timestamp,
+        "runs_per_fixture": runs_per_fixture,
+        "summary": summary,
+        "fixtures": fixtures_json,
+    }
+
+
+def save_report(report: Mapping[str, Any], results_dir: Path) -> Path:
+    """Write a report to ``baseline-<timestamp>.json`` in ``results_dir``."""
+    results_dir.mkdir(parents=True, exist_ok=True)
+    out = results_dir / f"baseline-{report['timestamp']}.json"
+    out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    return out
+
+
+def load_baseline(path: Path) -> Baseline:
+    """Load and normalize a baseline file (v1 or v2).
+
+    v1 files (no ``format_version``) recorded a single boolean run per
+    fixture and no category metadata: they normalize to
+    ``runs_total=1`` with consistency 1.0/0.0 and ``category=None``.
+
+    Raises ``ValueError`` on malformed content.
+    """
+    try:
+        data: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read baseline {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"baseline {path} is not a JSON object")
+
+    format_version = int(data.get("format_version", 1))
+    raw_fixtures = data.get("fixtures")
+    if not isinstance(raw_fixtures, list):
+        raise ValueError(f"baseline {path} has no 'fixtures' list")
+
+    fixtures: list[FixtureStats] = []
+    for entry in raw_fixtures:
+        if not isinstance(entry, dict):
+            raise ValueError(f"baseline {path}: fixture entry is not an object")
+        role = str(entry.get("role", ""))
+        fixture_id = str(entry.get("fixture_id", ""))
+        if not role or not fixture_id:
+            raise ValueError(
+                f"baseline {path}: fixture entry missing role/fixture_id"
+            )
+        if format_version >= 2:
+            fixtures.append(FixtureStats(
+                role=role,
+                fixture_id=fixture_id,
+                category=(
+                    str(entry["category"])
+                    if entry.get("category") is not None else None
+                ),
+                cwe=str(entry["cwe"]) if entry.get("cwe") is not None else None,
+                runs_total=int(entry.get("runs_total", 0)),
+                runs_errored=int(entry.get("runs_errored", 0)),
+                runs_detected=int(entry.get("runs_detected", 0)),
+            ))
+        else:
+            fixtures.append(FixtureStats(
+                role=role,
+                fixture_id=fixture_id,
+                category=None,
+                cwe=None,
+                runs_total=1,
+                runs_errored=0,
+                runs_detected=1 if bool(entry.get("caught")) else 0,
+            ))
+
+    return Baseline(
+        path=path,
+        model=str(data.get("model", "unknown")),
+        timestamp=str(data.get("timestamp", "unknown")),
+        format_version=format_version,
+        runs_per_fixture=int(data.get("runs_per_fixture", 1)),
+        fixtures=tuple(fixtures),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RateDelta:
+    """Old-vs-new detection rate for one role (category=None) or category."""
+
+    role: str
+    category: str | None
+    old_rate: float | None
+    new_rate: float | None
+
+    @property
+    def drop(self) -> float:
+        if self.old_rate is None or self.new_rate is None:
+            return 0.0
+        return self.old_rate - self.new_rate
+
+
+@dataclass(frozen=True)
+class Comparison:
+    """Result of comparing two baselines under the codified thresholds."""
+
+    old: Baseline
+    new: Baseline
+    role_deltas: tuple[RateDelta, ...]
+    category_deltas: tuple[RateDelta, ...]
+    failures: tuple[str, ...]
+    warnings: tuple[str, ...]
+    newly_missed: tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        return not self.failures
+
+
+def min_role_rate(role: str) -> float:
+    return MIN_ROLE_DETECTION_RATE.get(role, DEFAULT_MIN_ROLE_DETECTION_RATE)
+
+
+def compare_baselines(old: Baseline, new: Baseline) -> Comparison:
+    """Diff two baselines and apply the threshold block.
+
+    Failures (regression, exit 1): a role's rate dropping more than
+    ``MAX_ROLE_DETECTION_DROP``; a role's new rate below its
+    ``MIN_ROLE_DETECTION_RATE`` floor; a category's rate dropping more
+    than ``MAX_CATEGORY_DETECTION_DROP``.
+
+    Warnings (reported, exit stays 0): roles/categories present in the
+    old baseline but absent from the new one (partial runs are
+    legitimate - e.g. an architect-only re-run after a DECOMPOSE_PROMPT
+    edit), and comparisons across different models (H2-extended: those
+    measure the model change, not the prompt change).
+    """
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    if old.model != new.model:
+        warnings.append(
+            f"comparing across models ({old.model!r} -> {new.model!r}): "
+            "deltas measure the model change, not a prompt change "
+            "(H2-extended: re-calibrate on model change)"
+        )
+
+    old_rates = old.role_rates()
+    new_rates = new.role_rates()
+
+    role_deltas: list[RateDelta] = []
+    for role in sorted(set(old_rates) | set(new_rates)):
+        old_rate = old_rates.get(role)
+        new_rate = new_rates.get(role)
+        delta = RateDelta(role=role, category=None, old_rate=old_rate, new_rate=new_rate)
+        role_deltas.append(delta)
+        if new_rate is None:
+            warnings.append(
+                f"role {role!r} present in old baseline but not exercised in new"
+            )
+            continue
+        if new_rate < min_role_rate(role):
+            failures.append(
+                f"role {role!r} detection rate {new_rate:.2f} is below its "
+                f"floor {min_role_rate(role):.2f}"
+            )
+        if old_rate is not None and delta.drop > MAX_ROLE_DETECTION_DROP:
+            failures.append(
+                f"role {role!r} detection rate dropped "
+                f"{old_rate:.2f} -> {new_rate:.2f} "
+                f"(drop {delta.drop:.2f} > {MAX_ROLE_DETECTION_DROP:.2f})"
+            )
+
+    old_categories = old.category_rates()
+    new_categories = new.category_rates()
+    category_deltas: list[RateDelta] = []
+    for role in sorted(set(old_categories) | set(new_categories)):
+        old_by_cat = old_categories.get(role, {})
+        new_by_cat = new_categories.get(role, {})
+        if role not in new_rates:
+            continue  # whole role missing: already warned above
+        for category in sorted(set(old_by_cat) | set(new_by_cat)):
+            old_rate = old_by_cat.get(category)
+            new_rate = new_by_cat.get(category)
+            delta = RateDelta(
+                role=role, category=category, old_rate=old_rate, new_rate=new_rate,
+            )
+            category_deltas.append(delta)
+            if new_rate is None:
+                warnings.append(
+                    f"category {role}/{category} present in old baseline "
+                    "but not exercised in new"
+                )
+                continue
+            if old_rate is not None and delta.drop > MAX_CATEGORY_DETECTION_DROP:
+                failures.append(
+                    f"category {role}/{category} detection rate dropped "
+                    f"{old_rate:.2f} -> {new_rate:.2f} "
+                    f"(drop {delta.drop:.2f} > {MAX_CATEGORY_DETECTION_DROP:.2f})"
+                )
+
+    old_fixtures = {(f.role, f.fixture_id): f for f in old.fixtures}
+    new_fixtures = {(f.role, f.fixture_id): f for f in new.fixtures}
+    newly_missed = tuple(
+        f"{role}/{fixture_id}"
+        for (role, fixture_id), old_fixture in sorted(old_fixtures.items())
+        if old_fixture.detected
+        and (role, fixture_id) in new_fixtures
+        and not new_fixtures[(role, fixture_id)].detected
+    )
+
+    return Comparison(
+        old=old,
+        new=new,
+        role_deltas=tuple(role_deltas),
+        category_deltas=tuple(category_deltas),
+        failures=tuple(failures),
+        warnings=tuple(warnings),
+        newly_missed=newly_missed,
+    )
+
+
+def _format_rate(rate: float | None) -> str:
+    return "-" if rate is None else f"{rate:.2f}"
+
+
+def format_comparison(comparison: Comparison) -> str:
+    """Human-readable comparison report."""
+    old, new = comparison.old, comparison.new
+    lines: list[str] = [
+        "calibration compare",
+        f"  old: {old.path} (model={old.model}, "
+        f"runs={old.runs_per_fixture}, ts={old.timestamp})",
+        f"  new: {new.path} (model={new.model}, "
+        f"runs={new.runs_per_fixture}, ts={new.timestamp})",
+        "",
+        "per-role detection rate (mean per-fixture consistency):",
+    ]
+    for delta in comparison.role_deltas:
+        floor = min_role_rate(delta.role)
+        lines.append(
+            f"  {delta.role:<26} {_format_rate(delta.old_rate)} -> "
+            f"{_format_rate(delta.new_rate)}  (floor {floor:.2f})"
+        )
+    if comparison.category_deltas:
+        lines.append("")
+        lines.append("per-category detection rate:")
+        for delta in comparison.category_deltas:
+            lines.append(
+                f"  {delta.role}/{delta.category or '?':<24} "
+                f"{_format_rate(delta.old_rate)} -> {_format_rate(delta.new_rate)}"
+            )
+    if comparison.newly_missed:
+        lines.append("")
+        lines.append("fixtures newly missed (detected in old, not in new):")
+        for name in comparison.newly_missed:
+            lines.append(f"  {name}")
+    if comparison.warnings:
+        lines.append("")
+        lines.append("warnings:")
+        for warning in comparison.warnings:
+            lines.append(f"  WARN: {warning}")
+    lines.append("")
+    if comparison.passed:
+        lines.append("PASS: no calibration regression under the codified thresholds")
+    else:
+        lines.append("FAIL: calibration regression detected:")
+        for failure in comparison.failures:
+            lines.append(f"  FAIL: {failure}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Model drift (R5.5, H2-extended)
+# ---------------------------------------------------------------------------
+
+
+class CalibrationModelDriftWarning(UserWarning):
+    """The configured calibration model differs from the newest baseline's."""
+
+
+def newest_baseline_path(results_dir: Path) -> Path | None:
+    """Newest ``baseline-*.json`` by filename (baseline-YYYYMMDD-HHMMSS.json
+    sorts lexicographically = chronologically)."""
+    if not results_dir.is_dir():
+        return None
+    candidates = sorted(results_dir.glob("baseline-*.json"))
+    return candidates[-1] if candidates else None
+
+
+def model_drift_message(results_dir: Path, configured_model: str) -> str | None:
+    """Return a warning message when ``configured_model`` differs from the
+    newest baseline's recorded model, else None.
+
+    Tolerates a missing results dir, no baselines, or a malformed newest
+    baseline (all return None): this feeds an always-run structural test
+    that must warn, never fail (R5.5).
+    """
+    path = newest_baseline_path(results_dir)
+    if path is None:
+        return None
+    try:
+        baseline = load_baseline(path)
+    except ValueError:
+        return None
+    if baseline.model == configured_model:
+        return None
+    return (
+        f"configured calibration model {configured_model!r} differs from the "
+        f"newest baseline's model {baseline.model!r} ({path.name}). "
+        "H2-extended: calibration must be re-run on model change, not just "
+        "prompt change - capture a fresh baseline with "
+        "RALPH_RUN_CALIBRATION=1 before trusting detection rates."
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI: python -m ralph_py.calibration compare <old.json> <new.json>
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m ralph_py.calibration",
+        description="Calibration baseline tooling (R5.1).",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    compare_parser = subparsers.add_parser(
+        "compare",
+        help="Diff two baseline JSONs under the codified thresholds; "
+        "exit 1 on regression.",
+    )
+    compare_parser.add_argument("old", type=Path, help="older baseline JSON")
+    compare_parser.add_argument("new", type=Path, help="newer baseline JSON")
+    args = parser.parse_args(argv)
+
+    if args.command == "compare":
+        try:
+            old = load_baseline(args.old)
+            new = load_baseline(args.new)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        comparison = compare_baselines(old, new)
+        print(format_comparison(comparison))
+        return 0 if comparison.passed else 1
+    return 2  # pragma: no cover - argparse enforces the subcommand
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/adversarial_fixtures/_results/README.md
+++ b/tests/adversarial_fixtures/_results/README.md
@@ -1,0 +1,32 @@
+# Calibration baseline results
+
+One `baseline-<UTC-timestamp>.json` per calibration run of
+`tests/test_calibration.py` (opt-in via `RALPH_RUN_CALIBRATION=1`).
+Compare two files with:
+
+```bash
+uv run python -m ralph_py.calibration compare <old.json> <new.json>
+```
+
+## Format v2 (R5.1, `"format_version": 2`)
+
+Defined by `ralph_py/calibration.py` (`build_report` / `load_baseline`).
+
+- Header: `model` (calibration model id - R5.5 warns when it drifts from
+  the configured model), `timestamp`, `runs_per_fixture`
+  (`RALPH_CALIBRATION_RUNS`, default 3).
+- `fixtures[]`: one entry per fixture with `runs_total`, `runs_errored`
+  (agent-infrastructure failures, excluded from the consistency
+  denominator), `runs_detected`, `consistency` (= detected/completed),
+  `detected` (consistency >= 0.5), `category`, `cwe` (security only),
+  and the per-run `runs[]` detail.
+- `summary`: per role - `fixtures_total`, `fixtures_detected`,
+  `detection_rate` (mean per-fixture consistency), `by_category`, and
+  `by_cwe` for security.
+
+## Format v1 (pre-R5.1, no `format_version` key)
+
+Single run per fixture (`caught` boolean), no category metadata. The
+three `baseline-20260527-*.json` files are v1; keep them - they are the
+comparison anchor for the first v2 capture, and the tooling still loads
+them (v1 normalizes to `runs_total=1`).

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -9,10 +9,18 @@ burn API tokens.
 When run, the suite iterates over fixtures in
 ``tests/adversarial_fixtures/{security,concerns,specs}/``, feeds each
 fixture's diff or spec to the corresponding role prompt against a
-fast model (Haiku-class), and asserts the planted issue is caught.
-Per-role detection rates are written to
-``tests/adversarial_fixtures/_results/baseline-<UTC-date>.json`` so
-future prompt edits can be compared against the baseline.
+fast model (Haiku-class), and gates on detection over
+``RALPH_CALIBRATION_RUNS`` runs per fixture (default 3, R5.1): a
+fixture passes when a majority of its completed runs catch the
+planted issue (``calibration.FIXTURE_DETECTION_THRESHOLD``), so
+single-run LLM variance is reported as consistency instead of
+failing the suite, while a fixture that misses most runs is a
+regression and fails. Results (per-fixture consistency, per-role and
+per-category detection rates, the model id) are written to
+``tests/adversarial_fixtures/_results/baseline-<UTC-date>.json`` in
+the v2 format defined by :mod:`ralph_py.calibration`; compare against
+a previous baseline with
+``python -m ralph_py.calibration compare <old.json> <new.json>``.
 
 Why this matters: the entire adversarial-roles design relies on the
 LLM actually behaving adversarially under the framing. Without
@@ -23,12 +31,14 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Iterator
+import warnings
+from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
+from ralph_py import calibration
 from ralph_py.decompose import (
     DECOMPOSE_PROMPT,
     SpecIssue,
@@ -46,6 +56,11 @@ from ralph_py.security import (
 
 CALIBRATION_ENABLED = os.environ.get("RALPH_RUN_CALIBRATION") == "1"
 CALIBRATION_MODEL = os.environ.get("RALPH_CALIBRATION_MODEL", "haiku")
+CALIBRATION_RUNS = int(
+    os.environ.get(
+        "RALPH_CALIBRATION_RUNS", str(calibration.DEFAULT_CALIBRATION_RUNS),
+    )
+)
 
 FIXTURES_DIR = Path(__file__).parent / "adversarial_fixtures"
 RESULTS_DIR = FIXTURES_DIR / "_results"
@@ -209,22 +224,31 @@ def architect_caught(
     """Return ``(caught, detail)`` for the architect spec-issue matcher.
 
     Catches when: total issue count >= ``spec_issues_min``, every kind
-    in ``must_include_kind`` is present, and (when
-    ``blocker_or_major == True``) at least one issue is blocker or
-    major severity.
+    in ``must_include_kind`` is present *up to the documented synonym
+    map* (``calibration.KIND_SYNONYM_GROUPS`` - R5.1: the recorded
+    baselines show the model paraphrases within the spec-silence
+    family, so an exact-label demand grades taxonomy vocabulary, not
+    detection), and (when ``blocker_or_major == True``) at least one
+    issue is blocker or major severity. Whether the exact labels were
+    used is reported in the detail as a non-gating signal.
     """
     min_count = requirement.get("spec_issues_min", 1)
-    required_kinds = set(requirement.get("must_include_kind", []))
+    required_kinds = list(requirement.get("must_include_kind", []))
     must_be_major_or_blocker = requirement.get("blocker_or_major", False)
+    actual_kinds = {i.kind for i in issues}
     caught = (
         len(issues) >= min_count
-        and (not required_kinds or required_kinds.issubset({i.kind for i in issues}))
+        and calibration.required_kinds_satisfied(required_kinds, actual_kinds)
         and (
             not must_be_major_or_blocker
             or any(i.severity in {"blocker", "major"} for i in issues)
         )
     )
-    detail = f"got {len(issues)} issues: {[(i.severity, i.kind) for i in issues]}"
+    exact = calibration.exact_kinds_present(required_kinds, actual_kinds)
+    detail = (
+        f"got {len(issues)} issues (exact_kind_match={exact}): "
+        f"{[(i.severity, i.kind) for i in issues]}"
+    )
     return caught, detail
 
 
@@ -318,46 +342,49 @@ def architect_allowed_paths_caught(
 
 
 # ---------------------------------------------------------------------------
-# Detection rate report
+# Detection report (v2 format, built by ralph_py.calibration)
 # ---------------------------------------------------------------------------
 
 
 class _DetectionReport:
+    """Accumulates one record per RUN (not per fixture) and delegates
+    aggregation + the on-disk format to :mod:`ralph_py.calibration`."""
+
     def __init__(self) -> None:
-        self.results: list[dict] = []
+        self.records: list[dict] = []
 
     def record(
-        self, role: str, fixture_id: str, caught: bool, detail: str = "",
+        self,
+        role: str,
+        fixture_id: str,
+        caught: bool,
+        detail: str = "",
+        *,
+        category: str | None = None,
+        cwe: str | None = None,
+        error: bool = False,
     ) -> None:
-        self.results.append({
+        self.records.append({
             "role": role,
             "fixture_id": fixture_id,
+            "category": category,
+            "cwe": cwe,
             "caught": caught,
+            "error": error,
             "detail": detail,
         })
 
-    def save(self) -> Path:
-        RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    def save(self) -> Path | None:
+        if not self.records:
+            return None
         date_str = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
-        out = RESULTS_DIR / f"baseline-{date_str}.json"
-        summary: dict[str, dict] = {}
-        for entry in self.results:
-            role = entry["role"]
-            s = summary.setdefault(role, {"total": 0, "caught": 0})
-            s["total"] += 1
-            if entry["caught"]:
-                s["caught"] += 1
-        for counts in summary.values():
-            counts["detection_rate"] = (
-                counts["caught"] / counts["total"] if counts["total"] else 0.0
-            )
-        out.write_text(json.dumps({
-            "model": CALIBRATION_MODEL,
-            "timestamp": date_str,
-            "summary": summary,
-            "fixtures": self.results,
-        }, indent=2))
-        return out
+        report_data = calibration.build_report(
+            self.records,
+            model=CALIBRATION_MODEL,
+            timestamp=date_str,
+            runs_per_fixture=CALIBRATION_RUNS,
+        )
+        return calibration.save_report(report_data, RESULTS_DIR)
 
 
 @pytest.fixture(scope="module")
@@ -365,7 +392,64 @@ def report() -> Iterator[_DetectionReport]:
     r = _DetectionReport()
     yield r
     saved = r.save()
-    print(f"\nCalibration report saved to {saved}")
+    if saved is not None:
+        print(f"\nCalibration report saved to {saved}")
+
+
+# ---------------------------------------------------------------------------
+# N-run threshold gate (R5.1)
+#
+# Each fixture test runs the role CALIBRATION_RUNS times and gates on
+# consistency (fraction of completed runs that caught the planted
+# issue) instead of hard-asserting a single run. Agent-infrastructure
+# errors (the CLI is unavailable, the process dies) are excluded from
+# the denominator; unparseable model output is a completed miss - a
+# role that emits garbage failed to behave, which is exactly what
+# calibration measures.
+# ---------------------------------------------------------------------------
+
+
+class _AgentUnavailable(Exception):
+    """The agent could not run at all (infrastructure, not behavior)."""
+
+
+def _gate_on_consistency(
+    role: str,
+    fixture_id: str,
+    report: _DetectionReport,
+    run_once: Callable[[], tuple[bool, str]],
+    *,
+    category: str | None = None,
+    cwe: str | None = None,
+) -> None:
+    """Run ``run_once`` CALIBRATION_RUNS times, record every run, then
+    assert the fixture's consistency meets the codified threshold."""
+    detected = 0
+    errored = 0
+    details: list[str] = []
+    for run_index in range(CALIBRATION_RUNS):
+        try:
+            caught, detail = run_once()
+            error = False
+        except _AgentUnavailable as exc:
+            caught, detail, error = False, f"agent error: {exc}", True
+            errored += 1
+        if caught:
+            detected += 1
+        details.append(f"run {run_index + 1}: caught={caught} {detail}")
+        report.record(
+            role, fixture_id, caught, detail,
+            category=category, cwe=cwe, error=error,
+        )
+    completed = CALIBRATION_RUNS - errored
+    if completed == 0:
+        pytest.skip(f"agent unavailable for all {CALIBRATION_RUNS} runs")
+    observed = calibration.consistency(detected, completed)
+    assert observed >= calibration.FIXTURE_DETECTION_THRESHOLD, (
+        f"{role} missed planted issue {fixture_id} in most runs: "
+        f"consistency {detected}/{completed} = {observed:.2f} < "
+        f"{calibration.FIXTURE_DETECTION_THRESHOLD}\n" + "\n".join(details)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -386,23 +470,19 @@ def test_security_role_catches_planted_bug(
         diff_content=diff_content,
     )
 
-    agent = _get_calibration_agent()
-    output: list[str] = []
-    try:
-        output = _collect(agent, prompt, tmp_path)
-    except Exception as exc:  # noqa: BLE001
-        report.record("security", meta["fixture_id"], False, f"agent error: {exc}")
-        pytest.skip(f"agent unavailable: {exc}")
+    def run_once() -> tuple[bool, str]:
+        agent = _get_calibration_agent()
+        try:
+            output = _collect(agent, prompt, tmp_path)
+        except Exception as exc:  # noqa: BLE001
+            raise _AgentUnavailable(str(exc)) from exc
+        raw = _select_agent_output(agent, output)
+        result = parse_security_output(raw, SecurityMode.ADVISORY.value)
+        return security_caught(result, meta["must_detect"])
 
-    raw = _select_agent_output(agent, output)
-    result = parse_security_output(raw, SecurityMode.ADVISORY.value)
-
-    caught, detail = security_caught(result, meta["must_detect"])
-    report.record("security", meta["fixture_id"], caught, detail)
-    assert caught, (
-        f"Security role missed planted bug {meta['fixture_id']}: "
-        f"expected category={meta['must_detect']['category']}, "
-        f"got findings={[f.category for f in result.findings]}"
+    _gate_on_consistency(
+        "security", meta["fixture_id"], report, run_once,
+        category=meta["must_detect"]["category"], cwe=meta.get("cwe"),
     )
 
 
@@ -426,23 +506,19 @@ def test_reviewer_role_catches_planted_concern(
         verification_summary=_VERIFICATION_STUB,
     )
 
-    agent = _get_calibration_agent()
-    output: list[str] = []
-    try:
-        output = _collect(agent, prompt, tmp_path)
-    except Exception as exc:  # noqa: BLE001
-        report.record("reviewer", meta["fixture_id"], False, f"agent error: {exc}")
-        pytest.skip(f"agent unavailable: {exc}")
+    def run_once() -> tuple[bool, str]:
+        agent = _get_calibration_agent()
+        try:
+            output = _collect(agent, prompt, tmp_path)
+        except Exception as exc:  # noqa: BLE001
+            raise _AgentUnavailable(str(exc)) from exc
+        raw = _select_agent_output(agent, output)
+        result = parse_review_output(raw)
+        return reviewer_caught(result, meta["must_detect"])
 
-    raw = _select_agent_output(agent, output)
-    result = parse_review_output(raw)
-
-    caught, detail = reviewer_caught(result, meta["must_detect"])
-    report.record("reviewer", meta["fixture_id"], caught, detail)
-    assert caught, (
-        f"Reviewer missed planted concern {meta['fixture_id']}: "
-        f"expected category={meta['must_detect']['category']}, "
-        f"got concerns={[(c.category, c.severity) for c in result.concerns]}"
+    _gate_on_consistency(
+        "reviewer", meta["fixture_id"], report, run_once,
+        category=meta["must_detect"]["category"],
     )
 
 
@@ -464,27 +540,24 @@ def test_architect_role_flags_vague_spec(
         spec_content=spec_content,
     )
 
-    agent = _get_calibration_agent()
-    output: list[str] = []
-    try:
-        output = _collect(agent, prompt, tmp_path)
-    except Exception as exc:  # noqa: BLE001
-        report.record("architect", meta["fixture_id"], False, f"agent error: {exc}")
-        pytest.skip(f"agent unavailable: {exc}")
+    def run_once() -> tuple[bool, str]:
+        agent = _get_calibration_agent()
+        try:
+            output = _collect(agent, prompt, tmp_path)
+        except Exception as exc:  # noqa: BLE001
+            raise _AgentUnavailable(str(exc)) from exc
+        try:
+            data = _extract_agent_json(agent, output)
+        except ValueError as exc:
+            # Unparseable output is a completed behavioral miss, not
+            # an infrastructure error.
+            return False, f"json parse: {exc}"
+        issues = _parse_spec_issues(data)
+        return architect_caught(issues, meta["must_detect"])
 
-    try:
-        data = _extract_agent_json(agent, output)
-    except ValueError as exc:
-        report.record("architect", meta["fixture_id"], False, f"json parse: {exc}")
-        pytest.fail(f"Architect output did not parse for {meta['fixture_id']}: {exc}")
-        return  # unreachable but satisfies the type-checker
-
-    issues = _parse_spec_issues(data)
-
-    caught, detail = architect_caught(issues, meta["must_detect"])
-    report.record("architect", meta["fixture_id"], caught, detail)
-    assert caught, (
-        f"Architect missed planted vagueness in {meta['fixture_id']}: {detail}"
+    _gate_on_consistency(
+        "architect", meta["fixture_id"], report, run_once,
+        category="spec_issues",
     )
 
 
@@ -529,35 +602,23 @@ def test_architect_emits_sensible_allowed_paths(
         spec_content=spec_content,
     )
 
-    agent = _get_calibration_agent()
-    output: list[str] = []
-    try:
-        output = _collect(agent, prompt, tmp_path)
-    except Exception as exc:  # noqa: BLE001
-        report.record(
-            "architect_allowed_paths", meta["fixture_id"], False,
-            f"agent error: {exc}",
+    def run_once() -> tuple[bool, str]:
+        agent = _get_calibration_agent()
+        try:
+            output = _collect(agent, prompt, tmp_path)
+        except Exception as exc:  # noqa: BLE001
+            raise _AgentUnavailable(str(exc)) from exc
+        try:
+            data = _extract_agent_json(agent, output)
+        except ValueError as exc:
+            return False, f"json parse: {exc}"
+        return architect_allowed_paths_caught(
+            data, meta["must_emit_allowed_paths"],
         )
-        pytest.skip(f"agent unavailable: {exc}")
 
-    try:
-        data = _extract_agent_json(agent, output)
-    except ValueError as exc:
-        report.record(
-            "architect_allowed_paths", meta["fixture_id"], False,
-            f"json parse: {exc}",
-        )
-        pytest.fail(
-            f"Architect output did not parse for {meta['fixture_id']}: {exc}",
-        )
-        return
-
-    caught, detail = architect_allowed_paths_caught(
-        data, meta["must_emit_allowed_paths"],
-    )
-    report.record("architect_allowed_paths", meta["fixture_id"], caught, detail)
-    assert caught, (
-        f"Architect allowedPaths regression on {meta['fixture_id']}: {detail}"
+    _gate_on_consistency(
+        "architect_allowed_paths", meta["fixture_id"], report, run_once,
+        category="allowed_paths",
     )
 
 
@@ -645,4 +706,19 @@ class TestFixtureStructure:
                 assert "non_halting" in req
                 assert "every_component_has_allowed_paths" in req
 
-
+    def test_warns_when_calibration_model_differs_from_newest_baseline(
+        self,
+    ) -> None:
+        """R5.5 / H2-extended: calibration re-runs on model change, not
+        just prompt change. This structural check WARNS (never fails)
+        when the configured calibration model differs from the model
+        recorded in the newest baseline, because every recorded
+        detection rate was measured against that older model and does
+        not transfer."""
+        message = calibration.model_drift_message(RESULTS_DIR, CALIBRATION_MODEL)
+        if message is not None:
+            warnings.warn(
+                message,
+                calibration.CalibrationModelDriftWarning,
+                stacklevel=1,
+            )

--- a/tests/test_calibration_compare.py
+++ b/tests/test_calibration_compare.py
@@ -1,0 +1,500 @@
+"""R5.1/R5.5: unit tests for the calibration tooling in ralph_py.calibration.
+
+No LLM calls anywhere in this file. These tests prove:
+
+- consistency math (errored runs excluded from the denominator,
+  majority threshold gating);
+- the v2 report format (per-fixture runs, per-role and per-category
+  rates, model id) and its roundtrip through save/load;
+- v1 baseline normalization, including against the real v1 files
+  checked into tests/adversarial_fixtures/_results/;
+- the compare tool's codified thresholds: regression detected (role
+  drop, category drop, absolute floor), improvement passes, partial
+  runs and cross-model comparisons warn instead of failing;
+- the CLI exit-code contract (0 pass / 1 regression / 2 load error);
+- the R5.5 model-drift helper that backs the always-run warning test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ralph_py import calibration
+from ralph_py.calibration import Baseline, FixtureStats
+
+REPO_RESULTS_DIR = (
+    Path(__file__).parent / "adversarial_fixtures" / "_results"
+)
+
+
+def _fixture(
+    role: str,
+    fixture_id: str,
+    runs_detected: int,
+    *,
+    runs_total: int = 3,
+    runs_errored: int = 0,
+    category: str | None = None,
+    cwe: str | None = None,
+) -> FixtureStats:
+    return FixtureStats(
+        role=role,
+        fixture_id=fixture_id,
+        category=category,
+        cwe=cwe,
+        runs_total=runs_total,
+        runs_errored=runs_errored,
+        runs_detected=runs_detected,
+    )
+
+
+def _baseline(*fixtures: FixtureStats, model: str = "haiku") -> Baseline:
+    return Baseline(
+        path=None,
+        model=model,
+        timestamp="20260718-000000",
+        format_version=2,
+        runs_per_fixture=3,
+        fixtures=fixtures,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Consistency math
+# ---------------------------------------------------------------------------
+
+
+class TestConsistencyMath:
+    def test_consistency_is_detected_over_completed(self) -> None:
+        assert calibration.consistency(2, 3) == 2 / 3
+        assert calibration.consistency(0, 3) == 0.0
+        assert calibration.consistency(3, 3) == 1.0
+
+    def test_zero_completed_runs_yield_zero(self) -> None:
+        assert calibration.consistency(0, 0) == 0.0
+
+    def test_errored_runs_excluded_from_denominator(self) -> None:
+        """1 caught + 1 missed + 1 agent error = consistency 1/2, and
+        1/2 meets the majority threshold, so infra noise cannot turn a
+        detected fixture into a miss."""
+        fixture = _fixture("security", "sec-x", 1, runs_total=3, runs_errored=1)
+        assert fixture.runs_completed == 2
+        assert fixture.consistency == 0.5
+        assert fixture.detected
+
+    def test_minority_detection_is_not_detected(self) -> None:
+        assert not _fixture("architect", "spec-x", 1, runs_total=3).detected
+        assert _fixture("architect", "spec-x", 2, runs_total=3).detected
+
+    def test_all_runs_errored_is_not_detected(self) -> None:
+        fixture = _fixture(
+            "security", "sec-x", 0, runs_total=3, runs_errored=3,
+        )
+        assert not fixture.detected
+
+    def test_role_detection_rate_is_mean_consistency(self) -> None:
+        rate = calibration.role_detection_rate([
+            _fixture("architect", "a", 3),  # 1.0
+            _fixture("architect", "b", 1),  # 1/3
+        ])
+        assert rate == (1.0 + 1 / 3) / 2
+
+    def test_role_detection_rate_empty_is_zero(self) -> None:
+        assert calibration.role_detection_rate([]) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Report building + save/load roundtrip
+# ---------------------------------------------------------------------------
+
+
+def _run_record(
+    role: str,
+    fixture_id: str,
+    caught: bool,
+    *,
+    error: bool = False,
+    category: str | None = None,
+    cwe: str | None = None,
+) -> dict:
+    return {
+        "role": role,
+        "fixture_id": fixture_id,
+        "category": category,
+        "cwe": cwe,
+        "caught": caught,
+        "error": error,
+        "detail": "synthetic",
+    }
+
+
+class TestBuildReport:
+    def _report(self) -> dict:
+        records = [
+            # sec-a: 3 runs, 2 caught -> consistency 2/3, detected
+            _run_record("security", "sec-a", True, category="injection",
+                        cwe="CWE-89"),
+            _run_record("security", "sec-a", True, category="injection",
+                        cwe="CWE-89"),
+            _run_record("security", "sec-a", False, category="injection",
+                        cwe="CWE-89"),
+            # sec-b: 1 caught, 1 missed, 1 errored -> consistency 1/2
+            _run_record("security", "sec-b", True, category="auth_bypass",
+                        cwe="CWE-347"),
+            _run_record("security", "sec-b", False, category="auth_bypass",
+                        cwe="CWE-347"),
+            _run_record("security", "sec-b", False, error=True,
+                        category="auth_bypass", cwe="CWE-347"),
+            # architect fixture, no cwe
+            _run_record("architect", "spec-a", False, category="spec_issues"),
+            _run_record("architect", "spec-a", False, category="spec_issues"),
+            _run_record("architect", "spec-a", True, category="spec_issues"),
+        ]
+        return calibration.build_report(
+            records, model="haiku", timestamp="20260718-120000",
+            runs_per_fixture=3,
+        )
+
+    def test_report_header_records_model_and_format(self) -> None:
+        report = self._report()
+        assert report["format_version"] == calibration.REPORT_FORMAT_VERSION
+        assert report["model"] == "haiku"
+        assert report["runs_per_fixture"] == 3
+
+    def test_per_fixture_consistency_and_detail_kept(self) -> None:
+        report = self._report()
+        by_id = {f["fixture_id"]: f for f in report["fixtures"]}
+        assert by_id["sec-a"]["runs_detected"] == 2
+        assert by_id["sec-a"]["consistency"] == 2 / 3
+        assert by_id["sec-a"]["detected"] is True
+        assert len(by_id["sec-a"]["runs"]) == 3
+        # errored run excluded from denominator
+        assert by_id["sec-b"]["runs_errored"] == 1
+        assert by_id["sec-b"]["consistency"] == 0.5
+        # minority detection is not detected
+        assert by_id["spec-a"]["consistency"] == 1 / 3
+        assert by_id["spec-a"]["detected"] is False
+
+    def test_role_summary_rates(self) -> None:
+        report = self._report()
+        security = report["summary"]["security"]
+        assert security["fixtures_total"] == 2
+        assert security["fixtures_detected"] == 2
+        assert security["detection_rate"] == (2 / 3 + 0.5) / 2
+        architect = report["summary"]["architect"]
+        assert architect["fixtures_detected"] == 0
+
+    def test_per_category_and_per_cwe_rates(self) -> None:
+        report = self._report()
+        by_category = report["summary"]["security"]["by_category"]
+        assert by_category["injection"]["detection_rate"] == 2 / 3
+        assert by_category["auth_bypass"]["detection_rate"] == 0.5
+        by_cwe = report["summary"]["security"]["by_cwe"]
+        assert by_cwe["CWE-89"]["detection_rate"] == 2 / 3
+        assert "by_cwe" not in report["summary"]["architect"]
+
+    def test_save_load_roundtrip(self, tmp_path: Path) -> None:
+        report = self._report()
+        saved = calibration.save_report(report, tmp_path)
+        assert saved.name == "baseline-20260718-120000.json"
+        loaded = calibration.load_baseline(saved)
+        assert loaded.format_version == 2
+        assert loaded.model == "haiku"
+        assert loaded.runs_per_fixture == 3
+        rates = loaded.role_rates()
+        assert rates["security"] == (2 / 3 + 0.5) / 2
+        assert loaded.category_rates()["security"]["injection"] == 2 / 3
+
+
+class TestLoadV1Baseline:
+    def test_v1_fixture_normalizes_to_single_run(self, tmp_path: Path) -> None:
+        v1 = {
+            "model": "haiku",
+            "timestamp": "20260527-161822",
+            "summary": {},
+            "fixtures": [
+                {"role": "architect", "fixture_id": "spec-01",
+                 "caught": True, "detail": "..."},
+                {"role": "architect", "fixture_id": "spec-02",
+                 "caught": False, "detail": "..."},
+            ],
+        }
+        path = tmp_path / "baseline-20260527-161822.json"
+        path.write_text(json.dumps(v1))
+        baseline = calibration.load_baseline(path)
+        assert baseline.format_version == 1
+        assert baseline.runs_per_fixture == 1
+        assert baseline.role_rates() == {"architect": 0.5}
+        # v1 predates category recording
+        assert baseline.category_rates() == {}
+
+    def test_loads_real_checked_in_v1_baselines(self) -> None:
+        """The three recorded 20260527 baselines must stay loadable so
+        the first new-format capture can be compared against them."""
+        path = REPO_RESULTS_DIR / "baseline-20260527-161822.json"
+        baseline = calibration.load_baseline(path)
+        assert baseline.model == "haiku"
+        rates = baseline.role_rates()
+        assert rates["security"] == 1.0
+        assert rates["reviewer"] == 1.0
+        assert rates["architect"] == 2 / 3
+
+    def test_malformed_baseline_raises_value_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / "baseline-x.json"
+        bad.write_text("{not json")
+        try:
+            calibration.load_baseline(bad)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("expected ValueError for malformed JSON")
+
+
+# ---------------------------------------------------------------------------
+# Comparison thresholds
+# ---------------------------------------------------------------------------
+
+
+class TestCompareBaselines:
+    def test_improvement_passes(self) -> None:
+        old = _baseline(_fixture("architect", "spec-01", 2),
+                        _fixture("architect", "spec-02", 2))
+        new = _baseline(_fixture("architect", "spec-01", 3),
+                        _fixture("architect", "spec-02", 3))
+        comparison = calibration.compare_baselines(old, new)
+        assert comparison.passed
+        assert comparison.failures == ()
+
+    def test_role_drop_beyond_threshold_fails(self) -> None:
+        # 1.0 -> 2/3 is a drop of 1/3 > MAX_ROLE_DETECTION_DROP
+        old = _baseline(_fixture("architect", "spec-01", 3),
+                        _fixture("architect", "spec-02", 3),
+                        _fixture("architect", "spec-03", 3))
+        new = _baseline(_fixture("architect", "spec-01", 3),
+                        _fixture("architect", "spec-02", 3),
+                        _fixture("architect", "spec-03", 0))
+        comparison = calibration.compare_baselines(old, new)
+        assert not comparison.passed
+        assert any("architect" in f and "dropped" in f
+                   for f in comparison.failures)
+        assert "architect/spec-03" in comparison.newly_missed
+
+    def test_single_run_flip_is_within_tolerance(self) -> None:
+        """One run flipping on one fixture (drop 1/9 ~ 0.11) is
+        run-to-run variance, not a regression."""
+        old = _baseline(_fixture("architect", "spec-01", 3),
+                        _fixture("architect", "spec-02", 3),
+                        _fixture("architect", "spec-03", 3))
+        new = _baseline(_fixture("architect", "spec-01", 3),
+                        _fixture("architect", "spec-02", 3),
+                        _fixture("architect", "spec-03", 2))
+        comparison = calibration.compare_baselines(old, new)
+        assert comparison.passed
+
+    def test_new_rate_below_floor_fails_even_without_drop(self) -> None:
+        """The absolute floor stops a slow slide across successive
+        comparisons: old and new are equally bad, but the floor trips."""
+        old = _baseline(_fixture("security", "sec-01", 1),
+                        _fixture("security", "sec-02", 1))
+        new = _baseline(_fixture("security", "sec-01", 1),
+                        _fixture("security", "sec-02", 1))
+        comparison = calibration.compare_baselines(old, new)
+        assert not comparison.passed
+        assert any("floor" in f for f in comparison.failures)
+
+    def test_category_drop_beyond_threshold_fails(self) -> None:
+        """Category cat-a drops 1.0 -> 1/3 (drop 2/3 > 0.40) while the
+        role-level mean (drop 0.13, rate 0.87) stays inside both the
+        role allowance and the floor: the per-category gate catches a
+        regression the role-level averages would hide."""
+        old = _baseline(*[
+            _fixture("reviewer", f"c-{i}", 3, category=f"cat-{i}")
+            for i in "abcde"
+        ])
+        new = _baseline(
+            _fixture("reviewer", "c-a", 1, category="cat-a"),
+            *[
+                _fixture("reviewer", f"c-{i}", 3, category=f"cat-{i}")
+                for i in "bcde"
+            ],
+        )
+        comparison = calibration.compare_baselines(old, new)
+        assert not comparison.passed
+        assert any("reviewer/cat-a" in f for f in comparison.failures)
+        assert not any("floor" in f or "role" in f for f in comparison.failures)
+
+    def test_category_single_run_flip_tolerated(self) -> None:
+        old = _baseline(
+            _fixture("security", "sec-01", 3, category="injection"),
+            _fixture("security", "sec-02", 3, category="hardcoded_secret"),
+            _fixture("security", "sec-03", 3, category="auth_bypass"),
+        )
+        new = _baseline(
+            _fixture("security", "sec-01", 2, category="injection"),
+            _fixture("security", "sec-02", 3, category="hardcoded_secret"),
+            _fixture("security", "sec-03", 3, category="auth_bypass"),
+        )
+        comparison = calibration.compare_baselines(old, new)
+        assert comparison.passed
+
+    def test_role_missing_from_new_warns_but_passes(self) -> None:
+        """Partial runs are legitimate (e.g. architect-only re-run
+        after a DECOMPOSE_PROMPT edit): warn, do not fail."""
+        old = _baseline(_fixture("security", "sec-01", 3),
+                        _fixture("architect", "spec-01", 3))
+        new = _baseline(_fixture("architect", "spec-01", 3))
+        comparison = calibration.compare_baselines(old, new)
+        assert comparison.passed
+        assert any("not exercised" in w for w in comparison.warnings)
+
+    def test_cross_model_comparison_warns(self) -> None:
+        old = _baseline(_fixture("security", "sec-01", 3), model="haiku")
+        new = _baseline(_fixture("security", "sec-01", 3), model="sonnet")
+        comparison = calibration.compare_baselines(old, new)
+        assert comparison.passed
+        assert any("H2-extended" in w for w in comparison.warnings)
+
+    def test_v1_to_v2_comparison_works(self, tmp_path: Path) -> None:
+        """The first new-format capture will be compared against a
+        checked-in v1 baseline; that path must work end to end."""
+        old = calibration.load_baseline(
+            REPO_RESULTS_DIR / "baseline-20260527-161822.json",
+        )
+        new = _baseline(
+            _fixture("security", "sec-01-sql-injection", 3),
+            _fixture("security", "sec-02-command-injection", 3),
+            _fixture("security", "sec-03-hardcoded-secret", 3),
+            _fixture("security", "sec-04-predictable-token", 3),
+            _fixture("security", "sec-05-broken-jwt-verify", 3),
+            _fixture("reviewer", "concern-01-dead-code", 3),
+            _fixture("reviewer", "concern-02-tautological-test", 3),
+            _fixture("reviewer", "concern-03-scope-creep", 3),
+            _fixture("architect", "spec-01-no-error-handling", 3),
+            _fixture("architect", "spec-02-unspecified-auth", 3),
+            _fixture("architect", "spec-03-ambiguous-perf", 3),
+        )
+        comparison = calibration.compare_baselines(old, new)
+        assert comparison.passed
+
+    def test_format_comparison_mentions_verdict_and_rates(self) -> None:
+        old = _baseline(_fixture("architect", "spec-01", 3))
+        new = _baseline(_fixture("architect", "spec-01", 0))
+        text = calibration.format_comparison(
+            calibration.compare_baselines(old, new),
+        )
+        assert "FAIL" in text
+        assert "architect" in text
+
+    def test_min_role_rate_falls_back_to_default(self) -> None:
+        assert (
+            calibration.min_role_rate("brand_new_role")
+            == calibration.DEFAULT_MIN_ROLE_DETECTION_RATE
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCompareCli:
+    def _write(self, tmp_path: Path, name: str, fixtures: list[dict]) -> Path:
+        report = calibration.build_report(
+            fixtures, model="haiku", timestamp=name, runs_per_fixture=3,
+        )
+        return calibration.save_report(report, tmp_path / name)
+
+    def test_regression_exits_1(self, tmp_path: Path, capsys) -> None:
+        old = self._write(tmp_path, "old", [
+            _run_record("architect", "spec-01", True) for _ in range(3)
+        ])
+        new = self._write(tmp_path, "new", [
+            _run_record("architect", "spec-01", False) for _ in range(3)
+        ])
+        code = calibration.main(["compare", str(old), str(new)])
+        assert code == 1
+        out = capsys.readouterr().out
+        assert "FAIL" in out
+
+    def test_improvement_exits_0(self, tmp_path: Path, capsys) -> None:
+        records_old = [
+            _run_record("architect", "spec-01", i > 0) for i in range(3)
+        ]
+        records_new = [
+            _run_record("architect", "spec-01", True) for _ in range(3)
+        ]
+        old = self._write(tmp_path, "old", records_old)
+        new = self._write(tmp_path, "new", records_new)
+        code = calibration.main(["compare", str(old), str(new)])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "PASS" in out
+
+    def test_unreadable_baseline_exits_2(self, tmp_path: Path, capsys) -> None:
+        good = self._write(tmp_path, "old", [
+            _run_record("architect", "spec-01", True) for _ in range(3)
+        ])
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json")
+        code = calibration.main(["compare", str(good), str(bad)])
+        assert code == 2
+        err = capsys.readouterr().err
+        assert "error:" in err
+
+
+# ---------------------------------------------------------------------------
+# Model drift (R5.5)
+# ---------------------------------------------------------------------------
+
+
+class TestModelDrift:
+    def _write_baseline(
+        self, results_dir: Path, timestamp: str, model: str,
+    ) -> Path:
+        report = calibration.build_report(
+            [_run_record("architect", "spec-01", True)],
+            model=model, timestamp=timestamp, runs_per_fixture=1,
+        )
+        return calibration.save_report(report, results_dir)
+
+    def test_no_results_dir_is_silent(self, tmp_path: Path) -> None:
+        assert calibration.model_drift_message(
+            tmp_path / "missing", "haiku",
+        ) is None
+
+    def test_no_baselines_is_silent(self, tmp_path: Path) -> None:
+        assert calibration.model_drift_message(tmp_path, "haiku") is None
+
+    def test_matching_model_is_silent(self, tmp_path: Path) -> None:
+        self._write_baseline(tmp_path, "20260718-000000", "haiku")
+        assert calibration.model_drift_message(tmp_path, "haiku") is None
+
+    def test_differing_model_warns_citing_h2(self, tmp_path: Path) -> None:
+        self._write_baseline(tmp_path, "20260718-000000", "haiku")
+        message = calibration.model_drift_message(tmp_path, "sonnet")
+        assert message is not None
+        assert "H2-extended" in message
+        assert "haiku" in message and "sonnet" in message
+
+    def test_newest_baseline_by_filename_wins(self, tmp_path: Path) -> None:
+        """Filename timestamps sort chronologically; only the newest
+        baseline's model matters."""
+        self._write_baseline(tmp_path, "20260101-000000", "sonnet")
+        self._write_baseline(tmp_path, "20260718-000000", "haiku")
+        assert calibration.model_drift_message(tmp_path, "haiku") is None
+        assert calibration.model_drift_message(tmp_path, "sonnet") is not None
+
+    def test_malformed_newest_baseline_is_silent(self, tmp_path: Path) -> None:
+        """The always-run structural test must never fail on a corrupt
+        results file: warn-path only, silence on unreadable input."""
+        (tmp_path / "baseline-99999999-999999.json").write_text("{not json")
+        assert calibration.model_drift_message(tmp_path, "haiku") is None
+
+    def test_repo_baselines_match_default_model(self) -> None:
+        """The checked-in baselines were captured with the default
+        calibration model; if this fails, someone changed the default
+        without re-calibrating (H2-extended)."""
+        assert calibration.model_drift_message(
+            REPO_RESULTS_DIR, "haiku",
+        ) is None

--- a/tests/test_calibration_matchers.py
+++ b/tests/test_calibration_matchers.py
@@ -14,11 +14,13 @@ guarantees they at least *evaluate correctly* against the input shape
 they expect, even when nobody runs the LLM-driven integration.
 
 Tests are organized by role: TestSecurityMatcher / TestReviewerMatcher /
-TestArchitectMatcher.
+TestArchitectMatcher, plus TestKindSynonyms for the R5.1 synonym map
+that de-brittles the architect's ``must_include_kind`` matching.
 """
 
 from __future__ import annotations
 
+from ralph_py import calibration
 from ralph_py.decompose import SpecIssue
 from ralph_py.review import (
     CriterionReview,
@@ -323,19 +325,66 @@ class TestArchitectMatcher:
         })
         assert not caught
 
-    def test_no_match_when_required_kind_not_present(self) -> None:
+    def test_paraphrased_kind_within_synonym_family_is_a_hit(self) -> None:
         """This is the spec-01 case from the F5 baseline -- 8 blocker
-        issues but no ``undefined_failure_mode``. Strict matcher fails."""
+        issues, the planted failure-mode issue reported as
+        ``missing_detail`` instead of ``undefined_failure_mode``. The
+        strict matcher graded taxonomy vocabulary and failed; under the
+        R5.1 synonym map the paraphrase is a hit."""
         issues = [
             SpecIssue(kind="missing_detail", severity="blocker", summary="..."),
             SpecIssue(kind="missing_detail", severity="blocker", summary="..."),
             SpecIssue(kind="ambiguity", severity="blocker", summary="..."),
         ]
-        caught, _ = architect_caught(issues, {
+        caught, detail = architect_caught(issues, {
             "spec_issues_min": 2,
             "must_include_kind": ["undefined_failure_mode", "missing_detail"],
         })
+        assert caught
+        # The exact-label signal stays visible in the detail (non-gating).
+        assert "exact_kind_match=False" in detail
+
+    def test_spec_02_unstated_assumption_paraphrase_is_a_hit(self) -> None:
+        """The other recorded matcher artifact: spec-02 requires
+        ``unstated_assumption`` and the model reports it as
+        ``missing_detail`` (baselines 20260527-191337 / -195157)."""
+        issues = [
+            SpecIssue(kind="missing_detail", severity="blocker", summary="..."),
+            SpecIssue(kind="missing_detail", severity="major", summary="..."),
+        ]
+        caught, _ = architect_caught(issues, {
+            "spec_issues_min": 2,
+            "must_include_kind": ["missing_detail", "unstated_assumption"],
+            "blocker_or_major": True,
+        })
+        assert caught
+
+    def test_no_match_when_required_kind_outside_synonym_family(self) -> None:
+        """Kinds outside the spec-silence family still demand an exact
+        label: a required ``contradiction`` is NOT satisfied by any
+        number of missing_detail / ambiguity issues."""
+        issues = [
+            SpecIssue(kind="missing_detail", severity="blocker", summary="..."),
+            SpecIssue(kind="ambiguity", severity="blocker", summary="..."),
+        ]
+        caught, _ = architect_caught(issues, {
+            "spec_issues_min": 2,
+            "must_include_kind": ["contradiction"],
+        })
         assert not caught
+
+    def test_exact_kind_match_reported_true_when_labels_exact(self) -> None:
+        issues = [
+            SpecIssue(
+                kind="undefined_failure_mode", severity="blocker", summary="...",
+            ),
+        ]
+        caught, detail = architect_caught(issues, {
+            "spec_issues_min": 1,
+            "must_include_kind": ["undefined_failure_mode"],
+        })
+        assert caught
+        assert "exact_kind_match=True" in detail
 
     def test_no_match_when_blocker_or_major_required_but_only_minor(self) -> None:
         issues = [
@@ -388,3 +437,75 @@ class TestArchitectMatcher:
         empty: list[SpecIssue] = []
         caught_empty, _ = architect_caught(empty, {})
         assert not caught_empty
+
+
+# ---------------------------------------------------------------------------
+# Kind synonym map (R5.1)
+# ---------------------------------------------------------------------------
+
+
+class TestKindSynonyms:
+    """Unit tests for ``calibration.KIND_SYNONYM_GROUPS`` and its helpers.
+
+    The map exists because the boundary inside the "spec is silent
+    about X" family (missing_detail / unstated_assumption /
+    undefined_failure_mode) is a judgment call the model makes
+    differently run to run; every architect miss in the recorded
+    baselines is a paraphrase within that family.
+    """
+
+    def test_family_members_accept_each_other(self) -> None:
+        family = {"missing_detail", "unstated_assumption", "undefined_failure_mode"}
+        for required in family:
+            for actual in family:
+                assert calibration.required_kinds_satisfied([required], [actual]), (
+                    f"{required} should be satisfied by {actual}"
+                )
+
+    def test_non_family_kinds_only_match_themselves(self) -> None:
+        for kind in ("ambiguity", "contradiction", "out_of_scope_creep", "other"):
+            assert calibration.acceptable_kinds(kind) == frozenset({kind})
+            assert not calibration.required_kinds_satisfied(
+                [kind], ["missing_detail"],
+            )
+            assert calibration.required_kinds_satisfied([kind], [kind])
+
+    def test_ambiguity_not_satisfied_by_silence_family(self) -> None:
+        """Ambiguity is about vague language that IS present, not
+        absence: it deliberately stays outside the synonym family."""
+        assert not calibration.required_kinds_satisfied(
+            ["ambiguity"], ["missing_detail", "unstated_assumption"],
+        )
+
+    def test_all_required_kinds_must_be_satisfied(self) -> None:
+        assert not calibration.required_kinds_satisfied(
+            ["missing_detail", "contradiction"], ["missing_detail"],
+        )
+        assert calibration.required_kinds_satisfied(
+            ["missing_detail", "contradiction"],
+            ["unstated_assumption", "contradiction"],
+        )
+
+    def test_empty_required_kinds_always_satisfied(self) -> None:
+        assert calibration.required_kinds_satisfied([], [])
+        assert calibration.required_kinds_satisfied([], ["anything"])
+
+    def test_exact_kinds_present_ignores_synonyms(self) -> None:
+        assert not calibration.exact_kinds_present(
+            ["undefined_failure_mode"], ["missing_detail"],
+        )
+        assert calibration.exact_kinds_present(
+            ["undefined_failure_mode"], ["undefined_failure_mode"],
+        )
+
+    def test_synonym_groups_stay_within_decompose_taxonomy(self) -> None:
+        """Guard against a synonym group drifting away from the
+        DECOMPOSE taxonomy: every member must be a valid spec-issue
+        kind that ``_parse_spec_issues`` would accept."""
+        from ralph_py.decompose import _VALID_KINDS
+
+        for group in calibration.KIND_SYNONYM_GROUPS:
+            assert group <= _VALID_KINDS, (
+                f"synonym group {sorted(group)} contains kinds outside "
+                f"the DECOMPOSE taxonomy {sorted(_VALID_KINDS)}"
+            )


### PR DESCRIPTION
## Roadmap items

- **R5.1 (Calibration tooling)** - marked `[~]` partial: tooling, threshold gates, and the synonym matcher landed; it stays partial until a baseline in the new v2 format exists (capture commands at the bottom - the assistant cannot run the real-LLM suite).
- **R5.5 (Model-bump trigger)** - marked `[x]`.

## What changed

- **New `ralph_py/calibration.py`** - the non-LLM half of the calibration loop:
  - `python -m ralph_py.calibration compare <old.json> <new.json>`: per-role and per-category (per-CWE for security) deltas, exit 0 = pass / 1 = regression / 2 = load error. Loads both the checked-in v1 baselines and the new v2 format.
  - Codified thresholds in one documented constants block: `MAX_ROLE_DETECTION_DROP=0.15`, `MAX_CATEGORY_DETECTION_DROP=0.40`, per-role `MIN_ROLE_DETECTION_RATE` floors, `FIXTURE_DETECTION_THRESHOLD=0.5`, `DEFAULT_CALIBRATION_RUNS=3` (sizing rationale inline and in docs/adversarial-design.md).
  - v2 report format: per-fixture consistency over N runs (agent-infra errors excluded from the denominator; unparseable model output is a completed miss), per-role/per-category/per-CWE rates, run count, model id.
- **N-run mode**: `RALPH_CALIBRATION_RUNS` (default 3). Per-fixture hard asserts converted to majority-of-completed-runs consistency gates, so single-run LLM variance is reported as consistency instead of failing the suite, while a fixture missing most runs still fails (red on regression).
- **Matcher de-brittling**: `must_include_kind` now matches up to the documented symmetric synonym family `{missing_detail, unstated_assumption, undefined_failure_mode}` (`calibration.KIND_SYNONYM_GROUPS`). Every architect miss in the three recorded 20260527 baselines was this exact artifact (planted issue reported under a sibling label). `ambiguity`/`contradiction`/`out_of_scope_creep`/`other` still require exact labels; exact-label match is reported per run (`exact_kind_match=`) as a non-gating signal.
- **R5.5**: baselines record the model id; a new always-run structural test WARNS (never fails) via `CalibrationModelDriftWarning` when `RALPH_CALIBRATION_MODEL` differs from the newest baseline's recorded model, citing H2-extended (re-calibrate on model change, not just prompt change).
- Docs: usage + thresholds + synonym policy in `docs/adversarial-design.md`, `RALPH_CALIBRATION_RUNS` in `docs/env-vars.md`, format spec in `tests/adversarial_fixtures/_results/README.md`.
- **No prompt body, `*_PROMPT_VERSION`, or snapshot was touched** (per Shared rules #3).

## Tested

Behaviors proven by named tests (no LLM calls):

- Compare tool detects regression / passes improvement: `TestCompareBaselines::test_role_drop_beyond_threshold_fails`, `::test_improvement_passes`, `::test_single_run_flip_is_within_tolerance` (1 run-flip on a 3-fixture role is tolerated, a whole-fixture loss fails).
- Absolute floor stops a no-drop slide: `::test_new_rate_below_floor_fails_even_without_drop`.
- Per-category gate catches what role-level averaging hides: `::test_category_drop_beyond_threshold_fails`; single run flip per category tolerated: `::test_category_single_run_flip_tolerated`.
- Partial runs and cross-model comparisons warn instead of failing: `::test_role_missing_from_new_warns_but_passes`, `::test_cross_model_comparison_warns`.
- CLI exit-code contract 0/1/2: `TestCompareCli` (all three).
- Consistency math incl. errored-run exclusion and majority gating: `TestConsistencyMath` (6 tests).
- v2 report shape + save/load roundtrip + per-CWE rates: `TestBuildReport` (5 tests).
- v1 normalization against the real checked-in 20260527 baselines, and a v1-old vs v2-new comparison end to end: `TestLoadV1Baseline::test_loads_real_checked_in_v1_baselines`, `TestCompareBaselines::test_v1_to_v2_comparison_works`.
- Synonym matcher: both recorded architect-miss artifacts (spec-01, spec-02) are hits under the map, non-family kinds still require exact labels, groups stay inside the DECOMPOSE taxonomy: `TestArchitectMatcher::test_paraphrased_kind_within_synonym_family_is_a_hit`, `::test_spec_02_unstated_assumption_paraphrase_is_a_hit`, `::test_no_match_when_required_kind_outside_synonym_family`, `TestKindSynonyms` (7 tests).
- Model-drift helper: silent on missing/empty/malformed/matching, warns citing H2-extended on drift, newest-by-filename wins, repo baselines match the default model: `TestModelDrift` (8 tests).

Final check lines:

```
1211 passed, 14 skipped, 1 xfailed, 1 warning in 58.27s
Success: no issues found in 38 source files
All checks passed!
```

## Assumed (H4)

- **Green-at-baseline is inferred, not re-measured.** I cannot run the real-LLM suite. The claim rests on: (a) every recorded architect miss in the three 20260527 baselines is a synonym-family paraphrase (verified against the recorded `detail` strings, which the new matcher tests replay), and (b) security/reviewer were 5/5 and 3/3 in the full 20260527-161822 run. Whether the CURRENT prompts on the CURRENT model are green over 3 runs is exactly what the baseline capture below measures.
- Threshold values (0.15 / 0.40 / floors) are sized from fixture-count arithmetic, not measured variance; the first few v2 baselines will show whether they are too tight or too loose.
- `runs_per_fixture` triples calibration cost/latency (~3x LLM calls per fixture, 300s timeout per run); assumed acceptable for an opt-in suite.
- Detection on these fixtures still does not prove transfer to arbitrary real diffs (roadmap R5 caveat; R5.2 narrows this).

## Capture the new-format baseline (user action, then flip R5.1 to [x])

```bash
RALPH_RUN_CALIBRATION=1 RALPH_CALIBRATION_MODEL=haiku RALPH_CALIBRATION_RUNS=3 uv run pytest tests/test_calibration.py -v
```

Then compare against the last full v1 baseline (expect exit 0):

```bash
uv run python -m ralph_py.calibration compare \
  tests/adversarial_fixtures/_results/baseline-20260527-161822.json \
  tests/adversarial_fixtures/_results/baseline-<new-timestamp>.json
```

Commit the new `baseline-<new-timestamp>.json` and flip R5.1 from `[~]` to `[x]` in docs/remediation-roadmap.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)