### PR TITLE
TUI PR C: tailers + run discovery + fake-run fixture

### DIFF
--- a/ralph_py/tui/__init__.py
+++ b/ralph_py/tui/__init__.py
@@ -1,0 +1,8 @@
+"""Textual dashboard package for Ralph (TUI rewrite, stage 3).
+
+Import discipline: only :mod:`ralph_py.tui.state` may import the
+reducer, so any reducer-contract drift has a one-module blast radius.
+Nothing in ralph_py outside this package imports textual - the
+dependency stays optional-at-runtime for plain-mode users until PR D
+adds it to the project dependencies.
+"""

--- a/ralph_py/tui/runs.py
+++ b/ralph_py/tui/runs.py
@@ -1,0 +1,113 @@
+"""Run discovery for `ralph dash` (stage 3 PR C).
+
+A run is a directory under ``.ralph/runs/<run_id>/`` containing
+events.jsonl. run_ids are lexicographically sortable by construction
+(``factory-YYYYMMDD-HHMMSS.ffffff-<nonce>``), which discovery exploits.
+
+Liveness is a judgment from two cheap signals: recent events-file
+mtime, or the run-level factory.lock being held (a non-blocking flock
+probe - safe because the factory holds the lock for the whole run and
+we release our probe immediately).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+LIVE_MTIME_WINDOW_SECONDS = 60.0
+_COMPLETED_TAIL_BYTES = 8192
+
+
+@dataclass(frozen=True)
+class RunRef:
+    run_id: str
+    run_dir: Path
+    events_path: Path
+    mtime: float
+    completed: bool
+
+    @property
+    def live(self) -> bool:
+        return not self.completed and (
+            time.time() - self.mtime < LIVE_MTIME_WINDOW_SECONDS
+        )
+
+
+def _run_completed(events_path: Path) -> bool:
+    """factory_completed in the last ~8KB of the stream (cheap check;
+    a torn tail or missing marker just means "not completed")."""
+    try:
+        size = events_path.stat().st_size
+        with open(events_path, "rb") as f:
+            f.seek(max(0, size - _COMPLETED_TAIL_BYTES))
+            tail = f.read()
+    except OSError:
+        return False
+    return b'"factory_completed"' in tail
+
+
+def factory_lock_held(root_dir: Path) -> bool:
+    """Non-blocking probe of the run-level flock. True = a factory run
+    holds it right now. POSIX-only; returns False where fcntl is
+    unavailable (mirrors the factory's own degradation)."""
+    lock_path = root_dir / ".ralph" / "factory.lock"
+    if not lock_path.exists():
+        return False
+    try:
+        import fcntl
+    except ImportError:
+        return False
+    try:
+        with open(lock_path, "a+") as fp:
+            try:
+                fcntl.flock(fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                return True  # held by the factory
+            fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+            return False
+    except OSError:
+        return False
+
+
+def discover_runs(root_dir: Path) -> list[RunRef]:
+    """All runs with an events.jsonl, newest first."""
+    runs_root = root_dir / ".ralph" / "runs"
+    refs: list[RunRef] = []
+    try:
+        candidates = sorted(runs_root.iterdir(), key=lambda d: d.name,
+                            reverse=True)
+    except OSError:
+        return []
+    for run_dir in candidates:
+        events_path = run_dir / "events.jsonl"
+        try:
+            mtime = events_path.stat().st_mtime
+        except OSError:
+            continue
+        refs.append(RunRef(
+            run_id=run_dir.name,
+            run_dir=run_dir,
+            events_path=events_path,
+            mtime=mtime,
+            completed=_run_completed(events_path),
+        ))
+    return refs
+
+
+def latest_run(root_dir: Path) -> RunRef | None:
+    refs = discover_runs(root_dir)
+    return refs[0] if refs else None
+
+
+def find_run(root_dir: Path, run_id: str) -> RunRef | None:
+    """Exact match, or unique-prefix match."""
+    refs = discover_runs(root_dir)
+    for ref in refs:
+        if ref.run_id == run_id:
+            return ref
+    prefixed = [r for r in refs if r.run_id.startswith(run_id)]
+    if len(prefixed) == 1:
+        return prefixed[0]
+    return None

--- a/ralph_py/tui/runs.py
+++ b/ralph_py/tui/runs.py
@@ -12,6 +12,9 @@ we release our probe immediately).
 
 from __future__ import annotations
 
+import errno
+import json
+import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,25 +30,47 @@ class RunRef:
     events_path: Path
     mtime: float
     completed: bool
+    lock_held: bool = False
 
     @property
     def live(self) -> bool:
         return not self.completed and (
+            self.lock_held or
             time.time() - self.mtime < LIVE_MTIME_WINDOW_SECONDS
         )
 
 
 def _run_completed(events_path: Path) -> bool:
-    """factory_completed in the last ~8KB of the stream (cheap check;
-    a torn tail or missing marker just means "not completed")."""
+    """Find a factory_completed event near the end of the stream.
+
+    Parse complete JSONL records rather than searching raw bytes, since a
+    log payload can legitimately contain the event name as ordinary text.
+    A torn tail or missing marker means "not completed".
+    """
     try:
-        size = events_path.stat().st_size
         with open(events_path, "rb") as f:
-            f.seek(max(0, size - _COMPLETED_TAIL_BYTES))
+            size = os.fstat(f.fileno()).st_size
+            start = max(0, size - _COMPLETED_TAIL_BYTES)
+            f.seek(max(0, start - 1))
             tail = f.read()
     except OSError:
         return False
-    return b'"factory_completed"' in tail
+    if start:
+        if tail.startswith(b"\n"):
+            tail = tail[1:]
+        else:
+            _, separator, tail = tail.partition(b"\n")
+            if not separator:
+                return False
+    lines = tail.split(b"\n")
+    for raw in lines:
+        try:
+            obj = json.loads(raw)
+        except (UnicodeDecodeError, ValueError):
+            continue
+        if isinstance(obj, dict) and obj.get("event") == "factory_completed":
+            return True
+    return False
 
 
 def factory_lock_held(root_dir: Path) -> bool:
@@ -63,8 +88,8 @@ def factory_lock_held(root_dir: Path) -> bool:
         with open(lock_path, "a+") as fp:
             try:
                 fcntl.flock(fp.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except OSError:
-                return True  # held by the factory
+            except OSError as exc:
+                return exc.errno in (errno.EACCES, errno.EAGAIN)
             fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
             return False
     except OSError:
@@ -75,6 +100,7 @@ def discover_runs(root_dir: Path) -> list[RunRef]:
     """All runs with an events.jsonl, newest first."""
     runs_root = root_dir / ".ralph" / "runs"
     refs: list[RunRef] = []
+    lock_held = factory_lock_held(root_dir)
     try:
         candidates = sorted(runs_root.iterdir(), key=lambda d: d.name,
                             reverse=True)
@@ -92,6 +118,7 @@ def discover_runs(root_dir: Path) -> list[RunRef]:
             events_path=events_path,
             mtime=mtime,
             completed=_run_completed(events_path),
+            lock_held=lock_held and not refs,
         ))
     return refs
 

