### PR TITLE
TUI chunk 3: orchestrator dual-write onto the EventBus

### DIFF
--- a/ralph_py/events.py
+++ b/ralph_py/events.py
@@ -271,12 +271,14 @@ class ChunkBudgetInsufficient(Event):
 
 @dataclass(frozen=True, kw_only=True)
 class AdversarialAgentSelected(Event):
+    """Preserve unset agent metadata as JSON null in the v1 projection."""
+
     type: ClassVar[str] = "adversarial_agent_selected"
     phase: str = ""
     agent_source: str = ""
     identity: str = ""
-    agent_type: str = ""
-    model: str = ""
+    agent_type: str | None = None
+    model: str | None = None
     homogeneous: bool = False
 
 

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -24,6 +24,20 @@ from ralph_py.contract import (
     ContractResult,
     run_contract_testing,
 )
+from ralph_py.events import (
+    AdversarialAgentSelected,
+    ComponentFailed,
+    ComponentStarted,
+    EventBus,
+    JsonlSink,
+    RunCompleted,
+    RunPaths,
+    RunStarted,
+    V1CompatSink,
+)
+from ralph_py.events import (
+    ContractResult as ContractResultEvent,
+)
 from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
 from ralph_py.fixtures import FixturesConfig
 from ralph_py.git import fetch_base_branch, resolve_base_ref
