### PR TITLE
fix: R6.1-R6.4 evolution repair - real signatures, typed metrics, honest apply

### DIFF
--- a/docs/evolution-metrics.md
+++ b/docs/evolution-metrics.md
@@ -1,0 +1,91 @@
+# Evolution metrics and journal format
+
+This document defines every metric the evolution layer records: what is
+measured, where it comes from, and what it does NOT mean. Definitions
+describe the code as implemented (R6.4); nothing here is aspirational.
+
+## Journal: `.ralph/evolution.jsonl`
+
+Append-only JSONL. Every entry carries `schema_version` so future format
+migrations are detectable.
+
+- **Version 2** (current): structured failure signatures (R6.1).
+- **Version 1**: entries without a `schema_version` field (pre-R6
+  shape). Wave 1 (R4.1) archived the polluted v1 journals to
+  `.ralph/archive/`; they are kept for forensic reference only and are
+  never read by current metrics. Fresh journals contain v2 entries only.
+
+### Entry types
+
+| `event_type` | Written by | When |
+|---|---|---|
+| `component_result` | `EvolutionJournal.record_run` | Once per component at the end of every factory run |
+| `findings_superseded` | factory `_journal_superseded_findings` | When a retry supersedes an attempt's findings (R3.3) |
+| `contract_result` | factory `_record_contract_event` | After every contract-test tier, pass or fail (R0.3) |
+
+### `component_result` fields
+
+| Field | Definition |
+|---|---|
+| `schema_version` | Journal format version (see above). |
+| `timestamp` | UTC ISO-8601, one per run (shared by all components of the run). |
+| `run_id` | Factory run id (microsecond precision plus nonce, R1.6). |
+| `project` | `manifest.project_name`. |
+| `component_id` | Manifest component id. |
+| `status` | Terminal manifest status (`completed`, `failed`, `pending`, ...). `pending` with a non-empty `error` means the component was retried and the run ended before another attempt. |
+| `retries` | Retry counter at end of run. |
+| `error` | Flattened human-readable error of the last failure, `""` on success. Display only: metrics must use `failure_signatures`. |
+| `failure_signatures` | R6.1: list of structured `"<check>:<code>"` signatures for the last failed attempt, e.g. `linter:E501`, `typecheck:arg-type`, `test_suite:assertion-error`, `review:scope_creep`, `security:injection`, `diff_scope:files-outside-allowed-scope`, `contract:tier_1`, `engineer:component-timeout`, `token_budget:exceeded`, `pr:closed-without-merge`. Codes come from the tool parser (ruff rule, mypy error code, pytest exception type) or the finding taxonomy; sites without parser codes record a stable slug of the error text (paths, line numbers, and counts stripped). Empty on success. |
+| `check_name` / `error_signature` | Convenience split of the FIRST signature (`check_name:error_signature`). Kept for v1-shaped readers; new consumers should read `failure_signatures`. |
+| `failed_phase` / `failed_check` | R3.3 post-mortem pointers: which phase and gate fired last. |
+| `duration_seconds` | Wall-clock of the component's LAST attempt, measured from the PENDING->RUNNING transition to the terminal transition (completed / failed / merge-pending / retry scheduled / scheduler backstop). Includes the engineer loop, mechanical verification, review, security review, and PR flow. It is NOT the sum across retries, and 0.0 appears only for components that never started an attempt in this process (e.g. skipped, or state inherited from a crashed run). |
+| `iteration_count` | Engineer-loop iterations of the last attempt. |
+| `findings` | Full typed Finding stream of the last attempt (E3), attempt-tagged. |
+| `findings_summary` | Aggregates of `findings`: `total`, `by_phase`, `by_severity`, `by_category`, `by_owasp`, `infrastructure_errors`. |
+| `usage` | R3.1 per-phase token/cost self-reports (lower bounds when `unreported_calls` > 0). |
+
+## Experiments: `.ralph/experiments.tsv`
+
+One row per factory run, appended by `record_run`. Columns:
+
+| Column | Definition |
+|---|---|
+| `run_id` | Factory run id. |
+| `timestamp` | UTC ISO-8601 at record time. |
+| `project` | Manifest project name. |
+| `components_total` | Number of components in the manifest. |
+| `completed` / `failed` / `skipped` | Counts from the run's FactoryResult (skipped = cascade-skipped dependents of failures). |
+| `avg_iterations` | Mean engineer-loop iterations over components with `iteration_count` > 0. 0.00 when no component ran. |
+| `avg_duration_s` | Mean `duration_seconds` (last-attempt wall clock, see above) over components with a duration > 0. |
+| `retry_rate` | Total retries across ALL components divided by `components_total`: the average number of retries per component, NOT the fraction of components that were retried. A run of 4 components where one burned 3 retries records 0.75. Can exceed 1.0. |
+| `common_failure` | The most frequent full `"<check>:<code>"` failure signature among FAILED components this run; `""` when nothing failed. |
+| `total_tokens` / `total_cost_usd` / `unreported_calls` | R3.1 run totals. Empty string (not 0) when usage tracking was unavailable: zero would misread as "measured, free". Figures are agent-CLI self-reports and are lower bounds whenever `unreported_calls` > 0. |
+
+Rows written before a column existed keep their shorter header;
+`get_experiment_trends` (csv.DictReader) tolerates both shapes.
+
+## Concern hit rate (`ralph evolve` internals, D8)
+
+`get_concern_hit_rate` consumes `findings_summary.by_category` on
+`component_result` entries (R6.2). A component counts as "with concern"
+when it has at least one finding in a real category; the synthetic
+`infrastructure_error` and `phase_skipped` categories mark
+non-execution, not adversarial signal, and are excluded. `by_category`
+in the result sums finding counts (not component counts) per category
+across the window.
+
+## Proposals: `.ralph/proposals/prop-NNN.md`
+
+- IDs are monotonic across `ralph evolve` invocations: numbering
+  continues after the highest `prop-NNN.md` already on disk (R6.2).
+- Existing proposal files are never overwritten; a proposal whose title
+  already exists on disk is skipped, not duplicated.
+- `ralph evolve --apply PROP-NNN` (or `all`) really applies only
+  convention-type proposals (computational, target `claude_md`): after
+  explicit confirmation it appends the convention to the project
+  CLAUDE.md `## Agent Learnings` section and stamps the proposal file
+  with `**Applied**: <timestamp>` so a re-apply is a no-op.
+  `[evolution] auto_apply_computational = true` skips the confirmation
+  prompt. Every other target prints manual instructions (R6.3).
+- `[evolution] auto_propose = false` restricts `ralph evolve` to
+  pattern reporting; no proposal files are generated.

--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -533,25 +533,33 @@ First principles: a learning loop is only as good as its input signal. Fix the
 signal, then the metrics, then re-baseline: proposals stay untrusted until all
 three are done.
 
-- [ ] R6.1 (M) **Real error signatures** [MED evolution-signal]
+- [x] R6.1 (M) **Real error signatures** [MED evolution-signal]
   - Component failures record `check_name` + the parser's structured failure
     signature (e.g. `linter:E501`, `typecheck:arg-type`, `diff_scope:rename`)
     instead of flattened "Review failed" strings; review/security failures
     record finding categories.
   - `factory.py:1131`: use `EvolutionConfig.load(root_dir)`; journal paths
     resolve against root; drop the `except OSError: pass` for a logged warning.
-- [ ] R6.2 (S) **Metrics read the typed stream** [MED concern-hit-rate, LOW proposal-clobber]
+  - NOTE: `EvolutionConfig.load` + root-anchored paths had already landed via
+    R2.1/wave 4B; this session added the signature plumbing (every failure
+    site records `"<check>:<code>"`) and converted the remaining silent
+    excepts (journal/TSV/proposal writes, record_run wrapper) to warnings.
+- [x] R6.2 (S) **Metrics read the typed stream** [MED concern-hit-rate, LOW proposal-clobber]
   - `get_concern_hit_rate` consumes `findings_summary`; proposals derive from
     finding taxonomies + error signatures; proposal IDs are monotonic and
     prior proposal files are never clobbered.
-- [ ] R6.3 (S) **`evolve --apply` honesty** [D-evolve]
+- [x] R6.3 (S) **`evolve --apply` honesty** [D-evolve]
   - Implement the minimal real path: applying a convention-type proposal
     appends to the project CLAUDE.md Agent Learnings section after explicit
     confirmation; everything else prints "manual". Honor `auto_propose`.
-- [ ] R6.4 (S) **Re-baseline** [H-18 follow-through]
+- [x] R6.4 (S) **Re-baseline** [H-18 follow-through]
   - After R4.1 isolation: define `retry_rate` and duration semantics in
     `docs/`, fix duration recording (currently 0.0), start fresh journals, and
     keep the polluted archive for forensic reference only.
+  - Landed as `docs/evolution-metrics.md` (every experiments.tsv column,
+    retry_rate = avg retries per component, duration = last-attempt wall
+    clock stamped in `_end_attempt`); journal entries carry `schema_version`
+    (v2) so future migrations are detectable.
 
 Done when: after two real factory runs post-fix, `ralph evolve` produces at
 least one proposal traceable to a real recorded signature, and

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import copy
 import json
 import os
+import re
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import fields as dataclass_fields
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ralph_py.evolution import EvolutionConfig
 
 import click
 from click.core import ParameterSource