--- a/ralph_py/tui/tail.py
+++ b/ralph_py/tui/tail.py
@@ -1,0 +1,156 @@
+"""Byte-offset file tailers for the dashboard (stage 3 PR C).
+
+Promoted from the spike (spike/tui0/tailer.py) after its measurements:
+polling at 0.2-0.25s gives p95 tail latency ~240ms at BOTH realistic
+and 10x event rates with <1.3% CPU, and zero record loss under
+torn-tail injection. Polling (not watchdog/FSEvents) is deliberate:
+macOS FSEvents coalesces beyond our latency gate, the offset/torn-tail
+logic is needed regardless, and we poll at most a handful of files.
+
+Torn-tail contract (mirrors observability.read_progress_events): a
+trailing partial line is buffered, never parsed, and completed by a
+later poll; a complete line that is not valid JSON is skipped; a file
+that shrank (truncated/replaced) resets to offset zero and reports
+``truncated`` so consumers can rebuild state.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ralph_py.events import Event, event_from_dict
+
+
+@dataclass
+class TailChunk:
+    """One poll's yield: newly complete, parsed events."""
+
+    events: list[Event] = field(default_factory=list)
+    truncated: bool = False  # file shrank; offsets were reset
+
+
+class JsonlTailer:
+    """Tail one JSONL event file by byte offset."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._offset = 0
+        self._partial = b""
+
+    def poll(self) -> TailChunk:
+        chunk = TailChunk()
+        try:
+            size = self.path.stat().st_size
+        except OSError:
+            return chunk
+        if size < self._offset:
+            self._offset = 0
+            self._partial = b""
+            chunk.truncated = True
+        if size == self._offset:
+            return chunk
+        try:
+            with open(self.path, "rb") as f:
+                f.seek(self._offset)
+                data = f.read()
+                self._offset = f.tell()
+        except OSError:
+            return chunk
+        data = self._partial + data
+        lines = data.split(b"\n")
+        self._partial = lines.pop()  # b"" when data ended in a newline
+        for raw in lines:
+            if not raw.strip():
+                continue
+            try:
+                obj = json.loads(raw)
+            except ValueError:
+                continue
+            if isinstance(obj, dict):
+                chunk.events.append(event_from_dict(obj))
+        return chunk
+
+
+class TextTailer:
+    """Tail a plain-text transcript; yields new complete lines."""
+
+    def __init__(self, path: Path, max_lines: int = 2000) -> None:
+        self.path = path
+        self.max_lines = max_lines
+        self._offset = 0
+        self._partial = b""
+
+    def poll(self) -> list[str]:
+        try:
+            size = self.path.stat().st_size
+        except OSError:
+            return []
+        if size < self._offset:
+            self._offset = 0
+            self._partial = b""
+        if size == self._offset:
+            return []
+        try:
+            with open(self.path, "rb") as f:
+                f.seek(self._offset)
+                data = f.read()
+                self._offset = f.tell()
+        except OSError:
+            return []
+        data = self._partial + data
+        lines = data.split(b"\n")
+        self._partial = lines.pop()
+        decoded = [line.decode("utf-8", errors="replace") for line in lines]
+        # Bound a catch-up burst: the consumer is a display pane, and
+        # the spike measured that unbounded transcript floods starve
+        # input (finding 3) - the cap belongs at the source.
+        return decoded[-self.max_lines:]
+
+
+class RunTailer:
+    """Tail one run directory: events.jsonl + workers' engineer.jsonl.
+
+    Components appear on disk as workers start; each poll re-discovers
+    the components/ dir so late starters are picked up without restart.
+    Events across files are merged in (ts, source, seq) order.
+    """
+
+    def __init__(self, run_dir: Path) -> None:
+        self.run_dir = run_dir
+        self._events = JsonlTailer(run_dir / "events.jsonl")
+        self._workers: dict[str, JsonlTailer] = {}
+
+    def known_components(self) -> list[str]:
+        comp_root = self.run_dir / "components"
+        if not comp_root.is_dir():
+            return []
+        try:
+            return sorted(d.name for d in comp_root.iterdir() if d.is_dir())
+        except OSError:
+            return []
+
+    def _discover_workers(self) -> None:
+        comp_root = self.run_dir / "components"
+        if not comp_root.is_dir():
+            return
+        try:
+            entries = list(comp_root.iterdir())
+        except OSError:
+            return
+        for entry in entries:
+            if entry.name not in self._workers and (
+                entry / "engineer.jsonl"
+            ).exists():
+                self._workers[entry.name] = JsonlTailer(
+                    entry / "engineer.jsonl",
+                )
+
+    def poll_events(self) -> list[Event]:
+        self._discover_workers()
+        events = self._events.poll().events
+        for tailer in self._workers.values():
+            events.extend(tailer.poll().events)
+        events.sort(key=lambda e: (e.ts, e.source, e.seq))
+        return events

--- a/ralph_py/tui/tail.py
+++ b/ralph_py/tui/tail.py
@@ -156,10 +156,31 @@ class RunTailer:
                     entry / "engineer.jsonl",
                 )
 
-    def poll_events(self) -> list[Event]:
+    def _poll_once(self) -> TailChunk:
         self._discover_workers()
-        events = self._events.poll().events
+        run_chunk = self._events.poll()
+        events = run_chunk.events
+        truncated = run_chunk.truncated
         for tailer in self._workers.values():
-            events.extend(tailer.poll().events)
+            worker_chunk = tailer.poll()
+            events.extend(worker_chunk.events)
+            truncated = truncated or worker_chunk.truncated
         events.sort(key=lambda e: (e.ts, e.source, e.seq))
-        return events
+        return TailChunk(events=events, truncated=truncated)
+
+    def poll_events(self) -> TailChunk:
+        """Return new events, rebuilding a full snapshot after rewrites.
+
+        A reducer cannot safely apply a replaced worker stream on top of
+        its old state. If any constituent file reports truncation, reset
+        every offset and return one complete, consistently ordered snapshot
+        with ``truncated=True`` so the consumer can reset before folding it.
+        """
+        chunk = self._poll_once()
+        if not chunk.truncated:
+            return chunk
+        self._events = JsonlTailer(self.run_dir / "events.jsonl")
+        self._workers = {}
+        rebuilt = self._poll_once()
+        rebuilt.truncated = True
+        return rebuilt

--- a/ralph_py/tui/tail.py
+++ b/ralph_py/tui/tail.py
@@ -17,6 +17,7 @@ that shrank (truncated/replaced) resets to offset zero and reports
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -38,21 +39,24 @@ class JsonlTailer:
         self.path = path
         self._offset = 0
         self._partial = b""
+        self._identity: tuple[int, int] | None = None
 
     def poll(self) -> TailChunk:
         chunk = TailChunk()
         try:
-            size = self.path.stat().st_size
-        except OSError:
-            return chunk
-        if size < self._offset:
-            self._offset = 0
-            self._partial = b""
-            chunk.truncated = True
-        if size == self._offset:
-            return chunk
-        try:
             with open(self.path, "rb") as f:
+                stat = os.fstat(f.fileno())
+                identity = (stat.st_dev, stat.st_ino)
+                if (
+                    self._identity is not None
+                    and identity != self._identity
+                ) or stat.st_size < self._offset:
+                    self._offset = 0
+                    self._partial = b""
+                    chunk.truncated = True
+                self._identity = identity
+                if stat.st_size == self._offset:
+                    return chunk
                 f.seek(self._offset)
                 data = f.read()
                 self._offset = f.tell()
@@ -77,23 +81,28 @@ class TextTailer:
     """Tail a plain-text transcript; yields new complete lines."""
 
     def __init__(self, path: Path, max_lines: int = 2000) -> None:
+        if max_lines <= 0:
+            raise ValueError("max_lines must be positive")
         self.path = path
         self.max_lines = max_lines
         self._offset = 0
         self._partial = b""
+        self._identity: tuple[int, int] | None = None
 
     def poll(self) -> list[str]:
         try:
-            size = self.path.stat().st_size
-        except OSError:
-            return []
-        if size < self._offset:
-            self._offset = 0
-            self._partial = b""
-        if size == self._offset:
-            return []
-        try:
             with open(self.path, "rb") as f:
+                stat = os.fstat(f.fileno())
+                identity = (stat.st_dev, stat.st_ino)
+                if (
+                    self._identity is not None
+                    and identity != self._identity
+                ) or stat.st_size < self._offset:
+                    self._offset = 0
+                    self._partial = b""
+                self._identity = identity
+                if stat.st_size == self._offset:
+                    return []
                 f.seek(self._offset)
                 data = f.read()
                 self._offset = f.tell()

--- a/tests/helpers/fake_run.py
+++ b/tests/helpers/fake_run.py
@@ -1,0 +1,155 @@
+"""Synthetic run-directory fixture for tailer and Pilot tests (PR C).
+
+The spike's generator (spike/tui0/fake_run.py) promoted onto the REAL
+event classes, so fixtures exercise production serialization. Two
+modes: ``write_fake_run`` writes a complete run at once (static
+states); ``stream_fake_run`` yields after each write so tailer and
+live-update tests can step the run forward between polls.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from ralph_py import events as ev
+
+DEFAULT_RUN_ID = "factory-20260720-120000.000000-fake"
+
+
+@dataclass(frozen=True)
+class FakeRunSpec:
+    components: int = 3
+    iterations: int = 2
+    include_checkpoint: bool = False
+    include_unreported_usage: bool = True
+    include_findings: bool = True
+    complete: bool = True
+    max_total_tokens: int = 5_000_000
+    max_adversarial_calls: int = 40
+
+
+def _component_ids(spec: FakeRunSpec) -> list[str]:
+    return [f"comp-{chr(ord('a') + i)}" for i in range(spec.components)]
+
+
+def _emit_run(root: Path, spec: FakeRunSpec, run_id: str) -> Iterator[None]:
+    paths = ev.RunPaths.for_run(root, run_id)
+    bus = ev.EventBus(ev.JsonlSink(paths.events_file), run_id=run_id)
+    comps = _component_ids(spec)
+
+    bus.emit(ev.RunStarted(project="fake-project", components=len(comps)))
+    yield
+    bus.emit(ev.RunPlan(
+        components=tuple(
+            {"id": cid, "title": f"Component {cid[-1].upper()}",
+             "deps": [comps[i - 1]] if i else []}
+            for i, cid in enumerate(comps)
+        ),
+        max_total_tokens=spec.max_total_tokens,
+        max_adversarial_calls=spec.max_adversarial_calls,
+    ))
+    yield
+
+    for index, cid in enumerate(comps):
+        bus.emit(ev.ComponentStarted(component=cid))
+        bus.emit(ev.PhaseStarted(component=cid, phase="engineer", attempt=1))
+        yield
+        worker = ev.EventBus(
+            ev.JsonlSink(paths.engineer_events(cid)),
+            run_id=run_id, source="worker", component=cid,
+        )
+        log_path = paths.engineer_log(cid)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "a", encoding="utf-8") as log:
+            for iteration in range(1, spec.iterations + 1):
+                worker.emit(ev.IterationStarted(
+                    iteration=iteration, max_iterations=spec.iterations,
+                ))
+                log.write(f"[{cid}] editing src/{cid}/impl.py\n")
+                log.write(f"[{cid}] running tests (iteration {iteration})\n")
+                worker.emit(ev.IterationCompleted(
+                    iteration=iteration, duration_seconds=12.5,
+                    completed=iteration == spec.iterations,
+                ))
+                yield
+            worker.emit(ev.WorkerHeartbeat(pid=40000 + index,
+                                           elapsed_seconds=25.0))
+        worker.close()
+        bus.emit(ev.PhaseCompleted(
+            component=cid, phase="engineer", passed=True,
+            duration_seconds=25.0,
+        ))
+        bus.emit(ev.ComponentUsage(
+            component=cid, phase="engineer", calls=spec.iterations,
+            known_calls=(
+                spec.iterations - 1 if spec.include_unreported_usage
+                else spec.iterations
+            ),
+            unreported_calls=1 if spec.include_unreported_usage else 0,
+            input_tokens=40_000 * (index + 1),
+            output_tokens=8_000,
+            total_tokens=48_000 * (index + 1),
+            cost_usd=0.75 * (index + 1),
+            duration_seconds=25.0,
+        ))
+        yield
+        for phase in ("verify", "review", "security", "distill"):
+            bus.emit(ev.PhaseStarted(component=cid, phase=phase, attempt=1))
+            if phase == "review" and spec.include_findings:
+                bus.emit(ev.FindingRecorded(
+                    component=cid, phase="review", category="test_quality",
+                    severity="advisory",
+                    location=f"src/{cid}/impl.py:42",
+                    explanation="Assertion could be tighter.", attempt=1,
+                ))
+            bus.emit(ev.PhaseCompleted(
+                component=cid, phase=phase, passed=True,
+                duration_seconds=8.0,
+            ))
+            yield
+        if spec.include_checkpoint and index == len(comps) - 1:
+            bus.emit(ev.CheckpointRequested(
+                component=cid, kind="pr_merge",
+                question=f"Approve PR creation and merge for {cid}?",
+            ))
+            yield
+            # Left OPEN deliberately: dash renders the pending banner.
+        else:
+            bus.emit(ev.PrCreated(component=cid, pr_number=100 + index,
+                                  pr_url=f"https://example.test/pr/{100 + index}"))
+            bus.emit(ev.PrMerged(component=cid, pr_number=100 + index,
+                                 pr_url=f"https://example.test/pr/{100 + index}"))
+            bus.emit(ev.ComponentCompleted(
+                component=cid, duration_seconds=60.0 + index,
+                iterations=spec.iterations,
+            ))
+            yield
+
+    if spec.complete and not spec.include_checkpoint:
+        bus.emit(ev.RunCompleted(
+            completed=len(comps), failed=0, skipped=0,
+            duration_seconds=200.0,
+        ))
+        yield
+    bus.close()
+
+
+def write_fake_run(
+    root: Path, spec: FakeRunSpec | None = None, *,
+    run_id: str = DEFAULT_RUN_ID,
+) -> Path:
+    """Write the whole fake run at once; returns the run dir."""
+    spec = spec or FakeRunSpec()
+    for _ in _emit_run(root, spec, run_id):
+        pass
+    return root / ".ralph" / "runs" / run_id
+
+
+def stream_fake_run(
+    root: Path, spec: FakeRunSpec | None = None, *,
+    run_id: str = DEFAULT_RUN_ID,
+) -> Iterator[None]:
+    """Step the fake run forward one write-batch per iteration."""
+    return _emit_run(root, spec or FakeRunSpec(), run_id)

