### PR TITLE
feat: R7.2 wire fixtures, sandboxed (CRIT-3, H-6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,16 @@ flowchart TD
     Bisect --> Schedule
 ```
 
-## Approved fixtures - behavioral verification you control (not yet wired)
+## Approved fixtures - behavioral verification you control
 
-> **Status**: the fixture runner (`ralph_py/fixtures.py`) and the formats below exist, but they are not yet called from Phase 1 verification. Wiring lands with roadmap item R7.2 (sandboxed execution, off by default). Until then a `fixtures` array in a PRD is not executed, and there is no `[fixtures]` section in ralph.toml.
+Agent-generated tests can be written to pass trivially. Approved fixtures are input/output pairs, declared in the PRD, that the agent's code must satisfy - they run during Phase 1 mechanical verification, outside the project's own pytest, so a gamed conftest cannot deselect them.
 
-Agent-generated tests can be written to pass trivially. Approved fixtures are human-written input/output pairs that the agent's code must satisfy:
+Fixtures are **off by default**. Enable them in ralph.toml (they also do nothing unless the PRD has a `fixtures` array):
+
+```toml
+[fixtures]
+enabled = true
+```
 
 ```json
 {
@@ -201,7 +206,17 @@ Agent-generated tests can be written to pass trivially. Approved fixtures are hu
 }
 ```
 
-Three fixture types: `cli` (run a command, check output), `function` (import and call, check return), `file` (check existence and content).
+Three fixture types: `cli` (run a command, check output), `function` (import and call, check return), `file` (check existence and content). The schema is strict: unknown keys anywhere in a fixture entry are rejected at PRD validation, because a misspelled expectation key (`stdout_containz`) would otherwise be silently ignored and the fixture would pass vacuously.
+
+Because the PRD is LLM-emitted, fixture definitions are treated as untrusted input:
+
+- **`cli` fixtures run without a shell.** The command string is split with `shlex` and executed directly, so shell features - pipes, redirection, `&&`, `$VAR` expansion, globbing - are unsupported; metacharacters reach the program as literal arguments. Each command runs with a scrubbed environment (no API keys or tokens) in its own process group with a timeout.
+- **`function` fixtures run in a subprocess**, never in the harness process. The module/function spec travels as JSON to a `sys.executable` runner with cwd set to the component worktree, the same scrubbed environment, and a timeout. Two consequences: fixtures run under the harness's Python interpreter (not the project's venv), so keep them free of project-only third-party imports; and the `returns` comparison is JSON-shaped (dicts, lists, strings, numbers, booleans, null).
+- **`file` fixtures cannot leave the worktree.** Absolute paths, `..` components, and symlink escapes are rejected.
+
+**Snapshot regression**, behind the same `enabled` flag: when every fixture passes, actual outputs are saved to `snapshot_dir` keyed by component id; later runs fail Phase 1 if a previously-passing fixture fails or its output changes. If a change is intentional, delete `.ralph/snapshots/<component>.json` to reset the baseline. Snapshots resolve against the repo root, not the worktree, so they survive worktree recreation between runs.
+
+See the `[fixtures]` keys in the configuration reference below.
 
 ## Why not just use Claude Code directly?
 
@@ -319,6 +334,13 @@ subprocess_timeout = 300.0                         # seconds per verification su
 require_self_critique = false                      # fail Phase 1 if the ## Self-Critique block is missing/sparse
 self_critique_min_bullets = 3                      # minimum substantive bullets in the block
 progress_file_path = "scripts/ralph/progress.txt"  # progress file the self-critique check reads
+
+# Phase 1 approved-fixtures oracle (R7.2; default off)
+[fixtures]
+enabled = false                    # run PRD-defined fixtures during Phase 1 (sandboxed; opt-in)
+snapshot_on_success = true         # save passing outputs for cross-run regression comparison
+snapshot_dir = ".ralph/snapshots"  # relative paths resolve against the repo root
+timeout = 30.0                     # seconds per fixture subprocess
 
 # Phase 2.5 security review
 [security]

--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -577,7 +577,7 @@ by an integration test with a synthetic-but-realistic journal).
   - Measure the correlated-miss delta: run calibration with same-family and
     cross-family configs and record both (this is the E1 decision revisited
     with 2026 evidence; independent passes, never committee deliberation).
-- [ ] R7.2 (M) **Wire fixtures, sandboxed** [CRIT-3, H-6; user decision 4]
+- [x] R7.2 (M) **Wire fixtures, sandboxed** [CRIT-3, H-6; user decision 4]
   - Function fixtures execute in a subprocess (`sys.executable -c`) with the
     R2.6 scrubbed env: never in the harness process.
   - CLI fixtures: `shlex.split` + `shell=False`.

--- a/ralph.toml.example
+++ b/ralph.toml.example
@@ -96,6 +96,16 @@ require_self_critique = false      # opt-in: fail Phase 1 if engineer's ## Self-
 self_critique_min_bullets = 3
 progress_file_path = "scripts/ralph/progress.txt"
 
+# Phase 1 approved fixtures (R7.2): PRD-defined input/output pairs run as an
+# oracle independent of agent-authored tests. Opt-in: fixtures execute
+# PRD-supplied commands (no shell) and import PRD-named modules (in a
+# scrubbed-env subprocess), so the operator must enable them explicitly.
+[fixtures]
+enabled = false
+snapshot_on_success = true         # save passing outputs for cross-run regression comparison
+snapshot_dir = ".ralph/snapshots"  # relative = against the repo root, not the worktree
+timeout = 30.0                     # seconds per fixture subprocess
+
 # Phase 2.5 security review (independent adversarial pass focused on vulns).
 [security]
 mode = "skip"                      # skip | advisory | hard

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -25,6 +25,7 @@ from ralph_py.contract import (
 )
 from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
 from ralph_py.findings import Finding, tag_finding_with_attempt
+from ralph_py.fixtures import FixturesConfig
 from ralph_py.git import GitDiffError, fetch_base_branch, resolve_base_ref
 from ralph_py.knowledge import (
     KnowledgeConfig,
@@ -146,6 +147,12 @@ class FactoryConfig:
     # manifest and survive the next run's stale-worktree prune for as
     # long as the component stays FAILED.
     keep_worktrees_on_failure: bool = False
+    # R7.2: approved-fixtures oracle for Phase 1. None means run_factory
+    # loads FixturesConfig.load(root_dir) - toml [fixtures] section +
+    # env - so `ralph factory` honors the config with no CLI wiring.
+    # Default-off ([fixtures].enabled = false, roadmap user decision 4):
+    # fixtures execute PRD-defined commands, so the operator opts in.
+    fixtures_config: FixturesConfig | None = None
 
     @classmethod
     def from_env(cls) -> FactoryConfig:
@@ -1621,6 +1628,13 @@ def _run_factory_locked(
                 allowed_paths_error = f"PRD not found: {exc}"
             except ValueError as exc:
                 allowed_paths_error = f"PRD failed to parse: {exc}"
+            # R7.2: fixtures config resolves from toml/env when the
+            # caller did not inject one; enabled=false (the default)
+            # makes run_mechanical_verification skip the check entirely.
+            fixtures_cfg = (
+                factory_config.fixtures_config
+                or FixturesConfig.load(root_dir)
+            )
             verification = run_mechanical_verification(
                 wt_path,
                 wt_path / comp.prd_path,
@@ -1628,6 +1642,8 @@ def _run_factory_locked(
                 component_allowed_paths,
                 verify_config,
                 allowed_paths_error=allowed_paths_error,
+                fixtures_config=fixtures_cfg,
+                component_id=comp_id,
             )
             verify_duration = time.monotonic() - verify_start
             comp.verification_passed = verification.passed

--- a/ralph_py/fixtures.py
+++ b/ralph_py/fixtures.py
@@ -1,22 +1,36 @@
 """Approved fixtures - pre-approved input/output pairs for behavioral verification.
 
 Provides behavioral verification independent of agent-generated tests.
-Fixtures are defined in the PRD and checked during Phase 1 mechanical verification.
+Fixtures are defined in the PRD and checked during Phase 1 mechanical
+verification when ``[fixtures].enabled`` is set (R7.2; default off per
+the roadmap user decision).
+
+Threat model (R7.2 / CRIT-3): the PRD is LLM-emitted, so every fixture
+definition is untrusted input. Function fixtures therefore execute in a
+subprocess with the R2.6 scrubbed environment - the harness process
+never imports agent code - and CLI fixtures run with ``shell=False`` so
+metacharacters in a PRD-supplied command are literal arguments, never
+shell syntax. What sandboxing does NOT claim: agent code runs inside the
+fixture subprocess and could forge the result line, but that grants no
+power beyond hardcoding the function's return value, which fixtures
+legitimately accept - they verify behavior, they are not a defense
+against a malicious implementation.
 """
 
 from __future__ import annotations
 
-import importlib
 import json
+import os
+import shlex
 import subprocess
+import sys
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    pass
-
+from ralph_py.prd import PRD
 from ralph_py.verify import CheckResult, run_scrubbed
 
 
@@ -42,12 +56,70 @@ class FixtureResult:
 
 @dataclass
 class FixturesConfig:
-    """Configuration for the fixtures check."""
+    """Configuration for the fixtures check (``[fixtures]`` in ralph.toml).
+
+    ``enabled`` defaults to False (R7.2 user decision 4): fixtures run
+    PRD-defined commands and import PRD-named modules, so the operator
+    must opt in explicitly.
+    """
 
     enabled: bool = False
     snapshot_on_success: bool = True
     snapshot_dir: Path = field(default_factory=lambda: Path(".ralph/snapshots"))
     timeout: float = 30.0
+
+    @classmethod
+    def from_env(cls) -> FixturesConfig:
+        """Load fixtures config from environment variables."""
+        from ralph_py.config import _parse_bool
+
+        return cls(
+            enabled=_parse_bool(os.environ.get("RALPH_FIXTURES_ENABLED")),
+            snapshot_on_success=_parse_bool(
+                os.environ.get("RALPH_FIXTURES_SNAPSHOT_ON_SUCCESS", "1")
+            ),
+            snapshot_dir=Path(
+                os.environ.get("RALPH_FIXTURES_SNAPSHOT_DIR", ".ralph/snapshots")
+            ),
+            timeout=float(os.environ.get("RALPH_FIXTURES_TIMEOUT", "30")),
+        )
+
+    @classmethod
+    def load(cls, root_dir: Path | None = None) -> FixturesConfig:
+        """Load fixtures config with precedence: env > toml > defaults.
+
+        A relative ``snapshot_dir`` resolves against ``root_dir`` (the
+        operator's repo), NOT the component worktree: worktrees are
+        recreated across runs, so a worktree-relative snapshot would be
+        wiped before the next run could compare against it.
+        """
+        from ralph_py.config import _parse_bool, load_toml_section
+
+        if root_dir is None:
+            root_dir = Path.cwd()
+        config = cls()
+        section = load_toml_section(root_dir / "ralph.toml", "fixtures")
+        if "enabled" in section:
+            config.enabled = bool(section["enabled"])
+        if "snapshot_on_success" in section:
+            config.snapshot_on_success = bool(section["snapshot_on_success"])
+        if "snapshot_dir" in section:
+            config.snapshot_dir = Path(str(section["snapshot_dir"]))
+        if "timeout" in section:
+            config.timeout = float(section["timeout"])
+        if "RALPH_FIXTURES_ENABLED" in os.environ:
+            config.enabled = _parse_bool(os.environ["RALPH_FIXTURES_ENABLED"])
+        if "RALPH_FIXTURES_SNAPSHOT_ON_SUCCESS" in os.environ:
+            config.snapshot_on_success = _parse_bool(
+                os.environ["RALPH_FIXTURES_SNAPSHOT_ON_SUCCESS"]
+            )
+        if "RALPH_FIXTURES_SNAPSHOT_DIR" in os.environ:
+            config.snapshot_dir = Path(os.environ["RALPH_FIXTURES_SNAPSHOT_DIR"])
+        if "RALPH_FIXTURES_TIMEOUT" in os.environ:
+            config.timeout = float(os.environ["RALPH_FIXTURES_TIMEOUT"])
+        if not config.snapshot_dir.is_absolute():
+            config.snapshot_dir = root_dir / config.snapshot_dir
+        return config
 
 
 def run_cli_fixture(
@@ -56,9 +128,14 @@ def run_cli_fixture(
     """Run a CLI fixture by executing a command and checking output expectations.
 
     Checks exit_code, stdout_contains, and stdout_not_contains from expected.
+
+    The command string is tokenized with ``shlex.split`` and executed
+    with ``shell=False``: shell features (pipes, redirection, ``&&``,
+    variable expansion, globbing) are NOT supported, and metacharacters
+    in the PRD-supplied command reach the program as literal arguments.
     """
     command = fixture.input_data.get("command")
-    if not command:
+    if not command or not isinstance(command, str):
         return FixtureResult(
             fixture=fixture,
             passed=False,
@@ -66,7 +143,24 @@ def run_cli_fixture(
         )
 
     try:
-        result = run_scrubbed(command, cwd=cwd, timeout=timeout)
+        argv = shlex.split(command)
+    except ValueError as exc:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message=f"Could not parse command ({exc}); note that shell "
+            "features are unsupported - the command is split with shlex "
+            "and executed without a shell",
+        )
+    if not argv:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message="Command is empty after parsing",
+        )
+
+    try:
+        result = run_scrubbed(argv, cwd=cwd, timeout=timeout)
     except subprocess.TimeoutExpired:
         return FixtureResult(
             fixture=fixture,
@@ -117,13 +211,124 @@ def run_cli_fixture(
     )
 
 
-def run_function_fixture(fixture: Fixture, cwd: Path) -> FixtureResult:
-    """Run a function fixture by importing a module and calling a function.
+# Result line prefix the function-fixture runner prints. The parent scans
+# stdout for the LAST line with this prefix, so module-level prints from
+# agent code cannot shadow the runner's genuine verdict as long as the
+# runner completes (see the module docstring for the forgery equivalence
+# argument).
+_RESULT_MARKER = "RALPH-FIXTURE-RESULT-V1:"
 
-    Checks expected return value or expected exception type.
+# Source of the subprocess that imports and calls the agent-written
+# function. Composed with the marker constant so the two cannot drift.
+# It mirrors the pass/fail semantics the in-process runner used to have:
+# expected exception, unexpected exception, expected return, no expected
+# return (vacuous pass - rejected earlier by PRD validation).
+_FUNCTION_FIXTURE_RUNNER = (
+    "_MARKER = " + repr(_RESULT_MARKER) + "\n"
+    + '''
+import importlib
+import json
+import sys
+
+
+def _emit(passed, actual, message):
+    sys.stdout.flush()
+    sys.stdout.write(
+        "\\n" + _MARKER + json.dumps(
+            {"passed": passed, "actual": actual, "message": message}
+        ) + "\\n"
+    )
+    sys.stdout.flush()
+
+
+def _main():
+    spec = json.loads(sys.argv[1])
+    expected = spec.get("expected", {})
+    args = spec.get("args", [])
+    kwargs = spec.get("kwargs", {})
+    try:
+        mod = importlib.import_module(spec["module"])
+    except BaseException as exc:
+        _emit(False, "", "Failed to import module %r: %s: %s"
+              % (spec["module"], type(exc).__name__, exc))
+        return
+    func = getattr(mod, spec["function"], None)
+    if func is None:
+        _emit(False, "", "Function %r not found in module %r"
+              % (spec["function"], spec["module"]))
+        return
+    expected_raises = expected.get("raises")
+    if expected_raises:
+        try:
+            func(*args, **kwargs)
+        except Exception as exc:
+            name = type(exc).__name__
+            if name == expected_raises:
+                _emit(True, "raised " + name,
+                      "Function fixture passed - expected exception raised")
+            else:
+                _emit(False, "raised " + name,
+                      "Expected %s, got %s" % (expected_raises, name))
+            return
+        _emit(False, "no exception raised",
+              "Expected %s but no exception was raised" % expected_raises)
+        return
+    try:
+        actual = func(*args, **kwargs)
+    except Exception as exc:
+        _emit(False, "raised %s: %s" % (type(exc).__name__, exc),
+              "Unexpected exception: %s: %s" % (type(exc).__name__, exc))
+        return
+    if "returns" not in expected:
+        _emit(True, repr(actual),
+              "Function fixture passed (no expected return specified)")
+        return
+    expected_value = expected["returns"]
+    if actual == expected_value:
+        _emit(True, repr(actual), "Function fixture passed")
+    else:
+        _emit(False, repr(actual),
+              "Expected %r, got %r" % (expected_value, actual))
+
+
+_main()
+'''
+)
+
+
+def _parse_runner_result(stdout: str) -> dict[str, Any] | None:
+    """Extract the runner's verdict from subprocess stdout, last line wins."""
+    for line in reversed(stdout.splitlines()):
+        if line.startswith(_RESULT_MARKER):
+            try:
+                payload = json.loads(line[len(_RESULT_MARKER):])
+            except json.JSONDecodeError:
+                return None
+            if isinstance(payload, dict):
+                return payload
+            return None
+    return None
+
+
+def run_function_fixture(
+    fixture: Fixture, cwd: Path, timeout: float,
+) -> FixtureResult:
+    """Run a function fixture in a subprocess and check its reported result.
+
+    The spec (module, function, args, kwargs, expected) travels as a JSON
+    argv argument to ``sys.executable -c <runner>``; the runner imports
+    the module from ``cwd`` (the worktree), calls the function, compares
+    against ``expected`` in-process (Python ``==``), and prints a single
+    marker-prefixed JSON verdict line. The harness process never imports
+    agent code; the subprocess gets the R2.6 scrubbed environment, runs
+    in its own session, and is group-killed on timeout (``run_scrubbed``).
+
+    Two documented limitations: the fixture runs under the HARNESS's
+    Python interpreter (``sys.executable``), not the project's venv, so
+    fixtures must not need project-only third-party imports; and the
+    ``returns`` comparison is JSON-shaped (a function returning a tuple
+    will not equal a JSON array).
     """
-    import sys
-
     module_name = fixture.input_data.get("module")
     function_name = fixture.input_data.get("function")
     args = fixture.input_data.get("args", [])
@@ -141,115 +346,108 @@ def run_function_fixture(fixture: Fixture, cwd: Path) -> FixtureResult:
             passed=False,
             message="Missing or invalid 'function' in input_data",
         )
+    if not isinstance(args, list):
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message="'args' must be an array",
+        )
+    if not isinstance(kwargs, dict):
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message="'kwargs' must be an object",
+        )
 
-    cwd_str = str(cwd)
-    added_to_path = cwd_str not in sys.path
-    if added_to_path:
-        sys.path.insert(0, cwd_str)
-
+    spec = {
+        "module": module_name,
+        "function": function_name,
+        "args": args,
+        "kwargs": kwargs,
+        "expected": fixture.expected,
+    }
     try:
-        mod = importlib.import_module(module_name)
-
-        func = getattr(mod, function_name, None)
-        if func is None:
-            return FixtureResult(
-                fixture=fixture,
-                passed=False,
-                message=f"Function '{function_name}' not found in module '{module_name}'",
-            )
-
-        # Check if we expect an exception
-        expected_raises = fixture.expected.get("raises")
-        if expected_raises:
-            try:
-                func(*args, **kwargs)
-            except Exception as exc:
-                exc_type_name = type(exc).__name__
-                if exc_type_name == expected_raises:
-                    return FixtureResult(
-                        fixture=fixture,
-                        passed=True,
-                        actual=f"raised {exc_type_name}",
-                        message="Function fixture passed - expected exception raised",
-                    )
-                return FixtureResult(
-                    fixture=fixture,
-                    passed=False,
-                    actual=f"raised {exc_type_name}",
-                    message=f"Expected {expected_raises}, got {exc_type_name}",
-                )
-            return FixtureResult(
-                fixture=fixture,
-                passed=False,
-                actual="no exception raised",
-                message=f"Expected {expected_raises} but no exception was raised",
-            )
-
-        # Normal return value check
-        try:
-            actual = func(*args, **kwargs)
-        except Exception as exc:
-            return FixtureResult(
-                fixture=fixture,
-                passed=False,
-                actual=f"raised {type(exc).__name__}: {exc}",
-                message=f"Unexpected exception: {type(exc).__name__}: {exc}",
-            )
-
-        if "returns" not in fixture.expected:
-            return FixtureResult(
-                fixture=fixture,
-                passed=True,
-                actual=repr(actual),
-                message="Function fixture passed (no expected return specified)",
-            )
-
-        expected_value = fixture.expected["returns"]
-        if actual == expected_value:
-            return FixtureResult(
-                fixture=fixture,
-                passed=True,
-                actual=repr(actual),
-                message="Function fixture passed",
-            )
+        spec_json = json.dumps(spec)
+    except (TypeError, ValueError) as exc:
         return FixtureResult(
             fixture=fixture,
             passed=False,
-            actual=repr(actual),
-            message=f"Expected {expected_value!r}, got {actual!r}",
+            message=f"Fixture spec is not JSON-serializable: {exc}",
         )
 
-    except ImportError as exc:
+    argv = [sys.executable, "-c", _FUNCTION_FIXTURE_RUNNER, spec_json]
+    try:
+        result = run_scrubbed(argv, cwd=cwd, timeout=timeout)
+    except subprocess.TimeoutExpired:
         return FixtureResult(
             fixture=fixture,
             passed=False,
-            message=f"Failed to import module '{module_name}': {exc}",
+            message=f"Function fixture timed out after {timeout}s",
         )
-    finally:
-        # Clean up sys.modules to force re-import on next call
-        if module_name in sys.modules:
-            del sys.modules[module_name]
-        if added_to_path:
-            try:
-                sys.path.remove(cwd_str)
-            except ValueError:
-                pass
+    except OSError as exc:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message=f"Failed to launch fixture subprocess: {exc}",
+        )
+
+    payload = _parse_runner_result(result.stdout)
+    if payload is None:
+        stderr_tail = result.stderr.strip()[-500:]
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message=(
+                f"Fixture subprocess exited {result.returncode} without "
+                f"reporting a result (module-level crash or hard exit); "
+                f"stderr tail: {stderr_tail!r}"
+            ),
+        )
+    return FixtureResult(
+        fixture=fixture,
+        passed=bool(payload.get("passed", False)),
+        actual=str(payload.get("actual", "")),
+        message=str(payload.get("message", "")),
+    )
 
 
 def run_file_fixture(fixture: Fixture, cwd: Path) -> FixtureResult:
     """Run a file fixture by checking file existence and content.
 
     Checks expected existence, contains, and not_contains expectations.
+    The path must stay inside ``cwd``: PRD-supplied paths are untrusted,
+    and a traversal or symlink escape would leak file content outside
+    the worktree into ``actual`` (which flows into retry prompts and PR
+    bodies).
     """
     rel_path = fixture.input_data.get("path")
-    if not rel_path:
+    if not rel_path or not isinstance(rel_path, str):
         return FixtureResult(
             fixture=fixture,
             passed=False,
             message="No 'path' in input_data",
         )
 
-    full_path = cwd / rel_path
+    rel = Path(rel_path)
+    if rel.is_absolute() or ".." in rel.parts:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message=(
+                f"Path {rel_path!r} must be relative to the worktree "
+                "with no '..' components"
+            ),
+        )
+
+    full_path = cwd / rel
+    resolved_cwd = cwd.resolve()
+    resolved = full_path.resolve()
+    if resolved != resolved_cwd and resolved_cwd not in resolved.parents:
+        return FixtureResult(
+            fixture=fixture,
+            passed=False,
+            message=f"Path {rel_path!r} escapes the worktree (symlink?)",
+        )
     file_exists = full_path.exists()
 
     # Check existence expectation
@@ -321,7 +519,7 @@ def _dispatch_fixture(
     if fixture.fixture_type == "cli":
         return run_cli_fixture(fixture, cwd, timeout)
     if fixture.fixture_type == "function":
-        return run_function_fixture(fixture, cwd)
+        return run_function_fixture(fixture, cwd, timeout)
     if fixture.fixture_type == "file":
         return run_file_fixture(fixture, cwd)
     return FixtureResult(
@@ -335,11 +533,22 @@ def check_fixtures(
     fixtures: list[Fixture],
     cwd: Path,
     config: FixturesConfig,
+    component_id: str | None = None,
 ) -> CheckResult:
     """Run all fixtures and return a single CheckResult for the verification pipeline.
 
-    Each fixture is dispatched to the appropriate runner based on fixture_type.
-    Results are aggregated into one CheckResult compatible with verify.py.
+    Each fixture is dispatched to the appropriate runner based on
+    fixture_type. Results are aggregated into one CheckResult compatible
+    with verify.py; failure details name the fixture and what diverged
+    so ``VerificationResult.as_context()`` carries actionable retry
+    context.
+
+    When ``component_id`` is given, snapshot regression runs behind the
+    same ``[fixtures].enabled`` flag: current results are compared
+    against the component's saved snapshot (a previously-passing fixture
+    that now fails, or whose output changed, fails the check), and a
+    fully-passing run refreshes the snapshot when
+    ``config.snapshot_on_success`` is set.
     """
     start = time.monotonic()
 
@@ -359,31 +568,108 @@ def check_fixtures(
         results.append(result)
 
         status = "PASS" if result.passed else "FAIL"
-        details.append(f"[{status}] {fixture.description}: {result.message}")
+        line = f"[{status}] {fixture.description}: {result.message}"
+        if not result.passed and result.actual:
+            line += f" (actual: {result.actual[:200]!r})"
+        details.append(line)
 
     passed_count = sum(1 for r in results if r.passed)
     total = len(results)
     all_passed = passed_count == total
+    message = f"{passed_count}/{total} fixtures passed"
+
+    if component_id is not None:
+        snapshot_dir = (
+            config.snapshot_dir
+            if config.snapshot_dir.is_absolute()
+            else cwd / config.snapshot_dir
+        )
+        regressions = check_snapshot_regression(
+            component_id, results, snapshot_dir,
+        )
+        if regressions:
+            all_passed = False
+            message += f"; {len(regressions)} snapshot regression(s)"
+            details.extend(f"[REGRESSION] {r}" for r in regressions)
+            details.append(
+                "If the behavior change is intentional, delete "
+                f"{snapshot_dir / (component_id + '.json')} to reset the "
+                "baseline."
+            )
+        elif all_passed and config.snapshot_on_success:
+            save_snapshot(component_id, fixtures, results, snapshot_dir)
 
     return CheckResult(
         name="fixtures",
         passed=all_passed,
-        message=f"{passed_count}/{total} fixtures passed",
+        message=message,
         details=details,
         duration_seconds=time.monotonic() - start,
     )
 
 
+def check_fixtures_from_prd(
+    prd_path: Path,
+    cwd: Path,
+    config: FixturesConfig,
+    component_id: str | None = None,
+) -> CheckResult:
+    """Phase 1 entry point: load fixtures from the PRD on disk and run them.
+
+    Fails CLOSED on an unreadable or schema-invalid PRD: fixtures are the
+    independent oracle against agent-authored tests (H-6), so "could not
+    determine which fixtures to run" must never read as "fixtures
+    passed". A PRD without a ``fixtures`` key passes vacuously - that is
+    a legitimate "none defined", not an infrastructure failure.
+    """
+    start = time.monotonic()
+    try:
+        with open(prd_path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return CheckResult(
+            name="fixtures",
+            passed=False,
+            message=(
+                "PRD could not be read for the fixtures check "
+                "(failing closed)"
+            ),
+            details=[f"Error: {exc}"],
+            duration_seconds=time.monotonic() - start,
+        )
+    errors = PRD.validate_schema(data)
+    if errors:
+        return CheckResult(
+            name="fixtures",
+            passed=False,
+            message=(
+                "PRD failed schema validation; fixture definitions cannot "
+                "be trusted (failing closed)"
+            ),
+            details=errors[:10],
+            duration_seconds=time.monotonic() - start,
+        )
+    fixtures = load_fixtures_from_prd_data(data)
+    return check_fixtures(fixtures, cwd, config, component_id=component_id)
+
+
 def load_fixtures_from_prd_data(prd_data: dict[str, Any]) -> list[Fixture]:
     """Parse the optional 'fixtures' array from PRD JSON data.
 
-    Returns an empty list if no fixtures field is present.
-    Each fixture entry should have: description, fixture_type, input_data, expected.
+    Returns an empty list if no fixtures field is present. Malformed
+    entries raise ``ValueError`` naming the entry - an oracle that
+    silently drops a fixture is a silent degradation, and this codebase
+    fails loudly instead. Callers that need full strict validation run
+    ``PRD.validate_schema`` first (as ``check_fixtures_from_prd`` does).
     """
-    raw_fixtures = prd_data.get("fixtures", [])
-    fixtures: list[Fixture] = []
+    raw_fixtures = prd_data.get("fixtures") or []
+    if not isinstance(raw_fixtures, list):
+        raise ValueError("'fixtures' must be an array")
 
-    for entry in raw_fixtures:
+    fixtures: list[Fixture] = []
+    for i, entry in enumerate(raw_fixtures):
+        if not isinstance(entry, dict):
+            raise ValueError(f"fixtures[{i}]: must be an object")
         try:
             fixture = Fixture(
                 description=entry["description"],
@@ -391,9 +677,11 @@ def load_fixtures_from_prd_data(prd_data: dict[str, Any]) -> list[Fixture]:
                 input_data=entry.get("input_data", {}),
                 expected=entry.get("expected", {}),
             )
-            fixtures.append(fixture)
-        except KeyError:
-            continue
+        except KeyError as exc:
+            raise ValueError(
+                f"fixtures[{i}]: missing required key {exc.args[0]!r}"
+            ) from exc
+        fixtures.append(fixture)
 
     return fixtures
 
@@ -407,7 +695,8 @@ def save_snapshot(
     """Save successful fixture outputs as a JSON snapshot for regression detection.
 
     Only saves results for fixtures that passed. The snapshot captures the actual
-    output so future runs can detect behavioral regressions.
+    output so future runs can detect behavioral regressions. Written
+    atomically (mkstemp + os.replace) per the codebase convention.
     """
     snapshot_dir.mkdir(parents=True, exist_ok=True)
     snapshot_path = snapshot_dir / f"{component_id}.json"
@@ -427,7 +716,19 @@ def save_snapshot(
         "entries": snapshot_entries,
     }
 
-    snapshot_path.write_text(json.dumps(snapshot_data, indent=2) + "\n")
+    fd, tmp_name = tempfile.mkstemp(
+        dir=snapshot_dir, prefix=f".{component_id}-", suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(json.dumps(snapshot_data, indent=2) + "\n")
+        os.replace(tmp_name, snapshot_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 
 def check_snapshot_regression(

--- a/ralph_py/prd.py
+++ b/ralph_py/prd.py
@@ -20,6 +20,159 @@ class UserStory:
     notes: str
 
 
+# --- Fixture entry validation (R7.2) -----------------------------------
+# Fixture definitions are LLM-emitted and Phase 1 EXECUTES them, so
+# validation is strict: unknown keys are rejected rather than ignored,
+# because an ignored expectation key (a misspelled "stdout_contains",
+# say) silently weakens the oracle to a vacuous pass.
+
+_FIXTURE_ENTRY_KEYS = {"description", "fixture_type", "input_data", "expected"}
+
+# fixture_type -> {input_data key -> required}
+_FIXTURE_INPUT_KEYS: dict[str, dict[str, bool]] = {
+    "cli": {"command": True},
+    "function": {"module": True, "function": True, "args": False, "kwargs": False},
+    "file": {"path": True},
+}
+
+_FIXTURE_EXPECTED_KEYS: dict[str, set[str]] = {
+    "cli": {"exit_code", "stdout_contains", "stdout_not_contains"},
+    "function": {"returns", "raises"},
+    "file": {"exists", "contains", "not_contains"},
+}
+
+
+def _validate_string_list(prefix: str, value: Any) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(s, str) for s in value):
+        return [f"{prefix}: must be an array of strings"]
+    return []
+
+
+def _validate_fixture_entry(prefix: str, entry: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(entry, dict):
+        return [f"{prefix}: must be an object"]
+
+    actual_keys = set(entry.keys())
+    missing = _FIXTURE_ENTRY_KEYS - actual_keys
+    extra = actual_keys - _FIXTURE_ENTRY_KEYS
+    if missing:
+        errors.append(f"{prefix}: missing keys: {', '.join(sorted(missing))}")
+    if extra:
+        errors.append(f"{prefix}: unexpected keys: {', '.join(sorted(extra))}")
+    if missing or extra:
+        return errors
+
+    description = entry["description"]
+    if not isinstance(description, str) or not description:
+        errors.append(f"{prefix}.description: must be a non-empty string")
+    fixture_type = entry["fixture_type"]
+    if fixture_type not in _FIXTURE_INPUT_KEYS:
+        errors.append(
+            f"{prefix}.fixture_type: must be one of "
+            f"{sorted(_FIXTURE_INPUT_KEYS)} (got: {fixture_type!r})"
+        )
+        return errors
+    input_data = entry["input_data"]
+    expected = entry["expected"]
+    if not isinstance(input_data, dict):
+        errors.append(f"{prefix}.input_data: must be an object")
+    if not isinstance(expected, dict):
+        errors.append(f"{prefix}.expected: must be an object")
+    if errors:
+        return errors
+
+    key_spec = _FIXTURE_INPUT_KEYS[fixture_type]
+    unknown = set(input_data) - set(key_spec)
+    if unknown:
+        errors.append(
+            f"{prefix}.input_data: unexpected keys for {fixture_type} "
+            f"fixture: {', '.join(sorted(unknown))}"
+        )
+    for key, required in key_spec.items():
+        if required and key not in input_data:
+            errors.append(f"{prefix}.input_data: missing required key: {key}")
+
+    allowed_expected = _FIXTURE_EXPECTED_KEYS[fixture_type]
+    unknown_expected = set(expected) - allowed_expected
+    if unknown_expected:
+        errors.append(
+            f"{prefix}.expected: unexpected keys for {fixture_type} fixture: "
+            f"{', '.join(sorted(unknown_expected))} "
+            f"(allowed: {', '.join(sorted(allowed_expected))})"
+        )
+    if not expected:
+        errors.append(
+            f"{prefix}.expected: must not be empty - a fixture with no "
+            "expectations verifies nothing"
+        )
+    if errors:
+        return errors
+
+    if fixture_type == "cli":
+        command = input_data.get("command")
+        if not isinstance(command, str) or not command.strip():
+            errors.append(
+                f"{prefix}.input_data.command: must be a non-empty string"
+            )
+        if "exit_code" in expected and (
+            isinstance(expected["exit_code"], bool)
+            or not isinstance(expected["exit_code"], int)
+        ):
+            errors.append(f"{prefix}.expected.exit_code: must be an integer")
+        for key in ("stdout_contains", "stdout_not_contains"):
+            if key in expected:
+                errors.extend(
+                    _validate_string_list(
+                        f"{prefix}.expected.{key}", expected[key],
+                    )
+                )
+    elif fixture_type == "function":
+        for key in ("module", "function"):
+            value = input_data.get(key)
+            if not isinstance(value, str) or not value:
+                errors.append(
+                    f"{prefix}.input_data.{key}: must be a non-empty string"
+                )
+        if "args" in input_data and not isinstance(input_data["args"], list):
+            errors.append(f"{prefix}.input_data.args: must be an array")
+        if "kwargs" in input_data and not isinstance(input_data["kwargs"], dict):
+            errors.append(f"{prefix}.input_data.kwargs: must be an object")
+        if "raises" in expected:
+            if not isinstance(expected["raises"], str) or not expected["raises"]:
+                errors.append(
+                    f"{prefix}.expected.raises: must be a non-empty string"
+                )
+            if "returns" in expected:
+                errors.append(
+                    f"{prefix}.expected: 'returns' and 'raises' are "
+                    "mutually exclusive"
+                )
+    elif fixture_type == "file":
+        path_value = input_data.get("path")
+        if not isinstance(path_value, str) or not path_value:
+            errors.append(
+                f"{prefix}.input_data.path: must be a non-empty string"
+            )
+        elif Path(path_value).is_absolute() or ".." in Path(path_value).parts:
+            # The PRD is untrusted input; a path outside the worktree
+            # would leak file content into retry prompts and PR bodies.
+            errors.append(
+                f"{prefix}.input_data.path: must be relative to the "
+                "worktree with no '..' components"
+            )
+        if "exists" in expected and not isinstance(expected["exists"], bool):
+            errors.append(f"{prefix}.expected.exists: must be a boolean")
+        for key in ("contains", "not_contains"):
+            if key in expected:
+                errors.extend(
+                    _validate_string_list(
+                        f"{prefix}.expected.{key}", expected[key],
+                    )
+                )
+    return errors
+
+
 @dataclass
 class PRD:
     """Product Requirements Document."""
@@ -33,6 +186,11 @@ class PRD:
     # ``verify.check_diff_scope`` so the agent's diff is bounded per-
     # component rather than allowed to touch anywhere in the worktree.
     allowed_paths: list[str] | None = None
+    # Approved fixtures (R7.2): behavioral input/output pairs run during
+    # Phase 1 when [fixtures].enabled. Kept as the raw validated JSON
+    # entries - parsing into runner objects lives in ralph_py.fixtures
+    # (which imports this module; the reverse import would be a cycle).
+    fixtures: list[dict[str, Any]] | None = None
 
     @classmethod
     def load(cls, path: Path) -> PRD:
@@ -63,6 +221,7 @@ class PRD:
             branch_name=data["branchName"],
             user_stories=stories,
             allowed_paths=allowed_paths,
+            fixtures=data.get("fixtures"),
         )
 
     @classmethod
@@ -71,7 +230,7 @@ class PRD:
 
         Schema requirements:
         - Top-level must be dict with ``branchName`` and ``userStories``,
-          optionally ``allowedPaths``.
+          optionally ``allowedPaths`` and ``fixtures``.
         - branchName: non-empty string.
         - userStories: array of story objects, each with exactly 6 keys
           (id, title, acceptanceCriteria, priority, passes, notes).
@@ -79,6 +238,10 @@ class PRD:
           when present. An empty array is rejected because it silently
           disables diff-scope enforcement -- omit the field entirely
           to mean "no constraint".
+        - fixtures (optional): non-empty array of fixture entries, each
+          with exactly the keys description / fixture_type / input_data /
+          expected, validated strictly per type (see
+          ``_validate_fixture_entry``; R7.2).
         - Field types are strictly enforced.
         """
         errors: list[str] = []
@@ -88,7 +251,7 @@ class PRD:
             return errors
 
         required_keys = {"branchName", "userStories"}
-        optional_keys = {"allowedPaths"}
+        optional_keys = {"allowedPaths", "fixtures"}
         actual_keys = set(data.keys())
         missing = required_keys - actual_keys
         extra = actual_keys - required_keys - optional_keys
@@ -112,6 +275,22 @@ class PRD:
                 )
             elif not all(isinstance(p, str) and p for p in ap):
                 errors.append("allowedPaths: all items must be non-empty strings")
+
+        # Validate optional fixtures shape (strict; R7.2)
+        if "fixtures" in data:
+            fixtures = data["fixtures"]
+            if not isinstance(fixtures, list):
+                errors.append("fixtures must be an array")
+            elif not fixtures:
+                errors.append(
+                    "fixtures must be non-empty when present "
+                    "(omit the field entirely when there are none)"
+                )
+            else:
+                for i, entry in enumerate(fixtures):
+                    errors.extend(
+                        _validate_fixture_entry(f"fixtures[{i}]", entry)
+                    )
 
         # Validate branchName
         branch_name = data.get("branchName")
@@ -172,8 +351,14 @@ class PRD:
         return min(failing, key=lambda s: s.priority)
 
     def save(self, path: Path) -> None:
-        """Save PRD back to JSON file."""
-        data = {
+        """Save PRD back to JSON file.
+
+        Round-trips the optional fields: dropping ``allowedPaths`` on a
+        save would silently unbind the component's diff scope, and
+        dropping ``fixtures`` would silently disable the behavioral
+        oracle (R7.2).
+        """
+        data: dict[str, Any] = {
             "branchName": self.branch_name,
             "userStories": [
                 {
@@ -187,6 +372,10 @@ class PRD:
                 for s in self.user_stories
             ],
         }
+        if self.allowed_paths is not None:
+            data["allowedPaths"] = self.allowed_paths
+        if self.fixtures is not None:
+            data["fixtures"] = self.fixtures
         with open(path, "w") as f:
             json.dump(data, f, indent=2)
             f.write("\n")

--- a/ralph_py/verify.py
+++ b/ralph_py/verify.py
@@ -10,8 +10,12 @@ import subprocess
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ralph_py import git
+
+if TYPE_CHECKING:
+    from ralph_py.fixtures import FixturesConfig
 from ralph_py.guards import path_is_allowed
 from ralph_py.parsers import (
     ParsedOutput,
@@ -1074,8 +1078,17 @@ def run_mechanical_verification(
     allowed_paths: list[str] | None,
     config: VerifyConfig,
     allowed_paths_error: str | None = None,
+    fixtures_config: FixturesConfig | None = None,
+    component_id: str | None = None,
 ) -> VerificationResult:
-    """Run all 6 mechanical checks. All checks run even if earlier ones fail."""
+    """Run all mechanical checks. All checks run even if earlier ones fail.
+
+    ``fixtures_config`` (R7.2): when provided AND ``.enabled`` is true,
+    the approved-fixtures oracle runs against the PRD's ``fixtures``
+    entries - sandboxed subprocess execution lives in
+    ``ralph_py.fixtures``. ``component_id`` keys the fixture snapshot
+    used for regression detection; None disables snapshotting only.
+    """
     checks: list[CheckResult] = []
 
     checks.append(check_prd_stories(prd_path))
@@ -1117,6 +1130,16 @@ def run_mechanical_verification(
         progress_path = worktree_path / config.progress_file_path
         checks.append(check_self_critique(
             progress_path, config.self_critique_min_bullets,
+        ))
+
+    if fixtures_config is not None and fixtures_config.enabled:
+        # Imported lazily: fixtures.py imports CheckResult/run_scrubbed
+        # from this module, so a module-level import would be a cycle.
+        from ralph_py.fixtures import check_fixtures_from_prd
+
+        checks.append(check_fixtures_from_prd(
+            prd_path, worktree_path, fixtures_config,
+            component_id=component_id,
         ))
 
     passed = all(c.passed for c in checks)

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -122,6 +122,7 @@ def _section_specs() -> list[SectionSpec]:
     from ralph_py.evolution import EvolutionConfig
     from ralph_py.factory import FactoryConfig
     from ralph_py.feedforward import FeedforwardConfig
+    from ralph_py.fixtures import FixturesConfig
     from ralph_py.knowledge import KnowledgeConfig
     from ralph_py.security import SecurityConfig
     from ralph_py.timeout import TimeoutConfig
@@ -207,6 +208,14 @@ def _section_specs() -> list[SectionSpec]:
             identity_keys(VerifyConfig, [f.name for f in dataclasses.fields(VerifyConfig)]),
             lambda root: VerifyConfig.load(root_dir=root),
             VerifyConfig(), probe_undocumented_fields=True,
+        ),
+        SectionSpec(
+            "fixtures", "Phase 1 approved-fixtures oracle (R7.2; default off)",
+            identity_keys(FixturesConfig, [
+                f.name for f in dataclasses.fields(FixturesConfig)
+            ]),
+            lambda root: FixturesConfig.load(root_dir=root),
+            FixturesConfig(), probe_undocumented_fields=True,
         ),
         SectionSpec(
             "security", "Phase 2.5 security review",
@@ -306,6 +315,12 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
         "fail Phase 1 if the ## Self-Critique block is missing/sparse",
     ("verify", "self_critique_min_bullets"): "minimum substantive bullets in the block",
     ("verify", "progress_file_path"): "progress file the self-critique check reads",
+    ("fixtures", "enabled"):
+        "run PRD-defined fixtures during Phase 1 (sandboxed; opt-in)",
+    ("fixtures", "snapshot_on_success"):
+        "save passing outputs for cross-run regression comparison",
+    ("fixtures", "snapshot_dir"): "relative paths resolve against the repo root",
+    ("fixtures", "timeout"): "seconds per fixture subprocess",
     ("security", "mode"): "skip | advisory | hard",
     ("security", "agent_cmd"): "empty = inherit [agent]",
     ("security", "agent_type"): "empty = inherit [agent]",

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,21 +1,62 @@
-"""Tests for fixtures module."""
+"""Tests for fixtures module (R7.2: sandboxed wiring into Phase 1)."""
 
 from __future__ import annotations
 
 import json
+import os
+import sys
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 from ralph_py.fixtures import (
     Fixture,
     FixtureResult,
     FixturesConfig,
     check_fixtures,
+    check_fixtures_from_prd,
     check_snapshot_regression,
     load_fixtures_from_prd_data,
     run_cli_fixture,
     run_file_fixture,
+    run_function_fixture,
     save_snapshot,
 )
+from ralph_py.prd import PRD
+from ralph_py.verify import VerifyConfig, run_mechanical_verification
+
+
+def _story() -> dict[str, Any]:
+    return {
+        "id": "US-1",
+        "title": "Story",
+        "acceptanceCriteria": ["works"],
+        "priority": 1,
+        "passes": True,
+        "notes": "",
+    }
+
+
+def _prd_data(
+    fixtures: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "branchName": "ralph/fixtures-test",
+        "userStories": [_story()],
+    }
+    if fixtures is not None:
+        data["fixtures"] = fixtures
+    return data
+
+
+def _cli_fixture_entry() -> dict[str, Any]:
+    return {
+        "description": "echo works",
+        "fixture_type": "cli",
+        "input_data": {"command": "echo hi"},
+        "expected": {"exit_code": 0, "stdout_contains": ["hi"]},
+    }
 
 # ---------------------------------------------------------------------------
 # FixturesConfig defaults
@@ -184,7 +225,9 @@ class TestLoadFixturesFromPrdData:
         fixtures = load_fixtures_from_prd_data(prd_data)
         assert fixtures == []
 
-    def test_load_fixtures_from_prd_data_skips_invalid(self) -> None:
+    def test_load_fixtures_from_prd_data_rejects_invalid(self) -> None:
+        # A silently-dropped fixture is a silently-weakened oracle:
+        # malformed entries raise instead of being skipped.
         prd_data = {
             "fixtures": [
                 {"fixture_type": "cli"},  # missing description
@@ -196,9 +239,8 @@ class TestLoadFixturesFromPrdData:
                 },
             ]
         }
-        fixtures = load_fixtures_from_prd_data(prd_data)
-        assert len(fixtures) == 1
-        assert fixtures[0].description == "valid"
+        with pytest.raises(ValueError, match=r"fixtures\[0\].*description"):
+            load_fixtures_from_prd_data(prd_data)
 
 
 # ---------------------------------------------------------------------------
@@ -315,3 +357,533 @@ class TestSaveAndCheckSnapshot:
         result = FixtureResult(fixture=fixture, passed=True, actual="x\n")
         regressions = check_snapshot_regression("new-comp", [result], tmp_path)
         assert regressions == []
+
+
+# ---------------------------------------------------------------------------
+# R7.2: CLI fixtures run without a shell
+# ---------------------------------------------------------------------------
+
+
+class TestCliFixtureNoShell:
+    def test_shell_metacharacters_are_literal(self, tmp_path: Path) -> None:
+        # Under shell=True `echo hello && touch pwned` would run two
+        # commands; with shlex + shell=False the metacharacters reach
+        # echo as literal arguments.
+        fixture = Fixture(
+            description="metachars literal",
+            fixture_type="cli",
+            input_data={"command": "echo hello && touch pwned.txt"},
+            expected={
+                "exit_code": 0,
+                "stdout_contains": ["hello && touch pwned.txt"],
+            },
+        )
+        result = run_cli_fixture(fixture, tmp_path, timeout=10.0)
+        assert result.passed is True, result.message
+        assert not (tmp_path / "pwned.txt").exists()
+
+    def test_no_variable_expansion(self, tmp_path: Path) -> None:
+        fixture = Fixture(
+            description="no env expansion",
+            fixture_type="cli",
+            input_data={"command": "echo $HOME"},
+            expected={"exit_code": 0, "stdout_contains": ["$HOME"]},
+        )
+        result = run_cli_fixture(fixture, tmp_path, timeout=10.0)
+        assert result.passed is True, result.message
+
+    def test_unparseable_command_fails_with_hint(self, tmp_path: Path) -> None:
+        fixture = Fixture(
+            description="unterminated quote",
+            fixture_type="cli",
+            input_data={"command": "echo 'unterminated"},
+            expected={"exit_code": 0},
+        )
+        result = run_cli_fixture(fixture, tmp_path, timeout=10.0)
+        assert result.passed is False
+        assert "shell features are unsupported" in result.message
+
+
+# ---------------------------------------------------------------------------
+# R7.2: function fixtures run in a subprocess
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionFixtureSubprocess:
+    def test_round_trip_pass(self, tmp_path: Path) -> None:
+        (tmp_path / "adder.py").write_text("def add(a, b):\n    return a + b\n")
+        fixture = Fixture(
+            description="add works",
+            fixture_type="function",
+            input_data={"module": "adder", "function": "add", "args": [2, 3]},
+            expected={"returns": 5},
+        )
+        result = run_function_fixture(fixture, tmp_path, timeout=60.0)
+        assert result.passed is True, result.message
+        assert result.actual == "5"
+
+    def test_round_trip_fail(self, tmp_path: Path) -> None:
+        (tmp_path / "adder.py").write_text("def add(a, b):\n    return a + b\n")
+        fixture = Fixture(
+            description="add wrong expectation",
+            fixture_type="function",
+            input_data={"module": "adder", "function": "add", "args": [2, 3]},
+            expected={"returns": 6},
+        )
+        result = run_function_fixture(fixture, tmp_path, timeout=60.0)
+        assert result.passed is False
+        assert "Expected 6, got 5" in result.message
+
+    def test_expected_exception(self, tmp_path: Path) -> None:
+        (tmp_path / "boom.py").write_text(
+            "def explode():\n    raise ValueError('no')\n"
+        )
+        fixture = Fixture(
+            description="explode raises",
+            fixture_type="function",
+            input_data={"module": "boom", "function": "explode"},
+            expected={"raises": "ValueError"},
+        )
+        result = run_function_fixture(fixture, tmp_path, timeout=60.0)
+        assert result.passed is True, result.message
+
+    def test_import_crash_reports_failure(self, tmp_path: Path) -> None:
+        (tmp_path / "crasher.py").write_text("raise RuntimeError('boom')\n")
+        fixture = Fixture(
+            description="crashing module",
+            fixture_type="function",
+            input_data={"module": "crasher", "function": "anything"},
+            expected={"returns": 1},
+        )
+        result = run_function_fixture(fixture, tmp_path, timeout=60.0)
+        assert result.passed is False
+        assert "Failed to import module" in result.message
+
+    def test_env_scrubbed_inside_subprocess(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Plant a would-leak secret in the harness env; the fixture
+        # subprocess must not see any *_API_KEY / *SECRET* name.
+        monkeypatch.setenv("FAKE_API_KEY", "sk-super-secret")
+        monkeypatch.setenv("MY_DEPLOY_SECRET", "hunter2")
+        (tmp_path / "envprobe.py").write_text(
+            "import os\n"
+            "def leaked():\n"
+            "    return sorted(\n"
+            "        k for k in os.environ\n"
+            "        if 'API_KEY' in k or 'SECRET' in k\n"
+            "    )\n"
+        )
+        fixture = Fixture(
+            description="no secrets visible",
+            fixture_type="function",
+            input_data={"module": "envprobe", "function": "leaked"},
+            expected={"returns": []},
+        )
+        result = run_function_fixture(fixture, tmp_path, timeout=60.0)
+        assert result.passed is True, (
+            f"secrets leaked into fixture subprocess: {result.actual}"
+        )
+
+    def test_module_side_effects_cannot_touch_harness(
+        self, tmp_path: Path,
+    ) -> None:
+        # The module runs arbitrary code at import time. It must run in
+        # the SUBPROCESS: the sentinel file proves the code executed,
+        # while the harness process's environ and sys.modules stay clean.
+        (tmp_path / "evil_side_effect.py").write_text(
+            "import os\n"
+            "os.environ['RALPH_FIXTURE_PWNED'] = '1'\n"
+            "with open('sentinel.txt', 'w') as f:\n"
+            "    f.write('imported')\n"
+            "def probe():\n"
+            "    return 'ok'\n"
+        )
+        fixture = Fixture(
+            description="side-effecting module",
+            fixture_type="function",
+            input_data={"module": "evil_side_effect", "function": "probe"},
+            expected={"returns": "ok"},
+        )
+        result = run_function_fixture(fixture, tmp_path, timeout=60.0)
+        assert result.passed is True, result.message
+        # The agent code DID run (in the subprocess, cwd=worktree)...
+        assert (tmp_path / "sentinel.txt").read_text() == "imported"
+        # ...but never inside the harness process.
+        assert "RALPH_FIXTURE_PWNED" not in os.environ
+        assert "evil_side_effect" not in sys.modules
+
+    def test_timeout_kills_subprocess(self, tmp_path: Path) -> None:
+        (tmp_path / "sleeper.py").write_text(
+            "import time\n"
+            "def nap():\n"
+            "    time.sleep(60)\n"
+        )
+        fixture = Fixture(
+            description="sleeping function",
+            fixture_type="function",
+            input_data={"module": "sleeper", "function": "nap"},
+            expected={"returns": None},
+        )
+        result = run_function_fixture(fixture, tmp_path, timeout=1.0)
+        assert result.passed is False
+        assert "timed out" in result.message
+
+    def test_missing_function_reports_failure(self, tmp_path: Path) -> None:
+        (tmp_path / "adder.py").write_text("def add(a, b):\n    return a + b\n")
+        fixture = Fixture(
+            description="missing function",
+            fixture_type="function",
+            input_data={"module": "adder", "function": "subtract"},
+            expected={"returns": 1},
+        )
+        result = run_function_fixture(fixture, tmp_path, timeout=60.0)
+        assert result.passed is False
+        assert "not found" in result.message
+
+
+# ---------------------------------------------------------------------------
+# R7.2: file fixtures stay inside the worktree
+# ---------------------------------------------------------------------------
+
+
+class TestFileFixtureContainment:
+    @pytest.mark.parametrize("bad_path", ["/etc/passwd", "../outside.txt"])
+    def test_escaping_paths_rejected(
+        self, tmp_path: Path, bad_path: str,
+    ) -> None:
+        fixture = Fixture(
+            description="escape attempt",
+            fixture_type="file",
+            input_data={"path": bad_path},
+            expected={"exists": True},
+        )
+        result = run_file_fixture(fixture, tmp_path)
+        assert result.passed is False
+        assert "relative to the worktree" in result.message
+
+    def test_symlink_escape_rejected(self, tmp_path: Path) -> None:
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        outside = tmp_path / "outside.txt"
+        outside.write_text("secret material\n")
+        (worktree / "link.txt").symlink_to(outside)
+        fixture = Fixture(
+            description="symlink escape",
+            fixture_type="file",
+            input_data={"path": "link.txt"},
+            expected={"exists": True, "contains": ["secret"]},
+        )
+        result = run_file_fixture(fixture, worktree)
+        assert result.passed is False
+        assert "escapes the worktree" in result.message
+
+
+# ---------------------------------------------------------------------------
+# R7.2: strict PRD schema for the fixtures key
+# ---------------------------------------------------------------------------
+
+
+class TestPrdFixturesSchema:
+    def test_readme_examples_accepted(self) -> None:
+        data = _prd_data(fixtures=[
+            {
+                "description": "Login returns token",
+                "fixture_type": "cli",
+                "input_data": {"command": "curl -s localhost:8000/api/login"},
+                "expected": {"exit_code": 0, "stdout_contains": ["token"]},
+            },
+            {
+                "description": "Config is importable",
+                "fixture_type": "function",
+                "input_data": {
+                    "module": "src.config",
+                    "function": "get_settings",
+                    "args": [],
+                },
+                "expected": {"returns": {"debug": False}},
+            },
+            {
+                "description": "Migration file exists",
+                "fixture_type": "file",
+                "input_data": {"path": "migrations/001_users.sql"},
+                "expected": {
+                    "exists": True,
+                    "contains": ["CREATE TABLE users"],
+                },
+            },
+        ])
+        assert PRD.validate_schema(data) == []
+
+    @pytest.mark.parametrize(
+        ("mutation", "error_fragment"),
+        [
+            ({"shell": True}, "unexpected keys"),
+            ({"fixture_type": "shell"}, "fixture_type"),
+            (
+                {"expected": {"exit_code": 0, "stdout_containz": ["x"]}},
+                "unexpected keys for cli",
+            ),
+            ({"expected": {"exit_code": True}}, "must be an integer"),
+            ({"expected": {}}, "must not be empty"),
+            (
+                {"input_data": {"command": "echo hi", "shell": True}},
+                "unexpected keys for cli",
+            ),
+            ({"input_data": {}}, "missing required key: command"),
+        ],
+    )
+    def test_bad_cli_entries_rejected(
+        self, mutation: dict[str, Any], error_fragment: str,
+    ) -> None:
+        entry = _cli_fixture_entry()
+        entry.update(mutation)
+        errors = PRD.validate_schema(_prd_data(fixtures=[entry]))
+        assert errors, "expected schema errors"
+        assert any(error_fragment in e for e in errors), errors
+
+    @pytest.mark.parametrize("bad_path", ["/etc/passwd", "../secrets.txt"])
+    def test_file_fixture_escaping_path_rejected(self, bad_path: str) -> None:
+        entry = {
+            "description": "escape",
+            "fixture_type": "file",
+            "input_data": {"path": bad_path},
+            "expected": {"exists": True},
+        }
+        errors = PRD.validate_schema(_prd_data(fixtures=[entry]))
+        assert any("relative to the" in e for e in errors), errors
+
+    def test_function_returns_and_raises_mutually_exclusive(self) -> None:
+        entry = {
+            "description": "conflicting expectations",
+            "fixture_type": "function",
+            "input_data": {"module": "m", "function": "f"},
+            "expected": {"returns": 1, "raises": "ValueError"},
+        }
+        errors = PRD.validate_schema(_prd_data(fixtures=[entry]))
+        assert any("mutually exclusive" in e for e in errors), errors
+
+    def test_empty_fixtures_array_rejected(self) -> None:
+        errors = PRD.validate_schema(_prd_data(fixtures=[]))
+        assert any("non-empty" in e for e in errors), errors
+
+    def test_prd_round_trip_with_fixtures(self, tmp_path: Path) -> None:
+        data = _prd_data(fixtures=[_cli_fixture_entry()])
+        data["allowedPaths"] = ["src/"]
+        path = tmp_path / "prd.json"
+        path.write_text(json.dumps(data))
+
+        prd = PRD.load(path)
+        assert prd.fixtures == [_cli_fixture_entry()]
+
+        out_path = tmp_path / "prd_out.json"
+        prd.save(out_path)
+        reloaded = PRD.load(out_path)
+        assert reloaded.fixtures == [_cli_fixture_entry()]
+        assert reloaded.allowed_paths == ["src/"]
+
+
+# ---------------------------------------------------------------------------
+# R7.2: snapshot regression wired behind the same flag
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotWiring:
+    def _fixtures(self) -> list[Fixture]:
+        return [
+            Fixture(
+                description="cat output file",
+                fixture_type="cli",
+                input_data={"command": "cat out.txt"},
+                expected={"exit_code": 0},
+            ),
+        ]
+
+    def test_snapshot_saved_then_regression_detected(
+        self, tmp_path: Path,
+    ) -> None:
+        (tmp_path / "out.txt").write_text("v1\n")
+        config = FixturesConfig(
+            enabled=True, snapshot_dir=tmp_path / "snaps", timeout=10.0,
+        )
+
+        first = check_fixtures(
+            self._fixtures(), tmp_path, config, component_id="comp-a",
+        )
+        assert first.passed is True
+        assert (tmp_path / "snaps" / "comp-a.json").exists()
+
+        # Behavior changes while the fixture still "passes": the
+        # snapshot comparison catches it.
+        (tmp_path / "out.txt").write_text("v2\n")
+        second = check_fixtures(
+            self._fixtures(), tmp_path, config, component_id="comp-a",
+        )
+        assert second.passed is False
+        assert any("REGRESSION" in d for d in second.details)
+        assert any("delete" in d for d in second.details)
+
+    def test_no_component_id_means_no_snapshot(self, tmp_path: Path) -> None:
+        (tmp_path / "out.txt").write_text("v1\n")
+        config = FixturesConfig(
+            enabled=True, snapshot_dir=tmp_path / "snaps", timeout=10.0,
+        )
+        result = check_fixtures(self._fixtures(), tmp_path, config)
+        assert result.passed is True
+        assert not (tmp_path / "snaps").exists()
+
+
+# ---------------------------------------------------------------------------
+# R7.2: FixturesConfig control-plane loader
+# ---------------------------------------------------------------------------
+
+
+_FIXTURES_ENV_VARS = (
+    "RALPH_FIXTURES_ENABLED",
+    "RALPH_FIXTURES_SNAPSHOT_ON_SUCCESS",
+    "RALPH_FIXTURES_SNAPSHOT_DIR",
+    "RALPH_FIXTURES_TIMEOUT",
+)
+
+
+class TestFixturesConfigLoad:
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in _FIXTURES_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+
+    def test_defaults(self, tmp_path: Path) -> None:
+        config = FixturesConfig.load(tmp_path)
+        assert config.enabled is False
+        assert config.snapshot_on_success is True
+        assert config.timeout == 30.0
+        # Relative snapshot_dir resolves against the repo root so
+        # snapshots survive worktree recreation between runs.
+        assert config.snapshot_dir == tmp_path / ".ralph/snapshots"
+
+    def test_load_from_toml(self, tmp_path: Path) -> None:
+        (tmp_path / "ralph.toml").write_text(
+            "[fixtures]\n"
+            "enabled = true\n"
+            "snapshot_on_success = false\n"
+            'snapshot_dir = "snaps"\n'
+            "timeout = 12.5\n"
+        )
+        config = FixturesConfig.load(tmp_path)
+        assert config.enabled is True
+        assert config.snapshot_on_success is False
+        assert config.snapshot_dir == tmp_path / "snaps"
+        assert config.timeout == 12.5
+
+    def test_env_beats_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "ralph.toml").write_text("[fixtures]\nenabled = true\n")
+        monkeypatch.setenv("RALPH_FIXTURES_ENABLED", "0")
+        config = FixturesConfig.load(tmp_path)
+        assert config.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# R7.2: Phase 1 integration - run_mechanical_verification wiring
+# ---------------------------------------------------------------------------
+
+
+def _stub_verify_config() -> VerifyConfig:
+    # Stub out the heavyweight checks so the test exercises only the
+    # fixtures wiring; prd_stories still runs against the real PRD file.
+    return VerifyConfig(
+        test_command="echo tests-ok",
+        typecheck_command="echo mypy-ok",
+        lint_command="echo lint-ok",
+        check_diff_scope=False,
+        check_bad_patterns=False,
+    )
+
+
+class TestPhase1Integration:
+    def _write_prd(
+        self, worktree: Path, fixtures: list[dict[str, Any]],
+    ) -> Path:
+        prd_path = worktree / "prd.json"
+        prd_path.write_text(json.dumps(_prd_data(fixtures=fixtures)))
+        return prd_path
+
+    def test_fixtures_check_runs_when_enabled(self, tmp_path: Path) -> None:
+        (tmp_path / "adder.py").write_text("def add(a, b):\n    return a + b\n")
+        prd_path = self._write_prd(tmp_path, [
+            _cli_fixture_entry(),
+            {
+                "description": "adder works",
+                "fixture_type": "function",
+                "input_data": {
+                    "module": "adder", "function": "add", "args": [2, 3],
+                },
+                "expected": {"returns": 5},
+            },
+        ])
+        result = run_mechanical_verification(
+            tmp_path, prd_path, "main", None, _stub_verify_config(),
+            fixtures_config=FixturesConfig(
+                enabled=True, snapshot_dir=tmp_path / "snaps", timeout=60.0,
+            ),
+            component_id="comp-x",
+        )
+        by_name = {c.name: c for c in result.checks}
+        assert "fixtures" in by_name
+        assert by_name["fixtures"].passed is True, by_name["fixtures"].message
+        assert "2/2" in by_name["fixtures"].message
+        assert result.passed is True
+
+    def test_fixtures_check_absent_when_disabled(self, tmp_path: Path) -> None:
+        prd_path = self._write_prd(tmp_path, [_cli_fixture_entry()])
+        for fixtures_config in (None, FixturesConfig(enabled=False)):
+            result = run_mechanical_verification(
+                tmp_path, prd_path, "main", None, _stub_verify_config(),
+                fixtures_config=fixtures_config,
+                component_id="comp-x",
+            )
+            assert "fixtures" not in {c.name for c in result.checks}
+
+    def test_fixture_failure_yields_retry_context(self, tmp_path: Path) -> None:
+        prd_path = self._write_prd(tmp_path, [
+            {
+                "description": "output has magic token",
+                "fixture_type": "cli",
+                "input_data": {"command": "echo actual-output"},
+                "expected": {"stdout_contains": ["magic-token"]},
+            },
+        ])
+        result = run_mechanical_verification(
+            tmp_path, prd_path, "main", None, _stub_verify_config(),
+            fixtures_config=FixturesConfig(
+                enabled=True, snapshot_dir=tmp_path / "snaps", timeout=60.0,
+            ),
+            component_id="comp-x",
+        )
+        assert result.passed is False
+        context = result.as_context()
+        assert "fixtures" in context
+        assert "output has magic token" in context
+        assert "magic-token" in context
+
+    def test_unreadable_prd_fails_closed(self, tmp_path: Path) -> None:
+        prd_path = tmp_path / "prd.json"
+        prd_path.write_text("{not json")
+        check = check_fixtures_from_prd(
+            prd_path, tmp_path, FixturesConfig(enabled=True),
+        )
+        assert check.passed is False
+        assert "failing closed" in check.message
+
+    def test_invalid_fixture_schema_fails_closed(self, tmp_path: Path) -> None:
+        entry = _cli_fixture_entry()
+        entry["expected"] = {"stdout_containz": ["x"]}  # misspelled key
+        prd_path = tmp_path / "prd.json"
+        prd_path.write_text(json.dumps(_prd_data(fixtures=[entry])))
+        check = check_fixtures_from_prd(
+            prd_path, tmp_path, FixturesConfig(enabled=True),
+        )
+        assert check.passed is False
+        assert "failing closed" in check.message
+        assert any("stdout_containz" in d for d in check.details)

--- a/tests/test_harness_integration.py
+++ b/tests/test_harness_integration.py
@@ -325,7 +325,7 @@ class TestFixturesIntegration:
             input_data={"module": "adder", "function": "add", "args": [2, 3]},
             expected={"returns": 5},
         )
-        result = run_function_fixture(f, tmp_path)
+        result = run_function_fixture(f, tmp_path, timeout=60.0)
         assert result.passed
 
     def test_function_fixture_wrong_return(self, tmp_path: Path) -> None:
@@ -338,7 +338,7 @@ class TestFixturesIntegration:
             input_data={"module": "adder", "function": "add", "args": [2, 3]},
             expected={"returns": 6},
         )
-        result = run_function_fixture(f, tmp_path)
+        result = run_function_fixture(f, tmp_path, timeout=60.0)
         assert not result.passed
         assert "Expected 6" in result.message
 
@@ -359,7 +359,7 @@ class TestFixturesIntegration:
             },
             expected={"returns": "hi alice"},
         )
-        result = run_function_fixture(f, tmp_path)
+        result = run_function_fixture(f, tmp_path, timeout=60.0)
         assert result.passed
 
     def test_check_fixtures_pipeline(self, tmp_path: Path) -> None:

--- a/tests/test_scope_hardening.py
+++ b/tests/test_scope_hardening.py
@@ -420,6 +420,8 @@ class TestFactoryScopeSiteFailsClosed:
             allowed_paths: list[str] | None,
             verify_config: VerifyConfig,
             allowed_paths_error: str | None = None,
+            fixtures_config: object | None = None,
+            component_id: str | None = None,
         ) -> VerificationResult:
             captured["allowed_paths"] = allowed_paths
             captured["allowed_paths_error"] = allowed_paths_error
@@ -453,6 +455,8 @@ class TestFactoryScopeSiteFailsClosed:
             allowed_paths: list[str] | None,
             verify_config: VerifyConfig,
             allowed_paths_error: str | None = None,
+            fixtures_config: object | None = None,
+            component_id: str | None = None,
         ) -> VerificationResult:
             captured["allowed_paths_error"] = allowed_paths_error
             return VerificationResult(
@@ -497,6 +501,8 @@ class TestFactoryScopeSiteFailsClosed:
             allowed_paths: list[str] | None,
             verify_config: VerifyConfig,
             allowed_paths_error: str | None = None,
+            fixtures_config: object | None = None,
+            component_id: str | None = None,
         ) -> VerificationResult:
             captured["allowed_paths"] = allowed_paths
             captured["allowed_paths_error"] = allowed_paths_error


### PR DESCRIPTION
## Roadmap items

R7.2 **Wire fixtures, sandboxed** [CRIT-3, H-6; user decision 4]. Checkbox flipped in `docs/remediation-roadmap.md` in this PR.

## What changed

- **Function fixtures run in a subprocess, never in the harness process.** `run_function_fixture` launches `sys.executable -c <runner> <json-spec>` (spec passed via argv), cwd = component worktree, R2.6 scrubbed env, `start_new_session` + group kill on timeout (all via the wave-5 `run_scrubbed` helper). The runner prints a marker-prefixed JSON verdict line; the parent takes the last marker line. Previously agent code was imported with `importlib` inside the harness process with the harness env (API keys).
- **CLI fixtures: `shlex.split` + `shell=False`.** Shell features are unsupported and documented as such; metacharacters in the PRD-supplied command are literal argv.
- **`PRD.validate_schema` accepts `fixtures`** with strict per-type validation: unknown keys rejected at entry, `input_data`, and `expected` level (a misspelled expectation key would otherwise pass vacuously); `expected` must be non-empty; file paths must be worktree-relative with no `..`; `exit_code` rejects booleans; `returns`/`raises` mutually exclusive. `PRD.save` now round-trips `fixtures` AND `allowedPaths` (save previously dropped allowedPaths silently - a save would have unbound diff scope).
- **Phase 1 wiring:** `run_mechanical_verification` gains `fixtures_config`/`component_id` and runs `check_fixtures_from_prd` when `[fixtures].enabled` (default **false** per user decision 4). Unreadable or schema-invalid PRDs fail the check closed. Failures land in `VerificationResult.as_context()` with fixture description, divergence, and actual output.
- **Snapshot regression behind the same flag:** passing runs save outputs keyed by component id (atomic write); later runs fail on a previously-passing fixture failing or changing output, with a delete-to-reset hint. Relative `snapshot_dir` resolves against the repo root so snapshots survive worktree recreation.
- **File fixtures contained:** absolute paths, `..`, and symlink escapes rejected (defense in depth under the schema check - a leaked file body would flow into retry prompts/PR bodies).
- **Control plane:** `FixturesConfig.from_env()` + `load(root_dir)` (`[fixtures]` toml + `RALPH_FIXTURES_*` env, env beats toml) using `config.load_toml_section`; `FactoryConfig.fixtures_config` lazily resolves via `FixturesConfig.load(root_dir)` so `ralph factory` honors it with no CLI flag changes. `[fixtures]` enrolled in `scripts/gen_docs.py` (behavioral key probing) + `ralph.toml.example`; README config reference regenerated and the hand-written fixtures section rewritten to match what ships.
- `load_fixtures_from_prd_data` now raises on malformed entries instead of silently skipping them (a silently-dropped fixture is a silently-weakened oracle).

## Tested (named tests, all real subprocesses, no LLM)

- Subprocess function-fixture round trip pass/fail/expected-exception: `TestFunctionFixtureSubprocess::test_round_trip_pass/fail/expected_exception`
- Env scrub verified **inside** the fixture subprocess (planted `FAKE_API_KEY`/`MY_DEPLOY_SECRET` not visible): `test_env_scrubbed_inside_subprocess`
- Module-level side effect cannot touch the harness process (sentinel file proves the code ran in the subprocess; harness `os.environ` and `sys.modules` stay clean): `test_module_side_effects_cannot_touch_harness`
- Timeout kills the fixture subprocess: `test_timeout_kills_subprocess`
- CLI metacharacters not shell-interpreted (`&&` literal, no `pwned.txt` created; `$HOME` unexpanded): `TestCliFixtureNoShell`
- File fixture containment incl. symlink escape: `TestFileFixtureContainment`
- Strict PRD schema accept (README examples) + parametrized rejects (unknown keys, misspelled expectation, bool exit_code, empty expected, traversal/absolute paths, returns+raises, empty array): `TestPrdFixturesSchema`
- PRD round trip with fixtures + allowedPaths: `test_prd_round_trip_with_fixtures`
- Phase 1 integration: check present+passing when enabled, absent when disabled or config None, failure produces actionable retry context, unreadable/invalid PRD fails closed: `TestPhase1Integration`
- Snapshot save + output-change regression + no-snapshot-without-component-id: `TestSnapshotWiring`
- Loader precedence (toml, env-beats-toml, root-relative snapshot_dir): `TestFixturesConfigLoad`
- `[fixtures]` docs keys behaviorally probed by `scripts/gen_docs.py` via existing `tests/test_gen_docs.py` (README-in-sync + example-sections parity)

## Assumed (not tested)

- The factory Phase 1 call site plumbing (`fixtures_config=..., component_id=comp_id` at `factory.py`) is exercised only via the updated `test_scope_hardening.py` spies accepting the new kwargs, not via a full factory run with fixtures enabled.
- Forged-verdict equivalence argument (agent code printing a fake marker line grants no power beyond hardcoding the return value) is a design argument, not a test.
- Function fixtures needing project-venv-only imports fail with an import error (documented limitation; not covered by a test).
- Behavior on Windows (POSIX-first codebase; process-group semantics).

## Checks (final lines)

```
uv run pytest tests/ -q          -> 1340 passed, 28 skipped, 1 xfailed, 1 warning in 59.10s
uv run mypy ralph_py/ --strict   -> Success: no issues found in 38 source files
uv run ruff check ralph_py/ tests/ -> All checks passed!
```

## Notes for the reviewer

- `ralph config show` does not yet display the `[fixtures]` section: that lives in `cli.py`, which this session's scope excludes (there is no parity test between `config show` and gen_docs; `[notify]` has the same asymmetry today). One-line follow-up if wanted.
- No prompt bodies, `*_PROMPT_VERSION` constants, or snapshot tuples touched (H2/H3); no calibration cycle needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)