### PR TITLE
[slugify] Slugify utility implementation

### DIFF
--- a/scripts/ralph/feature/slugify-utility/prd.json
+++ b/scripts/ralph/feature/slugify-utility/prd.json
@@ -1,0 +1,79 @@
+{
+  "branchName": "ralph/factory/slugify-utility",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Basic ASCII and Unicode slugification",
+      "acceptanceCriteria": [
+        "WHEN input is \"Hello, World!\" WITH default separator THEN output is \"hello-world\"",
+        "WHEN input is \"Cr\u00e8me Br\u00fbl\u00e9e\" WITH default separator THEN output is \"creme-brulee\"",
+        "WHEN input contains only non-alphanumeric characters THEN output is empty string",
+        "Typecheck passes: uv run mypy tools/ --strict",
+        "Tests pass: uv run pytest tests/test_slugify.py -v"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "Whitespace and punctuation collapsing",
+      "acceptanceCriteria": [
+        "WHEN input is \"  --spaced--  out__ \" WITH default separator THEN output is \"spaced-out\"",
+        "WHEN input contains consecutive runs of punctuation/spaces/underscores THEN they collapse to a single separator",
+        "WHEN output would have leading or trailing separators THEN they are stripped",
+        "Tests pass: uv run pytest tests/test_slugify.py -v"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Custom separator support",
+      "acceptanceCriteria": [
+        "WHEN input is \"a b\" WITH separator=\"_\" THEN output is \"a_b\"",
+        "WHEN input is empty string WITH separator=\"_\" THEN output is empty string",
+        "WHEN separator is not the default character THEN the specified separator is used for collapsing",
+        "Tests pass: uv run pytest tests/test_slugify.py -v"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-004",
+      "title": "Separator validation and error handling",
+      "acceptanceCriteria": [
+        "WHEN separator is multi-character string \"ab\" THEN raise ValueError with message naming the single-character constraint",
+        "WHEN separator is alphanumeric character \"1\" THEN raise ValueError with message naming the punctuation constraint",
+        "WHEN ValueError is raised THEN the error message names which constraint was violated",
+        "Tests pass: uv run pytest tests/test_slugify.py -v"
+      ],
+      "priority": 4,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-005",
+      "title": "Edge cases, test coverage, and code quality",
+      "acceptanceCriteria": [
+        "WHEN test suite runs THEN it covers all acceptance criteria from other user stories",
+        "WHEN test suite runs THEN it includes at least two implementer-chosen edge cases (e.g., only-digits, leading/trailing non-alphanumeric, high Unicode characters)",
+        "WHEN source is analyzed THEN all function signatures have type hints and include `from __future__ import annotations`",
+        "Typecheck passes: uv run mypy tools/ --strict",
+        "Linting passes: uv run ruff check tools/ tests/test_slugify.py",
+        "Tests pass: uv run pytest tests/test_slugify.py -v"
+      ],
+      "priority": 5,
+      "passes": true,
+      "notes": ""
+    }
+  ],
+  "allowedPaths": [
+    "tools/slugify.py",
+    "tools/__init__.py",
+    "tests/test_slugify.py",
+    "scripts/ralph/feature/slugify-utility/"
+  ]
+}

--- a/tests/test_slugify.py
+++ b/tests/test_slugify.py
@@ -40,6 +40,15 @@ class TestCustomSeparator:
     def test_custom_separator_collapse(self) -> None:
         assert slugify("hello...world", separator="_") == "hello_world"
 
+    def test_backslash_separator(self) -> None:
+        assert slugify("hello world", separator="\\") == "hello\\world"
+
+    def test_dot_separator(self) -> None:
+        assert slugify("a b c", separator=".") == "a.b.c"
+
+    def test_pipe_separator(self) -> None:
+        assert slugify("foo bar", separator="|") == "foo|bar"
+
 
 class TestSeparatorValidation:
     def test_multi_char_separator(self) -> None:
@@ -47,12 +56,20 @@ class TestSeparatorValidation:
             slugify("hello", separator="ab")
 
     def test_digit_separator(self) -> None:
-        with pytest.raises(ValueError, match="alphanumeric"):
+        with pytest.raises(ValueError, match="punctuation"):
             slugify("hello", separator="1")
 
     def test_letter_separator(self) -> None:
-        with pytest.raises(ValueError, match="alphanumeric"):
+        with pytest.raises(ValueError, match="punctuation"):
             slugify("hello", separator="a")
+
+    def test_whitespace_separator(self) -> None:
+        with pytest.raises(ValueError, match="punctuation"):
+            slugify("hello", separator=" ")
+
+    def test_tab_separator(self) -> None:
+        with pytest.raises(ValueError, match="punctuation"):
+            slugify("hello", separator="\t")
 
 
 class TestEdgeCases:

--- a/tests/test_slugify.py
+++ b/tests/test_slugify.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from tools.slugify import slugify
+
+
+class TestBasicAsciiUnicode:
+    def test_simple_ascii(self) -> None:
+        assert slugify("Hello, World!") == "hello-world"
+
+    def test_unicode_accents(self) -> None:
+        assert slugify("Crème Brûlée") == "creme-brulee"
+
+    def test_only_non_alphanumeric(self) -> None:
+        assert slugify("!!!") == ""
+
+    def test_empty_string(self) -> None:
+        assert slugify("") == ""
+
+
+class TestWhitespaceCollapsing:
+    def test_spaced_out(self) -> None:
+        assert slugify("  --spaced--  out__ ") == "spaced-out"
+
+    def test_consecutive_punctuation(self) -> None:
+        assert slugify("hello...world") == "hello-world"
+
+    def test_leading_trailing_separators(self) -> None:
+        assert slugify("---hello---") == "hello"
+
+
+class TestCustomSeparator:
+    def test_underscore_separator(self) -> None:
+        assert slugify("a b", separator="_") == "a_b"
+
+    def test_empty_with_custom_separator(self) -> None:
+        assert slugify("", separator="_") == ""
+
+    def test_custom_separator_collapse(self) -> None:
+        assert slugify("hello...world", separator="_") == "hello_world"
+
+
+class TestSeparatorValidation:
+    def test_multi_char_separator(self) -> None:
+        with pytest.raises(ValueError, match="single character"):
+            slugify("hello", separator="ab")
+
+    def test_digit_separator(self) -> None:
+        with pytest.raises(ValueError, match="alphanumeric"):
+            slugify("hello", separator="1")
+
+    def test_letter_separator(self) -> None:
+        with pytest.raises(ValueError, match="alphanumeric"):
+            slugify("hello", separator="a")
+
+
+class TestEdgeCases:
+    def test_only_digits(self) -> None:
+        assert slugify("12345") == "12345"
+
+    def test_leading_trailing_non_alphanumeric(self) -> None:
+        assert slugify("!!!hello!!!") == "hello"
+
+    def test_high_unicode_characters(self) -> None:
+        assert slugify("Café naïve") == "cafe-naive"

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from tools.slugify import slugify
+
+__all__ = ["slugify"]

--- a/tools/slugify.py
+++ b/tools/slugify.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+
+def slugify(text: str, separator: str = "-") -> str:
+    if len(separator) != 1:
+        raise ValueError(f"Separator must be a single character, got {len(separator)}")
+    if separator.isalnum():
+        raise ValueError(f"Separator must not be alphanumeric, got '{separator}'")
+
+    text = text.lower()
+    text = unicodedata.normalize("NFD", text)
+    text = "".join(c for c in text if unicodedata.category(c) != "Mn")
+    text = re.sub(r"[^a-z0-9]+", separator, text)
+    text = text.strip(separator)
+    return text
+
+
+# ## Self-Critique
+# - If the input text contains only whitespace, this function will return an empty string after lowercasing, which matches the intent to only keep alphanumeric content.
+# - If the separator is a common regex metacharacter like '+' or '*', the strip() call will still work correctly because it treats the argument as a literal string, not a regex pattern.
+# - If the input contains the separator character itself (e.g., text="hello-world" with separator="-"), the separator validation occurs before processing, so invalid separators are rejected upfront; however, if the input naturally contains the chosen separator, it will not be preserved (it will be treated as a word boundary).

--- a/tools/slugify.py
+++ b/tools/slugify.py
@@ -19,6 +19,10 @@ def slugify(text: str, separator: str = "-") -> str:
 
 
 # ## Self-Critique
-# - If the input text contains only whitespace, this function will return an empty string after lowercasing, which matches the intent to only keep alphanumeric content.
-# - If the separator is a common regex metacharacter like '+' or '*', the strip() call will still work correctly because it treats the argument as a literal string, not a regex pattern.
-# - If the input contains the separator character itself (e.g., text="hello-world" with separator="-"), the separator validation occurs before processing, so invalid separators are rejected upfront; however, if the input naturally contains the chosen separator, it will not be preserved (it will be treated as a word boundary).
+# - If input is whitespace-only, strip() returns empty string, which matches the
+#   intent to keep only alphanumeric content.
+# - If separator is a regex metacharacter like '+', strip() treats it as a literal
+#   string, not a regex pattern, so the call still works correctly.
+# - If input contains the chosen separator (e.g., "hello-world" with sep="-"), it
+#   will not be preserved; the separator validation fails on invalid separators
+#   upfront, and valid separators within input text are treated as word boundaries.

--- a/tools/slugify.py
+++ b/tools/slugify.py
@@ -1,28 +1,32 @@
 from __future__ import annotations
 
 import re
+import string
 import unicodedata
 
 
 def slugify(text: str, separator: str = "-") -> str:
     if len(separator) != 1:
         raise ValueError(f"Separator must be a single character, got {len(separator)}")
-    if separator.isalnum():
-        raise ValueError(f"Separator must not be alphanumeric, got '{separator}'")
+    if separator not in string.punctuation:
+        raise ValueError(f"Separator must be a punctuation character, got '{separator}'")
 
     text = text.lower()
     text = unicodedata.normalize("NFD", text)
     text = "".join(c for c in text if unicodedata.category(c) != "Mn")
-    text = re.sub(r"[^a-z0-9]+", separator, text)
+    text = re.sub(r"[^a-z0-9]+", lambda m: separator, text)
     text = text.strip(separator)
     return text
 
 
 # ## Self-Critique
-# - If input is whitespace-only, strip() returns empty string, which matches the
-#   intent to keep only alphanumeric content.
-# - If separator is a regex metacharacter like '+', strip() treats it as a literal
-#   string, not a regex pattern, so the call still works correctly.
-# - If input contains the chosen separator (e.g., "hello-world" with sep="-"), it
-#   will not be preserved; the separator validation fails on invalid separators
-#   upfront, and valid separators within input text are treated as word boundaries.
+# - If separator is a regex metacharacter like backslash, the lambda callback
+#   ensures it is treated as a literal replacement string and never interpreted
+#   as regex escape syntax, preventing re.error from leaking to the caller.
+# - If input contains only non-alphanumeric characters, the regex pattern
+#   [^a-z0-9]+ matches all of them, re.sub replaces them with separators, and
+#   strip() removes all leading/trailing separators, correctly yielding an empty
+#   string.
+# - If separator validation rejects whitespace or control characters before
+#   re.sub is invoked, the function fails fast with a clear error message rather
+#   than silently accepting invalid input or producing unexpected slugs.


### PR DESCRIPTION
## Summary

Pure Python function to convert text to URL-safe slugs via Unicode normalization (NFKD), ASCII filtering, and separator collapsing. Includes validation of separator parameter and comprehensive test suite.

## Review Findings

**23 criteria passed, 0 failed, 0 advisory; 2 additional concerns**

**Reviewer model**: codex

- [pass] WHEN input is "Hello, World!" WITH default separator THEN output is "hello-world"
- [pass] WHEN input is "Crème Brûlée" WITH default separator THEN output is "creme-brulee"
- [pass] WHEN input contains only non-alphanumeric characters THEN output is empty string
- [pass] Typecheck passes: uv run mypy tools/ --strict
- [pass] Tests pass: uv run pytest tests/test_slugify.py -v
- [pass] WHEN input is "  --spaced--  out__ " WITH default separator THEN output is "spaced-out"
- [pass] WHEN input contains consecutive runs of punctuation/spaces/underscores THEN they collapse to a single separator
- [pass] WHEN output would have leading or trailing separators THEN they are stripped
- [pass] Tests pass: uv run pytest tests/test_slugify.py -v
- [pass] WHEN input is "a b" WITH separator="_" THEN output is "a_b"
- [pass] WHEN input is empty string WITH separator="_" THEN output is empty string
- [pass] WHEN separator is not the default character THEN the specified separator is used for collapsing
- [pass] Tests pass: uv run pytest tests/test_slugify.py -v
- [pass] WHEN separator is multi-character string "ab" THEN raise ValueError with message naming the single-character constraint
- [pass] WHEN separator is alphanumeric character "1" THEN raise ValueError with message naming the punctuation constraint
- [pass] WHEN ValueError is raised THEN the error message names which constraint was violated
- [pass] Tests pass: uv run pytest tests/test_slugify.py -v
- [pass] WHEN test suite runs THEN it covers all acceptance criteria from other user stories
- [pass] WHEN test suite runs THEN it includes at least two implementer-chosen edge cases (e.g., only-digits, leading/trailing non-alphanumeric, high Unicode characters)
- [pass] WHEN source is analyzed THEN all function signatures have type hints and include `from __future__ import annotations`
- [pass] Typecheck passes: uv run mypy tools/ --strict
- [pass] Linting passes: uv run ruff check tools/ tests/test_slugify.py
- [pass] Tests pass: uv run pytest tests/test_slugify.py -v

### Reviewer concerns (beyond PRD)
- [advisory] **test_quality** at `tests/test_slugify.py:81-82`
  - The test named `test_high_unicode_characters` only uses common decomposable Latin accents and substantially duplicates `test_unicode_accents` at tests/test_slugify.py:12-13. It does not expose the implementation's behavior for non-decomposable Unicode letters.
  - Suggestion: Replace or supplement it with cases containing non-decomposable Unicode letters or non-Latin scripts, and document whether unsupported letters should be transliterated, preserved, or removed.
- [advisory] **other** at `tools/slugify.py:14-18`
  - Despite the story's broad Unicode title, the implementation preserves only ASCII `[a-z0-9]`. Unicode letters that NFD does not decompose into an ASCII base are treated as separators, potentially producing lossy or surprising slugs.
  - Suggestion: Clarify the intended Unicode policy. If general Unicode slugification is required, use an explicit transliteration strategy or preserve Unicode alphanumeric characters and add representative tests.

**Notes**: The complete diff was examined. All explicit acceptance criteria are implemented and the supplied mechanical verification passed, but Unicode behavior is narrower than the story title and current tests imply.

## Adversarial Findings

### Security (0 findings)

- **PHASE SKIPPED**: security review disabled (mode=skip) (this role did not run for this PR)

## PRD

- File: `scripts/ralph/feature/slugify-utility/prd.json`
- Component: `slugify-utility`

---
Generated by [Ralph](https://github.com/0xfauzi/ralph-loop)