### PR TITLE
TUI chunk 5: EventBridgeUI migration shim

### DIFF
--- a/ralph_py/ui/bridge.py
+++ b/ralph_py/ui/bridge.py
@@ -1,0 +1,116 @@
+"""EventBridgeUI: the UI-protocol-to-event-stream migration shim.
+
+Chunk 5 of the TUI rewrite. The old ``UI`` protocol is an imperative
+line logger with ~390 call sites; rewriting them all at once is not a
+reviewable change. This bridge implements the protocol's 14 methods by
+emitting :class:`~ralph_py.events.Log` events on an
+:class:`~ralph_py.events.EventBus` instead of printing - the call sites
+keep compiling unchanged while every line they narrate becomes part of
+the replayable event stream. A renderer (chunk 7) projects the events
+back onto a concrete UI implementation, byte-identically.
+
+Interactivity does NOT go through events: ``choose``/``can_prompt``
+delegate to a real :class:`Prompter` (``PlainUI``/``RichUI`` satisfy it
+structurally), so blocking prompts remain synchronous and testable.
+
+Raw agent output is a transcript, not an event: ``stream_line`` calls
+whose tag is in ``transcript_tags`` route to the ``transcript`` callable
+(a file writer) instead of the bus - the spike measured that flooding a
+UI surface with full agent output starves input, and the event stream
+has the same interest in staying lean.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from ralph_py.events import EventBus, Log
+
+DEFAULT_TRANSCRIPT_TAGS = frozenset({"AI"})
+
+
+class Prompter(Protocol):
+    """The interactive sub-surface of the UI protocol."""
+
+    def choose(self, header: str, options: list[str], default: int = 0) -> int: ...
+
+    def can_prompt(self) -> bool: ...
+
+
+class NullPrompter:
+    """Non-interactive prompter: every choice resolves to the default."""
+
+    def choose(self, header: str, options: list[str], default: int = 0) -> int:
+        return default
+
+    def can_prompt(self) -> bool:
+        return False
+
+
+class EventBridgeUI:
+    """Implements the 14-method ``UI`` protocol as Log events on a bus."""
+
+    def __init__(
+        self,
+        bus: EventBus,
+        prompter: Prompter | None = None,
+        transcript: Callable[[str], None] | None = None,
+        transcript_tags: frozenset[str] = DEFAULT_TRANSCRIPT_TAGS,
+    ) -> None:
+        self.bus = bus
+        self.prompter: Prompter = prompter if prompter is not None else NullPrompter()
+        self._transcript = transcript
+        self._transcript_tags = transcript_tags
+
+    # -- display methods: one Log event each ---------------------------------
+
+    def title(self, text: str) -> None:
+        self.bus.emit(Log(kind="title", text=text))
+
+    def section(self, text: str) -> None:
+        self.bus.emit(Log(kind="section", text=text))
+
+    def subsection(self, text: str) -> None:
+        self.bus.emit(Log(kind="subsection", text=text))
+
+    def hr(self) -> None:
+        self.bus.emit(Log(kind="hr"))
+
+    def kv(self, key: str, value: str) -> None:
+        self.bus.emit(Log(kind="kv", key=key, text=value))
+
+    def startup_art(self) -> None:
+        self.bus.emit(Log(kind="startup_art"))
+
+    def info(self, text: str) -> None:
+        self.bus.emit(Log(severity="info", kind="line", text=text))
+
+    def ok(self, text: str) -> None:
+        self.bus.emit(Log(severity="ok", kind="line", text=text))
+
+    def warn(self, text: str) -> None:
+        self.bus.emit(Log(severity="warn", kind="line", text=text))
+
+    def err(self, text: str) -> None:
+        self.bus.emit(Log(severity="error", kind="line", text=text))
+
+    def channel_header(self, channel: str, title: str = "") -> None:
+        self.bus.emit(Log(kind="channel", key=channel, text=title))
+
+    def stream_line(self, tag: str, line: str) -> None:
+        if tag in self._transcript_tags and self._transcript is not None:
+            try:
+                self._transcript(line)
+            except Exception:  # noqa: BLE001 - transcripts never gate
+                self._transcript = None
+            return
+        self.bus.emit(Log(kind="stream", key=tag, text=line))
+
+    # -- interactive methods: delegate to the real prompter ------------------
+
+    def choose(self, header: str, options: list[str], default: int = 0) -> int:
+        return self.prompter.choose(header, options, default)
+
+    def can_prompt(self) -> bool:
+        return self.prompter.can_prompt()

--- a/tests/test_bridge_ui.py
+++ b/tests/test_bridge_ui.py
@@ -1,0 +1,131 @@
+"""Chunk 5 (TUI rewrite): EventBridgeUI shim."""
+
+from __future__ import annotations
+
+import io
+
+from ralph_py.events import CallbackSink, Event, EventBus, Log
+from ralph_py.ui.base import UI
+from ralph_py.ui.bridge import EventBridgeUI, NullPrompter, Prompter
+from ralph_py.ui.plain import PlainUI
+
+
+def _bridge_with_capture(
+    prompter: Prompter | None = None,
+    transcript_lines: list[str] | None = None,
+) -> tuple[EventBridgeUI, list[Event]]:
+    captured: list[Event] = []
+    bus = EventBus(CallbackSink(captured.append))
+    transcript = transcript_lines.append if transcript_lines is not None else None
+    return EventBridgeUI(bus, prompter=prompter, transcript=transcript), captured
+
+
+class TestProtocolConformance:
+    def test_assignable_to_ui_protocol(self) -> None:
+        bridge, _ = _bridge_with_capture()
+        ui: UI = bridge  # structural check at type level
+        assert ui.can_prompt() is False
+
+    def test_plain_ui_satisfies_prompter(self) -> None:
+        prompter: Prompter = PlainUI(no_color=True, file=io.StringIO())
+        assert prompter.can_prompt() in (True, False)
+
+
+class TestEventMapping:
+    def test_exact_event_per_method(self) -> None:
+        bridge, captured = _bridge_with_capture()
+        bridge.title("T")
+        bridge.section("S")
+        bridge.subsection("SS")
+        bridge.hr()
+        bridge.kv("Key", "Value")
+        bridge.startup_art()
+        bridge.info("i")
+        bridge.ok("o")
+        bridge.warn("w")
+        bridge.err("e")
+        bridge.channel_header("GUARD", "Disallowed")
+        bridge.stream_line("GIT", "git line")
+
+        expected = [
+            ("title", "info", "", "T"),
+            ("section", "info", "", "S"),
+            ("subsection", "info", "", "SS"),
+            ("hr", "info", "", ""),
+            ("kv", "info", "Key", "Value"),
+            ("startup_art", "info", "", ""),
+            ("line", "info", "", "i"),
+            ("line", "ok", "", "o"),
+            ("line", "warn", "", "w"),
+            ("line", "error", "", "e"),
+            ("channel", "info", "GUARD", "Disallowed"),
+            ("stream", "info", "GIT", "git line"),
+        ]
+        assert len(captured) == len(expected)
+        for event, (kind, severity, key, text) in zip(
+            captured, expected, strict=True,
+        ):
+            assert isinstance(event, Log)
+            assert (event.kind, event.severity, event.key, event.text) == (
+                kind, severity, key, text,
+            )
+
+
+class TestTranscriptRouting:
+    def test_tagged_stream_goes_to_transcript_not_bus(self) -> None:
+        lines: list[str] = []
+        bridge, captured = _bridge_with_capture(transcript_lines=lines)
+        bridge.stream_line("AI", "agent output line")
+        bridge.stream_line("GIT", "git output line")
+        assert lines == ["agent output line"]
+        assert len(captured) == 1  # only the GIT line became an event
+        assert isinstance(captured[0], Log)
+        assert captured[0].key == "GIT"
+
+    def test_no_transcript_configured_tagged_lines_become_events(self) -> None:
+        bridge, captured = _bridge_with_capture()
+        bridge.stream_line("AI", "agent line")
+        assert len(captured) == 1
+        assert isinstance(captured[0], Log)
+        assert captured[0].kind == "stream"
+        assert captured[0].key == "AI"
+
+    def test_transcript_failure_disables_not_raises(self) -> None:
+        calls: list[str] = []
+
+        def dying(line: str) -> None:
+            calls.append(line)
+            raise OSError("disk full")
+
+        bus = EventBus()
+        bridge = EventBridgeUI(bus, transcript=dying)
+        bridge.stream_line("AI", "one")  # raises inside, swallowed
+        bridge.stream_line("AI", "two")  # transcript disabled; becomes event
+        assert calls == ["one"]
+
+
+class TestPrompterDelegation:
+    def test_choose_delegates(self) -> None:
+        class Recorder:
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, list[str], int]] = []
+
+            def choose(self, header: str, options: list[str],
+                       default: int = 0) -> int:
+                self.calls.append((header, options, default))
+                return 2
+
+            def can_prompt(self) -> bool:
+                return True
+
+        rec = Recorder()
+        bridge, captured = _bridge_with_capture(prompter=rec)
+        assert bridge.choose("Q?", ["a", "b", "c"], 1) == 2
+        assert rec.calls == [("Q?", ["a", "b", "c"], 1)]
+        assert bridge.can_prompt() is True
+        assert captured == []  # interaction is not an event
+
+    def test_null_prompter_defaults(self) -> None:
+        p = NullPrompter()
+        assert p.can_prompt() is False
+        assert p.choose("Q?", ["a", "b"], 1) == 1


### PR DESCRIPTION
## Summary

Chunk 5 of the TUI rewrite plan (stacked on #105). Purely additive: `ralph_py/ui/bridge.py` + tests.

`EventBridgeUI` implements the legacy 14-method `UI` protocol by emitting typed `Log` events (`kind`: line/kv/section/subsection/title/hr/channel/stream/startup_art; `severity`: info/ok/warn/error) on an `EventBus` - the migration shim that lets ~390 imperative call sites keep working unchanged while becoming part of the replayable stream. `choose`/`can_prompt` delegate to a real `Prompter` (structural protocol; `PlainUI`/`RichUI` already satisfy it, `NullPrompter` for non-interactive contexts). `stream_line("AI", ...)` routes to a transcript file writer rather than the bus, per the spike's input-starvation finding; a failing writer disables itself and never raises.

Wiring comes next: chunk 6 uses it in workers (replacing the raw `PlainUI` on inherited stderr), chunk 7 swaps the 10 cli `get_ui()` sites behind `build_console()` with a byte-identical renderer round-trip.

Gates: 8 new tests; fast tier 1577 passed; `mypy --strict` clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)