### PR TITLE
fix: merged-PR-reported-as-failure + factory agent-type alias fallthrough (found by the first real factory run)

### DIFF
--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -1357,10 +1357,18 @@ def decompose(
         else os.environ.get("RALPH_AGENT_TYPE", "auto")
     )
 
-    if not effective_cmd and not CodexAgent.is_available() and not ClaudeCodeAgent.is_available():
-        ui_impl.err("No agent available (codex and claude not found in PATH)")
-        ui_impl.info("Install an agent or use --agent-cmd to specify a custom one")
+    # R2.4 mirror (measured 2026-07-20): canonicalize aliases like
+    # "claude" before get_agent, whose unrecognized-type fallthrough is
+    # codex; the preflight also covers the no-agent-available check.
+    canonical_type, type_error, type_hint = _agent_preflight(
+        effective_cmd, effective_type,
+    )
+    if type_error:
+        ui_impl.err(type_error)
+        if type_hint:
+            ui_impl.info(type_hint)
         sys.exit(1)
+    effective_type = canonical_type or effective_type
 
     agent = get_agent(effective_cmd, effective_model, effective_reasoning, effective_type)
 
@@ -1717,10 +1725,18 @@ def factory(
         else os.environ.get("RALPH_AGENT_TYPE", "auto")
     )
 
-    if not effective_cmd and not CodexAgent.is_available() and not ClaudeCodeAgent.is_available():
-        ui_impl.err("No agent available (codex and claude not found in PATH)")
-        ui_impl.info("Install an agent or use --agent-cmd to specify a custom one")
+    # R2.4 mirror (measured 2026-07-20): canonicalize aliases like
+    # "claude" before get_agent, whose unrecognized-type fallthrough is
+    # codex; the preflight also covers the no-agent-available check.
+    canonical_type, type_error, type_hint = _agent_preflight(
+        effective_cmd, effective_type,
+    )
+    if type_error:
+        ui_impl.err(type_error)
+        if type_hint:
+            ui_impl.info(type_hint)
         sys.exit(1)
+    effective_type = canonical_type or effective_type
 
     agent = get_agent(effective_cmd, effective_model, effective_reasoning, effective_type)
 
