### PR TITLE
TUI chunk 1: schema-v2 event model, sinks, run layout

### DIFF
--- a/ralph_py/events.py
+++ b/ralph_py/events.py
@@ -1,0 +1,777 @@
+"""Schema-v2 typed event model for Ralph runs (TUI rewrite, stage 1).
+
+The filesystem is the event bus: the orchestrator and its workers append
+one JSON object per line to files under ``.ralph/runs/<run_id>/`` and
+every surface (plain line output, the Textual TUI, ``ralph status``) is
+a projection of that stream. This module owns the vocabulary: the
+:class:`Event` dataclasses, the sinks that write them, the tolerant
+reader that parses them back, and the run-directory layout.
+
+Envelope (one JSON object per line)::
+
+    {"schema": 2, "event": "<type>", "ts": <float epoch seconds>,
+     "run_id": "...", "component": "...", "source": "orchestrator|worker",
+     "seq": <int>, "data": {<payload fields>}}
+
+Envelope fields are stamped by :meth:`EventBus.emit`, never by call
+sites. Decoding is TOTAL: every payload field has a default, unknown
+event names become :class:`UnknownEvent` (losslessly re-serializable),
+mistyped payload values degrade to the field default, and a torn tail
+line parses to ``None``. Sinks are observability, never control flow:
+:class:`EventBus` isolates sink exceptions and counts drops.
+
+Naming note: v1 compatibility (``.ralph/progress.jsonl``) is provided by
+:class:`V1CompatSink`, which delegates to a real
+:class:`~ralph_py.observability.ProgressLog` so its file format AND its
+attached ``ProgressSink`` observers (e.g. the Linear sink, R7.4) keep
+working unchanged.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import threading
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar, Final, Protocol, TextIO
+
+from ralph_py.observability import ProgressLog
+
+SCHEMA_VERSION: Final = 2
+
+_ENVELOPE_FIELDS: Final = frozenset({"ts", "run_id", "component", "source", "seq"})
+
+_REGISTRY: dict[str, type[Event]] = {}
+_FIELD_DEFAULTS: dict[str, dict[str, Any]] = {}
+
+
+@dataclass(frozen=True, kw_only=True)
+class Event:
+    """Base class for schema-v2 events.
+
+    Envelope fields (``ts``/``run_id``/``component``/``source``/``seq``)
+    are stamped by :meth:`EventBus.emit`; payload fields are everything a
+    subclass adds. Every payload field MUST have a default so decoding
+    is total (forward compatibility contract).
+    """
+
+    type: ClassVar[str] = ""  # registry key; "" = abstract base
+
+    ts: float = 0.0
+    run_id: str = ""
+    component: str = ""
+    source: str = "orchestrator"
+    seq: int = 0
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if cls.type:
+            _REGISTRY[cls.type] = cls
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {}
+        for f in dataclasses.fields(self):
+            if f.name in _ENVELOPE_FIELDS:
+                continue
+            value = getattr(self, f.name)
+            data[f.name] = list(value) if isinstance(value, tuple) else value
+        return {
+            "schema": SCHEMA_VERSION,
+            "event": type(self).type,
+            "ts": self.ts,
+            "run_id": self.run_id,
+            "component": self.component,
+            "source": self.source,
+            "seq": self.seq,
+            "data": data,
+        }
+
+    def to_json_line(self) -> str:
+        return json.dumps(self.to_dict(), separators=(",", ":"), default=str)
+
+
+@dataclass(frozen=True, kw_only=True)
+class UnknownEvent(Event):
+    """An event whose type or shape this build does not understand.
+
+    Preserves the raw envelope so copies/tees are lossless and reducers
+    can count what they skipped instead of crashing on it.
+    """
+
+    type: ClassVar[str] = "unknown"
+    type_name: str = ""
+    raw: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        if self.raw:
+            return dict(self.raw)
+        return super().to_dict()
+
+
+# ---------------------------------------------------------------------------
+# v1-named events (1:1 with ProgressLog's catalogue; V1CompatSink maps these)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, kw_only=True)
+class RunStarted(Event):
+    type: ClassVar[str] = "factory_started"
+    project: str = ""
+    components: int = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class ComponentStarted(Event):
+    type: ClassVar[str] = "component_started"
+
+
+@dataclass(frozen=True, kw_only=True)
+class ComponentCompleted(Event):
+    type: ClassVar[str] = "component_completed"
+    duration_seconds: float = 0.0
+    iterations: int = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class ComponentFailed(Event):
+    type: ClassVar[str] = "component_failed"
+    error: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class CircuitBreakerTripped(Event):
+    """R7.5: engineer loop halted on the no-progress breaker."""
+
+    type: ClassVar[str] = "circuit_breaker_tripped"
+    iterations: int = 0
+    error: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class ComponentRetrying(Event):
+    type: ClassVar[str] = "component_retrying"
+    attempt: int = 0
+    reason: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class VerificationResultEvent(Event):
+    type: ClassVar[str] = "verification_result"
+    passed: bool = False
+    checks: tuple[str, ...] = ()
+    failures: tuple[str, ...] = ()
+    duration_seconds: float = 0.0
+
+
+@dataclass(frozen=True, kw_only=True)
+class ReviewResultEvent(Event):
+    """Phase 2 review AND phase 2.5 security (mode startswith "security")."""
+
+    type: ClassVar[str] = "review_result"
+    passed: bool = False
+    mode: str = ""
+    fail_count: int = 0
+    advisory_count: int = 0
+    duration_seconds: float = 0.0
+
+
+@dataclass(frozen=True, kw_only=True)
+class ComponentUsage(Event):
+    """R3.1 cost meter capture: mirror of ``UsageTotals.to_dict()`` plus
+    the phase. Token/cost figures are CLI self-reports - lower bounds
+    whenever ``unreported_calls`` > 0."""
+
+    type: ClassVar[str] = "component_usage"
+    phase: str = ""
+    calls: int = 0
+    known_calls: int = 0
+    unreported_calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    total_tokens: int = 0
+    cost_usd: float = 0.0
+    duration_seconds: float = 0.0
+
+
+@dataclass(frozen=True, kw_only=True)
+class BudgetExceeded(Event):
+    type: ClassVar[str] = "budget_exceeded"
+    total_tokens: int = 0
+    max_total_tokens: int = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class ContractResult(Event):
+    type: ClassVar[str] = "contract_result"
+    tier: int = 0
+    passed: bool = False
+    breaker: str | None = None
+    duration_seconds: float = 0.0
+
+
+@dataclass(frozen=True, kw_only=True)
+class RunCompleted(Event):
+    type: ClassVar[str] = "factory_completed"
+    completed: int = 0
+    failed: int = 0
+    skipped: int = 0
+    duration_seconds: float = 0.0
+
+
+@dataclass(frozen=True, kw_only=True)
+class MergePendingV1(Event):
+    """v1-parity twin of :class:`PrMergePending` (kept so the compat
+    file's ``merge_pending`` line survives unchanged; the reducer
+    prefers the v2 event)."""
+
+    type: ClassVar[str] = "merge_pending"
+    pr_url: str = ""
+    error: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class PhaseSkipped(Event):
+    type: ClassVar[str] = "phase_skipped"
+    phase: str = ""
+    reason: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class DiffFetchFailed(Event):
+    type: ClassVar[str] = "diff_fetch_failed"
+    error: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class DiffUnsplittable(Event):
+    type: ClassVar[str] = "diff_unsplittable"
+    error: str = ""
+    diff_chars: int = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class DiffChunked(Event):
+    type: ClassVar[str] = "diff_chunked"
+    chunks: int = 0
+    diff_chars: int = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class ChunkBudgetInsufficient(Event):
+    type: ClassVar[str] = "chunk_budget_insufficient"
+    phase: str = ""
+    chunks: int = 0
+    remaining: int = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class AdversarialAgentSelected(Event):
+    type: ClassVar[str] = "adversarial_agent_selected"
+    phase: str = ""
+    agent_source: str = ""
+    identity: str = ""
+    agent_type: str = ""
+    model: str = ""
+    homogeneous: bool = False
+
+
+# ---------------------------------------------------------------------------
+# v2-only events (dropped by V1CompatSink; the TUI/reducer's real signal)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, kw_only=True)
+class RunPlan(Event):
+    """The component DAG plus budget caps, emitted right after
+    ``factory_started`` so consumers need no manifest read to draw the
+    board. ``components`` entries: {"id", "title", "deps": [...]}."""
+
+    type: ClassVar[str] = "run_plan"
+    components: tuple[Mapping[str, Any], ...] = ()
+    max_total_tokens: int = 0
+    max_adversarial_calls: int = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class PhaseStarted(Event):
+    type: ClassVar[str] = "phase_started"
+    phase: str = ""
+    attempt: int = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class PhaseCompleted(Event):
+    type: ClassVar[str] = "phase_completed"
+    phase: str = ""
+    passed: bool = False
+    detail: str = ""
+    duration_seconds: float = 0.0
+
+
+@dataclass(frozen=True, kw_only=True)
+class IterationStarted(Event):
+    type: ClassVar[str] = "iteration_started"
+    iteration: int = 0
+    max_iterations: int = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class IterationCompleted(Event):
+    type: ClassVar[str] = "iteration_completed"
+    iteration: int = 0
+    duration_seconds: float = 0.0
+    completed: bool = False
+    timed_out: bool = False
+
+
+@dataclass(frozen=True, kw_only=True)
+class WorkerHeartbeat(Event):
+    type: ClassVar[str] = "worker_heartbeat"
+    pid: int = 0
+    elapsed_seconds: float = 0.0
+
+
+@dataclass(frozen=True, kw_only=True)
+class CheckpointRequested(Event):
+    type: ClassVar[str] = "checkpoint_requested"
+    kind: str = ""
+    question: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class CheckpointResolved(Event):
+    """``decided_by``: "auto" (non-interactive default) or "operator"."""
+
+    type: ClassVar[str] = "checkpoint_resolved"
+    kind: str = ""
+    decision: str = ""
+    decided_by: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class PrCreated(Event):
+    type: ClassVar[str] = "pr_created"
+    pr_number: int = 0
+    pr_url: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class PrMerged(Event):
+    type: ClassVar[str] = "pr_merged"
+    pr_number: int = 0
+    pr_url: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class PrMergePending(Event):
+    type: ClassVar[str] = "pr_merge_pending"
+    pr_url: str = ""
+    error: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class DistillResult(Event):
+    type: ClassVar[str] = "distill_result"
+    facts_written: int = 0
+    duration_seconds: float = 0.0
+
+
+@dataclass(frozen=True, kw_only=True)
+class FindingRecorded(Event):
+    """One typed adversarial finding, streamed as it is recorded."""
+
+    type: ClassVar[str] = "finding_recorded"
+    phase: str = ""
+    category: str = ""
+    severity: str = ""
+    location: str = ""
+    explanation: str = ""
+    attempt: int = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class Log(Event):
+    """The escape hatch for imperative narration (the old UI protocol).
+
+    ``kind``: line | kv | section | subsection | title | hr | channel |
+    stream | startup_art. ``key`` carries the kv key / channel name /
+    stream tag; ``severity``: info | ok | warn | error.
+    """
+
+    type: ClassVar[str] = "log"
+    severity: str = "info"
+    kind: str = "line"
+    key: str = ""
+    text: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Decoding (total: never raises)
+# ---------------------------------------------------------------------------
+
+
+def _field_defaults(cls: type[Event]) -> dict[str, Any]:
+    cached = _FIELD_DEFAULTS.get(cls.type)
+    if cached is not None:
+        return cached
+    defaults: dict[str, Any] = {}
+    for f in dataclasses.fields(cls):
+        if f.name in _ENVELOPE_FIELDS:
+            continue
+        if f.default is not dataclasses.MISSING:
+            defaults[f.name] = f.default
+        elif f.default_factory is not dataclasses.MISSING:
+            defaults[f.name] = f.default_factory()
+    _FIELD_DEFAULTS[cls.type] = defaults
+    return defaults
+
+
+def _coerce(default: Any, value: Any) -> Any:
+    """Return a value type-compatible with ``default``, or the default.
+
+    bool is checked before int (bool subclasses int); ints are accepted
+    for float fields; lists become tuples for tuple fields.
+    """
+    if default is None:
+        return value
+    if isinstance(default, bool):
+        return value if isinstance(value, bool) else default
+    if isinstance(default, float):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return default
+        return float(value)
+    if isinstance(default, int):
+        if isinstance(value, bool) or not isinstance(value, int):
+            return default
+        return value
+    if isinstance(default, str):
+        return value if isinstance(value, str) else default
+    if isinstance(default, tuple):
+        return tuple(value) if isinstance(value, (list, tuple)) else default
+    return value
+
+
+def _envelope_kwargs(obj: Mapping[str, Any]) -> dict[str, Any]:
+    ts = obj.get("ts")
+    seq = obj.get("seq")
+    return {
+        "ts": float(ts) if isinstance(ts, (int, float)) and not isinstance(ts, bool) else 0.0,
+        "run_id": obj.get("run_id") if isinstance(obj.get("run_id"), str) else "",
+        "component": obj.get("component") if isinstance(obj.get("component"), str) else "",
+        "source": obj.get("source") if isinstance(obj.get("source"), str) else "orchestrator",
+        "seq": seq if isinstance(seq, int) and not isinstance(seq, bool) else 0,
+    }
+
+
+def event_from_dict(obj: Mapping[str, Any]) -> Event:
+    """Decode one envelope dict into a typed event. Never raises."""
+    name = obj.get("event")
+    cls = _REGISTRY.get(name) if isinstance(name, str) else None
+    envelope = _envelope_kwargs(obj)
+    if cls is None or cls is UnknownEvent:
+        return UnknownEvent(
+            type_name=name if isinstance(name, str) else "",
+            raw=dict(obj),
+            **envelope,
+        )
+    payload: dict[str, Any] = {}
+    raw_data = obj.get("data")
+    defaults = _field_defaults(cls)
+    if isinstance(raw_data, Mapping):
+        for fname, default in defaults.items():
+            if fname in raw_data:
+                payload[fname] = _coerce(default, raw_data[fname])
+    try:
+        return cls(**payload, **envelope)
+    except Exception:  # noqa: BLE001 - decode is total by contract
+        return UnknownEvent(
+            type_name=name if isinstance(name, str) else "",
+            raw=dict(obj),
+            **envelope,
+        )
+
+
+def parse_event_line(line: str) -> Event | None:
+    """One JSONL line -> Event, or None for torn/blank/non-dict lines."""
+    stripped = line.strip()
+    if not stripped:
+        return None
+    try:
+        obj = json.loads(stripped)
+    except ValueError:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    return event_from_dict(obj)
+
+
+def read_events(path: Path) -> list[Event]:
+    """Tolerant reader: skips torn/blank lines, returns [] for a missing
+    file (mirrors ``observability.read_progress_events``)."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except OSError:
+        return []
+    events: list[Event] = []
+    for line in lines:
+        event = parse_event_line(line)
+        if event is not None:
+            events.append(event)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Sinks and the bus
+# ---------------------------------------------------------------------------
+
+
+class EventSink(Protocol):
+    """Destination for stamped events. Sinks must never raise into the
+    run - EventBus isolates them anyway, but a sink should be cheap."""
+
+    def emit(self, event: Event) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class NullSink:
+    def emit(self, event: Event) -> None:  # noqa: ARG002 - protocol
+        return
+
+    def close(self) -> None:
+        return
+
+
+class CallbackSink:
+    """Wraps a callable; used for same-thread renderers and inline tees."""
+
+    def __init__(self, callback: Callable[[Event], None]) -> None:
+        self._callback = callback
+
+    def emit(self, event: Event) -> None:
+        self._callback(event)
+
+    def close(self) -> None:
+        return
+
+
+class JsonlSink:
+    """Append-only JSONL writer; one line per event, flushed, guarded by
+    a lock so heartbeat threads can share it with the main thread."""
+
+    def __init__(self, path: Path, *, mkdir: bool = True) -> None:
+        self.path = path
+        if mkdir:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._fh: TextIO | None = None
+
+    def emit(self, event: Event) -> None:
+        line = event.to_json_line()
+        with self._lock:
+            if self._fh is None:
+                self._fh = open(self.path, "a", encoding="utf-8")
+            self._fh.write(line + "\n")
+            self._fh.flush()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._fh is not None:
+                try:
+                    self._fh.close()
+                finally:
+                    self._fh = None
+
+
+class V1CompatSink:
+    """Projects v1-named events onto a real :class:`ProgressLog`.
+
+    Delegating (rather than re-serializing) keeps two contracts intact
+    by construction: the progress.jsonl line format, and the R7.4
+    ``ProgressSink`` observers attached to the log (e.g. Linear).
+    v2-only events are dropped silently - that is the point.
+    """
+
+    def __init__(self, progress_log: ProgressLog) -> None:
+        self._log = progress_log
+
+    @property
+    def path(self) -> Path:
+        return self._log.path
+
+    def emit(self, event: Event) -> None:  # noqa: C901 - flat dispatch table
+        log = self._log
+        comp = event.component
+        if isinstance(event, RunStarted):
+            log.factory_started(event.project, event.components)
+        elif isinstance(event, ComponentStarted):
+            log.component_started(comp)
+        elif isinstance(event, ComponentCompleted):
+            log.component_completed(comp, event.duration_seconds, event.iterations)
+        elif isinstance(event, CircuitBreakerTripped):
+            log.circuit_breaker_tripped(comp, event.iterations, event.error)
+        elif isinstance(event, ComponentFailed):
+            log.component_failed(comp, event.error)
+        elif isinstance(event, ComponentRetrying):
+            log.component_retrying(comp, event.attempt, event.reason)
+        elif isinstance(event, VerificationResultEvent):
+            log.verification_result(
+                comp, event.passed, list(event.checks), list(event.failures),
+                event.duration_seconds,
+            )
+        elif isinstance(event, ReviewResultEvent):
+            log.review_result(
+                comp, event.passed, event.mode, event.fail_count,
+                event.advisory_count, event.duration_seconds,
+            )
+        elif isinstance(event, ComponentUsage):
+            log.component_usage(comp, event.phase, {
+                "calls": event.calls,
+                "known_calls": event.known_calls,
+                "unreported_calls": event.unreported_calls,
+                "input_tokens": event.input_tokens,
+                "output_tokens": event.output_tokens,
+                "cache_read_tokens": event.cache_read_tokens,
+                "cache_creation_tokens": event.cache_creation_tokens,
+                "total_tokens": event.total_tokens,
+                "cost_usd": event.cost_usd,
+                "duration_seconds": event.duration_seconds,
+            })
+        elif isinstance(event, BudgetExceeded):
+            log.budget_exceeded(comp, event.total_tokens, event.max_total_tokens)
+        elif isinstance(event, ContractResult):
+            log.contract_result(
+                event.tier, event.passed, event.breaker, event.duration_seconds,
+            )
+        elif isinstance(event, RunCompleted):
+            log.factory_completed(
+                event.completed, event.failed, event.skipped,
+                event.duration_seconds,
+            )
+        elif isinstance(event, MergePendingV1):
+            log.emit("merge_pending", comp, {
+                "pr_url": event.pr_url, "error": event.error,
+            })
+        elif isinstance(event, PhaseSkipped):
+            log.emit("phase_skipped", comp, {
+                "phase": event.phase, "reason": event.reason,
+            })
+        elif isinstance(event, DiffFetchFailed):
+            log.emit("diff_fetch_failed", comp, {"error": event.error})
+        elif isinstance(event, DiffUnsplittable):
+            log.emit("diff_unsplittable", comp, {
+                "error": event.error, "diff_chars": event.diff_chars,
+            })
+        elif isinstance(event, DiffChunked):
+            log.emit("diff_chunked", comp, {
+                "chunks": event.chunks, "diff_chars": event.diff_chars,
+            })
+        elif isinstance(event, ChunkBudgetInsufficient):
+            log.emit("chunk_budget_insufficient", comp, {
+                "phase": event.phase, "chunks": event.chunks,
+                "remaining": event.remaining,
+            })
+        elif isinstance(event, AdversarialAgentSelected):
+            log.emit("adversarial_agent_selected", data={
+                "phase": event.phase,
+                "source": event.agent_source,
+                "identity": event.identity,
+                "agent_type": event.agent_type,
+                "model": event.model,
+                "homogeneous": event.homogeneous,
+            })
+        # v2-only events: dropped by design.
+
+    def close(self) -> None:
+        return
+
+
+class EventBus:
+    """Stamps the envelope and fans out to sinks, isolating failures.
+
+    ``run_id``/``component``/``source`` defaults fill empty envelope
+    fields; ``seq`` is per-bus monotonic; ``ts`` is wall-clock at emit
+    (the TUI's last-event-age depends on this being wall time).
+    """
+
+    def __init__(
+        self,
+        *sinks: EventSink,
+        run_id: str = "",
+        source: str = "orchestrator",
+        component: str = "",
+    ) -> None:
+        self._sinks: list[EventSink] = list(sinks)
+        self.run_id = run_id
+        self.source = source
+        self.component = component
+        self.dropped = 0
+        self._seq = 0
+        self._lock = threading.Lock()
+
+    def add_sink(self, sink: EventSink) -> None:
+        self._sinks.append(sink)
+
+    def emit(self, event: Event) -> Event:
+        with self._lock:
+            self._seq += 1
+            seq = self._seq
+        stamped = dataclasses.replace(
+            event,
+            ts=time.time(),
+            run_id=event.run_id or self.run_id,
+            component=event.component or self.component,
+            source=self.source,
+            seq=seq,
+        )
+        for sink in self._sinks:
+            try:
+                sink.emit(stamped)
+            except Exception:  # noqa: BLE001 - observability never breaks the run
+                self.dropped += 1
+        return stamped
+
+    def close(self) -> None:
+        for sink in self._sinks:
+            try:
+                sink.close()
+            except Exception:  # noqa: BLE001 - close is best-effort
+                self.dropped += 1
+
+
+# ---------------------------------------------------------------------------
+# Run directory layout
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RunPaths:
+    """Canonical layout of one run's on-disk stream."""
+
+    root: Path  # <project>/.ralph/runs/<run_id>
+
+    @classmethod
+    def for_run(cls, project_root: Path, run_id: str) -> RunPaths:
+        return cls(root=project_root / ".ralph" / "runs" / run_id)
+
+    @property
+    def events_file(self) -> Path:
+        return self.root / "events.jsonl"
+
+    def component_dir(self, component_id: str) -> Path:
+        return self.root / "components" / component_id
+
+    def engineer_events(self, component_id: str) -> Path:
+        return self.component_dir(component_id) / "engineer.jsonl"
+
+    def engineer_log(self, component_id: str) -> Path:
+        return self.component_dir(component_id) / "engineer.log"
+
+    def phase_log(self, component_id: str, phase: str) -> Path:
+        return self.component_dir(component_id) / f"{phase}.log"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,394 @@
+"""Chunk 1 (TUI rewrite): schema-v2 event model, sinks, run layout.
+
+The load-bearing test here is golden parity: V1CompatSink fed stamped v2
+events must produce byte-equivalent progress.jsonl lines (modulo ts) to
+calling the real ProgressLog convenience methods directly. That parity
+is what lets the whole migration keep .ralph/progress.jsonl consumers
+(ralph status v1 arm, the Linear ProgressSink) untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ralph_py import events as ev
+from ralph_py.observability import ProgressLog, read_progress_events
+
+
+def _sample_events() -> list[ev.Event]:
+    """One instance of every registered concrete type, non-default payloads."""
+    return [
+        ev.RunStarted(project="proj", components=3),
+        ev.ComponentStarted(component="comp-a"),
+        ev.ComponentCompleted(component="comp-a", duration_seconds=12.34, iterations=4),
+        ev.ComponentFailed(component="comp-b", error="boom"),
+        ev.CircuitBreakerTripped(component="comp-b", iterations=5, error="no progress"),
+        ev.ComponentRetrying(component="comp-b", attempt=2, reason="verify failed"),
+        ev.VerificationResultEvent(
+            component="comp-a", passed=True, checks=("tests", "lint"),
+            failures=(), duration_seconds=3.5,
+        ),
+        ev.ReviewResultEvent(
+            component="comp-a", passed=False, mode="hard", fail_count=2,
+            advisory_count=1, duration_seconds=60.0,
+        ),
+        ev.ComponentUsage(
+            component="comp-a", phase="engineer", calls=3, known_calls=2,
+            unreported_calls=1, input_tokens=100, output_tokens=50,
+            cache_read_tokens=10, cache_creation_tokens=5, total_tokens=165,
+            cost_usd=0.123456, duration_seconds=42.0,
+        ),
+        ev.BudgetExceeded(component="comp-a", total_tokens=100, max_total_tokens=50),
+        ev.ContractResult(tier=1, passed=False, breaker="comp-a", duration_seconds=9.9),
+        ev.RunCompleted(completed=2, failed=1, skipped=0, duration_seconds=100.0),
+        ev.MergePendingV1(component="comp-a", pr_url="http://pr/1", error="not confirmed"),
+        ev.PhaseSkipped(component="comp-a", phase="security", reason="budget"),
+        ev.DiffFetchFailed(component="comp-a", error="git failed"),
+        ev.DiffUnsplittable(component="comp-a", error="one hunk", diff_chars=99999),
+        ev.DiffChunked(component="comp-a", chunks=3, diff_chars=50000),
+        ev.ChunkBudgetInsufficient(component="comp-a", phase="review", chunks=4, remaining=2),
+        ev.AdversarialAgentSelected(
+            phase="review", agent_source="config", identity="codex (gpt-5)",
+            agent_type="codex", model="gpt-5", homogeneous=True,
+        ),
+        ev.RunPlan(
+            components=({"id": "comp-a", "title": "A", "deps": []},),
+            max_total_tokens=1000, max_adversarial_calls=10,
+        ),
+        ev.PhaseStarted(component="comp-a", phase="review", attempt=1),
+        ev.PhaseCompleted(component="comp-a", phase="review", passed=True,
+                          detail="", duration_seconds=30.0),
+        ev.IterationStarted(component="comp-a", iteration=1, max_iterations=10),
+        ev.IterationCompleted(component="comp-a", iteration=1,
+                              duration_seconds=20.0, completed=False, timed_out=False),
+        ev.WorkerHeartbeat(component="comp-a", pid=123, elapsed_seconds=45.0),
+        ev.CheckpointRequested(component="comp-a", kind="checkpoint",
+                               question="Approve?"),
+        ev.CheckpointResolved(component="comp-a", kind="checkpoint",
+                              decision="approved", decided_by="operator"),
+        ev.PrCreated(component="comp-a", pr_number=7, pr_url="http://pr/7"),
+        ev.PrMerged(component="comp-a", pr_number=7, pr_url="http://pr/7"),
+        ev.PrMergePending(component="comp-a", pr_url="http://pr/7", error="pending"),
+        ev.DistillResult(component="comp-a", facts_written=3, duration_seconds=12.0),
+        ev.FindingRecorded(component="comp-a", phase="review", category="test_quality",
+                           severity="fail", location="a.py:10",
+                           explanation="weak assert", attempt=1),
+        ev.Log(severity="warn", kind="kv", key="Root", text="/tmp/x"),
+    ]
+
+
+class TestRoundTrip:
+    def test_every_registered_type_round_trips(self) -> None:
+        for event in _sample_events():
+            stamped = ev.EventBus(run_id="r1").emit(event)
+            line = stamped.to_json_line()
+            parsed = ev.parse_event_line(line)
+            assert parsed is not None
+            assert type(parsed) is type(event), line
+            assert parsed.to_dict()["data"] == stamped.to_dict()["data"]
+            assert parsed.run_id == "r1"
+            assert parsed.seq == stamped.seq
+            assert parsed.ts == pytest.approx(stamped.ts)
+
+    def test_sample_covers_registry(self) -> None:
+        """Every registered type except the UnknownEvent fallback is
+        exercised by the round-trip test; a new event added without a
+        sample here fails loudly."""
+        sampled = {type(e).type for e in _sample_events()}
+        registered = set(ev._REGISTRY) - {"unknown"}
+        assert sampled == registered
+
+
+class TestTolerantDecode:
+    def test_unknown_event_name(self) -> None:
+        obj = {"schema": 2, "event": "flux_capacitor", "ts": 1.0, "run_id": "r",
+               "component": "c", "source": "orchestrator", "seq": 3,
+               "data": {"x": 1}}
+        event = ev.event_from_dict(obj)
+        assert isinstance(event, ev.UnknownEvent)
+        assert event.type_name == "flux_capacitor"
+        assert event.to_dict() == obj  # lossless re-serialization
+        assert event.component == "c"
+
+    def test_extra_keys_ignored(self) -> None:
+        obj = {"event": "component_failed", "data": {"error": "x", "novel_key": 1}}
+        event = ev.event_from_dict(obj)
+        assert isinstance(event, ev.ComponentFailed)
+        assert event.error == "x"
+
+    def test_missing_keys_default(self) -> None:
+        event = ev.event_from_dict({"event": "component_completed", "data": {}})
+        assert isinstance(event, ev.ComponentCompleted)
+        assert event.duration_seconds == 0.0
+        assert event.iterations == 0
+
+    def test_mistyped_values_degrade_to_defaults(self) -> None:
+        obj = {"event": "component_completed",
+               "data": {"duration_seconds": "fast", "iterations": 3}}
+        event = ev.event_from_dict(obj)
+        assert isinstance(event, ev.ComponentCompleted)
+        assert event.duration_seconds == 0.0  # mistyped -> default
+        assert event.iterations == 3          # well-typed -> kept
+
+    def test_bool_not_accepted_as_int(self) -> None:
+        obj = {"event": "component_completed", "data": {"iterations": True}}
+        event = ev.event_from_dict(obj)
+        assert isinstance(event, ev.ComponentCompleted)
+        assert event.iterations == 0
+
+    def test_int_accepted_for_float_field(self) -> None:
+        obj = {"event": "component_completed", "data": {"duration_seconds": 5}}
+        event = ev.event_from_dict(obj)
+        assert isinstance(event, ev.ComponentCompleted)
+        assert event.duration_seconds == 5.0
+
+    def test_list_becomes_tuple(self) -> None:
+        obj = {"event": "verification_result", "data": {"checks": ["a", "b"]}}
+        event = ev.event_from_dict(obj)
+        assert isinstance(event, ev.VerificationResultEvent)
+        assert event.checks == ("a", "b")
+
+    def test_non_dict_and_torn_lines(self) -> None:
+        assert ev.parse_event_line("") is None
+        assert ev.parse_event_line("   ") is None
+        assert ev.parse_event_line("[1, 2]") is None
+        assert ev.parse_event_line('{"event": "log", "data"') is None  # torn
+
+    def test_mangled_envelope_never_raises(self) -> None:
+        obj: dict[str, Any] = {"event": "log", "ts": "yesterday", "seq": "first",
+                               "run_id": 7, "component": None, "source": 3,
+                               "data": None}
+        event = ev.event_from_dict(obj)
+        assert event.ts == 0.0
+        assert event.seq == 0
+        assert event.run_id == ""
+        assert event.component == ""
+
+
+class TestReadEvents:
+    def test_missing_file(self, tmp_path: Path) -> None:
+        assert ev.read_events(tmp_path / "nope.jsonl") == []
+
+    def test_torn_tail_skipped(self, tmp_path: Path) -> None:
+        p = tmp_path / "events.jsonl"
+        good = ev.Log(text="hello").to_json_line()
+        p.write_text(good + "\n" + good[: len(good) // 2])
+        events = ev.read_events(p)
+        assert len(events) == 1
+        assert isinstance(events[0], ev.Log)
+
+    def test_seeded_replay_through_jsonl_sink(self, tmp_path: Path) -> None:
+        rng = random.Random(0)
+        pool = _sample_events()
+        chosen = [pool[rng.randrange(len(pool))] for _ in range(200)]
+        sink = ev.JsonlSink(tmp_path / "events.jsonl")
+        bus = ev.EventBus(sink, run_id="replay")
+        for event in chosen:
+            bus.emit(event)
+        bus.close()
+        back = ev.read_events(tmp_path / "events.jsonl")
+        assert len(back) == len(chosen)
+        assert [type(e) for e in back] == [type(e) for e in chosen]
+        assert [e.seq for e in back] == list(range(1, len(chosen) + 1))
+
+
+class TestEventBus:
+    def test_stamps_envelope(self) -> None:
+        bus = ev.EventBus(run_id="r9", source="worker", component="comp-x")
+        stamped = bus.emit(ev.Log(text="hi"))
+        assert stamped.run_id == "r9"
+        assert stamped.source == "worker"
+        assert stamped.component == "comp-x"
+        assert stamped.seq == 1
+        assert stamped.ts > 0
+
+    def test_explicit_component_wins_over_bus_default(self) -> None:
+        bus = ev.EventBus(component="bus-comp")
+        stamped = bus.emit(ev.ComponentFailed(component="explicit", error="e"))
+        assert stamped.component == "explicit"
+
+    def test_sink_exception_is_isolated_and_counted(self) -> None:
+        class Boom:
+            def emit(self, event: ev.Event) -> None:
+                raise RuntimeError("sink died")
+
+            def close(self) -> None:
+                raise RuntimeError("close died")
+
+        received: list[ev.Event] = []
+        bus = ev.EventBus(Boom(), ev.CallbackSink(received.append))
+        bus.emit(ev.Log(text="x"))
+        bus.close()
+        assert len(received) == 1  # later sink still ran
+        assert bus.dropped == 2  # one emit failure + one close failure
+
+    def test_add_sink_late(self, tmp_path: Path) -> None:
+        bus = ev.EventBus()
+        bus.emit(ev.Log(text="before"))
+        sink = ev.JsonlSink(tmp_path / "late.jsonl")
+        bus.add_sink(sink)
+        bus.emit(ev.Log(text="after"))
+        bus.close()
+        back = ev.read_events(tmp_path / "late.jsonl")
+        assert [e.to_dict()["data"]["text"] for e in back] == ["after"]
+
+
+def _strip_ts(event_dict: dict[str, Any]) -> dict[str, Any]:
+    out = dict(event_dict)
+    out.pop("ts", None)
+    return out
+
+
+class TestV1CompatGoldenParity:
+    """V1CompatSink(ProgressLog) output == direct ProgressLog calls."""
+
+    def test_named_methods_parity(self, tmp_path: Path) -> None:
+        direct_path = tmp_path / "direct.jsonl"
+        compat_path = tmp_path / "compat.jsonl"
+        direct = ProgressLog(direct_path, run_id="run-1")
+        compat = ProgressLog(compat_path, run_id="run-1")
+        bus = ev.EventBus(ev.V1CompatSink(compat), run_id="run-1")
+
+        direct.factory_started("proj", 3)
+        bus.emit(ev.RunStarted(project="proj", components=3))
+
+        direct.component_started("comp-a")
+        bus.emit(ev.ComponentStarted(component="comp-a"))
+
+        direct.component_completed("comp-a", 12.339, 4)
+        bus.emit(ev.ComponentCompleted(component="comp-a",
+                                       duration_seconds=12.339, iterations=4))
+
+        direct.component_failed("comp-b", "boom")
+        bus.emit(ev.ComponentFailed(component="comp-b", error="boom"))
+
+        direct.circuit_breaker_tripped("comp-b", 5, "stall")
+        bus.emit(ev.CircuitBreakerTripped(component="comp-b", iterations=5,
+                                          error="stall"))
+
+        direct.component_retrying("comp-b", 2, "verify failed")
+        bus.emit(ev.ComponentRetrying(component="comp-b", attempt=2,
+                                      reason="verify failed"))
+
+        direct.verification_result("comp-a", True, ["tests"], [], 3.456)
+        bus.emit(ev.VerificationResultEvent(
+            component="comp-a", passed=True, checks=("tests",), failures=(),
+            duration_seconds=3.456))
+
+        direct.review_result("comp-a", False, "hard", 2, 1, 60.0)
+        bus.emit(ev.ReviewResultEvent(
+            component="comp-a", passed=False, mode="hard", fail_count=2,
+            advisory_count=1, duration_seconds=60.0))
+
+        usage = {"calls": 3, "known_calls": 2, "unreported_calls": 1,
+                 "input_tokens": 100, "output_tokens": 50,
+                 "cache_read_tokens": 10, "cache_creation_tokens": 5,
+                 "total_tokens": 165, "cost_usd": 0.123456,
+                 "duration_seconds": 42.0}
+        direct.component_usage("comp-a", "engineer", dict(usage))
+        bus.emit(ev.ComponentUsage(component="comp-a", phase="engineer", **usage))
+
+        direct.budget_exceeded("comp-a", 100, 50)
+        bus.emit(ev.BudgetExceeded(component="comp-a", total_tokens=100,
+                                   max_total_tokens=50))
+
+        direct.contract_result(1, False, "comp-a", 9.876)
+        bus.emit(ev.ContractResult(tier=1, passed=False, breaker="comp-a",
+                                   duration_seconds=9.876))
+
+        direct.factory_completed(2, 1, 0, 100.0)
+        bus.emit(ev.RunCompleted(completed=2, failed=1, skipped=0,
+                                 duration_seconds=100.0))
+
+        direct.emit("merge_pending", "comp-a",
+                    {"pr_url": "http://pr/1", "error": "not confirmed"})
+        bus.emit(ev.MergePendingV1(component="comp-a", pr_url="http://pr/1",
+                                   error="not confirmed"))
+
+        direct.emit("phase_skipped", "comp-a",
+                    {"phase": "security", "reason": "budget"})
+        bus.emit(ev.PhaseSkipped(component="comp-a", phase="security",
+                                 reason="budget"))
+
+        direct.emit("diff_fetch_failed", "comp-a", {"error": "git failed"})
+        bus.emit(ev.DiffFetchFailed(component="comp-a", error="git failed"))
+
+        direct.emit("diff_unsplittable", "comp-a",
+                    {"error": "one hunk", "diff_chars": 99999})
+        bus.emit(ev.DiffUnsplittable(component="comp-a", error="one hunk",
+                                     diff_chars=99999))
+
+        direct.emit("diff_chunked", "comp-a", {"chunks": 3, "diff_chars": 50000})
+        bus.emit(ev.DiffChunked(component="comp-a", chunks=3, diff_chars=50000))
+
+        direct.emit("chunk_budget_insufficient", "comp-a",
+                    {"phase": "review", "chunks": 4, "remaining": 2})
+        bus.emit(ev.ChunkBudgetInsufficient(component="comp-a", phase="review",
+                                            chunks=4, remaining=2))
+
+        direct.emit("adversarial_agent_selected", data={
+            "phase": "review", "source": "config", "identity": "codex (gpt-5)",
+            "agent_type": "codex", "model": "gpt-5", "homogeneous": True,
+        })
+        bus.emit(ev.AdversarialAgentSelected(
+            phase="review", agent_source="config", identity="codex (gpt-5)",
+            agent_type="codex", model="gpt-5", homogeneous=True))
+
+        direct_lines = [_strip_ts(e) for e in read_progress_events(direct_path)]
+        compat_lines = [_strip_ts(e) for e in read_progress_events(compat_path)]
+        assert compat_lines == direct_lines
+        assert len(direct_lines) == 19  # every v1-named event type exercised
+
+    def test_v2_only_events_are_dropped(self, tmp_path: Path) -> None:
+        compat_path = tmp_path / "compat.jsonl"
+        bus = ev.EventBus(ev.V1CompatSink(ProgressLog(compat_path, run_id="r")),
+                          run_id="r")
+        bus.emit(ev.RunPlan(components=({"id": "a", "title": "A", "deps": []},)))
+        bus.emit(ev.PhaseStarted(component="a", phase="verify", attempt=1))
+        bus.emit(ev.WorkerHeartbeat(component="a", pid=1, elapsed_seconds=1.0))
+        bus.emit(ev.Log(text="narration"))
+        bus.emit(ev.PrMerged(component="a", pr_number=1, pr_url="u"))
+        assert read_progress_events(compat_path) == []
+
+    def test_progress_sinks_still_fed(self, tmp_path: Path) -> None:
+        """R7.4 ProgressSink observers (e.g. Linear) attached to the
+        wrapped ProgressLog receive events emitted through the bus."""
+        seen: list[dict[str, Any]] = []
+
+        class Recorder:
+            def handle_event(self, event: dict[str, Any]) -> None:
+                seen.append(event)
+
+        log = ProgressLog(tmp_path / "p.jsonl", run_id="r")
+        log.attach_sink(Recorder())
+        bus = ev.EventBus(ev.V1CompatSink(log), run_id="r")
+        bus.emit(ev.ComponentStarted(component="comp-a"))
+        bus.emit(ev.Log(text="dropped for v1"))
+        assert [e["event"] for e in seen] == ["component_started"]
+
+
+class TestRunPaths:
+    def test_layout(self, tmp_path: Path) -> None:
+        rp = ev.RunPaths.for_run(tmp_path, "run-42")
+        assert rp.events_file == tmp_path / ".ralph" / "runs" / "run-42" / "events.jsonl"
+        assert rp.engineer_events("c1").name == "engineer.jsonl"
+        assert rp.engineer_log("c1").parent == rp.component_dir("c1")
+        assert rp.phase_log("c1", "review").name == "review.log"
+
+
+class TestJsonlSink:
+    def test_append_and_reopen(self, tmp_path: Path) -> None:
+        p = tmp_path / "s.jsonl"
+        sink = ev.JsonlSink(p)
+        sink.emit(ev.EventBus().emit(ev.Log(text="one")))
+        sink.close()
+        sink2 = ev.JsonlSink(p)
+        sink2.emit(ev.EventBus().emit(ev.Log(text="two")))
+        sink2.close()
+        texts = [json.loads(line)["data"]["text"] for line in p.read_text().splitlines()]
+        assert texts == ["one", "two"]


### PR DESCRIPTION
## Summary

Chunk 1 of the TUI rewrite plan (stacked on #101). Adds `ralph_py/events.py` + `tests/test_events.py`. Purely additive - nothing consumes the module yet (dual-write is chunk 3).

- Typed frozen event dataclasses, registry via `__init_subclass__`, schema-2 envelope `{schema, event, ts, run_id, component, source, seq, data}` stamped only by `EventBus.emit`.
- Full catalogue: all 19 v1 `progress.jsonl` event types 1:1 (re-enumerated from current main, including R7.5's `circuit_breaker_tripped`) + v2-only events (`run_plan` with DAG + budget caps, `phase_started/completed`, iterations, `worker_heartbeat`, checkpoint request/resolve, `pr_created/merged/merge_pending`, `distill_result`, `finding_recorded`, `log`).
- **Total decode**: unknown event names -> lossless `UnknownEvent`; extra keys ignored; missing keys default; mistyped values degrade per-field; torn tail lines -> `None`. Forward-compat contract for every future consumer.
- Sinks: `JsonlSink` (thread-safe append), `CallbackSink`, `NullSink`, and `V1CompatSink` which **delegates to a real `ProgressLog`** - preserving both the v1 file bytes and the R7.4 `ProgressSink` fan-out (the Linear sink keeps receiving events untouched).
- `RunPaths`: canonical `.ralph/runs/<run_id>/` layout (events.jsonl + per-component engineer.jsonl/engineer.log/phase logs).

## Tests (23)

Round-trip of every registered type with a registry-coverage guard (a new event without a test sample fails loudly), tolerant-decode matrix, torn-tail/missing-file readers, seeded 200-event replay through `JsonlSink`, sink-failure isolation, and the load-bearing **golden parity test**: `V1CompatSink` output vs direct `ProgressLog` calls, per v1 event type, equal modulo `ts` - plus a test that attached ProgressSinks still fire and v2-only events are dropped.

Gates: full fast tier 1532+23 passed, `mypy --strict` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)