--- a/tests/test_tui_runs.py
+++ b/tests/test_tui_runs.py
@@ -1,0 +1,91 @@
+"""Stage 3 PR C (TUI rewrite): run discovery for `ralph dash`."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from ralph_py.tui.runs import (
+    discover_runs,
+    factory_lock_held,
+    find_run,
+    latest_run,
+)
+from tests.helpers.fake_run import FakeRunSpec, write_fake_run
+
+
+def _three_runs(root: Path) -> list[str]:
+    ids = [
+        "factory-20260718-100000.000000-old",
+        "factory-20260719-100000.000000-mid",
+        "factory-20260720-100000.000000-new",
+    ]
+    for run_id in ids:
+        write_fake_run(root, FakeRunSpec(components=1), run_id=run_id)
+    return ids
+
+
+class TestDiscovery:
+    def test_newest_first_and_completed_flag(self, tmp_path: Path) -> None:
+        ids = _three_runs(tmp_path)
+        refs = discover_runs(tmp_path)
+        assert [r.run_id for r in refs] == list(reversed(ids))
+        assert all(r.completed for r in refs)
+
+    def test_latest_run(self, tmp_path: Path) -> None:
+        _three_runs(tmp_path)
+        ref = latest_run(tmp_path)
+        assert ref is not None
+        assert ref.run_id.endswith("-new")
+
+    def test_empty_root(self, tmp_path: Path) -> None:
+        assert discover_runs(tmp_path) == []
+        assert latest_run(tmp_path) is None
+
+    def test_find_exact_and_unique_prefix(self, tmp_path: Path) -> None:
+        ids = _three_runs(tmp_path)
+        assert find_run(tmp_path, ids[0]) is not None
+        ref = find_run(tmp_path, "factory-20260719")
+        assert ref is not None and ref.run_id == ids[1]
+        # Ambiguous prefix -> None
+        assert find_run(tmp_path, "factory-2026") is None
+        assert find_run(tmp_path, "nope") is None
+
+    def test_incomplete_run_is_live_when_fresh(self, tmp_path: Path) -> None:
+        run_id = "factory-20260720-150000.000000-live"
+        write_fake_run(
+            tmp_path, FakeRunSpec(components=1, complete=False),
+            run_id=run_id,
+        )
+        ref = find_run(tmp_path, run_id)
+        assert ref is not None
+        assert ref.completed is False
+        assert ref.live is True  # mtime is fresh
+        # Age the file: no longer live.
+        old = time.time() - 3600
+        os.utime(ref.events_path, (old, old))
+        aged = find_run(tmp_path, run_id)
+        assert aged is not None
+        assert aged.live is False
+
+
+class TestFactoryLockProbe:
+    def test_no_lock_file(self, tmp_path: Path) -> None:
+        assert factory_lock_held(tmp_path) is False
+
+    def test_unheld_lock_file(self, tmp_path: Path) -> None:
+        lock = tmp_path / ".ralph" / "factory.lock"
+        lock.parent.mkdir(parents=True)
+        lock.write_text("12345\n")
+        assert factory_lock_held(tmp_path) is False
+
+    def test_held_lock_detected(self, tmp_path: Path) -> None:
+        import fcntl
+
+        lock = tmp_path / ".ralph" / "factory.lock"
+        lock.parent.mkdir(parents=True)
+        with open(lock, "a+") as holder:
+            fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            assert factory_lock_held(tmp_path) is True
+        assert factory_lock_held(tmp_path) is False

--- a/tests/test_tui_runs.py
+++ b/tests/test_tui_runs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from pathlib import Path
@@ -68,6 +69,41 @@ class TestDiscovery:
         aged = find_run(tmp_path, run_id)
         assert aged is not None
         assert aged.live is False
+
+    def test_log_text_does_not_mark_run_complete(self, tmp_path: Path) -> None:
+        run_id = "factory-20260720-150000.000000-log"
+        run_dir = tmp_path / ".ralph" / "runs" / run_id
+        run_dir.mkdir(parents=True)
+        (run_dir / "events.jsonl").write_text(json.dumps({
+            "event": "log",
+            "data": {"text": 'waiting for "factory_completed"'},
+        }) + "\n")
+
+        ref = find_run(tmp_path, run_id)
+
+        assert ref is not None
+        assert ref.completed is False
+
+    def test_held_lock_keeps_newest_incomplete_run_live(
+        self, tmp_path: Path,
+    ) -> None:
+        import fcntl
+
+        run_id = "factory-20260720-150000.000000-locked"
+        write_fake_run(
+            tmp_path, FakeRunSpec(components=1, complete=False),
+            run_id=run_id,
+        )
+        events = tmp_path / ".ralph" / "runs" / run_id / "events.jsonl"
+        old = time.time() - 3600
+        os.utime(events, (old, old))
+        lock = tmp_path / ".ralph" / "factory.lock"
+        with open(lock, "a+") as holder:
+            fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            ref = find_run(tmp_path, run_id)
+
+        assert ref is not None
+        assert ref.live is True
 
 
 class TestFactoryLockProbe:

--- a/tests/test_tui_tail.py
+++ b/tests/test_tui_tail.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from ralph_py import events as ev
@@ -57,6 +58,25 @@ class TestJsonlTailer:
         assert chunk.truncated is True
         assert [e.to_dict()["data"]["text"] for e in chunk.events] == ["fresh"]
 
+    def test_replaced_larger_file_resets_and_reports(self, tmp_path: Path) -> None:
+        path = tmp_path / "events.jsonl"
+        bus = ev.EventBus(ev.JsonlSink(path), run_id="r")
+        bus.emit(ev.Log(text="old"))
+        tailer = JsonlTailer(path)
+        assert len(tailer.poll().events) == 1
+        replacement = tmp_path / "replacement.jsonl"
+        replacement_bus = ev.EventBus(ev.JsonlSink(replacement), run_id="r")
+        replacement_bus.emit(ev.Log(text="fresh-one"))
+        replacement_bus.emit(ev.Log(text="fresh-two"))
+        os.replace(replacement, path)
+
+        chunk = tailer.poll()
+
+        assert chunk.truncated is True
+        assert [e.to_dict()["data"]["text"] for e in chunk.events] == [
+            "fresh-one", "fresh-two",
+        ]
+
     def test_invalid_json_line_skipped(self, tmp_path: Path) -> None:
         path = tmp_path / "events.jsonl"
         with open(path, "a") as f:
@@ -88,6 +108,12 @@ class TestTextTailer:
         lines = TextTailer(path, max_lines=100).poll()
         assert len(lines) == 100
         assert lines[-1] == "line 499"
+
+    def test_max_lines_must_be_positive(self, tmp_path: Path) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="max_lines must be positive"):
+            TextTailer(tmp_path / "engineer.log", max_lines=0)
 
 
 class TestRunTailer:

--- a/tests/test_tui_tail.py
+++ b/tests/test_tui_tail.py
@@ -1,0 +1,147 @@
+"""Stage 3 PR C (TUI rewrite): byte-offset tailers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ralph_py import events as ev
+from ralph_py import reducer
+from ralph_py.tui.tail import JsonlTailer, RunTailer, TextTailer
+from tests.helpers.fake_run import FakeRunSpec, stream_fake_run, write_fake_run
+
+
+class TestJsonlTailer:
+    def test_incremental_polls_see_only_new_events(self, tmp_path: Path) -> None:
+        path = tmp_path / "events.jsonl"
+        sink = ev.JsonlSink(path)
+        bus = ev.EventBus(sink, run_id="r")
+        tailer = JsonlTailer(path)
+
+        assert tailer.poll().events == []
+        bus.emit(ev.Log(text="one"))
+        first = tailer.poll().events
+        assert [e.to_dict()["data"]["text"] for e in first] == ["one"]
+        bus.emit(ev.Log(text="two"))
+        bus.emit(ev.Log(text="three"))
+        second = tailer.poll().events
+        assert [e.to_dict()["data"]["text"] for e in second] == ["two", "three"]
+        assert tailer.poll().events == []
+
+    def test_torn_tail_completed_across_polls(self, tmp_path: Path) -> None:
+        path = tmp_path / "events.jsonl"
+        line = ev.EventBus(run_id="r").emit(ev.Log(text="torn")).to_json_line()
+        cut = len(line) // 2
+        tailer = JsonlTailer(path)
+        with open(path, "a") as f:
+            f.write(line[:cut])
+            f.flush()
+        assert tailer.poll().events == []  # partial buffered, not parsed
+        with open(path, "a") as f:
+            f.write(line[cut:] + "\n")
+        events = tailer.poll().events
+        assert len(events) == 1
+        assert events[0].to_dict()["data"]["text"] == "torn"
+
+    def test_truncated_file_resets_and_reports(self, tmp_path: Path) -> None:
+        path = tmp_path / "events.jsonl"
+        bus = ev.EventBus(ev.JsonlSink(path), run_id="r")
+        bus.emit(ev.Log(text="old-1"))
+        bus.emit(ev.Log(text="old-2"))
+        tailer = JsonlTailer(path)
+        assert len(tailer.poll().events) == 2
+        path.write_text("")  # replaced/truncated under us
+        bus2 = ev.EventBus(ev.JsonlSink(path), run_id="r")
+        bus2.emit(ev.Log(text="fresh"))
+        chunk = tailer.poll()
+        assert chunk.truncated is True
+        assert [e.to_dict()["data"]["text"] for e in chunk.events] == ["fresh"]
+
+    def test_invalid_json_line_skipped(self, tmp_path: Path) -> None:
+        path = tmp_path / "events.jsonl"
+        with open(path, "a") as f:
+            f.write("{not json}\n")
+            f.write(json.dumps({"event": "log", "data": {"text": "ok"}}) + "\n")
+        events = JsonlTailer(path).poll().events
+        assert len(events) == 1
+
+    def test_missing_file_quiet(self, tmp_path: Path) -> None:
+        assert JsonlTailer(tmp_path / "nope.jsonl").poll().events == []
+
+
+class TestTextTailer:
+    def test_incremental_lines_and_partial(self, tmp_path: Path) -> None:
+        path = tmp_path / "engineer.log"
+        tailer = TextTailer(path)
+        with open(path, "a") as f:
+            f.write("line one\nline two\npart")
+        assert tailer.poll() == ["line one", "line two"]
+        with open(path, "a") as f:
+            f.write("ial three\n")
+        assert tailer.poll() == ["partial three"]
+
+    def test_catch_up_burst_bounded(self, tmp_path: Path) -> None:
+        path = tmp_path / "engineer.log"
+        with open(path, "a") as f:
+            for i in range(500):
+                f.write(f"line {i}\n")
+        lines = TextTailer(path, max_lines=100).poll()
+        assert len(lines) == 100
+        assert lines[-1] == "line 499"
+
+
+class TestRunTailer:
+    def test_streamed_run_arrives_incrementally_and_folds(
+        self, tmp_path: Path,
+    ) -> None:
+        """Step the fake run; every poll's events fold incrementally to
+        the same state a one-shot fold produces (fold == tailed apply)."""
+        run_id = "factory-20260720-130000.000000-t"
+        stepper = stream_fake_run(
+            tmp_path, FakeRunSpec(components=2), run_id=run_id,
+        )
+        tailer = RunTailer(tmp_path / ".ralph" / "runs" / run_id)
+        state = reducer.RunState()
+        polls_with_events = 0
+        for _ in stepper:
+            for event in tailer.poll_events():
+                reducer.apply(state, event)
+            polls_with_events += 1
+        for event in tailer.poll_events():  # final drain
+            reducer.apply(state, event)
+
+        expected, _ = reducer.load_run_state(tmp_path, run_id)
+        assert state == expected
+        assert polls_with_events > 3  # genuinely incremental
+        assert state.components["comp-a"].status == "completed"
+        assert state.finished is True
+
+    def test_worker_files_discovered_late(self, tmp_path: Path) -> None:
+        run_id = "factory-20260720-140000.000000-t"
+        run_dir = tmp_path / ".ralph" / "runs" / run_id
+        bus = ev.EventBus(
+            ev.JsonlSink(run_dir / "events.jsonl"), run_id=run_id,
+        )
+        tailer = RunTailer(run_dir)
+        bus.emit(ev.ComponentStarted(component="late"))
+        assert len(tailer.poll_events()) == 1
+        assert tailer.known_components() == []
+        # Worker dir appears AFTER the tailer started:
+        paths = ev.RunPaths.for_run(tmp_path, run_id)
+        worker = ev.EventBus(
+            ev.JsonlSink(paths.engineer_events("late")),
+            run_id=run_id, source="worker", component="late",
+        )
+        worker.emit(ev.IterationStarted(iteration=1, max_iterations=3))
+        events = tailer.poll_events()
+        assert [type(e).type for e in events] == ["iteration_started"]
+        assert tailer.known_components() == ["late"]
+
+    def test_merged_order_by_ts(self, tmp_path: Path) -> None:
+        write_fake_run(tmp_path, FakeRunSpec(components=2))
+        run_dir = tmp_path / ".ralph" / "runs"
+        (run_dir,) = list(run_dir.iterdir())
+        events = RunTailer(run_dir).poll_events()
+        timestamps = [e.ts for e in events]
+        assert timestamps == sorted(timestamps)
+        assert any(e.source == "worker" for e in events)

