### PR TITLE
TUI PR D: Textual dashboard skeleton + overview + ralph dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ You can, and for small tasks you should. Ralph is for when you want to:
 
 ```
 ralph config show                  Print the fully resolved config with the source of each value.
+ralph dash                         Live dashboard over a factory run (observe-only).
 ralph decompose                    Decompose a spec into components and generate PRDs.
 ralph evolve                       Analyze factory runs and propose harness improvements.
 ralph factory                      Run the software factory - decompose and execute a spec.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ license = "MIT"
 dependencies = [
     "rich>=13.0.0",
     "click>=8.0.0",
+    # TUI rewrite PR D: the dashboard engine. Pinned <6 (Textualize
+    # wind-down risk); 5.3.0 verified compatible with locked rich 14.3.3
+    # in the Stage 0 spike (spike/tui0/RESULTS.md).
+    "textual>=3.0,<6",
 ]
 
 # R7.6: the claude-sdk agent adapter is opt-in because the SDK carries a

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -2469,7 +2469,7 @@ def _render_status(
 )
 @click.option(
     "--poll",
-    type=float,
+    type=click.FloatRange(min=0, min_open=True),
     default=0.2,
     help="Tail poll interval in seconds (default: 0.2, spike-measured)",
 )

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -2440,6 +2440,70 @@ def _render_status(
     help="Project root path (defaults to current directory)",
 )
 @click.option(
+    "--run-id",
+    "run_id",
+    help="Run to observe (unique prefix ok; default: newest run)",
+)
+@click.option(
+    "--poll",
+    type=float,
+    default=0.2,
+    help="Tail poll interval in seconds (default: 0.2, spike-measured)",
+)
+def dash(root: Path | None, run_id: str | None, poll: float) -> None:
+    """Live dashboard over a factory run (observe-only).
+
+    Tails .ralph/runs/<run_id>/ - a run in flight in another terminal,
+    or a finished one (post-mortem replay works by construction). This
+    command never writes to the run; E6 checkpoints are answered where
+    the factory runs.
+    """
+    import sys as _sys
+
+    root_dir = root.resolve() if root else Path.cwd()
+    if not (_sys.stdout.isatty() and _sys.stdin.isatty()):
+        click.echo(
+            "ralph dash needs a terminal; use `ralph status` for "
+            "non-interactive output.",
+            err=True,
+        )
+        _sys.exit(2)
+
+    from ralph_py.tui.runs import find_run, latest_run
+
+    ref = find_run(root_dir, run_id) if run_id else latest_run(root_dir)
+    if ref is None:
+        click.echo(
+            f"No run found under {root_dir / '.ralph' / 'runs'}"
+            + (f" matching '{run_id}'" if run_id else "")
+            + ". Run `ralph factory` first, or check --root.",
+            err=True,
+        )
+        _sys.exit(1)
+
+    from ralph_py.tui.app import Mode, RalphTuiApp
+
+    app = RalphTuiApp(
+        run_dir=ref.run_dir, root_dir=root_dir,
+        mode=Mode.DASH, poll_interval=poll,
+    )
+    try:
+        code = app.run()
+    finally:
+        # Spike finding 2: belt-and-braces terminal restore for any
+        # exit path Textual could not clean up after.
+        _sys.stdout.write("\x1b[?1049l\x1b[?25h\x1b[0m")
+        _sys.stdout.flush()
+    _sys.exit(code or 0)
+
+
+@cli.command()
+@click.option(
+    "--root",
+    type=click.Path(path_type=Path),
+    help="Project root path (defaults to current directory)",
+)
+@click.option(
     "--manifest",
     "manifest_path",
     type=click.Path(path_type=Path),

--- a/ralph_py/tui/app.py
+++ b/ralph_py/tui/app.py
@@ -1,0 +1,85 @@
+"""RalphTuiApp: the dashboard application (stage 3 PR D).
+
+Render policy (all three measured in the Stage 0 spike, RESULTS.md):
+- Poll at 0.2s (p95 tail latency ~240ms at 1x AND 10x event rates for
+  <1.3% CPU); post StateChanged only when events actually arrived.
+- Diff row updates, single-component transcript tails (PR E) - full
+  rebuilds and multi-component floods measurably starve input.
+- ctrl+c is BOUND explicitly: raw mode delivers it as a key event, not
+  SIGINT (spike finding 1). SIGTERM handling is the embed layer's job
+  (finding 2, PR F).
+
+DASH mode is observe-only: q detaches immediately and the run is
+untouched. EMBEDDED mode (PR F) overrides the quit path with the
+graceful-shutdown flow.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from pathlib import Path
+
+from textual.app import App
+from textual.binding import Binding
+
+from ralph_py.tui.messages import StateChanged
+from ralph_py.tui.screens.overview import OverviewScreen
+from ralph_py.tui.state import StateStore
+from ralph_py.tui.tail import RunTailer
+
+DEFAULT_POLL_INTERVAL = 0.2  # measured, spike G1
+
+
+class Mode(StrEnum):
+    DASH = "dash"
+    EMBEDDED = "embedded"
+
+
+class RalphTuiApp(App[int]):
+    CSS_PATH = "styles.tcss"
+    TITLE = "ralph"
+    BINDINGS = [
+        Binding("q", "quit_or_detach", "Detach"),
+        # Spike finding 1: raw mode delivers ctrl+c as a KEY - unbound
+        # it does nothing at all.
+        Binding("ctrl+c", "quit_or_detach", show=False),
+    ]
+
+    def __init__(
+        self,
+        *,
+        run_dir: Path,
+        root_dir: Path,
+        mode: Mode = Mode.DASH,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+    ) -> None:
+        super().__init__()
+        self.run_dir = run_dir
+        self.root_dir = root_dir
+        self.mode = mode
+        self.poll_interval = poll_interval
+        self.tailer = RunTailer(run_dir)
+        self.store = StateStore(root_dir, run_id=run_dir.name)
+
+    def on_mount(self) -> None:
+        self.push_screen(OverviewScreen(
+            observe_only=self.mode is Mode.DASH,
+        ))
+        self.set_interval(self.poll_interval, self._poll)
+        self.set_interval(1.0, self._tick_ages)
+        self._poll()  # catch-up fold before the first frame settles
+
+    def _poll(self) -> None:
+        events = self.tailer.poll_events()
+        if self.store.apply_events(events):
+            self.screen.post_message(StateChanged(self.store.state))
+
+    def _tick_ages(self) -> None:
+        screen = self.screen
+        if isinstance(screen, OverviewScreen):
+            screen.tick_ages(self.store.state)
+
+    def action_quit_or_detach(self) -> None:
+        # DASH: detach immediately; the run (if live) is not ours to
+        # stop. EMBEDDED overrides this action in PR F.
+        self.exit(0)

--- a/ralph_py/tui/app.py
+++ b/ralph_py/tui/app.py
@@ -70,8 +70,10 @@ class RalphTuiApp(App[int]):
         self._poll()  # catch-up fold before the first frame settles
 
     def _poll(self) -> None:
-        events = self.tailer.poll_events()
-        if self.store.apply_events(events):
+        chunk = self.tailer.poll_events()
+        if chunk.truncated:
+            self.store.reset()
+        if self.store.apply_events(chunk.events):
             self.screen.post_message(StateChanged(self.store.state))
 
     def _tick_ages(self) -> None:

--- a/ralph_py/tui/messages.py
+++ b/ralph_py/tui/messages.py
@@ -1,0 +1,20 @@
+"""Textual messages for the dashboard (stage 3 PR D)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual.message import Message
+
+if TYPE_CHECKING:
+    from ralph_py.reducer import RunState
+
+
+class StateChanged(Message):
+    """New events were folded into the RunState. Posted at most once
+    per poll (coalescing is structural: polls are <=5Hz and only actual
+    changes post - spike finding 3's render policy)."""
+
+    def __init__(self, state: RunState) -> None:
+        super().__init__()
+        self.state = state

--- a/ralph_py/tui/screens/__init__.py
+++ b/ralph_py/tui/screens/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard screens (stage 3 PR D)."""

--- a/ralph_py/tui/screens/overview.py
+++ b/ralph_py/tui/screens/overview.py
@@ -1,0 +1,72 @@
+"""Overview screen: the run board (stage 3 PR D)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.screen import Screen
+from textual.widgets import Footer, Static
+
+from ralph_py.tui.messages import StateChanged
+from ralph_py.tui.widgets.component_table import ComponentTable
+from ralph_py.tui.widgets.cost_meter import CostMeter
+from ralph_py.tui.widgets.header import RunHeader
+
+if TYPE_CHECKING:
+    from ralph_py.reducer import RunState
+
+
+class CheckpointBanner(Static):
+    """Shown while any component has an unresolved checkpoint. In dash
+    (observe-only) mode it points at the factory terminal; embedded
+    mode (PR F) swaps the hint for the modal keybinding."""
+
+    def update_state(self, state: RunState, *, observe_only: bool) -> None:
+        open_components = [
+            comp.component_id
+            for comp in state.components.values() if comp.checkpoint_open
+        ]
+        if not open_components:
+            self.display = False
+            return
+        self.display = True
+        names = ", ".join(sorted(open_components))
+        hint = (
+            "answer in the `ralph factory` terminal"
+            if observe_only else "press c to answer"
+        )
+        self.update(f"⛳ checkpoint pending: {names} - {hint}")
+
+
+class OverviewScreen(Screen[None]):
+    def __init__(self, *, observe_only: bool) -> None:
+        super().__init__()
+        self.observe_only = observe_only
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="topbar"):
+            yield RunHeader(id="run-header")
+            yield CostMeter(id="cost-meter")
+        yield CheckpointBanner(id="checkpoint-banner")
+        yield ComponentTable(id="component-table")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.query_one(CheckpointBanner).display = False
+
+    def refresh_state(self, state: RunState) -> None:
+        self.query_one(RunHeader).update_state(state)
+        self.query_one(CostMeter).update_state(state)
+        self.query_one(ComponentTable).update_state(state)
+        self.query_one(CheckpointBanner).update_state(
+            state, observe_only=self.observe_only,
+        )
+
+    def tick_ages(self, state: RunState) -> None:
+        self.query_one(RunHeader).update_state(state)
+        self.query_one(ComponentTable).tick_ages(state)
+
+    def on_state_changed(self, message: StateChanged) -> None:
+        self.refresh_state(message.state)

--- a/ralph_py/tui/screens/overview.py
+++ b/ralph_py/tui/screens/overview.py
@@ -37,7 +37,7 @@ class CheckpointBanner(Static):
             "answer in the `ralph factory` terminal"
             if observe_only else "press c to answer"
         )
-        self.update(f"⛳ checkpoint pending: {names} - {hint}")
+        self.update(f"checkpoint pending: {names} - {hint}")
 
 
 class OverviewScreen(Screen[None]):

--- a/ralph_py/tui/state.py
+++ b/ralph_py/tui/state.py
@@ -1,0 +1,48 @@
+"""StateStore: the dashboard's single state source (stage 3 PR D).
+
+The ONLY module in ralph_py/tui/ that imports the reducer - any
+reducer-contract drift has a one-module blast radius (plan decision).
+The manifest join is lazy and mtime-cached: authoritative snapshot
+data (DAG, PR URLs, evidence pointers) without a read per frame.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ralph_py.events import Event
+from ralph_py.manifest import Manifest
+from ralph_py.reducer import RunState, apply
+
+
+class StateStore:
+    def __init__(self, root_dir: Path, run_id: str = "") -> None:
+        self.root_dir = root_dir
+        self._state = RunState(run_id=run_id)
+        self._manifest: Manifest | None = None
+        self._manifest_mtime = 0.0
+
+    @property
+    def state(self) -> RunState:
+        return self._state
+
+    def apply_events(self, events: list[Event]) -> bool:
+        """Fold tailed events; True when anything changed."""
+        for event in events:
+            apply(self._state, event)
+        return bool(events)
+
+    def manifest(self) -> Manifest | None:
+        """The factory manifest, reloaded only when its mtime moves."""
+        path = self.root_dir / "scripts" / "ralph" / "manifest.json"
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            return self._manifest
+        if mtime != self._manifest_mtime:
+            try:
+                self._manifest = Manifest.load(path)
+                self._manifest_mtime = mtime
+            except (OSError, ValueError):
+                pass
+        return self._manifest

--- a/ralph_py/tui/state.py
+++ b/ralph_py/tui/state.py
@@ -32,6 +32,10 @@ class StateStore:
             apply(self._state, event)
         return bool(events)
 
+    def reset(self) -> None:
+        """Discard folded event state before applying a rebuilt snapshot."""
+        self._state = RunState(run_id=self._state.run_id)
+
     def manifest(self) -> Manifest | None:
         """The factory manifest, reloaded only when its mtime moves."""
         path = self.root_dir / "scripts" / "ralph" / "manifest.json"

--- a/ralph_py/tui/styles.tcss
+++ b/ralph_py/tui/styles.tcss
@@ -1,0 +1,30 @@
+/* Ralph dashboard styles (stage 3 PR D). */
+
+#topbar {
+    dock: top;
+    height: 1;
+    background: $panel;
+}
+
+#run-header {
+    width: 1fr;
+    content-align: left middle;
+}
+
+#cost-meter {
+    width: auto;
+    content-align: right middle;
+    padding: 0 1;
+}
+
+#checkpoint-banner {
+    height: 1;
+    background: $warning 20%;
+    color: $warning;
+    text-style: bold;
+    padding: 0 1;
+}
+
+#component-table {
+    height: 1fr;
+}

--- a/ralph_py/tui/widgets/__init__.py
+++ b/ralph_py/tui/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard widgets (stage 3 PR D)."""

--- a/ralph_py/tui/widgets/component_table.py
+++ b/ralph_py/tui/widgets/component_table.py
@@ -17,13 +17,13 @@ if TYPE_CHECKING:
     from ralph_py.reducer import ComponentState, RunState
 
 STATUS_GLYPHS = {
-    "pending": ("·", "dim"),
-    "running": ("▶", "yellow"),
-    "verifying": ("⚙", "cyan"),
-    "completed": ("✓", "green"),
-    "merge_pending": ("⏸", "magenta"),
-    "failed": ("✗", "red"),
-    "skipped": ("○", "dim"),
+    "pending": (".", "dim"),
+    "running": (">", "yellow"),
+    "verifying": ("~", "cyan"),
+    "completed": ("+", "green"),
+    "merge_pending": ("=", "magenta"),
+    "failed": ("x", "red"),
+    "skipped": ("-", "dim"),
 }
 
 COLUMNS = ("", "component", "status", "phase", "att", "iter",
@@ -44,7 +44,7 @@ def _age(ts: float, now: float) -> str:
 def _row_values(comp: ComponentState, now: float) -> tuple[Text | str, ...]:
     glyph, style = STATUS_GLYPHS.get(comp.status, ("?", "dim"))
     marker = "+" if comp.unreported_calls else ""
-    checkpoint = " ⛳" if comp.checkpoint_open else ""
+    checkpoint = " !" if comp.checkpoint_open else ""
     return (
         Text(glyph, style=style),
         Text(f"{comp.component_id}{checkpoint}"),

--- a/ralph_py/tui/widgets/component_table.py
+++ b/ralph_py/tui/widgets/component_table.py
@@ -1,0 +1,91 @@
+"""Component board: one row per component, diff-updated.
+
+Spike finding 3 made the render policy binding: rows are updated in
+place (update_cell), never clear()+rebuilt per poll - full rebuilds at
+storm rates measurably starve keyboard input.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.widgets import DataTable
+
+if TYPE_CHECKING:
+    from ralph_py.reducer import ComponentState, RunState
+
+STATUS_GLYPHS = {
+    "pending": ("·", "dim"),
+    "running": ("▶", "yellow"),
+    "verifying": ("⚙", "cyan"),
+    "completed": ("✓", "green"),
+    "merge_pending": ("⏸", "magenta"),
+    "failed": ("✗", "red"),
+    "skipped": ("○", "dim"),
+}
+
+COLUMNS = ("", "component", "status", "phase", "att", "iter",
+           "age", "tokens", "cost")
+
+
+def _age(ts: float, now: float) -> str:
+    if ts <= 0:
+        return "-"
+    seconds = max(0, int(now - ts))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m{seconds % 60:02d}s"
+    return f"{seconds // 3600}h{(seconds % 3600) // 60:02d}m"
+
+
+def _row_values(comp: ComponentState, now: float) -> tuple[Text | str, ...]:
+    glyph, style = STATUS_GLYPHS.get(comp.status, ("?", "dim"))
+    marker = "+" if comp.unreported_calls else ""
+    checkpoint = " ⛳" if comp.checkpoint_open else ""
+    return (
+        Text(glyph, style=style),
+        Text(f"{comp.component_id}{checkpoint}"),
+        Text(comp.status, style=style),
+        comp.phase or "-",
+        str(comp.attempt or 1),
+        str(comp.iteration or "-"),
+        _age(comp.last_event_ts, now),
+        f"{comp.total_tokens}{marker}" if comp.total_tokens else "-",
+        f"${comp.cost_usd:.2f}{marker}" if comp.cost_usd else "-",
+    )
+
+
+class ComponentTable(DataTable[Text | str]):
+    def on_mount(self) -> None:
+        self.cursor_type = "row"
+        self.zebra_stripes = True
+        for column in COLUMNS:
+            self.add_column(column, key=column or "glyph")
+
+    def update_state(self, state: RunState) -> None:
+        now = time.time()
+        order = state.plan_order or sorted(state.components)
+        for comp_id in order:
+            comp = state.components.get(comp_id)
+            if comp is None:
+                continue
+            values = _row_values(comp, now)
+            if comp_id in self.rows:
+                for key, value in zip(
+                    ("glyph", *COLUMNS[1:]), values, strict=True,
+                ):
+                    self.update_cell(comp_id, key, value)
+            else:
+                self.add_row(*values, key=comp_id)
+
+    def tick_ages(self, state: RunState) -> None:
+        """1s label-only refresh of the age column."""
+        now = time.time()
+        for comp_id, comp in state.components.items():
+            if comp_id in self.rows:
+                self.update_cell(
+                    comp_id, "age", _age(comp.last_event_ts, now),
+                )

--- a/ralph_py/tui/widgets/cost_meter.py
+++ b/ralph_py/tui/widgets/cost_meter.py
@@ -1,0 +1,56 @@
+"""Cost meter: the R3.1 rollup with honest lower-bound semantics.
+
+The "+" marker is load-bearing: token/cost figures are CLI
+self-reports, and whenever unreported_calls > 0 every total is a
+LOWER BOUND (H4: totals are only as honest as their coverage). The
+meter must never turn an honest number into a false one.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from ralph_py.reducer import RunState
+
+
+def _format_tokens(tokens: int) -> str:
+    if tokens >= 1_000_000:
+        return f"{tokens / 1_000_000:.2f}M"
+    if tokens >= 1_000:
+        return f"{tokens / 1_000:.1f}k"
+    return str(tokens)
+
+
+def render_cost_meter(state: RunState) -> Text:
+    text = Text()
+    marker = "+" if state.unreported_calls else ""
+    text.append("tokens ", style="dim")
+    text.append(f"{_format_tokens(state.total_tokens)}{marker}", style="bold")
+    if state.max_total_tokens:
+        pct = min(
+            100, int(100 * state.total_tokens / state.max_total_tokens),
+        )
+        style = "bold red" if pct >= 90 else (
+            "bold yellow" if pct >= 70 else "dim"
+        )
+        text.append(
+            f" / {_format_tokens(state.max_total_tokens)} ({pct}%)",
+            style=style,
+        )
+    text.append("   cost ", style="dim")
+    text.append(f"${state.cost_usd:.2f}{marker}", style="bold")
+    if state.unreported_calls:
+        text.append(
+            f"   [{state.unreported_calls} call(s) unreported: lower bound]",
+            style="italic dim",
+        )
+    return text
+
+
+class CostMeter(Static):
+    def update_state(self, state: RunState) -> None:
+        self.update(render_cost_meter(state))

--- a/ralph_py/tui/widgets/header.py
+++ b/ralph_py/tui/widgets/header.py
@@ -1,0 +1,48 @@
+"""Run header: project, run id, state, elapsed (stage 3 PR D)."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from ralph_py.reducer import RunState
+
+
+def _format_elapsed(seconds: float) -> str:
+    seconds = max(0, int(seconds))
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{secs:02d}"
+    return f"{minutes}:{secs:02d}"
+
+
+def render_header(state: RunState) -> Text:
+    text = Text()
+    text.append(" ralph ", style="bold reverse")
+    text.append("  ")
+    text.append(state.project or "(no project)", style="bold")
+    if state.run_id:
+        text.append("  ")
+        text.append(state.run_id, style="dim")
+    text.append("  ")
+    if state.finished:
+        text.append("finished", style="bold green")
+        elapsed = state.last_event_ts - state.started_ts
+    else:
+        text.append("in flight", style="bold yellow")
+        elapsed = (time.time() - state.started_ts) if state.started_ts else 0.0
+    text.append(f"  {_format_elapsed(elapsed)}", style="dim")
+    return text
+
+
+class RunHeader(Static):
+    """One-line run summary; re-rendered on StateChanged and the 1s
+    age ticker (label-only updates - no layout churn)."""
+
+    def update_state(self, state: RunState) -> None:
+        self.update(render_header(state))

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -6,6 +6,7 @@ drives the real app without a terminal.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from rich.text import Text
@@ -92,6 +93,22 @@ class TestOverview:
             await pilot.pause()
             await pilot.press("ctrl+c")
         assert app.return_value == 0
+
+    async def test_stream_replacement_resets_before_rebuild(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            initial_tokens = app.store.state.total_tokens
+            replacement = tmp_path / "events.jsonl"
+            replacement.write_bytes((run_dir / "events.jsonl").read_bytes())
+            os.replace(replacement, run_dir / "events.jsonl")
+            app._poll()
+            await pilot.pause()
+
+            assert app.store.state.total_tokens == initial_tokens
 
 
 class TestRenderHelpers:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1,0 +1,126 @@
+"""Stage 3 PR D (TUI rewrite): dashboard app + overview screen.
+
+Textual Pilot tests over the fake-run fixture. Headless: run_test()
+drives the real app without a terminal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich.text import Text
+
+from ralph_py.reducer import RunState, load_run_state
+from ralph_py.tui.app import Mode, RalphTuiApp
+from ralph_py.tui.screens.overview import CheckpointBanner
+from ralph_py.tui.widgets.component_table import ComponentTable
+from ralph_py.tui.widgets.cost_meter import render_cost_meter
+from ralph_py.tui.widgets.header import render_header
+from tests.helpers.fake_run import FakeRunSpec, stream_fake_run, write_fake_run
+
+
+def _app(root: Path, run_dir: Path) -> RalphTuiApp:
+    return RalphTuiApp(
+        run_dir=run_dir, root_dir=root, mode=Mode.DASH, poll_interval=0.05,
+    )
+
+
+def _cell_text(value: object) -> str:
+    return value.plain if isinstance(value, Text) else str(value)
+
+
+class TestOverview:
+    async def test_renders_fake_run(self, tmp_path: Path) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=3))
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            table = app.screen.query_one(ComponentTable)
+            assert table.row_count == 3
+            row = table.get_row("comp-a")
+            texts = [_cell_text(cell) for cell in row]
+            assert "comp-a" in texts[1]
+            assert "completed" in texts[2]
+
+    async def test_live_updates_arrive(self, tmp_path: Path) -> None:
+        run_id = "factory-20260720-160000.000000-live"
+        stepper = stream_fake_run(
+            tmp_path, FakeRunSpec(components=2), run_id=run_id,
+        )
+        next(stepper)  # factory_started written; run dir exists
+        run_dir = tmp_path / ".ralph" / "runs" / run_id
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            table = app.screen.query_one(ComponentTable)
+            initial_rows = table.row_count
+            for _ in stepper:  # stream the rest while the app is live
+                pass
+            await pilot.pause(0.3)  # a few poll intervals
+            assert table.row_count == 2
+            assert table.row_count >= initial_rows
+            row = table.get_row("comp-b")
+            assert "completed" in _cell_text(row[2])
+
+    async def test_checkpoint_banner_in_dash_mode(self, tmp_path: Path) -> None:
+        run_dir = write_fake_run(
+            tmp_path,
+            FakeRunSpec(components=2, include_checkpoint=True, complete=False),
+        )
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            banner = app.screen.query_one(CheckpointBanner)
+            assert banner.display is True
+            rendered = str(banner.render())
+            assert "checkpoint pending" in rendered
+            assert "ralph factory" in rendered  # observe-only hint
+
+    async def test_q_detaches_with_zero(self, tmp_path: Path) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("q")
+        assert app.return_value == 0
+
+    async def test_ctrl_c_bound_and_detaches(self, tmp_path: Path) -> None:
+        """Spike finding 1: ctrl+c arrives as a key and must be bound."""
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+c")
+        assert app.return_value == 0
+
+
+class TestRenderHelpers:
+    def _state(self, tmp_path: Path) -> RunState:
+        write_fake_run(tmp_path, FakeRunSpec(components=2))
+        state, _ = load_run_state(tmp_path)
+        return state
+
+    def test_header_contains_project_and_state(self, tmp_path: Path) -> None:
+        text = render_header(self._state(tmp_path)).plain
+        assert "fake-project" in text
+        assert "finished" in text
+
+    def test_cost_meter_lower_bound_marker(self, tmp_path: Path) -> None:
+        state = self._state(tmp_path)
+        assert state.unreported_calls > 0  # fixture includes unreported
+        plain = render_cost_meter(state).plain
+        assert "+" in plain
+        assert "lower bound" in plain
+        assert "%" in plain  # cap percentage present
+
+    def test_cost_meter_without_unreported(self, tmp_path: Path) -> None:
+        write_fake_run(
+            tmp_path,
+            FakeRunSpec(components=1, include_unreported_usage=False),
+            run_id="factory-20260720-170000.000000-clean",
+        )
+        state, _ = load_run_state(
+            tmp_path, "factory-20260720-170000.000000-clean",
+        )
+        plain = render_cost_meter(state).plain
+        assert "lower bound" not in plain

--- a/uv.lock
+++ b/uv.lock
@@ -494,6 +494,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -503,6 +515,14 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321 },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+plugins = [
+    { name = "mdit-py-plugins" },
 ]
 
 [[package]]
@@ -528,6 +548,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620 },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663 },
 ]
 
 [[package]]
@@ -603,6 +635,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206 },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/cd/4f25b2f95b23f5d2c9c1fe43e49841bff5800562149b2666afc09309aa8f/platformdirs-4.10.1.tar.gz", hash = "sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695", size = 31678 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl", hash = "sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443", size = 22906 },
 ]
 
 [[package]]
@@ -867,6 +908,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "rich" },
+    { name = "textual" },
 ]
 
 [package.optional-dependencies]
@@ -889,6 +931,7 @@ requires-dist = [
     { name = "claude-agent-sdk", marker = "extra == 'sdk'", specifier = ">=0.2.123,<0.3" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "textual", specifier = ">=3.0,<6" },
 ]
 
 [package.metadata.requires-dev]
@@ -1112,6 +1155,22 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "5.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify", "plugins"] },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/ce/f0f938d33d9bebbf8629e0020be00c560ddfa90a23ebe727c2e5aa3f30cf/textual-5.3.0.tar.gz", hash = "sha256:1b6128b339adef2e298cc23ab4777180443240ece5c232f29b22960efd658d4d", size = 1557651 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/2f/f7c8a533bee50fbf5bb37ffc1621e7b2cdd8c9a6301fc51faa35fa50b09d/textual-5.3.0-py3-none-any.whl", hash = "sha256:02a6abc065514c4e21f94e79aaecea1f78a28a85d11d7bfc64abf3392d399890", size = 702671 },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1184,6 +1243,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611 },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Stage 3 PR D of the TUI rewrite plan (stacked on #114). The dashboard becomes real:

- `textual>=3,<6` added (5.3.0 against locked rich 14.3.3 - spike-verified compat, re-verified at `uv lock`).
- `ralph_py/tui/`: `StateStore` (sole reducer importer, per the one-module-blast-radius decision; mtime-cached manifest join), `RalphTuiApp` (spike-measured 0.2s poll; `StateChanged` posted only on actual change; 1s label-only age ticker; **ctrl+c bound** per spike finding 1; q detaches), `OverviewScreen` with `RunHeader`, `CostMeter`, `CheckpointBanner`, `ComponentTable`, `Footer`.
- **Render policy from spike finding 3 is enforced in code**: the table diff-updates rows via `update_cell`, never rebuilds.
- **Cost meter honors R3.1 semantics**: `+` lower-bound marker whenever `unreported_calls > 0`, cap percentage with 70/90% color thresholds.
- `ralph dash`: observe-only attach (live or post-mortem), newest run default, `--run-id` unique-prefix, TTY required (exit 2 -> `ralph status` hint), pending-checkpoint banner points at the factory terminal, ANSI restore in `finally` (spike finding 2).

## Tests (+12)

Headless Pilot: board rendering from the fixture, live updates while `stream_fake_run` advances mid-flight, checkpoint banner content, q and ctrl+c detach with exit 0. Render-helper units for header and both cost-meter states. README regenerated (docs drift gate).

Gates: fast 1641 passed, spine 25 passed, `mypy --strict` (textual ships py.typed) clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)