@@ -1292,7 +1306,15 @@ def _run_factory_locked(
     # join; [factory] progress_log_enabled = false (or env) opts out.
     # Every event carries run_id so runs sharing the default file stay
     # distinguishable.
+    # Dual-write (TUI rewrite chunk 3): typed schema-v2 events go to
+    # .ralph/runs/<run_id>/events.jsonl via the EventBus; V1CompatSink
+    # delegates the v1-named subset to a real ProgressLog so the
+    # progress.jsonl byte format AND its attached ProgressSink
+    # observers (Linear, R7.4) stay untouched. progress_log_enabled =
+    # false suppresses BOTH files (symmetric opt-out).
     progress_log: ProgressLog
+    bus = EventBus(run_id=run_id)
+    journal_path: Path | None = None
     if not factory_config.progress_log_enabled:
         progress_log = NullProgressLog()
     else:
@@ -1301,6 +1323,10 @@ def _run_factory_locked(
             or root_dir / ".ralph" / "progress.jsonl"
         )
         progress_log = ProgressLog(log_path, run_id=run_id, warn=ui.warn)
+        journal_path = log_path
+        run_paths = RunPaths.for_run(root_dir, run_id)
+        bus.add_sink(JsonlSink(run_paths.events_file))
+        bus.add_sink(V1CompatSink(progress_log))
 
     # R7.4: Linear sink - mirrors failure/budget events onto the issues
     # the decompose hook mapped in the manifest. Observability only;
@@ -1324,7 +1350,9 @@ def _run_factory_locked(
         warn=ui.warn,
     )
 
-    progress_log.factory_started(manifest.project_name, len(manifest.components))
+    bus.emit(RunStarted(
+        project=manifest.project_name, components=len(manifest.components),
+    ))
 
     # R7.1: resolve which model family reviews this run's diffs ONCE so
     # the choice is stable across components and the homogeneity warning
@@ -1375,17 +1403,14 @@ def _run_factory_locked(
             continue
         if _sel.warning:
             ui.warn(f"  {_sel.warning}")
-        progress_log.emit(
-            "adversarial_agent_selected",
-            data={
-                "phase": _sel.phase,
-                "source": _sel.source,
-                "identity": _sel.identity,
-                "agent_type": _sel.agent_type,
-                "model": _sel.model,
-                "homogeneous": _sel.warning is not None,
-            },
-        )
+        bus.emit(AdversarialAgentSelected(
+            phase=_sel.phase,
+            agent_source=_sel.source,
+            identity=_sel.identity,
+            agent_type=_sel.agent_type,
+            model=_sel.model,
+            homogeneous=_sel.warning is not None,
+        ))
 
     # Validate DAG
     ui.section("Factory: Validating DAG")
@@ -1448,7 +1473,8 @@ def _run_factory_locked(
         ui=ui,
         root_dir=root_dir,
         run_id=run_id,
-        progress_log=progress_log,
+        bus=bus,
+        journal_path=journal_path,
         notify=notify,
         review_selection=review_selection,
         security_selection=security_selection,
@@ -1718,7 +1744,7 @@ def _run_factory_locked(
                         continue
                     pipeline.begin_attempt(comp)
                     manifest.save(manifest_path)
-                    progress_log.component_started(comp.id)
+                    bus.emit(ComponentStarted(component=comp.id))
                     ui.info(f"  Starting: {comp.id}")
 
                     wt_path = _launch_component(comp)
@@ -1914,9 +1940,10 @@ def _run_factory_locked(
             break
 
         for cr in contract_results:
-            progress_log.contract_result(
-                cr.tier, cr.passed, cr.breaker, cr.duration_seconds,
-            )
+            bus.emit(ContractResultEvent(
+                tier=cr.tier, passed=cr.passed, breaker=cr.breaker,
+                duration_seconds=round(cr.duration_seconds, 2),
+            ))
             _record_contract_event(cr)
 
         failures = [cr for cr in contract_results if not cr.passed]
@@ -1983,11 +2010,13 @@ def _run_factory_locked(
                     factory_result.completed.remove(cr.breaker)
                 if cr.breaker not in factory_result.failed:
                     factory_result.failed.append(cr.breaker)
-                progress_log.component_failed(
-                    cr.breaker,
-                    f"Contract test failed at tier {cr.tier} "
-                    f"(retries exhausted)",
-                )
+                bus.emit(ComponentFailed(
+                    component=cr.breaker,
+                    error=(
+                        f"Contract test failed at tier {cr.tier} "
+                        f"(retries exhausted)"
+                    ),
+                ))
                 notify.fire_first_failure(
                     cr.breaker,
                     f"Contract test failed at tier {cr.tier} "
@@ -2031,12 +2060,13 @@ def _run_factory_locked(
 
     # Summary
     factory_duration = time.monotonic() - factory_start
-    progress_log.factory_completed(
-        len(factory_result.completed),
-        len(factory_result.failed),
-        len(factory_result.skipped),
-        factory_duration,
-    )
+    bus.emit(RunCompleted(
+        completed=len(factory_result.completed),
+        failed=len(factory_result.failed),
+        skipped=len(factory_result.skipped),
+        duration_seconds=round(factory_duration, 2),
+    ))
+    bus.close()
 
     # R0.2: collect components parked awaiting merge confirmation. Built
     # from the manifest (not accumulated during the run) so it reflects
@@ -2082,14 +2112,14 @@ def _run_factory_locked(
                 )
             if (
                 failed_comp.journal_offset_start >= 0
-                and not isinstance(progress_log, NullProgressLog)
+                and journal_path is not None
             ):
                 end = (
                     str(failed_comp.journal_offset_end)
                     if failed_comp.journal_offset_end >= 0 else "end"
                 )
                 ui.info(
-                    f"    journal: {progress_log.path} bytes "
+                    f"    journal: {journal_path} bytes "
                     f"[{failed_comp.journal_offset_start}:{end}]"
                 )
             ui.info(f"    retry with: ralph retry {failed_id}")

--- a/ralph_py/pipeline.py
+++ b/ralph_py/pipeline.py
@@ -37,13 +37,14 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from ralph_py import events as ev
 from ralph_py import git
 from ralph_py.agents.base import UsageTotals, collect_usage
 from ralph_py.context import IterationContext, IterationRecord
 from ralph_py.findings import Finding, tag_finding_with_attempt
 from ralph_py.fixtures import FixturesConfig
 from ralph_py.manifest import Component, ComponentStatus, Manifest
-from ralph_py.observability import NotifyHooks, NullProgressLog, ProgressLog
+from ralph_py.observability import NotifyHooks
 from ralph_py.prd import PRD
 from ralph_py.review import ReviewMode, ReviewResult
 from ralph_py.security import SecurityMode, SecurityResult
@@ -235,7 +236,8 @@ class ComponentPipeline:
         ui: UI,
         root_dir: Path,
         run_id: str,
-        progress_log: ProgressLog | NullProgressLog,
+        bus: ev.EventBus,
+        journal_path: Path | None,
         notify: NotifyHooks,
         review_selection: AdversarialAgentSelection,
         security_selection: AdversarialAgentSelection | None,
@@ -254,7 +256,8 @@ class ComponentPipeline:
         self.ui = ui
         self.root_dir = root_dir
         self.run_id = run_id
-        self.progress_log = progress_log
+        self.bus = bus
+        self.journal_path = journal_path
         self.notify = notify
         self.review_selection = review_selection
         self.security_selection = security_selection
@@ -324,7 +327,9 @@ class ComponentPipeline:
         )
         slot.merge(totals)
         self.run_usage.merge(totals)
-        self.progress_log.component_usage(comp_id, phase, totals.to_dict())
+        self.bus.emit(ev.ComponentUsage(
+            component=comp_id, phase=phase, **totals.to_dict(),
+        ))
 
     def token_budget_exceeded(self) -> bool:
         cap = self.factory_config.max_total_tokens
@@ -335,14 +340,19 @@ class ComponentPipeline:
     # ------------------------------------------------------------------
 
     def _journal_offset(self) -> int:
-        """Current byte size of the progress log; used to bracket one
+        """Current byte size of the v1 progress log; used to bracket one
         attempt's slice of events (R3.3). -1 when no real progress log
-        is configured for this run."""
-        if isinstance(self.progress_log, NullProgressLog):
+        is configured for this run. Deliberately pegged to the v1 compat
+        file, NOT events.jsonl - the manifest's journal_offset_start/end
+        semantics must not silently repoint (plan: explicit future
+        schema decision)."""
+        if self.journal_path is None:
             return -1
         try:
-            log_path = self.progress_log.path
-            return log_path.stat().st_size if log_path.exists() else 0
+            return (
+                self.journal_path.stat().st_size
+                if self.journal_path.exists() else 0
+            )
         except OSError:
             return -1
 
@@ -511,7 +521,9 @@ class ComponentPipeline:
             comp.error = error
             if context_json:
                 self.component_contexts[comp.id] = context_json
-            self.progress_log.component_retrying(comp.id, comp.retries, error)
+            self.bus.emit(ev.ComponentRetrying(
+                component=comp.id, attempt=comp.retries, reason=error,
+            ))
             self.ui.info(
                 f"  Retrying '{comp.id}' "
                 f"(attempt {comp.retries}/{self.factory_config.max_retries}): "
@@ -547,7 +559,7 @@ class ComponentPipeline:
         skipped = self.manifest.cascade_skip(comp.id)
         self.factory_result.failed.append(comp.id)
         self.factory_result.skipped.extend(skipped)
-        self.progress_log.component_failed(comp.id, error)
+        self.bus.emit(ev.ComponentFailed(component=comp.id, error=error))
         self.notify.fire_first_failure(comp.id, error)
         self.ui.err(f"  Failed: {comp.id}: {error[:80]}")
         self.manifest.save(self.manifest_path)
@@ -569,10 +581,11 @@ class ComponentPipeline:
         self._add_findings(comp, [Finding.infrastructure_error(
             phase=phase, explanation=error,
         )])
-        self.progress_log.budget_exceeded(
-            comp.id, self.run_usage.total_tokens,
-            self.factory_config.max_total_tokens,
-        )
+        self.bus.emit(ev.BudgetExceeded(
+            component=comp.id,
+            total_tokens=self.run_usage.total_tokens,
+            max_total_tokens=self.factory_config.max_total_tokens,
+        ))
         return self.fail(
             comp, error, phase=phase, check="token_budget",
             signatures=["token_budget:exceeded"],
@@ -589,9 +602,10 @@ class ComponentPipeline:
         comp.completed_at = _iso_now()
         self._end_attempt(comp)
         self.factory_result.completed.append(comp.id)
-        self.progress_log.component_completed(
-            comp.id, duration_seconds, iterations,
-        )
+        self.bus.emit(ev.ComponentCompleted(
+            component=comp.id, duration_seconds=duration_seconds,
+            iterations=iterations,
+        ))
         self.ui.ok(
             f"  COMPLETED: {comp.id} "
             f"({iterations} iterations, "
@@ -609,10 +623,9 @@ class ComponentPipeline:
         merge_pending event so the slice includes it."""
         comp.status = ComponentStatus.MERGE_PENDING.value
         comp.error = error
-        self.progress_log.emit(
-            "merge_pending", comp.id,
-            {"pr_url": comp.pr_url, "error": comp.error},
-        )
+        self.bus.emit(ev.MergePendingV1(
+            component=comp.id, pr_url=comp.pr_url, error=comp.error,
+        ))
         self.notify.fire_merge_pending(comp.id, comp.error)
         self._end_attempt(comp)
         self.ui.warn(
@@ -695,7 +708,7 @@ class ComponentPipeline:
         skipped = self.manifest.cascade_skip(comp.id)
         self.factory_result.failed.append(comp.id)
         self.factory_result.skipped.extend(skipped)
-        self.progress_log.component_failed(comp.id, comp.error)
+        self.bus.emit(ev.ComponentFailed(component=comp.id, error=comp.error))
         self.notify.fire_first_failure(comp.id, comp.error)
         self.ui.err(f"  Failed: {comp.id}: {comp.error[:120]}")
         self.manifest.save(self.manifest_path)
@@ -728,9 +741,9 @@ class ComponentPipeline:
             skipped = self.manifest.cascade_skip(comp_id)
             self.factory_result.failed.append(comp_id)
             self.factory_result.skipped.extend(skipped)
-            self.progress_log.component_failed(
-                comp_id, "component timeout",
-            )
+            self.bus.emit(ev.ComponentFailed(
+                component=comp_id, error="component timeout",
+            ))
             self.notify.fire_first_failure(comp_id, "component timeout")
         self.ui.err(
             f"  Failed: {comp_id}: component timeout "
@@ -792,9 +805,11 @@ class ComponentPipeline:
                     self.component_failure_signatures.pop(comp.id, None)
                     comp.completed_at = _iso_now()
                     self.factory_result.completed.append(comp.id)
-                    self.progress_log.component_completed(
-                        comp.id, comp.duration_seconds, comp.iteration_count,
-                    )
+                    self.bus.emit(ev.ComponentCompleted(
+                        component=comp.id,
+                        duration_seconds=comp.duration_seconds,
+                        iterations=comp.iteration_count,
+                    ))
                     self.ui.ok(
                         f"  PR #{pr_number} merged; '{comp.id}' completed"
                     )
@@ -810,7 +825,9 @@ class ComponentPipeline:
                     skipped = self.manifest.cascade_skip(comp.id)
                     self.factory_result.failed.append(comp.id)
                     self.factory_result.skipped.extend(skipped)
-                    self.progress_log.component_failed(comp.id, comp.error)
+                    self.bus.emit(ev.ComponentFailed(
+                        component=comp.id, error=comp.error,
+                    ))
                     self.notify.fire_first_failure(comp.id, comp.error)
                     self.ui.err(f"  Failed: {comp.id}: {comp.error}")
                 else:
@@ -831,10 +848,9 @@ class ComponentPipeline:
         the findings stream and the journal, so "ran clean" and
         "never ran" are distinguishable downstream."""
         self._add_findings(comp, [Finding.phase_skipped(phase, reason)])
-        self.progress_log.emit(
-            "phase_skipped", comp.id,
-            {"phase": phase, "reason": reason},
-        )
+        self.bus.emit(ev.PhaseSkipped(
+            component=comp.id, phase=phase, reason=reason,
+        ))
 
     def process_result(
         self, comp_id: str, comp_result: ComponentResult,
@@ -876,9 +892,10 @@ class ComponentPipeline:
             # signature for the evolution journal.
             if comp_result.no_progress:
                 error = comp_result.error or "no-progress circuit breaker tripped"
-                self.progress_log.circuit_breaker_tripped(
-                    comp_id, comp_result.iterations, error,
-                )
+                self.bus.emit(ev.CircuitBreakerTripped(
+                    component=comp_id, iterations=comp_result.iterations,
+                    error=error,
+                ))
                 return PipelineOutcome(
                     transition=self.fail(
                         comp, error,
@@ -1107,14 +1124,14 @@ class ComponentPipeline:
         )
         verify_duration = time.monotonic() - verify_start
         comp.verification_passed = verification.passed
-        self.progress_log.verification_result(
-            comp.id, verification.passed,
-            check_names=[c.name for c in verification.checks],
-            failures=[
+        self.bus.emit(ev.VerificationResultEvent(
+            component=comp.id, passed=verification.passed,
+            checks=tuple(c.name for c in verification.checks),
+            failures=tuple(
                 c.message for c in verification.checks if not c.passed
-            ],
-            duration=verify_duration,
-        )
+            ),
+            duration_seconds=round(verify_duration, 2),
+        ))
 
         if not verification.passed:
             failing = [c for c in verification.checks if not c.passed]
@@ -1174,9 +1191,7 @@ class ComponentPipeline:
                     f"review/security/knowledge cannot run: {exc}"
                 ),
             )])
-            self.progress_log.emit(
-                "diff_fetch_failed", comp.id, {"error": str(exc)},
-            )
+            self.bus.emit(ev.DiffFetchFailed(component=comp.id, error=str(exc)))
             ctx = IterationContext.from_json(comp_result.context_json or "{}")
             ctx.add_verification_failure(
                 f"git diff against {self.manifest.base_branch} failed: {exc}"
@@ -1233,10 +1248,10 @@ class ComponentPipeline:
                         "(R1.4: an unreviewable diff must not merge)"
                     ),
                 )])
-                self.progress_log.emit(
-                    "diff_unsplittable", comp.id,
-                    {"error": str(exc), "diff_chars": len(review_diff)},
-                )
+                self.bus.emit(ev.DiffUnsplittable(
+                    component=comp.id, error=str(exc),
+                    diff_chars=len(review_diff),
+                ))
                 ctx = IterationContext.from_json(
                     comp_result.context_json or "{}",
                 )
@@ -1260,13 +1275,10 @@ class ComponentPipeline:
                         signatures=["review:diff-unsplittable"],
                     ),
                 )
-            self.progress_log.emit(
-                "diff_chunked", comp.id,
-                {
-                    "chunks": len(review_chunks),
-                    "diff_chars": len(review_diff),
-                },
-            )
+            self.bus.emit(ev.DiffChunked(
+                component=comp.id, chunks=len(review_chunks),
+                diff_chars=len(review_diff),
+            ))
 
         return DiffPhaseResult(
             diff=shared_diff, review_diff=review_diff, chunks=review_chunks,
@@ -1321,14 +1333,10 @@ class ComponentPipeline:
                 self._add_findings(comp, [Finding.infrastructure_error(
                     phase="review", explanation=error,
                 )])
-                self.progress_log.emit(
-                    "chunk_budget_insufficient", comp.id,
-                    {
-                        "phase": "review",
-                        "chunks": len(review_chunks),
-                        "remaining": remaining,
-                    },
-                )
+                self.bus.emit(ev.ChunkBudgetInsufficient(
+                    component=comp.id, phase="review",
+                    chunks=len(review_chunks), remaining=remaining,
+                ))
                 return ReviewPhaseResult(
                     ran=False,
                     failure=PhaseFailure(
@@ -1440,13 +1448,13 @@ class ComponentPipeline:
         # historical meaning of fail_count = "failed PRD criteria".
         # Concern counts ride along separately via fail_concerns /
         # advisory_concerns so dashboards can distinguish.
-        self.progress_log.review_result(
-            comp.id, review_result.passed,
+        self.bus.emit(ev.ReviewResultEvent(
+            component=comp.id, passed=review_result.passed,
             mode=review_mode.value,
             fail_count=review_result.criterion_fail_count,
             advisory_count=review_result.criterion_advisory_count,
-            duration=review_result.duration_seconds,
-        )
+            duration_seconds=round(review_result.duration_seconds, 2),
+        ))
 
         if not review_result.passed:
             reason = (
@@ -1552,14 +1560,10 @@ class ComponentPipeline:
                 self._add_findings(comp, [Finding.infrastructure_error(
                     phase="security", explanation=error,
                 )])
-                self.progress_log.emit(
-                    "chunk_budget_insufficient", comp.id,
-                    {
-                        "phase": "security",
-                        "chunks": len(review_chunks),
-                        "remaining": remaining,
-                    },
-                )
+                self.bus.emit(ev.ChunkBudgetInsufficient(
+                    component=comp.id, phase="security",
+                    chunks=len(review_chunks), remaining=remaining,
+                ))
                 return SecurityPhaseResult(
                     ran=False,
                     failure=PhaseFailure(
@@ -1674,13 +1678,13 @@ class ComponentPipeline:
             )
 
         if sec_result is not None:
-            self.progress_log.review_result(
-                comp.id, sec_result.passed,
+            self.bus.emit(ev.ReviewResultEvent(
+                component=comp.id, passed=sec_result.passed,
                 mode=f"security-{sec_config.mode}",
                 fail_count=sec_result.critical_count + sec_result.high_count,
                 advisory_count=len(sec_result.findings),
-                duration=sec_result.duration_seconds,
-            )
+                duration_seconds=round(sec_result.duration_seconds, 2),
+            ))
 
             # E3: source-of-truth typed findings list, plus the
             # legacy rendered string for PR body / manifest readers.

--- a/tests/test_breaker.py
+++ b/tests/test_breaker.py
@@ -25,6 +25,7 @@ from ralph_py.config import RalphConfig
 from ralph_py.factory import ComponentResult
 from ralph_py.loop import run_loop
 from ralph_py.manifest import ComponentStatus
+from ralph_py.observability import read_progress_events
 from ralph_py.ui.plain import PlainUI
 
 
@@ -336,7 +337,8 @@ class TestPipelineRouting:
         assert pipeline.component_failure_signatures["comp-a"] == [
             "engineer:no-progress-stall",
         ]
-        events = pipeline.progress_log.read_events()
+        assert pipeline.journal_path is not None
+        events = read_progress_events(pipeline.journal_path)
         tripped = [
             e for e in events if e["event"] == "circuit_breaker_tripped"
         ]

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -1,0 +1,240 @@
+"""Chunk 3 (TUI rewrite): orchestrator dual-write equivalence.
+
+Runs the real run_factory with a stubbed worker and asserts the three
+contracts of the dual-write:
+
+1. .ralph/runs/<run_id>/events.jsonl exists and every line is schema 2.
+2. The v1 progress.jsonl produced through V1CompatSink is exactly the
+   projection of the v2 stream (same events, same order, same data) -
+   the load-bearing regression net for every progress.jsonl consumer.
+3. fold(events.jsonl) agrees with summarize_events(progress.jsonl) on
+   the shared fields, so ralph status can migrate in chunk 8 without
+   semantic drift.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from ralph_py import events as ev
+from ralph_py import reducer
+from ralph_py.agents.base import UsageRecord, UsageTotals
+from ralph_py.config import RalphConfig
+from ralph_py.factory import ComponentResult, FactoryConfig, run_factory
+from ralph_py.manifest import Component, Manifest
+from ralph_py.observability import (
+    latest_run_id,
+    read_progress_events,
+    summarize_events,
+)
+from ralph_py.ui.plain import PlainUI
+from ralph_py.verify import VerifyConfig
+
+
+def _setup_project(tmp_path: Path, component_ids: list[str]) -> Path:
+    ralph_dir = tmp_path / "scripts" / "ralph"
+    ralph_dir.mkdir(parents=True, exist_ok=True)
+    (ralph_dir / "prompt.md").write_text("test prompt")
+    (ralph_dir / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    (tmp_path / "ralph.toml").write_text("[knowledge]\nenabled = false\n")
+    for comp_id in component_ids:
+        feature_dir = ralph_dir / "feature" / comp_id
+        feature_dir.mkdir(parents=True, exist_ok=True)
+        (feature_dir / "prd.json").write_text(json.dumps({
+            "branchName": "test",
+            "userStories": [{
+                "id": "US-001", "title": "Test",
+                "acceptanceCriteria": ["AC1"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+    return tmp_path
+
+
+def _component(comp_id: str, deps: list[str] | None = None) -> Component:
+    return Component(
+        comp_id, comp_id.title(), "Desc", deps or [],
+        f"scripts/ralph/feature/{comp_id}/prd.json",
+        f"ralph/factory/{comp_id}",
+    )
+
+
+def _make_manifest(components: list[Component]) -> Manifest:
+    return Manifest(
+        version="1", spec_file="spec.md", project_name="test",
+        base_branch="main", single_pr=False, components=components,
+    )
+
+
+def _make_base_config(root_dir: Path) -> RalphConfig:
+    return RalphConfig(
+        prompt_file=root_dir / "scripts" / "ralph" / "prompt.md",
+        prd_file=root_dir / "scripts" / "ralph" / "prd.json",
+        sleep_seconds=0, agent_cmd="echo test",
+        ralph_branch="", ralph_branch_explicit=True,
+        ui_mode="plain", no_color=True,
+    )
+
+
+def _factory_config(tmp_path: Path, **overrides: Any) -> FactoryConfig:
+    defaults: dict[str, Any] = dict(
+        use_worktrees=False, create_prs=False, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true",
+            lint_command="true", check_diff_scope=False,
+            check_bad_patterns=False, subprocess_timeout=5.0,
+        ),
+        progress_log_path=tmp_path / "progress.jsonl",
+    )
+    defaults.update(overrides)
+    return FactoryConfig(**defaults)
+
+
+def _usage(total: int, cost: float = 0.01) -> UsageTotals:
+    totals = UsageTotals()
+    totals.add_record(UsageRecord(
+        input_tokens=total // 2, output_tokens=total - total // 2,
+        total_tokens=total, cost_usd=cost, duration_seconds=1.0,
+        source="claude-stream-json",
+    ))
+    return totals
+
+
+def _run_stub_factory(root: Path, comp_ids: list[str],
+                      success: bool = True) -> Path:
+    """Run run_factory with a stubbed worker; returns the root."""
+    _setup_project(root, comp_ids)
+    manifest = _make_manifest([_component(c) for c in comp_ids])
+    config = _factory_config(root)
+
+    def fake_component(comp_id: str, *args: Any, **kwargs: Any) -> ComponentResult:
+        return ComponentResult(
+            comp_id, success=success, iterations=2, duration_seconds=1.0,
+            error=None if success else "stub failure",
+            usage=_usage(500),
+        )
+
+    with patch(
+        "ralph_py.factory._run_component", side_effect=fake_component,
+    ), patch("ralph_py.git.get_diff_content", return_value=""):
+        run_factory(
+            manifest, config, _make_base_config(root),
+            PlainUI(no_color=True, file=io.StringIO()), root,
+        )
+    return root
+
+
+def _events_file(root: Path) -> Path:
+    run_dirs = sorted((root / ".ralph" / "runs").iterdir())
+    assert run_dirs, "no v2 run dir written"
+    return run_dirs[-1] / "events.jsonl"
+
+
+class TestDualWrite:
+    def test_v2_stream_written_all_schema_2(self, tmp_path: Path) -> None:
+        root = _run_stub_factory(tmp_path, ["comp-a", "comp-b"])
+        events_file = _events_file(root)
+        lines = [
+            json.loads(line)
+            for line in events_file.read_text().splitlines() if line.strip()
+        ]
+        assert lines, "events.jsonl is empty"
+        assert all(line["schema"] == 2 for line in lines)
+        names = [line["event"] for line in lines]
+        assert names[0] == "factory_started"
+        assert names[-1] == "factory_completed"
+        assert "component_started" in names
+        assert "component_usage" in names
+
+    def test_v1_projection_equivalence(self, tmp_path: Path) -> None:
+        """progress.jsonl == the v1-named projection of events.jsonl,
+        in order, with identical component and data fields."""
+        root = _run_stub_factory(tmp_path, ["comp-a", "comp-b"])
+        v1 = read_progress_events(root / "progress.jsonl")
+        v2 = ev.read_events(_events_file(root))
+
+        v1_names = {e["event"] for e in v1}
+        projected = [
+            e for e in v2
+            if type(e).type in v1_names or type(e).type in {
+                "merge_pending", "phase_skipped",
+            }
+        ]
+        # Project v2 events into (event, component, selected-data) and
+        # compare against the parsed v1 lines pairwise, in order.
+        assert len(v1) == len(projected), (
+            f"v1 has {len(v1)} events, v2 projection has {len(projected)}"
+        )
+        for v1_event, v2_event in zip(v1, projected, strict=True):
+            assert v1_event["event"] == type(v2_event).type
+            assert v1_event.get("component", "") == v2_event.component
+            v1_data = v1_event.get("data", {})
+            v2_data = v2_event.to_dict()["data"]
+            for key, value in v1_data.items():
+                v2_key = "agent_source" if (
+                    v1_event["event"] == "adversarial_agent_selected"
+                    and key == "source"
+                ) else key
+                assert v2_data.get(v2_key) == value, (
+                    f"{v1_event['event']}.{key}: v1={value!r} "
+                    f"v2={v2_data.get(v2_key)!r}"
+                )
+
+    def test_fold_agrees_with_summarize_events(self, tmp_path: Path) -> None:
+        root = _run_stub_factory(tmp_path, ["comp-a", "comp-b"])
+        raw_v1 = read_progress_events(root / "progress.jsonl")
+        activity = summarize_events(raw_v1, latest_run_id(raw_v1))
+        state = reducer.fold(ev.read_events(_events_file(root)))
+
+        assert state.finished is activity.finished
+        assert set(state.components) == set(activity.components)
+        for cid, comp_activity in activity.components.items():
+            comp = state.components[cid]
+            assert comp.phase == comp_activity.phase, cid
+            assert comp.usage_calls == comp_activity.usage_calls, cid
+            assert comp.total_tokens == comp_activity.total_tokens, cid
+
+    def test_failure_path_events_match(self, tmp_path: Path) -> None:
+        root = _run_stub_factory(tmp_path, ["comp-a"], success=False)
+        v1_names = [e["event"] for e in
+                    read_progress_events(root / "progress.jsonl")]
+        v2_names = [type(e).type for e in ev.read_events(_events_file(root))]
+        assert "component_failed" in v1_names
+        assert v1_names == [n for n in v2_names if n in set(v1_names)]
+
+    def test_progress_log_disabled_suppresses_both(self, tmp_path: Path) -> None:
+        """Symmetric opt-out: progress_log_enabled=false writes NEITHER
+        progress.jsonl NOR events.jsonl."""
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root, progress_log_enabled=False)
+        result = ComponentResult(
+            "comp-a", success=True, iterations=1, usage=_usage(10),
+        )
+        with patch(
+            "ralph_py.factory._run_component", return_value=result,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True, file=io.StringIO()), root,
+            )
+        assert not (root / "progress.jsonl").exists()
+        assert not (root / ".ralph" / "runs").exists()
+
+    def test_journal_offsets_still_bracket_v1_file(self, tmp_path: Path) -> None:
+        """Manifest journal_offset_start/end stay pegged to the v1 file."""
+        root = _run_stub_factory(tmp_path, ["comp-a"])
+        manifest = Manifest.load(root / "scripts" / "ralph" / "manifest.json")
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.journal_offset_start >= 0
+        assert comp.journal_offset_end >= comp.journal_offset_start
+        v1_size = (root / "progress.jsonl").stat().st_size
+        assert comp.journal_offset_end <= v1_size

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -19,6 +19,7 @@ import pytest
 
 from ralph_py.agents.base import UsageRecord, UsageTotals
 from ralph_py.config import RalphConfig
+from ralph_py.events import EventBus, V1CompatSink
 from ralph_py.factory import (
     AdversarialAgentSelection,
     ComponentResult,
@@ -171,7 +172,11 @@ def _make_pipeline(
         ui=ui,
         root_dir=tmp_path,
         run_id="run-test",
-        progress_log=ProgressLog(tmp_path / "progress.jsonl", run_id="run-test"),
+        bus=EventBus(
+            V1CompatSink(ProgressLog(tmp_path / "progress.jsonl", run_id="run-test")),
+            run_id="run-test",
+        ),
+        journal_path=tmp_path / "progress.jsonl",
         notify=NotifyHooks(
             NotifyConfig(), run_id="run-test", project="test", warn=ui.warn,
         ),


### PR DESCRIPTION
## Summary

Chunk 3 of the TUI rewrite plan (stacked on #103). The orchestrator now dual-writes: typed schema-v2 events to `.ralph/runs/<run_id>/events.jsonl` AND the byte-identical v1 `progress.jsonl` through `V1CompatSink`, which delegates to a real `ProgressLog` - so the R7.4 `ProgressSink` observers (the Linear sink attached at run start) keep receiving the exact same event dicts, and the manifest's `journal_offset_start/end` brackets stay pegged to the v1 file.

- `ComponentPipeline(bus=, journal_path=)` replaces `progress_log=`; all 20 pipeline emit sites + 6 factory sites converted 1:1 to typed events (including R7.5's `circuit_breaker_tripped`). **No new semantics** - semantic events (phase brackets, PR lifecycle, checkpoints) are chunk 4.
- `progress_log_enabled=false` now suppresses both files (symmetric opt-out, per plan decision).
- `AdversarialAgentSelected.agent_type/model` stay `str | None` so the v1 line's JSON `null` is preserved byte-for-byte.

## Tests

New `tests/test_event_stream.py` drives the real `run_factory` (stubbed worker) and asserts the three dual-write contracts:
1. every `events.jsonl` line is schema 2, `factory_started` first / `factory_completed` last;
2. `progress.jsonl` == the ordered v1-named projection of the v2 stream, field-for-field (the load-bearing regression net);
3. `reducer.fold(events.jsonl)` agrees with `summarize_events(progress.jsonl)` on shared fields (clears the path for chunk 8's status migration);
plus failure-path equivalence, symmetric opt-out, and journal-offset bracketing.

Touched tests: `test_pipeline.py` (ctor site), `test_breaker.py` (reads the journal file instead of the removed attribute).

Gates: fast tier 1561 passed, spine tier 24 passed, `mypy --strict` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)