### PR TITLE
[slugify] Implement slugify_max function for truncation

### DIFF
--- a/scripts/ralph/feature/slugify-max/prd.json
+++ b/scripts/ralph/feature/slugify-max/prd.json
@@ -1,0 +1,61 @@
+{
+  "branchName": "ralph/factory/slugify-max",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Boundary-respecting truncation at word separator",
+      "acceptanceCriteria": [
+        "WHEN slugify_max('Hello Brave World', 11) is called THEN it returns 'hello-brave'",
+        "WHEN slugify_max('Hello Brave World', 10) is called THEN it returns 'hello'",
+        "WHEN max_length is greater than or equal to the full slug length THEN return the entire slug unchanged",
+        "WHEN the slug contains separators and at least one separator fits within max_length THEN truncate at the last fitting word boundary without ending with a separator character"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Implemented in slugify_max (tools/slugify.py) alongside US-002/US-003 since a correct, non-half-finished truncation algorithm requires the hard-cut fallback and max_length validation as inseparable parts of the same function. Verified by tests/test_slugify.py::TestSlugifyMax."
+    },
+    {
+      "id": "US-002",
+      "title": "Hard-cut fallback for first words exceeding max_length",
+      "acceptanceCriteria": [
+        "WHEN slugify_max('Extraordinary', 5) is called THEN it returns 'extra'",
+        "WHEN the first word exceeds max_length and no separator fits within max_length THEN perform a hard truncation to exactly max_length characters"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "See US-001 note. Verified by test_hard_truncation_when_first_word_exceeds_max_length and test_hard_truncation_no_separator_present."
+    },
+    {
+      "id": "US-003",
+      "title": "Error handling for invalid max_length parameter",
+      "acceptanceCriteria": [
+        "WHEN slugify_max('x', 0) is called THEN raise ValueError",
+        "WHEN max_length is any negative integer THEN raise ValueError",
+        "WHEN max_length is 1 or greater THEN do not raise ValueError regardless of text input"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "See US-001 note. Verified by test_zero_max_length_raises_value_error, test_negative_max_length_raises_value_error, test_max_length_one_or_greater_never_raises."
+    },
+    {
+      "id": "US-004",
+      "title": "Code quality, type hints, and test coverage",
+      "acceptanceCriteria": [
+        "Code includes 'from __future__ import annotations' at the top of tools/slugify.py",
+        "All function signatures include full type hints matching repo coding standards",
+        "Ruff clean: uv run ruff check tools/slugify.py produces no errors or warnings",
+        "All existing tests in tests/test_slugify.py pass unchanged",
+        "New tests added covering all four specified acceptance criteria examples and at least two implementer-chosen edge cases",
+        "Tests pass: uv run pytest tests/test_slugify.py -v"
+      ],
+      "priority": 4,
+      "passes": true,
+      "notes": "uv run ruff check tools/slugify.py tests/test_slugify.py: clean. uv run mypy tools/slugify.py --strict: clean. uv run pytest tests/test_slugify.py -v: 19 passed."
+    }
+  ],
+  "allowedPaths": [
+    "tools/slugify.py",
+    "tests/test_slugify.py",
+    "scripts/ralph/feature/slugify-max/"
+  ]
+}

--- a/scripts/ralph/feature/slugify-max/prd.json
+++ b/scripts/ralph/feature/slugify-max/prd.json
@@ -12,7 +12,7 @@
       ],
       "priority": 1,
       "passes": true,
-      "notes": "Implemented in slugify_max (tools/slugify.py) alongside US-002/US-003 since a correct, non-half-finished truncation algorithm requires the hard-cut fallback and max_length validation as inseparable parts of the same function. Verified by tests/test_slugify.py::TestSlugifyMax."
+      "notes": "Implemented in slugify_max (tools/slugify.py) alongside US-002/US-003 since a correct, non-half-finished truncation algorithm requires the hard-cut fallback and max_length validation as inseparable parts of the same function. Verified by tests/test_slugify.py::TestSlugifyMax. [2026-07-20 review-fix] Truncation rewritten to split on whole words instead of character-position slicing so multi-character separators (e.g. '__') can never be cut mid-separator (review-confirmed FAIL). Separator is now validated as purely non-alphanumeric via _validate_separator so it can never collide with slug word content. See tests/test_slugify.py::TestSlugifyMaxMultiCharSeparator and ::TestSlugifySeparatorValidation."
     },
     {
       "id": "US-002",
@@ -50,7 +50,7 @@
       ],
       "priority": 4,
       "passes": true,
