### PR TITLE
fix: A+ gate re-run follow-ups - worktree recreation bug, gate-evidence tests, roadmap bookkeeping

### DIFF
--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -41,7 +41,27 @@ Process rules that bind this plan:
 4. **PRD fixtures default** (R7.2): once wired and sandboxed, fixtures ship
    default-off (`[fixtures].enabled = false`) unless decided otherwise.
 5. **Agent SDK spike go/no-go** (R7.5): decide after the measurement spike, not
-   before.
+   before. Spike is done: `docs/sdk-spike.md` recommends GO scoped to a
+   fourth adapter.
+6. **Untracked docs artifacts** (R3.4): commit or delete
+   `docs/end-to-end-flow.html`, `docs/phase-f-e2e-validation-v12.log`, and
+   `.claude/` in the main checkout.
+
+User-run measurements required (the other blocker class for `[~]` items;
+consolidated here 2026-07-19 - previously these lived only in item notes):
+
+- **Calibration v2 baseline capture** (R5.1/R5.2/R5.3):
+  `RALPH_RUN_CALIBRATION=1 uv run pytest tests/test_calibration.py -v` per
+  `docs/calibration-notes-r5.md`. Acceptance: green-at-baseline over 3 runs;
+  R5.2 hardness check `summary.security_hard.detection_rate < 1.0`; R5.3
+  before/after delta recorded.
+- **Reviewer-family baseline pair** (R7.1): same-family and cross-family
+  runs per `docs/adversarial-design.md` "Reviewer-family override".
+- **EARS/DECOMPOSE 1.4.0 capture** (R7.5): same calibration command against
+  the new prompt version.
+- **Two real factory runs** (knowledge + evolution A+ gates): knowledge
+  fact-utilization telemetry nonzero, and one `ralph evolve` proposal
+  traceable to a real recorded signature.
 
 Execution order: R0 -> R1 -> R2 -> R4 -> R3 -> R5 -> R6 -> R7.
 R4 (test spine) deliberately precedes R3/R5: the spine tests are the regression
@@ -354,6 +374,12 @@ mock-only coverage.
     recovery incl. the loud refusal path for a crashed branch with
     commits, diff-scope retry-context propagation e2e, and an unmocked
     `_run_component` plumbing smoke). Spine complete.
+  - The product bug the spine surfaced (registered-but-missing worktree:
+    dir deleted after a crash, `.git/worktrees/` entry survives,
+    `_setup_worktree` could not recreate) was fixed 2026-07-19 by making
+    the `worktree remove --force` unconditional (measured on git 2.47:
+    it clears the stale registration too); the strict xfail became a
+    passing spine test.
 - [x] R4.3 (M) **Fix misleading tests** [T-5, T-6, T-8, T-9, T-10, T-11, T-15]
   - C1 becomes a true 2-worker worktree test; C6 uses the same root and proves
     serialization (fails if the flock is removed); C4 asserts the breaker was
@@ -436,7 +462,14 @@ spending, (c) what do I do when I come back to a partial failure.
     recoverable. The `ralph.toml.example` tracking question was resolved
     in the R2.5 PR: `ralph.toml.example` is tracked and the live
     `ralph.toml` is gitignored. Still open: the remaining untracked docs
-    artifacts (a user commit-or-delete decision).
+    artifacts (user decision 6).
+  - Note (2026-07-19, gate re-run): the live `.ralph/evolution.jsonl` +
+    `experiments.tsv` had been re-polluted with synthetic test entries
+    (projects "test"/"t", pre-v2 schema) written between the R4.1
+    archive and the guard fixture landing; both were re-archived to
+    `.ralph/archive/` with a `-repolluted-20260713` suffix. The journals
+    now start empty; the first real post-fix factory runs are the
+    "User-run measurements" entry above.
 
 Done when: a deliberately failed 3-component run can be diagnosed and resumed
 using only `ralph status`, the failure summary, and `ralph retry`, without
