### PR TITLE
TUI PR E: component detail screen + E6 checkpoint modal

### DIFF
--- a/ralph_py/events.py
+++ b/ralph_py/events.py
@@ -395,6 +395,9 @@ class FindingRecorded(Event):
     location: str = ""
     explanation: str = ""
     attempt: int = 0
+    # R7.1 attribution: the reviewing model identity ("codex (gpt-5)"),
+    # extracted from the finding's model: tag; "" when no reviewer ran.
+    model: str = ""
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/ralph_py/pipeline.py
+++ b/ralph_py/pipeline.py
@@ -42,7 +42,7 @@ from ralph_py import events as ev
 from ralph_py import git
 from ralph_py.agents.base import UsageTotals, collect_usage
 from ralph_py.context import IterationContext, IterationRecord
-from ralph_py.findings import Finding, tag_finding_with_attempt
+from ralph_py.findings import MODEL_TAG_PREFIX, Finding, tag_finding_with_attempt
 from ralph_py.fixtures import FixturesConfig
 from ralph_py.interaction import (
     CheckpointContext,
@@ -451,6 +451,14 @@ class ComponentPipeline:
         # Chunk 4: stream each finding as a typed event the moment it is
         # recorded (the manifest only carries them at transition time).
         for finding in new_findings:
+            model = next(
+                (
+                    tag[len(MODEL_TAG_PREFIX):]
+                    for tag in finding.tags
+                    if tag.startswith(MODEL_TAG_PREFIX)
+                ),
+                "",
+            )
             self.bus.emit(ev.FindingRecorded(
                 component=comp.id,
                 phase=finding.phase,
@@ -459,6 +467,7 @@ class ComponentPipeline:
                 location=finding.location,
                 explanation=finding.explanation,
                 attempt=attempt,
+                model=model,
             ))
 
     def begin_attempt(self, comp: Component) -> None:

--- a/ralph_py/reducer.py
+++ b/ralph_py/reducer.py
@@ -58,6 +58,9 @@ class ComponentState:
     cost_usd: float = 0.0
     findings_count: int = 0
     recent_findings: list[dict[str, Any]] = field(default_factory=list)
+    # Completed-phase history for the detail screen's timeline:
+    # {"phase", "passed", "detail", "duration_seconds", "attempt"}.
+    phase_history: list[dict[str, Any]] = field(default_factory=list)
     pr_url: str = ""
     pr_number: int = 0
     pr_state: str = ""  # "" | created | merge_pending | merged
@@ -194,6 +197,13 @@ def apply(state: RunState, event: ev.Event) -> None:  # noqa: C901 - flat dispat
                 comp.status = "verifying"
     elif isinstance(event, ev.PhaseCompleted):
         comp.phase_explicit = True
+        comp.phase_history.append({
+            "phase": event.phase,
+            "passed": event.passed,
+            "detail": event.detail,
+            "duration_seconds": event.duration_seconds,
+            "attempt": comp.attempt or 1,
+        })
         if not event.passed and event.detail:
             comp.error = event.detail
     elif isinstance(event, ev.ComponentCompleted):
@@ -234,6 +244,7 @@ def apply(state: RunState, event: ev.Event) -> None:  # noqa: C901 - flat dispat
             "location": event.location,
             "explanation": event.explanation,
             "attempt": event.attempt,
+            "model": event.model,
         })
         if len(comp.recent_findings) > MAX_RECENT_FINDINGS:
             del comp.recent_findings[0]

--- a/ralph_py/tui/app.py
+++ b/ralph_py/tui/app.py
@@ -82,13 +82,13 @@ class RalphTuiApp(App[int]):
         changed = self.store.apply_events(chunk.events)
         screen = self.screen
         if changed:
-            if isinstance(screen, ComponentScreen):
+            if isinstance(screen, ComponentScreen) and screen.ready:
                 screen.refresh_state(self.store.state, self.store.manifest())
-            else:
+            elif not isinstance(screen, ComponentScreen):
                 screen.post_message(StateChanged(self.store.state))
         # Transcript: ONLY the top component screen's component
         # (finding 3 - never all components at once).
-        if isinstance(screen, ComponentScreen):
+        if isinstance(screen, ComponentScreen) and screen.ready:
             screen.feed_transcript(
                 self._transcript_tailer(screen.component_id).poll(),
             )