--- a/tests/test_tui_tail.py
+++ b/tests/test_tui_tail.py
@@ -130,10 +130,10 @@ class TestRunTailer:
         state = reducer.RunState()
         polls_with_events = 0
         for _ in stepper:
-            for event in tailer.poll_events():
+            for event in tailer.poll_events().events:
                 reducer.apply(state, event)
             polls_with_events += 1
-        for event in tailer.poll_events():  # final drain
+        for event in tailer.poll_events().events:  # final drain
             reducer.apply(state, event)
 
         expected, _ = reducer.load_run_state(tmp_path, run_id)
@@ -150,7 +150,7 @@ class TestRunTailer:
         )
         tailer = RunTailer(run_dir)
         bus.emit(ev.ComponentStarted(component="late"))
-        assert len(tailer.poll_events()) == 1
+        assert len(tailer.poll_events().events) == 1
         assert tailer.known_components() == []
         # Worker dir appears AFTER the tailer started:
         paths = ev.RunPaths.for_run(tmp_path, run_id)
@@ -159,7 +159,7 @@ class TestRunTailer:
             run_id=run_id, source="worker", component="late",
         )
         worker.emit(ev.IterationStarted(iteration=1, max_iterations=3))
-        events = tailer.poll_events()
+        events = tailer.poll_events().events
         assert [type(e).type for e in events] == ["iteration_started"]
         assert tailer.known_components() == ["late"]
 