@@ -1993,6 +2009,13 @@ def factory(
         base_config.sleep_seconds = sleep
     base_config.ui_mode = "plain"
     base_config.no_color = True
+
+    # R2.4 mirror for the factory path (measured 2026-07-20 on the first
+    # real factory run): without this, a toml alias like type = "claude"
+    # reaches get_agent RAW in every engineer worker and silently falls
+    # through to the codex default - and _cli_family misreads the
+    # engineer family, inverting the R7.1 reviewer rotation.
+    _check_agent_preflight(base_config, ui_impl)
 
     # Ensure prompt file exists
     if not base_config.prompt_file.exists():

--- a/ralph_py/pr.py
+++ b/ralph_py/pr.py
@@ -102,7 +102,15 @@ def merge_pr(pr_number: int, cwd: Path, method: str = "squash") -> str | None:
     """Merge a PR via gh CLI with auto-merge.
 
     Uses --auto so GitHub merges once status checks pass.
-    Uses --delete-branch to clean up the feature branch.
+
+    Deliberately does NOT pass ``--delete-branch`` (measured 2026-07-20
+    on the first real factory run): gh's local-branch deletion fails
+    when the branch is checked out in the component worktree - which it
+    always is at merge time - and gh then exits nonzero even though the
+    PR itself merged, turning a successful merge into a reported
+    failure. Remote-branch cleanup is an explicit post-confirmation
+    step in ``_merge_and_wait``; local branches are handled by the
+    factory's stale-branch machinery on the next run.
 
     Returns an error message, or None when a merge was initiated
     (confirmation is wait_for_merge's job).
@@ -116,7 +124,7 @@ def merge_pr(pr_number: int, cwd: Path, method: str = "squash") -> str | None:
         result = subprocess.run(
             [
                 "gh", "pr", "merge", str(pr_number),
-                f"--{method}", "--delete-branch", "--auto",
+                f"--{method}", "--auto",
             ],
             cwd=cwd,
             capture_output=True,
@@ -128,7 +136,7 @@ def merge_pr(pr_number: int, cwd: Path, method: str = "squash") -> str | None:
             result = subprocess.run(
                 [
                     "gh", "pr", "merge", str(pr_number),
-                    f"--{method}", "--delete-branch",
+                    f"--{method}",
                 ],
                 cwd=cwd,
                 capture_output=True,
@@ -266,6 +274,33 @@ def wait_for_merge(
     return "pending"
 
 
+def _delete_remote_branch(branch: str, cwd: Path) -> str | None:
+    """Best-effort remote-branch delete after a confirmed merge.
+
+    Replaces gh's ``--delete-branch`` (see :func:`merge_pr` for why that
+    flag is a hazard). A stale remote branch would make the next push of
+    a recreated same-name branch non-fast-forward, so this is cleanup
+    with a correctness angle - but it must never gate the merge outcome:
+    the caller logs the returned error and moves on.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "push", "--delete", "--", "origin", branch],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=PUSH_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return f"remote branch delete of {branch} timed out"
+    if result.returncode != 0:
+        return (
+            result.stderr.strip()
+            or f"remote branch delete of {branch} failed"
+        )
+    return None
+
+
 def _merge_and_wait(
     pr_number: int,
     pr_url: str,
@@ -274,9 +309,23 @@ def _merge_and_wait(
     ui: UI,
     merge_method: str,
     merge_timeout: float,
+    head_branch: str | None = None,
 ) -> PrOutcome:
     """Shared merge-initiate + confirm + fetch tail of the PR lifecycle."""
     merge_error = merge_pr(pr_number, cwd, merge_method)
+    if merge_error:
+        # gh pr merge can exit nonzero AFTER the merge itself succeeded
+        # (measured 2026-07-20 on the first real factory run: branch
+        # cleanup failed post-merge and gh reported failure while the PR
+        # sat MERGED on GitHub). R0.2 gates completion on the merge
+        # OUTCOME, so consult the PR state before declaring failure.
+        if _pr_state(pr_number, cwd) == "MERGED":
+            ui.warn(
+                f"  gh pr merge #{pr_number} reported an error "
+                f"({merge_error}) but the PR state is MERGED; "
+                f"continuing on the confirmed outcome"
+            )
+            merge_error = None
     if merge_error:
         ui.warn(f"  Failed to merge #{pr_number}: {merge_error}")
         # R7.5: distinguish "conflicting with base" from every other
@@ -300,6 +349,14 @@ def _merge_and_wait(
     state = wait_for_merge(pr_number, cwd, timeout=merge_timeout)
     if state == "merged":
         ui.ok(f"  PR #{pr_number} merged")
+        if head_branch:
+            delete_error = _delete_remote_branch(head_branch, cwd)
+            if delete_error:
+                ui.warn(
+                    f"  Remote cleanup of {head_branch} failed "
+                    f"({delete_error}); a later same-name push may need "
+                    f"the stale remote branch removed first"
+                )
         # Fetch (never pull, H-1) so origin/<base> includes the merged
         # code for downstream worktrees; the operator's checkout is
         # untouched. A failed fetch does not un-merge the PR, but it
@@ -395,6 +452,7 @@ def push_create_and_merge_pr(
         return _merge_and_wait(
             pr_number, component.pr_url, manifest.base_branch,
             cwd, ui, merge_method, merge_timeout,
+            head_branch=component.branch_name,
         )
 
     # Push
@@ -420,6 +478,7 @@ def push_create_and_merge_pr(
     return _merge_and_wait(
         pr_number, pr_url, manifest.base_branch,
         cwd, ui, merge_method, merge_timeout,
+        head_branch=component.branch_name,
     )
 
 

--- a/tests/test_pr_outcomes.py
+++ b/tests/test_pr_outcomes.py
@@ -119,9 +119,21 @@ def stub_gh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     GH_STUB_MERGE ("ok"|"fail"|"fail_once" - fail_once fails the FIRST
     merge call, tracked in GH_STUB_STATE_DIR, then succeeds),
     GH_STUB_VIEW_STATE ("MERGED"|"OPEN"|"CLOSED") and
-    GH_STUB_VIEW_MERGEABLE ("MERGEABLE"|"CONFLICTING"|"UNKNOWN")."""
+    GH_STUB_VIEW_MERGEABLE ("MERGEABLE"|"CONFLICTING"|"UNKNOWN").
+
+    The stub is merge-aware like real GitHub: a successful ``pr merge``
+    drops a marker in GH_STUB_STATE_DIR and ``pr view`` then reports
+    MERGED; before any successful merge it reports OPEN. An explicit
+    GH_STUB_VIEW_STATE always wins (for resume scenarios where the PR
+    merged before the test began). This mirrors the production
+    semantics the _merge_and_wait MERGED-rescue depends on: a failed
+    merge COMMAND on an unmerged PR must not read as merged.
+    """
     bin_dir = tmp_path / "stub-bin"
     bin_dir.mkdir()
+    state_dir = tmp_path / "stub-state"
+    state_dir.mkdir()
+    monkeypatch.setenv("GH_STUB_STATE_DIR", str(state_dir))
     gh = bin_dir / "gh"
     gh.write_text(textwrap.dedent(f"""\
         #!/bin/sh
@@ -147,10 +159,18 @@ def stub_gh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
                   echo "stub: pr merge conflict" >&2; exit 1
                 fi
               fi
+              touch "${{GH_STUB_STATE_DIR:-/nonexistent}}/merged" 2>/dev/null
               exit 0 ;;
             view)
+              if [ -n "${{GH_STUB_VIEW_STATE:-}}" ]; then
+                state="$GH_STUB_VIEW_STATE"
+              elif [ -f "${{GH_STUB_STATE_DIR:-/nonexistent}}/merged" ]; then
+                state="MERGED"
+              else
+                state="OPEN"
+              fi
               printf '{{"state": "%s", "mergeable": "%s"}}\\n' \\
-                "${{GH_STUB_VIEW_STATE:-MERGED}}" \\
+                "$state" \\
                 "${{GH_STUB_VIEW_MERGEABLE:-UNKNOWN}}"
               exit 0 ;;
           esac
@@ -417,7 +437,12 @@ class TestMergePendingResume:
 
     def test_resume_repolls_merged_pr_and_unblocks_dependents(
         self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        # The PR merged BEFORE this resume run - no in-test merge call
+        # exists to flip the stub's merge-aware view state, so the
+        # already-merged reality is pinned explicitly.
+        monkeypatch.setenv("GH_STUB_VIEW_STATE", "MERGED")
         root = _make_repo(tmp_path, ["alpha", "beta"])
         manifest = self._manifest_with_pending_alpha()
 
@@ -495,6 +520,95 @@ class TestPrOutcomeDataclass:
             pushed=True, pr_number=7, pr_url=STUB_PR_URL,
             merged=True, merge_pending=False, error=None,
         )
+
+    def test_merge_command_failure_with_merged_pr_still_completes(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The first real factory run's regression (2026-07-20): gh pr
+        merge exited nonzero on post-merge cleanup while the PR sat
+        MERGED on GitHub, and the component was failed despite a
+        delivered artifact. The merge OUTCOME gates completion (R0.2),
+        so a failed merge COMMAND with a MERGED PR is a success."""
+        monkeypatch.setenv("GH_STUB_MERGE", "fail")
+        monkeypatch.setenv("GH_STUB_VIEW_STATE", "MERGED")
+        root = _make_repo(tmp_path, ["alpha"])
+        manifest = _two_component_manifest()
+        comp = self._single_component(manifest, root)
+
+        outcome = push_create_and_merge_pr(
+            comp, manifest, root, PlainUI(no_color=True), merge_timeout=2.0,
+        )
+
+        assert outcome.merged is True
+        assert outcome.error is None
+
+    def test_merge_command_failure_with_open_pr_still_fails(
+        self, tmp_path: Path, stub_gh: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The rescue must not soften REAL merge failures: a failed
+        merge command on a PR that is genuinely not merged stays an
+        error."""
+        monkeypatch.setenv("GH_STUB_MERGE", "fail")
+        root = _make_repo(tmp_path, ["alpha"])
+        manifest = _two_component_manifest()
+        comp = self._single_component(manifest, root)
+
+        outcome = push_create_and_merge_pr(
+            comp, manifest, root, PlainUI(no_color=True), merge_timeout=2.0,
+        )
+
+        assert outcome.merged is False
+        assert outcome.error is not None
+        assert "merge failed" in outcome.error
+
+    def test_merge_pr_never_passes_delete_branch(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        """--delete-branch is the measured hazard: its local-branch
+        deletion fails inside a component worktree and gh reports the
+        whole (successful) merge as failed. It must never come back."""
+        from ralph_py import pr as pr_module
+
+        seen: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            seen.append(list(cmd))
+
+            class _R:
+                returncode = 1  # force both invocation shapes to run
+                stderr = "nope"
+                stdout = ""
+
+            return _R()
+
+        monkeypatch.setattr(pr_module.subprocess, "run", fake_run)
+        pr_module.merge_pr(7, tmp_path)
+
+        assert len(seen) == 2  # --auto attempt, then direct
+        for cmd in seen:
+            assert "--delete-branch" not in cmd
+
+    def test_remote_branch_deleted_after_confirmed_merge(
+        self, tmp_path: Path, stub_gh: Path,
+    ) -> None:
+        """Explicit remote cleanup replaces gh's --delete-branch: after
+        a confirmed merge the pushed branch is removed from origin so a
+        recreated same-name branch can push fast-forward next run."""
+        root = _make_repo(tmp_path, ["alpha"])
+        manifest = _two_component_manifest()
+        comp = self._single_component(manifest, root)
+
+        outcome = push_create_and_merge_pr(
+            comp, manifest, root, PlainUI(no_color=True), merge_timeout=2.0,
+        )
+        assert outcome.merged is True
+
+        remote_refs = _git(
+            "ls-remote", "--heads", "origin", cwd=root,
+        )
+        assert comp.branch_name not in remote_refs
 
     def test_wait_timeout_outcome(
         self, tmp_path: Path, stub_gh: Path,

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -356,3 +356,109 @@ class TestRunPrdPreflight:
         # downstream get_agent calls select the agent preflight verified.
         base_config = factory_calls[0]["args"][2]
         assert base_config.agent_type == "auto"
+
+
+class TestFactoryPreflightWiring:
+    """R2.4 mirror on the factory path (measured 2026-07-20 on the first
+    real factory run): toml ``[agent] type = "claude"`` reached
+    ``get_agent`` RAW in every engineer worker and silently fell through
+    to the codex default - inverting the R7.1 rotation's family
+    detection along the way."""
+
+    def test_factory_canonicalizes_toml_claude_alias(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from ralph_py.manifest import Component, Manifest
+
+        _availability(monkeypatch, claude=True, codex=True)
+        root = tmp_path / "proj"
+        root.mkdir()
+        _scaffold(root)
+        (root / "ralph.toml").write_text('[agent]\ntype = "claude"\n')
+
+        manifest = Manifest(
+            version="1", spec_file="spec.md", project_name="p",
+            base_branch="main", single_pr=False,
+            components=[Component(
+                "alpha", "Alpha", "First", [],
+                "scripts/ralph/feature/alpha/prd.json",
+                "ralph/factory/alpha",
+            )],
+        )
+        manifest_file = tmp_path / "manifest.json"
+        manifest_file.write_text("{}")  # click existence check only
+        monkeypatch.setattr(
+            cli_mod.Manifest, "load",
+            classmethod(lambda cls, path: manifest),
+        )
+
+        captured: dict[str, Any] = {}
+
+        def fake_run_factory(
+            manifest_arg: Any, factory_config: Any, base_config: Any,
+            *args: Any, **kwargs: Any,
+        ) -> SimpleNamespace:
+            captured["agent_type"] = base_config.agent_type
+            return SimpleNamespace(exit_code=0)
+
+        monkeypatch.setattr(cli_mod, "run_factory", fake_run_factory)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "factory", "--manifest", str(manifest_file),
+                "--root", str(root), "--yes",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert captured.get("agent_type") == "claude-code", result.output
+
+    def test_factory_blocks_unknown_agent_type_loudly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The other half of the fallthrough hazard: a typo'd type must
+        exit with the R2.4 error, never reach a codex engineer."""
+        _availability(monkeypatch, claude=True, codex=True)
+        root = tmp_path / "proj"
+        root.mkdir()
+        _scaffold(root)
+        (root / "ralph.toml").write_text('[agent]\ntype = "clade"\n')
+
+        from ralph_py.manifest import Component, Manifest
+
+        manifest = Manifest(
+            version="1", spec_file="spec.md", project_name="p",
+            base_branch="main", single_pr=False,
+            components=[Component(
+                "alpha", "Alpha", "First", [],
+                "scripts/ralph/feature/alpha/prd.json",
+                "ralph/factory/alpha",
+            )],
+        )
+        manifest_file = tmp_path / "manifest.json"
+        manifest_file.write_text("{}")
+        monkeypatch.setattr(
+            cli_mod.Manifest, "load",
+            classmethod(lambda cls, path: manifest),
+        )
+
+        called: list[bool] = []
+        monkeypatch.setattr(
+            cli_mod, "run_factory",
+            lambda *a, **k: called.append(True) or SimpleNamespace(exit_code=0),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "factory", "--manifest", str(manifest_file),
+                "--root", str(root), "--yes",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Unknown agent type" in result.output
+        assert not called

--- a/tests/test_spine_pr_failures.py
+++ b/tests/test_spine_pr_failures.py
@@ -104,9 +104,13 @@ class TestSpinePrFailurePaths:
         assert result.completed == ["alpha", "beta"]
         assert result.exit_code == 0
         assert len(result.pr_urls) == 2
-        # The pushes were real: the bare origin has both branch refs.
+        # The pushes were real - the PR lifecycle cannot complete
+        # without them - and the post-merge remote cleanup then removed
+        # both branch refs from origin (the --delete-branch replacement;
+        # a stale remote branch would break the next same-name push).
         for branch in ("ralph/factory/alpha", "ralph/factory/beta"):
-            assert git("rev-parse", f"refs/heads/{branch}", cwd=origin)
+            refs = git("ls-remote", "--heads", "origin", branch, cwd=root)
+            assert refs == "", branch + " not cleaned from origin: " + refs
 
     def test_push_failure_fails_component_and_skips_dependents(
         self, tmp_path: Path, stub_gh: Path,
@@ -163,6 +167,10 @@ class TestSpinePrFailurePaths:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("GH_SPINE_MERGE", "fail")
+        # A REAL merge failure means the PR is not merged; without this
+        # pin the stub's MERGED default would trigger _merge_and_wait's
+        # (deliberate) merged-outcome rescue and complete the component.
+        monkeypatch.setenv("GH_SPINE_VIEW_STATE", "OPEN")
         root = tmp_path / "repo"
         init_ralph_repo(root, ("alpha", "beta"), with_origin=True)
         manifest = _alpha_beta_manifest()


### PR DESCRIPTION
Two defects surfaced live on 2026-07-20 during the first real factory runs (the knowledge/evolution A+ gate evidence capture). Both measured, both with regression tests.

## 1. Merged PRs reported as failures (`pr.py`) - R0.2

`gh pr merge --delete-branch` fails on its **local**-branch deletion whenever the branch is checked out in the component worktree - which it always is at merge time - and gh exits nonzero even though the PR merged. Measured: factory PR #99 sat MERGED on GitHub while the component was FAILED with `merge failed for PR #99: failed to delete local branch...`.

Fixes:
- Drop `--delete-branch` from both merge invocations.
- `_merge_and_wait` consults the actual PR state when the merge *command* fails and continues on a confirmed `MERGED` outcome - R0.2 gates completion on the merge **outcome**, not gh's exit code. A genuinely unmerged PR still fails (tested).
- Remote-branch cleanup becomes an explicit best-effort step after merge confirmation (a stale remote branch would break the next same-name push - the reason --delete-branch existed).

## 2. Factory path uses raw toml agent-type aliases (`cli.py`) - R2.4 mirror

`ralph run` canonicalizes `[agent] type = "claude"` via the R2.4 preflight; `ralph factory` passed it **raw** into `get_agent` in every engineer worker, whose unrecognized-type fallthrough is codex. Measured: toml `"claude"` + `MODEL=haiku` produced a `codex (haiku)` engineer (HTTP 400 on a ChatGPT account) - and `_cli_family` misread the engineer family, which would invert the R7.1 reviewer rotation.

Fixes: the factory command runs `_check_agent_preflight` on `base_config`; the decompose-agent path in both `decompose` and `factory` canonicalizes `effective_type` through `_agent_preflight` (which also subsumes the manual no-agent check).

## Tests

- gh stub in `test_pr_outcomes` is now **merge-aware** (view reports MERGED only after a successful stub merge; explicit override wins) so a failed merge command on an unmerged PR can never read as merged in tests.
- New: MERGED-rescue completes; unmerged failure still fails; `--delete-branch` never passed; remote branch cleaned post-merge; factory canonicalizes the alias before `run_factory`; unknown type blocks loudly before any engineer.
- Adjusted: spine merge-failure test pins the unmerged state; spine happy-path asserts the post-merge remote cleanup.

Gates: 1539 passed / 28 skipped, mypy --strict clean, ruff clean.

Found-by context: these runs are the roadmap's "two real factory runs" measurement; the fix is cherry-picked onto the throwaway `factory/e2e-base` runtime branch so run 2 can proceed - this PR is the mainline landing.

Per H1, not self-reviewed; gating reviewer is the user or `/code-review ultra`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)