--- a/ralph_py/tui/app.py
+++ b/ralph_py/tui/app.py
@@ -1,12 +1,13 @@
-"""RalphTuiApp: the dashboard application (stage 3 PR D).
+"""RalphTuiApp: the dashboard application (stage 3 PR D/E).
 
-Render policy (all three measured in the Stage 0 spike, RESULTS.md):
+Render policy (all measured in the Stage 0 spike, RESULTS.md):
 - Poll at 0.2s (p95 tail latency ~240ms at 1x AND 10x event rates for
   <1.3% CPU); post StateChanged only when events actually arrived.
-- Diff row updates, single-component transcript tails (PR E) - full
-  rebuilds and multi-component floods measurably starve input.
+- Diff row updates; the transcript pane tails ONE component (the top
+  screen's) with a bounded buffer - full rebuilds and multi-component
+  floods measurably starve input (finding 3).
 - ctrl+c is BOUND explicitly: raw mode delivers it as a key event, not
-  SIGINT (spike finding 1). SIGTERM handling is the embed layer's job
+  SIGINT (finding 1). SIGTERM handling is the embed layer's job
   (finding 2, PR F).
 
 DASH mode is observe-only: q detaches immediately and the run is
@@ -21,11 +22,13 @@ from pathlib import Path
 
 from textual.app import App
 from textual.binding import Binding
+from textual.widgets import DataTable
 
 from ralph_py.tui.messages import StateChanged
+from ralph_py.tui.screens.component import ComponentScreen
 from ralph_py.tui.screens.overview import OverviewScreen
 from ralph_py.tui.state import StateStore
-from ralph_py.tui.tail import RunTailer
+from ralph_py.tui.tail import RunTailer, TextTailer
 
 DEFAULT_POLL_INTERVAL = 0.2  # measured, spike G1
 
@@ -60,6 +63,7 @@ class RalphTuiApp(App[int]):
         self.poll_interval = poll_interval
         self.tailer = RunTailer(run_dir)
         self.store = StateStore(root_dir, run_id=run_dir.name)
+        self._transcript_tailers: dict[str, TextTailer] = {}
 
     def on_mount(self) -> None:
         self.push_screen(OverviewScreen(
@@ -69,15 +73,51 @@ class RalphTuiApp(App[int]):
         self.set_interval(1.0, self._tick_ages)
         self._poll()  # catch-up fold before the first frame settles
 
+    # -- data flow -----------------------------------------------------------
+
     def _poll(self) -> None:
-        events = self.tailer.poll_events()
-        if self.store.apply_events(events):
-            self.screen.post_message(StateChanged(self.store.state))
+        changed = self.store.apply_events(self.tailer.poll_events())
+        screen = self.screen
+        if changed:
+            if isinstance(screen, ComponentScreen):
+                screen.refresh_state(self.store.state, self.store.manifest())
+            else:
+                screen.post_message(StateChanged(self.store.state))
+        # Transcript: ONLY the top component screen's component
+        # (finding 3 - never all components at once).
+        if isinstance(screen, ComponentScreen):
+            screen.feed_transcript(
+                self._transcript_tailer(screen.component_id).poll(),
+            )
+
+    def _transcript_tailer(self, component_id: str) -> TextTailer:
+        tailer = self._transcript_tailers.get(component_id)
+        if tailer is None:
+            tailer = TextTailer(
+                self.run_dir / "components" / component_id / "engineer.log",
+            )
+            self._transcript_tailers[component_id] = tailer
+        return tailer
 
     def _tick_ages(self) -> None:
         screen = self.screen
         if isinstance(screen, OverviewScreen):
             screen.tick_ages(self.store.state)
+
+    # -- navigation ----------------------------------------------------------
+
+    def on_data_table_row_selected(
+        self, event: DataTable.RowSelected,
+    ) -> None:
+        if not isinstance(self.screen, OverviewScreen):
+            return
+        if event.row_key.value is None:
+            return
+        self.open_component(str(event.row_key.value))
+
+    def open_component(self, component_id: str) -> None:
+        # The screen fills itself in on_mount (compose must run first).
+        self.push_screen(ComponentScreen(component_id))
 
     def action_quit_or_detach(self) -> None:
         # DASH: detach immediately; the run (if live) is not ours to

--- a/ralph_py/tui/screens/checkpoint.py
+++ b/ralph_py/tui/screens/checkpoint.py
@@ -1,0 +1,107 @@
+"""E6 checkpoint modal (PR E).
+
+Turns the checkpoint from a rubber stamp into an inspection surface:
+the bounded diff excerpt, both finding streams, and the attempt's
+spend - everything PromptRequest.checkpoint carries (PR A). Dismissal
+values: 0 Approve / 1 Reject / 2 Retry / None leave-pending (Esc).
+Wired to actually ANSWER the interaction channel in PR F; dash mode
+never opens it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, Static
+
+if TYPE_CHECKING:
+    from ralph_py.interaction import PromptRequest
+
+
+def _findings_block(title: str, findings: tuple[object, ...]) -> Text:
+    text = Text()
+    text.append(f"{title}\n", style="bold underline")
+    if not findings:
+        text.append("  (none)\n", style="dim")
+        return text
+    for finding in findings:
+        severity = getattr(finding, "severity", "")
+        location = getattr(finding, "location", "")
+        explanation = getattr(finding, "explanation", "")
+        style = "red" if severity in ("critical", "high", "fail") else "yellow"
+        text.append(f"  [{severity}] ", style=style)
+        text.append(f"{location}  ", style="bold")
+        text.append(f"{explanation}\n")
+    return text
+
+
+class CheckpointModal(ModalScreen[int | None]):
+    BINDINGS = [
+        Binding("a", "decide(0)", "Approve"),
+        Binding("r", "decide(1)", "Reject"),
+        Binding("t", "decide(2)", "Retry"),
+        Binding("escape", "leave_pending", "Later"),
+    ]
+
+    def __init__(self, request: PromptRequest) -> None:
+        super().__init__()
+        self.request = request
+
+    def compose(self) -> ComposeResult:
+        ctx = self.request.checkpoint
+        with Vertical(id="checkpoint-dialog"):
+            yield Label(self.request.header, id="checkpoint-question")
+            if ctx is not None:
+                summary = Text()
+                if ctx.branch:
+                    summary.append("branch ", style="dim")
+                    summary.append(ctx.branch, style="bold")
+                if ctx.usage is not None and ctx.usage.calls:
+                    marker = "+" if ctx.usage.unreported_calls else ""
+                    summary.append("   spend ", style="dim")
+                    summary.append(
+                        f"{ctx.usage.total_tokens}{marker} tokens, "
+                        f"${ctx.usage.cost_usd:.2f}{marker}",
+                        style="bold",
+                    )
+                yield Static(summary, id="checkpoint-summary")
+                with VerticalScroll(id="checkpoint-body"):
+                    yield Static(_findings_block(
+                        "Review findings", ctx.review_findings,
+                    ))
+                    yield Static(_findings_block(
+                        "Security findings", ctx.security_findings,
+                    ))
+                    diff_text = Text()
+                    diff_text.append("Diff\n", style="bold underline")
+                    if ctx.diff_excerpt:
+                        for line in ctx.diff_excerpt.splitlines():
+                            style = (
+                                "green" if line.startswith("+")
+                                else "red" if line.startswith("-")
+                                else "dim"
+                            )
+                            diff_text.append(line + "\n", style=style)
+                    else:
+                        diff_text.append("  (no diff captured)\n", style="dim")
+                    yield Static(diff_text)
+            with Horizontal(id="checkpoint-buttons"):
+                yield Button("Approve (a)", id="approve", variant="success")
+                yield Button("Reject (r)", id="reject", variant="error")
+                yield Button("Retry (t)", id="retry", variant="warning")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss({"approve": 0, "reject": 1, "retry": 2}[
+            event.button.id or "approve"
+        ])
+
+    def action_decide(self, choice: int) -> None:
+        self.dismiss(choice)
+
+    def action_leave_pending(self) -> None:
+        self.dismiss(None)

--- a/ralph_py/tui/screens/component.py
+++ b/ralph_py/tui/screens/component.py
@@ -1,0 +1,85 @@
+"""Component detail screen (PR E)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Static
+
+from ralph_py.tui.messages import StateChanged
+from ralph_py.tui.widgets.evidence import EvidencePanel
+from ralph_py.tui.widgets.findings_table import FindingsTable
+from ralph_py.tui.widgets.phase_timeline import PhaseTimeline
+from ralph_py.tui.widgets.transcript import TranscriptTail
+
+if TYPE_CHECKING:
+    from ralph_py.manifest import Manifest
+    from ralph_py.reducer import ComponentState, RunState
+
+
+class ComponentScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "app.pop_screen", "Back"),
+        Binding("f", "toggle_follow", "Follow"),
+    ]
+
+    def __init__(self, component_id: str) -> None:
+        super().__init__()
+        self.component_id = component_id
+
+    def compose(self) -> ComposeResult:
+        yield Static(id="component-header")
+        yield PhaseTimeline(id="phase-timeline")
+        yield FindingsTable(id="findings-table")
+        yield TranscriptTail(id="transcript")
+        yield EvidencePanel(id="evidence")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        # Initial fill happens here, not at push time - compose has not
+        # run yet when the app pushes the screen. Duck-typed pull keeps
+        # this module import-free of app.py.
+        store = getattr(self.app, "store", None)
+        if store is not None:
+            self.refresh_state(store.state, store.manifest())
+
+    def refresh_state(
+        self, state: RunState, manifest: Manifest | None,
+    ) -> None:
+        comp: ComponentState | None = state.components.get(self.component_id)
+        if comp is None:
+            return
+        header = Text()
+        header.append(f" {self.component_id} ", style="bold reverse")
+        if comp.title:
+            header.append(f"  {comp.title}", style="bold")
+        header.append(f"  {comp.status}", style="yellow")
+        if comp.findings_count:
+            header.append(f"  {comp.findings_count} finding(s)", style="dim")
+        self.query_one("#component-header", Static).update(header)
+        self.query_one(PhaseTimeline).update_state(comp)
+        self.query_one(FindingsTable).update_state(comp)
+        manifest_comp = (
+            manifest.get_component(self.component_id)
+            if manifest is not None else None
+        )
+        self.query_one(EvidencePanel).update_state(comp, manifest_comp)
+
+    def feed_transcript(self, lines: list[str]) -> None:
+        self.query_one(TranscriptTail).feed_lines(lines)
+
+    def action_toggle_follow(self) -> None:
+        following = self.query_one(TranscriptTail).toggle_follow()
+        self.notify(
+            "following transcript" if following else "follow paused",
+            timeout=1.5,
+        )
+
+    def on_state_changed(self, message: StateChanged) -> None:
+        # Manifest join is injected by the app poll; message-only
+        # refresh covers state (manifest may lag one poll harmlessly).
+        self.refresh_state(message.state, None)

--- a/ralph_py/tui/screens/component.py
+++ b/ralph_py/tui/screens/component.py
@@ -39,6 +39,11 @@ class ComponentScreen(Screen[None]):
         yield EvidencePanel(id="evidence")
         yield Footer()
 
+    @property
+    def ready(self) -> bool:
+        """Whether compose has mounted the widgets used by poll delivery."""
+        return next(iter(self.query(TranscriptTail)), None) is not None
+
     def on_mount(self) -> None:
         # Initial fill happens here, not at push time - compose has not
         # run yet when the app pushes the screen. Duck-typed pull keeps

--- a/ralph_py/tui/styles.tcss
+++ b/ralph_py/tui/styles.tcss
@@ -28,3 +28,74 @@
 #component-table {
     height: 1fr;
 }
