### PR TITLE
TUI PR F: embedded mode - orchestrator thread + bridge + crash fallback

### DIFF
--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -2076,6 +2076,13 @@ def factory(
         and _normalize_ui_mode(ui) != "plain"
     )
     if use_tui:
+        if not (sys.stdout.isatty() and sys.stdin.isatty()):
+            click.echo(
+                "--tui requires an interactive terminal; use --no-tui "
+                "for non-interactive execution.",
+                err=True,
+            )
+            sys.exit(2)
         # PR F: embedded dashboard. The pre-execution confirm already
         # happened on the plain terminal (plan decision: no
         # modal-before-app); everything from here renders in Textual.

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -1677,7 +1677,15 @@ def decompose(
     is_flag=True,
     help="Disable colors",
 )
+@click.option(
+    "--tui/--no-tui",
+    "tui",
+    default=None,
+    help="Embedded dashboard (default: auto - on when stdin/stdout are "
+         "TTYs and --ui is not plain; RALPH_NO_TUI=1 forces off)",
+)
 def factory(
+    tui: bool | None,
     spec: Path | None,
     manifest_path: Path | None,
     root: Path | None,
@@ -2038,6 +2046,23 @@ def factory(
     # R0.5 (H-15): state saves back to the file it was loaded from.
     # --manifest /custom.json persists to /custom.json; --spec runs keep
     # the default scripts/ralph/manifest.json that decompose wrote.
+    use_tui = tui if tui is not None else (
+        sys.stdout.isatty()
+        and sys.stdin.isatty()
+        and os.environ.get("RALPH_NO_TUI") != "1"
+        and _normalize_ui_mode(ui) != "plain"
+    )
+    if use_tui:
+        # PR F: embedded dashboard. The pre-execution confirm already
+        # happened on the plain terminal (plan decision: no
+        # modal-before-app); everything from here renders in Textual.
+        from ralph_py.tui.embed import run_factory_embedded
+
+        sys.exit(run_factory_embedded(
+            manifest, factory_config, base_config, root_dir,
+            manifest_path,
+        ))
+
     stop = StopController()
     uninstall = install_signal_handlers(stop)
     try:

--- a/ralph_py/factory.py
+++ b/ralph_py/factory.py
@@ -1478,6 +1478,7 @@ def run_factory(
     interaction: InteractionChannel | None = None,
     stop: StopController | None = None,
     run_id: str | None = None,
+    notify_capture_output: bool = False,
 ) -> FactoryResult:
     """Run the factory orchestrator with 3-phase verification.
 
@@ -1509,6 +1510,7 @@ def run_factory(
             manifest, factory_config, base_config, ui, root_dir,
             manifest_path=manifest_path, lock_held=run_lock.held,
             interaction=interaction, stop=stop, run_id_override=run_id,
+            notify_capture_output=notify_capture_output,
         )
     finally:
         run_lock.release()
@@ -1525,6 +1527,7 @@ def _run_factory_locked(
     interaction: InteractionChannel | None = None,
     stop: StopController | None = None,
     run_id_override: str | None = None,
+    notify_capture_output: bool = False,
 ) -> FactoryResult:
     """run_factory body; runs with the run-level lock resolved (held, or
     explicitly degraded via --force-lock / no-fcntl platforms)."""
@@ -1610,6 +1613,7 @@ def _run_factory_locked(
         run_id=run_id,
         project=manifest.project_name,
         warn=ui.warn,
+        capture_output=notify_capture_output,
     )
 
     bus.emit(RunStarted(

--- a/ralph_py/observability.py
+++ b/ralph_py/observability.py
@@ -508,12 +508,18 @@ class NotifyHooks:
         run_id: str = "",
         project: str = "",
         warn: Callable[[str], None] | None = None,
+        capture_output: bool = False,
     ) -> None:
         self._config = config
         self._run_id = run_id
         self._project = project
         self._warn = warn or (lambda _msg: None)
         self._fired: set[str] = set()
+        # PR F: when a TUI owns the terminal, hook output must not
+        # reach the inherited fds (measured alt-screen corruption in
+        # the Stage 0 spike). Default False keeps terminal bells
+        # working for plain-mode users.
+        self.capture_output = capture_output
 
     def fire_complete(self, detail: str = "") -> None:
         self._fire("run_complete", self._config.on_complete, detail=detail)
@@ -551,9 +557,11 @@ class NotifyHooks:
             "RALPH_NOTIFY_DETAIL": detail,
         })
         try:
+            sink = subprocess.DEVNULL if self.capture_output else None
             proc = subprocess.run(
                 command, shell=True, env=env,
                 stdin=subprocess.DEVNULL,
+                stdout=sink, stderr=sink,
                 timeout=self._config.hook_timeout,
             )
             if proc.returncode != 0:

--- a/ralph_py/tui/app.py
+++ b/ralph_py/tui/app.py
@@ -24,9 +24,17 @@ from textual.app import App
 from textual.binding import Binding
 from textual.widgets import DataTable
 
+from ralph_py.interaction import (
+    PromptKind,
+    PromptRequest,
+    QueueInteractionChannel,
+)
+from ralph_py.tui.bridge import OrchestratorHandle
 from ralph_py.tui.messages import StateChanged
+from ralph_py.tui.screens.checkpoint import CheckpointModal
 from ralph_py.tui.screens.component import ComponentScreen
 from ralph_py.tui.screens.overview import OverviewScreen
+from ralph_py.tui.screens.quit import QuitModal
 from ralph_py.tui.state import StateStore
 from ralph_py.tui.tail import RunTailer, TextTailer
 
@@ -46,6 +54,7 @@ class RalphTuiApp(App[int]):
         # Spike finding 1: raw mode delivers ctrl+c as a KEY - unbound
         # it does nothing at all.
         Binding("ctrl+c", "quit_or_detach", show=False),
+        Binding("c", "answer_checkpoint", "Checkpoint", show=False),
     ]
 
     def __init__(
@@ -55,15 +64,21 @@ class RalphTuiApp(App[int]):
         root_dir: Path,
         mode: Mode = Mode.DASH,
         poll_interval: float = DEFAULT_POLL_INTERVAL,
+        channel: QueueInteractionChannel | None = None,
+        orchestrator: OrchestratorHandle | None = None,
     ) -> None:
         super().__init__()
         self.run_dir = run_dir
         self.root_dir = root_dir
         self.mode = mode
         self.poll_interval = poll_interval
+        self.channel = channel
+        self.orchestrator = orchestrator
         self.tailer = RunTailer(run_dir)
         self.store = StateStore(root_dir, run_id=run_dir.name)
         self._transcript_tailers: dict[str, TextTailer] = {}
+        self._pending_prompts: dict[str, PromptRequest] = {}
+        self._stopping = False
 
     def on_mount(self) -> None:
         self.push_screen(OverviewScreen(
@@ -71,6 +86,19 @@ class RalphTuiApp(App[int]):
         ))
         self.set_interval(self.poll_interval, self._poll)
         self.set_interval(1.0, self._tick_ages)
+        if self.mode is Mode.EMBEDDED:
+            self.set_interval(0.5, self._check_orchestrator)
+            if self.channel is not None:
+                # Attach HERE, not before app.run(): call_from_thread on
+                # a not-yet-running app raises, which would degrade the
+                # request to its non-interactive default. Until attach,
+                # can_prompt() is False and a checkpoint proceeds
+                # NOT_PROMPTED - exactly the non-TTY semantics.
+                self.channel.attach(
+                    lambda req: self.call_from_thread(
+                        self.on_prompt_request, req,
+                    ),
+                )
         self._poll()  # catch-up fold before the first frame settles
 
     # -- data flow -----------------------------------------------------------
@@ -119,7 +147,76 @@ class RalphTuiApp(App[int]):
         # The screen fills itself in on_mount (compose must run first).
         self.push_screen(ComponentScreen(component_id))
 
+    # -- embedded mode (PR F) ------------------------------------------------
+
+    def _check_orchestrator(self) -> None:
+        handle = self.orchestrator
+        if handle is None or not handle.done():
+            return
+        self._poll()  # final drain before leaving the screen
+        self.exit(
+            130 if handle.stop.is_set() else handle.exit_code,
+        )
+
+    def on_prompt_request(self, request: PromptRequest) -> None:
+        """The interaction channel's notify callback (call_from_thread -
+        the sole orchestrator-to-UI crossing, spike-G4 validated)."""
+        self._pending_prompts[request.request_id] = request
+        self._open_prompt(request)
+
+    def _open_prompt(self, request: PromptRequest) -> None:
+        if self.channel is None:
+            return
+
+        def _resolve(choice: int | None) -> None:
+            if choice is None:
+                # Left pending (Esc): the banner keeps pointing at it;
+                # press c to reopen. The orchestrator stays blocked -
+                # that is what a checkpoint IS.
+                self.notify(
+                    "checkpoint left pending - press c to answer",
+                    severity="warning",
+                )
+                return
+            if self.channel is not None and self.channel.resolve(
+                request.request_id, choice,
+            ):
+                self._pending_prompts.pop(request.request_id, None)
+
+        if request.kind is PromptKind.CHECKPOINT:
+            self.push_screen(CheckpointModal(request), _resolve)
+        else:
+            # Generic prompts reuse the checkpoint chrome minus context.
+            self.push_screen(CheckpointModal(request), _resolve)
+
+    def action_answer_checkpoint(self) -> None:
+        if isinstance(self.screen, CheckpointModal):
+            return
+        for request in self._pending_prompts.values():
+            self._open_prompt(request)
+            return
+
     def action_quit_or_detach(self) -> None:
-        # DASH: detach immediately; the run (if live) is not ours to
-        # stop. EMBEDDED overrides this action in PR F.
-        self.exit(0)
+        if self.mode is Mode.DASH:
+            # Detach immediately; the run (if live) is not ours to stop.
+            self.exit(0)
+            return
+        handle = self.orchestrator
+        if handle is None:
+            self.exit(0)
+            return
+        if self._stopping or handle.stop.is_set():
+            # Second request escalates to force (mirrors the second
+            # Ctrl-C signal semantics of PR B).
+            handle.stop.request("forced from TUI", force=True)
+            self.exit(130)
+            return
+
+        def _confirmed(stop_run: bool | None) -> None:
+            if not stop_run:
+                return
+            self._stopping = True
+            handle.stop.request("stopped from TUI")
+            self.notify("shutting down - waiting for cleanup", timeout=10)
+
+        self.push_screen(QuitModal(), _confirmed)

--- a/ralph_py/tui/bridge.py
+++ b/ralph_py/tui/bridge.py
@@ -1,0 +1,88 @@
+"""Orchestrator thread handle for embedded mode (stage 3 PR F).
+
+The orchestrator runs run_factory on a NON-daemon background thread;
+Textual owns the main thread. The only crossings are:
+- QueueInteractionChannel (PR A): orchestrator blocks, TUI resolves
+  via App.call_from_thread - the mechanism the spike's G4 soak
+  validated (zero deadlocks across 33k events).
+- StopController (PR B): both sides can request a stop.
+- This handle: the TUI polls done() and reads the result.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ralph_py.factory import run_factory
+
+if TYPE_CHECKING:
+    from ralph_py.config import RalphConfig
+    from ralph_py.factory import FactoryConfig, FactoryResult
+    from ralph_py.interaction import QueueInteractionChannel
+    from ralph_py.manifest import Manifest
+    from ralph_py.shutdown import StopController
+    from ralph_py.ui.base import UI
+
+
+@dataclass
+class OrchestratorHandle:
+    thread: threading.Thread
+    stop: StopController
+    result_box: list[FactoryResult] = field(default_factory=list)
+    error_box: list[BaseException] = field(default_factory=list)
+
+    def done(self) -> bool:
+        return not self.thread.is_alive()
+
+    def join(self, timeout: float | None = None) -> None:
+        self.thread.join(timeout)
+
+    @property
+    def exit_code(self) -> int:
+        if self.error_box:
+            return 1
+        if self.result_box:
+            return self.result_box[0].exit_code
+        return 1  # died without a result
+
+
+def start_orchestrator(
+    manifest: Manifest,
+    factory_config: FactoryConfig,
+    base_config: RalphConfig,
+    ui: UI,
+    root_dir: Path,
+    manifest_path: Path | None,
+    *,
+    run_id: str,
+    stop: StopController,
+    channel: QueueInteractionChannel,
+) -> OrchestratorHandle:
+    result_box: list[FactoryResult] = []
+    error_box: list[BaseException] = []
+
+    def _target() -> None:
+        try:
+            result_box.append(run_factory(
+                manifest, factory_config, base_config, ui, root_dir,
+                manifest_path=manifest_path,
+                interaction=channel,
+                stop=stop,
+                run_id=run_id,
+                notify_capture_output=True,
+            ))
+        except BaseException as exc:  # noqa: BLE001 - surfaced via the box
+            error_box.append(exc)
+
+    thread = threading.Thread(
+        target=_target, name="ralph-orchestrator", daemon=False,
+    )
+    handle = OrchestratorHandle(
+        thread=thread, stop=stop,
+        result_box=result_box, error_box=error_box,
+    )
+    thread.start()
+    return handle

--- a/ralph_py/tui/embed.py
+++ b/ralph_py/tui/embed.py
@@ -1,0 +1,139 @@
+"""Embedded mode: `ralph factory` with the dashboard (stage 3 PR F).
+
+Sequence (each step maps to a spike finding or plan decision):
+1.  Mint the run id BEFORE anything starts (PR B's override) so the
+    run dir is known to the TUI from frame one.
+2.  Orchestrator narration renders to <run_dir>/orchestrator.log
+    through the SAME console architecture as the terminal (bridge ->
+    bus -> UIBackedRenderer -> PlainUI-on-a-file); run_factory then
+    attaches the run's file sinks to that bus as usual. A root logging
+    FileHandler catches module loggers (evolution, agents) that would
+    otherwise scribble on the alt screen; notify hooks run
+    output-captured (spike: measured 5-line alt-screen corruption).
+3.  Signal handlers install BEFORE app.run() (spike finding 2: Textual
+    leaves the terminal raw on SIGTERM); a signal requests the same
+    graceful stop as the TUI's quit flow.
+4.  The TUI tails the SAME files as `ralph dash` - one data path, so a
+    TUI crash cannot lose orchestrator state: the fallback loop keeps
+    streaming events as plain lines until the run finishes.
+5.  finally: detach the channel (pending prompts degrade to their
+    non-interactive defaults - a dead TUI never hangs the run), join
+    the orchestrator, restore the terminal.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ralph_py.events import CallbackSink, EventBus, RunPaths
+from ralph_py.interaction import QueueInteractionChannel
+from ralph_py.knowledge import current_run_id
+from ralph_py.render import UIBackedRenderer
+from ralph_py.shutdown import StopController, install_signal_handlers
+from ralph_py.tui.app import Mode, RalphTuiApp
+from ralph_py.tui.bridge import OrchestratorHandle, start_orchestrator
+from ralph_py.tui.tail import RunTailer
+from ralph_py.ui.bridge import EventBridgeUI, NullPrompter
+from ralph_py.ui.plain import PlainUI
+
+if TYPE_CHECKING:
+    from ralph_py.config import RalphConfig
+    from ralph_py.factory import FactoryConfig
+    from ralph_py.manifest import Manifest
+
+ANSI_RESTORE = "\x1b[?1049l\x1b[?25h\x1b[0m"
+
+
+def run_factory_embedded(
+    manifest: Manifest,
+    factory_config: FactoryConfig,
+    base_config: RalphConfig,
+    root_dir: Path,
+    manifest_path: Path | None,
+    *,
+    poll_interval: float = 0.2,
+) -> int:
+    run_id = current_run_id()
+    run_paths = RunPaths.for_run(root_dir, run_id)
+    run_paths.root.mkdir(parents=True, exist_ok=True)
+
+    # Orchestrator narration -> orchestrator.log via the standard
+    # console stack; prompts go through the queue channel, never a TTY.
+    log_fh = open(
+        run_paths.root / "orchestrator.log", "a",
+        buffering=1, encoding="utf-8",
+    )
+    renderer = UIBackedRenderer(PlainUI(no_color=True, file=log_fh))
+    bus = EventBus(CallbackSink(renderer.handle))
+    orchestrator_ui = EventBridgeUI(bus, prompter=NullPrompter())
+
+    channel = QueueInteractionChannel()
+    stop = StopController()
+
+    # Module loggers (evolution, agents/*) must not hit the alt screen.
+    root_logger = logging.getLogger()
+    log_handler = logging.FileHandler(
+        run_paths.root / "orchestrator.log", encoding="utf-8",
+    )
+    root_logger.addHandler(log_handler)
+
+    uninstall = install_signal_handlers(stop)
+    handle: OrchestratorHandle | None = None
+    try:
+        handle = start_orchestrator(
+            manifest, factory_config, base_config, orchestrator_ui,
+            root_dir, manifest_path,
+            run_id=run_id, stop=stop, channel=channel,
+        )
+        app = RalphTuiApp(
+            run_dir=run_paths.root, root_dir=root_dir,
+            mode=Mode.EMBEDDED, poll_interval=poll_interval,
+            channel=channel, orchestrator=handle,
+        )
+        # The app attaches the channel itself in on_mount - attaching
+        # before app.run() would race call_from_thread on a
+        # not-yet-running app (found by test).
+        try:
+            code = app.run()
+        except Exception as exc:  # noqa: BLE001 - TUI crash != run crash
+            sys.stdout.write(ANSI_RESTORE)
+            sys.stdout.flush()
+            print(
+                f"TUI failed ({exc}); the run continues - streaming "
+                f"plain output until it finishes.",
+                file=sys.stderr,
+            )
+            channel.detach()
+            code = _plain_fallback(handle, run_paths.root)
+        return code if code is not None else handle.exit_code
+    finally:
+        channel.detach()
+        if handle is not None:
+            handle.join()
+        uninstall()
+        root_logger.removeHandler(log_handler)
+        log_handler.close()
+        try:
+            log_fh.close()
+        except OSError:
+            pass
+        sys.stdout.write(ANSI_RESTORE)
+        sys.stdout.flush()
+
+
+def _plain_fallback(handle: OrchestratorHandle, run_dir: Path) -> int:
+    """TUI died: stream the run's events as plain lines until done."""
+    renderer = UIBackedRenderer(PlainUI(no_color=True))
+    tailer = RunTailer(run_dir)
+    while True:
+        for event in tailer.poll_events():
+            renderer.handle(event)
+        if handle.done():
+            for event in tailer.poll_events():  # final drain
+                renderer.handle(event)
+            return handle.exit_code
+        time.sleep(0.5)

--- a/ralph_py/tui/embed.py
+++ b/ralph_py/tui/embed.py
@@ -48,6 +48,27 @@ if TYPE_CHECKING:
 ANSI_RESTORE = "\x1b[?1049l\x1b[?25h\x1b[0m"
 
 
+def _install_exclusive_root_handler(
+    root_logger: logging.Logger, handler: logging.Handler,
+) -> list[logging.Handler]:
+    """Route root-logger output only to ``handler`` until restored."""
+    previous = list(root_logger.handlers)
+    for existing in previous:
+        root_logger.removeHandler(existing)
+    root_logger.addHandler(handler)
+    return previous
+
+
+def _restore_root_handlers(
+    root_logger: logging.Logger,
+    handler: logging.Handler,
+    previous: list[logging.Handler],
+) -> None:
+    root_logger.removeHandler(handler)
+    for existing in previous:
+        root_logger.addHandler(existing)
+
+
 def run_factory_embedded(
     manifest: Manifest,
     factory_config: FactoryConfig,
@@ -79,7 +100,9 @@ def run_factory_embedded(
     log_handler = logging.FileHandler(
         run_paths.root / "orchestrator.log", encoding="utf-8",
     )
-    root_logger.addHandler(log_handler)
+    previous_log_handlers = _install_exclusive_root_handler(
+        root_logger, log_handler,
+    )
 
     uninstall = install_signal_handlers(stop)
     handle: OrchestratorHandle | None = None
@@ -115,7 +138,9 @@ def run_factory_embedded(
         if handle is not None:
             handle.join()
         uninstall()
-        root_logger.removeHandler(log_handler)
+        _restore_root_handlers(
+            root_logger, log_handler, previous_log_handlers,
+        )
         log_handler.close()
         try:
             log_fh.close()
@@ -130,10 +155,10 @@ def _plain_fallback(handle: OrchestratorHandle, run_dir: Path) -> int:
     renderer = UIBackedRenderer(PlainUI(no_color=True))
     tailer = RunTailer(run_dir)
     while True:
-        for event in tailer.poll_events():
+        for event in tailer.poll_events().events:
             renderer.handle(event)
         if handle.done():
-            for event in tailer.poll_events():  # final drain
+            for event in tailer.poll_events().events:  # final drain
                 renderer.handle(event)
             return handle.exit_code
         time.sleep(0.5)

--- a/ralph_py/tui/screens/checkpoint.py
+++ b/ralph_py/tui/screens/checkpoint.py
@@ -10,7 +10,7 @@ never opens it.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
 from rich.text import Text
 from textual.app import ComposeResult
@@ -45,6 +45,9 @@ class CheckpointModal(ModalScreen[int | None]):
         Binding("a", "decide(0)", "Approve"),
         Binding("r", "decide(1)", "Reject"),
         Binding("t", "decide(2)", "Retry"),
+        Binding("1", "decide(0)", show=False),
+        Binding("2", "decide(1)", show=False),
+        Binding("3", "decide(2)", show=False),
         Binding("escape", "leave_pending", "Later"),
     ]
 
@@ -91,18 +94,33 @@ class CheckpointModal(ModalScreen[int | None]):
                         diff_text.append("  (no diff captured)\n", style="dim")
                     yield Static(diff_text)
             with Horizontal(id="checkpoint-buttons"):
-                yield Button("Approve (a)", id="approve", variant="success")
-                yield Button("Reject (r)", id="reject", variant="error")
-                yield Button("Retry (t)", id="retry", variant="warning")
+                variants = ("success", "error", "warning")
+                for index, option in enumerate(self.request.options):
+                    yield Button(
+                        f"{option} ({index + 1})",
+                        id=f"choice-{index}",
+                        variant=cast(
+                            Literal[
+                                "default", "primary", "success", "warning",
+                                "error",
+                            ],
+                            variants[min(index, len(variants) - 1)],
+                        ),
+                    )
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        choices = {"approve": 0, "reject": 1, "retry": 2}
-        choice = choices.get(event.button.id or "")
-        if choice is not None:
-            self.dismiss(choice)
+        button_id = event.button.id or ""
+        if not button_id.startswith("choice-"):
+            return
+        try:
+            choice = int(button_id.removeprefix("choice-"))
+        except ValueError:
+            return
+        self.action_decide(choice)
 
     def action_decide(self, choice: int) -> None:
-        self.dismiss(choice)
+        if 0 <= choice < len(self.request.options):
+            self.dismiss(choice)
 
     def action_leave_pending(self) -> None:
         self.dismiss(None)

--- a/ralph_py/tui/screens/quit.py
+++ b/ralph_py/tui/screens/quit.py
@@ -1,0 +1,39 @@
+"""Quit confirmation for embedded mode (stage 3 PR F)."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label
+
+
+class QuitModal(ModalScreen[bool]):
+    BINDINGS = [
+        Binding("y", "confirm", "Stop run"),
+        Binding("n", "keep", "Keep running"),
+        Binding("escape", "keep", show=False),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="quit-dialog"):
+            yield Label("Stop the run?", id="quit-question")
+            yield Label(
+                "In-flight agents will be group-killed, worktrees "
+                "cleaned, the manifest flushed; the run exits 130. "
+                "Press q again after confirming to force-kill.",
+                id="quit-detail",
+            )
+            with Horizontal(id="quit-buttons"):
+                yield Button("Stop (y)", id="stop", variant="error")
+                yield Button("Keep running (n)", id="keep", variant="primary")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "stop")
+
+    def action_confirm(self) -> None:
+        self.dismiss(True)
+
+    def action_keep(self) -> None:
+        self.dismiss(False)

--- a/ralph_py/tui/styles.tcss
+++ b/ralph_py/tui/styles.tcss
@@ -99,3 +99,35 @@ CheckpointModal {
 #checkpoint-buttons Button {
     margin: 0 2;
 }
+
+/* Quit confirmation (PR F). */
+
+QuitModal {
+    align: center middle;
+}
+
+#quit-dialog {
+    width: 64;
+    height: auto;
+    border: thick $error;
+    background: $surface;
+    padding: 1 2;
+}
+
+#quit-question {
+    text-style: bold;
+}
+
+#quit-detail {
+    color: $text-muted;
+    margin-bottom: 1;
+}
+
+#quit-buttons {
+    height: 3;
+    align-horizontal: center;
+}
+
+#quit-buttons Button {
+    margin: 0 2;
+}

--- a/tests/test_tui_embed.py
+++ b/tests/test_tui_embed.py
@@ -3,6 +3,8 @@ quit flow, notify capture."""
 
 from __future__ import annotations
 
+import io
+import logging
 import subprocess
 import threading
 import time
@@ -22,6 +24,11 @@ from ralph_py.observability import NotifyConfig, NotifyHooks
 from ralph_py.shutdown import StopController
 from ralph_py.tui.app import Mode, RalphTuiApp
 from ralph_py.tui.bridge import OrchestratorHandle, start_orchestrator
+from ralph_py.tui.embed import (
+    _install_exclusive_root_handler,
+    _plain_fallback,
+    _restore_root_handlers,
+)
 from ralph_py.tui.screens.checkpoint import CheckpointModal
 from ralph_py.tui.screens.quit import QuitModal
 
@@ -231,6 +238,67 @@ class TestEmbeddedApp:
                 await pilot.pause(0.05)
                 assert time.monotonic() < deadline
         assert decisions == [2]
+
+    async def test_generic_prompt_uses_request_labels_and_valid_choices(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = _write_minimal_run(tmp_path, "factory-20260720-generic")
+        app = RalphTuiApp(
+            run_dir=run_dir, root_dir=tmp_path, mode=Mode.DASH,
+            poll_interval=0.05,
+        )
+        request = PromptRequest(
+            kind=PromptKind.ITERATION,
+            header="Iteration complete. What next?",
+            options=("Continue", "Quit"),
+        )
+        results: list[int | None] = []
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            app.push_screen(CheckpointModal(request), results.append)
+            await pilot.pause()
+            labels = [button.label.plain for button in app.screen.query("Button")]
+            assert labels == ["Continue (1)", "Quit (2)"]
+            await pilot.press("t")
+            await pilot.pause()
+            assert isinstance(app.screen, CheckpointModal)
+            await pilot.press("2")
+            await pilot.pause()
+
+        assert results == [1]
+
+
+class TestFallbackAndLogging:
+    def test_plain_fallback_accepts_tailer_chunks(self, tmp_path: Path) -> None:
+        run_dir = _write_minimal_run(tmp_path, "factory-20260720-fallback")
+        result = FactoryResult()
+        result.exit_code = 7
+        thread = threading.Thread(target=lambda: None)
+        thread.start()
+        thread.join()
+        handle = OrchestratorHandle(
+            thread=thread, stop=StopController(), result_box=[result],
+        )
+
+        assert _plain_fallback(handle, run_dir) == 7
+
+    def test_root_logging_is_exclusive_and_restored(self) -> None:
+        logger = logging.Logger("embed-test")
+        old_stream = io.StringIO()
+        tui_stream = io.StringIO()
+        old_handler = logging.StreamHandler(old_stream)
+        tui_handler = logging.StreamHandler(tui_stream)
+        logger.addHandler(old_handler)
+
+        previous = _install_exclusive_root_handler(logger, tui_handler)
+        logger.warning("during tui")
+        _restore_root_handlers(logger, tui_handler, previous)
+        logger.warning("after tui")
+
+        assert "during tui" not in old_stream.getvalue()
+        assert "after tui" in old_stream.getvalue()
+        assert "during tui" in tui_stream.getvalue()
+        assert "after tui" not in tui_stream.getvalue()
 
 
 class TestNotifyCapture:

--- a/tests/test_tui_embed.py
+++ b/tests/test_tui_embed.py
@@ -1,0 +1,266 @@
+"""Stage 3 PR F (TUI rewrite): embedded mode - bridge, modal answering,
+quit flow, notify capture."""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from ralph_py import events as ev
+from ralph_py.factory import FactoryResult
+from ralph_py.interaction import (
+    CheckpointContext,
+    PromptKind,
+    PromptRequest,
+    QueueInteractionChannel,
+)
+from ralph_py.observability import NotifyConfig, NotifyHooks
+from ralph_py.shutdown import StopController
+from ralph_py.tui.app import Mode, RalphTuiApp
+from ralph_py.tui.bridge import OrchestratorHandle, start_orchestrator
+from ralph_py.tui.screens.checkpoint import CheckpointModal
+from ralph_py.tui.screens.quit import QuitModal
+
+
+def _write_minimal_run(root: Path, run_id: str) -> Path:
+    paths = ev.RunPaths.for_run(root, run_id)
+    bus = ev.EventBus(ev.JsonlSink(paths.events_file), run_id=run_id)
+    bus.emit(ev.RunStarted(project="embed-test", components=1))
+    bus.emit(ev.ComponentStarted(component="comp-a"))
+    bus.close()
+    return paths.root
+
+
+class TestBridge:
+    def test_start_orchestrator_runs_and_reports(self, tmp_path: Path) -> None:
+        stop = StopController()
+        channel = QueueInteractionChannel()
+        result = FactoryResult()
+        result.exit_code = 0
+
+        with patch(
+            "ralph_py.tui.bridge.run_factory", return_value=result,
+        ) as fake:
+            handle = start_orchestrator(
+                object(), object(), object(), object(),  # type: ignore[arg-type]
+                tmp_path, None,
+                run_id="run-x", stop=stop, channel=channel,
+            )
+            handle.join(timeout=5)
+        assert handle.done()
+        assert handle.exit_code == 0
+        kwargs = fake.call_args.kwargs
+        assert kwargs["run_id"] == "run-x"
+        assert kwargs["interaction"] is channel
+        assert kwargs["stop"] is stop
+        assert kwargs["notify_capture_output"] is True
+
+    def test_orchestrator_exception_lands_in_error_box(
+        self, tmp_path: Path,
+    ) -> None:
+        with patch(
+            "ralph_py.tui.bridge.run_factory",
+            side_effect=RuntimeError("boom"),
+        ):
+            handle = start_orchestrator(
+                object(), object(), object(), object(),  # type: ignore[arg-type]
+                tmp_path, None,
+                run_id="run-x", stop=StopController(),
+                channel=QueueInteractionChannel(),
+            )
+            handle.join(timeout=5)
+        assert handle.done()
+        assert handle.error_box
+        assert handle.exit_code == 1
+
+
+def _fake_orchestrator(
+    channel: QueueInteractionChannel,
+    stop: StopController,
+    decisions: list[int],
+    *,
+    wait_for_stop: bool = False,
+) -> OrchestratorHandle:
+    """A thread standing in for run_factory: optionally asks one
+    checkpoint question, then finishes (or waits for stop)."""
+    result_box: list[FactoryResult] = []
+    error_box: list[BaseException] = []
+
+    def _target() -> None:
+        if decisions is not None and not wait_for_stop:
+            # Real-world semantics: the app attaches on mount; a request
+            # fired before that degrades NOT_PROMPTED. Wait for attach.
+            deadline = time.monotonic() + 5
+            while not channel.can_prompt() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            response = channel.request(PromptRequest(
+                kind=PromptKind.CHECKPOINT,
+                header="Approve PR creation and merge for comp-a?",
+                options=("Approve", "Reject", "Retry"),
+                default=0,
+                component_id="comp-a",
+                checkpoint=CheckpointContext(
+                    component_id="comp-a", diff_excerpt="+x\n",
+                ),
+            ))
+            decisions.append(response.choice if response.answered else -1)
+        if wait_for_stop:
+            stop.wait(timeout=30)
+        result = FactoryResult()
+        result.exit_code = 130 if stop.is_set() else 0
+        result_box.append(result)
+
+    thread = threading.Thread(target=_target, daemon=False)
+    handle = OrchestratorHandle(
+        thread=thread, stop=stop,
+        result_box=result_box, error_box=error_box,
+    )
+    thread.start()
+    return handle
+
+
+class TestEmbeddedApp:
+    async def test_checkpoint_modal_answers_the_channel(
+        self, tmp_path: Path,
+    ) -> None:
+        """The full bridge loop: orchestrator thread blocks on the
+        channel -> call_from_thread opens the modal -> keypress
+        resolves -> orchestrator unblocks with the choice -> app exits
+        with the run's code."""
+        run_dir = _write_minimal_run(tmp_path, "factory-20260720-embed1")
+        channel = QueueInteractionChannel()
+        stop = StopController()
+        decisions: list[int] = []
+        handle = _fake_orchestrator(channel, stop, decisions)
+        app = RalphTuiApp(
+            run_dir=run_dir, root_dir=tmp_path, mode=Mode.EMBEDDED,
+            poll_interval=0.05, channel=channel, orchestrator=handle,
+        )
+        async with app.run_test(size=(120, 40)) as pilot:
+            deadline = time.monotonic() + 5
+            while not isinstance(app.screen, CheckpointModal):
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline, "modal never opened"
+            await pilot.press("a")
+            deadline = time.monotonic() + 5
+            while not handle.done():
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline, "orchestrator stuck"
+            await pilot.pause(0.6)  # _check_orchestrator interval
+        assert decisions == [0]
+        assert app.return_value == 0
+
+    async def test_quit_flow_requests_graceful_stop(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = _write_minimal_run(tmp_path, "factory-20260720-embed2")
+        channel = QueueInteractionChannel()
+        stop = StopController()
+        handle = _fake_orchestrator(channel, stop, [], wait_for_stop=True)
+        app = RalphTuiApp(
+            run_dir=run_dir, root_dir=tmp_path, mode=Mode.EMBEDDED,
+            poll_interval=0.05, channel=channel, orchestrator=handle,
+        )
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("q")
+            await pilot.pause()
+            assert isinstance(app.screen, QuitModal)
+            await pilot.press("y")
+            deadline = time.monotonic() + 5
+            while not handle.done():
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline
+            await pilot.pause(0.6)
+        assert stop.is_set()
+        assert "TUI" in stop.reason
+        assert app.return_value == 130
+        handle.join(timeout=2)
+
+    async def test_quit_declined_keeps_running(self, tmp_path: Path) -> None:
+        run_dir = _write_minimal_run(tmp_path, "factory-20260720-embed3")
+        channel = QueueInteractionChannel()
+        stop = StopController()
+        handle = _fake_orchestrator(channel, stop, [], wait_for_stop=True)
+        app = RalphTuiApp(
+            run_dir=run_dir, root_dir=tmp_path, mode=Mode.EMBEDDED,
+            poll_interval=0.05, channel=channel, orchestrator=handle,
+        )
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("q")
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            assert not stop.is_set()
+            assert not handle.done()
+            # Now actually stop so the thread does not leak.
+            stop.request("test cleanup")
+        handle.join(timeout=5)
+
+    async def test_pending_checkpoint_reopens_with_c(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = _write_minimal_run(tmp_path, "factory-20260720-embed4")
+        channel = QueueInteractionChannel()
+        stop = StopController()
+        decisions: list[int] = []
+        handle = _fake_orchestrator(channel, stop, decisions)
+        app = RalphTuiApp(
+            run_dir=run_dir, root_dir=tmp_path, mode=Mode.EMBEDDED,
+            poll_interval=0.05, channel=channel, orchestrator=handle,
+        )
+        async with app.run_test(size=(120, 40)) as pilot:
+            deadline = time.monotonic() + 5
+            while not isinstance(app.screen, CheckpointModal):
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline
+            await pilot.press("escape")  # leave pending
+            await pilot.pause()
+            assert not handle.done()  # orchestrator still blocked
+            await pilot.press("c")  # reopen
+            await pilot.pause()
+            assert isinstance(app.screen, CheckpointModal)
+            await pilot.press("t")  # retry
+            deadline = time.monotonic() + 5
+            while not handle.done():
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline
+        assert decisions == [2]
+
+
+class TestNotifyCapture:
+    def test_captured_hook_writes_nothing_to_terminal(
+        self, capfd: Any,
+    ) -> None:
+        hooks = NotifyHooks(
+            NotifyConfig(on_complete="echo HOOK-NOISE"),
+            run_id="r", project="p", capture_output=True,
+        )
+        hooks.fire_complete("done")
+        out, err = capfd.readouterr()
+        assert "HOOK-NOISE" not in out
+        assert "HOOK-NOISE" not in err
+
+    def test_default_keeps_terminal_bell_path(self, capfd: Any) -> None:
+        hooks = NotifyHooks(
+            NotifyConfig(on_complete="echo HOOK-RINGS"),
+            run_id="r", project="p",
+        )
+        hooks.fire_complete("done")
+        out, _ = capfd.readouterr()
+        assert "HOOK-RINGS" in out
+
+    def test_subprocess_module_is_what_fire_uses(self) -> None:
+        # Guard against the sink accidentally applying to DEVNULL stdin
+        # only; the spike measured fd-level leakage, so stdout/stderr
+        # must be the captured pair.
+        import inspect
+
+        src = inspect.getsource(NotifyHooks._fire)
+        assert "stdout=sink" in src and "stderr=sink" in src
+        assert subprocess.DEVNULL  # imported, used above


### PR DESCRIPTION
## Summary

Stage 3 PR F of the TUI rewrite plan (stacked on #117). The integration PR: `ralph factory` on a TTY runs the dashboard, and the E6 checkpoint modal actually answers the run.

- `tui/bridge.py`: `OrchestratorHandle` + `start_orchestrator` - `run_factory` on a non-daemon thread with result/error boxes; passes `interaction`/`stop`/`run_id`/`notify_capture_output=True`.
- `tui/embed.py`: the full sequence, each step tied to a spike finding - pre-minted run id, orchestrator narration to `orchestrator.log` via the standard console stack (file sinks attach to the same bus), root-logger FileHandler + captured notify hooks (measured alt-screen corruption), signal handlers before `app.run()`, **TUI tails the same files as dash** (one data path), plain-stream fallback on TUI crash, channel detach + join + ANSI restore in `finally`.
- App EMBEDDED mode: checkpoint modal resolves the queue channel (blocked orchestrator proceeds with the human's choice); Esc leaves pending with `c` to reopen; `q` -> QuitModal -> graceful stop via PR B (second `q` forces); exits with the orchestrator's code when it finishes.
- **Race found by the tests, fixed properly**: the channel attaches in `App.on_mount`, not before `app.run()` - an early checkpoint degrades to NOT_PROMPTED (exactly non-TTY semantics) instead of crashing `call_from_thread`.
- cli: `--tui/--no-tui` (auto: both stdio TTYs + `--ui` not plain + `RALPH_NO_TUI` unset); `NotifyHooks(capture_output=)`.

## Tests (+9)

Bridge result/error propagation with kwarg assertions; the full **modal-answers-channel** loop (real threads, real blocking request, Pilot keypress, orchestrator unblocked with choice, app exit code); quit confirm -> stop.reason + 130; quit declined -> still running; Esc-then-`c` reopen -> retry decision; notify capture on/off via capfd plus a source guard that stdout/stderr are the captured pair.

Gates: fast 1655 passed, spine 25 passed, `mypy --strict` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)