@@ -672,14 +705,25 @@ listed gate is green and the claim is backed by a named test or measurement
 | Dimension (review grade) | A+ gate |
 |---|---|
 | Architect / decompose (B+) | R0.6 + R1.5 + R1.7 + R1.8 + R5.3 spec-as-data + calibration: architect detection >= baseline on hard fixtures, 0 hallucinated findings across 3 consecutive runs, spec_issues persisted |
-| Mechanical verification (B-) | R1.5 rename-aware scope + R2.6 env scrub + R5.4 self-critique correctness + R7.2 fixtures wired sandboxed: an adversarial-agent test battery (tautological test, conftest deselect, rename-move, sweep-in commit) all caught |
+| Mechanical verification (B-) | R1.5 rename-aware scope + R2.6 env scrub + R5.4 self-critique correctness + R7.2 fixtures wired sandboxed: an adversarial-agent test battery (tautological test, conftest deselect, rename-move, sweep-in commit) all caught - `tests/test_adversarial_battery.py` (first two; module docstring maps all four) + `tests/test_scope_hardening.py` / `tests/test_verify.py` (latter two). Caveat: the fixtures-oracle scenarios require `[fixtures].enabled`, which ships default-off (decision 4) |
 | LLM review + security (C+) | R1.1-R1.4 + R5.3: empty/partial/oversized/truncated outputs all fail closed; injection battery (in-diff instructions) does not flip a verdict on the calibration negatives; FP rate measured and under threshold |
 | Knowledge layer (C-) | R1.6: decay regression tests green; evidence-field injection battery rejected; utilization telemetry nonzero on a real run |
-| Factory orchestration (C) | R0.1-R0.6 + R2.3 + R7.3: induced hang/push-fail/conflict battery green; state machine unit-tested in isolation; no subprocess call without a timeout (enforced by a grep test) |
+| Factory orchestration (C) | R0.1-R0.6 + R2.3 + R7.3: induced hang/push-fail/conflict battery green; state machine unit-tested in isolation; no subprocess call without a timeout (enforced by `tests/test_timeout_enforcement.py::TestSubprocessTimeoutAudit`, an alias-aware AST audit with a Popen allowlist for the two deadline-managed runners) |
 | Evolution / learning (D) | R4.1 + R6.1-R6.4: journal clean, signatures real, hit-rate live, one traceable proposal from real runs |
 | Test suite (B) | R4.1-R4.4: five spine behaviors covered unmocked; suite network-free by default; coverage ratcheted; zero misleading-name tests from the T-findings list remain |
 | Calibration (C+) | R5.1-R5.2 + R5.5: green-at-baseline, FP + consistency + per-category measured over 3 runs, diff tool with codified thresholds, model-bump trigger |
 | Docs and product surface (C-) | R2.1-R2.5 + R3.1-R3.3: generated CLI/config docs CI-checked; every README command exists; config show/status live; cost + notify + retry shipped; install story resolved |
+
+Gate re-run 2026-07-19 (against origin/main 5423f0d): every mechanical gate
+green - fast tier 1427 passed / 28 skipped (all skips are the two opt-in env
+gates, so the suite is network-free), spine tier fully passing, mypy --strict
+and ruff clean, `gen_docs.py --check` current, `config show`/`status` live,
+subprocess-timeout audit green. Amber dimensions are exactly those whose
+final evidence is a user-run measurement (see "User-run measurements
+required" above): architect / review+security / calibration await the
+calibration captures; knowledge / evolution await the two real factory runs.
+Docs gate is green with decision 1 (install story) formally open;
+clone-install is documented truthfully as the interim.
 
 ---
 

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -631,11 +631,16 @@ def _setup_worktree(
         # A killed prior attempt may have left git mid-operation.
         _remove_stale_index_lock(root_dir, component_id)
 
-        if worktree_path.exists():
-            subprocess.run(
-                ["git", "worktree", "remove", "--force", str(worktree_path)],
-                cwd=root_dir, capture_output=True, timeout=30,
-            )
+        # Unconditional: a crashed attempt's directory may be gone (tmp
+        # cleaner, operator rm -rf) while its .git/worktrees/<comp>/
+        # registration survives, and `git worktree add` refuses over a
+        # registered-but-missing entry. remove --force clears the
+        # registration in that state too (measured on git 2.47); when
+        # nothing is registered it fails harmlessly, like `branch -D`.
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree_path)],
+            cwd=root_dir, capture_output=True, timeout=30,
+        )
 
         if fresh_from_base:
             # Delete the branch from the killed attempt so the add below