+
+/* Component detail screen (PR E). */
+
+#component-header {
+    dock: top;
+    height: 1;
+    background: $panel;
+}
+
+#phase-timeline {
+    height: auto;
+    padding: 0 1;
+    border-bottom: solid $panel;
+}
+
+#findings-table {
+    height: auto;
+    max-height: 30%;
+}
+
+#transcript {
+    height: 1fr;
+    border-top: solid $accent 40%;
+}
+
+#evidence {
+    dock: bottom;
+    height: auto;
+    max-height: 8;
+    padding: 0 1;
+    background: $panel;
+}
+
+/* E6 checkpoint modal (PR E). */
+
+CheckpointModal {
+    align: center middle;
+}
+
+#checkpoint-dialog {
+    width: 90%;
+    max-width: 120;
+    height: 80%;
+    border: thick $warning;
+    background: $surface;
+    padding: 1 2;
+}
+
+#checkpoint-question {
+    text-style: bold;
+}
+
+#checkpoint-summary {
+    height: 1;
+    margin-bottom: 1;
+}
+
+#checkpoint-body {
+    height: 1fr;
+    border: solid $panel;
+    padding: 0 1;
+}
+
+#checkpoint-buttons {
+    height: 3;
+    align-horizontal: center;
+}
+
+#checkpoint-buttons Button {
+    margin: 0 2;
+}