@@ -2661,7 +2665,10 @@ def evolve(
 
     Without arguments, analyzes recent runs and shows proposals.
     Use --status to see experiment trends.
-    Use --apply to apply proposals.
+    Use --apply PROP-NNN (or 'all') to apply proposals: convention-type
+    proposals (target claude_md) are appended to the project CLAUDE.md
+    Agent Learnings section after confirmation; every other target
+    prints manual instructions.
     """
     from ralph_py.evolution import EvolutionConfig, EvolutionJournal
 
@@ -2699,13 +2706,10 @@ def evolve(
         if not proposals_dir.exists():
             ui_impl.err("No proposals found. Run `ralph evolve` first.")
             sys.exit(1)
-
-        ui_impl.info(f"Applying proposal: {apply_id}")
-        ui_impl.warn(
-            "Proposal application is not yet automated. "
-            "Review proposals in .ralph/proposals/ and apply manually."
+        exit_code = _evolve_apply(
+            apply_id, proposals_dir, root_dir, evo_config, ui_impl,
         )
-        sys.exit(0)
+        sys.exit(exit_code)
 
     # Default: analyze and propose
     ui_impl.section("Evolution: Analyzing Runs")
@@ -2723,19 +2727,203 @@ def evolve(
             f"(seen in {pattern.frequency} components)"
         )
 
+    # R6.3: honor [evolution] auto_propose - when disabled, evolve only
+    # reports patterns and never writes proposal files.
+    if not evo_config.auto_propose:
+        ui_impl.info(
+            "auto_propose is disabled ([evolution] auto_propose = false); "
+            "patterns reported, no proposals generated."
+        )
+        sys.exit(0)
+
+    proposals_dir = root_dir / ".ralph" / "proposals"
     proposals = journal.propose_improvements(patterns)
-    if proposals:
-        proposals_dir = root_dir / ".ralph" / "proposals"
-        paths = journal.save_proposals(proposals, proposals_dir)
+    # Idempotence across repeated `ralph evolve` runs: a proposal whose
+    # title already exists on disk is the same pattern re-detected, not
+    # new signal - skip it rather than duplicating files.
+    existing_titles = _existing_proposal_titles(proposals_dir)
+    fresh = [p for p in proposals if p.title not in existing_titles]
+    already = len(proposals) - len(fresh)
+    # R6.2: monotonic IDs across invocations - number only the fresh
+    # proposals, continuing after the highest PROP number on disk, so a
+    # deduped batch never burns or reuses an existing number.
+    start = journal.next_proposal_number(proposals_dir)
+    for offset, proposal in enumerate(fresh):
+        proposal.id = f"PROP-{start + offset:03d}"
+    if fresh:
+        paths = journal.save_proposals(fresh, proposals_dir)
         ui_impl.section("Proposals Generated")
         for path in paths:
             ui_impl.info(f"  {path}")
+        if already:
+            ui_impl.info(
+                f"  ({already} proposal(s) already on disk; not duplicated)"
+            )
         ui_impl.info("")
         ui_impl.info("Review proposals and apply with `ralph evolve --apply <ID>`")
+    elif already:
+        ui_impl.info(
+            f"All {already} proposal(s) for these patterns already exist "
+            f"in {proposals_dir}."
+        )
     else:
         ui_impl.info("No actionable proposals generated from current patterns.")
 
     sys.exit(0)
+
+
+_PROPOSAL_TITLE_RE = re.compile(r"^# (PROP-\d+): (.+)$")
+_PROPOSAL_FIELD_RE = re.compile(r"^\*\*(Type|Target)\*\*: (.+)$")
+_PROPOSAL_APPLIED_RE = re.compile(r"^\*\*Applied\*\*: (.+)$")
+
+
+def _existing_proposal_titles(proposals_dir: Path) -> set[str]:
+    """Titles of every proposal already saved to disk."""
+    titles: set[str] = set()
+    if not proposals_dir.is_dir():
+        return titles
+    for path in sorted(proposals_dir.glob("prop-*.md")):
+        try:
+            first_line = path.read_text().splitlines()[0]
+        except (OSError, IndexError):
+            continue
+        m = _PROPOSAL_TITLE_RE.match(first_line)
+        if m:
+            titles.add(m.group(2))
+    return titles
+
+
+def _parse_proposal_file(path: Path) -> dict[str, str]:
+    """Parse the structured fields save_proposals writes.
+
+    Returns keys: id, title, type, target, convention (the blockquote
+    body of the suggested change, "" when none), applied (timestamp or
+    "")."""
+    parsed = {
+        "id": "", "title": "", "type": "", "target": "",
+        "convention": "", "applied": "",
+    }
+    convention_lines: list[str] = []
+    for line in path.read_text().splitlines():
+        m = _PROPOSAL_TITLE_RE.match(line)
+        if m and not parsed["id"]:
+            parsed["id"], parsed["title"] = m.group(1), m.group(2)
+            continue
+        m = _PROPOSAL_FIELD_RE.match(line)
+        if m:
+            parsed[m.group(1).lower()] = m.group(2).strip()
+            continue
+        m = _PROPOSAL_APPLIED_RE.match(line)
+        if m:
+            parsed["applied"] = m.group(1).strip()
+            continue
+        if line.startswith("> "):
+            convention_lines.append(line[2:].strip())
+    parsed["convention"] = " ".join(convention_lines).strip()
+    return parsed
+
+
+def _append_to_agent_learnings(
+    claude_md: Path, proposal_id: str, convention: str,
+) -> bool:
+    """Append one convention bullet to the end of the "## Agent
+    Learnings" section of the project CLAUDE.md. Returns False (no
+    write) when the file or the section is missing - the caller then
+    falls back to honest manual instructions instead of guessing a
+    location."""
+    try:
+        content = claude_md.read_text()
+    except OSError:
+        return False
+    marker = "## Agent Learnings"
+    idx = content.find(marker)
+    if idx == -1:
+        return False
+    # End of the section = next level-2 header after it, else EOF.
+    next_header = content.find("\n## ", idx + len(marker))
+    insert_at = len(content) if next_header == -1 else next_header
+    entry = f"- {convention} (applied from {proposal_id} by ralph evolve)\n"
+    head = content[:insert_at]
+    if not head.endswith("\n"):
+        head += "\n"
+    claude_md.write_text(head + entry + content[insert_at:])
+    return True
+
+
+def _evolve_apply(
+    apply_id: str,
+    proposals_dir: Path,
+    root_dir: Path,
+    evo_config: EvolutionConfig,
+    ui_impl: UI,
+) -> int:
+    """R6.3: the minimal REAL apply path. Convention-type proposals
+    (computational, target=claude_md) append to the project CLAUDE.md
+    Agent Learnings section after explicit confirmation
+    (auto_apply_computational=true skips the prompt); every other
+    proposal type prints honest manual instructions - no false
+    "applied" claims."""
+    if apply_id.lower() == "all":
+        paths = sorted(proposals_dir.glob("prop-*.md"))
+        if not paths:
+            ui_impl.err(f"No proposal files in {proposals_dir}.")
+            return 1
+    else:
+        candidate = proposals_dir / f"{apply_id.lower()}.md"
+        if not candidate.exists():
+            ui_impl.err(
+                f"Proposal '{apply_id}' not found "
+                f"(expected {candidate})."
+            )
+            return 1
+        paths = [candidate]
+
+    claude_md = root_dir / "CLAUDE.md"
+    failures = 0
+    for path in paths:
+        proposal = _parse_proposal_file(path)
+        pid = proposal["id"] or path.stem.upper()
+        if proposal["applied"]:
+            ui_impl.info(
+                f"{pid} already applied at {proposal['applied']}; skipping."
+            )
+            continue
+        is_convention = (
+            proposal["type"] == "computational"
+            and proposal["target"] == "claude_md"
+            and bool(proposal["convention"])
+        )
+        if not is_convention:
+            ui_impl.info(f"{pid}: {proposal['title']}")
+            ui_impl.warn(
+                f"  Automated apply only covers convention-type proposals "
+                f"(target claude_md). This one targets "
+                f"'{proposal['target'] or 'unknown'}': review {path} and "
+                f"apply it manually."
+            )
+            continue
+        ui_impl.info(f"{pid}: {proposal['title']}")
+        ui_impl.info(f"  Convention: {proposal['convention']}")
+        if not evo_config.auto_apply_computational and not click.confirm(
+            f"Append this convention to {claude_md}?", default=False,
+        ):
+            ui_impl.info(f"  {pid} not applied (declined).")
+            continue
+        if not _append_to_agent_learnings(
+            claude_md, pid, proposal["convention"],
+        ):
+            ui_impl.err(
+                f"  Could not apply {pid}: {claude_md} is missing or has "
+                f"no '## Agent Learnings' section. Add the section or "
+                f"apply manually from {path}."
+            )
+            failures += 1
+            continue
+        applied_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with open(path, "a") as f:
+            f.write(f"\n**Applied**: {applied_at}\n")
+        ui_impl.ok(f"  {pid} appended to {claude_md}.")
+    return 1 if failures else 0
 
 
 def main() -> None:

--- a/ralph_py/evolution.py
+++ b/ralph_py/evolution.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import csv
 import io
 import json
+import logging
 import os
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -20,6 +22,16 @@ if TYPE_CHECKING:
     from ralph_py.factory import FactoryResult
     from ralph_py.findings import Finding
     from ralph_py.manifest import Component, Manifest
+    from ralph_py.verify import CheckResult
+
+logger = logging.getLogger("ralph.evolution")
+
+# R6.4: journal entries carry an explicit schema version so future
+# format migrations are detectable. Version 2 = structured failure
+# signatures (R6.1). Entries without the field are version 1 (the
+# pre-R6 shape); wave 1 (R4.1) archived the polluted v1 journals to
+# .ralph/archive/, so fresh journals contain v2 entries only.
+JOURNAL_SCHEMA_VERSION = 2
 
 
 # ---------------------------------------------------------------------------
@@ -123,9 +135,11 @@ class FailurePattern:
     total_components: int
     affected_components: list[str]
     check_name: str  # e.g. "test_suite", "typecheck", "linter", "review"
-    # normalized error pattern (e.g. "S608" for ruff, "missing-argument" for pytest)
+    # structured failure code (e.g. "S608" for ruff, "arg-type" for mypy,
+    # "scope_creep" for a review concern) - the part after the colon in
+    # the full "<check>:<code>" signature
     error_signature: str
-    category: str  # "verification", "review", "contract", "iteration"
+    category: str  # "verification", "review", "security", "contract", "iteration"
 
 
 @dataclass
@@ -214,6 +228,129 @@ def _classify_check(error: str) -> tuple[str, str]:
     return "unknown", "iteration"
 
 
+# ---------------------------------------------------------------------------
+# Structured failure signatures (R6.1)
+#
+# A failure signature is "<check_name>:<code>", e.g. "linter:E501",
+# "typecheck:arg-type", "review:scope_creep", "diff_scope:files-outside-
+# allowed-scope". The check prefix comes from the gate that fired; the
+# code comes from the tool's parser (ruff rule, mypy error code, finding
+# category) rather than from re-parsing a flattened error string, so
+# cross-run grouping is on real, stable identifiers.
+# ---------------------------------------------------------------------------
+
+# Digit runs are counts/limits ("3 files outside scope", "600s wall
+# clock") - stripping them keeps slugs stable across runs whose only
+# difference is the number.
+_DIGIT_RUN_RE = re.compile(r"\d+")
+
+# Leading Python exception name in a pytest failure message.
+_EXC_NAME_RE = re.compile(
+    r"^([A-Z][A-Za-z0-9]*(?:Error|Exception|Failure|Warning|Exit|Interrupt))\b"
+)
+
+_CATEGORY_BY_CHECK = {
+    "linter": "verification",
+    "typecheck": "verification",
+    "test_suite": "verification",
+    "diff_scope": "verification",
+    "bad_patterns": "verification",
+    "self_critique": "verification",
+    "dead_code": "verification",
+    "mutation_testing": "verification",
+    "prd_stories": "verification",
+    "verification": "verification",
+    "review": "review",
+    "security": "security",
+    "contract": "contract",
+}
+
+# Cap on distinct per-check signatures so one catastrophic run (e.g. 40
+# distinct ruff rules) cannot flood the journal entry.
+_MAX_SIGNATURES_PER_CHECK = 5
+
+
+def signature_slug(text: str) -> str:
+    """Stable low-cardinality slug for a failure message.
+
+    Strips file paths, line/column numbers, quoted names, and standalone
+    counts, then slugifies the first line. Unlike ``_normalize_error``
+    this never extracts linter codes (callers get those from the parser
+    directly) and never keeps varying counts."""
+    if not text:
+        return ""
+    normalized = _PATH_RE.sub("", text)
+    normalized = _LINENO_RE.sub("", normalized)
+    normalized = _QUOTED_NAME_RE.sub("", normalized)
+    normalized = _DIGIT_RUN_RE.sub("", normalized)
+    first_line = normalized.strip().split("\n")[0].strip()
+    slug = re.sub(r"[^a-z0-9]+", "-", first_line.lower()).strip("-")
+    return slug[:60]
+
+
+def signature_for_error(check_name: str, error: str) -> str:
+    """Fallback signature when no parser-level codes are available."""
+    slug = signature_slug(error) or "failed"
+    return f"{check_name or 'unknown'}:{slug}"
+
+
+def split_signature(signature: str) -> tuple[str, str]:
+    """Split "check:code" into (check_name, code)."""
+    check, sep, code = signature.partition(":")
+    if not sep:
+        return "unknown", signature
+    return check or "unknown", code or "failed"
+
+
+def category_for_check(check_name: str) -> str:
+    """Map a check/gate name to a FailurePattern category."""
+    return _CATEGORY_BY_CHECK.get(check_name, "iteration")
+
+
+def signatures_from_verification(checks: Iterable[CheckResult]) -> list[str]:
+    """Derive structured signatures from failed mechanical checks.
+
+    Prefers the parser's structured codes (ruff rule, mypy error code,
+    pytest exception type); falls back to a slug of the check message
+    when no parse is available."""
+    signatures: list[str] = []
+    for check in checks:
+        if check.passed:
+            continue
+        codes: list[str] = []
+        parsed = check.parsed
+        if parsed is not None and parsed.failures:
+            if parsed.tool in ("ruff", "mypy"):
+                codes = [f.rule_or_test for f in parsed.failures if f.rule_or_test]
+            elif parsed.tool == "pytest":
+                for failure in parsed.failures:
+                    m = _EXC_NAME_RE.match(failure.message or "")
+                    if m:
+                        codes.append(
+                            re.sub(r"(?<!^)(?=[A-Z])", "-", m.group(1)).lower()
+                        )
+        if codes:
+            distinct = list(dict.fromkeys(codes))[:_MAX_SIGNATURES_PER_CHECK]
+            signatures.extend(f"{check.name}:{code}" for code in distinct)
+        else:
+            signatures.append(signature_for_error(check.name, check.message))
+    return list(dict.fromkeys(signatures))
+
+
+def signatures_from_findings(phase: str, findings: Iterable[Finding]) -> list[str]:
+    """Derive signatures from the typed findings that failed a review or
+    security gate: "<phase>:<category>" for every gating finding
+    (severity fail/critical/high) and "<phase>:infrastructure" when the
+    role itself failed to run."""
+    signatures: list[str] = []
+    for finding in findings:
+        if finding.is_infrastructure_error:
+            signatures.append(f"{phase}:infrastructure")
+        elif finding.severity in ("fail", "critical", "high"):
+            signatures.append(f"{phase}:{finding.category}")
+    return list(dict.fromkeys(signatures))[:_MAX_SIGNATURES_PER_CHECK]
+
+
 def _timestamp_now() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -265,6 +402,7 @@ class EvolutionJournal:
         factory_result: FactoryResult,
         usage_by_component: dict[str, dict[str, dict[str, Any]]] | None = None,
         run_usage: dict[str, Any] | None = None,
+        failure_signatures: dict[str, list[str]] | None = None,
     ) -> None:
         """Record a completed factory run to the journal.
 