@@ -167,7 +167,35 @@ class TestRunTailer:
         write_fake_run(tmp_path, FakeRunSpec(components=2))
         run_dir = tmp_path / ".ralph" / "runs"
         (run_dir,) = list(run_dir.iterdir())
-        events = RunTailer(run_dir).poll_events()
+        events = RunTailer(run_dir).poll_events().events
         timestamps = [e.ts for e in events]
         assert timestamps == sorted(timestamps)
         assert any(e.source == "worker" for e in events)
+
+    def test_worker_replacement_rebuilds_complete_snapshot(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=2))
+        tailer = RunTailer(run_dir)
+        initial = tailer.poll_events()
+        assert initial.events
+        worker_path = run_dir / "components" / "comp-a" / "engineer.jsonl"
+        replacement = tmp_path / "replacement.jsonl"
+        replacement_bus = ev.EventBus(
+            ev.JsonlSink(replacement), run_id=run_dir.name,
+            source="worker", component="comp-a",
+        )
+        replacement_bus.emit(ev.Log(text="replacement worker stream"))
+        replacement_bus.emit(ev.Log(text="second replacement event"))
+        os.replace(replacement, worker_path)
+
+        rebuilt = tailer.poll_events()
+
+        assert rebuilt.truncated is True
+        assert any(isinstance(event, ev.RunStarted) for event in rebuilt.events)
+        replacement_logs = [
+            event for event in rebuilt.events
+            if isinstance(event, ev.Log)
+            and event.text.startswith("replacement")
+        ]
+        assert len(replacement_logs) == 1


