### PR TITLE
TUI PR B: graceful shutdown + signal handling

### DIFF
--- a/ralph_py/agents/proc.py
+++ b/ralph_py/agents/proc.py
@@ -20,6 +20,7 @@ import signal
 import subprocess
 import threading
 import time
+import weakref
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -36,6 +37,29 @@ DEFAULT_FINISH_WAIT_SECONDS = 10.0
 def timeout_message(timeout: float | None) -> str:
     """Uniform timeout line yielded by every adapter."""
     return f"{TIMEOUT_MESSAGE_PREFIX} after {timeout}s"
+
+
+# PR B (TUI rewrite): live streamers register here so a shutdown signal
+# can group-kill every in-flight agent subprocess. WeakSet: a streamer
+# that was garbage collected is by definition no longer streaming.
+_ACTIVE: weakref.WeakSet[DeadlineStreamer] = weakref.WeakSet()
+
+
+def kill_active_process_groups() -> int:
+    """SIGTERM->grace->SIGKILL every live agent process group.
+
+    The shutdown path for both worker SIGTERM forwarding (pool mode)
+    and the parent's inline-executor abort. Returns the number of
+    streamers signalled; never raises.
+    """
+    count = 0
+    for streamer in list(_ACTIVE):
+        try:
+            streamer.kill()
+            count += 1
+        except Exception:  # noqa: BLE001 - shutdown must not raise
+            pass
+    return count
 
 
 class DeadlineStreamer:
@@ -81,6 +105,7 @@ class DeadlineStreamer:
         self._writer.start()
         self._reader = threading.Thread(target=self._read_stdout, daemon=True)
         self._reader.start()
+        _ACTIVE.add(self)
 
     def lines(self) -> Iterator[str]:
         """Yield stdout lines (newline-stripped) until EOF or breach.
@@ -116,6 +141,7 @@ class DeadlineStreamer:
             self.kill()
         self._reader.join(timeout=1.0)
         self._writer.join(timeout=1.0)
+        _ACTIVE.discard(self)
 
     def kill(self) -> None:
         """SIGTERM the process group, wait a grace period, then SIGKILL."""

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -51,6 +51,7 @@ from ralph_py.output import build_console
 from ralph_py.prd import PRD
 from ralph_py.reducer import ComponentState, RunState, fold, load_run_state, upconvert_v1
 from ralph_py.sandbox import SandboxConfig
+from ralph_py.shutdown import StopController, install_signal_handlers
 from ralph_py.timeout import TimeoutConfig
 from ralph_py.ui.base import UI
 
@@ -641,10 +642,16 @@ def run(
 
     # R0.5 (H-15): `ralph run` persists to its own run-manifest.json so
     # it can never clobber a factory run's resumable manifest.json.
-    factory_result = run_factory(
-        manifest, factory_cfg, config, ui_impl, root_dir,
-        manifest_path=root_dir / "scripts" / "ralph" / "run-manifest.json",
-    )
+    stop = StopController()
+    uninstall = install_signal_handlers(stop)
+    try:
+        factory_result = run_factory(
+            manifest, factory_cfg, config, ui_impl, root_dir,
+            manifest_path=root_dir / "scripts" / "ralph" / "run-manifest.json",
+            stop=stop,
+        )
+    finally:
+        uninstall()
     sys.exit(factory_result.exit_code)
 
 
@@ -2031,10 +2038,16 @@ def factory(
     # R0.5 (H-15): state saves back to the file it was loaded from.
     # --manifest /custom.json persists to /custom.json; --spec runs keep
     # the default scripts/ralph/manifest.json that decompose wrote.
-    result = run_factory(
-        manifest, factory_config, base_config, ui_impl, root_dir,
-        manifest_path=manifest_path,
-    )
+    stop = StopController()
+    uninstall = install_signal_handlers(stop)
+    try:
+        result = run_factory(
+            manifest, factory_config, base_config, ui_impl, root_dir,
+            manifest_path=manifest_path,
+            stop=stop,
+        )
+    finally:
+        uninstall()
     sys.exit(result.exit_code)
 
 
@@ -2765,10 +2778,16 @@ def retry(
     if keep_worktrees_on_failure:
         factory_config.keep_worktrees_on_failure = True
 
-    result = run_factory(
-        manifest, factory_config, base_config, ui_impl, root_dir,
-        manifest_path=manifest_file,
-    )
+    stop = StopController()
+    uninstall = install_signal_handlers(stop)
+    try:
+        result = run_factory(
+            manifest, factory_config, base_config, ui_impl, root_dir,
+            manifest_path=manifest_file,
+            stop=stop,
+        )
+    finally:
+        uninstall()
     sys.exit(result.exit_code)
 
 

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -6,6 +6,7 @@ import functools
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -17,6 +18,7 @@ from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, TextIO
 
 from ralph_py.agents.base import UsageTotals, collect_usage
+from ralph_py.agents.proc import kill_active_process_groups
 from ralph_py.breaker import BreakerConfig
 from ralph_py.config import RalphConfig
 from ralph_py.context import IterationContext
@@ -78,6 +80,7 @@ from ralph_py.security import (
     run_chunked_security_review,
     run_security_review,
 )
+from ralph_py.shutdown import StopController
 from ralph_py.timeout import TimeoutConfig
 from ralph_py.ui.bridge import EventBridgeUI
 from ralph_py.verify import VerifyConfig, run_mechanical_verification
@@ -943,6 +946,7 @@ def _run_component(
     run_id: str = "",
     redirect_output: bool = True,
     live_line: Callable[[str], None] | None = None,
+    stop_check: Callable[[], bool] | None = None,
 ) -> ComponentResult:
     """Run a single component's implementation loop.
 
