### PR TITLE
TUI chunk 4: semantic events + always-captured phase transcripts

### DIFF
--- a/ralph_py/decompose.py
+++ b/ralph_py/decompose.py
@@ -8,6 +8,7 @@ import re
 import secrets
 import tempfile
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
@@ -365,9 +366,15 @@ def collect_agent_output(
     timeout: float | None = None,
     *,
     max_bytes: int = MAX_AGENT_OUTPUT_BYTES,
+    on_line: Callable[[str], None] | None = None,
 ) -> list[str]:
     """Drain ``agent.run(...)`` into a list, aborting if total bytes
     exceed ``max_bytes``.
+
+    ``on_line`` observes each streamed line as it arrives (phase
+    transcripts, TUI rewrite chunk 4). An observer failure disables the
+    observer for the rest of the run - a dead transcript file must
+    never abort an agent call.
 
     Raises :class:`AgentOutputTooLarge` when the cap is hit. Callers
     are expected to catch it and translate to their phase-specific
@@ -377,6 +384,11 @@ def collect_agent_output(
     total_bytes = 0
     for line in agent.run(prompt, cwd=cwd, timeout=timeout):
         output_lines.append(line)
+        if on_line is not None:
+            try:
+                on_line(line)
+            except Exception:  # noqa: BLE001 - transcripts never gate
+                on_line = None
         total_bytes += len(line) + 1  # +1 for the implicit newline
         if total_bytes > max_bytes:
             raise AgentOutputTooLarge(

--- a/ralph_py/events.py
+++ b/ralph_py/events.py
@@ -271,12 +271,15 @@ class ChunkBudgetInsufficient(Event):
 
 @dataclass(frozen=True, kw_only=True)
 class AdversarialAgentSelected(Event):
+    """agent_type/model stay optional (None, not ""): the v1 line wrote
+    JSON null for unset values and byte parity is this chunk's contract."""
+
     type: ClassVar[str] = "adversarial_agent_selected"
     phase: str = ""
     agent_source: str = ""
     identity: str = ""
-    agent_type: str = ""
-    model: str = ""
+    agent_type: str | None = None
+    model: str | None = None
     homogeneous: bool = False
 
 

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -30,8 +30,10 @@ from ralph_py.events import (
     ComponentStarted,
     EventBus,
     JsonlSink,
+    PhaseStarted,
     RunCompleted,
     RunPaths,
+    RunPlan,
     RunStarted,
     V1CompatSink,
 )
