### PR TITLE
feat: R7.1 cross-model review rotation - codex reviews Claude code

### DIFF
--- a/docs/adversarial-design.md
+++ b/docs/adversarial-design.md
@@ -128,6 +128,28 @@ Partial runs (a role present in the old baseline but not exercised in the new on
 
 The architect matcher's `must_include_kind` used to demand exact taxonomy labels, but every architect miss in the recorded 20260527 baselines was the planted issue reported under a sibling label (`missing_detail` instead of `undefined_failure_mode` / `unstated_assumption`) - a matcher artifact, not a detection failure. `calibration.KIND_SYNONYM_GROUPS` documents the one symmetric family that collapses: `{missing_detail, unstated_assumption, undefined_failure_mode}` ("the spec is silent about X"). `ambiguity`, `contradiction`, `out_of_scope_creep`, and `other` still require exact labels - ambiguity is about vague language that IS present, not absence. Exact-label matching is still recorded in run details (`exact_kind_match=`) as a non-gating signal so taxonomy drift stays visible.
 
+### Reviewer-family override (R7.1)
+
+To measure the same-family vs cross-family correlated-miss delta, the calibration runner accepts a reviewer-family override that applies to the reviewer and security roles only (the architect keeps the base calibration agent - rotation applies to reviewers, not the spec red-team):
+
+```bash
+# Baseline 1: same family end to end
+RALPH_RUN_CALIBRATION=1 RALPH_CALIBRATION_MODEL=haiku \
+  uv run pytest tests/test_calibration.py -v
+
+# Baseline 2: reviewer + security roles on the second family (codex CLI)
+RALPH_RUN_CALIBRATION=1 RALPH_CALIBRATION_MODEL=haiku \
+  RALPH_CALIBRATION_REVIEWER_AGENT_TYPE=codex \
+  uv run pytest tests/test_calibration.py -v
+
+# Compare (the cross-model warning is expected: the delta measures the family change)
+uv run python -m ralph_py.calibration compare \
+  tests/adversarial_fixtures/_results/baseline-<same-family>.json \
+  tests/adversarial_fixtures/_results/baseline-<cross-family>.json
+```
+
+`RALPH_CALIBRATION_REVIEWER_MODEL` optionally pins the reviewer model within the overridden family. Override runs record their model id as `<base>+reviewer:<type>/<model>` so `compare` surfaces the family change as its cross-model warning instead of hiding it.
+
 ### Model drift (R5.5, H2-extended)
 
 Baselines record the model id, and an always-run structural test (`tests/test_calibration.py::TestFixtureStructure::test_warns_when_calibration_model_differs_from_newest_baseline`) warns - never fails - when `RALPH_CALIBRATION_MODEL` differs from the newest baseline's recorded model. H2 extended: calibration re-runs on model change, not just prompt change; a detection rate measured against an older model does not transfer.
@@ -159,7 +181,7 @@ Healthy state: empty file. Persistent non-zero values per build are the signal t
 
 ## Known limitations
 
-1. **Correlated failure.** The architect, engineer, reviewer, security reviewer, and distiller can all be the same model. They will fail on the same inputs in the same way. Multi-model rotation (roadmap E1) was deliberately deferred; until it lands, treat "all roles agree" as one data point, not several.
+1. **Correlated failure (partially mitigated by R7.1 rotation).** The review and security phases now default to the OPPOSITE model family from the engineer when that CLI is available (user decision 2: the OpenAI family via the codex CLI reviews Claude-engineered code; a codex engineer flips the default to claude-code). Explicit reviewer config always wins; when the cross family's CLI is missing (or the engineer runs a custom command whose family is unknowable) the factory prints a homogeneity warning naming the self-preference risk and falls back to the old same-family behavior. Every reviewer-produced `Finding` carries a `model:<id>` tag, the PR body's findings sections name the reviewer model, and the journal serializes the tag - so same-family and cross-family review outcomes stay attributable and measurable. What REMAINS correlated: the architect, engineer, and knowledge distiller still run on the primary family, so a spec misreading or implementation blind spot shared by that family is not caught by rotation - treat architect+engineer+distiller agreement as one data point. The correlated-miss delta is measured, not assumed: capture same-family vs cross-family calibration baselines (see "Reviewer-family override" below) before trusting the rotation's effect size.
 2. **`exhaustively_searched` is self-reported.** Both reviewer and security results expose the flag, but it cannot be verified at runtime. The trustworthy signal is calibration rate, not the flag.
 3. **Fact-utilization is a lower bound.** `measure_fact_utilization` uses a 30-character case-insensitive substring match. LLMs paraphrase, so a false negative just means we under-count.
 4. **Calibration baseline is non-deterministic.** LLMs vary; the suite now runs each fixture `RALPH_CALIBRATION_RUNS` times (default 3) and reports per-fixture consistency (R5.1), but 3 runs is still a small sample - treat a consistency of 2/3 as "flaky", not as a precise 0.67.

--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -33,6 +33,9 @@ Process rules that bind this plan:
 2. **Second model family for review rotation** (R7.1): which family reviews
    Claude-engineered code (codex CLI is already an adapter). Needed before the
    correlated-failure gate in the A+ criteria can be measured.
+   **Decided 2026-07-19: the OpenAI family via the codex CLI.** Review and
+   security default to codex when the CLI is available (a codex engineer
+   flips the default to claude-code); explicit config always wins.
 3. **Linear workspace admin approval** (R7.4): app-actor OAuth requires a
    workspace admin to approve the app identity.
 4. **PRD fixtures default** (R7.2): once wired and sandboxed, fixtures ship
@@ -570,13 +573,18 @@ by an integration test with a synthetic-but-realistic journal).
 
 ## Phase R7 - Strategic (the A+ differentiators)
 
-- [ ] R7.1 (M) **Cross-model review rotation** [research topic 3; user decision 2]
+- [~] R7.1 (M) **Cross-model review rotation** [research topic 3; user decision 2]
   - Default `review_model`/`security_model` to a different family than the
     engineer's when a second CLI is available; warn on homogeneity; record the
     reviewing model identity on every Finding and in the PR body.
   - Measure the correlated-miss delta: run calibration with same-family and
     cross-family configs and record both (this is the E1 decision revisited
     with 2026 evidence; independent passes, never committee deliberation).
+  - Partial (2026-07-19): rotation default, homogeneity warning, `model:<id>`
+    finding tags, PR-body/journal attribution, and the calibration
+    reviewer-family override all landed. Stays `[~]` until the user records
+    BOTH baselines (same-family and cross-family; commands in
+    docs/adversarial-design.md "Reviewer-family override").
 - [x] R7.2 (M) **Wire fixtures, sandboxed** [CRIT-3, H-6; user decision 4]
   - Function fixtures execute in a subprocess (`sys.executable -c`) with the
     R2.6 scrubbed env: never in the harness process.

