### PR TITLE
refactor: R7.3 PR 2 re-land - scheduler swap onto main

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -595,7 +595,7 @@ by an integration test with a synthetic-but-realistic journal).
   - This restores the independent oracle against agent-authored tests (H-6's
     conftest gaming is also mitigated: fixtures do not run under the project's
     pytest and cannot be deselected by it).
-- [ ] R7.3 (L) **run_factory refactor: scheduler + ComponentPipeline** [architecture]
+- [x] R7.3 (L) **run_factory refactor: scheduler + ComponentPipeline** [architecture]
   - Extract the phase chain into a `ComponentPipeline` with typed phase
     results; single scheduling loop for sequential and parallel; the state
     machine becomes unit-testable; `knowledge_config` late-binding accident
@@ -605,6 +605,13 @@ by an integration test with a synthetic-but-realistic journal).
     machine. Failure mode: big-bang refactor risk: land it as a
     strangler (pipeline object first, scheduler swap second) with the R4 spine
     tests as the net.
+  - DONE (two PRs, strangler as planned): PR 1 extracts
+    `ralph_py/pipeline.py::ComponentPipeline` (typed phase results, single
+    transition dispatch, hooks-injected phase functions, late-binding fix,
+    distiller pinned PRE-PR as a named step) with
+    `tests/test_pipeline.py` covering every transition in isolation; PR 2
+    unifies the scheduling loops behind `_InlineExecutor`
+    (`tests/test_scheduler.py`).
 - [ ] R7.4 (L) **Linear integration** [P-6; user decision 3]
   - GraphQL + app-actor OAuth adapter implementing a `LinearSink` on the
     ProgressLog event bus (factory.py untouched); decompose output creates one

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -7,7 +7,7 @@ import os
 import shutil
 import subprocess
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1054,6 +1054,33 @@ def _run_component(
         )
 
 