@@ -1315,6 +1317,7 @@ def _run_factory_locked(
     progress_log: ProgressLog
     bus = EventBus(run_id=run_id)
     journal_path: Path | None = None
+    run_paths: RunPaths | None = None
     if not factory_config.progress_log_enabled:
         progress_log = NullProgressLog()
     else:
@@ -1352,6 +1355,16 @@ def _run_factory_locked(
 
     bus.emit(RunStarted(
         project=manifest.project_name, components=len(manifest.components),
+    ))
+    # Chunk 4: the component DAG + budget caps as one event, so a
+    # dashboard can draw the board without reading the manifest.
+    bus.emit(RunPlan(
+        components=tuple(
+            {"id": c.id, "title": c.title, "deps": list(c.dependencies)}
+            for c in manifest.components
+        ),
+        max_total_tokens=factory_config.max_total_tokens,
+        max_adversarial_calls=factory_config.max_adversarial_calls,
     ))
 
     # R7.1: resolve which model family reviews this run's diffs ONCE so
@@ -1475,6 +1488,7 @@ def _run_factory_locked(
         run_id=run_id,
         bus=bus,
         journal_path=journal_path,
+        run_paths=run_paths,
         notify=notify,
         review_selection=review_selection,
         security_selection=security_selection,
@@ -1745,6 +1759,11 @@ def _run_factory_locked(
                     pipeline.begin_attempt(comp)
                     manifest.save(manifest_path)
                     bus.emit(ComponentStarted(component=comp.id))
+                    # Engineer bracket opener; process_result closes it.
+                    bus.emit(PhaseStarted(
+                        component=comp.id, phase="engineer",
+                        attempt=comp.retries + 1,
+                    ))
                     ui.info(f"  Starting: {comp.id}")
 
                     wt_path = _launch_component(comp)

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -1759,11 +1759,6 @@ def _run_factory_locked(
                     pipeline.begin_attempt(comp)
                     manifest.save(manifest_path)
                     bus.emit(ComponentStarted(component=comp.id))
-                    # Engineer bracket opener; process_result closes it.
-                    bus.emit(PhaseStarted(
-                        component=comp.id, phase="engineer",
-                        attempt=comp.retries + 1,
-                    ))
                     ui.info(f"  Starting: {comp.id}")
 
                     wt_path = _launch_component(comp)
@@ -1771,6 +1766,13 @@ def _run_factory_locked(
                         transitioned_without_launch += 1
                         continue
 
+                    # Provisioning succeeded: the engineer phase starts
+                    # immediately before submission. process_result closes
+                    # normal exits; fail_scheduler_backstop closes timeouts.
+                    bus.emit(PhaseStarted(
+                        component=comp.id, phase="engineer",
+                        attempt=comp.retries + 1,
+                    ))
                     args = _submit_args(comp, wt_path)
                     future = executor.submit(_run_component, *args)
                     running_futures[future] = comp.id

--- a/ralph_py/knowledge.py
+++ b/ralph_py/knowledge.py
@@ -25,6 +25,7 @@ import os
 import re
 import tempfile
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -1142,6 +1143,8 @@ def distill_facts(
     config: KnowledgeConfig,
     worktree_path: Path,
     review_passed: bool | None,
+    *,
+    on_line: Callable[[str], None] | None = None,
 ) -> tuple[int, str]:
     """Run the LLM distillation call and persist any facts returned.
 
@@ -1174,6 +1177,7 @@ def distill_facts(
         output_lines = collect_agent_output(
             agent, prompt, cwd=worktree_path,
             timeout=config.distill_timeout_seconds,
+            on_line=on_line,
         )
     except AgentOutputTooLarge as exc:
         return 0, f"knowledge.agent_output_too_large: {exc}"

--- a/ralph_py/pipeline.py
+++ b/ralph_py/pipeline.py
@@ -810,6 +810,15 @@ class ComponentPipeline:
             skipped = self.manifest.cascade_skip(comp_id)
             self.factory_result.failed.append(comp_id)
             self.factory_result.skipped.extend(skipped)
+            started = self._attempt_started_monotonic.get(comp_id)
+            duration = time.monotonic() - started if started is not None else 0.0
+            self.bus.emit(ev.PhaseCompleted(
+                component=comp_id,
+                phase="engineer",
+                passed=False,
+                detail="component timeout",
+                duration_seconds=round(duration, 2),
+            ))
             self.bus.emit(ev.ComponentFailed(
                 component=comp_id, error="component timeout",
             ))

--- a/ralph_py/pipeline.py
+++ b/ralph_py/pipeline.py
@@ -31,7 +31,8 @@ from __future__ import annotations
 
 import json
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -238,6 +239,7 @@ class ComponentPipeline:
         run_id: str,
         bus: ev.EventBus,
         journal_path: Path | None,
+        run_paths: ev.RunPaths | None = None,
         notify: NotifyHooks,
         review_selection: AdversarialAgentSelection,
         security_selection: AdversarialAgentSelection | None,
@@ -258,6 +260,7 @@ class ComponentPipeline:
         self.run_id = run_id
         self.bus = bus
         self.journal_path = journal_path
+        self.run_paths = run_paths
         self.notify = notify
         self.review_selection = review_selection
         self.security_selection = security_selection
@@ -356,6 +359,55 @@ class ComponentPipeline:
         except OSError:
             return -1
 
+    @contextmanager
+    def _phase_transcript(
+        self, comp_id: str, phase: str,
+    ) -> Iterator[Callable[[str], None] | None]:
+        """Line writer onto RunPaths.phase_log for one phase invocation.
+
+        Yields None when no run dir is configured (progress logging
+        disabled) or the file cannot be opened - transcripts are
+        observability and must never gate a phase (chunk 4). Repeated
+        invocations (retries, chunked passes) append.
+        """
+        if self.run_paths is None:
+            yield None
+            return
+        path = self.run_paths.phase_log(comp_id, phase)
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            fh = open(path, "a", buffering=1, encoding="utf-8")
+        except OSError:
+            yield None
+            return
+        def _write_line(line: str) -> None:
+            fh.write(line + "\n")
+
+        try:
+            yield _write_line
+        finally:
+            try:
+                fh.close()
+            except OSError:
+                pass
+
+    def _phase_started(self, comp: Component, phase: str) -> float:
+        """Emit the authoritative phase bracket opener; returns the
+        monotonic start for the matching _phase_completed."""
+        self.bus.emit(ev.PhaseStarted(
+            component=comp.id, phase=phase, attempt=comp.retries + 1,
+        ))
+        return time.monotonic()
+
+    def _phase_completed(
+        self, comp: Component, phase: str, started: float,
+        passed: bool, detail: str = "",
+    ) -> None:
+        self.bus.emit(ev.PhaseCompleted(
+            component=comp.id, phase=phase, passed=passed, detail=detail,
+            duration_seconds=round(time.monotonic() - started, 2),
+        ))
+
     def _debug_dir_for(self, comp_id: str) -> Path:
         """Forensic raw-output dir for this run's component (R1.2)."""
         return self.root_dir / ".ralph" / "debug" / self.run_id / comp_id
@@ -370,6 +422,18 @@ class ComponentPipeline:
         comp.findings.extend(
             tag_finding_with_attempt(f, attempt) for f in new_findings
         )
+        # Chunk 4: stream each finding as a typed event the moment it is
+        # recorded (the manifest only carries them at transition time).
+        for finding in new_findings:
+            self.bus.emit(ev.FindingRecorded(
+                component=comp.id,
+                phase=finding.phase,
+                category=finding.category,
+                severity=finding.severity,
+                location=finding.location,
+                explanation=finding.explanation,
+                attempt=attempt,
+            ))
 
     def begin_attempt(self, comp: Component) -> None:
         """PENDING -> RUNNING transition for one attempt (R3.3).
@@ -623,6 +687,11 @@ class ComponentPipeline:
         merge_pending event so the slice includes it."""
         comp.status = ComponentStatus.MERGE_PENDING.value
         comp.error = error
+        # Richer v2 event first; the v1-parity twin keeps progress.jsonl
+        # unchanged (the reducer prefers the v2 event, chunk 2).
+        self.bus.emit(ev.PrMergePending(
+            component=comp.id, pr_url=comp.pr_url, error=comp.error,
+        ))
         self.bus.emit(ev.MergePendingV1(
             component=comp.id, pr_url=comp.pr_url, error=comp.error,
         ))
@@ -870,6 +939,15 @@ class ComponentPipeline:
         comp.duration_seconds = comp_result.duration_seconds
         comp.iteration_count = comp_result.iterations
 
+        # Engineer bracket closer: PhaseStarted(engineer) was emitted by
+        # the scheduler at submit time; the worker's exit lands here.
+        self.bus.emit(ev.PhaseCompleted(
+            component=comp_id, phase="engineer",
+            passed=comp_result.success,
+            detail=comp_result.error or "",
+            duration_seconds=round(comp_result.duration_seconds, 2),
+        ))
+
         # R3.1: engineer-loop spend counts BEFORE the success branch -
         # failed attempts cost real tokens too.
         if comp_result.usage is not None:
@@ -922,14 +1000,24 @@ class ComponentPipeline:
         comp.status = ComponentStatus.VERIFYING.value
         self.manifest.save(self.manifest_path)
 
+        t0 = self._phase_started(comp, "verify")
         verify = self._phase_verify(comp, comp_result, wt_path)
+        self._phase_completed(
+            comp, "verify", t0, verify.failure is None,
+            verify.failure.error if verify.failure else "",
+        )
         if verify.failure is not None:
             return PipelineOutcome(
                 transition=self._route_failure(comp, verify.failure),
                 verify=verify,
             )
 
+        t0 = self._phase_started(comp, "diff")
         diff = self._phase_diff(comp, comp_result, wt_path)
+        self._phase_completed(
+            comp, "diff", t0, diff.failure is None,
+            diff.failure.error if diff.failure else "",
+        )
         if diff.failure is not None:
             return PipelineOutcome(
                 transition=self._route_failure(comp, diff.failure),
@@ -937,9 +1025,14 @@ class ComponentPipeline:
             )
 
         # PHASE 2: Second-opinion review
+        t0 = self._phase_started(comp, "review")
         review = self._phase_review(
             comp, comp_result, wt_path, verify.verification,
             diff.review_diff, diff.chunks,
+        )
+        self._phase_completed(
+            comp, "review", t0, review.failure is None,
+            review.failure.error if review.failure else "",
         )
         if review.failure is not None:
             return PipelineOutcome(
@@ -948,8 +1041,13 @@ class ComponentPipeline:
             )
 
         # PHASE 2.5: Security review
+        t0 = self._phase_started(comp, "security")
         security = self._phase_security(
             comp, comp_result, wt_path, diff.review_diff, diff.chunks,
+        )
+        self._phase_completed(
+            comp, "security", t0, security.failure is None,
+            security.failure.error if security.failure else "",
         )
         if security.failure is not None:
             return PipelineOutcome(
@@ -958,7 +1056,11 @@ class ComponentPipeline:
             )
 
         # Knowledge distillation: a NAMED PRE-PR step (R7.3 decision).
+        t0 = self._phase_started(comp, "distill")
         distill = self._phase_distill(comp, comp_result, wt_path, diff.diff)
+        self._phase_completed(
+            comp, "distill", t0, True, distill.skip_reason or "",
+        )
 
         # HITL checkpoint + PR create/merge (per-component PR mode only).
         checkpoint = CheckpointDecision.NOT_PROMPTED
@@ -993,7 +1095,16 @@ class ComponentPipeline:
                     checkpoint=checkpoint,
                 )
 
+            t0 = self._phase_started(comp, "pr")
             pr = self._phase_pr(comp)
+            self._phase_completed(
+                comp, "pr", t0,
+                pr.disposition in (
+                    PrDisposition.MERGED, PrDisposition.NO_GH,
+                    PrDisposition.SKIPPED,
+                ),
+                pr.error,
+            )
             if pr.disposition == PrDisposition.CONFLICT:
                 return PipelineOutcome(
                     transition=self._retry_after_merge_conflict(
@@ -1387,31 +1498,35 @@ class ComponentPipeline:
             if review_mode == ReviewMode.HARD and review_chunks is not None:
                 # R1.4: one pass per chunk, each consuming budget;
                 # any chunk failure fails the merged result.
-                review_result = self.hooks.run_chunked_review(
-                    review_agent,
-                    wt_path / comp.prd_path,
-                    wt_path,
-                    self.manifest.base_branch,
-                    verification,
-                    review_mode,
-                    self.ui,
-                    diff_chunks=review_chunks,
-                    budget_remaining=self.adversarial_budget_remaining(),
-                    consume_budget=self.adversarial_budget_consume,
-                    debug_dir=adversarial_debug_dir,
-                )
+                with self._phase_transcript(comp.id, "review") as on_line:
+                    review_result = self.hooks.run_chunked_review(
+                        review_agent,
+                        wt_path / comp.prd_path,
+                        wt_path,
+                        self.manifest.base_branch,
+                        verification,
+                        review_mode,
+                        self.ui,
+                        diff_chunks=review_chunks,
+                        budget_remaining=self.adversarial_budget_remaining(),
+                        consume_budget=self.adversarial_budget_consume,
+                        debug_dir=adversarial_debug_dir,
+                        on_line=on_line,
+                    )
             else:
-                review_result = self.hooks.run_review(
-                    review_agent,
-                    wt_path / comp.prd_path,
-                    wt_path,
-                    self.manifest.base_branch,
-                    verification,
-                    review_mode,
-                    self.ui,
-                    diff_content=review_diff,
-                    debug_dir=adversarial_debug_dir,
-                )
+                with self._phase_transcript(comp.id, "review") as on_line:
+                    review_result = self.hooks.run_review(
+                        review_agent,
+                        wt_path / comp.prd_path,
+                        wt_path,
+                        self.manifest.base_branch,
+                        verification,
+                        review_mode,
+                        self.ui,
+                        diff_content=review_diff,
+                        debug_dir=adversarial_debug_dir,
+                        on_line=on_line,
+                    )
         except Exception as exc:  # noqa: BLE001
             self.ui.warn(f"  Review crashed: {exc}")
             review_result = ReviewResult(
@@ -1618,29 +1733,33 @@ class ComponentPipeline:
                 # R1.4: one pass per chunk, each consuming budget
                 # via consume_budget; any chunk failure fails the
                 # merged result.
-                sec_result = self.hooks.run_chunked_security_review(
-                    sec_agent,
-                    wt_path / comp.prd_path,
-                    wt_path,
-                    self.manifest.base_branch,
-                    sec_config,
-                    self.ui,
-                    diff_chunks=review_chunks,
-                    budget_remaining=self.adversarial_budget_remaining(),
-                    consume_budget=self.adversarial_budget_consume,
-                    debug_dir=adversarial_debug_dir,
-                )
+                with self._phase_transcript(comp.id, "security") as on_line:
+                    sec_result = self.hooks.run_chunked_security_review(
+                        sec_agent,
+                        wt_path / comp.prd_path,
+                        wt_path,
+                        self.manifest.base_branch,
+                        sec_config,
+                        self.ui,
+                        diff_chunks=review_chunks,
+                        budget_remaining=self.adversarial_budget_remaining(),
+                        consume_budget=self.adversarial_budget_consume,
+                        debug_dir=adversarial_debug_dir,
+                        on_line=on_line,
+                    )
             else:
-                sec_result = self.hooks.run_security_review(
-                    sec_agent,
-                    wt_path / comp.prd_path,
-                    wt_path,
-                    self.manifest.base_branch,
-                    sec_config,
-                    self.ui,
-                    diff_content=review_diff,
-                    debug_dir=adversarial_debug_dir,
-                )
+                with self._phase_transcript(comp.id, "security") as on_line:
+                    sec_result = self.hooks.run_security_review(
+                        sec_agent,
+                        wt_path / comp.prd_path,
+                        wt_path,
+                        self.manifest.base_branch,
+                        sec_config,
+                        self.ui,
+                        diff_content=review_diff,
+                        debug_dir=adversarial_debug_dir,
+                        on_line=on_line,
+                    )
         except Exception as exc:  # noqa: BLE001
             # Agent infrastructure failed before run_security_review
             # could classify the outcome. Synthesize an infra result
@@ -1832,18 +1951,27 @@ class ComponentPipeline:
                 self.base_config.model_reasoning_effort,
                 self.base_config.agent_type,
             )
-            written, status = self.hooks.distill_facts(
-                distill_agent,
-                comp,
-                diff_content,
-                wt_path / comp.prd_path,
-                comp_result.iterations,
-                self.run_id,
-                knowledge_config.knowledge_root,
-                knowledge_config,
-                wt_path,
-                comp.review_passed,
-            )
+            distill_start = time.monotonic()
+            with self._phase_transcript(comp.id, "distill") as on_line:
+                written, status = self.hooks.distill_facts(
+                    distill_agent,
+                    comp,
+                    diff_content,
+                    wt_path / comp.prd_path,
+                    comp_result.iterations,
+                    self.run_id,
+                    knowledge_config.knowledge_root,
+                    knowledge_config,
+                    wt_path,
+                    comp.review_passed,
+                    on_line=on_line,
+                )
+            self.bus.emit(ev.DistillResult(
+                component=comp.id, facts_written=written,
+                duration_seconds=round(
+                    time.monotonic() - distill_start, 2,
+                ),
+            ))
             if written > 0:
                 self.ui.ok(f"  Knowledge: {status}")
             else:
@@ -1907,16 +2035,24 @@ class ComponentPipeline:
         than block indefinitely."""
         if not self.factory_config.pause_before_pr_merge:
             return CheckpointDecision.NOT_PROMPTED
+        question = f"Approve PR creation and merge for {comp.id}?"
+        self.bus.emit(ev.CheckpointRequested(
+            component=comp.id, kind="pr_merge", question=question,
+        ))
         if not self.ui.can_prompt():
             self.ui.warn(
                 f"  pause_before_pr_merge requested but UI is "
                 f"non-interactive; proceeding without prompt for {comp.id}"
             )
+            self.bus.emit(ev.CheckpointResolved(
+                component=comp.id, kind="pr_merge",
+                decision="not_prompted", decided_by="auto",
+            ))
             return CheckpointDecision.NOT_PROMPTED
         self.ui.section(f"Human checkpoint: {comp.id}")
         self.ui.info(comp.review_findings or "(no review findings)")
         choice = self.ui.choose(
-            f"Approve PR creation and merge for {comp.id}?",
+            question,
             [
                 "Approve",
                 "Reject (fail component, skip dependents)",
@@ -1924,18 +2060,24 @@ class ComponentPipeline:
             ],
             default=0,
         )
-        if choice == 1:
+        decision = {
+            1: CheckpointDecision.REJECTED,
+            2: CheckpointDecision.RETRY,
+        }.get(choice, CheckpointDecision.APPROVED)
+        self.bus.emit(ev.CheckpointResolved(
+            component=comp.id, kind="pr_merge",
+            decision=decision.name.lower(), decided_by="operator",
+        ))
+        if decision == CheckpointDecision.REJECTED:
             self.ui.warn(
                 f"  Human rejected {comp.id} at PR checkpoint"
             )
-            return CheckpointDecision.REJECTED
-        if choice == 2:
+        elif decision == CheckpointDecision.RETRY:
             self.ui.warn(
                 f"  Human requested retry for {comp.id} "
                 f"at PR checkpoint"
             )
-            return CheckpointDecision.RETRY
-        return CheckpointDecision.APPROVED
+        return decision
 
     def _phase_pr(self, comp: Component) -> PrPhaseResult:
         """Per-component PR create+merge. single_pr mode is exempt
@@ -1963,6 +2105,10 @@ class ComponentPipeline:
         )
         if outcome.pr_url:
             self.factory_result.pr_urls.append(outcome.pr_url)
+            self.bus.emit(ev.PrCreated(
+                component=comp.id, pr_number=comp.pr_number or 0,
+                pr_url=outcome.pr_url,
+            ))
         self.manifest.save(self.manifest_path)
 
         # R0.2 (CRIT-2): COMPLETED requires a CONFIRMED merge.
@@ -1987,6 +2133,10 @@ class ComponentPipeline:
                 pr_url=outcome.pr_url,
                 error=outcome.error or "PR flow failed",
             )
+        self.bus.emit(ev.PrMerged(
+            component=comp.id, pr_number=comp.pr_number or 0,
+            pr_url=outcome.pr_url,
+        ))
         return PrPhaseResult(
             disposition=PrDisposition.MERGED, pr_url=outcome.pr_url,
         )

--- a/ralph_py/review.py
+++ b/ralph_py/review.py
@@ -641,6 +641,7 @@ def run_review(
     diff_content: str | None = None,
     *,
     debug_dir: Path | None = None,
+    on_line: Callable[[str], None] | None = None,
 ) -> ReviewResult:
     """Run the full review: build prompt, run agent, parse output.
 
@@ -682,6 +683,7 @@ def run_review(
         ]
         output_lines = collect_agent_output(
             agent, prompt, cwd=worktree_path, timeout=timeout,
+            on_line=on_line,
         )
     except AgentOutputTooLarge as exc:
         # Hostile/buggy agent flooding output. The review never
@@ -834,6 +836,7 @@ def run_chunked_review(
     budget_remaining: int | None = None,
     consume_budget: Callable[[], None] | None = None,
     debug_dir: Path | None = None,
+    on_line: Callable[[str], None] | None = None,
 ) -> ReviewResult:
     """R1.4 (H-16): review an oversized diff chunk by chunk, one agent
     pass per chunk, and merge the verdicts.
@@ -864,6 +867,11 @@ def run_chunked_review(
         if consume_budget is not None:
             consume_budget()
         ui.info(f"    Review chunk {i}/{n}...")
+        if on_line is not None:
+            try:
+                on_line(f"--- chunk {i}/{n} ---")
+            except Exception:  # noqa: BLE001 - transcripts never gate
+                on_line = None
         results.append(run_review(
             agent, prd_path, worktree_path, base_branch,
             verification_result, mode, ui,
@@ -872,5 +880,6 @@ def run_chunked_review(
             # Per-chunk subdir: dump_raw_debug writes fixed filenames,
             # so sharing one dir would overwrite earlier chunks' dumps.
             debug_dir=debug_dir / f"chunk-{i}" if debug_dir else None,
+            on_line=on_line,
         ))
     return merge_review_results(results, mode.value)

--- a/ralph_py/security.py
+++ b/ralph_py/security.py
@@ -579,6 +579,7 @@ def run_security_review(
     diff_content: str | None = None,
     *,
     debug_dir: Path | None = None,
+    on_line: Callable[[str], None] | None = None,
 ) -> SecurityResult:
     """Run the security review phase. Always non-fatal: on any
     infrastructure error returns a SecurityResult with empty findings
@@ -613,6 +614,7 @@ def run_security_review(
     try:
         output_lines = collect_agent_output(
             agent, prompt, cwd=worktree_path, timeout=config.timeout_seconds,
+            on_line=on_line,
         )
     except (AgentOutputTooLarge, Exception) as exc:  # noqa: BLE001
         # Agent crashed mid-run OR streamed more than MAX_AGENT_OUTPUT_BYTES.
@@ -747,6 +749,7 @@ def run_chunked_security_review(
     budget_remaining: int | None = None,
     consume_budget: Callable[[], None] | None = None,
     debug_dir: Path | None = None,
+    on_line: Callable[[str], None] | None = None,
 ) -> SecurityResult:
     """R1.4 (H-16): security-review an oversized diff chunk by chunk,
     one agent pass per chunk, and merge the verdicts.
@@ -779,11 +782,17 @@ def run_chunked_security_review(
         if consume_budget is not None:
             consume_budget()
         ui.info(f"    Security review chunk {i}/{n}...")
+        if on_line is not None:
+            try:
+                on_line(f"--- chunk {i}/{n} ---")
+            except Exception:  # noqa: BLE001 - transcripts never gate
+                on_line = None
         results.append(run_security_review(
             agent, prd_path, worktree_path, base_branch, config, ui,
             diff_content=chunk,
             # Per-chunk subdir: dump_raw_debug writes fixed filenames,
             # so sharing one dir would overwrite earlier chunks' dumps.
             debug_dir=debug_dir / f"chunk-{i}" if debug_dir else None,
+            on_line=on_line,
         ))
     return merge_security_results(results, config.mode)

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -238,3 +238,175 @@ class TestDualWrite:
         assert comp.journal_offset_end >= comp.journal_offset_start
         v1_size = (root / "progress.jsonl").stat().st_size
         assert comp.journal_offset_end <= v1_size
+
+
+def _v2_names_for(events: list[ev.Event], comp: str) -> list[str]:
+    out = []
+    for e in events:
+        if e.component != comp:
+            continue
+        name = type(e).type
+        if name in ("phase_started", "phase_completed"):
+            name = f"{name}:{e.to_dict()['data']['phase']}"
+        out.append(name)
+    return out
+
+
+class TestSemanticEvents:
+    def test_run_plan_follows_factory_started(self, tmp_path: Path) -> None:
+        root = _run_stub_factory(tmp_path, ["comp-a", "comp-b"])
+        events = ev.read_events(_events_file(root))
+        names = [type(e).type for e in events]
+        assert names[0] == "factory_started"
+        assert names[1] == "run_plan"
+        plan = events[1]
+        assert isinstance(plan, ev.RunPlan)
+        assert [c["id"] for c in plan.components] == ["comp-a", "comp-b"]
+
+    def test_phase_bracket_ordering_success(self, tmp_path: Path) -> None:
+        root = _run_stub_factory(tmp_path, ["comp-a"])
+        events = ev.read_events(_events_file(root))
+        names = _v2_names_for(events, "comp-a")
+
+        def pos(name: str) -> int:
+            return names.index(name)
+
+        assert pos("component_started") < pos("phase_started:engineer")
+        assert pos("phase_started:engineer") < pos("phase_completed:engineer")
+        assert pos("phase_completed:engineer") < pos("phase_started:verify")
+        assert pos("phase_started:verify") < pos("verification_result")
+        assert pos("verification_result") < pos("phase_completed:verify")
+        assert pos("phase_completed:verify") < pos("phase_started:diff")
+        assert pos("phase_completed:diff") < pos("phase_started:review")
+        assert pos("phase_completed:review") < pos("phase_started:security")
+        assert pos("phase_completed:security") < pos("phase_started:distill")
+        assert pos("phase_completed:distill") < pos("component_completed")
+
+    def test_failure_path_stops_at_engineer(self, tmp_path: Path) -> None:
+        root = _run_stub_factory(tmp_path, ["comp-a"], success=False)
+        events = ev.read_events(_events_file(root))
+        names = _v2_names_for(events, "comp-a")
+        assert "phase_completed:engineer" in names
+        engineer_done = [
+            e for e in events
+            if isinstance(e, ev.PhaseCompleted) and e.phase == "engineer"
+        ]
+        assert engineer_done[0].passed is False
+        assert "stub failure" in engineer_done[0].detail
+        assert "phase_started:verify" not in names
+
+    def test_v1_file_has_no_semantic_events(self, tmp_path: Path) -> None:
+        root = _run_stub_factory(tmp_path, ["comp-a"])
+        v1_names = {e["event"] for e in
+                    read_progress_events(root / "progress.jsonl")}
+        assert not v1_names & {
+            "run_plan", "phase_started", "phase_completed",
+            "checkpoint_requested", "checkpoint_resolved", "pr_created",
+            "pr_merged", "pr_merge_pending", "distill_result",
+            "finding_recorded",
+        }
+
+    def test_reducer_sees_explicit_phases(self, tmp_path: Path) -> None:
+        root = _run_stub_factory(tmp_path, ["comp-a"])
+        state = reducer.fold(ev.read_events(_events_file(root)))
+        comp = state.components["comp-a"]
+        assert comp.phase_explicit is True
+        assert comp.status == "completed"
+        assert comp.phase == "done"
+
+    def test_checkpoint_events_auto_resolution(self, tmp_path: Path) -> None:
+        """pause_before_pr_merge on a non-TTY: requested then resolved
+        with decided_by=auto, and the run proceeds (NO_GH path)."""
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(
+            root, create_prs=True, pause_before_pr_merge=True,
+        )
+        result = ComponentResult(
+            "comp-a", success=True, iterations=1, usage=_usage(10),
+        )
+        with patch(
+            "ralph_py.factory._run_component", return_value=result,
+        ), patch("ralph_py.git.get_diff_content", return_value=""), patch(
+            "ralph_py.pr.is_gh_available", return_value=False,
+        ):
+            run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True, file=io.StringIO()), root,
+            )
+        events = ev.read_events(_events_file(root))
+        requested = [e for e in events if isinstance(e, ev.CheckpointRequested)]
+        resolved = [e for e in events if isinstance(e, ev.CheckpointResolved)]
+        assert len(requested) == 1
+        assert requested[0].kind == "pr_merge"
+        assert len(resolved) == 1
+        assert resolved[0].decision == "not_prompted"
+        assert resolved[0].decided_by == "auto"
+
+
+class TestPhaseTranscripts:
+    def test_review_transcript_written(self, tmp_path: Path) -> None:
+        """The pipeline threads a transcript writer into the review
+        hook; lines the reviewer streams land in review.log."""
+        from ralph_py.review import ReviewResult
+
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root, review_mode="advisory")
+        result = ComponentResult(
+            "comp-a", success=True, iterations=1, usage=_usage(10),
+        )
+
+        def fake_review(*args: Any, **kwargs: Any) -> ReviewResult:
+            on_line = kwargs.get("on_line")
+            assert on_line is not None, "pipeline must pass a transcript writer"
+            on_line("reviewer line one")
+            on_line("reviewer line two")
+            return ReviewResult(passed=True, mode="advisory")
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=result,
+        ), patch("ralph_py.git.get_diff_content", return_value="+x\n"), patch(
+            "ralph_py.factory.run_review", side_effect=fake_review,
+        ):
+            run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True, file=io.StringIO()), root,
+            )
+
+        run_dir = _events_file(root).parent
+        review_log = run_dir / "components" / "comp-a" / "review.log"
+        assert review_log.exists()
+        assert review_log.read_text() == "reviewer line one\nreviewer line two\n"
+
+    def test_run_review_streams_lines(self, tmp_path: Path) -> None:
+        """review.run_review forwards each streamed agent line to on_line."""
+        from ralph_py.review import ReviewMode, run_review
+        from ralph_py.ui.plain import PlainUI as _PlainUI
+        from ralph_py.verify import VerificationResult
+
+        class _Agent:
+            @property
+            def name(self) -> str:
+                return "fake"
+
+            def run(self, prompt: str, cwd: Path | None = None,
+                    timeout: float | None = None) -> Any:
+                yield from ["line-a", "line-b"]
+
+            @property
+            def final_message(self) -> str | None:
+                return None
+
+        (tmp_path / "prd.json").write_text(
+            '{"branchName": "b", "userStories": []}'
+        )
+        seen: list[str] = []
+        run_review(
+            _Agent(), tmp_path / "prd.json", tmp_path, "main",
+            VerificationResult(passed=True, checks=[]),
+            ReviewMode.ADVISORY, _PlainUI(no_color=True, file=io.StringIO()),
+            diff_content="+x\n",
+            on_line=seen.append,
+        )
+        assert seen == ["line-a", "line-b"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -19,7 +19,7 @@ import pytest
 
 from ralph_py.agents.base import UsageRecord, UsageTotals
 from ralph_py.config import RalphConfig
-from ralph_py.events import EventBus, V1CompatSink
+from ralph_py.events import CallbackSink, Event, EventBus, PhaseCompleted, V1CompatSink
 from ralph_py.factory import (
     AdversarialAgentSelection,
     ComponentResult,
@@ -897,6 +897,8 @@ class TestSchedulerFacingTransitions:
 
     def test_scheduler_backstop_failure(self, tmp_path: Path) -> None:
         pipeline, manifest, result, _ = _make_pipeline(tmp_path)
+        captured: list[Event] = []
+        pipeline.bus.add_sink(CallbackSink(captured.append))
         comp = manifest.get_component("comp-a")
         assert comp is not None
         pipeline.begin_attempt(comp)
@@ -909,6 +911,11 @@ class TestSchedulerFacingTransitions:
         assert result.failed == ["comp-a"]
         # The worktree entry survives: a leaked worker may still own it.
         assert "comp-a" in pipeline.worktree_paths
+        completed = [e for e in captured if isinstance(e, PhaseCompleted)]
+        assert len(completed) == 1
+        assert completed[0].phase == "engineer"
+        assert completed[0].passed is False
+        assert completed[0].detail == "component timeout"
 
 
 class TestDistillPlacement:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+from ralph_py import events as ev
 from ralph_py.config import RalphConfig
 from ralph_py.factory import (
     ComponentResult,
@@ -168,3 +169,11 @@ class TestUnifiedSchedulingLoop:
         assert result.failed == ["comp-a"]
         assert result.completed == ["comp-b"]
         assert real_setup_calls == ["comp-a", "comp-b"]
+        run_dir = sorted((tmp_path / ".ralph" / "runs").iterdir())[-1]
+        events = ev.read_events(run_dir / "events.jsonl")
+        engineer_starts = [
+            event for event in events
+            if isinstance(event, ev.PhaseStarted)
+            and event.phase == "engineer"
+        ]
+        assert [event.component for event in engineer_starts] == ["comp-b"]


### PR DESCRIPTION
## Summary

Chunk 4 of the TUI rewrite plan (stacked on #104). The event stream becomes semantically complete - the dashboard's real signal:

- **Authoritative phase brackets**: `phase_started`/`phase_completed` (attempt, verdict, duration) around engineer (opened at scheduler submit, closed in `process_result`), verify, diff, review, security, distill, and pr. The reducer's inference heuristic is now only a v1 fallback.
- **`run_plan`** right after `factory_started`: component ids/titles/deps + `max_total_tokens`/`max_adversarial_calls` caps.
- **Checkpoint events** in the E6 gate: `checkpoint_requested` -> `checkpoint_resolved` with `decision` (approved/rejected/retry/not_prompted) and `decided_by` (operator/auto).
- **PR lifecycle**: `pr_created`, `pr_merged`, `pr_merge_pending` (emitted beside the v1-parity `merge_pending` twin; reducer prefers v2).
- **`distill_result`** (facts written + duration) and **`finding_recorded`** per typed finding as it is recorded.
- **Always-captured phase transcripts**: `collect_agent_output` gains a crash-proof `on_line` observer, threaded through all four adversarial runners; the pipeline writes `components/<comp>/{review,security,distill}.log` under the run dir, with `--- chunk i/n ---` separators for chunked passes. Until now this output was captured and discarded unless a parse failed.

All new events are dropped by `V1CompatSink`; a dedicated test proves `progress.jsonl` gains no new event names.

## Tests (+8)

Bracket ordering on a successful run, fail-fast absence after engineer failure (with verdict+detail assertions), `run_plan` position/content, checkpoint auto-resolution on non-TTY (gh stubbed to the NO_GH path), reducer sees explicit phases, v1-unaffected guard, transcript threading end-to-end (factory -> pipeline -> hook -> review.log) and unit-level (`run_review` forwards each streamed line).

Gates: fast tier 1569 passed, spine 24 passed, `mypy --strict` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)