--- a/ralph_py/calibration.py
+++ b/ralph_py/calibration.py
@@ -607,6 +607,49 @@ def format_comparison(comparison: Comparison) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Reviewer-family override (R7.1)
+# ---------------------------------------------------------------------------
+
+
+def reviewer_override_from_env(
+    environ: Mapping[str, str],
+) -> tuple[str | None, str | None]:
+    """(agent_type, model) override for the reviewer and security
+    calibration agents (R7.1), read from
+    ``RALPH_CALIBRATION_REVIEWER_AGENT_TYPE`` /
+    ``RALPH_CALIBRATION_REVIEWER_MODEL``. Empty values mean unset.
+
+    The override exists so the calibration suite can measure the
+    same-family vs cross-family correlated-miss delta: one baseline with
+    no override (same family end to end), one with the reviewer roles on
+    the second family. The architect always keeps the base calibration
+    agent - rotation applies to reviewers, not the spec red-team."""
+    agent_type = environ.get("RALPH_CALIBRATION_REVIEWER_AGENT_TYPE") or None
+    model = environ.get("RALPH_CALIBRATION_REVIEWER_MODEL") or None
+    return agent_type, model
+
+
+def reviewer_override_label(
+    base_model: str,
+    reviewer_agent_type: str | None,
+    reviewer_model: str | None,
+) -> str:
+    """Baseline ``model`` label for a run with a reviewer override.
+
+    No override keeps the plain base model id. Override runs get
+    ``<base>+reviewer:<type>/<model>`` so ``compare_baselines``'s
+    cross-model warning fires exactly when the reviewer family differs
+    between the two baselines - that comparison measures the family
+    change, which is what R7.1 wants surfaced, not hidden."""
+    if not reviewer_agent_type and not reviewer_model:
+        return base_model
+    reviewer = "/".join(
+        part for part in (reviewer_agent_type, reviewer_model) if part
+    )
+    return f"{base_model}+reviewer:{reviewer}"
+
+
+# ---------------------------------------------------------------------------
 # Model drift (R5.5, H2-extended)
 # ---------------------------------------------------------------------------
 

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -255,6 +255,188 @@ class FactoryConfig:
         return config
 
 
+# R7.1: cross-model review rotation. Self-preference bias means a
+# same-family reviewer systematically misses the bug classes its own
+# family produces, so when no explicit reviewer config is given the
+# review and security phases default to the OPPOSITE model family from
+# the engineer (user decision 2: the OpenAI family via the codex CLI
+# reviews Claude-engineered code; a codex engineer flips the default to
+# claude-code). The engineer always keeps the primary family.
+_CROSS_FAMILY_TYPE: dict[str, str] = {
+    "claude-code": "codex",
+    "codex": "claude-code",
+}
+
+
+def _cli_family(
+    agent_cmd: str | None,
+    agent_type: str | None,
+    claude_available: bool,
+) -> str | None:
+    """Which CLI family a (cmd, type) config resolves to, mirroring
+    ``agents.get_agent`` dispatch exactly: a custom command is an
+    unknown family (None); "auto"/None auto-detects claude-code first;
+    any unrecognized type string falls through to codex."""
+    if agent_cmd:
+        return None
+    if agent_type == "claude-code":
+        return "claude-code"
+    if agent_type in (None, "auto"):
+        return "claude-code" if claude_available else "codex"
+    return "codex"
+
+
+def _agent_identity(
+    agent_cmd: str | None,
+    agent_type: str | None,
+    model: str | None,
+    claude_available: bool,
+) -> str:
+    """Reviewing-model identity for a configuration, matching the agent
+    adapters' ``name`` property ("codex (gpt-5)", "claude-code",
+    "custom (<cmd>)") so findings attributed before an agent exists
+    match what a live run stamps on its results."""
+    if agent_cmd:
+        return f"custom ({agent_cmd})"
+    family = _cli_family(agent_cmd, agent_type, claude_available) or "unknown"
+    if model:
+        return f"{family} ({model})"
+    return family
+
+
+@dataclass(frozen=True)
+class AdversarialAgentSelection:
+    """Resolved agent configuration for one adversarial phase (R7.1).
+
+    ``source`` records how the resolution went: "explicit" (operator
+    config always wins), "cross-family-default" (the R7.1 rotation
+    default), or "same-family-fallback" (heterogeneity unavailable;
+    ``warning`` then carries the homogeneity risk statement to print).
+    """
+
+    phase: str
+    agent_cmd: str | None
+    agent_type: str | None
+    model: str | None
+    reasoning: str | None
+    source: str
+    identity: str
+    warning: str | None = None
+
+
+def resolve_adversarial_selection(
+    phase: str,
+    *,
+    explicit_cmd: str | None,
+    explicit_type: str | None,
+    explicit_model: str | None,
+    fallback_cmd: str | None,
+    fallback_type: str | None,
+    fallback_model: str | None,
+    fallback_reasoning: str | None,
+    engineer_cmd: str | None,
+    engineer_type: str | None,
+    claude_available: bool | None = None,
+    codex_available: bool | None = None,
+) -> AdversarialAgentSelection:
+    """Resolve which agent reviews this run's diffs (R7.1).
+
+    Precedence:
+    1. Any explicit field (cmd/type/model) makes the whole selection
+       explicit: each unset field falls back to the phase's historical
+       fallback, exactly as before R7.1. No warning - an operator who
+       pins a same-family reviewer has decided so deliberately.
+    2. Otherwise, when the engineer's family is known and the opposite
+       family's CLI is available, the reviewer defaults to that family
+       (adapter-default model; reasoning deliberately not inherited -
+       effort strings do not transfer across families).
+    3. Otherwise the reviewer falls back to the same configuration as
+       today (same family as the engineer) and ``warning`` names the
+       self-preference risk.
+
+    ``claude_available``/``codex_available`` default to probing the
+    real CLIs; tests inject both.
+    """
+    from ralph_py.agents import ClaudeCodeAgent, CodexAgent
+
+    if claude_available is None:
+        claude_available = ClaudeCodeAgent.is_available()
+    if codex_available is None:
+        codex_available = CodexAgent.is_available()
+
+    explicit = any(
+        v is not None for v in (explicit_cmd, explicit_type, explicit_model)
+    )
+    if explicit:
+        cmd = explicit_cmd if explicit_cmd is not None else fallback_cmd
+        agent_type = (
+            explicit_type if explicit_type is not None else fallback_type
+        )
+        model = explicit_model if explicit_model is not None else fallback_model
+        return AdversarialAgentSelection(
+            phase=phase,
+            agent_cmd=cmd,
+            agent_type=agent_type,
+            model=model,
+            reasoning=fallback_reasoning,
+            source="explicit",
+            identity=_agent_identity(cmd, agent_type, model, claude_available),
+        )
+
+    engineer_family = _cli_family(engineer_cmd, engineer_type, claude_available)
+    cross_type = (
+        _CROSS_FAMILY_TYPE.get(engineer_family) if engineer_family else None
+    )
+    cross_available = (
+        codex_available if cross_type == "codex" else claude_available
+    )
+    if cross_type is not None and cross_available:
+        return AdversarialAgentSelection(
+            phase=phase,
+            agent_cmd=None,
+            agent_type=cross_type,
+            model=None,
+            reasoning=None,
+            source="cross-family-default",
+            identity=_agent_identity(None, cross_type, None, claude_available),
+        )
+
+    if engineer_family is None:
+        warning = (
+            f"Homogeneity risk (R7.1): the engineer runs a custom agent "
+            f"command, so its model family is unknown and the "
+            f"cross-family default cannot be applied; the {phase} "
+            f"reviewer falls back to the same configuration. "
+            "Self-preference bias means a same-family reviewer "
+            "systematically misses the bug classes its own family "
+            f"produces. Set an explicit {phase} agent config on a "
+            "different model family to restore cross-family review."
+        )
+    else:
+        warning = (
+            f"Homogeneity risk (R7.1): the {cross_type} CLI is not "
+            f"available, so the {phase} reviewer runs on the same model "
+            f"family as the engineer ({engineer_family}). "
+            "Self-preference bias means a same-family reviewer "
+            "systematically misses the bug classes its own family "
+            f"produces. Install the {cross_type} CLI for cross-family "
+            f"review, or set an explicit {phase} agent config to accept "
+            "the risk silently."
+        )
+    return AdversarialAgentSelection(
+        phase=phase,
+        agent_cmd=fallback_cmd,
+        agent_type=fallback_type,
+        model=fallback_model,
+        reasoning=fallback_reasoning,
+        source="same-family-fallback",
+        identity=_agent_identity(
+            fallback_cmd, fallback_type, fallback_model, claude_available,
+        ),
+        warning=warning,
+    )
+
+
 @dataclass
 class ComponentResult:
     """Result from running a single component."""