--- a/ralph_py/tui/widgets/evidence.py
+++ b/ralph_py/tui/widgets/evidence.py
@@ -1,0 +1,53 @@
+"""Evidence panel: where this component's artifacts live (PR E).
+
+Joins the temporal state (PR URL/state from events) with the
+authoritative manifest snapshot (branch, evidence worktree, debug dir)
+- the TUI is a view; when a run breaks, these paths are where the
+operator goes.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from ralph_py.manifest import Component
+    from ralph_py.reducer import ComponentState
+
+
+def render_evidence(
+    comp: ComponentState, manifest_comp: Component | None,
+) -> Text:
+    text = Text()
+
+    def row(label: str, value: str, style: str = "") -> None:
+        text.append(f"{label:>10}  ", style="dim")
+        text.append(value, style=style)
+        text.append("\n")
+
+    if manifest_comp is not None and manifest_comp.branch_name:
+        row("branch", manifest_comp.branch_name)
+    pr_url = comp.pr_url or (manifest_comp.pr_url if manifest_comp else "")
+    if pr_url:
+        note = f" ({comp.pr_state})" if comp.pr_state else ""
+        row("pr", f"{pr_url}{note}", "bold")
+    if manifest_comp is not None:
+        if manifest_comp.evidence_worktree:
+            row("worktree", manifest_comp.evidence_worktree)
+        if manifest_comp.evidence_debug_dir:
+            row("raw dumps", manifest_comp.evidence_debug_dir)
+    if comp.error:
+        row("error", comp.error, "red")
+    if not text.plain:
+        text.append("no evidence recorded", style="dim")
+    return text
+
+
+class EvidencePanel(Static):
+    def update_state(
+        self, comp: ComponentState, manifest_comp: Component | None,
+    ) -> None:
+        self.update(render_evidence(comp, manifest_comp))

--- a/ralph_py/tui/widgets/findings_table.py
+++ b/ralph_py/tui/widgets/findings_table.py
@@ -1,0 +1,49 @@
+"""Findings table: the typed adversarial finding stream (PR E)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from rich.text import Text
+from textual.widgets import DataTable
+
+if TYPE_CHECKING:
+    from ralph_py.reducer import ComponentState
+
+_SEVERITY_STYLES = {
+    "critical": "bold red",
+    "high": "red",
+    "fail": "red",
+    "medium": "yellow",
+    "advisory": "yellow",
+    "low": "dim",
+}
+
+COLUMNS = ("phase", "severity", "category", "location", "model", "att")
+
+
+class FindingsTable(DataTable[Text | str]):
+    def on_mount(self) -> None:
+        self.cursor_type = "row"
+        self.zebra_stripes = True
+        for column in COLUMNS:
+            self.add_column(column, key=column)
+        self._rendered = 0
+
+    def update_state(self, comp: ComponentState) -> None:
+        findings: list[dict[str, Any]] = comp.recent_findings
+        if len(findings) < self._rendered:
+            # Bounded list rolled over (or a retry superseded): rebuild.
+            self.clear()
+            self._rendered = 0
+        for finding in findings[self._rendered:]:
+            severity = str(finding.get("severity", ""))
+            self.add_row(
+                str(finding.get("phase", "")),
+                Text(severity, style=_SEVERITY_STYLES.get(severity, "")),
+                str(finding.get("category", "")),
+                str(finding.get("location", "")),
+                str(finding.get("model", "") or "-"),
+                str(finding.get("attempt", "")),
+            )
+        self._rendered = len(findings)

