### PR TITLE
TUI chunk 6: worker event channel, fd redirection, heartbeat

### DIFF
--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import os
 import shutil
 import subprocess
+import sys
+import threading
 import time
 from collections.abc import Callable, Mapping
 from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any, TextIO
 
 from ralph_py.agents.base import UsageTotals, collect_usage
 from ralph_py.breaker import BreakerConfig
@@ -36,6 +39,7 @@ from ralph_py.events import (
     RunPlan,
     RunStarted,
     V1CompatSink,
+    WorkerHeartbeat,
 )
 from ralph_py.events import (
     ContractResult as ContractResultEvent,
@@ -932,14 +936,29 @@ def _run_component(
     sandbox_enabled: bool = False,
     sandbox_allow_network: bool = False,
     agent_budget_usd: float | None = None,
+    events_dir_str: str | None = None,
+    run_id: str = "",
+    redirect_output: bool = True,
+    live_line: Callable[[str], None] | None = None,
 ) -> ComponentResult:
     """Run a single component's implementation loop.
 
     Top-level function (picklable for ProcessPoolExecutor).
     Creates all objects internally - no shared state.
+
+    Chunk 6 (TUI rewrite): with ``events_dir_str`` set, the worker
+    writes typed events to <events_dir>/components/<id>/engineer.jsonl,
+    the raw agent transcript to engineer.log, and (pool mode) dup2's
+    its inherited stdout/stderr onto that same log so parallel workers
+    stop interleaving raw lines on the parent terminal. ``live_line``
+    (inline mode only - never pickled) mirrors each transcript line to
+    the parent's UI so sequential runs keep live engineer output.
+    Without ``events_dir_str`` the legacy PlainUI-on-stderr behavior is
+    preserved for direct callers.
     """
     from ralph_py.agents import get_agent
     from ralph_py.loop import run_loop
+    from ralph_py.ui.bridge import EventBridgeUI, NullPrompter
     from ralph_py.ui.plain import PlainUI
 
     start = time.monotonic()
@@ -952,7 +971,45 @@ def _run_component(
     # to the harness DEFAULT_PROMPT (phase-f e2e validation, line 38).
     root_dir = Path(root_dir_str)
 
-    ui = PlainUI(no_color=True)
+    ui: UI
+    worker_bus: EventBus | None = None
+    transcript_fh: TextIO | None = None
+    stop_heartbeat: Callable[[], None] | None = None
+    if events_dir_str is None:
+        ui = PlainUI(no_color=True)
+    else:
+        run_paths = RunPaths(root=Path(events_dir_str))
+        comp_dir = run_paths.component_dir(component_id)
+        try:
+            comp_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
+        if redirect_output:
+            # dup2 BEFORE any threads start (chunk 6 invariant); stray
+            # library writes land in the transcript, never the terminal.
+            _redirect_worker_output(run_paths.engineer_log(component_id))
+        try:
+            transcript_fh = open(
+                run_paths.engineer_log(component_id),
+                "a", buffering=1, encoding="utf-8",
+            )
+        except OSError:
+            transcript_fh = None
+
+        def _transcript(line: str) -> None:
+            if transcript_fh is not None:
+                transcript_fh.write(line + "\n")
+            if live_line is not None:
+                live_line(line)
+
+        worker_bus = EventBus(
+            JsonlSink(run_paths.engineer_events(component_id)),
+            run_id=run_id, source="worker", component=component_id,
+        )
+        ui = EventBridgeUI(
+            worker_bus, prompter=NullPrompter(), transcript=_transcript,
+        )
+        stop_heartbeat = _start_heartbeat(worker_bus)
     agent = get_agent(
         agent_cmd, model, reasoning, agent_type,
         sandbox=SandboxConfig(
@@ -1075,6 +1132,7 @@ def _run_component(
             config, ui, agent, worktree_path,
             context_prefix=context_prefix, timeouts=timeouts,
             breaker_config=breaker_config,
+            bus=worker_bus,
         )
         # Report which limit fired so the retry/fail path can act on it
         # (timeout errors trigger the recreate-from-base retry hygiene).
@@ -1120,6 +1178,63 @@ def _run_component(
             # cost tokens; collect what the agent recorded (R3.1).
             usage=collect_usage(agent),
         )
+    finally:
+        if stop_heartbeat is not None:
+            stop_heartbeat()
+        if worker_bus is not None:
+            worker_bus.close()
+        if transcript_fh is not None:
+            try:
+                transcript_fh.close()
+            except OSError:
+                pass
+
+
+_HEARTBEAT_INTERVAL_SECONDS = 15.0
+
+
+def _redirect_worker_output(log_path: Path) -> None:
+    """Point the worker's fds 1/2 (and sys.stdout/stderr) at its
+    transcript so nothing reaches the parent terminal (chunk 6). Best
+    effort: a worker that cannot redirect keeps inherited fds rather
+    than dying."""
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        f = open(log_path, "a", buffering=1, encoding="utf-8", errors="replace")
+        os.dup2(f.fileno(), 1)
+        os.dup2(f.fileno(), 2)
+        sys.stdout = f
+        sys.stderr = f
+    except OSError:
+        pass
+
+
+def _start_heartbeat(
+    bus: EventBus, interval: float | None = None,
+) -> Callable[[], None]:
+    """Emit WorkerHeartbeat every ``interval`` seconds on a daemon
+    thread until the returned stop callable runs. JsonlSink's lock
+    makes the cross-thread emit safe."""
+    stop_event = threading.Event()
+    period = _HEARTBEAT_INTERVAL_SECONDS if interval is None else interval
+    started = time.monotonic()
+    pid = os.getpid()
+
+    def _beat() -> None:
+        while not stop_event.wait(period):
+            bus.emit(WorkerHeartbeat(
+                pid=pid,
+                elapsed_seconds=round(time.monotonic() - started, 1),
+            ))
+
+    thread = threading.Thread(target=_beat, daemon=True, name="ralph-heartbeat")
+    thread.start()
+
+    def _stop() -> None:
+        stop_event.set()
+        thread.join(timeout=1.0)
+
+    return _stop
 
 
 class _InlineExecutor:
@@ -1705,6 +1820,10 @@ def _run_factory_locked(
             sandbox_cfg.allow_network,
             # R7.6: in-loop USD budget for the claude-sdk engineer.
             base_config.agent_budget_usd,
+            # Chunk 6: worker event channel (None when progress logging
+            # is disabled - transcripts and events off together).
+            str(run_paths.root) if run_paths is not None else None,
+            run_id,
         )
 
     def _run_scheduling_pass() -> None:
@@ -1772,7 +1891,26 @@ def _run_factory_locked(
                         continue
 
                     args = _submit_args(comp, wt_path)
-                    future = executor.submit(_run_component, *args)
+                    if isinstance(executor, _InlineExecutor):
+                        # In-process worker: no fd redirection (it would
+                        # hijack the parent terminal), and each transcript
+                        # line mirrors to the parent UI so sequential runs
+                        # keep live engineer output. functools.partial
+                        # binds ralph_py.factory._run_component AT SUBMIT
+                        # TIME, so tests patching it still intercept.
+                        # mypy cannot prove the unknown-length *args
+                        # tuple stops before the kwargs; _submit_args
+                        # ends at run_id by construction.
+                        task = functools.partial(
+                            _run_component, *args,
+                            redirect_output=False,  # type: ignore[misc]
+                            live_line=functools.partial(
+                                ui.stream_line, "AI",
+                            ),
+                        )
+                        future = executor.submit(task)
+                    else:
+                        future = executor.submit(_run_component, *args)
                     running_futures[future] = comp.id
                     if backstop_seconds > 0:
                         future_deadlines[future] = (

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -975,6 +975,7 @@ def _run_component(
     worker_bus: EventBus | None = None
     transcript_fh: TextIO | None = None
     stop_heartbeat: Callable[[], None] | None = None
+    run_paths: RunPaths | None = None
     if events_dir_str is None:
         ui = PlainUI(no_color=True)
     else:
@@ -988,28 +989,7 @@ def _run_component(
             # dup2 BEFORE any threads start (chunk 6 invariant); stray
             # library writes land in the transcript, never the terminal.
             _redirect_worker_output(run_paths.engineer_log(component_id))
-        try:
-            transcript_fh = open(
-                run_paths.engineer_log(component_id),
-                "a", buffering=1, encoding="utf-8",
-            )
-        except OSError:
-            transcript_fh = None
 
-        def _transcript(line: str) -> None:
-            if transcript_fh is not None:
-                transcript_fh.write(line + "\n")
-            if live_line is not None:
-                live_line(line)
-
-        worker_bus = EventBus(
-            JsonlSink(run_paths.engineer_events(component_id)),
-            run_id=run_id, source="worker", component=component_id,
-        )
-        ui = EventBridgeUI(
-            worker_bus, prompter=NullPrompter(), transcript=_transcript,
-        )
-        stop_heartbeat = _start_heartbeat(worker_bus)
     agent = get_agent(
         agent_cmd, model, reasoning, agent_type,
         sandbox=SandboxConfig(
@@ -1126,6 +1106,33 @@ def _run_component(
         test_command=breaker_test_command,
         test_timeout=breaker_test_timeout,
     )
+
+    # Start event-owned resources only after setup succeeds. A get_agent,
+    # file-copy, or config failure therefore cannot leak a heartbeat thread
+    # or open JSONL/transcript handles in a reusable pool worker.
+    if run_paths is not None:
+        try:
+            transcript_fh = open(
+                run_paths.engineer_log(component_id),
+                "a", buffering=1, encoding="utf-8",
+            )
+        except OSError:
+            transcript_fh = None
+
+        def _transcript(line: str) -> None:
+            if transcript_fh is not None:
+                transcript_fh.write(line + "\n")
+            if live_line is not None:
+                live_line(line)
+
+        worker_bus = EventBus(
+            JsonlSink(run_paths.engineer_events(component_id)),
+            run_id=run_id, source="worker", component=component_id,
+        )
+        ui = EventBridgeUI(
+            worker_bus, prompter=NullPrompter(), transcript=_transcript,
+        )
+        stop_heartbeat = _start_heartbeat(worker_bus)
 
     try:
         result = run_loop(

--- a/ralph_py/loop.py
+++ b/ralph_py/loop.py
@@ -231,29 +231,30 @@ def run_loop(
         # Run agent
         completion_seen = False
         iteration_timed_out = False
-        for line in agent.run(prompt, cwd, timeout=iteration_timeout):
-            if line.strip() == COMPLETION_MARKER:
-                completion_seen = True
-            if line.startswith(TIMEOUT_MESSAGE_PREFIX):
-                iteration_timed_out = True
-            ui.stream_line("AI", line)
+        try:
+            for line in agent.run(prompt, cwd, timeout=iteration_timeout):
+                if line.strip() == COMPLETION_MARKER:
+                    completion_seen = True
+                if line.startswith(TIMEOUT_MESSAGE_PREFIX):
+                    iteration_timed_out = True
+                ui.stream_line("AI", line)
 
-        final_message = agent.final_message
-        if not completion_seen and final_message:
-            completion_seen = any(
-                line.strip() == COMPLETION_MARKER
-                for line in final_message.splitlines()
-            )
-
-        iter_duration = time.monotonic() - iter_start
-        iteration_durations.append(iter_duration)
-        if bus is not None:
-            bus.emit(IterationCompleted(
-                iteration=iteration,
-                duration_seconds=round(iter_duration, 2),
-                completed=completion_seen,
-                timed_out=iteration_timed_out,
-            ))
+            final_message = agent.final_message
+            if not completion_seen and final_message:
+                completion_seen = any(
+                    line.strip() == COMPLETION_MARKER
+                    for line in final_message.splitlines()
+                )
+        finally:
+            iter_duration = time.monotonic() - iter_start
+            iteration_durations.append(iter_duration)
+            if bus is not None:
+                bus.emit(IterationCompleted(
+                    iteration=iteration,
+                    duration_seconds=round(iter_duration, 2),
+                    completed=completion_seen,
+                    timed_out=iteration_timed_out,
+                ))
 
         if iteration_timed_out:
             timed_out_iterations += 1

--- a/ralph_py/loop.py
+++ b/ralph_py/loop.py
@@ -11,6 +11,7 @@ from ralph_py import git, guards
 from ralph_py.agents.base import UsageTotals, collect_usage
 from ralph_py.agents.proc import TIMEOUT_MESSAGE_PREFIX
 from ralph_py.breaker import BreakerConfig, NoProgressBreaker
+from ralph_py.events import EventBus, IterationCompleted, IterationStarted
 from ralph_py.prd import PRD
 from ralph_py.timeout import TimeoutConfig
 
@@ -57,6 +58,8 @@ def run_loop(
     context_prefix: str | None = None,
     timeouts: TimeoutConfig | None = None,
     breaker_config: BreakerConfig | None = None,
+    *,
+    bus: EventBus | None = None,
 ) -> LoopResult:
     """Run the main agentic loop.
 
@@ -206,6 +209,10 @@ def run_loop(
     for iteration in range(1, config.max_iterations + 1):
         ui.section(f"Iteration {iteration} / {config.max_iterations}")
         iter_start = time.monotonic()
+        if bus is not None:
+            bus.emit(IterationStarted(
+                iteration=iteration, max_iterations=config.max_iterations,
+            ))
 
         # Bound the iteration by the per-iteration limit AND the remaining
         # component budget, so one iteration cannot blow far past the
@@ -240,6 +247,13 @@ def run_loop(
 
         iter_duration = time.monotonic() - iter_start
         iteration_durations.append(iter_duration)
+        if bus is not None:
+            bus.emit(IterationCompleted(
+                iteration=iteration,
+                duration_seconds=round(iter_duration, 2),
+                completed=completion_seen,
+                timed_out=iteration_timed_out,
+            ))
 
         if iteration_timed_out:
             timed_out_iterations += 1

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -410,3 +410,125 @@ class TestPhaseTranscripts:
             on_line=seen.append,
         )
         assert seen == ["line-a", "line-b"]
+
+
+class TestWorkerChannel:
+    def _worker_args(self, root: Path, events_dir: Path | None,
+                     agent_cmd: str) -> dict[str, Any]:
+        from ralph_py.factory import _run_component  # noqa: F401 - existence
+        _setup_project(root, ["comp-a"])
+        return dict(
+            component_id="comp-a",
+            prd_path_str="scripts/ralph/feature/comp-a/prd.json",
+            worktree_path_str=str(root),
+            root_dir_str=str(root),
+            prompt_file_str="scripts/ralph/prompt.md",
+            agent_cmd=agent_cmd,
+            model=None, reasoning=None, agent_type=None,
+            sleep_seconds=0.0,
+            max_iterations=1,
+            events_dir_str=str(events_dir) if events_dir else None,
+            run_id="run-w",
+            redirect_output=False,  # NEVER dup2 inside the test process
+        )
+
+    def test_worker_writes_events_and_transcript(
+        self, tmp_path: Path, capfd: Any,
+    ) -> None:
+        from ralph_py.factory import _run_component
+
+        events_dir = tmp_path / ".ralph" / "runs" / "run-w"
+        result = _run_component(**self._worker_args(
+            tmp_path, events_dir, "echo engineer-output-line",
+        ))
+        assert result.component_id == "comp-a"
+
+        comp_dir = events_dir / "components" / "comp-a"
+        worker_events = ev.read_events(comp_dir / "engineer.jsonl")
+        assert worker_events, "worker emitted no events"
+        assert all(e.source == "worker" for e in worker_events)
+        assert all(e.component == "comp-a" for e in worker_events)
+        names = [type(e).type for e in worker_events]
+        assert "iteration_started" in names
+        assert "iteration_completed" in names
+        assert "log" in names  # bridge narration (banner, sections)
+
+        transcript = (comp_dir / "engineer.log").read_text()
+        assert "engineer-output-line" in transcript
+
+        # The bridge path writes NOTHING to the inherited terminal.
+        out, err = capfd.readouterr()
+        assert out == ""
+        assert err == ""
+
+    def test_worker_without_events_dir_keeps_legacy_stderr(
+        self, tmp_path: Path, capfd: Any,
+    ) -> None:
+        from ralph_py.factory import _run_component
+
+        _run_component(**self._worker_args(
+            tmp_path, None, "echo legacy-line",
+        ))
+        _, err = capfd.readouterr()
+        assert "legacy-line" in err  # PlainUI on stderr, as before
+
+    def test_heartbeat_thread_emits(self) -> None:
+        import time as _time
+
+        from ralph_py.factory import _start_heartbeat
+
+        captured: list[ev.Event] = []
+        bus = ev.EventBus(
+            ev.CallbackSink(captured.append),
+            run_id="run-h", source="worker", component="comp-a",
+        )
+        stop = _start_heartbeat(bus, interval=0.01)
+        _time.sleep(0.08)
+        stop()
+        beats = [e for e in captured if isinstance(e, ev.WorkerHeartbeat)]
+        assert beats, "no heartbeat emitted"
+        assert beats[0].pid > 0
+        count_after_stop = len(beats)
+        _time.sleep(0.05)
+        assert len([
+            e for e in captured if isinstance(e, ev.WorkerHeartbeat)
+        ]) == count_after_stop  # stopped means stopped
+
+    def test_inline_factory_tees_live_lines_and_persists_files(
+        self, tmp_path: Path,
+    ) -> None:
+        """max_parallel=1 runs the REAL worker in-process: the parent UI
+        still shows live AI lines, while events + transcript land in the
+        run dir (the same layout as pool mode)."""
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root)
+        ui_buffer = io.StringIO()
+
+        marker = "<promise>COMPLETE</promise>"
+        base = _make_base_config(root)
+        base.agent_cmd = f"echo '{marker}'"
+        with patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, base,
+                PlainUI(no_color=True, file=ui_buffer), root,
+            )
+        # The echo agent emits the completion marker: component succeeds.
+        assert "comp-a" in result.completed
+
+        # Live tee: the AI line reached the parent UI.
+        assert marker in ui_buffer.getvalue()
+
+        run_dir = _events_file(root).parent
+        comp_dir = run_dir / "components" / "comp-a"
+        assert (comp_dir / "engineer.log").exists()
+        assert marker in (comp_dir / "engineer.log").read_text()
+        worker_events = ev.read_events(comp_dir / "engineer.jsonl")
+        assert any(
+            isinstance(e, ev.IterationCompleted) and e.completed
+            for e in worker_events
+        )
+
+        # The reducer merges worker files into the run view.
+        state, _ = reducer.load_run_state(root)
+        assert state.components["comp-a"].iteration == 1

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -472,6 +472,54 @@ class TestWorkerChannel:
         _, err = capfd.readouterr()
         assert "legacy-line" in err  # PlainUI on stderr, as before
 
+    def test_setup_failure_does_not_start_heartbeat(self, tmp_path: Path) -> None:
+        from ralph_py.factory import _run_component
+
+        with patch(
+            "ralph_py.agents.get_agent", side_effect=RuntimeError("no agent"),
+        ), patch("ralph_py.factory._start_heartbeat") as start_heartbeat:
+            try:
+                _run_component(**self._worker_args(
+                    tmp_path, tmp_path / ".ralph" / "runs" / "run-w", "bad",
+                ))
+            except RuntimeError as exc:
+                assert str(exc) == "no agent"
+            else:  # pragma: no cover - get_agent must fail
+                raise AssertionError("expected get_agent failure")
+        start_heartbeat.assert_not_called()
+
+    def test_agent_crash_closes_iteration_event(self, tmp_path: Path) -> None:
+        from ralph_py.factory import _run_component
+
+        class CrashingAgent:
+            usage_records: list[Any] = []
+
+            @property
+            def name(self) -> str:
+                return "crashing"
+
+            def run(self, *args: Any, **kwargs: Any) -> Any:
+                raise RuntimeError("agent crashed")
+
+            @property
+            def final_message(self) -> str | None:
+                return None
+
+        events_dir = tmp_path / ".ralph" / "runs" / "run-w"
+        with patch("ralph_py.agents.get_agent", return_value=CrashingAgent()):
+            result = _run_component(**self._worker_args(
+                tmp_path, events_dir, "crash",
+            ))
+        assert result.success is False
+        assert result.error == "agent crashed"
+        events = ev.read_events(
+            events_dir / "components" / "comp-a" / "engineer.jsonl"
+        )
+        starts = [e for e in events if isinstance(e, ev.IterationStarted)]
+        completed = [e for e in events if isinstance(e, ev.IterationCompleted)]
+        assert len(starts) == len(completed) == 1
+        assert completed[0].completed is False
+
     def test_heartbeat_thread_emits(self) -> None:
         import time as _time
 

--- a/tests/test_run_honesty.py
+++ b/tests/test_run_honesty.py
@@ -156,6 +156,7 @@ class TestIterationForwarding:
             config: RalphConfig, ui: Any, agent: Any,
             cwd: Path | None = None, context_prefix: str | None = None,
             timeouts: Any = None, breaker_config: Any = None,
+            **kwargs: Any,
         ) -> LoopResult:
             captured["config"] = config
             return LoopResult(completed=True, iterations=1, exit_code=0)


### PR DESCRIPTION
## Summary

Chunk 6 of the TUI rewrite plan (stacked on #106). This is the chunk that fixes the worst structural defect the analysis found: parallel workers interleaving raw lines on the shared terminal, and factory engineer transcripts existing only as ephemeral stderr.

- `_run_component` (with an events dir): worker-owned `EventBus` (`source="worker"`, component stamped) -> `components/<id>/engineer.jsonl`; `EventBridgeUI` replaces `PlainUI(no_color=True)`; agent transcript -> `engineer.log`; pool mode dup2's fds 1/2 onto the log before any threads start. Legacy behavior preserved when no events dir is passed (direct callers).
- `worker_heartbeat` every 15s from a daemon thread (stop callable in `finally`; interval injectable for tests).
- `run_loop(bus=...)` emits `iteration_started`/`iteration_completed` around the agent drain.
- Pickle boundary: two trailing strings on `_submit_args` (`events_dir_str`, `run_id`).
- Inline mode (`max_parallel<=1`): no redirection + `live_line` tee to the parent UI, bound via `functools.partial` at submit time so `patch("ralph_py.factory._run_component")` still intercepts. Sequential UX unchanged; parallel terminals go quiet by design until the TUI multiplexes the files (PR D/E).

## Tests (+4, 18 total in test_event_stream.py)

Worker channel end-to-end with a real `echo` agent (events with `source=worker`, transcript content, `capfd` proves zero terminal bytes), legacy-fallback stderr behavior, heartbeat emit/stop, and a full inline `run_factory` with a completion-marker agent asserting the live tee + persisted files + `load_run_state` merge. One existing stub updated (`test_run_honesty` fake_run_loop accepts `**kwargs`).

Gates: fast tier 1592 passed, spine 24 passed, `mypy --strict` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)