@@ -1071,6 +1253,67 @@ def _run_factory_locked(
 
     progress_log.factory_started(manifest.project_name, len(manifest.components))
 
+    # R7.1: resolve which model family reviews this run's diffs ONCE so
+    # the choice is stable across components and the homogeneity warning
+    # prints once per run, not per component. Explicit config always
+    # wins; otherwise review/security default to the opposite family
+    # from the engineer when that CLI is available. The selection is an
+    # audit-trail event: same-family and cross-family runs must stay
+    # distinguishable in the progress log.
+    review_selection = resolve_adversarial_selection(
+        "review",
+        explicit_cmd=factory_config.review_agent_cmd,
+        explicit_type=factory_config.review_agent_type,
+        explicit_model=factory_config.review_model,
+        fallback_cmd=None,
+        fallback_type=base_config.agent_type,
+        fallback_model=None,
+        fallback_reasoning=None,
+        engineer_cmd=base_config.agent_cmd,
+        engineer_type=base_config.agent_type,
+    )
+    security_selection: AdversarialAgentSelection | None = None
+    if factory_config.security_config is not None:
+        sec_cfg = factory_config.security_config
+        security_selection = resolve_adversarial_selection(
+            "security",
+            explicit_cmd=sec_cfg.agent_cmd,
+            explicit_type=sec_cfg.agent_type,
+            explicit_model=sec_cfg.model,
+            fallback_cmd=base_config.agent_cmd,
+            fallback_type=base_config.agent_type,
+            fallback_model=base_config.model,
+            fallback_reasoning=base_config.model_reasoning_effort,
+            engineer_cmd=base_config.agent_cmd,
+            engineer_type=base_config.agent_type,
+        )
+    _review_phase_enabled = (
+        factory_config.review_mode != ReviewMode.SKIP.value
+    )
+    _security_phase_enabled = (
+        factory_config.security_config is not None
+        and factory_config.security_config.mode != SecurityMode.SKIP.value
+    )
+    for _sel, _enabled in (
+        (review_selection, _review_phase_enabled),
+        (security_selection, _security_phase_enabled),
+    ):
+        if _sel is None or not _enabled:
+            continue
+        if _sel.warning:
+            ui.warn(f"  {_sel.warning}")
+        progress_log.emit(
+            "adversarial_agent_selected",
+            data={
+                "phase": _sel.phase,
+                "source": _sel.source,
+                "identity": _sel.identity,
+                "agent_type": _sel.agent_type,
+                "model": _sel.model,
+                "homogeneous": _sel.warning is not None,
+            },
+        )
+
     # Validate DAG
     ui.section("Factory: Validating DAG")
     dag_errors = manifest.validate_dag()
@@ -1868,11 +2111,14 @@ def _run_factory_locked(
             # failure; it must never abort the whole factory run.
             review_agent: Any = None
             try:
+                # R7.1: the run-level selection (explicit config, or the
+                # cross-family default, or the warned same-family
+                # fallback) decides who reviews.
                 review_agent = get_agent(
-                    factory_config.review_agent_cmd,
-                    factory_config.review_model,
-                    None,
-                    factory_config.review_agent_type or base_config.agent_type,
+                    review_selection.agent_cmd,
+                    review_selection.model,
+                    review_selection.reasoning,
+                    review_selection.agent_type,
                 )
                 if review_mode == ReviewMode.HARD and review_chunks is not None:
                     # R1.4: one pass per chunk, each consuming budget;
@@ -1909,6 +2155,9 @@ def _run_factory_locked(
                     mode=review_mode.value,
                     overall_notes=f"Review agent crashed: {exc}",
                     infrastructure_error=True,
+                    # R7.1: a crash before/inside the run is still
+                    # attributed to the selected reviewer identity.
+                    reviewer_model=review_selection.identity,
                 )
             # R3.1: the instance is fresh per phase, so its accumulated
             # records are exactly this review's spend (N records for a
@@ -2054,18 +2303,23 @@ def _run_factory_locked(
             )
             sec_result = None
             sec_agent: Any = None
+            # R7.1: the run-level selection already folded in the
+            # explicit sec_config fields and the engineer fallbacks (or
+            # picked the cross-family default). sec_config is non-None
+            # and non-skip here, so the selection was resolved at run
+            # start.
+            assert security_selection is not None
             # The try/except deliberately wraps ONLY the agent-driven
             # work (getting the agent + running the review). Errors in
             # the retry-or-fail path below must NOT be swallowed - if
             # they were, a hard-mode security failure could fall through
             # to PR creation as if it had passed.
             try:
-                sec_model = sec_config.model or base_config.model
                 sec_agent = _get_sec_agent(
-                    sec_config.agent_cmd or base_config.agent_cmd,
-                    sec_model,
-                    base_config.model_reasoning_effort,
-                    sec_config.agent_type or base_config.agent_type,
+                    security_selection.agent_cmd,
+                    security_selection.model,
+                    security_selection.reasoning,
+                    security_selection.agent_type,
                 )
                 if (
                     sec_config.mode == SecurityMode.HARD.value
@@ -2113,6 +2367,9 @@ def _run_factory_locked(
                         f"completion: {exc}"
                     ),
                     infrastructure_error=True,
+                    # R7.1: a crash before/inside the run is still
+                    # attributed to the selected reviewer identity.
+                    reviewer_model=security_selection.identity,
                 )
 
             # R3.1: record security spend before pass/fail handling so

--- a/ralph_py/findings.py
+++ b/ralph_py/findings.py
@@ -30,6 +30,15 @@ _PHASE_SKIPPED_CATEGORY = "phase_skipped"
 # (an attempt that was retried) from the shipped attempt's findings.
 ATTEMPT_TAG_PREFIX = "attempt:"
 
+# R7.1: every finding a reviewer produces is tagged with the reviewing
+# model identity (e.g. "model:codex (gpt-5)"), so the journal and PR
+# body can attribute each finding to the model family that raised it -
+# the measurement substrate for the same-family vs cross-family
+# correlated-miss comparison. Findings recorded when NO reviewer ran
+# (phase_skipped, pre-agent budget failures) carry no model tag: there
+# is no reviewing model to attribute them to.
+MODEL_TAG_PREFIX = "model:"
+
 
 @dataclass(frozen=True)
 class Finding:
@@ -200,6 +209,32 @@ def tag_finding_with_attempt(finding: Finding, attempt: int) -> Finding:
     )
 
 
+def tag_finding_with_model(finding: Finding, model_id: str) -> Finding:
+    """Return a copy of *finding* tagged ``model:<id>`` (R7.1).
+
+    Idempotent: a finding already carrying a model tag is returned
+    unchanged, so merged chunk results and resumed manifests cannot
+    stack conflicting identities. An empty ``model_id`` is a no-op -
+    tagging with an unknown identity would be a fabricated claim."""
+    if not model_id:
+        return finding
+    if any(t.startswith(MODEL_TAG_PREFIX) for t in finding.tags):
+        return finding
+    return replace(
+        finding, tags=finding.tags + (f"{MODEL_TAG_PREFIX}{model_id}",),
+    )
+
+
+def finding_model(finding: Finding) -> str | None:
+    """The reviewing model identity a finding was recorded under, or
+    None for findings that predate R7.1 model tagging (or were recorded
+    without a reviewer having run)."""
+    for tag in finding.tags:
+        if tag.startswith(MODEL_TAG_PREFIX):
+            return tag[len(MODEL_TAG_PREFIX):] or None
+    return None
+
+
 def finding_attempt(finding: Finding) -> int | None:
     """The attempt number a finding was recorded on, or None for
     findings that predate the R3.3 attempt tagging."""
@@ -273,6 +308,12 @@ def render_findings_markdown(findings: list[Finding]) -> str:
 
         lines.append(f"### {phase.capitalize()} ({len(real)} findings)")
         lines.append("")
+        # R7.1: attribute the phase's findings to the model(s) that
+        # produced them so a PR reader can see who reviewed whom.
+        models = sorted({m for m in (finding_model(f) for f in items) if m})
+        if models:
+            lines.append(f"Reviewer model: {', '.join(models)}")
+            lines.append("")
         if infra:
             for f in infra:
                 lines.append(

--- a/ralph_py/review.py
+++ b/ralph_py/review.py
@@ -17,7 +17,7 @@ from ralph_py.decompose import (
     collect_agent_output,
     generate_data_delimiter,
 )
-from ralph_py.findings import Finding, dump_raw_debug
+from ralph_py.findings import Finding, dump_raw_debug, tag_finding_with_model
 from ralph_py.prd import PRD
 from ralph_py.verify import VerificationResult
 
@@ -119,6 +119,12 @@ class ReviewResult:
     # hard mode never accepts a partial review - the factory chunks
     # the diff and runs one pass per chunk instead.
     partial: bool = False
+    # R7.1: identity of the model that produced this review (the
+    # agent's ``name``, e.g. "codex (gpt-5)"). Stamped by run_review;
+    # empty when no reviewer ran (mode=skip). Flows onto every Finding
+    # as a ``model:<id>`` tag and into the PR body, so same-family vs
+    # cross-family review outcomes stay attributable.
+    reviewer_model: str = ""
 
     def as_retry_context(self) -> str:
         """Format failing/advisory findings for injection into retry prompt."""
@@ -162,6 +168,9 @@ class ReviewResult:
             f"{criterion_adv} advisory; "
             f"{len(self.concerns)} additional concerns**"
         )
+        if self.reviewer_model:
+            lines.append("")
+            lines.append(f"**Reviewer model**: {self.reviewer_model}")
         if self.partial:
             lines.append("")
             lines.append(
@@ -249,14 +258,22 @@ class ReviewResult:
         single synthetic infrastructure_error Finding so downstream
         consumers can distinguish "clean review" (empty list) from
         "review never ran" (one infra finding).
+
+        R7.1: every returned Finding is tagged ``model:<reviewer_model>``
+        when the reviewing model identity is known, so the journal can
+        attribute findings (and misses) to the model family that
+        reviewed the diff.
         """
         if self.infrastructure_error:
-            return [Finding.infrastructure_error(
-                phase="review",
-                explanation=(
-                    self.overall_notes
-                    or "Reviewer agent did not produce parseable output"
+            return [tag_finding_with_model(
+                Finding.infrastructure_error(
+                    phase="review",
+                    explanation=(
+                        self.overall_notes
+                        or "Reviewer agent did not produce parseable output"
+                    ),
                 ),
+                self.reviewer_model,
             )]
         out: list[Finding] = []
         for cr in self.criteria:
@@ -278,7 +295,9 @@ class ReviewResult:
                 explanation=concern.explanation,
                 suggestion=concern.suggestion,
             ))
-        return out
+        return [
+            tag_finding_with_model(f, self.reviewer_model) for f in out
+        ]
 
 
 REVIEWER_PROMPT_VERSION = "1.1.0"
@@ -637,6 +656,10 @@ def run_review(
 
     ui.info("  Running second-opinion review...")
     start = time.monotonic()
+    # R7.1: the agent's name IS the reviewing model identity ("codex
+    # (gpt-5)", "claude-code (haiku)", "custom (<cmd>)"). Captured up
+    # front so even crash/oversize results stay attributable.
+    reviewer_model = getattr(agent, "name", "") or ""
 
     truncated = False
     try:
@@ -670,6 +693,7 @@ def run_review(
             mode=mode.value,
             overall_notes=f"Reviewer agent output too large: {exc}",
             infrastructure_error=True,
+            reviewer_model=reviewer_model,
         )
         result.duration_seconds = time.monotonic() - start
         return result
@@ -683,6 +707,7 @@ def run_review(
             mode=mode.value,
             overall_notes=f"Reviewer agent failed: {exc}",
             infrastructure_error=True,
+            reviewer_model=reviewer_model,
         )
         result.duration_seconds = time.monotonic() - start
         return result
@@ -692,6 +717,7 @@ def run_review(
         raw_output, expected_story_ids, debug_dir=debug_dir,
     )
     result.mode = mode.value
+    result.reviewer_model = reviewer_model
     result.duration_seconds = time.monotonic() - start
 
     if truncated and not result.infrastructure_error:
@@ -776,6 +802,9 @@ def merge_review_results(
         infrastructure_error=any(r.infrastructure_error for r in results),
         exhaustively_searched=all(r.exhaustively_searched for r in results),
         partial=any(r.partial for r in results),
+        # R7.1: every chunk runs on the same agent instance, so the
+        # first chunk's identity is the merged review's identity.
+        reviewer_model=results[0].reviewer_model,
     )
     notes = [f"Chunked review: {n} passes over an oversized diff (R1.4)."]
     raw_parts: list[str] = []

--- a/ralph_py/security.py
+++ b/ralph_py/security.py
@@ -31,7 +31,7 @@ from ralph_py.decompose import (
     collect_agent_output,
     generate_data_delimiter,
 )
-from ralph_py.findings import Finding, dump_raw_debug
+from ralph_py.findings import Finding, dump_raw_debug, tag_finding_with_model
 
 if TYPE_CHECKING:
     from ralph_py.agents.base import Agent
@@ -121,6 +121,11 @@ class SecurityResult:
     # annotation + a low-severity marker finding); hard mode never
     # accepts one - the factory chunks the diff instead.
     partial: bool = False
+    # R7.1: identity of the model that produced this security review
+    # (the agent's ``name``). Stamped by run_security_review; empty when
+    # no reviewer ran (mode=skip). Flows onto every Finding as a
+    # ``model:<id>`` tag and into the PR body.
+    reviewer_model: str = ""
 
     def as_retry_context(self) -> str:
         """Format failing findings for injection into the implementer's
@@ -144,11 +149,16 @@ class SecurityResult:
             "prompt size cap; only a truncated prefix was reviewed**"
             if self.partial else ""
         )
+        model_note = (
+            f"\n\n**Reviewer model**: {self.reviewer_model}"
+            if self.reviewer_model else ""
+        )
         if not self.findings:
             return (
                 "## Security Review\n\n"
                 f"**No findings ({self.mode} mode, "
                 f"{'exhaustively' if self.exhaustively_searched else 'briefly'} searched)**"
+                + model_note
                 + partial_note
             )
         lines = ["## Security Review", ""]
@@ -160,6 +170,9 @@ class SecurityResult:
             f"**{crit} critical, {high} high, {med} medium, {low} low "
             f"({self.mode} mode)**"
         )