-      "notes": "uv run ruff check tools/slugify.py tests/test_slugify.py: clean. uv run mypy tools/slugify.py --strict: clean. uv run pytest tests/test_slugify.py -v: 19 passed."
+      "notes": "uv run ruff check tools/slugify.py tests/test_slugify.py: clean. uv run mypy tools/slugify.py --strict: clean. uv run pytest tests/test_slugify.py -v: 19 passed. [2026-07-20 review-fix] After fixing the multi-char-separator and alphanumeric-separator defects (see US-001 notes), re-ran all three: still clean/passing, now 30 passed."
     }
   ],
   "allowedPaths": [

--- a/tests/test_slugify.py
+++ b/tests/test_slugify.py
@@ -1,0 +1,81 @@
+"""Tests for the tools.slugify module."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.slugify import slugify, slugify_max
+
+
+class TestSlugify:
+    def test_basic_words(self) -> None:
+        assert slugify("Hello Brave World") == "hello-brave-world"
+
+    def test_single_word(self) -> None:
+        assert slugify("Extraordinary") == "extraordinary"
+
+    def test_collapses_punctuation_runs(self) -> None:
+        assert slugify("Hello,   Brave---World!!") == "hello-brave-world"
+
+    def test_all_punctuation_yields_empty_string(self) -> None:
+        assert slugify("!!!") == ""
+
+    def test_custom_separator(self) -> None:
+        assert slugify("Hello Brave World", separator="_") == "hello_brave_world"
+
+    def test_empty_separator_raises(self) -> None:
+        with pytest.raises(ValueError):
+            slugify("Hello World", separator="")
+
+
+class TestSlugifyMax:
+    def test_truncates_at_word_boundary_exact_fit(self) -> None:
+        assert slugify_max("Hello Brave World", 11) == "hello-brave"
+
+    def test_truncates_at_earlier_word_boundary_on_mid_word_cut(self) -> None:
+        assert slugify_max("Hello Brave World", 10) == "hello"
+
+    def test_max_length_covers_full_slug_returns_unchanged(self) -> None:
+        assert slugify_max("Hello Brave World", 100) == "hello-brave-world"
+
+    def test_max_length_equal_to_full_slug_length_returns_unchanged(self) -> None:
+        full = slugify("Hello Brave World")
+        assert slugify_max("Hello Brave World", len(full)) == full
+
+    def test_hard_truncation_when_first_word_exceeds_max_length(self) -> None:
+        assert slugify_max("Extraordinary", 5) == "extra"
+
+    def test_hard_truncation_no_separator_present(self) -> None:
+        assert slugify_max("Supercalifragilisticexpialidocious", 4) == "supe"
+
+    def test_zero_max_length_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="at least 1"):
+            slugify_max("x", 0)
+
+    def test_negative_max_length_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="at least 1"):
+            slugify_max("x", -5)
+
+    def test_max_length_one_or_greater_never_raises(self) -> None:
+        # Sweep a handful of inputs, including ones that slugify to empty,
+        # to confirm no ValueError is raised once max_length >= 1.
+        for text in ("Hello Brave World", "Extraordinary", "!!!", "", "a"):
+            for max_length in (1, 2, 5, 50):
+                slugify_max(text, max_length)  # must not raise
+
+    def test_empty_slug_returns_empty_string_regardless_of_max_length(self) -> None:
+        assert slugify_max("!!!", 1) == ""
+        assert slugify_max("!!!", 50) == ""
+
+    def test_custom_separator_forwarded_to_slugify(self) -> None:
+        assert slugify_max("Hello Brave World", 11, separator="_") == "hello_brave"
+
+    def test_result_length_never_exceeds_max_length(self) -> None:
+        for max_length in range(1, 20):
+            result = slugify_max("Hello Brave World", max_length)
+            assert len(result) <= max_length
+
+    def test_result_never_ends_with_separator(self) -> None:
+        for max_length in range(1, 18):
+            result = slugify_max("Hello Brave World", max_length)
+            assert not result.endswith("-")

--- a/tests/test_slugify.py
+++ b/tests/test_slugify.py
@@ -79,3 +79,59 @@ class TestSlugifyMax:
         for max_length in range(1, 18):
             result = slugify_max("Hello Brave World", max_length)
             assert not result.endswith("-")
+
+
+class TestSlugifyMaxMultiCharSeparator:
+    def test_cut_mid_separator_does_not_leave_partial_fragment(self) -> None:
+        # slug is "foo__bar__baz"; max_length=4 lands one character past
+        # the first underscore of the "foo" -> "bar" separator, i.e.
+        # inside the two-character separator itself.
+        assert slugify_max("foo bar baz", 4, separator="__") == "foo"
+
+    def test_cut_exactly_at_separator_boundary(self) -> None:
+        assert slugify_max("foo bar baz", 3, separator="__") == "foo"
+
+    def test_cut_after_full_word_and_separator(self) -> None:
+        assert slugify_max("foo bar baz", 8, separator="__") == "foo__bar"
+
+    def test_hard_truncation_with_multi_char_separator(self) -> None:
+        assert slugify_max("extraordinarily nice", 5, separator="__") == "extra"
+
+    def test_no_trailing_partial_separator_across_all_cut_points(self) -> None:
+        text = "foo bar baz qux"
+        separator = "__"
+        full = slugify(text, separator=separator)
+        for max_length in range(1, len(full) + 5):
+            result = slugify_max(text, max_length, separator=separator)
+            assert len(result) <= max_length
+            assert not result.endswith("_")
+            assert not result.startswith("_")
+
+
+class TestSlugifySeparatorValidation:
+    def test_alphanumeric_letter_separator_raises(self) -> None:
+        with pytest.raises(ValueError, match="alphanumeric"):
+            slugify("Hello World", separator="x")
+
+    def test_alphanumeric_digit_separator_raises(self) -> None:
+        with pytest.raises(ValueError, match="alphanumeric"):
+            slugify("Hello World", separator="1")
+
+    def test_mixed_alphanumeric_separator_raises(self) -> None:
+        with pytest.raises(ValueError, match="alphanumeric"):
+            slugify("Hello World", separator="a-")
+
+    def test_alphanumeric_separator_raises_via_slugify_max(self) -> None:
+        with pytest.raises(ValueError, match="alphanumeric"):
+            slugify_max("Hello World", 5, separator="ab")
+
+    def test_alphanumeric_separator_cannot_eat_leading_text(self) -> None:
+        # Regression guard: an alphanumeric separator must be rejected
+        # rather than silently stripped from real word content that
+        # happens to match it (e.g. text starting with "xy" and
+        # separator="xy").
+        with pytest.raises(ValueError):
+            slugify("xylophone show", separator="xy")
+
+    def test_non_alnum_multi_char_separator_still_allowed(self) -> None:
+        assert slugify("Hello World", separator="::") == "hello::world"

--- a/tools/slugify.py
+++ b/tools/slugify.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import re
+
+_NON_ALNUM_RUN_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _strip_separator(value: str, separator: str) -> str:
+    """Strip leading/trailing occurrences of the literal separator string."""
+    while value.startswith(separator):
+        value = value[len(separator) :]
+    while value.endswith(separator):
+        value = value[: -len(separator)]
+    return value
+
+
+def slugify(text: str, separator: str = "-") -> str:
+    """Convert text to a lowercase slug with runs of non-alphanumeric
+    characters collapsed into a single separator occurrence.
+    """
+    if not separator:
+        raise ValueError("separator must be a non-empty string")
+    normalized = text.strip().lower()
+    # Escape backslashes so the separator is treated as a literal
+    # replacement rather than a regex backreference (e.g. "\1").
+    escaped_separator = separator.replace("\\", "\\\\")
+    collapsed = _NON_ALNUM_RUN_RE.sub(escaped_separator, normalized)
+    return _strip_separator(collapsed, separator)
+
+
+def slugify_max(text: str, max_length: int, separator: str = "-") -> str:
+    """Slugify text and truncate the result to at most max_length characters.
+
+    When the full slug is too long, truncation prefers the last word
+    boundary that fits within max_length so a word is never cut in half.
+    If even the first word exceeds max_length (no separator fits), the
+    result is hard-truncated to exactly max_length characters.
+    """
+    if max_length < 1:
+        raise ValueError(f"max_length must be at least 1, got {max_length!r}")
+    slug = slugify(text, separator=separator)
+    if len(slug) <= max_length:
+        return slug
+    truncated = slug[:max_length]
+    if slug.startswith(separator, max_length):
+        return truncated
+    boundary = truncated.rfind(separator)
+    if boundary == -1:
+        return truncated
+    return truncated[:boundary]

--- a/tools/slugify.py
+++ b/tools/slugify.py
@@ -5,6 +5,15 @@ import re
 _NON_ALNUM_RUN_RE = re.compile(r"[^a-z0-9]+")
 
 
+def _validate_separator(separator: str) -> None:
+    if not separator:
+        raise ValueError("separator must be a non-empty string")
+    if any(char.isalnum() for char in separator):
+        raise ValueError(
+            f"separator must not contain alphanumeric characters, got {separator!r}"
+        )
+
+
 def _strip_separator(value: str, separator: str) -> str:
     """Strip leading/trailing occurrences of the literal separator string."""
     while value.startswith(separator):
@@ -17,9 +26,14 @@ def _strip_separator(value: str, separator: str) -> str:
 def slugify(text: str, separator: str = "-") -> str:
     """Convert text to a lowercase slug with runs of non-alphanumeric
     characters collapsed into a single separator occurrence.
+
+    separator must consist entirely of non-alphanumeric characters. This
+    guarantees the separator can never collide with slug word content
+    (which is always [a-z0-9] after normalization), so leading/trailing
+    stripping and word-boundary truncation can never eat or split real
+    text.
     """
-    if not separator:
-        raise ValueError("separator must be a non-empty string")
+    _validate_separator(separator)
     normalized = text.strip().lower()
     # Escape backslashes so the separator is treated as a literal
     # replacement rather than a regex backreference (e.g. "\1").
@@ -33,18 +47,28 @@ def slugify_max(text: str, max_length: int, separator: str = "-") -> str:
 
     When the full slug is too long, truncation prefers the last word
     boundary that fits within max_length so a word is never cut in half.
-    If even the first word exceeds max_length (no separator fits), the
-    result is hard-truncated to exactly max_length characters.
+    Truncation operates on whole words split on the (validated, purely
+    non-alphanumeric) separator, so a cut can never land inside - or leave
+    a partial fragment of - a multi-character separator. If even the
+    first word exceeds max_length (no separator fits), the result is
+    hard-truncated to exactly max_length characters.
     """
     if max_length < 1:
         raise ValueError(f"max_length must be at least 1, got {max_length!r}")
     slug = slugify(text, separator=separator)
     if len(slug) <= max_length:
         return slug
-    truncated = slug[:max_length]
-    if slug.startswith(separator, max_length):
-        return truncated
-    boundary = truncated.rfind(separator)
-    if boundary == -1:
-        return truncated
-    return truncated[:boundary]
+
+    words = slug.split(separator)
+    fitted: list[str] = []
+    length = 0
+    for word in words:
+        addition = len(word) + (len(separator) if fitted else 0)
+        if length + addition > max_length:
+            break
+        fitted.append(word)
+        length += addition
+
+    if not fitted:
+        return words[0][:max_length]
+    return separator.join(fitted)


### PR DESCRIPTION
## Summary

Add slugify_max(text, max_length, separator='-') to tools/slugify.py to truncate slugs to a maximum length without ending on a separator and without cutting words when avoidable.

## Review Findings

**15 criteria passed, 0 failed, 0 advisory; 1 additional concerns**

**Reviewer model**: codex

- [pass] WHEN slugify_max('Hello Brave World', 11) is called THEN it returns 'hello-brave'
- [pass] WHEN slugify_max('Hello Brave World', 10) is called THEN it returns 'hello'
- [pass] WHEN max_length is greater than or equal to the full slug length THEN return the entire slug unchanged
- [pass] WHEN the slug contains separators and at least one separator fits within max_length THEN truncate at the last fitting word boundary without ending with a separator character
- [pass] WHEN slugify_max('Extraordinary', 5) is called THEN it returns 'extra'
- [pass] WHEN the first word exceeds max_length and no separator fits within max_length THEN perform a hard truncation to exactly max_length characters
- [pass] WHEN slugify_max('x', 0) is called THEN raise ValueError
- [pass] WHEN max_length is any negative integer THEN raise ValueError
- [pass] WHEN max_length is 1 or greater THEN do not raise ValueError regardless of text input
- [pass] Code includes 'from __future__ import annotations' at the top of tools/slugify.py
- [pass] All function signatures include full type hints matching repo coding standards
- [pass] Ruff clean: uv run ruff check tools/slugify.py produces no errors or warnings
- [pass] All existing tests in tests/test_slugify.py pass unchanged
- [pass] New tests added covering all four specified acceptance criteria examples and at least two implementer-chosen edge cases
- [pass] Tests pass: uv run pytest tests/test_slugify.py -v

### Reviewer concerns (beyond PRD)
- [advisory] **scope_creep** at `tools/slugify.py:8-14`
  - The change introduces an undocumented API restriction that rejects every separator containing an alphanumeric character. The PRD only specifies max_length validation and truncation behavior, while tests/test_slugify.py:104-137 add substantial coverage that locks in this unrelated separator policy.
  - Suggestion: Either document alphanumeric separators as intentionally unsupported in the feature contract or implement boundary truncation without narrowing the accepted separator input space.

**Notes**: Every hunk of the complete diff was examined. The requested truncation and max_length behavior is implemented correctly, and mechanical verification reports tests, type checking, lint, and scope checks passing. The only identified issue is the additional separator-validation policy, which is broader than the PRD.

## Adversarial Findings

### Security (0 findings)

- **PHASE SKIPPED**: security review disabled (mode=skip) (this role did not run for this PR)

## PRD

- File: `scripts/ralph/feature/slugify-max/prd.json`
- Component: `slugify-utility`

---
Generated by [Ralph](https://github.com/0xfauzi/ralph-loop)