@@ -991,6 +995,11 @@ def _run_component(
             # dup2 BEFORE any threads start (chunk 6 invariant); stray
             # library writes land in the transcript, never the terminal.
             _redirect_worker_output(run_paths.engineer_log(component_id))
+            # PR B: a shutdown SIGTERM from the parent must group-kill
+            # this worker's agent subprocess (its own session leader),
+            # not orphan it. Pool mode only - inline mode runs in the
+            # parent, whose handlers belong to the cli/TUI.
+            _install_worker_signal_forwarding()
         try:
             transcript_fh = open(
                 run_paths.engineer_log(component_id),
@@ -1136,6 +1145,7 @@ def _run_component(
             context_prefix=context_prefix, timeouts=timeouts,
             breaker_config=breaker_config,
             bus=worker_bus,
+            stop_check=stop_check,
         )
         # Report which limit fired so the retry/fail path can act on it
         # (timeout errors trigger the recreate-from-base retry hygiene).
@@ -1194,6 +1204,25 @@ def _run_component(
 
 
 _HEARTBEAT_INTERVAL_SECONDS = 15.0
+
+
+def _install_worker_signal_forwarding() -> None:
+    """Pool-worker SIGTERM handler: kill the agent's process group,
+    then exit 130. Installed only on a worker's main thread."""
+    if threading.current_thread() is not threading.main_thread():
+        return
+
+    def _on_term(signum: int, frame: object) -> None:
+        del signum, frame
+        try:
+            kill_active_process_groups()
+        finally:
+            os._exit(130)
+
+    try:
+        signal.signal(signal.SIGTERM, _on_term)
+    except (ValueError, OSError):
+        pass
 
 
 def _redirect_worker_output(log_path: Path) -> None:
@@ -1265,6 +1294,94 @@ class _InlineExecutor:
         self, wait: bool = True, cancel_futures: bool = False,
     ) -> None:
         """Nothing to shut down: every submit already ran to completion."""
+
+
+def _wait_interruptible(
+    futures: set[Future[ComponentResult]],
+    timeout: float | None,
+    stop: StopController | None,
+    slice_seconds: float = 0.5,
+) -> tuple[set[Future[ComponentResult]], bool]:
+    """concurrent.futures.wait in stop-checkable slices (PR B).
+
+    Returns (done, stopped). Worst-case stop latency is one slice;
+    the backstop deadline math is preserved by honoring ``timeout``.
+    """
+    if stop is None:
+        done, _ = wait(futures, timeout=timeout, return_when=FIRST_COMPLETED)
+        return done, False
+    deadline = (
+        time.monotonic() + timeout if timeout is not None else None
+    )
+    while True:
+        if stop.is_set():
+            return set(), True
+        remaining = (
+            None if deadline is None
+            else max(0.0, deadline - time.monotonic())
+        )
+        slice_t = (
+            slice_seconds if remaining is None
+            else min(slice_seconds, remaining)
+        )
+        done, _ = wait(futures, timeout=slice_t, return_when=FIRST_COMPLETED)
+        if done:
+            return done, False
+        if remaining is not None and remaining <= slice_seconds:
+            return set(), False
+
+
+def _abort_inflight(
+    executor: ProcessPoolExecutor | _InlineExecutor,
+    running_futures: dict[Future[ComponentResult], str],
+    pipeline: ComponentPipeline,
+    ui: UI,
+    reason: str,
+    term_grace: float = 5.0,
+) -> None:
+    """Group-terminate in-flight workers and record their components as
+    aborted (PR B). Pool mode SIGTERMs each worker pid - the worker's
+    forwarding handler group-kills its agent subprocess and exits 130;
+    stragglers get SIGKILL after the grace period. `_processes` is
+    private executor API: guarded, with the pre-PR-B behavior
+    (shutdown without waiting + leak warning) as the fallback.
+    """
+    procs = getattr(executor, "_processes", None)
+    pids: list[int] = list(procs.keys()) if procs else []
+    if pids:
+        for pid in pids:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except (ProcessLookupError, OSError):
+                pass
+        deadline = time.monotonic() + term_grace
+        while time.monotonic() < deadline:
+            alive = []
+            for pid in pids:
+                try:
+                    os.kill(pid, 0)
+                    alive.append(pid)
+                except (ProcessLookupError, OSError):
+                    pass
+            if not alive:
+                break
+            time.sleep(0.1)
+        for pid in pids:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+    else:
+        # Inline executor (or _processes gone): the agents live in THIS
+        # process - group-kill them directly.
+        killed = kill_active_process_groups()
+        if killed:
+            ui.warn(f"  Terminated {killed} in-flight agent process group(s)")
+    for future, comp_id in list(running_futures.items()):
+        pipeline.fail_aborted(comp_id, reason)
+        running_futures.pop(future, None)
+    ui.warn(f"  Aborted in-flight work: {reason}")
+    executor.shutdown(wait=False, cancel_futures=True)
 
 
 def _next_backstop_wait(
@@ -1359,6 +1476,8 @@ def run_factory(
     manifest_path: Path | None = None,
     *,
     interaction: InteractionChannel | None = None,
+    stop: StopController | None = None,
+    run_id: str | None = None,
 ) -> FactoryResult:
     """Run the factory orchestrator with 3-phase verification.
 
@@ -1389,7 +1508,7 @@ def run_factory(
         return _run_factory_locked(
             manifest, factory_config, base_config, ui, root_dir,
             manifest_path=manifest_path, lock_held=run_lock.held,
-            interaction=interaction,
+            interaction=interaction, stop=stop, run_id_override=run_id,
         )
     finally:
         run_lock.release()
@@ -1404,6 +1523,8 @@ def _run_factory_locked(
     manifest_path: Path | None,
     lock_held: bool,
     interaction: InteractionChannel | None = None,
+    stop: StopController | None = None,
+    run_id_override: str | None = None,
 ) -> FactoryResult:
     """run_factory body; runs with the run-level lock resolved (held, or
     explicitly degraded via --force-lock / no-fcntl platforms)."""
@@ -1415,7 +1536,9 @@ def _run_factory_locked(
     # collide on .ralph/knowledge/<comp>/<run_id>/ directories nor
     # order ambiguously (R1.6: same-second knowledge run dirs must sort
     # by creation time, not by nonce).
-    run_id = current_run_id()
+    # PR F needs the run dir known before the TUI starts: the caller
+    # may mint the id (format unchanged - knowledge.current_run_id).
+    run_id = run_id_override if run_id_override else current_run_id()
 
     # R6.1: structured "<check>:<code>" failure signatures per component
     # (e.g. "linter:E501", "review:scope_creep"), recorded at each
@@ -1878,6 +2001,11 @@ def _run_factory_locked(
         future_deadlines: dict[Future[ComponentResult], float] = {}
         try:
             while True:
+                if stop is not None and stop.is_set():
+                    _abort_inflight(
+                        executor, running_futures, pipeline, ui, stop.reason,
+                    )
+                    return
                 ready = manifest.get_ready_components()
                 slots = slots_cap - len(running_futures)
 
@@ -1929,6 +2057,9 @@ def _run_factory_locked(
                             live_line=functools.partial(
                                 ui.stream_line, "AI",
                             ),
+                            stop_check=(
+                                stop.is_set if stop is not None else None
+                            ),
                         )
                         future = executor.submit(task)
                     else:
@@ -1952,11 +2083,15 @@ def _run_factory_locked(
                 wait_timeout = _next_backstop_wait(
                     running_futures, future_deadlines, time.monotonic(),
                 )
-                done, _pending = wait(
-                    set(running_futures),
-                    timeout=wait_timeout,
-                    return_when=FIRST_COMPLETED,
+                done, stopped = _wait_interruptible(
+                    set(running_futures), wait_timeout, stop,
                 )
+                if stopped:
+                    _abort_inflight(
+                        executor, running_futures, pipeline, ui,
+                        stop.reason if stop else "stop requested",
+                    )
+                    return
 
                 if done:
                     # Preserve pre-R0.1 semantics: process one completion
@@ -2094,6 +2229,10 @@ def _run_factory_locked(
     while True:
         _run_scheduling_pass()
         _cleanup_pass_worktrees()
+
+        if stop is not None and stop.is_set():
+            ui.warn(f"  Run stopped: {stop.reason}")
+            break
 
         # PHASE 3: Contract testing
         contract_config = factory_config.contract_config
@@ -2333,7 +2472,9 @@ def _run_factory_locked(
             "re-poll them: " + ", ".join(factory_result.merge_pending)
         )
 
-    if factory_result.failed or factory_result.contract_failures:
+    if stop is not None and stop.is_set():
+        factory_result.exit_code = 130
+    elif factory_result.failed or factory_result.contract_failures:
         factory_result.exit_code = 1
     elif factory_result.merge_pending:
         # Incomplete, not failed: unconfirmed merges blocked their

--- a/ralph_py/loop.py
+++ b/ralph_py/loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -67,6 +68,7 @@ def run_loop(
     *,
     bus: EventBus | None = None,
     interaction: InteractionChannel | None = None,
+    stop_check: Callable[[], bool] | None = None,
 ) -> LoopResult:
     """Run the main agentic loop.
 
@@ -218,6 +220,15 @@ def run_loop(
         )
 
     for iteration in range(1, config.max_iterations + 1):
+        if stop_check is not None and stop_check():
+            ui.warn("Stop requested; ending loop before next iteration")
+            return LoopResult(
+                completed=False, iterations=iteration - 1, exit_code=130,
+                duration_seconds=time.monotonic() - loop_start,
+                iteration_durations=iteration_durations,
+                timed_out_iterations=timed_out_iterations,
+                usage=collect_usage(agent),
+            )
         ui.section(f"Iteration {iteration} / {config.max_iterations}")
         iter_start = time.monotonic()
         if bus is not None:

--- a/ralph_py/pipeline.py
+++ b/ralph_py/pipeline.py
@@ -626,6 +626,19 @@ class ComponentPipeline:
             comp, error, phase=phase, check=check, signatures=signatures,
         )
 
+    def fail_aborted(self, comp_id: str, reason: str) -> None:
+        """PR B: a shutdown aborted this component's in-flight attempt.
+        Recorded as a plain FAILED with phase="aborted" so a resume can
+        retry it; distinct from every organic failure signature."""
+        comp = self.manifest.get_component(comp_id)
+        if comp is None:
+            return
+        self.fail(
+            comp, f"aborted: {reason}",
+            phase="aborted", check="shutdown",
+            signatures=["aborted:shutdown"],
+        )
+
     def fail(
         self,
         comp: Component,

--- a/ralph_py/shutdown.py
+++ b/ralph_py/shutdown.py
@@ -1,0 +1,82 @@
+"""Graceful shutdown: StopController + signal handlers.
+
+Stage 3 PR B of the TUI rewrite. Before this, Ctrl-C relied on Click's
+default KeyboardInterrupt abort: worktree cleanup was skipped, the
+executor's ``finally`` could block indefinitely on live workers, and
+agent subprocesses were orphaned to their own sessions. Now SIGINT and
+SIGTERM request a stop that the scheduling loop honors within its
+0.5s wait slice: in-flight workers are group-terminated (grace, then
+kill), aborted components are recorded as failed_phase="aborted",
+the manifest is flushed, the normal cleanup pass runs, and the run
+exits 130. A second signal escalates to force (immediate kill).
+"""
+
+from __future__ import annotations
+
+import signal
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from types import FrameType
+
+
+@dataclass
+class StopController:
+    """Cross-thread stop request. ``request`` is idempotent; the second
+    call (or a second signal) sets ``force``."""
+
+    reason: str = ""
+    force: bool = False
+    _event: threading.Event = field(default_factory=threading.Event)
+
+    def request(self, reason: str, *, force: bool = False) -> None:
+        if self._event.is_set():
+            # Second request escalates.
+            self.force = True
+        else:
+            self.reason = reason
+            self.force = force
+            self._event.set()
+
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return self._event.wait(timeout)
+
+
+def install_signal_handlers(
+    stop: StopController,
+    *,
+    on_second: Callable[[], None] | None = None,
+) -> Callable[[], None]:
+    """Route SIGINT/SIGTERM into ``stop``; returns an uninstaller.
+
+    Main-thread only (signal.signal requirement). The first signal
+    requests a graceful stop; the second sets ``force`` and calls
+    ``on_second`` (the immediate-kill path). The uninstaller restores
+    the previous handlers - call it in a ``finally``.
+    """
+    previous: dict[int, object] = {}
+
+    def _handler(signum: int, frame: FrameType | None) -> None:
+        del frame
+        name = signal.Signals(signum).name
+        if stop.is_set():
+            stop.request(f"second {name}", force=True)
+            if on_second is not None:
+                on_second()
+        else:
+            stop.request(f"received {name}")
+
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        previous[signum] = signal.signal(signum, _handler)
+
+    def _uninstall() -> None:
+        for signum, handler in previous.items():
+            try:
+                signal.signal(signum, handler)  # type: ignore[arg-type]
+            except (ValueError, TypeError, OSError):
+                pass
+
+    return _uninstall

--- a/tests/test_config_control_plane.py
+++ b/tests/test_config_control_plane.py
@@ -55,6 +55,7 @@ def captured(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
         ui: Any,
         root_dir: Path,
         manifest_path: Path | None = None,
+        **kwargs: Any,
     ) -> FactoryResult:
         box["manifest"] = manifest
         box["factory_config"] = factory_config

--- a/tests/test_resume_ergonomics.py
+++ b/tests/test_resume_ergonomics.py
@@ -571,6 +571,7 @@ class TestRetryCli:
             ui_impl: object,
             root_dir: Path,
             manifest_path: Path | None = None,
+            **kwargs: object,
         ) -> FactoryResult:
             captured["manifest"] = manifest
             captured["manifest_path"] = manifest_path

--- a/tests/test_run_honesty.py
+++ b/tests/test_run_honesty.py
@@ -268,6 +268,7 @@ class TestCliWiring:
             manifest: Manifest, factory_config: FactoryConfig,
             base_config: RalphConfig, ui: Any, root_dir: Path,
             manifest_path: Path | None = None,
+            **kwargs: Any,
         ) -> FactoryResult:
             captured["factory_config"] = factory_config
             captured["base_config"] = base_config

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,305 @@
+"""Stage 3 PR B (TUI rewrite): graceful shutdown.
+
+Before PR B, Ctrl-C relied on Click's default abort: cleanup was
+skipped, executor shutdown could block on live workers, and agent
+subprocesses were orphaned. These tests pin the new contract:
+stop-request honored within the wait slice, in-flight components
+recorded as aborted, agents group-killed (real subprocess test),
+worktree cleanup running, exit code 130.
+"""
+
+from __future__ import annotations
+
+import io
+import signal
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from ralph_py.agents.proc import DeadlineStreamer, kill_active_process_groups
+from ralph_py.factory import ComponentResult, _wait_interruptible, run_factory
+from ralph_py.shutdown import StopController, install_signal_handlers
+from ralph_py.ui.plain import PlainUI
+from tests.test_event_stream import (
+    _component,
+    _factory_config,
+    _make_base_config,
+    _make_manifest,
+    _setup_project,
+)
+
+
+class TestStopController:
+    def test_request_and_escalation(self) -> None:
+        stop = StopController()
+        assert stop.is_set() is False
+        stop.request("first")
+        assert stop.is_set() is True
+        assert stop.reason == "first"
+        assert stop.force is False
+        stop.request("second")
+        assert stop.force is True
+        assert stop.reason == "first"  # original reason preserved
+
+    def test_signal_handlers_route_and_restore(self) -> None:
+        stop = StopController()
+        seconds: list[bool] = []
+        before = signal.getsignal(signal.SIGTERM)
+        uninstall = install_signal_handlers(
+            stop, on_second=lambda: seconds.append(True),
+        )
+        try:
+            handler = signal.getsignal(signal.SIGTERM)
+            assert callable(handler)
+            handler(signal.SIGTERM, None)
+            assert stop.is_set() is True
+            assert "SIGTERM" in stop.reason
+            handler(signal.SIGINT, None)
+            assert stop.force is True
+            assert seconds == [True]
+        finally:
+            uninstall()
+        assert signal.getsignal(signal.SIGTERM) is before
+
+
+class TestWaitInterruptible:
+    def test_no_stop_behaves_like_wait(self) -> None:
+        from concurrent.futures import Future
+
+        future: Future[Any] = Future()
+        future.set_result(1)
+        done, stopped = _wait_interruptible({future}, 1.0, None)
+        assert done == {future}
+        assert stopped is False
+
+    def test_stop_returns_within_slice(self) -> None:
+        from concurrent.futures import Future
+
+        future: Future[Any] = Future()  # never completes
+        stop = StopController()
+
+        def _later() -> None:
+            time.sleep(0.1)
+            stop.request("test")
+
+        threading.Thread(target=_later).start()
+        started = time.monotonic()
+        done, stopped = _wait_interruptible(
+            {future}, 30.0, stop, slice_seconds=0.2,
+        )
+        elapsed = time.monotonic() - started
+        assert stopped is True
+        assert done == set()
+        assert elapsed < 2.0  # honored well before the 30s backstop
+
+    def test_timeout_expiry_without_stop(self) -> None:
+        from concurrent.futures import Future
+
+        future: Future[Any] = Future()
+        stop = StopController()
+        done, stopped = _wait_interruptible(
+            {future}, 0.2, stop, slice_seconds=0.1,
+        )
+        assert stopped is False
+        assert done == set()
+
+
+class TestAgentGroupKill:
+    def test_kill_active_process_groups_kills_real_subprocess(self) -> None:
+        """A live DeadlineStreamer child (own session) dies on the
+        shutdown group-kill; nothing is orphaned."""
+        streamer = DeadlineStreamer(
+            ["sh", "-c", "sleep 60"], timeout=60.0, term_grace=1.0,
+        )
+        pid = streamer._proc.pid
+        time.sleep(0.1)
+        killed = kill_active_process_groups()
+        assert killed >= 1
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if streamer._proc.poll() is not None:
+                break
+            time.sleep(0.05)
+        assert streamer._proc.poll() is not None, f"pid {pid} survived"
+        streamer.finish(timeout=2.0)
+
+
+class TestFactoryShutdown:
+    def test_pre_set_stop_aborts_before_launch(self, tmp_path: Path) -> None:
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        stop = StopController()
+        stop.request("pre-set")
+        launched: list[str] = []
+
+        def fake_component(comp_id: str, *a: Any, **k: Any) -> ComponentResult:
+            launched.append(comp_id)
+            return ComponentResult(comp_id, success=True, iterations=1)
+
+        with patch(
+            "ralph_py.factory._run_component", side_effect=fake_component,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, _factory_config(root), _make_base_config(root),
+                PlainUI(no_color=True, file=io.StringIO()), root,
+                stop=stop,
+            )
+        assert launched == []  # nothing started after the stop
+        assert result.exit_code == 130
+        assert manifest.completed_at  # terminal state stamped
+
+    def test_stop_mid_run_aborts_inflight_and_records(
+        self, tmp_path: Path,
+    ) -> None:
+        """Two components; the stop fires while comp-a's worker runs.
+        comp-a is recorded aborted, comp-b never launches, cleanup and
+        the manifest flush still happen, exit code 130."""
+        root = _setup_project(tmp_path, ["comp-a", "comp-b"])
+        comps = [_component("comp-a"), _component("comp-b", deps=["comp-a"])]
+        manifest = _make_manifest(comps)
+        stop = StopController()
+
+        def slow_component(comp_id: str, *a: Any, **k: Any) -> ComponentResult:
+            stop.request("mid-run test stop")
+            time.sleep(1.0)  # keep the future in flight past the stop
+            return ComponentResult(comp_id, success=True, iterations=1)
+
+        buf = io.StringIO()
+        with patch(
+            "ralph_py.factory._run_component", side_effect=slow_component,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, _factory_config(root), _make_base_config(root),
+                PlainUI(no_color=True, file=buf), root,
+                stop=stop,
+            )
+
+        assert result.exit_code == 130
+        comp_a = manifest.get_component("comp-a")
+        assert comp_a is not None
+        assert comp_a.status == "failed"
+        assert comp_a.failed_phase == "aborted"
+        assert "aborted" in (comp_a.error or "")
+        comp_b = manifest.get_component("comp-b")
+        assert comp_b is not None
+        assert comp_b.status in ("pending", "skipped")  # never launched
+        assert "Aborted in-flight work" in buf.getvalue()
+
+    def test_run_id_override_used(self, tmp_path: Path) -> None:
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        result = ComponentResult("comp-a", success=True, iterations=1)
+        with patch(
+            "ralph_py.factory._run_component", return_value=result,
+        ), patch("ralph_py.git.get_diff_content", return_value=""):
+            run_factory(
+                manifest, _factory_config(root), _make_base_config(root),
+                PlainUI(no_color=True, file=io.StringIO()), root,
+                run_id="factory-20260720-999999.000000-fixed",
+            )
+        assert (
+            root / ".ralph" / "runs" / "factory-20260720-999999.000000-fixed"
+            / "events.jsonl"
+        ).exists()
+
+
+class TestLoopStopCheck:
+    def test_stop_between_iterations(self, tmp_path: Path) -> None:
+        from ralph_py.config import RalphConfig
+        from ralph_py.loop import run_loop
+
+        class CountingAgent:
+            def __init__(self) -> None:
+                self.runs = 0
+
+            @property
+            def name(self) -> str:
+                return "counting"
+
+            def run(self, prompt: str, cwd: Path | None = None,
+                    timeout: float | None = None) -> Any:
+                self.runs += 1
+                yield "line"
+
+            @property
+            def final_message(self) -> str | None:
+                return None
+
+            @property
+            def usage_records(self) -> list[Any]:
+                return []
+
+        calls = {"n": 0}
+
+        def stop_after_first() -> bool:
+            calls["n"] += 1
+            return calls["n"] > 1  # allow iteration 1, stop iteration 2
+
+        agent = CountingAgent()
+        config = RalphConfig(
+            max_iterations=5, sleep_seconds=0,
+            prompt_file=tmp_path / "prompt.md",
+            prd_file=tmp_path / "prd.json",
+            ralph_branch="", ralph_branch_explicit=True,
+            ui_mode="plain", no_color=True,
+        )
+        (tmp_path / "prompt.md").write_text("p")
+        result = run_loop(
+            config, PlainUI(no_color=True, file=io.StringIO()), agent,
+            tmp_path, stop_check=stop_after_first,
+        )
+        assert agent.runs == 1
+        assert result.exit_code == 130
+        assert result.completed is False
+
+
+@pytest.mark.spine
+class TestWorkerSigterm:
+    def test_pool_worker_sigterm_kills_agent_group(
+        self, tmp_path: Path,
+    ) -> None:
+        """A REAL pool worker running a sleeping agent: SIGTERM to the
+        worker must kill the agent's process group (no orphans) and the
+        component must be recorded aborted."""
+        import subprocess
+
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        base = _make_base_config(root)
+        base.agent_cmd = "sleep 60"
+        config = _factory_config(root, max_parallel=2)
+        stop = StopController()
+
+        def stop_soon() -> None:
+            deadline = time.monotonic() + 15
+            while time.monotonic() < deadline:
+                out = subprocess.run(
+                    ["pgrep", "-f", "sleep 60"], capture_output=True,
+                )
+                if out.returncode == 0:
+                    break
+                time.sleep(0.2)
+            stop.request("sigterm spine test")
+
+        threading.Thread(target=stop_soon).start()
+        with patch("ralph_py.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, base,
+                PlainUI(no_color=True, file=io.StringIO()), root,
+                stop=stop,
+            )
+        assert result.exit_code == 130
+        # No orphaned agent: the sleep 60 process group must be gone.
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            out = subprocess.run(
+                ["pgrep", "-f", "sleep 60"], capture_output=True,
+            )
+            if out.returncode != 0:
+                break
+            time.sleep(0.2)
+        assert out.returncode != 0, "agent subprocess orphaned"


### PR DESCRIPTION
## Summary

Stage 3 PR B of the TUI rewrite plan (stacked on #112). Fixes the analysis-phase finding that Ctrl-C skips cleanup and orphans agents, and builds the stop machinery embedded mode (PR F) reuses.

- `ralph_py/shutdown.py`: `StopController` + `install_signal_handlers` (second signal escalates to force; uninstaller restores).
- `run_factory(stop=, run_id=)`: stop honored at scheduling-loop top, inside the wait (0.5s slices via `_wait_interruptible`, backstop math preserved), and before the contract phase; `run_id` override lets PR F know the run dir before `app.run()`.
- `_abort_inflight`: SIGTERM pool worker pids (guarded `_processes`; fallback = old behavior), 5s grace, SIGKILL; components recorded `failed_phase="aborted"` via `pipeline.fail_aborted`; manifest flushed; the normal cleanup pass runs; **exit 130**.
- Worker side: `agents/proc.py` gains a `WeakSet` registry + `kill_active_process_groups()`; pool workers install a SIGTERM handler that group-kills their agent then `os._exit(130)` - no orphaned sessions. Inline mode: `run_loop(stop_check=)` between iterations + direct in-process group kill.
- cli `run`/`factory`/`retry` wire the handlers with `finally` restore.

## Tests (+11, one spine)

Controller/handler semantics with restore assertion, wait-slice latency, real `DeadlineStreamer` group-kill, pre-set and mid-run stop through real `run_factory` (aborted recording, dependents unlaunched, terminal manifest stamp, exit 130), `run_id` override, loop `stop_check`, and a **spine test that SIGTERMs a real pool worker running `sleep 60` and proves the agent process group is gone** (pgrep). Three `run_factory` stubs updated for the new kwargs.

Gates: fast 1615 passed, spine 25 passed, `mypy --strict`, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)