+        if self.reviewer_model:
+            lines.append("")
+            lines.append(f"**Reviewer model**: {self.reviewer_model}")
         if self.partial:
             lines.append("")
             lines.append(
@@ -196,24 +209,33 @@ class SecurityResult:
         (security agent crashed, output unparseable, timeout) returns a
         single synthetic infrastructure_error Finding so downstream
         consumers can distinguish "clean security review" (empty list)
-        from "security review never ran" (one infra finding)."""
+        from "security review never ran" (one infra finding).
+
+        R7.1: every returned Finding is tagged ``model:<reviewer_model>``
+        when the reviewing model identity is known."""
         if self.infrastructure_error:
-            return [Finding.infrastructure_error(
-                phase="security",
-                explanation=(
-                    self.overall_notes
-                    or "Security reviewer agent did not produce parseable output"
+            return [tag_finding_with_model(
+                Finding.infrastructure_error(
+                    phase="security",
+                    explanation=(
+                        self.overall_notes
+                        or "Security reviewer agent did not produce parseable output"
+                    ),
                 ),
+                self.reviewer_model,
             )]
         return [
-            Finding.from_security_finding(
-                category=f.category,
-                severity=f.severity,
-                location=f.location,
-                explanation=f.explanation,
-                suggestion=f.suggestion,
-                owasp=category_owasp(f.category),
-                cwe=category_cwe(f.category),
+            tag_finding_with_model(
+                Finding.from_security_finding(
+                    category=f.category,
+                    severity=f.severity,
+                    location=f.location,
+                    explanation=f.explanation,
+                    suggestion=f.suggestion,
+                    owasp=category_owasp(f.category),
+                    cwe=category_cwe(f.category),
+                ),
+                self.reviewer_model,
             )
             for f in self.findings
         ]
@@ -567,6 +589,9 @@ def run_security_review(
 
     ui.info("  Running security review...")
     start = time.monotonic()
+    # R7.1: the agent's name IS the reviewing model identity. Captured
+    # up front so even crash results stay attributable.
+    reviewer_model = getattr(agent, "name", "") or ""
 
     prd_text = ""
     try:
@@ -601,10 +626,12 @@ def run_security_review(
             overall_notes=f"Security review agent failed: {exc}",
             duration_seconds=time.monotonic() - start,
             infrastructure_error=True,
+            reviewer_model=reviewer_model,
         )
 
     raw_output = _select_agent_output(agent, output_lines)
     result = parse_security_output(raw_output, mode, debug_dir=debug_dir)
+    result.reviewer_model = reviewer_model
     if result.infrastructure_error:
         # Parsing failed - we have no usable findings list, so don't
         # let _passes_threshold overwrite passed=False with True. In
@@ -688,6 +715,9 @@ def merge_security_results(
         infrastructure_error=any(r.infrastructure_error for r in results),
         exhaustively_searched=all(r.exhaustively_searched for r in results),
         partial=any(r.partial for r in results),
+        # R7.1: every chunk runs on the same agent instance, so the
+        # first chunk's identity is the merged review's identity.
+        reviewer_model=results[0].reviewer_model,
     )
     notes = [
         f"Chunked security review: {n} passes over an oversized diff "

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -87,6 +87,18 @@ CALIBRATION_RUNS = int(
         "RALPH_CALIBRATION_RUNS", str(calibration.DEFAULT_CALIBRATION_RUNS),
     )
 )
+# R7.1: optional reviewer-family override so the user can capture
+# same-family vs cross-family baselines with the same tooling. Applies
+# to the reviewer and security roles only; the architect keeps the base
+# calibration agent. The report's model label carries the override so
+# baseline comparisons surface the family change as a cross-model
+# warning instead of hiding it.
+REVIEWER_AGENT_TYPE, REVIEWER_MODEL = calibration.reviewer_override_from_env(
+    os.environ,
+)
+REPORT_MODEL_LABEL = calibration.reviewer_override_label(
+    CALIBRATION_MODEL, REVIEWER_AGENT_TYPE, REVIEWER_MODEL,
+)
 
 FIXTURES_DIR = Path(__file__).parent / "adversarial_fixtures"
 RESULTS_DIR = FIXTURES_DIR / "_results"
@@ -236,6 +248,20 @@ def _get_calibration_agent():
         model=CALIBRATION_MODEL,
         model_reasoning_effort=None,
         agent_type="claude-code",
+    )
+
+
+def _get_reviewer_calibration_agent():
+    """Agent for the reviewer and security roles: the base calibration
+    agent unless the R7.1 reviewer-family override
+    (RALPH_CALIBRATION_REVIEWER_AGENT_TYPE / _MODEL) selects another
+    family for the same-family vs cross-family baseline comparison."""
+    from ralph_py.agents import get_agent
+    return get_agent(
+        agent_cmd=None,
+        model=REVIEWER_MODEL or CALIBRATION_MODEL,
+        model_reasoning_effort=None,
+        agent_type=REVIEWER_AGENT_TYPE or "claude-code",
     )
 
 
@@ -640,14 +666,14 @@ class _DetectionReport:
         if self.records:
             report_data: dict = calibration.build_report(
                 self.records,
-                model=CALIBRATION_MODEL,
+                model=REPORT_MODEL_LABEL,
                 timestamp=date_str,
                 runs_per_fixture=CALIBRATION_RUNS,
             )
         else:
             report_data = {
                 "format_version": calibration.REPORT_FORMAT_VERSION,
-                "model": CALIBRATION_MODEL,
+                "model": REPORT_MODEL_LABEL,
                 "timestamp": date_str,
                 "runs_per_fixture": CALIBRATION_RUNS,
                 "summary": {},
@@ -802,7 +828,8 @@ def _security_run_once(
     # R5.3: build through the harness path so calibration exercises the
     # per-run data delimiters exactly as production does.
     prompt = _build_security_prompt(prd_text, diff_content)
-    agent = _get_calibration_agent()
+    # R7.1: security is a reviewer role - it honors the family override.
+    agent = _get_reviewer_calibration_agent()
     try:
         output = _collect(agent, prompt, tmp_path)
     except Exception as exc:  # noqa: BLE001
@@ -902,7 +929,8 @@ def _reviewer_run_once(
         verification_summary=render_verification(meta),
         data_delimiter=generate_data_delimiter(),
     )
-    agent = _get_calibration_agent()
+    # R7.1: the reviewer role honors the family override.
+    agent = _get_reviewer_calibration_agent()
     try:
         output = _collect(agent, prompt, tmp_path)
     except Exception as exc:  # noqa: BLE001
@@ -1207,8 +1235,12 @@ class TestFixtureStructure:
         when the configured calibration model differs from the model
         recorded in the newest baseline, because every recorded
         detection rate was measured against that older model and does
-        not transfer."""
-        message = calibration.model_drift_message(RESULTS_DIR, CALIBRATION_MODEL)
+        not transfer. Compares the full R7.1 label (base model plus any
+        reviewer-family override) so a standing override does not warn
+        against its own baselines - and a dropped override does."""
+        message = calibration.model_drift_message(
+            RESULTS_DIR, REPORT_MODEL_LABEL,
+        )
         if message is not None:
             warnings.warn(
                 message,

--- a/tests/test_reviewer_rotation.py
+++ b/tests/test_reviewer_rotation.py
@@ -1,0 +1,538 @@
+"""R7.1: cross-model review rotation.
+
+Covers the three test surfaces the roadmap item names:
+- the default-selection matrix (both CLIs present / one absent /
+  explicit override / custom engineer command),
+- the ``model:<id>`` identity tag flowing from a review run onto every
+  Finding, into the PR body, and into the journal serialization,
+- the homogeneity warning firing (resolver-level and through a real
+  ``run_factory`` invocation),
+plus the calibration reviewer-override helpers that make the
+same-family vs cross-family baseline comparison capturable.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+from ralph_py import calibration
+from ralph_py.config import RalphConfig
+from ralph_py.factory import (
+    AdversarialAgentSelection,
+    FactoryConfig,
+    resolve_adversarial_selection,
+    run_factory,
+)
+from ralph_py.findings import (
+    Finding,
+    finding_model,
+    render_findings_markdown,
+    tag_finding_with_attempt,
+    tag_finding_with_model,
+)
+from ralph_py.manifest import Component, Manifest
+from ralph_py.observability import read_progress_events
+from ralph_py.pr import _generate_pr_body
+from ralph_py.review import (
+    ReviewMode,
+    ReviewResult,
+    merge_review_results,
+    run_review,
+)
+from ralph_py.security import (
+    SecurityConfig,
+    SecurityResult,
+    merge_security_results,
+    run_security_review,
+)
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import CheckResult, VerificationResult
+
+
+def _resolve(
+    phase: str = "review",
+    *,
+    explicit_cmd: str | None = None,
+    explicit_type: str | None = None,
+    explicit_model: str | None = None,
+    fallback_cmd: str | None = None,
+    fallback_type: str | None = None,
+    fallback_model: str | None = None,
+    fallback_reasoning: str | None = None,
+    engineer_cmd: str | None = None,
+    engineer_type: str | None = None,
+    claude_available: bool = True,
+    codex_available: bool = True,
+) -> AdversarialAgentSelection:
+    """Call the resolver with availability always injected: these tests
+    must never depend on which CLIs the test machine has installed."""
+    return resolve_adversarial_selection(
+        phase,
+        explicit_cmd=explicit_cmd,
+        explicit_type=explicit_type,
+        explicit_model=explicit_model,
+        fallback_cmd=fallback_cmd,
+        fallback_type=fallback_type,
+        fallback_model=fallback_model,
+        fallback_reasoning=fallback_reasoning,
+        engineer_cmd=engineer_cmd,
+        engineer_type=engineer_type,
+        claude_available=claude_available,
+        codex_available=codex_available,
+    )
+
+
+class TestSelectionMatrix:
+    """Default-selection matrix for resolve_adversarial_selection."""
+
+    def test_claude_engineer_defaults_to_codex_when_available(self) -> None:
+        sel = _resolve(engineer_type="claude-code", fallback_type="claude-code")
+        assert sel.source == "cross-family-default"
+        assert sel.agent_type == "codex"
+        assert sel.agent_cmd is None
+        assert sel.model is None
+        assert sel.identity == "codex"
+        assert sel.warning is None
+
+    def test_auto_engineer_resolves_to_claude_then_crosses_to_codex(self) -> None:
+        # agent_type None ("auto") with claude installed is a claude
+        # engineer, so the reviewer crosses to codex.
+        sel = _resolve(engineer_type=None, fallback_type=None)
+        assert sel.source == "cross-family-default"
+        assert sel.agent_type == "codex"
+
+    def test_codex_engineer_defaults_to_claude_when_available(self) -> None:
+        sel = _resolve(engineer_type="codex", fallback_type="codex")
+        assert sel.source == "cross-family-default"
+        assert sel.agent_type == "claude-code"
+        assert sel.identity == "claude-code"
+        assert sel.warning is None
+
+    def test_claude_engineer_falls_back_when_codex_absent(self) -> None:
+        sel = _resolve(
+            engineer_type="claude-code",
+            fallback_type="claude-code",
+            codex_available=False,
+        )
+        assert sel.source == "same-family-fallback"
+        assert sel.agent_type == "claude-code"
+        assert sel.warning is not None
+        assert "codex CLI is not available" in sel.warning
+        assert "Self-preference bias" in sel.warning
+
+    def test_codex_engineer_falls_back_when_claude_absent(self) -> None:
+        # auto-detect with claude missing resolves the engineer to
+        # codex; the cross family (claude-code) is the missing one.
+        sel = _resolve(
+            engineer_type=None,
+            fallback_type=None,
+            claude_available=False,
+        )
+        assert sel.source == "same-family-fallback"
+        assert sel.warning is not None
+        assert "claude-code CLI is not available" in sel.warning
+
+    def test_explicit_model_wins_over_cross_family_default(self) -> None:
+        # Both CLIs present, but the operator pinned a review model:
+        # explicit config always wins, silently (no homogeneity nag for
+        # a deliberate choice).
+        sel = _resolve(
+            explicit_model="opus",
+            fallback_type="claude-code",
+            engineer_type="claude-code",
+        )
+        assert sel.source == "explicit"
+        assert sel.agent_type == "claude-code"
+        assert sel.model == "opus"
+        assert sel.identity == "claude-code (opus)"
+        assert sel.warning is None
+
+    def test_explicit_agent_cmd_wins_and_identity_is_custom(self) -> None:
+        sel = _resolve(
+            explicit_cmd="./my-reviewer.sh",
+            fallback_type="claude-code",
+            engineer_type="claude-code",
+        )
+        assert sel.source == "explicit"
+        assert sel.agent_cmd == "./my-reviewer.sh"
+        assert sel.identity == "custom (./my-reviewer.sh)"
+        assert sel.warning is None
+
+    def test_explicit_type_pins_the_family(self) -> None:
+        sel = _resolve(
+            explicit_type="claude-code",
+            fallback_type="claude-code",
+            engineer_type="claude-code",
+        )
+        assert sel.source == "explicit"
+        assert sel.agent_type == "claude-code"
+
+    def test_custom_engineer_cmd_warns_family_unknown(self) -> None:
+        # A custom engineer command has an unknown family even with both
+        # CLIs installed: heterogeneity cannot be established, so the
+        # fallback fires WITH the warning.
+        sel = _resolve(
+            engineer_cmd="./fake-engineer.sh",
+            fallback_cmd="./fake-engineer.sh",
+            fallback_type=None,
+        )
+        assert sel.source == "same-family-fallback"
+        assert sel.agent_cmd == "./fake-engineer.sh"
+        assert sel.warning is not None
+        assert "custom agent command" in sel.warning
+        assert "Self-preference bias" in sel.warning
+
+    def test_security_fallback_keeps_engineer_cmd_and_model(self) -> None:
+        # The security phase's historical fallback inherits the
+        # engineer's cmd/model/reasoning; the same-family fallback must
+        # preserve that exactly (only the warning is new).
+        sel = _resolve(
+            "security",
+            engineer_type="claude-code",
+            fallback_type="claude-code",
+            fallback_model="opus",
+            fallback_reasoning="high",
+            codex_available=False,
+        )
+        assert sel.source == "same-family-fallback"
+        assert sel.model == "opus"
+        assert sel.reasoning == "high"
+        assert sel.identity == "claude-code (opus)"
+
+    def test_cross_family_default_does_not_inherit_reasoning(self) -> None:
+        # Effort strings do not transfer across families.
+        sel = _resolve(
+            "security",
+            engineer_type="claude-code",
+            fallback_type="claude-code",
+            fallback_model="opus",
+            fallback_reasoning="high",
+        )
+        assert sel.source == "cross-family-default"
+        assert sel.model is None
+        assert sel.reasoning is None
+
+
+class MockAgent:
+    """Predetermined-output agent with a real ``name`` identity."""
+
+    def __init__(self, output: str, name: str = "codex (gpt-5)"):
+        self._output = output
+        self._name = name
+        self._final_message: str | None = None
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        yield from self._output.splitlines()
+
+    @property
+    def final_message(self) -> str | None:
+        return self._final_message
+
+
+class CrashingAgent(MockAgent):
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        raise RuntimeError("agent exploded")
+        yield ""  # pragma: no cover
+
+
+REVIEW_OUTPUT_WITH_CONCERN = json.dumps({
+    "stories": [{
+        "storyId": "US-001",
+        "storyTitle": "Test",
+        "criteria": [{
+            "criterion": "AC1",
+            "verdict": "fail",
+            "explanation": "not implemented",
+            "suggestion": "implement it",
+        }],
+    }],
+    "concerns": [{
+        "category": "dead_code",
+        "severity": "advisory",
+        "location": "a.py:1",
+        "explanation": "unused helper",
+        "suggestion": "remove",
+    }],
+    "exhaustively_searched": True,
+    "overallNotes": "",
+})
+
+SECURITY_OUTPUT_WITH_FINDING = json.dumps({
+    "findings": [{
+        "category": "hardcoded_secret",
+        "severity": "high",
+        "location": "b.py:3",
+        "explanation": "API key in source",
+        "suggestion": "move to env",
+    }],
+    "exhaustively_searched": True,
+    "overallNotes": "",
+})
+
+
+def _write_prd(tmp_path: Path) -> Path:
+    prd_path = tmp_path / "prd.json"
+    prd_path.write_text(json.dumps({
+        "branchName": "test",
+        "userStories": [{
+            "id": "US-001", "title": "Test",
+            "acceptanceCriteria": ["AC1"], "priority": 1,
+            "passes": True, "notes": "",
+        }],
+    }))
+    return prd_path
+
+
+class TestModelTagEndToEnd:
+    def test_review_findings_carry_model_tag(self, tmp_path: Path) -> None:
+        prd_path = _write_prd(tmp_path)
+        agent = MockAgent(REVIEW_OUTPUT_WITH_CONCERN)
+        result = run_review(
+            agent, prd_path, tmp_path, "main",
+            VerificationResult(
+                passed=True, checks=[CheckResult("test_suite", True, "ok")],
+            ),
+            ReviewMode.HARD, PlainUI(no_color=True),
+            diff_content="+change\n",
+        )
+        assert result.reviewer_model == "codex (gpt-5)"
+        findings = result.as_findings()
+        assert findings
+        for f in findings:
+            assert "model:codex (gpt-5)" in f.tags
+            assert finding_model(f) == "codex (gpt-5)"
+        # Journal shape: record_run serializes findings via to_dict.
+        assert "model:codex (gpt-5)" in findings[0].to_dict()["tags"]
+        # PR body names the reviewer model.
+        assert "**Reviewer model**: codex (gpt-5)" in result.as_pr_body_section()
+
+    def test_review_crash_still_attributes_reviewer(self, tmp_path: Path) -> None:
+        prd_path = _write_prd(tmp_path)
+        agent = CrashingAgent("", name="codex (gpt-5)")
+        result = run_review(
+            agent, prd_path, tmp_path, "main",
+            VerificationResult(passed=True, checks=[]),
+            ReviewMode.HARD, PlainUI(no_color=True),
+            diff_content="+change\n",
+        )
+        assert result.infrastructure_error is True
+        assert result.reviewer_model == "codex (gpt-5)"
+        (finding,) = result.as_findings()
+        assert finding.is_infrastructure_error
+        assert finding_model(finding) == "codex (gpt-5)"
+
+    def test_security_findings_carry_model_tag(self, tmp_path: Path) -> None:
+        agent = MockAgent(SECURITY_OUTPUT_WITH_FINDING, name="codex")
+        result = run_security_review(
+            agent, tmp_path / "missing-prd.json", tmp_path, "main",
+            SecurityConfig(mode="advisory"), PlainUI(no_color=True),
+            diff_content="+change\n",
+        )
+        assert result.reviewer_model == "codex"
+        findings = result.as_findings()
+        assert findings
+        for f in findings:
+            assert finding_model(f) == "codex"
+        assert "**Reviewer model**: codex" in result.as_pr_body_section()
+
+    def test_security_clean_result_still_names_reviewer(self) -> None:
+        result = SecurityResult(
+            passed=True, mode="hard", reviewer_model="codex (gpt-5)",
+        )
+        assert "**Reviewer model**: codex (gpt-5)" in result.as_pr_body_section()
+
+    def test_merges_carry_reviewer_model(self) -> None:
+        chunks_r = [
+            ReviewResult(passed=True, mode="hard", reviewer_model="codex"),
+            ReviewResult(passed=True, mode="hard", reviewer_model="codex"),
+        ]
+        assert merge_review_results(chunks_r, "hard").reviewer_model == "codex"
+        chunks_s = [
+            SecurityResult(passed=True, mode="hard", reviewer_model="codex"),
+            SecurityResult(passed=True, mode="hard", reviewer_model="codex"),
+        ]
+        assert (
+            merge_security_results(chunks_s, "hard").reviewer_model == "codex"
+        )
+
+    def test_model_tag_is_idempotent_and_composes_with_attempt(self) -> None:
+        f = Finding.from_review_concern(
+            category="dead_code", severity="advisory",
+            location="a.py:1", explanation="x",
+        )
+        tagged = tag_finding_with_model(f, "codex")
+        again = tag_finding_with_model(tagged, "claude-code")
+        assert again.tags.count("model:codex") == 1
+        assert "model:claude-code" not in again.tags
+        # Empty identity is a no-op, never a fabricated "model:" tag.
+        assert tag_finding_with_model(f, "") == f
+        with_attempt = tag_finding_with_attempt(tagged, 2)
+        assert finding_model(with_attempt) == "codex"
+        assert "attempt:2" in with_attempt.tags
+
+    def test_render_findings_markdown_names_reviewer_model(self) -> None:
+        f = tag_finding_with_model(
+            Finding.infrastructure_error("security", "boom"), "codex (gpt-5)",
+        )
+        rendered = render_findings_markdown([f])
+        assert "Reviewer model: codex (gpt-5)" in rendered
+
+    def test_pr_body_names_reviewer_model(self, tmp_path: Path) -> None:
+        prd_path = _write_prd(tmp_path)
+        agent = MockAgent(REVIEW_OUTPUT_WITH_CONCERN)
+        result = run_review(
+            agent, prd_path, tmp_path, "main",
+            VerificationResult(passed=True, checks=[]),
+            ReviewMode.HARD, PlainUI(no_color=True),
+            diff_content="+change\n",
+        )
+        comp = Component(
+            id="comp-a", title="Comp A", description="does things",
+            dependencies=[], prd_path="prd.json",
+            branch_name="ralph/factory/comp-a",
+        )
+        comp.review_findings = result.as_pr_body_section()
+        comp.findings = result.as_findings()
+        manifest = Manifest(
+            version="1", spec_file="spec.md", project_name="p",
+            base_branch="main", single_pr=False, components=[comp],
+        )
+        body = _generate_pr_body(comp, manifest)
+        assert "**Reviewer model**: codex (gpt-5)" in body
+
+
+class RecordingUI(PlainUI):
+    def __init__(self) -> None:
+        super().__init__(no_color=True)
+        self.warnings: list[str] = []
+
+    def warn(self, message: str) -> None:
+        self.warnings.append(message)
+        super().warn(message)
+
+
+class TestHomogeneityWarningFires:
+    def test_run_factory_warns_once_and_journals_selection(
+        self, tmp_path: Path,
+    ) -> None:
+        """A real run_factory invocation with a custom engineer command
+        (family unknowable, so the warning fires regardless of which
+        CLIs this machine has) prints the homogeneity warning for both
+        enabled reviewer phases and journals the selection event."""
+        manifest = Manifest(
+            version="1", spec_file="spec.md", project_name="p",
+            base_branch="main", single_pr=False, components=[],
+        )
+        config = FactoryConfig(
+            review_mode=ReviewMode.HARD.value,
+            security_config=SecurityConfig(mode="hard"),
+            create_prs=False,
+        )
+        base = RalphConfig(agent_cmd="./fake-engineer.sh")
+        ui = RecordingUI()
+        result = run_factory(
+            manifest, config, base, ui, tmp_path,
+            manifest_path=tmp_path / "manifest.json",
+        )
+        assert result.exit_code == 0
+        homogeneity = [w for w in ui.warnings if "Homogeneity risk" in w]
+        assert len(homogeneity) == 2  # once per enabled phase, per run
+        events = read_progress_events(tmp_path / ".ralph" / "progress.jsonl")
+        selections = [
+            e for e in events if e["event"] == "adversarial_agent_selected"
+        ]
+        assert {e["data"]["phase"] for e in selections} == {
+            "review", "security",
+        }
+        assert all(e["data"]["homogeneous"] for e in selections)
+        assert all(
+            e["data"]["source"] == "same-family-fallback" for e in selections
+        )
+
+    def test_no_warning_when_reviewer_phases_disabled(
+        self, tmp_path: Path,
+    ) -> None:
+        manifest = Manifest(
+            version="1", spec_file="spec.md", project_name="p",
+            base_branch="main", single_pr=False, components=[],
+        )
+        config = FactoryConfig(
+            review_mode=ReviewMode.SKIP.value,
+            security_config=None,
+            create_prs=False,
+        )
+        base = RalphConfig(agent_cmd="./fake-engineer.sh")
+        ui = RecordingUI()
+        run_factory(
+            manifest, config, base, ui, tmp_path,
+            manifest_path=tmp_path / "manifest.json",
+        )
+        assert not [w for w in ui.warnings if "Homogeneity risk" in w]
+
+
+class TestCalibrationReviewerOverride:
+    def test_override_from_env_reads_both_vars(self) -> None:
+        env = {
+            "RALPH_CALIBRATION_REVIEWER_AGENT_TYPE": "codex",
+            "RALPH_CALIBRATION_REVIEWER_MODEL": "gpt-5",
+        }
+        assert calibration.reviewer_override_from_env(env) == ("codex", "gpt-5")
+
+    def test_override_from_env_treats_empty_as_unset(self) -> None:
+        env = {
+            "RALPH_CALIBRATION_REVIEWER_AGENT_TYPE": "",
+            "RALPH_CALIBRATION_REVIEWER_MODEL": "",
+        }
+        assert calibration.reviewer_override_from_env(env) == (None, None)
+        assert calibration.reviewer_override_from_env({}) == (None, None)
+
+    def test_label_plain_without_override(self) -> None:
+        assert calibration.reviewer_override_label("haiku", None, None) == "haiku"
+
+    def test_label_encodes_override(self) -> None:
+        assert (
+            calibration.reviewer_override_label("haiku", "codex", "gpt-5")
+            == "haiku+reviewer:codex/gpt-5"
+        )
+        assert (
+            calibration.reviewer_override_label("haiku", "codex", None)
+            == "haiku+reviewer:codex"
+        )
+
+    def test_cross_family_baselines_compare_with_warning_not_failure(
+        self,
+    ) -> None:
+        """The whole point of the label: comparing a same-family baseline
+        against a cross-family one warns (deltas measure the family
+        change) instead of silently pretending both measured the same
+        configuration."""
+        old = calibration.Baseline(
+            path=None, model="haiku", timestamp="t1",
+            format_version=2, runs_per_fixture=3,
+            fixtures=(calibration.FixtureStats(
+                role="security", fixture_id="sec-01",
+                category="injection", cwe="CWE-89",
+                runs_total=3, runs_errored=0, runs_detected=3,
+            ),),
+        )
+        new = calibration.Baseline(
+            path=None,
+            model=calibration.reviewer_override_label(
+                "haiku", "codex", "gpt-5",
+            ),
+            timestamp="t2", format_version=2, runs_per_fixture=3,
+            fixtures=old.fixtures,
+        )
+        comparison = calibration.compare_baselines(old, new)
+        assert comparison.passed
+        assert any("comparing across models" in w for w in comparison.warnings)


### PR DESCRIPTION
## Roadmap item

R7.1 (Phase R7, user decision 2 - **decided: the OpenAI family via the codex CLI**). Marked `[~]` in `docs/remediation-roadmap.md`: code landed, stays partial until the user records BOTH calibration baselines below.

## What changed

- **Cross-family default** (`ralph_py/factory.py::resolve_adversarial_selection`): when no explicit reviewer config is given, review and security default to the opposite model family from the engineer (claude engineer -> codex reviewer; codex engineer -> claude-code reviewer). The engineer keeps the primary family. Explicit config (any of cmd/type/model) always wins, silently. When the cross family's CLI is missing - or the engineer runs a custom command whose family is unknowable - the factory prints a homogeneity warning naming the self-preference risk, once per run, and journals an `adversarial_agent_selected` progress event either way.
- **Model identity on every reviewer finding** (`findings.py`, `review.py`, `security.py`): `ReviewResult`/`SecurityResult` gain `reviewer_model` (stamped from the agent's `name`, including crash/oversize infra paths and chunk merges); `as_findings()` tags every Finding `model:<id>`; the PR body's Review Findings and Security Review sections name the reviewer model; the evolution journal carries the tag via the existing `Finding.to_dict()` serialization. Findings recorded when no reviewer ran (phase skips, pre-agent budget failures) deliberately carry no model tag.
- **Independence preserved**: reviews remain independent single passes; no cross-reviewer deliberation was added anywhere.
- **Calibration reviewer override** (`calibration.py`, `tests/test_calibration.py`): `RALPH_CALIBRATION_REVIEWER_AGENT_TYPE` / `RALPH_CALIBRATION_REVIEWER_MODEL` swap the reviewer+security calibration roles onto the second family (architect keeps the base agent). Override runs record the model label `<base>+reviewer:<type>/<model>` so `calibration compare` surfaces the family change as its cross-model warning.
- **Docs**: `docs/adversarial-design.md` known-limitation #1 rewritten (new default; architect/engineer/distiller remain correlated) plus a "Reviewer-family override" section with the exact measurement commands.

## Measurement plan (run these to complete R7.1)

```bash
# Baseline 1: same family end to end
RALPH_RUN_CALIBRATION=1 RALPH_CALIBRATION_MODEL=haiku \
  uv run pytest tests/test_calibration.py -v

# Baseline 2: reviewer + security roles on the second family (codex CLI)
RALPH_RUN_CALIBRATION=1 RALPH_CALIBRATION_MODEL=haiku \
  RALPH_CALIBRATION_REVIEWER_AGENT_TYPE=codex \
  uv run pytest tests/test_calibration.py -v

# Compare (the cross-model warning is expected: the delta measures the family change)
uv run python -m ralph_py.calibration compare \
  tests/adversarial_fixtures/_results/baseline-<same-family>.json \
  tests/adversarial_fixtures/_results/baseline-<cross-family>.json
```

Once both baselines are recorded, flip R7.1 from `[~]` to `[x]`.

## Tested (named tests, tests/test_reviewer_rotation.py unless noted)

- Default-selection matrix: `TestSelectionMatrix` - both CLIs present (claude engineer -> codex, codex engineer -> claude-code, auto-detect variants), one CLI absent (same-family fallback + warning text), explicit override wins for each of model/cmd/type with no warning, custom engineer command warns family-unknown, security fallback preserves the historical engineer cmd/model/reasoning inheritance, cross-family default does not inherit reasoning.
- Model tag end to end: `TestModelTagEndToEnd` - `run_review`/`run_security_review` with mock agents stamp `reviewer_model`; every Finding (including crash-path infra findings) carries `model:<id>`; `to_dict()` serializes it (the journal payload shape used by `evolution.record_run`); `as_pr_body_section` and `pr._generate_pr_body` name the reviewer model; chunk merges carry the identity; tagging is idempotent, empty-identity is a no-op, and composes with `attempt:` tags; `render_findings_markdown` shows the reviewer model line.
- Homogeneity warning fires: `TestHomogeneityWarningFires::test_run_factory_warns_once_and_journals_selection` - a real `run_factory` invocation warns once per enabled reviewer phase and journals `adversarial_agent_selected` with `homogeneous: true`; `test_no_warning_when_reviewer_phases_disabled` proves skip-mode runs stay silent.
- Calibration override: `TestCalibrationReviewerOverride` - env parsing, empty-as-unset, label encoding, and that a same-family vs cross-family baseline comparison passes with the cross-model warning.
- No regression: full suite, mypy --strict, ruff (final lines below).

## Assumed (claimed but not tested)

- No real cross-family LLM run was executed: the actual correlated-miss delta is unmeasured until the two calibration baselines above are recorded (that measurement is deliberately the user's step; R7.1 stays `[~]`).
- The codex CLI's adapter-default model is a sensible reviewer; the cross-family default passes `model=None` and inherits no reasoning effort (effort strings do not transfer across families).
- CLI availability probes (`shutil.which`) at run start remain valid for the whole run.
- `agent.name` is a faithful model identity; for custom commands it identifies the command, not the underlying model family.
- Live-run PR bodies and progress events were exercised through unit/integration tests with mock agents, not against a real GitHub PR.

## Checks

```
uv run pytest tests/ -q          -> 1329 passed, 28 skipped, 1 xfailed, 1 warning in 57.50s
uv run mypy ralph_py/ --strict   -> Success: no issues found in 38 source files
uv run ruff check ralph_py/ tests/ -> All checks passed!
```

(The 1 warning is a pre-existing knowledge-test RuntimeWarning about a deliberately corrupt fixture file, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)