--- a/ralph_py/tui/widgets/phase_timeline.py
+++ b/ralph_py/tui/widgets/phase_timeline.py
@@ -1,0 +1,41 @@
+"""Phase timeline: the component's journey with verdicts (PR E)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from ralph_py.reducer import ComponentState
+
+
+def render_timeline(comp: ComponentState) -> Text:
+    text = Text()
+    if not comp.phase_history and not comp.phase:
+        text.append("no phases yet", style="dim")
+        return text
+    for i, entry in enumerate(comp.phase_history):
+        if i:
+            text.append("  ->  ", style="dim")
+        verdict = "✓" if entry.get("passed") else "✗"
+        style = "green" if entry.get("passed") else "red"
+        duration = entry.get("duration_seconds") or 0.0
+        text.append(f"{entry.get('phase', '?')} {verdict}", style=style)
+        if duration:
+            text.append(f" {duration:.0f}s", style="dim")
+    current = comp.phase
+    finished_phases = {e.get("phase") for e in comp.phase_history}
+    if current and comp.status in ("running", "verifying") and (
+        current not in finished_phases
+    ):
+        if comp.phase_history:
+            text.append("  ->  ", style="dim")
+        text.append(f"{current} …", style="bold yellow")
+    return text
+
+
+class PhaseTimeline(Static):
+    def update_state(self, comp: ComponentState) -> None:
+        self.update(render_timeline(comp))

--- a/ralph_py/tui/widgets/transcript.py
+++ b/ralph_py/tui/widgets/transcript.py
@@ -1,0 +1,34 @@
+"""Transcript tail pane (PR E).
+
+Spike finding 3 is binding here: ONE component's transcript, bounded
+buffer, follow-toggleable. The pane pulls via feed_lines from the
+app's poll (only while its screen is on top - the app gates that), so
+a backgrounded detail screen costs nothing.
+"""
+
+from __future__ import annotations
+
+from textual.widgets import RichLog
+
+MAX_BUFFER_LINES = 1000
+
+
+class TranscriptTail(RichLog):
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(
+            max_lines=MAX_BUFFER_LINES, wrap=False, highlight=False,
+            **kwargs,  # type: ignore[arg-type]
+        )
+        self.follow = True
+
+    def feed_lines(self, lines: list[str]) -> None:
+        if not lines:
+            return
+        self.auto_scroll = self.follow
+        for line in lines:
+            self.write(line)
+
+    def toggle_follow(self) -> bool:
+        self.follow = not self.follow
+        self.auto_scroll = self.follow
+        return self.follow

--- a/tests/test_tui_detail.py
+++ b/tests/test_tui_detail.py
@@ -1,0 +1,150 @@
+"""Stage 3 PR E (TUI rewrite): component detail screen + checkpoint modal."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ralph_py.agents.base import UsageTotals
+from ralph_py.findings import Finding
+from ralph_py.interaction import CheckpointContext, PromptKind, PromptRequest
+from ralph_py.tui.app import Mode, RalphTuiApp
+from ralph_py.tui.screens.checkpoint import CheckpointModal
+from ralph_py.tui.screens.component import ComponentScreen
+from ralph_py.tui.screens.overview import OverviewScreen
+from ralph_py.tui.widgets.findings_table import FindingsTable
+from ralph_py.tui.widgets.phase_timeline import render_timeline
+from ralph_py.tui.widgets.transcript import TranscriptTail
+from tests.helpers.fake_run import FakeRunSpec, write_fake_run
+
+
+def _app(root: Path, run_dir: Path) -> RalphTuiApp:
+    return RalphTuiApp(
+        run_dir=run_dir, root_dir=root, mode=Mode.DASH, poll_interval=0.05,
+    )
+
+
+def _checkpoint_request() -> PromptRequest:
+    return PromptRequest(
+        kind=PromptKind.CHECKPOINT,
+        header="Approve PR creation and merge for comp-a?",
+        options=("Approve", "Reject", "Retry"),
+        default=0,
+        component_id="comp-a",
+        checkpoint=CheckpointContext(
+            component_id="comp-a",
+            diff_excerpt="+added line\n-removed line\n context\n",
+            review_findings=(Finding(
+                phase="review", category="test_quality", severity="advisory",
+                location="src/x.py:10", explanation="weak assertion",
+            ),),
+            security_findings=(),
+            usage=_usage_totals(),
+            branch="ralph/factory/comp-a",
+        ),
+    )
+
+
+def _usage_totals() -> UsageTotals:
+    totals = UsageTotals()
+    totals.calls = 3
+    totals.known_calls = 2
+    totals.total_tokens = 4321
+    totals.cost_usd = 1.25
+    return totals
+
+
+class TestComponentScreen:
+    async def test_enter_opens_detail_and_escape_returns(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=2))
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            assert isinstance(app.screen, OverviewScreen)
+            await pilot.press("enter")  # select the cursor row
+            await pilot.pause()
+            assert isinstance(app.screen, ComponentScreen)
+            assert app.screen.component_id == "comp-a"
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, OverviewScreen)
+
+    async def test_detail_shows_timeline_findings_transcript(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app.open_component("comp-a")
+            await pilot.pause(0.2)  # a couple of polls for the transcript
+            screen = app.screen
+            assert isinstance(screen, ComponentScreen)
+            findings = screen.query_one(FindingsTable)
+            assert findings.row_count == 1  # fixture's advisory finding
+            transcript = screen.query_one(TranscriptTail)
+            assert len(transcript.lines) > 0  # engineer.log tailed
+            timeline = render_timeline(
+                app.store.state.components["comp-a"],
+            ).plain
+            assert "engineer ✓" in timeline
+            assert "review ✓" in timeline
+
+    async def test_follow_toggle(self, tmp_path: Path) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app.open_component("comp-a")
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, ComponentScreen)
+            tail = screen.query_one(TranscriptTail)
+            assert tail.follow is True
+            await pilot.press("f")
+            assert tail.follow is False
+            await pilot.press("f")
+            assert tail.follow is True
+
+
+class TestCheckpointModal:
+    async def test_renders_context_and_approves(self, tmp_path: Path) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _app(tmp_path, run_dir)
+        results: list[int | None] = []
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app.push_screen(CheckpointModal(_checkpoint_request()), results.append)
+            await pilot.pause()
+            assert isinstance(app.screen, CheckpointModal)
+            # The inspection surface is populated:
+            body = app.screen.query_one("#checkpoint-body")
+            rendered = "".join(
+                str(static.render()) for static in body.query("Static")
+            )
+            assert "weak assertion" in rendered
+            assert "+added line" in rendered
+            summary = str(
+                app.screen.query_one("#checkpoint-summary").render(),
+            )
+            assert "ralph/factory/comp-a" in summary
+            assert "4321+" in summary  # lower-bound marker (unreported)
+            await pilot.press("a")
+            await pilot.pause()
+        assert results == [0]
+
+    async def test_reject_retry_and_escape(self, tmp_path: Path) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _app(tmp_path, run_dir)
+        results: list[int | None] = []
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            for key in ("r", "t", "escape"):
+                app.push_screen(
+                    CheckpointModal(_checkpoint_request()), results.append,
+                )
+                await pilot.pause()
+                await pilot.press(key)
+                await pilot.pause()
+        assert results == [1, 2, None]