@@ -277,11 +415,19 @@ class EvolutionJournal:
         feeds the TSV totals columns. Both optional so pre-R3.1 callers
         keep working; token/cost figures are CLI self-reports and are
         lower bounds whenever ``unreported_calls`` > 0.
+
+        R6.1: ``failure_signatures`` maps component id -> the structured
+        "<check>:<code>" signatures the factory recorded when the
+        component's last attempt failed (e.g. "linter:E501",
+        "review:scope_creep"). When absent for a failed component, the
+        legacy flattened-string classification is the fallback so
+        journal entries never lose the signature fields entirely.
         """
         from ralph_py.manifest import ComponentStatus
 
         timestamp = _timestamp_now()
         usage_by_component = usage_by_component or {}
+        failure_signatures = failure_signatures or {}
 
         # --- JSONL entries per component ---
         entries: list[dict[str, Any]] = []
@@ -290,11 +436,19 @@ class EvolutionJournal:
                 ComponentStatus.FAILED.value,
                 ComponentStatus.PENDING.value,  # retried components reset to pending
             )
+            comp_signatures: list[str] = []
             check_name = ""
             error_sig = ""
             if has_error:
-                check_name, _ = _classify_check(comp.error)
-                error_sig = _normalize_error(comp.error)
+                comp_signatures = list(failure_signatures.get(comp.id) or [])
+                if not comp_signatures:
+                    # Legacy fallback: classify the flattened string.
+                    legacy_check, _ = _classify_check(comp.error)
+                    legacy_sig = _normalize_error(comp.error)
+                    if legacy_sig:
+                        comp_signatures = [f"{legacy_check}:{legacy_sig}"]
+                if comp_signatures:
+                    check_name, error_sig = split_signature(comp_signatures[0])
             # E3-consume: include typed findings in the journal so
             # downstream aggregations (concern hit-rate, OWASP-bucket
             # frequency, infrastructure_error rate) can query the
@@ -303,6 +457,7 @@ class EvolutionJournal:
             findings_serialized = [f.to_dict() for f in comp.findings]
             findings_summary = _summarize_findings(comp.findings)
             entry = {
+                "schema_version": JOURNAL_SCHEMA_VERSION,
                 "timestamp": timestamp,
                 "run_id": run_id,
                 "project": manifest.project_name,
@@ -313,6 +468,9 @@ class EvolutionJournal:
                 "error": comp.error,
                 "check_name": check_name,
                 "error_signature": error_sig,
+                "failure_signatures": comp_signatures,
+                "failed_phase": comp.failed_phase,
+                "failed_check": comp.failed_check,
                 "duration_seconds": comp.duration_seconds,
                 "iteration_count": comp.iteration_count,
                 "findings": findings_serialized,
@@ -326,8 +484,11 @@ class EvolutionJournal:
             with open(self.config.journal_path, "a") as f:
                 for entry in entries:
                     f.write(json.dumps(entry, separators=(",", ":")) + "\n")
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.warning(
+                "evolution journal write failed (non-fatal): %s: %s",
+                self.config.journal_path, exc,
+            )
 
         # --- Experiments TSV summary line ---
         total = len(manifest.components)
@@ -346,11 +507,17 @@ class EvolutionJournal:
         retry_total = sum(c.retries for c in manifest.components)
         retry_rate = retry_total / total if total > 0 else 0.0
 
-        # Most common failure signature
+        # Most common failure signature (full "<check>:<code>" form).
         failure_sigs: dict[str, int] = {}
         for comp in manifest.components:
-            if comp.status == ComponentStatus.FAILED.value and comp.error:
-                sig = _normalize_error(comp.error)
+            if comp.status != ComponentStatus.FAILED.value or not comp.error:
+                continue
+            sigs = list(failure_signatures.get(comp.id) or [])
+            if not sigs:
+                sigs = [signature_for_error(
+                    _classify_check(comp.error)[0], comp.error,
+                )]
+            for sig in sigs:
                 failure_sigs[sig] = failure_sigs.get(sig, 0) + 1
         common_failure = max(failure_sigs, key=failure_sigs.get, default="") if failure_sigs else ""  # type: ignore[arg-type]
 
@@ -389,8 +556,11 @@ class EvolutionJournal:
                 if needs_header:
                     f.write(header + "\n")
                 f.write(row + "\n")
-        except OSError:
-            pass
+        except OSError as exc:
+            logger.warning(
+                "experiments.tsv write failed (non-fatal): %s: %s",
+                self.config.experiments_path, exc,
+            )
 
     # ------------------------------------------------------------------
     # extract_failure_patterns (single run)
@@ -400,13 +570,19 @@ class EvolutionJournal:
         self,
         manifest: Manifest,
         min_frequency: int = 2,
+        signatures_by_component: dict[str, list[str]] | None = None,
     ) -> list[FailurePattern]:
         """Extract recurring failure patterns from a single run.
 
-        Looks at failed/retried components to find common error signatures.
-        Groups by check_name and error_signature.
+        Looks at failed/retried components to find common failure
+        signatures, grouped by the full "<check>:<code>" signature.
+        ``signatures_by_component`` carries the factory's structured
+        signatures (R6.1); components absent from it fall back to
+        classifying their flattened error string.
         """
         from ralph_py.manifest import ComponentStatus
+
+        signatures_by_component = signatures_by_component or {}
 
         # Collect components that failed or were retried.
         troubled: list[Component] = [
@@ -418,35 +594,38 @@ class EvolutionJournal:
         if not troubled:
             return []
 
-        # Group by (check_name, error_signature).
-        groups: dict[tuple[str, str], list[str]] = {}
-        sig_errors: dict[tuple[str, str], str] = {}
+        # Group by full signature string.
+        groups: dict[str, list[str]] = {}
         for comp in troubled:
             if not comp.error:
                 continue
-            check_name, category = _classify_check(comp.error)
-            sig = _normalize_error(comp.error)
-            key = (check_name, sig)
-            groups.setdefault(key, []).append(comp.id)
-            sig_errors.setdefault(key, comp.error)
+            sigs = list(signatures_by_component.get(comp.id) or [])
+            if not sigs:
+                legacy_check, _ = _classify_check(comp.error)
+                legacy_sig = _normalize_error(comp.error)
+                if not legacy_sig:
+                    continue
+                sigs = [f"{legacy_check}:{legacy_sig}"]
+            for sig in sigs:
+                groups.setdefault(sig, []).append(comp.id)
 
         total = len(manifest.components)
         patterns: list[FailurePattern] = []
-        for (check_name, sig), comp_ids in groups.items():
+        for full_sig, comp_ids in groups.items():
             if len(comp_ids) < min_frequency:
                 continue
-            _, category = _classify_check(sig_errors[(check_name, sig)])
+            check_name, code = split_signature(full_sig)
             patterns.append(
                 FailurePattern(
                     description=(
-                        f"{check_name} failure '{sig}' in {len(comp_ids)}/{total} components"
+                        f"{check_name} failure '{code}' in {len(comp_ids)}/{total} components"
                     ),
                     frequency=len(comp_ids),
                     total_components=total,
                     affected_components=comp_ids,
                     check_name=check_name,
-                    error_signature=sig,
-                    category=category,
+                    error_signature=code,
+                    category=category_for_check(check_name),
                 )
             )
 
@@ -463,40 +642,49 @@ class EvolutionJournal:
     ) -> list[FailurePattern]:
         """Get patterns that recur across multiple factory runs.
 