--- a/tests/test_adversarial_battery.py
+++ b/tests/test_adversarial_battery.py
@@ -1,0 +1,164 @@
+"""Adversarial-agent test battery for the mechanical-verification A+ gate.
+
+The gate (docs/remediation-roadmap.md, "Mechanical verification" row) names
+four ways an agent can game Phase 1 and requires each to be caught:
+
+- tautological test        -> TestTautologicalTestCaught (here)
+- conftest deselect        -> TestConftestDeselectCaught (here)
+- rename-move              -> tests/test_scope_hardening.py::
+                              TestRenameAwareScope::test_rename_move_fails_diff_scope
+- sweep-in commit          -> tests/test_verify.py::TestCheckDiffScope::
+                              test_out_of_scope (+ rename variants in
+                              test_scope_hardening.py)
+
+The two scenarios here share one shape: the agent's OWN test suite passes
+(that is the gamed signal), and the PRD fixtures oracle (R7.2) - which runs
+in a sandboxed subprocess, never under the project's pytest - still fails
+the component. Fixtures must be enabled for this defense; they ship
+default-off ([fixtures].enabled = false, user decision 4).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from ralph_py.fixtures import FixturesConfig
+from ralph_py.verify import VerifyConfig, check_test_suite, run_mechanical_verification
+
+# The toy project's pytest must resolve inside the scrubbed env
+# (run_scrubbed keeps PATH/VIRTUAL_ENV), so invoke it via the harness
+# interpreter rather than assuming a `pytest` shim on PATH.
+_PYTEST_CMD = f"{sys.executable} -m pytest -q -p no:cacheprovider"
+
+# A single no-op keeps the non-target checks green without external tools.
+_NOOP = "true"
+
+
+def _write_prd(root: Path) -> Path:
+    """PRD whose fixture is the independent oracle: add(2, 2) must be 4."""
+    prd = {
+        "branchName": "ralph/battery",
+        "userStories": [
+            {
+                "id": "US-1",
+                "title": "add() adds",
+                "acceptanceCriteria": ["add(2, 2) returns 4"],
+                "priority": 1,
+                "passes": True,
+                "notes": "",
+            }
+        ],
+        "fixtures": [
+            {
+                "description": "add(2, 2) returns 4",
+                "fixture_type": "function",
+                "input_data": {
+                    "module": "app",
+                    "function": "add",
+                    "args": [2, 2],
+                },
+                "expected": {"returns": 4},
+            }
+        ],
+    }
+    prd_path = root / "prd.json"
+    prd_path.write_text(json.dumps(prd))
+    return prd_path
+
+
+def _verify_config() -> VerifyConfig:
+    return VerifyConfig(
+        test_command=_PYTEST_CMD,
+        typecheck_command=_NOOP,
+        lint_command=_NOOP,
+        # Scope/pattern checks need a git worktree; they have their own
+        # battery entries (see module docstring) and are not under test here.
+        check_diff_scope=False,
+        check_bad_patterns=False,
+        subprocess_timeout=120.0,
+    )
+
+
+def _run(root: Path, prd_path: Path) -> Any:
+    return run_mechanical_verification(
+        worktree_path=root,
+        prd_path=prd_path,
+        base_branch="main",
+        allowed_paths=None,
+        config=_verify_config(),
+        fixtures_config=FixturesConfig(enabled=True, timeout=60.0),
+        component_id=None,
+    )
+
+
+def _check(result: Any, name: str) -> Any:
+    matches = [c for c in result.checks if c.name == name]
+    assert len(matches) == 1, f"expected exactly one {name!r} check"
+    return matches[0]
+
+
+class TestTautologicalTestCaught:
+    def test_tautological_test_passes_pytest_but_fixture_fails_component(
+        self, tmp_path: Path,
+    ) -> None:
+        """Agent ships a broken add() plus `assert True` tests. Its own
+        suite is green; the function fixture calls add(2, 2) in a
+        sandboxed subprocess and fails the component."""
+        (tmp_path / "app.py").write_text("def add(a, b):\n    return 0\n")
+        (tmp_path / "test_app.py").write_text(
+            "def test_add_exists():\n"
+            "    import app\n"
+            "    assert True\n"
+        )
+        prd_path = _write_prd(tmp_path)
+
+        result = _run(tmp_path, prd_path)
+
+        assert _check(result, "test_suite").passed, (
+            "precondition broken: the tautological suite must pass pytest "
+            "for this scenario to prove anything"
+        )
+        fixtures_check = _check(result, "fixtures")
+        assert not fixtures_check.passed
+        assert result.passed is False
+
+
+class TestConftestDeselectCaught:
+    def test_conftest_deselect_hides_failing_test_but_fixture_fails(
+        self, tmp_path: Path,
+    ) -> None:
+        """Agent writes a real (failing) test, then hides it with a
+        conftest collect_ignore plus a dummy green test so pytest exits 0.
+        The fixtures oracle never runs under the project's pytest, so the
+        conftest cannot deselect it."""
+        (tmp_path / "app.py").write_text("def add(a, b):\n    return 0\n")
+        (tmp_path / "test_real.py").write_text(
+            "import app\n"
+            "def test_add():\n"
+            "    assert app.add(2, 2) == 4\n"
+        )
+        (tmp_path / "test_dummy.py").write_text(
+            "def test_ok():\n    assert True\n"
+        )
+        (tmp_path / "conftest.py").write_text(
+            'collect_ignore = ["test_real.py"]\n'
+        )
+        prd_path = _write_prd(tmp_path)
+
+        result = _run(tmp_path, prd_path)
+
+        assert _check(result, "test_suite").passed, (
+            "precondition broken: the conftest must hide the failing test "
+            "for this scenario to prove anything"
+        )
+        assert not _check(result, "fixtures").passed
+        assert result.passed is False
+
+        # Prove the conftest was the gaming vector: without it the same
+        # suite fails on its own.
+        (tmp_path / "conftest.py").unlink()
+        honest = check_test_suite(tmp_path, _PYTEST_CMD, timeout=120.0)
+        assert not honest.passed

--- a/tests/test_spine_worktree.py
+++ b/tests/test_spine_worktree.py
@@ -215,24 +215,14 @@ class TestWorktreeLifecycle:
         assert head != crashed_sha
         assert not (wt2 / "poisoned.txt").exists()
 
-    # Product bug found by this spine test (report in the R4.2 PR body):
-    # when a crashed attempt's worktree DIRECTORY is gone (tmp cleaner,
-    # operator rm -rf) but its .git/worktrees/<comp>/ registration
-    # survives, _setup_worktree cannot recreate it: the exists() guard
-    # skips `git worktree remove`, and `git worktree add` then refuses
-    # with "missing but already registered worktree". Recovery needs a
-    # remove/prune of the registered-but-missing entry before the add
-    # (ralph_py/factory.py::_setup_worktree).
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "known product bug: _setup_worktree cannot recreate a "
-            "registered-but-missing worktree (dir deleted after crash)"
-        ),
-    )
     def test_recreate_when_crashed_worktree_dir_was_deleted(
         self, tmp_path: Path,
     ) -> None:
+        """A worktree directory deleted after a crash (tmp cleaner,
+        operator rm -rf) leaves a registered-but-missing entry under
+        .git/worktrees/<comp>/. Setup must clear the registration and
+        recreate the worktree on the same branch (reuse semantics, like
+        any other same-run retry)."""
         root = tmp_path / "repo"
         _init_plain_repo(root)
         wt = _setup_worktree(COMP, BRANCH, "develop", root, RUN_ID)

--- a/tests/test_timeout_enforcement.py
+++ b/tests/test_timeout_enforcement.py
@@ -17,6 +17,7 @@ Covers the enforcement layers end to end:
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import subprocess
@@ -854,3 +855,97 @@ class TestCliTimeoutFlags:
         )
         assert factory_config.timeout_config is not None
         assert factory_config.timeout_config.agent_iteration == 111.0
+
+
+# ---------------------------------------------------------------------------
+# Static audit: no subprocess call without a timeout (A+ orchestration gate)
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessTimeoutAudit:
+    """The A+ factory-orchestration gate requires that no subprocess call
+    in ralph_py ships without a timeout, enforced by a static test. This
+    is that test: an AST walk over every module, alias-aware
+    (``import subprocess as _sp`` counts), so a new call site without a
+    ``timeout=`` fails CI instead of hanging a run someday.
+
+    ``Popen`` takes no timeout kwarg; it is legitimate ONLY in modules
+    that implement their own deadline management, each covered by the
+    runtime kill tests in this file's suite or their own:
+
+    - ralph_py/agents/proc.py: reader-thread deadline + group kill (R0.1)
+    - ralph_py/verify.py: run_scrubbed communicate(timeout) + group kill
+      (R2.6)
+    """
+
+    SPAWN_FUNCS = frozenset({"run", "call", "check_call", "check_output"})
+    POPEN_ALLOWLIST = frozenset({
+        "ralph_py/agents/proc.py",
+        "ralph_py/verify.py",
+    })
+
+    @staticmethod
+    def _subprocess_aliases(tree: ast.Module) -> tuple[set[str], set[str]]:
+        """Names bound to the subprocess module / its spawn functions."""
+        module_aliases: set[str] = set()
+        direct_funcs: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "subprocess":
+                        module_aliases.add(alias.asname or alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module == "subprocess":
+                    for alias in node.names:
+                        direct_funcs.add(alias.asname or alias.name)
+        return module_aliases, direct_funcs
+
+    def test_every_subprocess_call_has_timeout(self) -> None:
+        package_root = Path(__file__).resolve().parent.parent / "ralph_py"
+        violations: list[str] = []
+        popen_violations: list[str] = []
+        sites_seen = 0
+
+        for py_file in sorted(package_root.rglob("*.py")):
+            rel = py_file.relative_to(package_root.parent).as_posix()
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            module_aliases, direct_funcs = self._subprocess_aliases(tree)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                called: str | None = None
+                if (
+                    isinstance(fn, ast.Attribute)
+                    and isinstance(fn.value, ast.Name)
+                    and fn.value.id in module_aliases
+                ):
+                    called = fn.attr
+                elif isinstance(fn, ast.Name) and fn.id in direct_funcs:
+                    called = fn.id
+                if called is None:
+                    continue
+                if called == "Popen":
+                    sites_seen += 1
+                    if rel not in self.POPEN_ALLOWLIST:
+                        popen_violations.append(f"{rel}:{node.lineno}")
+                elif called in self.SPAWN_FUNCS:
+                    sites_seen += 1
+                    if not any(k.arg == "timeout" for k in node.keywords):
+                        violations.append(f"{rel}:{node.lineno} {called}")
+
+        # If the walk ever finds nothing, the audit itself broke (import
+        # style changed, package moved) - fail loudly, never vacuously.
+        assert sites_seen >= 20, (
+            f"audit only found {sites_seen} subprocess call sites; "
+            "the scan is broken, not the code clean"
+        )
+        assert not violations, (
+            "subprocess calls without an explicit timeout= (add one, or "
+            "route through a deadline-managed runner):\n  "
+            + "\n  ".join(violations)
+        )
+        assert not popen_violations, (
+            "Popen outside the deadline-managed allowlist (see class "
+            "docstring):\n  " + "\n  ".join(popen_violations)
+        )


### PR DESCRIPTION
## Context

The 2026-07-19 A+ gate re-run (roadmap gate table, run against origin/main 5423f0d) found every mechanical gate green but surfaced three defects in the gates/product themselves. This PR fixes all three; a fourth defect (re-polluted live journals) was local gitignored state and was re-archived directly to `.ralph/archive/` with a README note, no diff here.

## Changes

1. **Worktree recreation bug (product fix)**: a crashed attempt whose worktree directory was deleted (tmp cleaner, operator rm -rf) leaves a registered-but-missing `.git/worktrees/<comp>/` entry that `_setup_worktree` could not recreate - the `exists()` guard skipped `git worktree remove` and `git worktree add` then refused. The remove is now unconditional: measured on git 2.47.1, `worktree remove --force` clears the stale registration in that state and fails harmlessly when nothing is registered (same pattern as the adjacent `branch -D`). The strict xfail documenting the bug (`test_recreate_when_crashed_worktree_dir_was_deleted`) is now a passing spine test.

2. **Subprocess-timeout audit (missing gate evidence)**: the orchestration A+ gate named a "grep test" that never existed. `TestSubprocessTimeoutAudit` in `tests/test_timeout_enforcement.py` is that test: alias-aware AST walk over `ralph_py` (`import subprocess as _sp` counts), every `run/call/check_call/check_output` must pass `timeout=`, `Popen` allowed only in the two deadline-managed runners (`agents/proc.py` R0.1, `verify.py::run_scrubbed` R2.6), plus a >=20-sites floor so the audit can never pass vacuously.

3. **Adversarial battery completion (missing gate evidence)**: the mechanical-verification gate's battery had named tests for only rename-move and sweep-in commit. `tests/test_adversarial_battery.py` adds the other two: a tautological `assert True` suite that passes pytest while the R7.2 function fixture fails the component ("Expected 4, got 0" - real sandboxed execution), and a conftest `collect_ignore` that hides a failing test from pytest but cannot deselect the fixtures oracle (with a control assertion that the suite fails once the conftest is removed). The module docstring maps all four battery entries to their tests.

4. **Roadmap bookkeeping**: user-run measurements (calibration v2 capture, reviewer-family baseline pair, EARS capture, two real factory runs) consolidated into the pending section next to the numbered decisions; decision 6 (untracked docs artifacts) added; both amended gate rows now name their evidence; the 2026-07-19 gate re-run result is recorded under the gate table; R3.4/R4.2 notes updated.

## Tested

- Fast tier: 1430 passed, 28 skipped (all skips are the two opt-in env gates), 0 failed.
- Spine tier: 24 passed, 0 xfailed (the former xfail now passes against real git).
- `mypy ralph_py/ --strict` and `ruff check` clean.
- The audit test was mutation-tested: a planted timeout-less `subprocess.run` and a planted aliased `Popen` outside the allowlist each turn it red; reverted, it is green.
- git behavior for registered-but-missing worktrees was measured in a scratch repo (git 2.47.1), not assumed.

## Assumed

- `worktree remove --force` semantics on materially older git versions were not measured; the fallback failure mode is the pre-fix behavior (loud RuntimeError), not silent corruption.
- The battery proves the fixtures oracle catches the two gaming shapes when fixtures are enabled; fixtures remain default-off per user decision 4 (caveat recorded in the gate row).

No prompt bodies touched (no H2 calibration cycle needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)