### PR TITLE
TUI PR A: interaction seam + prompt_toolkit removal + evolve-apply fix

### DIFF
--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -34,6 +34,11 @@ from ralph_py.config import RalphConfig, _parse_paths, load_toml_section
 from ralph_py.decompose import SpecBlockerError, decompose_spec
 from ralph_py.factory import FactoryConfig, run_factory
 from ralph_py.init_cmd import DEFAULT_FEATURE_UNDERSTAND, run_init
+from ralph_py.interaction import (
+    PromptKind,
+    PromptRequest,
+    UiInteractionChannel,
+)
 from ralph_py.loop import run_loop
 from ralph_py.manifest import Manifest
 from ralph_py.observability import (
@@ -1214,18 +1219,20 @@ def feature(
     if implementation_auto_run:
         ui_impl.info("IMPLEMENTATION_AUTO_RUN enabled: skipping review gate")
     else:
-        if not ui_impl.can_prompt():
+        channel = UiInteractionChannel(ui_impl)
+        if not channel.can_prompt():
             ui_impl.err(
                 "Interactive review required. Re-run with --implementation-auto-run."
             )
             sys.exit(2)
 
-        choice = ui_impl.choose(
-            "Review the understand file and confirm implementation start:",
-            ["Start implementation", "Quit to amend"],
+        response = channel.request(PromptRequest(
+            kind=PromptKind.CONFIRM,
+            header="Review the understand file and confirm implementation start:",
+            options=("Start implementation", "Quit to amend"),
             default=0,
-        )
-        if choice != 0:
+        ))
+        if not response.answered or response.choice != 0:
             ui_impl.info("Amend the understand file and re-run `ralph feature`.")
             sys.exit(0)
 
@@ -1989,13 +1996,15 @@ def factory(
         deps = f" (depends on: {dep_list})" if dep_list else ""
         ui_impl.info(f"  {i}. {comp_id} [{status}]{deps}")
 
-    if not yes and ui_impl.can_prompt():
-        choice = ui_impl.choose(
-            "Proceed with factory execution?",
-            ["Start", "Quit"],
+    _factory_channel = UiInteractionChannel(ui_impl)
+    if not yes and _factory_channel.can_prompt():
+        response = _factory_channel.request(PromptRequest(
+            kind=PromptKind.CONFIRM,
+            header="Proceed with factory execution?",
+            options=("Start", "Quit"),
             default=0,
-        )
-        if choice != 0:
+        ))
+        if response.answered and response.choice != 0:
             sys.exit(0)
 
     ralph_dir = root_dir / "scripts" / "ralph"
@@ -2714,13 +2723,15 @@ def retry(
 
     manifest.save(manifest_file)
 
-    if not yes and ui_impl.can_prompt():
-        choice = ui_impl.choose(
-            f"Re-enter the factory to retry '{component_id}'?",
-            ["Start", "Quit"],
+    _retry_channel = UiInteractionChannel(ui_impl)
+    if not yes and _retry_channel.can_prompt():
+        response = _retry_channel.request(PromptRequest(
+            kind=PromptKind.CONFIRM,
+            header=f"Re-enter the factory to retry '{component_id}'?",
+            options=("Start", "Quit"),
             default=0,
-        )
-        if choice != 0:
+        ))
+        if response.answered and response.choice != 0:
             sys.exit(0)
 
     # Config assembly mirrors `ralph factory` with no flags: every phase
@@ -3041,11 +3052,22 @@ def _evolve_apply(
             continue
         ui_impl.info(f"{pid}: {proposal['title']}")
         ui_impl.info(f"  Convention: {proposal['convention']}")
-        if not evo_config.auto_apply_computational and not click.confirm(
-            f"Append this convention to {claude_md}?", default=False,
-        ):
-            ui_impl.info(f"  {pid} not applied (declined).")
-            continue
+        if not evo_config.auto_apply_computational:
+            # PR A: the old bare click.confirm raised click.Abort on
+            # non-TTY EOF and crashed the command. Piped input
+            # ("echo y | ralph evolve --apply ...") must keep working,
+            # so this stays click.confirm - with EOF now meaning
+            # "declined", never a crash.
+            try:
+                confirmed = click.confirm(
+                    f"Append this convention to {claude_md}?", default=False,
+                )
+            except click.Abort:
+                ui_impl.info("")
+                confirmed = False
+            if not confirmed:
+                ui_impl.info(f"  {pid} not applied (declined).")
+                continue
         if not _append_to_agent_learnings(
             claude_md, pid, proposal["convention"],
         ):

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -48,6 +48,7 @@ from ralph_py.events import (
 from ralph_py.feedforward import FeedforwardConfig, build_feedforward_context
 from ralph_py.fixtures import FixturesConfig
 from ralph_py.git import fetch_base_branch, resolve_base_ref
+from ralph_py.interaction import InteractionChannel
 from ralph_py.knowledge import (
     KnowledgeConfig,
     build_knowledge_context,
@@ -1356,6 +1357,8 @@ def run_factory(
     ui: UI,
     root_dir: Path,
     manifest_path: Path | None = None,
+    *,
+    interaction: InteractionChannel | None = None,
 ) -> FactoryResult:
     """Run the factory orchestrator with 3-phase verification.
 
@@ -1386,6 +1389,7 @@ def run_factory(
         return _run_factory_locked(
             manifest, factory_config, base_config, ui, root_dir,
             manifest_path=manifest_path, lock_held=run_lock.held,
+            interaction=interaction,
         )
     finally:
         run_lock.release()
@@ -1399,6 +1403,7 @@ def _run_factory_locked(
     root_dir: Path,
     manifest_path: Path | None,
     lock_held: bool,
+    interaction: InteractionChannel | None = None,
 ) -> FactoryResult:
     """run_factory body; runs with the run-level lock resolved (held, or
     explicitly degraded via --force-lock / no-fcntl platforms)."""
@@ -1620,6 +1625,7 @@ def _run_factory_locked(
         bus=bus,
         journal_path=journal_path,
         run_paths=run_paths,
+        interaction=interaction,
         notify=notify,
         review_selection=review_selection,
         security_selection=security_selection,

--- a/ralph_py/guards.py
+++ b/ralph_py/guards.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ralph_py import git
+from ralph_py.interaction import (
+    InteractionChannel,
+    PromptKind,
+    PromptRequest,
+    UiInteractionChannel,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -51,6 +57,7 @@ def enforce_allowed_paths(
     config: RalphConfig,
     ui: UI,
     cwd: Path | None = None,
+    interaction: InteractionChannel | None = None,
 ) -> tuple[bool, list[str]]:
     """Enforce ALLOWED_PATHS after an iteration.
 
@@ -91,17 +98,23 @@ def enforce_allowed_paths(
         )
         return False, violations
 
-    # Interactive mode - prompt for action
-    if not ui.can_prompt():
+    # Interactive mode - prompt for action (PR A: through the seam)
+    channel = interaction if interaction is not None else UiInteractionChannel(ui)
+    if not channel.can_prompt():
         # Non-TTY in interactive mode - take default action (quit)
         ui.warn("Non-TTY in interactive mode, defaulting to quit")
         return False, violations
 
-    choice = ui.choose(
-        "Disallowed changes detected. What would you like to do?",
-        ["Quit", "Revert and continue", "Continue anyway"],
+    response = channel.request(PromptRequest(
+        kind=PromptKind.GUARD,
+        header="Disallowed changes detected. What would you like to do?",
+        options=("Quit", "Revert and continue", "Continue anyway"),
         default=0,
-    )
+    ))
+    if not response.answered:
+        ui.warn("Prompt unavailable, defaulting to quit")
+        return False, violations
+    choice = response.choice
 
     if choice == 0:
         # Quit

--- a/ralph_py/interaction.py
+++ b/ralph_py/interaction.py
@@ -65,6 +65,12 @@ class PromptRequest:
     checkpoint: CheckpointContext | None = None
     request_id: str = field(default_factory=lambda: uuid.uuid4().hex)
 
+    def __post_init__(self) -> None:
+        if not self.options:
+            raise ValueError("prompt options must not be empty")
+        if self.default < 0 or self.default >= len(self.options):
+            raise ValueError("prompt default must index an option")
+
 
 @dataclass(frozen=True)
 class PromptResponse:
@@ -94,6 +100,10 @@ class UiInteractionChannel:
                 request_id=req.request_id, choice=req.default, answered=False,
             )
         choice = self._ui.choose(req.header, list(req.options), req.default)
+        if isinstance(choice, bool) or not 0 <= choice < len(req.options):
+            return PromptResponse(
+                request_id=req.request_id, choice=req.default, answered=False,
+            )
         return PromptResponse(
             request_id=req.request_id, choice=choice, answered=True,
         )
@@ -167,10 +177,16 @@ class QueueInteractionChannel:
 
     def resolve(self, request_id: str, choice: int) -> bool:
         """Answer one pending request; False when it is unknown (already
-        cancelled, double-answered, or never existed)."""
+        cancelled, double-answered, never existed, or out of range)."""
         with self._lock:
             pending = self._pending.get(request_id)
             if pending is None or pending.event.is_set():
+                return False
+            if (
+                isinstance(choice, bool)
+                or choice < 0
+                or choice >= len(pending.request.options)
+            ):
                 return False
             pending.choice = choice
             pending.event.set()

--- a/ralph_py/interaction.py
+++ b/ralph_py/interaction.py
@@ -1,0 +1,184 @@
+"""The interaction seam: every blocking prompt as a typed request.
+
+Stage 3 PR A of the TUI rewrite. The harness has exactly seven places
+that block on a human (E6 checkpoint, guards, iteration pause, feature
+gate, factory/retry confirms, evolve apply). Each becomes a
+:class:`PromptRequest` sent through an :class:`InteractionChannel`:
+
+- :class:`UiInteractionChannel` reproduces today's terminal behavior
+  exactly (``ui.choose`` under a ``can_prompt`` guard) - the plain-mode
+  degradation path.
+- :class:`QueueInteractionChannel` is the thread-safe bridge for
+  embedded mode (PR F): the orchestrator thread blocks on a
+  ``threading.Event`` while the Textual UI answers via
+  ``resolve``; ``detach``/``cancel_all`` degrade pending prompts to
+  their non-interactive defaults so a dead TUI can never hang a run.
+
+``PromptResponse.answered`` is the load-bearing bit: ``False`` means
+"nobody was there to ask" and maps onto today's NOT_PROMPTED /
+skip-the-gate semantics at every call site.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from ralph_py.agents.base import UsageTotals
+    from ralph_py.findings import Finding
+    from ralph_py.ui.base import UI
+
+
+class PromptKind(StrEnum):
+    CHECKPOINT = "checkpoint"
+    GUARD = "guard"
+    ITERATION = "iteration"
+    CONFIRM = "confirm"
+
+
+@dataclass(frozen=True)
+class CheckpointContext:
+    """Everything a human needs to judge an E6 checkpoint: the diff,
+    both finding streams, and the spend so far - not just the review
+    summary string the old prompt showed."""
+
+    component_id: str
+    diff_excerpt: str = ""
+    review_findings: tuple[Finding, ...] = ()
+    security_findings: tuple[Finding, ...] = ()
+    usage: UsageTotals | None = None
+    branch: str = ""
+
+
+@dataclass(frozen=True)
+class PromptRequest:
+    kind: PromptKind
+    header: str
+    options: tuple[str, ...]
+    default: int = 0
+    component_id: str = ""
+    checkpoint: CheckpointContext | None = None
+    request_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+
+@dataclass(frozen=True)
+class PromptResponse:
+    request_id: str
+    choice: int
+    answered: bool  # False = non-interactive default (NOT_PROMPTED)
+
+
+class InteractionChannel(Protocol):
+    def can_prompt(self) -> bool: ...
+
+    def request(self, req: PromptRequest) -> PromptResponse: ...
+
+
+class UiInteractionChannel:
+    """Terminal-mode channel: exactly today's ui.choose behavior."""
+
+    def __init__(self, ui: UI) -> None:
+        self._ui = ui
+
+    def can_prompt(self) -> bool:
+        return self._ui.can_prompt()
+
+    def request(self, req: PromptRequest) -> PromptResponse:
+        if not self._ui.can_prompt():
+            return PromptResponse(
+                request_id=req.request_id, choice=req.default, answered=False,
+            )
+        choice = self._ui.choose(req.header, list(req.options), req.default)
+        return PromptResponse(
+            request_id=req.request_id, choice=choice, answered=True,
+        )
+
+
+class _Pending:
+    def __init__(self, request: PromptRequest) -> None:
+        self.request = request
+        self.event = threading.Event()
+        self.choice: int | None = None
+
+
+class QueueInteractionChannel:
+    """Thread-safe request/response bridge (embedded mode, PR F).
+
+    The requesting thread blocks in :meth:`request` until a resolver
+    answers via :meth:`resolve` or the channel is detached/cancelled.
+    ``attach`` registers the resolver notification callback (the TUI's
+    ``call_from_thread`` entry point - the only orchestrator-to-UI
+    crossing, per the spike's G4 validation).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pending: dict[str, _Pending] = {}
+        self._on_request: Callable[[PromptRequest], None] | None = None
+
+    def attach(self, on_request: Callable[[PromptRequest], None]) -> None:
+        with self._lock:
+            self._on_request = on_request
+
+    def detach(self) -> None:
+        """Subsequent requests degrade to answered=False; pending ones
+        are released with their defaults."""
+        with self._lock:
+            self._on_request = None
+        self.cancel_all()
+
+    def can_prompt(self) -> bool:
+        with self._lock:
+            return self._on_request is not None
+
+    def request(self, req: PromptRequest) -> PromptResponse:
+        with self._lock:
+            notify = self._on_request
+            if notify is None:
+                return PromptResponse(
+                    request_id=req.request_id, choice=req.default,
+                    answered=False,
+                )
+            pending = _Pending(req)
+            self._pending[req.request_id] = pending
+        try:
+            notify(req)
+        except Exception:  # noqa: BLE001 - a dying UI must not hang the run
+            with self._lock:
+                self._pending.pop(req.request_id, None)
+            return PromptResponse(
+                request_id=req.request_id, choice=req.default, answered=False,
+            )
+        pending.event.wait()
+        with self._lock:
+            self._pending.pop(req.request_id, None)
+        if pending.choice is None:
+            return PromptResponse(
+                request_id=req.request_id, choice=req.default, answered=False,
+            )
+        return PromptResponse(
+            request_id=req.request_id, choice=pending.choice, answered=True,
+        )
+
+    def resolve(self, request_id: str, choice: int) -> bool:
+        """Answer one pending request; False when it is unknown (already
+        cancelled, double-answered, or never existed)."""
+        with self._lock:
+            pending = self._pending.get(request_id)
+            if pending is None or pending.event.is_set():
+                return False
+            pending.choice = choice
+            pending.event.set()
+            return True
+
+    def cancel_all(self) -> None:
+        """Release every waiter with its default (answered=False)."""
+        with self._lock:
+            waiters = list(self._pending.values())
+        for pending in waiters:
+            pending.event.set()

--- a/ralph_py/loop.py
+++ b/ralph_py/loop.py
@@ -12,6 +12,12 @@ from ralph_py.agents.base import UsageTotals, collect_usage
 from ralph_py.agents.proc import TIMEOUT_MESSAGE_PREFIX
 from ralph_py.breaker import BreakerConfig, NoProgressBreaker
 from ralph_py.events import EventBus, IterationCompleted, IterationStarted
+from ralph_py.interaction import (
+    InteractionChannel,
+    PromptKind,
+    PromptRequest,
+    UiInteractionChannel,
+)
 from ralph_py.prd import PRD
 from ralph_py.timeout import TimeoutConfig
 
@@ -60,6 +66,7 @@ def run_loop(
     breaker_config: BreakerConfig | None = None,
     *,
     bus: EventBus | None = None,
+    interaction: InteractionChannel | None = None,
 ) -> LoopResult:
     """Run the main agentic loop.
 
@@ -190,6 +197,10 @@ def run_loop(
     else:
         ui.info("ALLOWED_PATHS is empty; enforcement disabled")
 
+    # PR A: one interaction channel for the whole loop (guards + pause).
+    channel: InteractionChannel = (
+        interaction if interaction is not None else UiInteractionChannel(ui)
+    )
     loop_start = time.monotonic()
     iteration_durations: list[float] = []
     timed_out_iterations = 0
@@ -268,7 +279,9 @@ def run_loop(
         # When enforcement fails the iteration is treated as failed even
         # if the marker was seen.
         if config.allowed_paths and is_repo:
-            ok, _ = guards.enforce_allowed_paths(config, ui, cwd)
+            ok, _ = guards.enforce_allowed_paths(
+                config, ui, cwd, interaction=channel,
+            )
             if not ok:
                 return LoopResult(
                     completed=False,
@@ -333,17 +346,18 @@ def run_loop(
                 usage=collect_usage(agent),
             )
 
-        # Interactive pause
-        if config.interactive and ui.can_prompt():
-            choice = ui.choose(
-                "Iteration complete. What next?",
-                ["Continue", "Skip interactive", "Quit"],
+        # Interactive pause (PR A: through the interaction seam)
+        if config.interactive and channel.can_prompt():
+            response = channel.request(PromptRequest(
+                kind=PromptKind.ITERATION,
+                header="Iteration complete. What next?",
+                options=("Continue", "Skip interactive", "Quit"),
                 default=0,
-            )
-            if choice == 1:
+            ))
+            if response.answered and response.choice == 1:
                 # Disable interactive for remaining iterations
                 config.interactive = False
-            elif choice == 2:
+            elif response.answered and response.choice == 2:
                 return LoopResult(
                     completed=False, iterations=iteration, exit_code=0,
                     usage=collect_usage(agent),

--- a/ralph_py/pipeline.py
+++ b/ralph_py/pipeline.py
@@ -44,6 +44,13 @@ from ralph_py.agents.base import UsageTotals, collect_usage
 from ralph_py.context import IterationContext, IterationRecord
 from ralph_py.findings import Finding, tag_finding_with_attempt
 from ralph_py.fixtures import FixturesConfig
+from ralph_py.interaction import (
+    CheckpointContext,
+    InteractionChannel,
+    PromptKind,
+    PromptRequest,
+    UiInteractionChannel,
+)
 from ralph_py.manifest import Component, ComponentStatus, Manifest
 from ralph_py.observability import NotifyHooks
 from ralph_py.prd import PRD
@@ -61,6 +68,11 @@ if TYPE_CHECKING:
     )
     from ralph_py.knowledge import KnowledgeConfig
     from ralph_py.ui.base import UI
+
+
+# PR A: the E6 checkpoint shows a real diff excerpt, not just the
+# review summary string. Bounded so a huge diff cannot flood the modal.
+CHECKPOINT_DIFF_CHAR_LIMIT = 20_000
 
 
 def _iso_now() -> str:
@@ -240,6 +252,7 @@ class ComponentPipeline:
         bus: ev.EventBus,
         journal_path: Path | None,
         run_paths: ev.RunPaths | None = None,
+        interaction: InteractionChannel | None = None,
         notify: NotifyHooks,
         review_selection: AdversarialAgentSelection,
         security_selection: AdversarialAgentSelection | None,
@@ -261,6 +274,11 @@ class ComponentPipeline:
         self.bus = bus
         self.journal_path = journal_path
         self.run_paths = run_paths
+        # PR A: the interaction seam. Defaults to today's terminal
+        # behavior; embedded mode (PR F) injects a QueueInteractionChannel.
+        self.interaction: InteractionChannel = (
+            interaction if interaction is not None else UiInteractionChannel(ui)
+        )
         self.notify = notify
         self.review_selection = review_selection
         self.security_selection = security_selection
@@ -333,6 +351,14 @@ class ComponentPipeline:
         self.bus.emit(ev.ComponentUsage(
             component=comp_id, phase=phase, **totals.to_dict(),
         ))
+
+    def usage_totals_for(self, comp_id: str) -> UsageTotals:
+        """One component's spend across all phases (PR A: shown at the
+        E6 checkpoint so the human sees what the attempt cost)."""
+        totals = UsageTotals()
+        for phase_totals in self.usage_meter.get(comp_id, {}).values():
+            totals.merge(phase_totals)
+        return totals
 
     def token_budget_exceeded(self) -> bool:
         cap = self.factory_config.max_total_tokens
@@ -1066,7 +1092,9 @@ class ComponentPipeline:
         checkpoint = CheckpointDecision.NOT_PROMPTED
         pr = PrPhaseResult(disposition=PrDisposition.SKIPPED)
         if self.factory_config.create_prs and not self.factory_config.single_pr:
-            checkpoint = self._phase_checkpoint(comp)
+            checkpoint = self._phase_checkpoint(
+                comp, diff_text=diff.review_diff,
+            )
             if checkpoint == CheckpointDecision.REJECTED:
                 return PipelineOutcome(
                     transition=self.fail(
@@ -2020,7 +2048,9 @@ class ComponentPipeline:
 
         return DistillPhaseResult(ran=True)
 
-    def _phase_checkpoint(self, comp: Component) -> CheckpointDecision:
+    def _phase_checkpoint(
+        self, comp: Component, *, diff_text: str = "",
+    ) -> CheckpointDecision:
         """E6: human-in-the-loop checkpoint. When opt-in, prompt
         before pushing+merging so a human can inspect the diff,
         the review findings, and the security findings before
@@ -2039,7 +2069,32 @@ class ComponentPipeline:
         self.bus.emit(ev.CheckpointRequested(
             component=comp.id, kind="pr_merge", question=question,
         ))
-        if not self.ui.can_prompt():
+        request = PromptRequest(
+            kind=PromptKind.CHECKPOINT,
+            header=question,
+            options=(
+                "Approve",
+                "Reject (fail component, skip dependents)",
+                "Retry (consume a retry, re-run component)",
+            ),
+            default=0,
+            component_id=comp.id,
+            checkpoint=CheckpointContext(
+                component_id=comp.id,
+                diff_excerpt=git.truncate_diff_for_prompt(
+                    diff_text, CHECKPOINT_DIFF_CHAR_LIMIT,
+                ) if diff_text else "",
+                review_findings=tuple(
+                    f for f in comp.findings if f.phase == "review"
+                ),
+                security_findings=tuple(
+                    f for f in comp.findings if f.phase == "security"
+                ),
+                usage=self.usage_totals_for(comp.id),
+                branch=comp.branch_name,
+            ),
+        )
+        if not self.interaction.can_prompt():
             self.ui.warn(
                 f"  pause_before_pr_merge requested but UI is "
                 f"non-interactive; proceeding without prompt for {comp.id}"
@@ -2051,19 +2106,19 @@ class ComponentPipeline:
             return CheckpointDecision.NOT_PROMPTED
         self.ui.section(f"Human checkpoint: {comp.id}")
         self.ui.info(comp.review_findings or "(no review findings)")
-        choice = self.ui.choose(
-            question,
-            [
-                "Approve",
-                "Reject (fail component, skip dependents)",
-                "Retry (consume a retry, re-run component)",
-            ],
-            default=0,
-        )
+        response = self.interaction.request(request)
+        if not response.answered:
+            # The channel lost its resolver between the guard and the
+            # answer (detached TUI): same semantics as non-interactive.
+            self.bus.emit(ev.CheckpointResolved(
+                component=comp.id, kind="pr_merge",
+                decision="not_prompted", decided_by="auto",
+            ))
+            return CheckpointDecision.NOT_PROMPTED
         decision = {
             1: CheckpointDecision.REJECTED,
             2: CheckpointDecision.RETRY,
-        }.get(choice, CheckpointDecision.APPROVED)
+        }.get(response.choice, CheckpointDecision.APPROVED)
         self.bus.emit(ev.CheckpointResolved(
             component=comp.id, kind="pr_merge",
             decision=decision.name.lower(), decided_by="operator",

--- a/ralph_py/ui/plain.py
+++ b/ralph_py/ui/plain.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import TextIO
@@ -158,25 +157,6 @@ class PlainUI:
         """Interactive choice, returns selected index."""
         if not self.can_prompt():
             return default
-
-        prompt_radiolist_dialog: Callable[..., Any] | None
-        try:
-            from prompt_toolkit.shortcuts import (  # type: ignore[import-not-found]
-                radiolist_dialog as _radiolist_dialog,
-            )
-        except Exception:
-            prompt_radiolist_dialog = None
-        else:
-            prompt_radiolist_dialog = _radiolist_dialog
-
-        if prompt_radiolist_dialog is not None:
-            values = [(idx, opt) for idx, opt in enumerate(options)]
-            result = prompt_radiolist_dialog(
-                title="Ralph", text=header, values=values
-            ).run()
-            if result is None:
-                return default
-            return int(result)
 
         self._print(f"\n{header}")
         for i, opt in enumerate(options):

--- a/ralph_py/ui/rich_ui.py
+++ b/ralph_py/ui/rich_ui.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import sys
 import time
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from rich import box
 from rich.align import Align
@@ -215,25 +214,6 @@ class RichUI:
         """Interactive choice, returns selected index."""
         if not self.can_prompt():
             return default
-
-        prompt_radiolist_dialog: Callable[..., Any] | None
-        try:
-            from prompt_toolkit.shortcuts import (  # type: ignore[import-not-found]
-                radiolist_dialog as _radiolist_dialog,
-            )
-        except Exception:
-            prompt_radiolist_dialog = None
-        else:
-            prompt_radiolist_dialog = _radiolist_dialog
-
-        if prompt_radiolist_dialog is not None:
-            values = [(idx, opt) for idx, opt in enumerate(options)]
-            result = prompt_radiolist_dialog(
-                title="Ralph", text=header, values=values
-            ).run()
-            if result is None:
-                return default
-            return int(result)
 
         self.console.print(f"\n{header}")
         for i, opt in enumerate(options):

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -49,12 +49,28 @@ class TestUiInteractionChannel:
 
             def choose(self, header: str, options: list[str],
                        default: int = 0) -> int:
-                return 2
+                return 1
 
         channel = UiInteractionChannel(FakeUI(no_color=True, file=io.StringIO()))
         response = channel.request(_req())
         assert response.answered is True
-        assert response.choice == 2
+        assert response.choice == 1
+
+    def test_invalid_ui_choice_degrades_to_default(self) -> None:
+        class InvalidUI(PlainUI):
+            def can_prompt(self) -> bool:
+                return True
+
+            def choose(self, header: str, options: list[str],
+                       default: int = 0) -> int:
+                return len(options)
+
+        channel = UiInteractionChannel(
+            InvalidUI(no_color=True, file=io.StringIO()),
+        )
+        response = channel.request(_req(default=1))
+        assert response.answered is False
+        assert response.choice == 1
 
 
 class TestQueueInteractionChannel:
@@ -101,6 +117,24 @@ class TestQueueInteractionChannel:
     def test_unknown_request_id_rejected(self) -> None:
         channel = QueueInteractionChannel()
         assert channel.resolve("nope", 0) is False
+
+    def test_out_of_range_choice_rejected_without_releasing_waiter(self) -> None:
+        channel = QueueInteractionChannel()
+        seen: list[PromptRequest] = []
+        channel.attach(seen.append)
+        results: list[PromptResponse] = []
+        thread = threading.Thread(
+            target=lambda: results.append(channel.request(_req())),
+        )
+        thread.start()
+        while not seen:
+            time.sleep(0.005)
+        assert channel.resolve(seen[0].request_id, 2) is False
+        assert thread.is_alive()
+        assert channel.resolve(seen[0].request_id, 1) is True
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+        assert results[0].choice == 1
 
     def test_cancel_all_releases_waiters_with_defaults(self) -> None:
         channel = QueueInteractionChannel()

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -1,0 +1,241 @@
+"""Stage 3 PR A (TUI rewrite): the interaction seam.
+
+Covers the channel primitives (Ui + Queue), the E6 checkpoint context,
+and the evolve-apply fix (the one prompt that previously crashed with
+click.Abort on non-TTY EOF).
+"""
+
+from __future__ import annotations
+
+import io
+import threading
+import time
+from pathlib import Path
+
+from ralph_py.interaction import (
+    CheckpointContext,
+    PromptKind,
+    PromptRequest,
+    PromptResponse,
+    QueueInteractionChannel,
+    UiInteractionChannel,
+)
+from ralph_py.ui.plain import PlainUI
+
+
+def _req(default: int = 0) -> PromptRequest:
+    return PromptRequest(
+        kind=PromptKind.CONFIRM,
+        header="Proceed?",
+        options=("Yes", "No"),
+        default=default,
+    )
+
+
+class TestUiInteractionChannel:
+    def test_non_tty_returns_default_unanswered(self) -> None:
+        channel = UiInteractionChannel(PlainUI(no_color=True, file=io.StringIO()))
+        # pytest's stdin is not a tty -> can_prompt False.
+        assert channel.can_prompt() is False
+        response = channel.request(_req(default=1))
+        assert response == PromptResponse(
+            request_id=response.request_id, choice=1, answered=False,
+        )
+
+    def test_delegates_to_ui_choose(self) -> None:
+        class FakeUI(PlainUI):
+            def can_prompt(self) -> bool:
+                return True
+
+            def choose(self, header: str, options: list[str],
+                       default: int = 0) -> int:
+                return 2
+
+        channel = UiInteractionChannel(FakeUI(no_color=True, file=io.StringIO()))
+        response = channel.request(_req())
+        assert response.answered is True
+        assert response.choice == 2
+
+
+class TestQueueInteractionChannel:
+    def test_detached_degrades_to_default(self) -> None:
+        channel = QueueInteractionChannel()
+        assert channel.can_prompt() is False
+        response = channel.request(_req(default=1))
+        assert response.answered is False
+        assert response.choice == 1
+
+    def test_request_resolve_round_trip_across_threads(self) -> None:
+        channel = QueueInteractionChannel()
+        seen: list[PromptRequest] = []
+        channel.attach(seen.append)
+        results: list[PromptResponse] = []
+
+        def requester() -> None:
+            results.append(channel.request(_req()))
+
+        thread = threading.Thread(target=requester)
+        thread.start()
+        deadline = time.monotonic() + 2
+        while not seen and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert seen, "resolver never notified"
+        assert channel.resolve(seen[0].request_id, 1) is True
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+        assert results[0].answered is True
+        assert results[0].choice == 1
+
+    def test_double_resolve_rejected(self) -> None:
+        channel = QueueInteractionChannel()
+        seen: list[PromptRequest] = []
+        channel.attach(seen.append)
+        thread = threading.Thread(target=lambda: channel.request(_req()))
+        thread.start()
+        while not seen:
+            time.sleep(0.005)
+        assert channel.resolve(seen[0].request_id, 0) is True
+        assert channel.resolve(seen[0].request_id, 1) is False
+        thread.join(timeout=2)
+
+    def test_unknown_request_id_rejected(self) -> None:
+        channel = QueueInteractionChannel()
+        assert channel.resolve("nope", 0) is False
+
+    def test_cancel_all_releases_waiters_with_defaults(self) -> None:
+        channel = QueueInteractionChannel()
+        channel.attach(lambda req: None)  # resolver that never answers
+        results: list[PromptResponse] = []
+        thread = threading.Thread(
+            target=lambda: results.append(channel.request(_req(default=1))),
+        )
+        thread.start()
+        time.sleep(0.02)
+        channel.cancel_all()
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+        assert results[0].answered is False
+        assert results[0].choice == 1
+
+    def test_detach_releases_and_degrades(self) -> None:
+        channel = QueueInteractionChannel()
+        channel.attach(lambda req: None)
+        results: list[PromptResponse] = []
+        thread = threading.Thread(
+            target=lambda: results.append(channel.request(_req())),
+        )
+        thread.start()
+        time.sleep(0.02)
+        channel.detach()
+        thread.join(timeout=2)
+        assert results[0].answered is False
+        # After detach, new requests degrade immediately (no hang).
+        response = channel.request(_req(default=1))
+        assert response.answered is False
+
+    def test_dying_notifier_never_hangs(self) -> None:
+        channel = QueueInteractionChannel()
+
+        def boom(req: PromptRequest) -> None:
+            raise RuntimeError("UI died")
+
+        channel.attach(boom)
+        response = channel.request(_req(default=1))
+        assert response.answered is False
+        assert response.choice == 1
+
+
+class TestCheckpointContext:
+    def test_pipeline_builds_full_context(self, tmp_path: Path) -> None:
+        """The E6 request carries diff/findings/usage - not just the
+        review summary string (verified through a recording channel)."""
+        from unittest.mock import patch
+
+        from ralph_py.factory import ComponentResult, run_factory
+        from tests.test_event_stream import (
+            _component,
+            _factory_config,
+            _make_base_config,
+            _make_manifest,
+            _setup_project,
+            _usage,
+        )
+
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(
+            root, create_prs=True, pause_before_pr_merge=True,
+        )
+        result = ComponentResult(
+            "comp-a", success=True, iterations=1, usage=_usage(1234),
+        )
+
+        requests: list[PromptRequest] = []
+
+        class Recorder:
+            def can_prompt(self) -> bool:
+                return True
+
+            def request(self, req: PromptRequest) -> PromptResponse:
+                requests.append(req)
+                return PromptResponse(
+                    request_id=req.request_id, choice=0, answered=True,
+                )
+
+        with patch(
+            "ralph_py.factory._run_component", return_value=result,
+        ), patch(
+            "ralph_py.git.get_diff_content", return_value="+real diff\n",
+        ), patch("ralph_py.pr.is_gh_available", return_value=False):
+            run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True, file=io.StringIO()), root,
+                interaction=Recorder(),
+            )
+
+        assert len(requests) == 1
+        req = requests[0]
+        assert req.kind == PromptKind.CHECKPOINT
+        assert req.component_id == "comp-a"
+        ctx = req.checkpoint
+        assert isinstance(ctx, CheckpointContext)
+        assert "+real diff" in ctx.diff_excerpt
+        assert ctx.usage is not None
+        assert ctx.usage.total_tokens == 1234
+        assert ctx.branch == "ralph/factory/comp-a"
+
+
+class TestEvolveApplyNonTty:
+    def test_no_click_abort_on_non_tty(self, tmp_path: Path) -> None:
+        """The old raw click.confirm crashed with click.Abort on EOF;
+        the seam degrades to a clean "not applied" skip."""
+        from click.testing import CliRunner
+
+        from ralph_py.cli import cli
+        from ralph_py.evolution import (
+            EvolutionConfig,
+            EvolutionJournal,
+            FailurePattern,
+        )
+
+        (tmp_path / "CLAUDE.md").write_text(
+            "# X\n\n## Agent Learnings\n\n### Conventions\n",
+        )
+        journal = EvolutionJournal(EvolutionConfig())
+        proposals = journal.propose_improvements([FailurePattern(
+            description="linter failure 'S608' in 2/4 components",
+            frequency=2, total_components=4,
+            affected_components=["a", "b"], check_name="linter",
+            error_signature="S608", category="verification",
+        )])
+        journal.save_proposals(proposals, tmp_path / ".ralph" / "proposals")
+
+        # No input= at all: stdin is at EOF, which used to raise
+        # click.Abort out of the raw click.confirm.
+        result = CliRunner().invoke(cli, [
+            "evolve", "--apply", "PROP-001", "--root", str(tmp_path),
+            "--ui", "plain", "--no-color",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "not applied (declined)" in result.output
+        assert "S608" not in (tmp_path / "CLAUDE.md").read_text()


### PR DESCRIPTION
## Summary

Stage 3 PR A of the TUI rewrite plan (stacked on #110). The prompt surface becomes a typed seam the Textual UI can drive:

- `ralph_py/interaction.py`: `PromptKind`/`PromptRequest`/`PromptResponse` (+`CheckpointContext`), `InteractionChannel` protocol, `UiInteractionChannel` (today's behavior, exactly), and `QueueInteractionChannel` - the thread-safe request/resolve bridge for embedded mode with detach/cancel-all release semantics (a dead TUI can never hang the orchestrator; validated in the spike's G4 soak).
- Six of the seven prompt sites route through the seam; the E6 checkpoint request now carries a real **CheckpointContext** (bounded diff excerpt, review + security findings, attempt usage, branch) so PR E's modal can show an actual inspection surface, not a summary string.
- `run_factory(interaction=...)` threaded to the pipeline.
- **Evolve-apply fix**: the one raw `click.confirm` kept (piped `echo y |` input must keep working - the seam's isatty gate would break it) but `click.Abort` on non-TTY EOF now means "declined" instead of crashing. Deviation from the plan's original "convert site 7" note, reasoned in-code.
- **prompt_toolkit removed** from both UIs; the numbered `input()` fallback is the only `choose` path (identical to prior behavior when the optional dep was absent).

## Tests (+11)

Cross-thread request/resolve round trip, double-resolve rejection, unknown-id rejection, cancel_all/detach release-with-defaults, dying-notifier degradation, Ui channel delegation + non-TTY defaults, full E6 context assertion through a recording channel on a real `run_factory`, and the evolve-apply EOF regression test.

Gates: fast tier 1605 passed, spine 24 passed, `mypy --strict` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)