+class _InlineExecutor:
+    """Synchronous stand-in for ProcessPoolExecutor when max_parallel
+    is 1 (R7.3): the worker runs in-process (no pickling, no process
+    spawn - the historical sequential path), wrapped in an already-
+    resolved Future so ONE scheduling loop serves both modes. A worker
+    exception lands on the future and surfaces at ``future.result()``,
+    exactly where a pool worker's would.
+    """
+
+    def submit(
+        self, fn: Callable[..., ComponentResult], /, *args: Any,
+    ) -> Future[ComponentResult]:
+        future: Future[ComponentResult] = Future()
+        try:
+            result = fn(*args)
+        except Exception as exc:
+            future.set_exception(exc)
+        else:
+            future.set_result(result)
+        return future
+
+    def shutdown(
+        self, wait: bool = True, cancel_futures: bool = False,
+    ) -> None:
+        """Nothing to shut down: every submit already ran to completion."""
+
+
 def _next_backstop_wait(
     running: Mapping[Future[ComponentResult], str],
     deadlines: Mapping[Future[ComponentResult], float],
@@ -1545,55 +1572,46 @@ def _run_factory_locked(
         the outer loop in run_factory (R0.3) - previously the reset
         happened after the only scheduling loop had exited, so the
         promised retry never ran.
+
+        ONE loop serves sequential and parallel scheduling (R7.3): the
+        launch protocol (budget gate -> begin_attempt -> provisioning ->
+        submit) appears exactly once. max_parallel <= 1 swaps the
+        process pool for _InlineExecutor, which runs the worker
+        synchronously in-process - the historical sequential behavior -
+        behind the identical submit/wait/result flow.
+
+        Manual executor lifecycle: on a backstop breach we must NOT wait
+        for the (possibly hung) worker at shutdown, which the
+        `with ProcessPoolExecutor(...)` form would do.
         """
+        executor: ProcessPoolExecutor | _InlineExecutor
         if max_parallel <= 1:
-            while True:
-                ready = manifest.get_ready_components()
-                if not ready:
-                    break
-
-                comp = ready[0]
-                # R3.1 scheduling gate: a blown token budget fails
-                # pending components loudly instead of launching an
-                # engineer loop that would only add spend.
-                if pipeline.token_budget_exceeded():
-                    pipeline.fail_for_budget(comp, "scheduling")
-                    continue
-                pipeline.begin_attempt(comp)
-                manifest.save(manifest_path)
-                progress_log.component_started(comp.id)
-                ui.info(f"  Starting: {comp.id}")
-
-                wt_path = _launch_component(comp)
-                if wt_path is None:
-                    continue
-
-                args = _submit_args(comp, wt_path)
-                try:
-                    comp_result = _run_component(*args)
-                except Exception as exc:
-                    comp_result = ComponentResult(
-                        component_id=comp.id, success=False, error=str(exc),
-                    )
-
-                pipeline.process_result(comp.id, comp_result)
-            return
-
-        # Manual executor lifecycle: on a backstop breach we must NOT wait
-        # for the (possibly hung) worker at shutdown, which the
-        # `with ProcessPoolExecutor(...)` form would do.
-        executor = ProcessPoolExecutor(max_workers=max_parallel)
+            executor = _InlineExecutor()
+        else:
+            executor = ProcessPoolExecutor(max_workers=max_parallel)
+        slots_cap = max(1, max_parallel)
         running_futures: dict[Future[ComponentResult], str] = {}
         future_deadlines: dict[Future[ComponentResult], float] = {}
         try:
             while True:
                 ready = manifest.get_ready_components()
-                slots = max_parallel - len(running_futures)
+                slots = slots_cap - len(running_futures)
 
+                # Components transitioned WITHOUT a launch this pass
+                # (budget gate, provisioning failure). When that happens
+                # and nothing is running, the loop must re-derive the
+                # ready set rather than stop - R3.1's scheduling gate
+                # promises to fail every remaining pending component
+                # loudly, and a provisioning failure must not strand
+                # still-schedulable siblings.
+                transitioned_without_launch = 0
                 for comp in ready[:slots]:
-                    # R3.1 scheduling gate (see sequential path above).
+                    # R3.1 scheduling gate: a blown token budget fails
+                    # pending components loudly instead of launching an
+                    # engineer loop that would only add spend.
                     if pipeline.token_budget_exceeded():
                         pipeline.fail_for_budget(comp, "scheduling")
+                        transitioned_without_launch += 1
                         continue
                     pipeline.begin_attempt(comp)
                     manifest.save(manifest_path)
@@ -1602,6 +1620,7 @@ def _run_factory_locked(
 
                     wt_path = _launch_component(comp)
                     if wt_path is None:
+                        transitioned_without_launch += 1
                         continue
 
                     args = _submit_args(comp, wt_path)
@@ -1613,6 +1632,8 @@ def _run_factory_locked(
                         )
 
                 if not running_futures:
+                    if transitioned_without_launch:
+                        continue
                     break
 
                 # Wait for the next completion, bounded by the nearest

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,170 @@
+"""R7.3 PR 2: unified scheduling loop regression tests.
+
+The sequential and parallel scheduler paths are now ONE loop (an
+_InlineExecutor stands in for the process pool when max_parallel <= 1).
+These tests pin the loop-shape behaviors that a naive unification would
+lose: a pass that transitions components without launching anything
+(provisioning failure, budget gate) must re-derive the ready set
+instead of stopping while schedulable components remain.
+
+The budget-gate fail-all behavior is already pinned by
+tests/test_usage_meter.py (comp-b never launches: the scheduling gate
+fails it loudly too); the in-process execution of the sequential mode
+is pinned by every test that patches ralph_py.factory._run_component
+with an unpicklable MagicMock.
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from ralph_py.config import RalphConfig
+from ralph_py.factory import (
+    ComponentResult,
+    FactoryConfig,
+    _InlineExecutor,
+    run_factory,
+)
+from ralph_py.fixtures import FixturesConfig
+from ralph_py.manifest import Component, ComponentStatus, Manifest
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args], cwd=root, check=True, capture_output=True,
+    )
+
+
+def _init_repo(root: Path) -> None:
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "test@test")
+    _git(root, "config", "user.name", "test")
+    (root / "README.md").write_text("seed\n")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-m", "seed")
+
+
+def _component(comp_id: str, deps: list[str] | None = None) -> Component:
+    return Component(
+        comp_id, comp_id.title(), "Desc", deps or [],
+        f"scripts/ralph/feature/{comp_id}/prd.json",
+        f"ralph/factory/{comp_id}",
+    )
+
+
+def _manifest(components: list[Component]) -> Manifest:
+    return Manifest(
+        version="1", spec_file="spec.md", project_name="test",
+        base_branch="main", single_pr=False, components=components,
+    )
+
+
+def _base_config(root: Path) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root / "scripts" / "ralph" / "prompt.md",
+        prd_file=root / "scripts" / "ralph" / "prd.json",
+        sleep_seconds=0,
+        agent_cmd="echo test",
+        ralph_branch="",
+        ralph_branch_explicit=True,
+        ui_mode="plain",
+        no_color=True,
+    )
+
+
+def _factory_config(tmp_path: Path, **overrides: Any) -> FactoryConfig:
+    defaults: dict[str, Any] = dict(
+        max_parallel=1, max_retries=0, retry_delay=0,
+        create_prs=False, use_worktrees=True, review_mode="skip",
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_diff_scope=False,
+            check_bad_patterns=False, subprocess_timeout=5.0,
+        ),
+        fixtures_config=FixturesConfig(),
+        progress_log_path=tmp_path / "progress.jsonl",
+    )
+    defaults.update(overrides)
+    return FactoryConfig(**defaults)
+
+
+class TestInlineExecutor:
+    def test_submit_resolves_result(self) -> None:
+        future = _InlineExecutor().submit(lambda: ComponentResult("a", True))
+        assert future.done()
+        assert future.result().component_id == "a"
+
+    def test_submit_captures_exception_for_result_time(self) -> None:
+        def _boom() -> ComponentResult:
+            raise RuntimeError("worker exploded")
+
+        future = _InlineExecutor().submit(_boom)
+        assert future.done()
+        # The exception surfaces at result(), where a pool worker's
+        # would - the shared loop's except Exception handles both.
+        try:
+            future.result()
+        except RuntimeError as exc:
+            assert "worker exploded" in str(exc)
+        else:  # pragma: no cover - the assert above must fire
+            raise AssertionError("expected RuntimeError")
+
+
+class TestUnifiedSchedulingLoop:
+    def test_provisioning_failure_does_not_strand_siblings(
+        self, tmp_path: Path,
+    ) -> None:
+        """comp-a's worktree setup fails; comp-b is INDEPENDENT and must
+        still be scheduled. A pass that only transitioned components
+        without launching (provisioning failure) has to re-derive the
+        ready set - the old sequential loop did this via its per-
+        component while-pass, and the unified loop must not lose it."""
+        _init_repo(tmp_path)
+        manifest = _manifest([_component("comp-a"), _component("comp-b")])
+        config = _factory_config(tmp_path)
+        success_b = ComponentResult("comp-b", success=True, iterations=1)
+
+        real_setup_calls: list[str] = []
+
+        def _setup(comp_id: str, *args: Any, **kwargs: Any) -> Path:
+            real_setup_calls.append(comp_id)
+            if comp_id == "comp-a":
+                raise RuntimeError("worktree add failed (simulated)")
+            wt = tmp_path / ".ralph" / "worktrees" / "run" / comp_id
+            prd = wt / "scripts" / "ralph" / "feature" / comp_id / "prd.json"
+            prd.parent.mkdir(parents=True, exist_ok=True)
+            prd.write_text(
+                '{"branchName": "test", "userStories": [{"id": "US-001", '
+                '"title": "T", "acceptanceCriteria": ["AC1"], "priority": 1, '
+                '"passes": true, "notes": ""}]}'
+            )
+            return wt
+
+        with patch(
+            "ralph_py.factory._setup_worktree", side_effect=_setup,
+        ), patch(
+            "ralph_py.factory._run_component", return_value=success_b,
+        ), patch(
+            "ralph_py.git.get_diff_content", return_value="",
+        ):
+            result = run_factory(
+                manifest, config, _base_config(tmp_path),
+                PlainUI(no_color=True, file=io.StringIO()), tmp_path,
+                manifest_path=tmp_path / "manifest.json",
+            )
+
+        comp_a = manifest.get_component("comp-a")
+        comp_b = manifest.get_component("comp-b")
+        assert comp_a is not None and comp_b is not None
+        assert comp_a.status == ComponentStatus.FAILED.value
+        assert comp_a.failed_phase == "provisioning"
+        assert comp_b.status == ComponentStatus.COMPLETED.value
+        assert result.failed == ["comp-a"]
+        assert result.completed == ["comp-b"]
+        assert real_setup_calls == ["comp-a", "comp-b"]


