### PR TITLE
docs: documentation audit - README accuracy + polish, config doc gaps, LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Fauzi (0xfauzi)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Ralph
 
+[![CI](https://github.com/0xfauzi/ralph-loop/actions/workflows/ci.yml/badge.svg)](https://github.com/0xfauzi/ralph-loop/actions/workflows/ci.yml)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](pyproject.toml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+
 Ralph is a harness for AI coding agents. You hand it a feature spec and walk away. It steers the agent with codebase context, verifies the output with structured checks, retries with actionable feedback, and learns from its mistakes across runs.
 
 The problem it solves: AI coding agents are powerful, but they work on a single prompt at a time. If the agent doesn't finish in one shot, you're back to manually re-prompting, checking progress, and deciding what to try next. And even when the agent says "done," there's no guarantee the code actually works. Ralph automates the outer loop - iteration, verification, and improvement - so the agent produces working code, not just code that claims to work.
@@ -10,32 +14,34 @@ Most agent wrappers are retry loops: run the agent, check if it's done, retry if
 
 ```mermaid
 flowchart TD
-    PRD["PRD + Prompt"] --> FF["Phase 0: Feedforward\nModule map, interfaces,\ndependency graph, conventions"]
-    FF --> Knowledge["Knowledge prefix\nDurable facts from prior components"]
-    Knowledge --> Agent["Implementing agent\nClaude Code, Codex, or custom"]
-    Agent --> P1["Phase 1: Mechanical verification\nTests, typecheck, lint, scope,\nbad patterns, optional self-critique"]
-    P1 -->|fail| Retry["Structured retry context\nSource lines + fix hints"]
+    PRD["PRD + Prompt"] --> FF["Phase 0: Feedforward<br/>Module map, interfaces,<br/>dependency graph, conventions"]
+    FF --> Knowledge["Knowledge prefix<br/>Durable facts from prior components"]
+    Knowledge --> Agent["Implementing agent<br/>Claude Code, Codex, or custom"]
+    Agent --> P1["Phase 1: Mechanical verification<br/>Tests, typecheck, lint, scope,<br/>bad patterns, optional self-critique"]
+    P1 -->|fail| Retry["Structured retry context<br/>Source lines + fix hints"]
     Retry --> Agent
-    P1 -->|pass| P2["Phase 2: Code reviewer\nPRD criteria + concerns:\nscope_creep, test_quality,\ndead_code, error_handling..."]
+    P1 -->|pass| P2["Phase 2: Code reviewer<br/>PRD criteria + concerns:<br/>scope_creep, test_quality,<br/>dead_code, error_handling..."]
     P2 -->|fail| Retry
-    P2 -->|pass| P25["Phase 2.5: Security reviewer\nInjection, auth_bypass,\nhardcoded_secret, crypto,\nrace, SSRF, XSS, DoS\nMapped to OWASP+CWE"]
+    P2 -->|pass| P25["Phase 2.5: Security reviewer<br/>Injection, auth_bypass,<br/>hardcoded_secret, crypto,<br/>race, SSRF, XSS, DoS<br/>Mapped to OWASP+CWE"]
     P25 -->|fail| Retry
-    P25 -->|pass| Distill["Knowledge distiller\nDurable facts written to\n.ralph/knowledge/<comp>/<run>/\nbefore the PR is created"]
-    Distill --> HITL["Optional human checkpoint\npause_before_pr_merge"]
+    P25 -->|pass| Distill["Knowledge distiller<br/>Durable facts written to<br/>.ralph/knowledge/&lt;comp&gt;/&lt;run&gt;/<br/>before the PR is created"]
+    Distill --> HITL["Optional human checkpoint<br/>pause_before_pr_merge"]
     HITL --> PR["Create + merge PR"]
-    PR --> P3["Phase 3: Contract testing\nTier-by-tier merge +\nintegration tests"]
+    PR --> P3["Phase 3: Contract testing<br/>Tier-by-tier merge +<br/>integration tests"]
     P3 -->|fail breaker| Retry
     P3 -->|pass| Done["Done"]
-    P1 --> Journal["Evolution journal\nPatterns, concern hit-rate,\nharness improvement proposals"]
+    P1 --> Journal["Evolution journal<br/>Patterns, concern hit-rate,<br/>harness improvement proposals"]
     P2 --> Journal
     P25 --> Journal
 ```
 
-Phase 0 also includes an architect/PRD-red-team pass at decompose time that halts on blocker-severity spec issues. See [docs/adversarial-design.md](docs/adversarial-design.md) for the full 8-role taxonomy, [docs/env-vars.md](docs/env-vars.md) for every env var, and [docs/runbook.md](docs/runbook.md) for operator failure recovery.
+Phase 0 also includes an architect/PRD-red-team pass at decompose time that halts on blocker-severity spec issues.
+
+**Documentation**: [docs/adversarial-design.md](docs/adversarial-design.md) covers the full 8-role taxonomy, [docs/env-vars.md](docs/env-vars.md) every environment variable, [docs/runbook.md](docs/runbook.md) operator failure recovery, and [docs/linear-integration.md](docs/linear-integration.md) the optional Linear mirror. [examples/](examples/) has a scaffolded uv project and two sample feature specs.
 
 ## Quick start
 
-Ralph is not published to PyPI (the `ralph-cli` name there is an unrelated project). Install from a clone:
+Ralph is not published to PyPI - the `ralph-cli` name there belongs to an unrelated project. Install from a clone:
 
 ```bash
 git clone https://github.com/0xfauzi/ralph-loop.git
@@ -50,13 +56,17 @@ ralph run 25                       # let the agent work for up to 25 iterations
 
 You need at least one AI coding agent CLI:
 
-| Agent | Install | Models |
-|-------|---------|--------|
+| Agent | Install | Example models |
+|-------|---------|----------------|
 | Claude Code (recommended) | [claude.ai/code](https://claude.ai/code) | sonnet, opus, haiku |
-| OpenAI Codex | [github.com/openai/codex](https://github.com/openai/codex) | o3, o4-mini |
+| OpenAI Codex | [github.com/openai/codex](https://github.com/openai/codex) | gpt-5, o3 |
 | Custom | Any command that reads stdin | - |
 
-**Python-first honesty note**: Ralph works best on Python projects managed with uv. The feedforward interface and dependency analysis parse Python (`ast` and import statements), and the default verification commands are `uv run pytest` / `uv run mypy` / `uv run ruff check`. Other stacks work by overriding the `[verify]` commands in ralph.toml, but they get a reduced feedforward context (module map and conventions only).
+Ralph does not validate model names: `[agent].model` is passed straight through to the CLI (`claude --model` / `codex -m`), so any model the installed CLI accepts works.
+
+There is also an opt-in in-process adapter, `[agent] type = "claude-sdk"`, that drives Claude through the [Claude Agent SDK](https://docs.claude.com/en/api/agent-sdk/overview) instead of a CLI subprocess and supports an in-loop USD budget ceiling (`[agent].budget_usd`). It requires the `sdk` extra (`uv sync --extra sdk`) and is never chosen by auto-detect.
+
+**Python-first**: Ralph works best on Python projects managed with uv. The feedforward interface and dependency analysis parse Python (`ast` and import statements), and the default verification commands are `uv run pytest` / `uv run mypy` / `uv run ruff check`. Other stacks work by overriding the `[verify]` commands in ralph.toml, but they get a reduced feedforward context (module map and conventions only).
 
 ## How it works
 
@@ -95,15 +105,13 @@ When the agent signals completion, ralph doesn't just trust it. Every run goes t
 When verification fails, ralph doesn't dump raw stderr into the retry prompt. It parses tool output into structured failures with file paths, source context, and fix hints:
 
 ```
-1. src/api/auth.py:23
-   error: Argument 1 to "verify_password" has incompatible type "str | None"
-
-   21 |     password = request.form.get("password")
-   22 |     user = get_user(username)
- > 23 |     if verify_password(password, user.password_hash):
-   24 |         return create_token(user)
-
-   FIX: Add a None check before calling verify_password, or provide a default value.
+[mypy] Found 1 error in 1 file (checked 14 source files)
+  src/api/auth.py:23 [arg-type] Argument 1 to "verify_password" has incompatible type "str | None"; expected "str"
+    |     21 |     password = request.form.get("password")
+    |     22 |     user = get_user(username)
+    | >   23 |     if verify_password(password, user.password_hash):
+    |     24 |         return create_token(user)
+    hint: Type mismatch in argument - convert or check the value before passing it.
 ```
 
 ### Continuous learning - the harness improves itself
@@ -112,12 +120,12 @@ After each factory run, ralph records outcomes to an evolution journal. Over mul
 
 ```mermaid
 flowchart LR
-    Run1["Factory run N"] --> Record["Record outcomes\n.ralph/evolution.jsonl\n.ralph/experiments.tsv"]
-    Record --> Extract["Extract patterns\nGroup by error signature"]
-    Extract --> Propose["Generate proposals\n.ralph/proposals/*.md"]
+    Run1["Factory run N"] --> Record["Record outcomes<br/>.ralph/evolution.jsonl<br/>.ralph/experiments.tsv"]
+    Record --> Extract["Extract patterns<br/>Group by error signature"]
+    Extract --> Propose["Generate proposals<br/>.ralph/proposals/*.md"]
     Propose --> Review["Human review"]
-    Review -->|approve| Apply["Update CLAUDE.md,\npyproject.toml,\nfeedforward config"]
-    Apply --> Run2["Factory run N+1\nBenefits from\nimproved harness"]
+    Review -->|approve| Apply["Update CLAUDE.md,<br/>pyproject.toml,<br/>feedforward config"]
+    Apply --> Run2["Factory run N+1<br/>Benefits from<br/>improved harness"]
 ```
 
 ```bash
@@ -138,33 +146,33 @@ ralph decompose --spec features.md --project-name myproject
 ralph factory --manifest scripts/ralph/manifest.json --max-parallel 4
 ```
 
-Each component runs in an isolated git worktree with its own PRD. `ralph run` is actually factory mode with a single component - the same verification pipeline runs whether you're building one feature or twenty.
+Each component runs in an isolated git worktree (`.ralph/worktrees/<run>/<component>`) with its own PRD. `ralph run` is actually factory mode with a single component - the same verification pipeline runs whether you're building one feature or twenty.
 
 ```mermaid
 flowchart TD
-    Spec["Markdown spec"] --> Decompose["ralph decompose\nLLM-driven spec decomposition"]
-    Decompose --> Manifest["Manifest\nComponent DAG with dependencies"]
-    Manifest --> Validate["Validate DAG\nTopological sort, cycle detection"]
-    Validate --> Schedule["Schedule components\nRespect dependency order"]
+    Spec["Markdown spec"] --> Decompose["ralph decompose<br/>LLM-driven spec decomposition"]
+    Decompose --> Manifest["Manifest<br/>Component DAG with dependencies"]
+    Manifest --> Validate["Validate DAG<br/>Topological sort, cycle detection"]
+    Validate --> Schedule["Schedule components<br/>Respect dependency order"]
 
-    Schedule --> WT1["Worktree A\nComponent A"]
-    Schedule --> WT2["Worktree B\nComponent B"]
-    Schedule --> WT3["Worktree C\nComponent C"]
+    Schedule --> WT1["Worktree A<br/>Component A"]
+    Schedule --> WT2["Worktree B<br/>Component B"]
+    Schedule --> WT3["Worktree C<br/>Component C"]
 
-    WT1 --> V1["Phase 0-2\nFeedforward + verify + review"]
-    WT2 --> V2["Phase 0-2\nFeedforward + verify + review"]
-    WT3 --> V3["Phase 0-2\nFeedforward + verify + review"]
+    WT1 --> V1["Phase 0-2<br/>Feedforward + verify + review"]
+    WT2 --> V2["Phase 0-2<br/>Feedforward + verify + review"]
+    WT3 --> V3["Phase 0-2<br/>Feedforward + verify + review"]
 
     V1 --> PR1["PR + merge"]
     V2 --> PR2["PR + merge"]
     V3 --> PR3["PR + merge"]
 
-    PR1 --> Contract["Phase 3: Contract testing\nTier-by-tier merge + integration tests"]
+    PR1 --> Contract["Phase 3: Contract testing<br/>Tier-by-tier merge + integration tests"]
     PR2 --> Contract
     PR3 --> Contract
 
     Contract -->|pass| Done["Done"]
-    Contract -->|fail| Bisect["Bisect breaker\nIdentify which component\nbroke integration"]
+    Contract -->|fail| Bisect["Bisect breaker<br/>Identify which component<br/>broke integration"]
     Bisect --> Schedule
 ```
 
@@ -263,10 +271,11 @@ Ralph reads `ralph.toml` at the project root; copy [ralph.toml.example](ralph.to
 ```toml
 # Agent selection
 [agent]
-type = ""              # "claude" | "codex" | "custom"
-command = ""           # shell command (only used when type = "custom")
-model = ""             # e.g. "sonnet" (claude) or "o3" (codex); empty = agent default
+type = ""              # "claude-code" | "claude-sdk" | "codex"; empty/"auto" = auto-detect
+command = ""           # custom agent shell command; overrides type
+model = ""             # e.g. "sonnet" (claude) or "gpt-5" (codex); empty = agent default
 reasoning_effort = ""  # low | medium | high | max (model-dependent)
+budget_usd = ""        # in-loop USD ceiling; claude-sdk adapter only; empty/0 = unlimited (R7.6)
 
 # Loop behavior
 [run]
@@ -307,7 +316,7 @@ scheduler_backstop_margin = 60.0  # extra slack before the scheduler declares a 
 max_parallel = 4                   # concurrent component workers
 max_retries = 3                    # per-component retry budget across all phases
 retry_delay = 5.0                  # seconds between retry attempts
-use_worktrees = true               # isolate each component in .ralph/worktrees/<id>
+use_worktrees = true               # isolate each component in .ralph/worktrees/<run>/<id>
 single_pr = false                  # one PR for the whole run instead of per-component
 create_prs = true                  # push + merge PRs via gh
 review_mode = "hard"               # hard | advisory | skip (Phase 2)
@@ -398,6 +407,12 @@ lookback_runs = 10                           # past runs to analyze
 auto_propose = true                          # generate proposals after each factory run
 auto_apply_computational = false             # auto-apply computational proposals
 
+# Run-milestone notification hooks (R3.2)
+[notify]
+on_complete = ""       # shell hook fired once when the run finishes; empty = disabled
+on_first_failure = ""  # shell hook fired once on the first component failure
+hook_timeout = 30.0    # seconds before a hook command is killed
+
 # Linear integration (R7.4; default off)
 [linear]
 enabled = false                             # mirror runs into Linear (project/issues/status via GitHub linking)
@@ -452,24 +467,24 @@ This is what happens inside each component's execution loop:
 ```mermaid
 flowchart TD
     subgraph Init["Initialization"]
-        A1["Load config\ntoml + env vars + CLI flags"] --> A2["Load PRD"]
+        A1["Load config<br/>toml + env vars + CLI flags"] --> A2["Load PRD"]
         A2 --> A3["Checkout branch"]
-        A3 --> A4["Run scaffold\n(if configured)"]
-        A4 --> A5["Build feedforward context\nModule map, interfaces,\ndependency graph, conventions"]
+        A3 --> A4["Run scaffold<br/>(if configured)"]
+        A4 --> A5["Build feedforward context<br/>Module map, interfaces,<br/>dependency graph, conventions"]
     end
 
     subgraph Iteration["Iteration (repeats up to N times)"]
-        B1["Build prompt\nfeedforward + retry context + instructions"] --> B2["Run agent\nStream output line by line"]
-        B2 --> B3{"COMPLETE\nmarker?"}
-        B3 -->|No| B4["Enforce allowed paths\nRevert out-of-scope changes"]
+        B1["Build prompt<br/>feedforward + retry context + instructions"] --> B2["Run agent<br/>Stream output line by line"]
+        B2 --> B3{"COMPLETE<br/>marker?"}
+        B3 -->|No| B4["Enforce allowed paths<br/>Revert out-of-scope changes"]
         B4 --> B1
-        B3 -->|Yes| B5["Phase 1: Mechanical verification\nTests, typecheck, lint, scope"]
+        B3 -->|Yes| B5["Phase 1: Mechanical verification<br/>Tests, typecheck, lint, scope"]
     end
 
     subgraph Verify["Verification"]
-        B5 -->|fail| B6["Parse failures\nSource context + fix hints"]
+        B5 -->|fail| B6["Parse failures<br/>Source context + fix hints"]
         B6 --> B1
-        B5 -->|pass| B7["Phase 2: Review\nSecond-opinion agent"]
+        B5 -->|pass| B7["Phase 2: Review<br/>Second-opinion agent"]
         B7 -->|fail| B6
         B7 -->|pass| B8["Complete"]
     end
@@ -493,7 +508,7 @@ flowchart TB
     end
 
     subgraph Execution["Agent execution"]
-        Loop["Agentic loop\n(iterate until COMPLETE)"]
+        Loop["Agentic loop<br/>(iterate until COMPLETE)"]
     end
 
     subgraph Phase1["Phase 1: Mechanical verification"]
@@ -505,11 +520,11 @@ flowchart TB
     end
 
     subgraph Phase2["Phase 2: Review"]
-        Review["Second-opinion agent\nreviews diff against spec"]
+        Review["Second-opinion agent<br/>reviews diff against spec"]
     end
 
     subgraph Phase3["Phase 3: Contract testing"]
-        Contract["Tier-by-tier merge\n+ integration tests"]
+        Contract["Tier-by-tier merge<br/>+ integration tests"]
     end
 
     subgraph Learning["Continuous learning"]
@@ -542,7 +557,7 @@ git clone https://github.com/0xfauzi/ralph-loop.git
 cd ralph-loop
 uv sync
 uv tool install -e .
-uv run pytest tests/           # 1119 tests measured at the time of writing (2026-07)
+uv run pytest tests/           # 1695 tests collected at the time of writing (2026-07)
 uv run mypy ralph_py/ --strict
 uv run ruff check ralph_py/ tests/
 ```

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -23,12 +23,24 @@ Precedence: **CLI flag > env var > `ralph.toml` > dataclass default**.
 | `MODEL_REASONING_EFFORT` | str | unset | `low\|medium\|high\|max` |
 | `RALPH_AGENT_TYPE` | str | unset | `claude-code\|claude-sdk\|codex\|auto` (`claude-sdk` needs the `sdk` extra: `uv sync --extra sdk`) |
 | `RALPH_AGENT_BUDGET_USD` | float | unset | In-loop USD budget ceiling; enforced per turn by the `claude-sdk` adapter only (R7.6). Non-positive or unparseable values are ignored |
-| `RALPH_TIMEOUT_AGENT_ITERATION` | float | 1800 | Per-agent.run() timeout (seconds) |
-| `RALPH_TIMEOUT_COMPONENT` | float | 7200 | Per-component total timeout |
-| `RALPH_TIMEOUT_DEFAULT` | float | 60 | Generic subprocess timeout |
 | `RALPH_UI` | str | auto | `auto\|rich\|plain` |
 | `NO_COLOR` | bool flag | false | Disables colors |
 | `RALPH_ASCII` | bool | false | ASCII-only UI |
+
+## TimeoutConfig (`[timeout]`)
+
+All values are seconds; 0 or less disables that limit.
+
+| Env var | Type | Default | Notes |
+|---|---|---|---|
+| `RALPH_TIMEOUT_GIT` | float | 30 | Per git subprocess |
+| `RALPH_TIMEOUT_AGENT_ITERATION` | float | 1800 | One engineer iteration |
+| `RALPH_TIMEOUT_COMPONENT` | float | 7200 | Wall clock per component across iterations |
+| `RALPH_TIMEOUT_VERIFY` | float | 300 | Each Phase 1 check subprocess (also read by `VerifyConfig.subprocess_timeout`) |
+| `RALPH_TIMEOUT_REVIEW` | float | 600 | Phase 2 reviewer call |
+| `RALPH_TIMEOUT_CONTRACT` | float | 600 | Phase 3 contract test run (also read by `ContractConfig.timeout`) |
+| `RALPH_TIMEOUT_DEFAULT` | float | 60 | Any other subprocess |
+| `RALPH_TIMEOUT_BACKSTOP_MARGIN` | float | 60 | Extra slack before the scheduler declares a worker dead |
 
 ## FactoryConfig (`[factory]`)
 
@@ -39,7 +51,10 @@ Precedence: **CLI flag > env var > `ralph.toml` > dataclass default**.
 | `FACTORY_RETRY_DELAY` | float | 5.0 |
 | `FACTORY_MERGE_TIMEOUT` | float | 300.0 |
 | `RALPH_FACTORY_MAX_ADVERSARIAL_CALLS` | int | 0 (unbounded) |
+| `RALPH_FACTORY_MAX_TOTAL_TOKENS` | int | 0 (unbounded) |
 | `RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE` | bool (`1`/`true`/`yes`) | false |
+| `RALPH_FACTORY_PROGRESS_LOG_ENABLED` | bool | true |
+| `RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE` | bool | false |
 
 The two safety knobs (E4 `max_adversarial_calls`, E6 `pause_before_pr_merge`) are reachable via all three surfaces since R2.2: the env vars above, `[factory]` keys in ralph.toml, and the `--max-adversarial-calls` / `--pause-before-pr-merge` CLI flags.
 
@@ -83,6 +98,17 @@ agent's worktree by construction on both CLIs.
 | `RALPH_VERIFY_SELF_CRITIQUE_MIN_BULLETS` | int | 3 |
 | `RALPH_VERIFY_PROGRESS_FILE` | path | `scripts/ralph/progress.txt` |
 
+## FixturesConfig (`[fixtures]`)
+
+Phase 1 approved-fixtures oracle (R7.2). Off by default: fixtures execute PRD-supplied commands and import PRD-named modules, so the operator must opt in explicitly.
+
+| Env var | Type | Default |
+|---|---|---|
+| `RALPH_FIXTURES_ENABLED` | bool | false |
+| `RALPH_FIXTURES_SNAPSHOT_ON_SUCCESS` | bool | true |
+| `RALPH_FIXTURES_SNAPSHOT_DIR` | path | `.ralph/snapshots` (relative = against the repo root) |
+| `RALPH_FIXTURES_TIMEOUT` | float | 30 |
+
 ## ContractConfig (`[contract]`)
 
 | Env var | Type | Default |
@@ -97,14 +123,14 @@ Invalid mode raises ValueError (Phase B8).
 
 | Env var | Type | Default |
 |---|---|---|
-| `RALPH_SECURITY_MODE` | str | `advisory` (`skip\|advisory\|hard`) |
+| `RALPH_SECURITY_MODE` | str | `skip` (`skip\|advisory\|hard`) |
 | `RALPH_SECURITY_AGENT_CMD` | str | unset |
 | `RALPH_SECURITY_AGENT_TYPE` | str | unset |
 | `RALPH_SECURITY_MODEL` | str | unset |
 | `RALPH_SECURITY_TIMEOUT` | float | 600 |
 | `RALPH_SECURITY_FAIL_THRESHOLD` | str | `high` (`critical\|high\|medium\|low`) |
 
-Invalid mode or threshold raises ValueError (Phase B8). Note: the `ralph_py factory` CLI defaults `--security-mode` to `skip` for backward compat; the dataclass default of `advisory` only applies to programmatic construction.
+Invalid mode or threshold raises ValueError (Phase B8). The default mode is `skip` everywhere (dataclass, env, CLI); enable the pass with `advisory` or `hard`.
 
 ## KnowledgeConfig (`[knowledge]`)
 
@@ -139,6 +165,16 @@ Invalid mode or threshold raises ValueError (Phase B8). Note: the `ralph_py fact
 | `RALPH_EVOLUTION_ENABLED` | bool | true |
 | `RALPH_EVOLUTION_JOURNAL_PATH` | path | `.ralph/evolution.jsonl` |
 | `RALPH_EVOLUTION_LOOKBACK_RUNS` | int | 10 |
+
+## NotifyConfig (`[notify]`)
+
+Run-milestone shell hooks (R3.2), each fired at most once per run. The hook command runs via the shell with `RALPH_NOTIFY_EVENT` (`run_complete` | `first_failure` | `merge_pending`), `RALPH_NOTIFY_RUN_ID`, `RALPH_NOTIFY_PROJECT`, `RALPH_NOTIFY_COMPONENT` and `RALPH_NOTIFY_DETAIL` set in its environment.
+
+| Env var | Type | Default |
+|---|---|---|
+| `RALPH_NOTIFY_ON_COMPLETE` | str | unset (hook disabled) |
+| `RALPH_NOTIFY_ON_FIRST_FAILURE` | str | unset (hook disabled) |
+| `RALPH_NOTIFY_HOOK_TIMEOUT` | float | 30 |
 
 ## LinearConfig (`[linear]`)
 

--- a/ralph.toml.example
+++ b/ralph.toml.example
@@ -3,10 +3,11 @@
 # Environment variables override these settings (see README for mapping).
 
 [agent]
-type = "claude"                    # "claude" | "codex" | "custom"
-command = ""                       # shell command (only used when type = "custom")
-model = ""                         # e.g., "sonnet" for claude, "o3" for codex (empty = default)
+type = ""                          # "claude-code" | "claude-sdk" | "codex" (empty = auto-detect)
+command = ""                       # custom agent shell command; overrides type
+model = ""                         # e.g., "sonnet" for claude, "gpt-5" for codex (empty = default)
 reasoning_effort = ""              # low|medium|high|max
+budget_usd = 0                     # in-loop USD ceiling; claude-sdk adapter only; 0 = unlimited (R7.6)
 
 [run]
 max_iterations = 10
@@ -94,7 +95,7 @@ dependency_scope = "direct"
 max_parallel = 4                   # concurrent component workers
 max_retries = 3                    # per-component retry budget across all phases
 retry_delay = 5.0                  # seconds between retry attempts
-use_worktrees = true               # branch each component into .ralph/worktrees/<id>
+use_worktrees = true               # branch each component into .ralph/worktrees/<run>/<id>
 single_pr = false                  # one PR for the whole factory vs per-component
 create_prs = true                  # call `gh` to push + merge per component
 review_mode = "hard"               # hard | advisory | skip
@@ -102,6 +103,8 @@ merge_timeout = 300.0              # seconds to wait for PR merge confirmation (
 max_adversarial_calls = 0          # 0 = unbounded; otherwise cap review+security+distill calls per run
 max_total_tokens = 0               # run-level token budget; 0 = unbounded (R3.1)
 pause_before_pr_merge = false      # opt-in HITL checkpoint before each PR push+merge
+progress_log_enabled = true        # JSONL event log at .ralph/progress.jsonl (R3.2)
+keep_worktrees_on_failure = false  # keep failed components' worktrees for post-mortem (R3.3)
 
 # Phase 1 mechanical verification.
 [verify]
@@ -161,6 +164,15 @@ min_pattern_frequency = 2
 lookback_runs = 10
 auto_propose = true                # generate proposals after each factory run
 auto_apply_computational = false   # auto-apply computational proposals
+
+# Run-milestone notification hooks (R3.2). Shell commands fired at most
+# once per run, with RALPH_NOTIFY_EVENT (run_complete | first_failure |
+# merge_pending), RALPH_NOTIFY_RUN_ID, RALPH_NOTIFY_PROJECT,
+# RALPH_NOTIFY_COMPONENT and RALPH_NOTIFY_DETAIL set in their environment.
+[notify]
+on_complete = ""                   # e.g. "printf '\\a'" for a terminal bell
+on_first_failure = ""              # e.g. a curl webhook one-liner
+hook_timeout = 30.0                # seconds before a hook command is killed
 
 # Linear integration (R7.4). Off by default. When enabled, decompose
 # creates one Linear project per manifest and one issue per component

--- a/ralph_py/init_cmd.py
+++ b/ralph_py/init_cmd.py
@@ -375,9 +375,9 @@ DEFAULT_RALPH_TOML = """\
 # file > built-in default. See docs/env-vars.md for the env-var mapping.
 
 [agent]
-# type = ""                        # "claude" | "codex" | "custom" (empty = auto-detect)
-# command = ""                     # shell command (only used when type = "custom")
-# model = ""                       # e.g. "sonnet" for claude, "o3" for codex (empty = agent default)
+# type = ""                        # "claude-code" | "claude-sdk" | "codex" (empty = auto-detect)
+# command = ""                     # custom agent shell command; overrides type
+# model = ""                       # e.g. "sonnet" for claude, "gpt-5" for codex (empty = agent default)
 # reasoning_effort = ""            # low|medium|high|max
 
 [run]

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -126,6 +126,7 @@ def _section_specs() -> list[SectionSpec]:
     from ralph_py.fixtures import FixturesConfig
     from ralph_py.knowledge import KnowledgeConfig
     from ralph_py.linear import LinearConfig
+    from ralph_py.observability import NotifyConfig
     from ralph_py.sandbox import SandboxConfig
     from ralph_py.security import SecurityConfig
     from ralph_py.timeout import TimeoutConfig
@@ -155,6 +156,7 @@ def _section_specs() -> list[SectionSpec]:
                 "command": "agent_cmd",
                 "model": "model",
                 "reasoning_effort": "model_reasoning_effort",
+                "budget_usd": "agent_budget_usd",
             },
             ralph_loader, ralph_defaults, probe_undocumented_fields=False,
         ),
@@ -276,6 +278,14 @@ def _section_specs() -> list[SectionSpec]:
             EvolutionConfig(), probe_undocumented_fields=True,
         ),
         SectionSpec(
+            "notify", "Run-milestone notification hooks (R3.2)",
+            identity_keys(NotifyConfig, [
+                f.name for f in dataclasses.fields(NotifyConfig)
+            ]),
+            lambda root: NotifyConfig.load(root_dir=root),
+            NotifyConfig(), probe_undocumented_fields=True,
+        ),
+        SectionSpec(
             "linear", "Linear integration (R7.4; default off)",
             identity_keys(LinearConfig, [f.name for f in dataclasses.fields(LinearConfig)]),
             lambda root: LinearConfig.load(root_dir=root),
@@ -288,10 +298,13 @@ def _section_specs() -> list[SectionSpec]:
 # One-line description per documented key. Regeneration fails when a key
 # has no description, so new keys cannot land undocumented.
 KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
-    ("agent", "type"): '"claude" | "codex" | "custom"',
-    ("agent", "command"): "shell command (only used when type = \"custom\")",
-    ("agent", "model"): 'e.g. "sonnet" (claude) or "o3" (codex); empty = agent default',
+    ("agent", "type"):
+        '"claude-code" | "claude-sdk" | "codex"; empty/"auto" = auto-detect',
+    ("agent", "command"): "custom agent shell command; overrides type",
+    ("agent", "model"): 'e.g. "sonnet" (claude) or "gpt-5" (codex); empty = agent default',
     ("agent", "reasoning_effort"): "low | medium | high | max (model-dependent)",
+    ("agent", "budget_usd"):
+        "in-loop USD ceiling; claude-sdk adapter only; empty/0 = unlimited (R7.6)",
     ("run", "max_iterations"): "iteration budget per component",
     ("run", "sleep_seconds"): "pause between iterations",
     ("run", "interactive"): "human-in-the-loop mode for the legacy loop",
@@ -315,7 +328,7 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("factory", "max_parallel"): "concurrent component workers",
     ("factory", "max_retries"): "per-component retry budget across all phases",
     ("factory", "retry_delay"): "seconds between retry attempts",
-    ("factory", "use_worktrees"): "isolate each component in .ralph/worktrees/<id>",
+    ("factory", "use_worktrees"): "isolate each component in .ralph/worktrees/<run>/<id>",
     ("factory", "single_pr"): "one PR for the whole run instead of per-component",
     ("factory", "create_prs"): "push + merge PRs via gh",
     ("factory", "review_mode"): "hard | advisory | skip (Phase 2)",
@@ -389,6 +402,11 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("evolution", "lookback_runs"): "past runs to analyze",
     ("evolution", "auto_propose"): "generate proposals after each factory run",
     ("evolution", "auto_apply_computational"): "auto-apply computational proposals",
+    ("notify", "on_complete"):
+        "shell hook fired once when the run finishes; empty = disabled",
+    ("notify", "on_first_failure"):
+        "shell hook fired once on the first component failure",
+    ("notify", "hook_timeout"): "seconds before a hook command is killed",
     ("linear", "enabled"): "mirror runs into Linear (project/issues/status via GitHub linking)",
     ("linear", "team_id"): "Linear team UUID (required when enabled)",
     ("linear", "token_env"): "NAME of the env var holding the API token",
@@ -399,10 +417,12 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("linear", "min_request_interval"): "client-side throttle between requests (seconds)",
 }
 
-# Sentinel values for keys whose loader validates against an enum; the
-# generic type-derived sentinel would be rejected.
-ENUM_SENTINELS: dict[tuple[str, str], str] = {
+# Sentinel values for keys whose loader validates the value (enum
+# membership, or a typed check the generic type-derived sentinel would
+# fail - e.g. budget_usd ignores non-numeric and non-positive values).
+ENUM_SENTINELS: dict[tuple[str, str], str | float] = {
     ("agent", "type"): "codex",
+    ("agent", "budget_usd"): 123.5,
     ("agent", "reasoning_effort"): "high",
     ("factory", "review_mode"): "advisory",
     ("security", "mode"): "hard",


### PR DESCRIPTION
## Summary

Full audit of user-facing documentation against `ralph_py/`, with every claim verified in code before editing. Accuracy fixes plus presentation polish.

### README.md
- **Agent table**: `o4-mini` appears nowhere in the code; model names are passed through unvalidated (`claude --model` / `codex -m`), so the table now shows examples and says so. Documents the opt-in `claude-sdk` adapter and `[agent].budget_usd` (R7.6).
- **Retry-context example**: replaced the invented format (`1.`, `error:`, `FIX:`) with the real `parsers.format_for_prompt` output shape, character-accurate to the format strings.
- **Paths**: worktrees are `.ralph/worktrees/<run>/<component>`, not `<id>`.
- **Stale test count**: 1119 -> 1695 collected.
- **Presentation**: CI/Python/MIT badges, a Documentation paragraph linking `docs/linear-integration.md` and `examples/` (previously unreachable from the README), mermaid `\n` labels converted to `<br/>` (reliable across renderers) and `<comp>`/`<run>` escaped so HTML-label mermaid does not swallow them.

### docs/env-vars.md
- Factual error: `RALPH_SECURITY_MODE` default documented as `advisory`; code defaults to `skip` everywhere.
- Added missing coverage: `[timeout]` section (8 vars; 3 were misattributed to RalphConfig), `[fixtures]` (4 vars), `[notify]` (3 vars), and 3 factory vars.

### ralph.toml.example + scripts/gen_docs.py
- Enrolled `NotifyConfig` (`[notify]`) in the generated config reference and the example - it was undocumented in every user-facing surface.
- Documented `[agent].budget_usd` with a numeric probe sentinel (the loader rejects non-numeric/non-positive values).
- Fixed `[agent] type` docs: valid values are `claude-code | claude-sdk | codex` (empty/`auto` = auto-detect); `"claude"` was never a valid value and silently fell through to codex. The example also no longer mislabels `type = "claude"` as the default.
- Added missing factory keys `progress_log_enabled` and `keep_worktrees_on_failure`.

### LICENSE
- Added MIT license text: README and pyproject both declare MIT but no license file existed. Copyright line uses the git author name - adjust if you want a different legal name.

## Verification

- `uv run python scripts/gen_docs.py --check` clean (generated sections current, [notify] and budget_usd behaviorally probed)
- `uv run pytest tests/`: 1667 passed, 28 skipped (1695 collected)
- `uv run mypy ralph_py/ --strict` clean
- `uv run ruff check ralph_py/ tests/ scripts/gen_docs.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)