--- a/tests/test_tui_detail.py
+++ b/tests/test_tui_detail.py
@@ -107,6 +107,18 @@ class TestComponentScreen:
             await pilot.press("f")
             assert tail.follow is True
 
+    async def test_poll_during_screen_mount_is_safe(self, tmp_path: Path) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app.open_component("comp-a")
+
+            app._poll()
+
+            await pilot.pause()
+            assert isinstance(app.screen, ComponentScreen)
+
     async def test_findings_rollover_rebuilds_same_length_table(
         self, tmp_path: Path,
     ) -> None:


### PR DESCRIPTION
## Summary

Stage 3 PR E of the TUI rewrite plan (stacked on #115).

- **ComponentScreen** (enter from the board, escape back): `PhaseTimeline` (verdict + duration per completed phase, live phase highlighted), `FindingsTable` (severity-styled; **model attribution** - `finding_recorded` events now carry the R7.1 `model:` tag extracted in `_add_findings`), `TranscriptTail` (bounded RichLog, `f` toggles follow; the app polls ONLY the top screen's component per spike finding 3), `EvidencePanel` (temporal PR state joined with manifest branch/worktree/debug-dir pointers).
- **CheckpointModal**: the E6 gate as a real inspection surface - bounded +/- styled diff excerpt, both finding streams, branch, attempt spend with the honest lower-bound marker. `a`/`r`/`t`/`Esc` -> 0/1/2/None. Answer wiring lands in PR F; dash mode never opens it.
- Reducer additions: `ComponentState.phase_history` (timeline source) and `model` on recent findings; both covered by the existing fold/apply property tests.

## Tests (+5 Pilot)

Navigation round-trip, detail population (timeline glyphs, findings row, tailed transcript), follow toggle, modal content + all four dismissal paths.

Gates: fast 1646 passed, `mypy --strict` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)