### PR DESCRIPTION
## Why this PR exists

PR #89 (R7.3 PR 2, the scheduler swap) was merged into `refactor/r7-3-pipeline` at 10:57:22 - twelve seconds AFTER that branch had already been merged into main via #88 (10:57:10). The scheduler swap therefore never reached main; it sat stranded on the already-merged branch. This also explains why the R7.3 checkbox in the roadmap was still unflipped.

This PR is a mechanical re-land: a single `git cherry-pick -x f5a70b4` of the stranded commit onto current main. The resulting tree is **bit-identical** to the stranded commit's tree (`git rev-parse HEAD^{tree}` == `f5a70b4^{tree}`), so the content is exactly what was already reviewed and approved in #89, including its R7.3 checkbox flip. Zero new content.

## Checks (run on this branch)

- `uv run pytest tests/ -q`: `1398 passed, 28 skipped, 1 xfailed, 1 warning in 61.62s`
- `uv run mypy ralph_py/ --strict`: `Success: no issues found in 39 source files`
- `uv run ruff check ralph_py/ tests/`: `All checks passed!`

## Tested

- Tree equality with the stranded #89 commit verified by hash comparison (mechanical re-land proof).
- Full suite / mypy --strict / ruff green on the re-landed state (lines above).

## Assumed

- The #89 review approval carries over, since the tree is provably identical.

Note: R7.4 (Linear integration, `feat/r7-4-linear`) is stacked on this branch and will retarget to main when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)