-        Reads the journal, groups entries by error_signature,
-        returns patterns that appear in >= min_pattern_frequency runs.
+        Reads the journal, groups entries by their structured failure
+        signatures ("<check>:<code>", R6.1), and returns patterns that
+        appear in >= min_pattern_frequency distinct runs. Legacy v1
+        entries without ``failure_signatures`` fall back to composing
+        the signature from their check_name/error_signature fields.
         """
         entries = self._read_journal_entries(lookback_runs)
         if not entries:
             return []
 
-        # Group by error_signature across distinct run_ids.
+        # Group by full signature across distinct run_ids.
         sig_runs: dict[str, set[str]] = {}
         sig_components: dict[str, list[str]] = {}
-        sig_check: dict[str, str] = {}
-        sig_error: dict[str, str] = {}
 
         for entry in entries:
-            sig = entry.get("error_signature", "")
-            if not sig:
+            if entry.get("event_type", "component_result") != "component_result":
                 continue
+            sigs = entry.get("failure_signatures") or []
+            if not sigs:
+                # v1 fallback: compose from the legacy scalar fields.
+                legacy_sig = entry.get("error_signature", "")
+                if not legacy_sig:
+                    continue
+                legacy_check = entry.get("check_name") or "unknown"
+                sigs = [f"{legacy_check}:{legacy_sig}"]
             run_id = entry.get("run_id", "")
             comp_id = entry.get("component_id", "")
-            check = entry.get("check_name", "unknown")
-            error = entry.get("error", "")
+            for sig in sigs:
+                if not isinstance(sig, str) or not sig:
+                    continue
+                sig_runs.setdefault(sig, set()).add(run_id)
+                sig_components.setdefault(sig, []).append(comp_id)
 
-            sig_runs.setdefault(sig, set()).add(run_id)
-            sig_components.setdefault(sig, []).append(comp_id)
-            sig_check.setdefault(sig, check)
-            sig_error.setdefault(sig, error)
-
-        total_runs = len({e.get("run_id") for e in entries})
+        total_runs = len({
+            e.get("run_id") for e in entries
+            if e.get("event_type", "component_result") == "component_result"
+        })
         patterns: list[FailurePattern] = []
 
         for sig, run_ids in sig_runs.items():
             if len(run_ids) < self.config.min_pattern_frequency:
                 continue
-            _, category = _classify_check(sig_error.get(sig, ""))
+            check_name, code = split_signature(sig)
             unique_comps = list(dict.fromkeys(sig_components.get(sig, [])))
             patterns.append(
                 FailurePattern(
@@ -507,9 +695,9 @@ class EvolutionJournal:
                     frequency=len(run_ids),
                     total_components=total_runs,
                     affected_components=unique_comps,
-                    check_name=sig_check.get(sig, "unknown"),
-                    error_signature=sig,
-                    category=category,
+                    check_name=check_name,
+                    error_signature=code,
+                    category=category_for_check(check_name),
                 )
             )
 
@@ -523,6 +711,7 @@ class EvolutionJournal:
     def propose_improvements(
         self,
         patterns: list[FailurePattern],
+        starting_number: int = 1,
     ) -> list[HarnessProposal]:
         """Generate concrete harness improvement proposals from patterns.
 
@@ -530,9 +719,16 @@ class EvolutionJournal:
         - Recurring linter errors - suggest CLAUDE.md convention entry
         - Recurring typecheck patterns - suggest config change
         - Recurring test failures on same module - suggest feedforward focus
+        - Recurring review/security finding categories - suggest CLAUDE.md
+          guidance derived from the finding taxonomy
+
+        R6.2: IDs are monotonic across runs - pass
+        ``next_proposal_number(output_dir)`` as ``starting_number`` so a
+        second `ralph evolve` continues numbering instead of restarting
+        at PROP-001 and clobbering earlier files.
         """
         proposals: list[HarnessProposal] = []
-        counter = 0
+        counter = starting_number - 1
 
         for pattern in patterns:
             counter += 1
@@ -612,7 +808,8 @@ class EvolutionJournal:
                         id=proposal_id,
                         title=f"Add review guidance for '{pattern.error_signature}'",
                         description=(
-                            f"Review finding '{pattern.error_signature}' appeared in "
+                            f"Review finding category '{pattern.error_signature}' "
+                            f"(reviewer concern taxonomy) appeared in "
                             f"{pattern.frequency} components. Adding explicit guidance to "
                             f"CLAUDE.md can help the agent avoid this in the first pass."
                         ),
@@ -622,6 +819,33 @@ class EvolutionJournal:
                             f"Add to CLAUDE.md:\n"
                             f"> Reviewer repeatedly flags '{pattern.error_signature}'. "
                             f"Address this pattern proactively."
+                        ),
+                        source_patterns=[pattern.description],
+                    )
+                )
+
+            elif pattern.check_name == "security":
+                proposals.append(
+                    HarnessProposal(
+                        id=proposal_id,
+                        title=(
+                            f"Add security guidance for "
+                            f"'{pattern.error_signature}'"
+                        ),
+                        description=(
+                            f"Security finding category '{pattern.error_signature}' "
+                            f"(OWASP-mapped taxonomy) appeared in "
+                            f"{pattern.frequency} components. Adding an explicit "
+                            f"convention to CLAUDE.md can prevent the vulnerability "
+                            f"class from being introduced at all."
+                        ),
+                        proposal_type="computational",
+                        target="claude_md",
+                        suggested_change=(
+                            f"Add to CLAUDE.md:\n"
+                            f"> Security reviewer repeatedly flags "
+                            f"'{pattern.error_signature}'. Follow the secure "
+                            f"pattern for this category from the start."
                         ),
                         source_patterns=[pattern.description],
                     )
@@ -655,6 +879,21 @@ class EvolutionJournal:
     # save_proposals
     # ------------------------------------------------------------------
 
+    def next_proposal_number(self, output_dir: Path) -> int:
+        """Next monotonic proposal number: max existing PROP number in
+        ``output_dir`` plus one (R6.2). 1 when the directory is empty or
+        missing."""
+        highest = 0
+        try:
+            candidates = list(output_dir.glob("prop-*.md"))
+        except OSError:
+            return 1
+        for path in candidates:
+            m = re.fullmatch(r"prop-(\d+)\.md", path.name)
+            if m:
+                highest = max(highest, int(m.group(1)))
+        return highest + 1
+
     def save_proposals(
         self,
         proposals: list[HarnessProposal],
@@ -662,17 +901,32 @@ class EvolutionJournal:
     ) -> list[Path]:
         """Write proposals as markdown files to output_dir.
 
-        Returns list of written file paths.
+        Returns list of written file paths. Never overwrites an existing
+        proposal file (R6.2): a filename collision means the caller
+        numbered the batch wrong (see ``next_proposal_number``), and
+        clobbering would silently rewrite audit history - skip and warn
+        instead.
         """
         written: list[Path] = []
         try:
             output_dir.mkdir(parents=True, exist_ok=True)
-        except OSError:
+        except OSError as exc:
+            logger.warning(
+                "proposal dir creation failed (non-fatal): %s: %s",
+                output_dir, exc,
+            )
             return written
 
         for proposal in proposals:
             filename = f"{proposal.id.lower()}.md"
             filepath = output_dir / filename
+
+            if filepath.exists():
+                logger.warning(
+                    "refusing to overwrite existing proposal %s; "
+                    "renumber with next_proposal_number()", filepath,
+                )
+                continue
 
             sources_block = "\n".join(
                 f"- {s}" for s in proposal.source_patterns
@@ -698,8 +952,11 @@ class EvolutionJournal:
             try:
                 filepath.write_text(content)
                 written.append(filepath)
-            except OSError:
-                pass
+            except OSError as exc:
+                logger.warning(
+                    "proposal write failed (non-fatal): %s: %s",
+                    filepath, exc,
+                )
 
         return written
 
@@ -708,39 +965,48 @@ class EvolutionJournal:
     # ------------------------------------------------------------------
 
     def get_concern_hit_rate(self, lookback_runs: int = 10) -> dict[str, Any]:
-        """Aggregate reviewer-concern signal across recent factory runs.
+        """Aggregate reviewer/security finding signal across recent runs.
 
         Returns ``{"runs": N, "components": M, "with_concern": K,
         "by_category": {...}}`` so dashboards can ask "did the
-        adversarial reviewer surface anything across the last N runs?"
+        adversarial reviewers surface anything across the last N runs?"
 
-        Today the evolution journal does not persist concerns as a
-        structured field (concerns are rendered into ``component.error``
-        or PR-body text). This method returns the LOWER BOUND of
-        concern surface based on the existing journal shape; a richer
-        implementation would write a dedicated concerns entry per
-        component. Tracked as a follow-up in
-        docs/adversarial-roadmap.md (Phase E3 - structured findings).
+        R6.2: consumes the typed ``findings_summary`` that record_run
+        writes on every component_result entry (E3 stream), replacing
+        the old error-string scan that was structurally zero (concern
+        categories never appeared in ``component.error``). A component
+        counts as "with concern" when its summary has at least one
+        finding in a real category - the synthetic
+        ``infrastructure_error`` and ``phase_skipped`` categories mark
+        non-execution, not adversarial signal, and are excluded.
         """
-        entries = self._read_journal_entries(lookback_runs)
+        entries = [
+            e for e in self._read_journal_entries(lookback_runs)
+            if e.get("event_type", "component_result") == "component_result"
+        ]
         runs = len({e.get("run_id", "") for e in entries})
         components = len(entries)
         with_concern = 0
         by_category: dict[str, int] = {}
         for entry in entries:
-            error = (entry.get("error") or "").lower()
-            # Recognize concern-shaped errors by the reviewer prefix
-            # that as_retry_context emits ("FAIL <category>:" or
-            # "ADVISORY <category>:"). Best-effort signal only.
-            for category in (
-                "scope_creep", "security_concern", "test_quality",
-                "unrelated_change", "dead_code", "error_handling",
-                "copy_paste",
-            ):
-                if category in error:
-                    with_concern += 1
-                    by_category[category] = by_category.get(category, 0) + 1
-                    break
+            summary = entry.get("findings_summary") or {}
+            cat_counts = summary.get("by_category") or {}
+            if not isinstance(cat_counts, dict):
+                continue
+            hit = False
+            for category, count in cat_counts.items():
+                if category in ("infrastructure_error", "phase_skipped"):
+                    continue
+                try:
+                    n = int(count)
+                except (TypeError, ValueError):
+                    continue
+                if n <= 0:
+                    continue
+                hit = True
+                by_category[category] = by_category.get(category, 0) + n
+            if hit:
+                with_concern += 1
         return {
             "runs": runs,
             "components": components,

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -1025,6 +1025,19 @@ def _run_factory_locked(
     # by creation time, not by nonce).
     run_id = current_run_id()
 
+    # R6.1: structured "<check>:<code>" failure signatures per component
+    # (e.g. "linter:E501", "review:scope_creep"), recorded at each
+    # failure site from the parser/finding stream and handed to the
+    # evolution journal at record_run. In-memory only: the manifest
+    # already persists failed_phase/failed_check; the full signature
+    # list is a journal concern.
+    component_failure_signatures: dict[str, list[str]] = {}
+    # R6.4: monotonic start of each component's current attempt, so the
+    # recorded duration covers the whole attempt (engineer loop +
+    # verify + review + security + PR flow), not just the engineer loop,
+    # and backstop-timeout failures stop recording 0.0.
+    attempt_started_monotonic: dict[str, float] = {}
+
     # Set up progress log. R3.2: defaults ON under .ralph/ so a
     # walk-away run always leaves an event trail `ralph status` can
     # join; [factory] progress_log_enabled = false (or env) opts out.
@@ -1119,6 +1132,7 @@ def _run_factory_locked(
                     fetch_base_branch(manifest.base_branch, root_dir)
                     comp.status = ComponentStatus.COMPLETED.value
                     comp.error = ""
+                    component_failure_signatures.pop(comp.id, None)
                     comp.completed_at = _iso_now()
                     factory_result.completed.append(comp.id)
                     progress_log.component_completed(
@@ -1131,6 +1145,9 @@ def _run_factory_locked(
                     comp.completed_at = _iso_now()
                     comp.failed_phase = "pr"
                     comp.failed_check = "pr_closed"
+                    component_failure_signatures[comp.id] = [
+                        "pr:closed-without-merge",
+                    ]
                     skipped = manifest.cascade_skip(comp.id)
                     factory_result.failed.append(comp.id)
                     factory_result.skipped.extend(skipped)
@@ -1318,12 +1335,21 @@ def _run_factory_locked(
         comp.journal_offset_end = -1
         comp.status = ComponentStatus.RUNNING.value
         comp.started_at = _iso_now()
+        component_failure_signatures.pop(comp.id, None)
+        attempt_started_monotonic[comp.id] = time.monotonic()
 
     def _end_attempt(comp: Component) -> None:
         """Stamp the attempt's evidence pointers when it stops running:
         the progress-log slice end, and the debug dir when any phase
-        dumped raw output there (R3.3)."""
+        dumped raw output there (R3.3). Also stamp the attempt's full
+        wall-clock duration (R6.4): every terminal transition (retry,
+        fail, merge-pending, completed, scheduler backstop) routes
+        through here, so duration_seconds covers engineer + verify +
+        review + security + PR instead of the engineer loop only."""
         comp.journal_offset_end = _journal_offset()
+        started = attempt_started_monotonic.get(comp.id)
+        if started is not None:
+            comp.duration_seconds = time.monotonic() - started
         debug_dir = _debug_dir_for(comp.id)
         if debug_dir.exists():
             comp.evidence_debug_dir = str(debug_dir)
@@ -1337,26 +1363,31 @@ def _run_factory_locked(
         Non-fatal on I/O errors, matching _record_contract_event."""
         if not comp.findings:
             return
-        from ralph_py.evolution import EvolutionConfig
+        from ralph_py.evolution import JOURNAL_SCHEMA_VERSION, EvolutionConfig
 
         evo_config = EvolutionConfig.load(root_dir)
         if not evo_config.enabled:
             return
         entry = {
+            "schema_version": JOURNAL_SCHEMA_VERSION,
             "timestamp": _iso_now(),
             "run_id": run_id,
             "project": manifest.project_name,
             "component_id": comp.id,
             "event_type": "findings_superseded",
             "attempt": comp.retries + 1,
+            "failure_signatures": component_failure_signatures.get(comp.id, []),
             "findings": [f.to_dict() for f in comp.findings],
         }
         try:
             evo_config.journal_path.parent.mkdir(parents=True, exist_ok=True)
             with open(evo_config.journal_path, "a") as f:
                 f.write(json.dumps(entry, separators=(",", ":")) + "\n")
-        except OSError:
-            pass  # evolution recording is non-fatal
+        except OSError as exc:
+            # Evolution recording is non-fatal, but never silent (R6.1).
+            ui.warn(
+                f"  Evolution journal write failed (non-fatal): {exc}"
+            )
 
     def _fail_component_for_budget(comp: Component, phase: str) -> None:
         """R3.1: halt LOUDLY on a blown token budget. Mirrors the R1.2/
@@ -1377,7 +1408,10 @@ def _run_factory_locked(
         progress_log.budget_exceeded(
             comp.id, run_usage.total_tokens, factory_config.max_total_tokens,
         )
-        _fail_component(comp, error, phase=phase, check="token_budget")
+        _fail_component(
+            comp, error, phase=phase, check="token_budget",
+            signatures=["token_budget:exceeded"],
+        )
 
     def _path_relative_to_root(path: Path) -> str:
         """Render `path` relative to root_dir for use inside per-component
@@ -1397,16 +1431,36 @@ def _run_factory_locked(
     progress_file_rel = _path_relative_to_root(base_config.progress_file)
     codebase_map_file_rel = _path_relative_to_root(base_config.codebase_map_file)
 
+    def _record_failure_signatures(
+        comp: Component, phase: str, error: str, signatures: list[str] | None,
+    ) -> None:
+        """R6.1: remember the structured signatures for this failure so
+        record_run journals real "<check>:<code>" identifiers instead of
+        re-deriving a degenerate slug from the flattened error string.
+        Sites without parser-level codes fall back to a slug of the
+        error text under the failing phase."""
+        from ralph_py.evolution import signature_for_error
+
+        if signatures:
+            component_failure_signatures[comp.id] = list(signatures)
+        else:
+            component_failure_signatures[comp.id] = [
+                signature_for_error(phase or "unknown", error),
+            ]
+
     def _retry_or_fail(
         comp: Component,
         error: str,
         context_json: str | None,
         phase: str = "",
         check: str = "",
+        signatures: list[str] | None = None,
     ) -> None:
         """Retry a component or mark it as failed. ``phase``/``check``
         name the gate that fired (R3.3); on a retry they describe the
-        superseded attempt until the next attempt clears them."""
+        superseded attempt until the next attempt clears them.
+        ``signatures`` are the structured failure signatures (R6.1)."""
+        _record_failure_signatures(comp, phase, error, signatures)
         if comp.retries < factory_config.max_retries:
             # A timeout failure means the agent was killed mid-flight: the
             # worktree/branch state cannot be trusted. Note the hygiene
@@ -1441,16 +1495,20 @@ def _run_factory_locked(
             time.sleep(factory_config.retry_delay)
             manifest.save(manifest_path)
         else:
-            _fail_component(comp, error, phase=phase, check=check)
+            _fail_component(
+                comp, error, phase=phase, check=check, signatures=signatures,
+            )
 
     def _fail_component(
         comp: Component, error: str, phase: str = "", check: str = "",
+        signatures: list[str] | None = None,
     ) -> None:
         """Mark a component FAILED with no retry. Direct callers are
         conditions a retry can never fix (R1.4: chunked-review budget
         insufficiency - the adversarial budget only shrinks, so
         re-running the engineer would burn LLM calls to hit the same
         wall); _retry_or_fail routes here once retries are exhausted."""
+        _record_failure_signatures(comp, phase, error, signatures)
         comp.status = ComponentStatus.FAILED.value
         comp.error = error
         comp.completed_at = _iso_now()
@@ -1592,10 +1650,17 @@ def _run_factory_locked(
                     comp_result.context_json or "{}",
                 )
                 ctx.add_verification_failure(verification.as_context())
+                # R6.1: carry the parser's structured codes (ruff rule,
+                # mypy error code, pytest exception type) into the
+                # journal instead of the flattened string.
+                from ralph_py.evolution import signatures_from_verification
                 _retry_or_fail(
                     comp, "Mechanical verification failed", ctx.to_json(),
                     phase="verify",
                     check=", ".join(c.name for c in failing),
+                    signatures=signatures_from_verification(
+                        verification.checks,
+                    ),
                 )
                 return
 
@@ -1634,6 +1699,7 @@ def _run_factory_locked(
             _retry_or_fail(
                 comp, f"Diff fetch failed (infrastructure): {exc}",
                 ctx.to_json(), phase="diff", check="git_diff",
+                signatures=["diff:fetch-failed"],
             )
             return
 
@@ -1706,6 +1772,7 @@ def _run_factory_locked(
                     comp,
                     f"Review diff unsplittable at the prompt cap: {exc}",
                     ctx.to_json(), phase="review", check="diff_chunking",
+                    signatures=["review:diff-unsplittable"],
                 )
                 return
             progress_log.emit(
@@ -1765,6 +1832,7 @@ def _run_factory_locked(
                 _fail_component(
                     comp, f"Review infrastructure error: {error}",
                     phase="review", check="adversarial_budget",
+                    signatures=["review:chunk-budget-insufficient"],
                 )
                 return
         if review_mode != ReviewMode.SKIP:
@@ -1864,11 +1932,18 @@ def _run_factory_locked(
                 )
                 ctx = IterationContext.from_json(comp_result.context_json or "{}")
                 ctx.add_review_finding(review_result.as_retry_context())
+                # R6.1: journal the finding categories that failed the
+                # gate ("review:scope_creep", "review:prd_criterion",
+                # "review:infrastructure"), not the flattened reason.
+                from ralph_py.evolution import signatures_from_findings
                 _retry_or_fail(
                     comp, reason, ctx.to_json(), phase="review",
                     check=(
                         "infrastructure"
                         if review_result.infrastructure_error else "criteria"
+                    ),
+                    signatures=signatures_from_findings(
+                        "review", review_result.as_findings(),
                     ),
                 )
                 return
@@ -1943,6 +2018,7 @@ def _run_factory_locked(
                 _fail_component(
                     comp, f"Security review infrastructure error: {error}",
                     phase="security", check="adversarial_budget",
+                    signatures=["security:chunk-budget-insufficient"],
                 )
                 return
         if sec_config and sec_config.mode != SecurityMode.SKIP.value:
@@ -2074,12 +2150,18 @@ def _run_factory_locked(
                         or "Security review infrastructure error: "
                         + sec_result.overall_notes
                     )
+                    # R6.1: journal the vuln categories that failed the
+                    # gate ("security:injection", ...), not the reason.
+                    from ralph_py.evolution import signatures_from_findings
                     _retry_or_fail(
                         comp, reason, ctx.to_json(), phase="security",
                         check=(
                             "infrastructure"
                             if sec_result.infrastructure_error
                             else "findings"
+                        ),
+                        signatures=signatures_from_findings(
+                            "security", sec_result.as_findings(),
                         ),
                     )
                     return
@@ -2307,6 +2389,9 @@ def _run_factory_locked(
                         comp.completed_at = _iso_now()
                         comp.failed_phase = "pr"
                         comp.failed_check = "pr_flow"
+                        _record_failure_signatures(
+                            comp, "pr", comp.error, None,
+                        )
                         _end_attempt(comp)
                         skipped = manifest.cascade_skip(comp_id)
                         factory_result.failed.append(comp_id)
@@ -2333,6 +2418,7 @@ def _run_factory_locked(
         # Mark completed
         comp.status = ComponentStatus.COMPLETED.value
         comp.error = ""
+        component_failure_signatures.pop(comp_id, None)
         comp.completed_at = _iso_now()
         _end_attempt(comp)
         factory_result.completed.append(comp_id)
@@ -2539,6 +2625,9 @@ def _run_factory_locked(
                         timed_out_comp.completed_at = _iso_now()
                         timed_out_comp.failed_phase = "engineer"
                         timed_out_comp.failed_check = "scheduler_backstop"
+                        component_failure_signatures[comp_id] = [
+                            "engineer:component-timeout",
+                        ]
                         _end_attempt(timed_out_comp)
                         # The worktree stays (leaked worker may own it);
                         # point the evidence at it (R3.3).
@@ -2627,7 +2716,7 @@ def _run_factory_locked(
         that a breaker retry later resolves. Non-fatal on I/O errors,
         matching EvolutionJournal.record_run.
         """
-        from ralph_py.evolution import EvolutionConfig
+        from ralph_py.evolution import JOURNAL_SCHEMA_VERSION, EvolutionConfig
 
         # R2.1: honor [evolution] in ralph.toml + env, resolved against
         # the factory root rather than whatever the process CWD is.
@@ -2635,6 +2724,7 @@ def _run_factory_locked(
         if not evo_config.enabled:
             return
         entry = {
+            "schema_version": JOURNAL_SCHEMA_VERSION,
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "run_id": run_id,
             "project": manifest.project_name,
@@ -2651,8 +2741,11 @@ def _run_factory_locked(
             evo_config.journal_path.parent.mkdir(parents=True, exist_ok=True)
             with open(evo_config.journal_path, "a") as f:
                 f.write(json.dumps(entry, separators=(",", ":")) + "\n")
-        except OSError:
-            pass  # evolution recording is non-fatal
+        except OSError as exc:
+            # Evolution recording is non-fatal, but never silent (R6.1).
+            ui.warn(
+                f"  Evolution journal write failed (non-fatal): {exc}"
+            )
 
     # Per-component PRs are squash-merged into base as each component
     # completes, so at contract time tier re-merges would be content
@@ -2718,6 +2811,9 @@ def _run_factory_locked(
                 breaker.retries += 1
                 breaker.status = ComponentStatus.PENDING.value
                 breaker.error = f"Contract test failed at tier {cr.tier}"
+                component_failure_signatures[cr.breaker] = [
+                    f"contract:tier_{cr.tier}",
+                ]
                 # Remove from completed list
                 if cr.breaker in factory_result.completed:
                     factory_result.completed.remove(cr.breaker)
@@ -2753,6 +2849,9 @@ def _run_factory_locked(
                     breaker.completed_at = _iso_now()
                     breaker.failed_phase = "contract"
                     breaker.failed_check = f"tier_{cr.tier}"
+                    component_failure_signatures[cr.breaker] = [
+                        f"contract:tier_{cr.tier}",
+                    ]
                 if cr.breaker in factory_result.completed:
                     factory_result.completed.remove(cr.breaker)
                 if cr.breaker not in factory_result.failed:
@@ -2938,8 +3037,10 @@ def _run_factory_locked(
                     for comp_id, phases in usage_meter.items()
                 },
                 run_usage=run_usage.to_dict(),
+                failure_signatures=component_failure_signatures,
             )
-    except Exception:
-        pass  # evolution recording is non-fatal
+    except Exception as exc:
+        # Evolution recording is non-fatal, but never silent (R6.1).
+        ui.warn(f"Evolution journal recording failed (non-fatal): {exc}")
 
     return factory_result

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -6,9 +6,14 @@ import json
 from pathlib import Path
 
 from ralph_py.evolution import (
+    JOURNAL_SCHEMA_VERSION,
     EvolutionConfig,
     EvolutionJournal,
     FailurePattern,
+    signature_for_error,
+    signatures_from_findings,
+    signatures_from_verification,
+    split_signature,
 )
 from ralph_py.factory import FactoryResult
 from ralph_py.manifest import Component, ComponentStatus, Manifest
@@ -247,23 +252,61 @@ class TestConcernHitRate:
             "runs": 0, "components": 0, "with_concern": 0, "by_category": {},
         }
 
-    def test_counts_categories(self, tmp_path: Path) -> None:
+    def test_counts_categories_from_findings_summary(
+        self, tmp_path: Path,
+    ) -> None:
+        """R6.2: the hit rate consumes the typed findings_summary that
+        record_run writes, not the error string (concern categories
+        never appear there, so the old scan was structurally zero)."""
         journal_path = tmp_path / "evolution.jsonl"
         self._write_entries(journal_path, [
-            {"run_id": "run-1", "component_id": "a", "error": "FAIL scope_creep: x"},
-            {"run_id": "run-1", "component_id": "b", "error": "ADVISORY test_quality: y"},
-            {"run_id": "run-2", "component_id": "c", "error": "FAIL security_concern: hardcoded key"},
-            {"run_id": "run-2", "component_id": "d", "error": ""},
+            {
+                "run_id": "run-1", "component_id": "a",
+                "event_type": "component_result",
+                "findings_summary": {
+                    "total": 2,
+                    "by_category": {"scope_creep": 1, "test_quality": 1},
+                },
+            },
+            {
+                "run_id": "run-1", "component_id": "b",
+                "event_type": "component_result",
+                # Infrastructure-only summaries are non-execution, not
+                # adversarial signal.
+                "findings_summary": {
+                    "total": 1,
+                    "by_category": {"infrastructure_error": 1},
+                },
+            },
+            {
+                "run_id": "run-2", "component_id": "c",
+                "event_type": "component_result",
+                "findings_summary": {
+                    "total": 1,
+                    "by_category": {"security_concern": 1},
+                },
+            },
+            {
+                "run_id": "run-2", "component_id": "d",
+                "event_type": "component_result",
+                "findings_summary": {"total": 0, "by_category": {}},
+            },
+            # Non-component entries are excluded from the denominator.
+            {
+                "run_id": "run-2", "component_id": "",
+                "event_type": "contract_result", "tier": 1, "passed": True,
+            },
         ])
         config = EvolutionConfig(journal_path=journal_path)
         journal = EvolutionJournal(config)
         result = journal.get_concern_hit_rate()
         assert result["runs"] == 2
         assert result["components"] == 4
-        assert result["with_concern"] == 3
-        assert result["by_category"]["scope_creep"] == 1
-        assert result["by_category"]["test_quality"] == 1
-        assert result["by_category"]["security_concern"] == 1
+        assert result["with_concern"] == 2
+        assert result["by_category"] == {
+            "scope_creep": 1, "test_quality": 1, "security_concern": 1,
+        }
+        assert "infrastructure_error" not in result["by_category"]
 
 
 # ---------------------------------------------------------------------------
@@ -342,3 +385,298 @@ class TestSaveProposals:
         assert "PROP-001" in content
         assert "E501" in content
         assert "computational" in content
+
+
+# ---------------------------------------------------------------------------
+# R6.1: structured failure signatures
+# ---------------------------------------------------------------------------
+
+
+class TestSignatureHelpers:
+    def test_signatures_from_verification_uses_parser_codes(self) -> None:
+        from ralph_py.parsers import ParsedFailure, ParsedOutput
+        from ralph_py.verify import CheckResult
+
+        ruff = ParsedOutput(tool="ruff", failures=[
+            ParsedFailure(file="a.py", line=1, rule_or_test="E501", message="x"),
+            ParsedFailure(file="b.py", line=2, rule_or_test="S608", message="y"),
+            ParsedFailure(file="c.py", line=3, rule_or_test="E501", message="z"),
+        ])
+        mypy = ParsedOutput(tool="mypy", failures=[
+            ParsedFailure(file="a.py", line=4, rule_or_test="arg-type", message="m"),
+        ])
+        pytest_out = ParsedOutput(tool="pytest", failures=[
+            ParsedFailure(
+                file="tests/test_a.py", rule_or_test="test_x",
+                message="AssertionError: assert 1 == 2",
+            ),
+        ])
+        checks = [
+            CheckResult(name="linter", passed=False, message="Linter failed",
+                        parsed=ruff),
+            CheckResult(name="typecheck", passed=False,
+                        message="Typecheck failed", parsed=mypy),
+            CheckResult(name="test_suite", passed=False,
+                        message="Tests failed", parsed=pytest_out),
+            CheckResult(name="bad_patterns", passed=True, message="ok"),
+        ]
+        sigs = signatures_from_verification(checks)
+        assert "linter:E501" in sigs
+        assert "linter:S608" in sigs
+        assert "typecheck:arg-type" in sigs
+        assert "test_suite:assertion-error" in sigs
+        # Passing checks contribute nothing; duplicates collapse.
+        assert sigs.count("linter:E501") == 1
+        assert not any(s.startswith("bad_patterns") for s in sigs)
+
+    def test_signatures_from_verification_fallback_slug(self) -> None:
+        from ralph_py.verify import CheckResult
+
+        checks = [CheckResult(
+            name="diff_scope", passed=False,
+            message="3 files outside allowed scope (diff vs base branch 'main')",
+        )]
+        sigs = signatures_from_verification(checks)
+        assert len(sigs) == 1
+        check, code = split_signature(sigs[0])
+        assert check == "diff_scope"
+        # Counts and quoted names are stripped so the slug is stable
+        # across runs with different violation counts.
+        assert "3" not in code
+        assert "main" not in code
+        assert "outside-allowed-scope" in code
+
+    def test_signatures_from_findings(self) -> None:
+        from ralph_py.findings import Finding
+
+        findings = [
+            Finding.from_review_concern(
+                category="scope_creep", severity="fail",
+                location="a.py", explanation="x",
+            ),
+            Finding.from_review_concern(
+                category="test_quality", severity="advisory",
+                location="b.py", explanation="y",
+            ),
+        ]
+        assert signatures_from_findings("review", findings) == [
+            "review:scope_creep",
+        ]
+
+    def test_signatures_from_findings_infrastructure(self) -> None:
+        from ralph_py.findings import Finding
+
+        findings = [Finding.infrastructure_error("review", "crashed")]
+        assert signatures_from_findings("review", findings) == [
+            "review:infrastructure",
+        ]
+
+    def test_signature_for_error_stable(self) -> None:
+        sig1 = signature_for_error(
+            "engineer", "component timeout: exceeded 600s wall clock",
+        )
+        sig2 = signature_for_error(
+            "engineer", "component timeout: exceeded 1200s wall clock",
+        )
+        assert sig1 == sig2
+        assert sig1.startswith("engineer:")
+
+
+class TestRecordRunSignatures:
+    def test_journal_entry_carries_structured_signatures(
+        self, tmp_path: Path,
+    ) -> None:
+        config = EvolutionConfig(
+            journal_path=tmp_path / "evolution.jsonl",
+            experiments_path=tmp_path / "experiments.tsv",
+        )
+        journal = EvolutionJournal(config)
+        comp = _make_component(
+            "b", status=ComponentStatus.FAILED.value,
+            error="Mechanical verification failed", retries=1,
+        )
+        comp.failed_phase = "verify"
+        comp.failed_check = "linter"
+        manifest = _make_manifest([comp])
+        factory_result = FactoryResult(completed=[], failed=["b"], skipped=[])
+
+        journal.record_run(
+            "run-001", manifest, factory_result,
+            failure_signatures={"b": ["linter:S608", "linter:E501"]},
+        )
+
+        entry = json.loads(config.journal_path.read_text().strip())
+        assert entry["schema_version"] == JOURNAL_SCHEMA_VERSION
+        assert entry["failure_signatures"] == ["linter:S608", "linter:E501"]
+        assert entry["check_name"] == "linter"
+        assert entry["error_signature"] == "S608"
+        assert entry["failed_phase"] == "verify"
+        assert entry["failed_check"] == "linter"
+        # TSV common_failure carries the full signature, not a slug of
+        # the flattened string.
+        tsv = config.experiments_path.read_text()
+        assert "linter:S608" in tsv
+
+    def test_legacy_fallback_without_signatures(self, tmp_path: Path) -> None:
+        """A failed component with no recorded signatures still gets a
+        classified signature from its error string, so entries never
+        lose the fields entirely."""
+        config = EvolutionConfig(
+            journal_path=tmp_path / "evolution.jsonl",
+            experiments_path=tmp_path / "experiments.tsv",
+        )
+        journal = EvolutionJournal(config)
+        comp = _make_component(
+            "b", status=ComponentStatus.FAILED.value,
+            error="ruff: S608 violation",
+        )
+        manifest = _make_manifest([comp])
+        journal.record_run(
+            "run-001", manifest,
+            FactoryResult(completed=[], failed=["b"], skipped=[]),
+        )
+        entry = json.loads(config.journal_path.read_text().strip())
+        assert entry["failure_signatures"] == ["linter:S608"]
+
+
+class TestEvolutionIntegration:
+    """R6 'done when': a synthetic-but-realistic journal (real signature
+    strings, typed findings) yields a proposal traceable to a recorded
+    signature and a nonzero concern hit rate."""
+
+    def _failed_component(self, comp_id: str) -> Component:
+        from ralph_py.findings import Finding
+
+        comp = _make_component(
+            comp_id, status=ComponentStatus.FAILED.value,
+            error="Review failed", retries=1, duration_seconds=42.0,
+            iteration_count=3,
+        )
+        comp.failed_phase = "review"
+        comp.failed_check = "criteria"
+        comp.findings = [
+            Finding.from_review_concern(
+                category="scope_creep", severity="fail",
+                location=f"{comp_id}.py", explanation="touched other files",
+            ),
+        ]
+        return comp
+
+    def test_journal_to_traceable_proposal(self, tmp_path: Path) -> None:
+        config = EvolutionConfig(
+            journal_path=tmp_path / "evolution.jsonl",
+            experiments_path=tmp_path / "experiments.tsv",
+            min_pattern_frequency=2,
+        )
+        journal = EvolutionJournal(config)
+
+        # Two runs, each with one linter:S608 failure and one review
+        # scope_creep failure - the shapes record_run actually writes.
+        for run_id in ("run-001", "run-002"):
+            lint_comp = _make_component(
+                "comp-lint", status=ComponentStatus.FAILED.value,
+                error="Mechanical verification failed", retries=2,
+                duration_seconds=30.0, iteration_count=2,
+            )
+            lint_comp.failed_phase = "verify"
+            lint_comp.failed_check = "linter"
+            review_comp = self._failed_component("comp-review")
+            manifest = _make_manifest([lint_comp, review_comp])
+            journal.record_run(
+                run_id, manifest,
+                FactoryResult(
+                    completed=[], failed=["comp-lint", "comp-review"],
+                    skipped=[],
+                ),
+                failure_signatures={
+                    "comp-lint": ["linter:S608"],
+                    "comp-review": ["review:scope_creep"],
+                },
+            )
+
+        patterns = journal.get_cross_run_patterns(lookback_runs=10)
+        linter_patterns = [
+            p for p in patterns
+            if p.check_name == "linter" and p.error_signature == "S608"
+        ]
+        assert linter_patterns, (
+            f"expected a linter:S608 pattern, got "
+            f"{[(p.check_name, p.error_signature) for p in patterns]}"
+        )
+        assert linter_patterns[0].frequency == 2
+        review_patterns = [
+            p for p in patterns
+            if p.check_name == "review" and p.error_signature == "scope_creep"
+        ]
+        assert review_patterns
+
+        # Proposals trace back to the recorded signature: the S608
+        # linter fast path fires, and the review proposal derives from
+        # the finding taxonomy.
+        proposals = journal.propose_improvements(patterns)
+        s608 = [p for p in proposals if "S608" in p.title]
+        assert s608 and s608[0].target == "claude_md"
+        assert any("S608" in src for src in s608[0].source_patterns)
+        assert any("scope_creep" in p.title for p in proposals)
+
+        # Concern hit rate is nonzero because findings_summary carries
+        # the scope_creep finding.
+        hit_rate = journal.get_concern_hit_rate()
+        assert hit_rate["with_concern"] > 0
+        assert hit_rate["by_category"].get("scope_creep", 0) > 0
+
+
+class TestProposalIdMonotonicity:
+    def test_ids_continue_across_invocations(self, tmp_path: Path) -> None:
+        """R6.2: a second `evolve` run continues numbering after the
+        files already on disk and never clobbers them."""
+        config = EvolutionConfig()
+        journal = EvolutionJournal(config)
+        output_dir = tmp_path / "proposals"
+
+        def _pattern(sig: str) -> FailurePattern:
+            return FailurePattern(
+                description=f"linter failure '{sig}' in 2/4 components",
+                frequency=2, total_components=4,
+                affected_components=["a", "b"],
+                check_name="linter", error_signature=sig,
+                category="verification",
+            )
+
+        first = journal.propose_improvements(
+            [_pattern("S608")],
+            starting_number=journal.next_proposal_number(output_dir),
+        )
+        assert first[0].id == "PROP-001"
+        journal.save_proposals(first, output_dir)
+        first_content = (output_dir / "prop-001.md").read_text()
+
+        second = journal.propose_improvements(
+            [_pattern("E501")],
+            starting_number=journal.next_proposal_number(output_dir),
+        )
+        assert second[0].id == "PROP-002"
+        written = journal.save_proposals(second, output_dir)
+        assert [p.name for p in written] == ["prop-002.md"]
+        # Prior file untouched.
+        assert (output_dir / "prop-001.md").read_text() == first_content
+
+    def test_save_never_clobbers_existing_file(self, tmp_path: Path) -> None:
+        config = EvolutionConfig()
+        journal = EvolutionJournal(config)
+        output_dir = tmp_path / "proposals"
+        output_dir.mkdir()
+        (output_dir / "prop-001.md").write_text("# PROP-001: original\n")
+
+        clashing = journal.propose_improvements([
+            FailurePattern(
+                description="linter failure 'E501' in 2/4 components",
+                frequency=2, total_components=4,
+                affected_components=["a", "b"],
+                check_name="linter", error_signature="E501",
+                category="verification",
+            ),
+        ])
+        written = journal.save_proposals(clashing, output_dir)
+        assert written == []
+        assert (output_dir / "prop-001.md").read_text() == "# PROP-001: original\n"

--- a/tests/test_evolve_apply.py
+++ b/tests/test_evolve_apply.py
@@ -1,0 +1,255 @@
+"""R6.3: `ralph evolve --apply` - the minimal REAL apply path.
+
+Convention-type proposals (computational, target claude_md) append to
+the project CLAUDE.md Agent Learnings section after explicit
+confirmation; everything else prints honest manual instructions.
+auto_propose and auto_apply_computational are honored.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from ralph_py.cli import _append_to_agent_learnings, cli
+from ralph_py.evolution import (
+    EvolutionConfig,
+    EvolutionJournal,
+    FailurePattern,
+)
+
+CLAUDE_MD = """# Test project
+
+## Coding standards
+
+- type hints everywhere
+
+## Agent Learnings
+
+### Conventions
+
+- existing convention
+"""
+
+
+def _linter_pattern(sig: str = "S608") -> FailurePattern:
+    return FailurePattern(
+        description=f"linter failure '{sig}' in 2/4 components",
+        frequency=2,
+        total_components=4,
+        affected_components=["a", "b"],
+        check_name="linter",
+        error_signature=sig,
+        category="verification",
+    )
+
+
+def _root_with_proposal(
+    tmp_path: Path, pattern: FailurePattern | None = None,
+) -> Path:
+    """Project root with CLAUDE.md and one saved proposal."""
+    (tmp_path / "CLAUDE.md").write_text(CLAUDE_MD)
+    journal = EvolutionJournal(EvolutionConfig())
+    proposals = journal.propose_improvements([pattern or _linter_pattern()])
+    journal.save_proposals(proposals, tmp_path / ".ralph" / "proposals")
+    return tmp_path
+
+
+def _invoke(root: Path, *args: str, input: str | None = None) -> tuple[int, str]:
+    result = CliRunner().invoke(
+        cli,
+        ["evolve", *args, "--root", str(root), "--ui", "plain", "--no-color"],
+        input=input,
+    )
+    return result.exit_code, result.output
+
+
+class TestEvolveApply:
+    def test_apply_appends_exactly_once_with_confirmation(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _root_with_proposal(tmp_path)
+
+        exit_code, output = _invoke(
+            root, "--apply", "PROP-001", input="y\n",
+        )
+        assert exit_code == 0, output
+        content = (root / "CLAUDE.md").read_text()
+        assert content.count("Avoid triggering linter rule S608") == 1
+        assert "PROP-001" in content
+        # Existing content untouched.
+        assert "existing convention" in content
+        # Proposal stamped as applied.
+        proposal_text = (
+            root / ".ralph" / "proposals" / "prop-001.md"
+        ).read_text()
+        assert "**Applied**:" in proposal_text
+
+        # Second apply is a no-op: still exactly one entry.
+        exit_code, output = _invoke(
+            root, "--apply", "PROP-001", input="y\n",
+        )
+        assert exit_code == 0, output
+        assert "already applied" in output
+        content = (root / "CLAUDE.md").read_text()
+        assert content.count("Avoid triggering linter rule S608") == 1
+
+    def test_apply_declined_appends_nothing(self, tmp_path: Path) -> None:
+        root = _root_with_proposal(tmp_path)
+        exit_code, output = _invoke(
+            root, "--apply", "PROP-001", input="n\n",
+        )
+        assert exit_code == 0, output
+        assert "not applied" in output
+        content = (root / "CLAUDE.md").read_text()
+        assert "S608" not in content
+        proposal_text = (
+            root / ".ralph" / "proposals" / "prop-001.md"
+        ).read_text()
+        assert "**Applied**:" not in proposal_text
+
+    def test_auto_apply_computational_skips_prompt(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _root_with_proposal(tmp_path)
+        (root / "ralph.toml").write_text(
+            "[evolution]\nauto_apply_computational = true\n"
+        )
+        # No input provided: a prompt would abort the runner.
+        exit_code, output = _invoke(root, "--apply", "PROP-001")
+        assert exit_code == 0, output
+        content = (root / "CLAUDE.md").read_text()
+        assert content.count("Avoid triggering linter rule S608") == 1
+
+    def test_non_convention_proposal_prints_manual(
+        self, tmp_path: Path,
+    ) -> None:
+        """typecheck proposals target pyproject: the CLI must be honest
+        that only manual application exists, and touch nothing."""
+        pattern = FailurePattern(
+            description="typecheck failure 'arg-type' in 2/4 components",
+            frequency=2, total_components=4,
+            affected_components=["a", "b"],
+            check_name="typecheck", error_signature="arg-type",
+            category="verification",
+        )
+        root = _root_with_proposal(tmp_path, pattern)
+        before = (root / "CLAUDE.md").read_text()
+        exit_code, output = _invoke(root, "--apply", "PROP-001")
+        assert exit_code == 0, output
+        assert "manually" in output
+        assert (root / "CLAUDE.md").read_text() == before
+
+    def test_apply_unknown_id_errors(self, tmp_path: Path) -> None:
+        root = _root_with_proposal(tmp_path)
+        exit_code, output = _invoke(root, "--apply", "PROP-999")
+        assert exit_code == 1
+        assert "not found" in output
+
+    def test_apply_without_agent_learnings_section_fails_honestly(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _root_with_proposal(tmp_path)
+        (root / "CLAUDE.md").write_text("# No learnings section\n")
+        exit_code, output = _invoke(
+            root, "--apply", "PROP-001", input="y\n",
+        )
+        assert exit_code == 1
+        assert "Agent Learnings" in output
+
+
+class TestAppendToAgentLearnings:
+    def test_appends_before_next_section(self, tmp_path: Path) -> None:
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(
+            "## Agent Learnings\n\n- old entry\n\n## Footer\n\ntext\n"
+        )
+        assert _append_to_agent_learnings(claude_md, "PROP-007", "new rule")
+        content = claude_md.read_text()
+        assert content.index("new rule") < content.index("## Footer")
+        assert "- new rule (applied from PROP-007 by ralph evolve)" in content
+
+    def test_missing_file_returns_false(self, tmp_path: Path) -> None:
+        assert not _append_to_agent_learnings(
+            tmp_path / "absent.md", "PROP-001", "rule",
+        )
+
+
+class TestAutoPropose:
+    def _journal_with_pattern(self, root: Path) -> None:
+        entries = []
+        for run_id in ("run-001", "run-002"):
+            entries.append({
+                "schema_version": 2,
+                "run_id": run_id,
+                "component_id": "comp-a",
+                "event_type": "component_result",
+                "status": "failed",
+                "error": "Mechanical verification failed",
+                "failure_signatures": ["linter:S608"],
+                "findings_summary": {"total": 0, "by_category": {}},
+            })
+        journal_path = root / ".ralph" / "evolution.jsonl"
+        journal_path.parent.mkdir(parents=True, exist_ok=True)
+        journal_path.write_text(
+            "\n".join(json.dumps(e) for e in entries) + "\n"
+        )
+
+    def test_auto_propose_false_reports_patterns_only(
+        self, tmp_path: Path,
+    ) -> None:
+        self._journal_with_pattern(tmp_path)
+        (tmp_path / "ralph.toml").write_text(
+            "[evolution]\nauto_propose = false\n"
+        )
+        exit_code, output = _invoke(tmp_path)
+        assert exit_code == 0, output
+        assert "S608" in output
+        assert "auto_propose is disabled" in output
+        assert not (tmp_path / ".ralph" / "proposals").exists()
+
+    def test_auto_propose_default_generates_monotonic_ids(
+        self, tmp_path: Path,
+    ) -> None:
+        """Two `ralph evolve` invocations: the second run neither
+        clobbers nor duplicates; a new pattern continues the numbering."""
+        self._journal_with_pattern(tmp_path)
+        exit_code, output = _invoke(tmp_path)
+        assert exit_code == 0, output
+        proposals_dir = tmp_path / ".ralph" / "proposals"
+        assert (proposals_dir / "prop-001.md").exists()
+        first_content = (proposals_dir / "prop-001.md").read_text()
+
+        # Re-run with the same journal: same pattern, no duplicate file.
+        exit_code, output = _invoke(tmp_path)
+        assert exit_code == 0, output
+        assert sorted(p.name for p in proposals_dir.glob("*.md")) == [
+            "prop-001.md",
+        ]
+        assert (proposals_dir / "prop-001.md").read_text() == first_content
+        assert "already exist" in output
+
+        # A new signature appears: numbering continues at PROP-002.
+        journal_path = tmp_path / ".ralph" / "evolution.jsonl"
+        extra = []
+        for run_id in ("run-003", "run-004"):
+            extra.append({
+                "schema_version": 2,
+                "run_id": run_id,
+                "component_id": "comp-b",
+                "event_type": "component_result",
+                "status": "failed",
+                "error": "Mechanical verification failed",
+                "failure_signatures": ["linter:E501"],
+                "findings_summary": {"total": 0, "by_category": {}},
+            })
+        with open(journal_path, "a") as f:
+            for e in extra:
+                f.write(json.dumps(e) + "\n")
+        exit_code, output = _invoke(tmp_path)
+        assert exit_code == 0, output
+        names = sorted(p.name for p in proposals_dir.glob("*.md"))
+        assert names == ["prop-001.md", "prop-002.md"]
+        assert "E501" in (proposals_dir / "prop-002.md").read_text()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -372,3 +372,79 @@ class TestRunFactoryExecution:
         comp = manifest.get_component("a")
         assert comp is not None
         assert comp.retries == 1
+
+
+class TestEvolutionRecording:
+    """R6.1 + R6.4 end to end: a real factory run journals structured
+    failure signatures and a nonzero attempt duration."""
+
+    def test_failure_signature_and_duration_reach_journal(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _setup_project(tmp_path)
+        prd_rel = "scripts/ralph/feature/a/prd.json"
+        manifest = _make_manifest([
+            Component("a", "A", "", [], prd_rel, "b/a"),
+        ])
+        config = FactoryConfig(
+            use_worktrees=False, create_prs=False, max_parallel=1,
+            max_retries=0, retry_delay=0, review_mode="skip",
+            verify_config=VerifyConfig(
+                test_command="false",  # tests will fail
+                typecheck_command="true",
+                lint_command="true",
+                check_diff_scope=False,
+                check_bad_patterns=False,
+                subprocess_timeout=5.0,
+            ),
+        )
+        base = _make_base_config(root)
+        ui = PlainUI(no_color=True)
+
+        feature_dir = root / "scripts" / "ralph" / "feature" / "a"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "prd.json").write_text(json.dumps({
+            "branchName": "test",
+            "userStories": [{
+                "id": "US-001", "title": "Test",
+                "acceptanceCriteria": ["AC1"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+
+        success_result = ComponentResult("a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=success_result,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(manifest, config, base, ui, root)
+
+        assert "a" in result.failed
+
+        journal_path = root / ".ralph" / "evolution.jsonl"
+        entries = [
+            json.loads(line)
+            for line in journal_path.read_text().strip().splitlines()
+        ]
+        comp_entries = [
+            e for e in entries
+            if e.get("event_type") == "component_result"
+            and e.get("component_id") == "a"
+        ]
+        assert comp_entries, f"no component_result entry in {entries}"
+        entry = comp_entries[-1]
+        # R6.4: journal format is versioned.
+        assert entry["schema_version"] == 2
+        # R6.1: the structured signature from the failing check, not a
+        # slug of "Mechanical verification failed".
+        assert entry["failure_signatures"] == [
+            "test_suite:tests-failed-exit-code",
+        ]
+        assert entry["check_name"] == "test_suite"
+        assert entry["error_signature"] == "tests-failed-exit-code"
+        # R6.4: duration is the attempt wall clock, not 0.0. The mocked
+        # engineer returns instantly, so any nonzero value proves the
+        # stamp comes from the factory's own attempt clock.
+        assert entry["duration_seconds"] > 0
+        comp = manifest.get_component("a")
+        assert comp is not None
+        assert comp.duration_seconds > 0


### PR DESCRIPTION
## Roadmap items

R6.1 (real error signatures), R6.2 (metrics read the typed stream), R6.3 (`evolve --apply` honesty), R6.4 (re-baseline: durations, metric docs, journal versioning). Checkboxes flipped in `docs/remediation-roadmap.md` in this PR.

## What changed

- **R6.1**: every factory failure site records structured `"<check>:<code>"` signatures (`linter:E501`, `typecheck:arg-type`, `test_suite:assertion-error`, `review:scope_creep`, `security:injection`, `contract:tier_N`, `engineer:component-timeout`, `token_budget:exceeded`, `pr:closed-without-merge`, ...) sourced from the tool parsers (`CheckResult.parsed`) and the Finding taxonomy. `record_run` journals the list plus the legacy `check_name`/`error_signature` split of the primary signature; `extract_failure_patterns` / `get_cross_run_patterns` group on full signatures. Sites without parser codes fall back to a stable slug (paths, line numbers, digits stripped). Remaining silent excepts on journal/TSV/proposal writes are logged warnings (`ui.warn` in factory, `logging` in evolution.py).
  - Note: `EvolutionConfig.load(root_dir)` + root-anchored journal paths had already landed via R2.1/wave 4B; this PR completes the R6.1 bullet with the signature plumbing and the warning conversions.
- **R6.2**: `get_concern_hit_rate` consumes `findings_summary.by_category` from the typed E3 stream (excluding the synthetic `infrastructure_error`/`phase_skipped` categories) instead of scanning `entry["error"]` for categories that never appear there. Proposal IDs are monotonic across invocations (`next_proposal_number` scans the dir); `save_proposals` never overwrites an existing file; repeated `ralph evolve` runs dedupe proposals by title instead of duplicating. New `security` proposal branch derives from the OWASP-mapped finding taxonomy.
- **R6.3**: `ralph evolve --apply PROP-NNN|all` implements the minimal real path: convention-type proposals (computational, target `claude_md`) append to the project CLAUDE.md `## Agent Learnings` section after explicit confirmation (`auto_apply_computational = true` skips the prompt), and the proposal file is stamped `**Applied**:` so re-apply is a no-op. Every other target prints honest manual instructions. `auto_propose = false` restricts `ralph evolve` to pattern reporting.
- **R6.4**: `duration_seconds` is now the last-attempt wall clock stamped in `_end_attempt` (engineer + verify + review + security + PR flow; scheduler-backstop timeouts no longer record 0.0). All journal entry types carry `schema_version = 2`. `docs/evolution-metrics.md` defines every `experiments.tsv` column, `retry_rate` (average retries per component, can exceed 1.0), duration semantics, the concern-hit-rate definition, and the wave-1 archive re-baseline.

## Verification (all green)

```
uv run pytest tests/ -q         -> 1303 passed, 28 skipped, 1 xfailed, 1 warning in 58.51s
uv run mypy ralph_py/ --strict  -> Success: no issues found in 38 source files
uv run ruff check ralph_py/ tests/ -> All checks passed!
```

## Tested (proven by named tests)

- Factory-to-journal e2e: a real `run_factory` with a failing test command journals `failure_signatures == ["test_suite:tests-failed-exit-code"]`, `schema_version == 2`, and `duration_seconds > 0` on both the entry and the manifest component (`test_factory.py::TestEvolutionRecording::test_failure_signature_and_duration_reach_journal`).
- Parser-code signature derivation for ruff/mypy/pytest incl. dedup, passing-check exclusion, and count/quoted-name-stable fallback slugs (`test_evolution.py::TestSignatureHelpers`, 5 tests).
- Journal entries carry signatures + legacy split + failed_phase/check; TSV `common_failure` is the full signature; legacy fallback classifies un-signatured errors (`TestRecordRunSignatures`, 2 tests).
- Integration: a synthetic-but-realistic journal (two `record_run` calls with `linter:S608` + `review:scope_creep`) yields cross-run patterns with real check/code splits, an S608 proposal traceable to its source signature, a scope_creep proposal from the finding taxonomy, and a NONZERO concern hit rate from `findings_summary` (`TestEvolutionIntegration::test_journal_to_traceable_proposal`) - the phase "Done when" shape.
- Concern hit rate counts categories from `findings_summary`, excludes `infrastructure_error`, excludes non-component entries from the denominator (`TestConcernHitRate::test_counts_categories_from_findings_summary`).
- Proposal-ID monotonicity across two invocations (PROP-001 then PROP-002, prior file byte-identical) and no-clobber on filename collision (`TestProposalIdMonotonicity`, 2 tests).
- `--apply` appends exactly once with confirmation; re-apply is a "already applied" no-op; declined confirmation appends nothing; `auto_apply_computational` skips the prompt; non-convention targets print "manually" and touch nothing; unknown ID exits 1; missing Agent Learnings section fails honestly with exit 1 (`test_evolve_apply.py::TestEvolveApply`, 6 tests; `TestAppendToAgentLearnings` covers mid-file section insertion).
- `auto_propose = false` reports patterns without writing proposal files; the default path dedupes re-detected patterns and continues numbering for genuinely new signatures (`TestAutoPropose`, 2 tests).
- Config load path (toml + env overlay, root-anchored journal paths) was already covered by `test_config_control_plane.py` (TestEvolveCommandTomlRoundTrip, env-overlay tests); still green.

## Assumed (claimed but not directly tested)

- Signature quality on real LLM-driven runs: the e2e test exercises the verify path; review/security/contract/PR/backstop signature sites are exercised only at the unit level (`signatures_from_findings`) plus existing factory-path tests - no live factory run with a real reviewer was performed.
- The security-gate signature list uses static gating severities (fail/critical/high); a hard-mode gate configured with a `medium` fail threshold would fail the component while journaling only the >= high categories present.
- `_append_to_agent_learnings` assumes the Agent Learnings section ends at the next level-2 header or EOF; exotic CLAUDE.md layouts (e.g. Agent Learnings inside a code fence) were not tested.
- Duration semantics for components inherited mid-flight from a crashed run (no `_begin_attempt` in this process) keep whatever the manifest carried; documented in `docs/evolution-metrics.md`, not tested.
- The roadmap's `diff_scope:rename` example signature does not exist as such: diff-scope failures record the stable slug form (`diff_scope:files-outside-allowed-scope-...` / scope-config-error), since the check does not classify rename vs add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)