### PR TITLE
chore: R3.4 repo hygiene close (decision 6: ignore .claude/, drop phase-F artifacts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ scripts/ralph/understand_prompt.md
 
 # Live per-checkout config; ralph.toml.example is the tracked template (R3.4)
 /ralph.toml
+
+# Claude Code session dir: personal settings + live session worktrees (R3.4)
+.claude/

--- a/docs/remediation-roadmap.md
+++ b/docs/remediation-roadmap.md
@@ -471,7 +471,7 @@ spending, (c) what do I do when I come back to a partial failure.
     coordination note; superseded findings are journaled as
     `findings_superseded` events (attempt-tagged) while `component_result`
     carries only the final attempt's stream.
-- [~] R3.4 (S) **Repo hygiene** [LOW hygiene]
+- [x] R3.4 (S) **Repo hygiene** [LOW hygiene]
   - `.gitignore` covers `.ralph/`; remove the 99MB stale worktree
     (`git worktree remove .claude/worktrees/tender-leakey` after confirming the
     branch has no unique commits: check first, it is a destructive step for the
@@ -487,6 +487,18 @@ spending, (c) what do I do when I come back to a partial failure.
     in the R2.5 PR: `ralph.toml.example` is tracked and the live
     `ralph.toml` is gitignored. Still open: the remaining untracked docs
     artifacts (user decision 6).
+  - CLOSED 2026-07-20 (user decision 6: delete the regenerables):
+    `docs/end-to-end-flow.html` and `docs/phase-f-e2e-validation-v12.log`
+    (both regenerable phase-F artifacts) deleted from the main checkout;
+    `.claude/` (personal settings + live session worktrees) added to
+    `.gitignore` rather than committed or deleted - it hosts running
+    Claude Code sessions. `docs/user-actions.md` (the user's own
+    working checklist, untracked on purpose per its own header) is
+    deliberately NOT touched - the user deletes it when its list is
+    done. Verification note: the earlier "ralph.toml is gitignored"
+    claim is TRUE on main (`/ralph.toml` entry); it looked untracked
+    only because the main checkout sat on the stale pre-entry
+    `fix/r1-4-truncation` branch - resolved by checking main out there.
   - Note (2026-07-19, gate re-run): the live `.ralph/evolution.jsonl` +
     `experiments.tsv` had been re-polluted with synthetic test entries
     (projects "test"/"t", pre-v2 schema) written between the R4.1


### PR DESCRIPTION
Closes the last R3.4 sub-item per **user decision 6** (delete the regenerables).

## Changes in this PR
- `.gitignore`: add `.claude/` (personal settings + **live session worktrees** - must be neither committed nor deleted).
- `docs/remediation-roadmap.md`: R3.4 `[~] -> [x]` with the close-out record.

## Companion actions done directly in the main checkout (untracked files, not PR-able)
- Deleted `docs/end-to-end-flow.html` + `docs/phase-f-e2e-validation-v12.log` (regenerable phase-F artifacts).
- Moved the checkout off the stale merged `fix/r1-4-truncation` branch onto up-to-date `main` (which also resolves the "ralph.toml looks untracked" illusion - the `/ralph.toml` ignore entry existed on main all along; the checkout was just on a pre-entry branch). Removed the leftover clean `wt-r7-1` session worktree that was holding `main`, then deleted the stale branch.
- `docs/user-actions.md` left untouched: it is the user's own checklist, untracked on purpose per its header.

Docs + gitignore only; no code paths. Per H1, gating review is the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)