### PR TITLE
[slugify] Implement unique_slug function for collision-free naming

### DIFF
--- a/scripts/ralph/feature/unique-slug/prd.json
+++ b/scripts/ralph/feature/unique-slug/prd.json
@@ -1,0 +1,62 @@
+{
+  "branchName": "ralph/factory/unique-slug",
+  "userStories": [
+    {
+      "id": "US-005",
+      "title": "Return slug unchanged when not in existing set",
+      "acceptanceCriteria": [
+        "WHEN unique_slug('Post', set()) is called THEN it returns 'post'",
+        "WHEN the slug resulting from slugify(text, separator) is not present in the existing set THEN return that slug unchanged"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Implemented in unique_slug (tools/slugify.py) alongside US-006/US-007 since a correct, non-half-finished uniqueness check requires the collision-suffix loop and the empty-slug fallback as inseparable parts of the same function (same precedent as slugify_max US-001-US-004). Verified by tests/test_slugify.py::TestUniqueSlug."
+    },
+    {
+      "id": "US-006",
+      "title": "Append numeric suffix for collision resolution",
+      "acceptanceCriteria": [
+        "WHEN unique_slug('Post', {'post'}) is called THEN it returns 'post-2'",
+        "WHEN unique_slug('Post', {'post', 'post-2'}) is called THEN it returns 'post-3'",
+        "WHEN the slug is in the existing set THEN append separator + N where N is the smallest integer >= 2 such that the result is not in existing",
+        "WHEN appending the suffix produces a collision, continue incrementing N until a unique slug is found"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "See US-005 note. Verified by test_appends_suffix_2_on_first_collision, test_appends_suffix_3_when_suffix_2_also_collides, test_keeps_incrementing_past_multiple_collisions."
+    },
+    {
+      "id": "US-007",
+      "title": "Handle empty slug by mapping to 'untitled'",
+      "acceptanceCriteria": [
+        "WHEN unique_slug('!!!', set()) is called THEN it returns 'untitled'",
+        "WHEN slugify produces an empty string THEN treat it as 'untitled' before applying uniqueness logic",
+        "WHEN 'untitled' itself is in the existing set THEN apply the same collision-resolution logic ('untitled-2', 'untitled-3', etc.)"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "See US-005 note. Verified by test_empty_slug_maps_to_untitled, test_untitled_collision_resolution, test_untitled_collision_resolution_multiple."
+    },
+    {
+      "id": "US-008",
+      "title": "Code quality, type hints, immutability guarantee, and test coverage",
+      "acceptanceCriteria": [
+        "Code includes 'from __future__ import annotations' at the top of tools/slugify.py",
+        "All function signatures include full type hints matching repo coding standards",
+        "Ruff clean: uv run ruff check tools/slugify.py produces no errors or warnings",
+        "The existing set parameter is never mutated by the function",
+        "All existing tests in tests/test_slugify.py pass unchanged",
+        "New tests added covering all three specified acceptance criteria examples and at least two implementer-chosen edge cases",
+        "Tests pass: uv run pytest tests/test_slugify.py -v"
+      ],
+      "priority": 4,
+      "passes": true,
+      "notes": "uv run ruff check tools/slugify.py tests/test_slugify.py: clean. uv run mypy tools/slugify.py --strict: clean. uv run pytest tests/test_slugify.py -v: 41 passed (all 30 pre-existing tests pass unchanged, 11 new). Immutability covered by test_does_not_mutate_existing_set (asserts the input set is byte-for-byte unchanged after the call)."
+    }
+  ],
+  "allowedPaths": [
+    "tools/slugify.py",
+    "tests/test_slugify.py",
+    "scripts/ralph/feature/unique-slug/"
+  ]
+}

--- a/tests/test_slugify.py
+++ b/tests/test_slugify.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from tools.slugify import slugify, slugify_max
+from tools.slugify import slugify, slugify_max, unique_slug
 
 
 class TestSlugify:
@@ -135,3 +135,48 @@ class TestSlugifySeparatorValidation:
 
     def test_non_alnum_multi_char_separator_still_allowed(self) -> None:
         assert slugify("Hello World", separator="::") == "hello::world"
+
+
+class TestUniqueSlug:
+    def test_returns_slug_unchanged_when_not_in_existing_set(self) -> None:
+        assert unique_slug("Post", set()) == "post"
+
+    def test_unchanged_slug_not_present_in_larger_existing_set(self) -> None:
+        assert unique_slug("Post", {"other-post", "another"}) == "post"
+
+    def test_appends_suffix_2_on_first_collision(self) -> None:
+        assert unique_slug("Post", {"post"}) == "post-2"
+
+    def test_appends_suffix_3_when_suffix_2_also_collides(self) -> None:
+        assert unique_slug("Post", {"post", "post-2"}) == "post-3"
+
+    def test_keeps_incrementing_past_multiple_collisions(self) -> None:
+        existing = {"post", "post-2", "post-3", "post-4"}
+        assert unique_slug("Post", existing) == "post-5"
+
+    def test_empty_slug_maps_to_untitled(self) -> None:
+        assert unique_slug("!!!", set()) == "untitled"
+
+    def test_untitled_collision_resolution(self) -> None:
+        assert unique_slug("!!!", {"untitled"}) == "untitled-2"
+
+    def test_untitled_collision_resolution_multiple(self) -> None:
+        assert unique_slug("!!!", {"untitled", "untitled-2"}) == "untitled-3"
+
+    def test_does_not_mutate_existing_set(self) -> None:
+        existing = {"post"}
+        result = unique_slug("Post", existing)
+        assert result == "post-2"
+        assert existing == {"post"}
+
+    def test_custom_separator_used_for_suffix(self) -> None:
+        assert unique_slug("Post", {"post"}, separator="_") == "post_2"
+
+    def test_sequential_calls_build_a_unique_set(self) -> None:
+        existing: set[str] = set()
+        slugs = []
+        for _ in range(3):
+            slug = unique_slug("Post", existing)
+            existing.add(slug)
+            slugs.append(slug)
+        assert slugs == ["post", "post-2", "post-3"]

--- a/tools/slugify.py
+++ b/tools/slugify.py
@@ -72,3 +72,27 @@ def slugify_max(text: str, max_length: int, separator: str = "-") -> str:
     if not fitted:
         return words[0][:max_length]
     return separator.join(fitted)
+
+
+def unique_slug(text: str, existing: set[str], separator: str = "-") -> str:
+    """Slugify text and disambiguate it against a set of existing slugs.
+
+    If slugify(text, separator) is empty (e.g. text is all punctuation),
+    it is treated as "untitled" before uniqueness is checked. If the
+    resulting slug is already present in existing, a numeric suffix
+    (separator + N, starting at N=2) is appended and incremented until a
+    slug not in existing is found. The existing set is read-only and is
+    never mutated by this function.
+    """
+    slug = slugify(text, separator=separator)
+    if not slug:
+        slug = "untitled"
+    if slug not in existing:
+        return slug
+
+    suffix = 2
+    candidate = f"{slug}{separator}{suffix}"
+    while candidate in existing:
+        suffix += 1
+        candidate = f"{slug}{separator}{suffix}"
+    return candidate


### PR DESCRIPTION
## Summary

Add unique_slug(text, existing, separator='-') to tools/slugify.py to ensure slug uniqueness by appending numeric suffixes to collisions, with special handling for empty slugs.

## Dependencies

- [Implement slugify_max function for truncation](https://github.com/0xfauzi/ralph-loop/pull/108)

## Review Findings

**16 criteria passed, 0 failed, 0 advisory; 0 additional concerns**

**Reviewer model**: codex

- [pass] WHEN unique_slug('Post', set()) is called THEN it returns 'post'
- [pass] WHEN the slug resulting from slugify(text, separator) is not present in the existing set THEN return that slug unchanged
- [pass] WHEN unique_slug('Post', {'post'}) is called THEN it returns 'post-2'
- [pass] WHEN unique_slug('Post', {'post', 'post-2'}) is called THEN it returns 'post-3'
- [pass] WHEN the slug is in the existing set THEN append separator + N where N is the smallest integer >= 2 such that the result is not in existing
- [pass] WHEN appending the suffix produces a collision, continue incrementing N until a unique slug is found
- [pass] WHEN unique_slug('!!!', set()) is called THEN it returns 'untitled'
- [pass] WHEN slugify produces an empty string THEN treat it as 'untitled' before applying uniqueness logic
- [pass] WHEN 'untitled' itself is in the existing set THEN apply the same collision-resolution logic ('untitled-2', 'untitled-3', etc.)
- [pass] Code includes 'from __future__ import annotations' at the top of tools/slugify.py
- [pass] All function signatures include full type hints matching repo coding standards
- [pass] Ruff clean: uv run ruff check tools/slugify.py produces no errors or warnings
- [pass] The existing set parameter is never mutated by the function
- [pass] All existing tests in tests/test_slugify.py pass unchanged
- [pass] New tests added covering all three specified acceptance criteria examples and at least two implementer-chosen edge cases
- [pass] Tests pass: uv run pytest tests/test_slugify.py -v

## Adversarial Findings

### Security (0 findings)

- **PHASE SKIPPED**: security review disabled (mode=skip) (this role did not run for this PR)

## PRD

- File: `scripts/ralph/feature/unique-slug/prd.json`
- Component: `unique-slug`

---
Generated by [Ralph](https://github.com/0xfauzi/ralph-loop)