### PR DESCRIPTION
## Summary

Stage 3 PR C of the TUI rewrite plan (stacked on #113). No Textual yet - the pure-stdlib substrate `ralph dash` and the embedded app will tail.

- `ralph_py/tui/tail.py`: `JsonlTailer` / `TextTailer` / `RunTailer`, promoted from the spike onto production `Event` decoding. Torn-tail buffering, truncation reset + report, bounded transcript catch-up (spike finding 3: unbounded floods starve input - capped at the source), late worker-file discovery, `(ts, source, seq)` merge order.
- `ralph_py/tui/runs.py`: `RunRef` discovery (newest-first via lexicographic run_ids), completed-detection from the stream tail, unique-prefix `find_run`, liveness = fresh mtime or a non-blocking flock probe of `factory.lock`.
- `tests/helpers/fake_run.py`: the spike generator as a shared fixture (`write_fake_run` / `stream_fake_run`) on real event serialization - PR D/E's Pilot tests build on it.

## Tests (+18)

Tailer increments/torn-tail/truncation/bounds, late worker discovery, merge order, and the load-bearing property: **stepping the fake run while tailing + `reducer.apply` reproduces exactly the state of a one-shot `load_run_state` fold**. Run discovery: ordering, completed flags, prefix matching, liveness aging (utime), and a real same-process flock-probe test.

Gates: fast tier 1633 passed, `mypy --strict` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)