### PR TITLE
TUI PR G: polish, animation retirement, snapshots, docs

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -27,6 +27,7 @@ Precedence: **CLI flag > env var > `ralph.toml` > dataclass default**.
 | `RALPH_TIMEOUT_COMPONENT` | float | 7200 | Per-component total timeout |
 | `RALPH_TIMEOUT_DEFAULT` | float | 60 | Generic subprocess timeout |
 | `RALPH_UI` | str | auto | `auto\|rich\|plain` |
+| `RALPH_NO_TUI` | bool | unset | `1` disables the embedded factory dashboard (plain output) |
 | `NO_COLOR` | bool flag | false | Disables colors |
 | `RALPH_ASCII` | bool | false | ASCII-only UI |
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -108,8 +108,9 @@ If `ReviewResult.infrastructure_error=True`, the reviewer agent itself failed (t
 ## The dashboard (TUI)
 
 `ralph factory` on a terminal runs the embedded dashboard by default
-(`--no-tui`, `--ui plain`, or `RALPH_NO_TUI=1` opt out; non-TTY stdio
-always falls back to plain output). `ralph dash` attaches a read-only
+(`--no-tui`, `--ui plain`, or `RALPH_NO_TUI=1` opt out; automatic
+selection uses plain output for non-TTY stdio, while explicit `--tui`
+requires a terminal). `ralph dash` attaches a read-only
 dashboard to a live run from another terminal, or replays a finished
 one (`--run-id` takes a unique prefix; newest run is the default).
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -105,11 +105,47 @@ If `ReviewResult.infrastructure_error=True`, the reviewer agent itself failed (t
 
 **Resolve**: either revert the prompt change or update the fixture's `must_detect` if the change deliberately narrowed scope. Do not just unskip the test — a calibration regression is the signal you wrote the system to produce.
 
+## The dashboard (TUI)
+
+`ralph factory` on a terminal runs the embedded dashboard by default
+(`--no-tui`, `--ui plain`, or `RALPH_NO_TUI=1` opt out; non-TTY stdio
+always falls back to plain output). `ralph dash` attaches a read-only
+dashboard to a live run from another terminal, or replays a finished
+one (`--run-id` takes a unique prefix; newest run is the default).
+
+Keys: `enter` opens a component's detail (phase timeline, findings,
+live transcript, evidence paths), `escape` returns, `f` toggles
+transcript follow, `c` reopens a pending E6 checkpoint, `q` quits.
+
+Quit semantics differ by mode. In `ralph dash`, `q` detaches
+immediately - the run is not yours to stop. Embedded, `q` asks first:
+confirming group-kills in-flight agents, runs the worktree cleanup
+pass, flushes the manifest, and exits 130; a second `q` (or second
+Ctrl-C) force-kills. This is also what Ctrl-C now does in plain mode -
+the pre-TUI behavior (skipped cleanup, orphaned agents) was a bug,
+fixed in the same rewrite.
+
+The E6 checkpoint modal shows the diff excerpt, review + security
+findings, and the attempt's spend; approve/reject/retry with
+`a`/`r`/`t`, or `escape` to leave it pending (the run stays blocked -
+that is what a checkpoint is - and the banner points back at it).
+
+Tradeoff to know: in embedded mode, notify hooks run with their
+output captured (a hook writing to the terminal would corrupt the
+alt screen - measured in the Stage 0 spike), so a `printf '\a'`
+terminal bell only rings in plain mode. Everything the dashboard
+shows also exists on disk: `.ralph/runs/<run_id>/events.jsonl`
+(schema-v2 event stream), `components/<id>/engineer.log` (agent
+transcripts), `components/<id>/{review,security,distill}.log` (phase
+transcripts), and `orchestrator.log` (embedded-mode narration). When
+a run breaks, those files are the record; the TUI is only a view.
+
 ## Where to find things
 
 - Tracker for the hardening roadmap: `docs/adversarial-roadmap.md`
 - Adversarial design overview: `docs/adversarial-design.md`
 - Env-var reference: `docs/env-vars.md`
 - Per-run captures: `.ralph/evolution.jsonl`, `.ralph/experiments.tsv`
+- Run event stream + transcripts: `.ralph/runs/<run_id>/`
 - Distillation debug dumps: `.ralph/knowledge/<comp>/<run>/_distill_raw.txt` (on failure)
 - Phase F sample real-world run log: `docs/phase-f-run-log.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     # The sdk extra is part of the dev set so the R7.6 unit tests and
     # mypy always exercise the adapter+runner.
     "claude-agent-sdk>=0.2.123,<0.3",
+    "pytest-textual-snapshot>=1.0.0",
 ]
 
 [build-system]

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -2682,7 +2682,7 @@ def status(
             and not watch
         ):
             ui_impl.info("")
-            ui_impl.info("Live view: ralph dash")
+            ui_impl.info("Dashboard: ralph dash")
         return 0
 
     if not watch:

--- a/ralph_py/cli.py
+++ b/ralph_py/cli.py
@@ -2646,6 +2646,13 @@ def status(
             state=state, source_path=source_path,
             root_dir=root_dir,
         )
+        if (
+            source_path is not None
+            and source_path.name == "events.jsonl"
+            and not watch
+        ):
+            ui_impl.info("")
+            ui_impl.info("Live view: ralph dash")
         return 0
 
     if not watch:

--- a/ralph_py/tui/app.py
+++ b/ralph_py/tui/app.py
@@ -108,7 +108,10 @@ class RalphTuiApp(App[int]):
         if chunk.truncated:
             self.store.reset()
         changed = self.store.apply_events(chunk.events)
-        screen = self.screen
+        screen_stack = self.screen_stack
+        if not screen_stack:
+            return
+        screen = screen_stack[-1]
         if changed:
             if isinstance(screen, ComponentScreen) and screen.ready:
                 screen.refresh_state(self.store.state, self.store.manifest())
@@ -131,7 +134,10 @@ class RalphTuiApp(App[int]):
         return tailer
 
     def _tick_ages(self) -> None:
-        screen = self.screen
+        screen_stack = self.screen_stack
+        if not screen_stack:
+            return
+        screen = screen_stack[-1]
         if isinstance(screen, OverviewScreen):
             screen.tick_ages(self.store.state)
 

--- a/ralph_py/ui/animated_art.py
+++ b/ralph_py/ui/animated_art.py
@@ -1,100 +1,17 @@
-"""Animated ASCII art for Ralph UI."""
+"""Static brand mark for Ralph (PR G).
+
+The 24fps Lissajous loop animation retired with the TUI rewrite: the
+spike set 24fps as the ceiling, not the norm, and a blocking
+1-second-plus Live animation on every `ralph run` start earns its
+keep worse than a one-line mark. `brand_mark()` is the identity that
+remains; the dashboard's identity is the dashboard itself.
+"""
+
 from __future__ import annotations
 
-import math
-from collections.abc import Iterable
-
-from rich.text import Text
-
-LARGE_ACCENT = "o"
-LARGE_ACCENT_SECONDARY = "O"
-LARGE_PRIMARY = "."
-LARGE_SECONDARY = ":"
+BRAND_MARK = "\u25cd ralph"
 
 
-def _lissajous_points(
-    center_x: int,
-    center_y: int,
-    amp_x: float,
-    amp_y: float,
-    steps: int,
-    a: int = 1,
-    b: int = 2,
-    phase: float = 0.0,
-) -> list[tuple[int, int]]:
-    points: list[tuple[int, int]] = []
-    for idx in range(steps):
-        t = (2 * math.pi * idx) / steps
-        x = int(round(center_x + math.sin(a * t + phase) * amp_x))
-        y = int(round(center_y + math.sin(b * t) * amp_y))
-        points.append((x, y))
-    return points
-
-
-def build_loop_frames(width: int = 31, height: int = 11, steps: int = 48) -> list[list[str]]:
-    """Build abstract loop frames with orbiting highlights."""
-    center_x = width // 2
-    center_y = height // 2
-    outer = _lissajous_points(center_x, center_y, width * 0.4, height * 0.32, steps)
-    inner = _lissajous_points(
-        center_x,
-        center_y,
-        width * 0.23,
-        height * 0.18,
-        steps,
-        phase=math.pi / 2,
-    )
-
-    base_grid = [[" " for _ in range(width)] for _ in range(height)]
-    for x, y in set(outer):
-        if 0 <= y < height and 0 <= x < width:
-            base_grid[y][x] = LARGE_PRIMARY
-    for x, y in set(inner):
-        if 0 <= y < height and 0 <= x < width:
-            if base_grid[y][x] == " ":
-                base_grid[y][x] = LARGE_SECONDARY
-
-    frames: list[list[str]] = []
-    for idx in range(steps):
-        grid = [row[:] for row in base_grid]
-        outer_point = outer[idx % len(outer)]
-        inner_point = inner[(idx * 2) % len(inner)]
-        outer_trail = outer[(idx - 2) % len(outer)]
-        inner_trail = inner[(idx * 2 - 2) % len(inner)]
-        grid[outer_trail[1]][outer_trail[0]] = LARGE_SECONDARY
-        grid[inner_trail[1]][inner_trail[0]] = LARGE_SECONDARY
-        grid[outer_point[1]][outer_point[0]] = LARGE_ACCENT
-        grid[inner_point[1]][inner_point[0]] = LARGE_ACCENT_SECONDARY
-        frames.append(["".join(row) for row in grid])
-    return frames
-
-
-def render_loop_frame(lines: Iterable[str]) -> Text:
-    """Render a loop frame into styled Rich text."""
-    text = Text()
-    for line in lines:
-        for ch in line:
-            if ch == LARGE_ACCENT:
-                text.append(ch, style="bold cyan")
-            elif ch == LARGE_ACCENT_SECONDARY:
-                text.append(ch, style="bold white")
-            elif ch.isalpha():
-                text.append(ch, style="bold white")
-            elif ch == LARGE_PRIMARY:
-                text.append(ch, style="dim")
-            elif ch == LARGE_SECONDARY:
-                text.append(ch, style="dim")
-            elif ch.strip():
-                text.append(ch, style="dim")
-            else:
-                text.append(ch)
-        text.append("\n")
-    if text:
-        text.rstrip()
-    return text
-
-
-def large_loop_frames() -> list[Text]:
-    """Return rendered large loop frames."""
-    raw_frames = build_loop_frames()
-    return [render_loop_frame(frame) for frame in raw_frames]
+def brand_mark() -> str:
+    """One-line static mark, printed once at startup on rich TTYs."""
+    return BRAND_MARK

--- a/ralph_py/ui/rich_ui.py
+++ b/ralph_py/ui/rich_ui.py
@@ -3,14 +3,9 @@
 from __future__ import annotations
 
 import sys
-import time
 from typing import TYPE_CHECKING
 
-from rich import box
-from rich.align import Align
 from rich.console import Console
-from rich.live import Live
-from rich.panel import Panel
 from rich.prompt import Prompt
 from rich.text import Text
 
@@ -115,38 +110,15 @@ class RichUI:
         self.console.print()
 
     def startup_art(self) -> None:
-        """Display startup animation."""
+        """Print the static brand mark once (PR G: the 24fps Live
+        animation retired - a blocking intro loop on every start earns
+        its keep worse than one line; spike RESULTS.md set 24fps as the
+        ceiling, not the norm)."""
         if not self._animations_enabled():
             return
-        frames = animated_art.large_loop_frames()
-        if not frames:
-            return
-        delay = 1 / 24
-        panel = Panel(
-            "",
-            title=Text("Ralph", style="bold"),
-            subtitle=Text("agentic loop", style="dim"),
-            border_style="dim",
-            box=box.SQUARE,
-            padding=(1, 2),
-            expand=False,
+        self.console.print(
+            Text(animated_art.brand_mark(), style="bold"), justify="center",
         )
-        try:
-            with Live(panel, console=self.console, refresh_per_second=24, transient=True) as live:
-                for art in frames:
-                    panel = Panel(
-                        Align.center(art),
-                        title=Text("Ralph", style="bold"),
-                        subtitle=Text("agentic loop", style="dim"),
-                        border_style="dim",
-                        box=box.SQUARE,
-                        padding=(1, 2),
-                        expand=False,
-                    )
-                    live.update(panel, refresh=True)
-                    time.sleep(delay)
-        except Exception:
-            self.console.print(panel)
 
     def section(self, text: str) -> None:
         """Display a section header."""

--- a/tests/__snapshots__/test_tui_snapshots/test_component_detail_snapshot.raw
+++ b/tests/__snapshots__/test_tui_snapshots/test_component_detail_snapshot.raw
@@ -19,191 +19,191 @@
         font-weight: 700;
     }
 
-    .terminal-1876533864-matrix {
+    .terminal-1103601350-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-1876533864-title {
+    .terminal-1103601350-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-1876533864-r1 { fill: #242f38;font-weight: bold }
-.terminal-1876533864-r2 { fill: #e0e0e0;font-weight: bold }
-.terminal-1876533864-r3 { fill: #fd971f }
-.terminal-1876533864-r4 { fill: #a0a3a6 }
-.terminal-1876533864-r5 { fill: #c5c8c6 }
-.terminal-1876533864-r6 { fill: #98e024 }
-.terminal-1876533864-r7 { fill: #999999 }
-.terminal-1876533864-r8 { fill: #242f38 }
-.terminal-1876533864-r9 { fill: #e0e0e0 }
-.terminal-1876533864-r10 { fill: #ddedf9;font-weight: bold }
-.terminal-1876533864-r11 { fill: #704d1c }
-.terminal-1876533864-r12 { fill: #ffa62b;font-weight: bold }
-.terminal-1876533864-r13 { fill: #495259 }
+    .terminal-1103601350-r1 { fill: #242f38;font-weight: bold }
+.terminal-1103601350-r2 { fill: #e0e0e0;font-weight: bold }
+.terminal-1103601350-r3 { fill: #fd971f }
+.terminal-1103601350-r4 { fill: #a0a3a6 }
+.terminal-1103601350-r5 { fill: #c5c8c6 }
+.terminal-1103601350-r6 { fill: #98e024 }
+.terminal-1103601350-r7 { fill: #999999 }
+.terminal-1103601350-r8 { fill: #242f38 }
+.terminal-1103601350-r9 { fill: #e0e0e0 }
+.terminal-1103601350-r10 { fill: #ddedf9;font-weight: bold }
+.terminal-1103601350-r11 { fill: #704d1c }
+.terminal-1103601350-r12 { fill: #ffa62b;font-weight: bold }
+.terminal-1103601350-r13 { fill: #495259 }
     </style>
 
     <defs>
-    <clipPath id="terminal-1876533864-clip-terminal">
+    <clipPath id="terminal-1103601350-clip-terminal">
       <rect x="0" y="0" width="1463.0" height="877.4" />
     </clipPath>
-    <clipPath id="terminal-1876533864-line-0">
+    <clipPath id="terminal-1103601350-line-0">
     <rect x="0" y="1.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-1">
+<clipPath id="terminal-1103601350-line-1">
     <rect x="0" y="25.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-2">
+<clipPath id="terminal-1103601350-line-2">
     <rect x="0" y="50.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-3">
+<clipPath id="terminal-1103601350-line-3">
     <rect x="0" y="74.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-4">
+<clipPath id="terminal-1103601350-line-4">
     <rect x="0" y="99.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-5">
+<clipPath id="terminal-1103601350-line-5">
     <rect x="0" y="123.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-6">
+<clipPath id="terminal-1103601350-line-6">
     <rect x="0" y="147.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-7">
+<clipPath id="terminal-1103601350-line-7">
     <rect x="0" y="172.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-8">
+<clipPath id="terminal-1103601350-line-8">
     <rect x="0" y="196.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-9">
+<clipPath id="terminal-1103601350-line-9">
     <rect x="0" y="221.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-10">
+<clipPath id="terminal-1103601350-line-10">
     <rect x="0" y="245.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-11">
+<clipPath id="terminal-1103601350-line-11">
     <rect x="0" y="269.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-12">
+<clipPath id="terminal-1103601350-line-12">
     <rect x="0" y="294.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-13">
+<clipPath id="terminal-1103601350-line-13">
     <rect x="0" y="318.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-14">
+<clipPath id="terminal-1103601350-line-14">
     <rect x="0" y="343.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-15">
+<clipPath id="terminal-1103601350-line-15">
     <rect x="0" y="367.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-16">
+<clipPath id="terminal-1103601350-line-16">
     <rect x="0" y="391.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-17">
+<clipPath id="terminal-1103601350-line-17">
     <rect x="0" y="416.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-18">
+<clipPath id="terminal-1103601350-line-18">
     <rect x="0" y="440.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-19">
+<clipPath id="terminal-1103601350-line-19">
     <rect x="0" y="465.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-20">
+<clipPath id="terminal-1103601350-line-20">
     <rect x="0" y="489.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-21">
+<clipPath id="terminal-1103601350-line-21">
     <rect x="0" y="513.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-22">
+<clipPath id="terminal-1103601350-line-22">
     <rect x="0" y="538.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-23">
+<clipPath id="terminal-1103601350-line-23">
     <rect x="0" y="562.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-24">
+<clipPath id="terminal-1103601350-line-24">
     <rect x="0" y="587.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-25">
+<clipPath id="terminal-1103601350-line-25">
     <rect x="0" y="611.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-26">
+<clipPath id="terminal-1103601350-line-26">
     <rect x="0" y="635.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-27">
+<clipPath id="terminal-1103601350-line-27">
     <rect x="0" y="660.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-28">
+<clipPath id="terminal-1103601350-line-28">
     <rect x="0" y="684.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-29">
+<clipPath id="terminal-1103601350-line-29">
     <rect x="0" y="709.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-30">
+<clipPath id="terminal-1103601350-line-30">
     <rect x="0" y="733.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-31">
+<clipPath id="terminal-1103601350-line-31">
     <rect x="0" y="757.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-32">
+<clipPath id="terminal-1103601350-line-32">
     <rect x="0" y="782.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-33">
+<clipPath id="terminal-1103601350-line-33">
     <rect x="0" y="806.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1876533864-line-34">
+<clipPath id="terminal-1103601350-line-34">
     <rect x="0" y="831.1" width="1464" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="926.4" rx="8"/><text class="terminal-1876533864-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">ralph</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="926.4" rx="8"/><text class="terminal-1103601350-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">ralph</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-1876533864-clip-terminal)">
-    <rect fill="#e0e0e0" x="0" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="97.6" y="1.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="256.2" y="1.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="390.4" y="1.5" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="561.2" y="1.5" width="902.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="12.2" y="25.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="134.2" y="25.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="183" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="256.2" y="25.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="353.8" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="390.4" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="463.6" y="25.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="561.2" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="597.8" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="671" y="25.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="793" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="25.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1049.2" y="25.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="0" y="74.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="97.6" y="74.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="219.6" y="74.7" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="390.4" y="74.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="671" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="756.4" y="74.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2b3339" x="817.4" y="74.7" width="646.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="0" y="99.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="97.6" y="99.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="219.6" y="99.1" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="390.4" y="99.1" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="671" y="99.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="756.4" y="99.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="817.4" y="99.1" width="646.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="587.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="587.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="611.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="635.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="660.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="684.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="709.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="709.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="733.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="733.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="757.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="757.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="782.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="782.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="806.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="806.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="831.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="12.2" y="831.1" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="158.6" y="831.1" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="597.8" y="831.1" width="866.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="855.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="61" y="855.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="122" y="855.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="158.6" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="244" y="855.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="280.6" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="366" y="855.5" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1317.6" y="855.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1329.8" y="855.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1354.2" y="855.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1451.8" y="855.5" width="12.2" height="24.65" shape-rendering="crispEdges"/>
-    <g class="terminal-1876533864-matrix">
-    <text class="terminal-1876533864-r1" x="0" y="20" textLength="97.6" clip-path="url(#terminal-1876533864-line-0)">&#160;comp-a&#160;</text><text class="terminal-1876533864-r2" x="97.6" y="20" textLength="158.6" clip-path="url(#terminal-1876533864-line-0)">&#160;&#160;Component&#160;A</text><text class="terminal-1876533864-r3" x="256.2" y="20" textLength="134.2" clip-path="url(#terminal-1876533864-line-0)">&#160;&#160;completed</text><text class="terminal-1876533864-r4" x="390.4" y="20" textLength="170.8" clip-path="url(#terminal-1876533864-line-0)">&#160;&#160;1&#160;finding(s)</text><text class="terminal-1876533864-r5" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-1876533864-line-0)">
-</text><text class="terminal-1876533864-r6" x="12.2" y="44.4" textLength="122" clip-path="url(#terminal-1876533864-line-1)">engineer&#160;✓</text><text class="terminal-1876533864-r7" x="134.2" y="44.4" textLength="48.8" clip-path="url(#terminal-1876533864-line-1)">&#160;25s</text><text class="terminal-1876533864-r7" x="183" y="44.4" textLength="73.2" clip-path="url(#terminal-1876533864-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1876533864-r6" x="256.2" y="44.4" textLength="97.6" clip-path="url(#terminal-1876533864-line-1)">verify&#160;✓</text><text class="terminal-1876533864-r7" x="353.8" y="44.4" textLength="36.6" clip-path="url(#terminal-1876533864-line-1)">&#160;8s</text><text class="terminal-1876533864-r7" x="390.4" y="44.4" textLength="73.2" clip-path="url(#terminal-1876533864-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1876533864-r6" x="463.6" y="44.4" textLength="97.6" clip-path="url(#terminal-1876533864-line-1)">review&#160;✓</text><text class="terminal-1876533864-r7" x="561.2" y="44.4" textLength="36.6" clip-path="url(#terminal-1876533864-line-1)">&#160;8s</text><text class="terminal-1876533864-r7" x="597.8" y="44.4" textLength="73.2" clip-path="url(#terminal-1876533864-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1876533864-r6" x="671" y="44.4" textLength="122" clip-path="url(#terminal-1876533864-line-1)">security&#160;✓</text><text class="terminal-1876533864-r7" x="793" y="44.4" textLength="36.6" clip-path="url(#terminal-1876533864-line-1)">&#160;8s</text><text class="terminal-1876533864-r7" x="829.6" y="44.4" textLength="73.2" clip-path="url(#terminal-1876533864-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1876533864-r6" x="902.8" y="44.4" textLength="109.8" clip-path="url(#terminal-1876533864-line-1)">distill&#160;✓</text><text class="terminal-1876533864-r7" x="1012.6" y="44.4" textLength="36.6" clip-path="url(#terminal-1876533864-line-1)">&#160;8s</text><text class="terminal-1876533864-r5" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-1)">
-</text><text class="terminal-1876533864-r8" x="0" y="68.8" textLength="1464" clip-path="url(#terminal-1876533864-line-2)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1876533864-r5" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-2)">
-</text><text class="terminal-1876533864-r2" x="0" y="93.2" textLength="97.6" clip-path="url(#terminal-1876533864-line-3)">&#160;phase&#160;&#160;</text><text class="terminal-1876533864-r2" x="97.6" y="93.2" textLength="122" clip-path="url(#terminal-1876533864-line-3)">&#160;severity&#160;</text><text class="terminal-1876533864-r2" x="219.6" y="93.2" textLength="170.8" clip-path="url(#terminal-1876533864-line-3)">&#160;category&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1876533864-r2" x="390.4" y="93.2" textLength="280.6" clip-path="url(#terminal-1876533864-line-3)">&#160;location&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1876533864-r2" x="671" y="93.2" textLength="85.4" clip-path="url(#terminal-1876533864-line-3)">&#160;model&#160;</text><text class="terminal-1876533864-r2" x="756.4" y="93.2" textLength="61" clip-path="url(#terminal-1876533864-line-3)">&#160;att&#160;</text><text class="terminal-1876533864-r5" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-3)">
-</text><text class="terminal-1876533864-r10" x="0" y="117.6" textLength="97.6" clip-path="url(#terminal-1876533864-line-4)">&#160;review&#160;</text><text class="terminal-1876533864-r10" x="97.6" y="117.6" textLength="122" clip-path="url(#terminal-1876533864-line-4)">&#160;advisory&#160;</text><text class="terminal-1876533864-r10" x="219.6" y="117.6" textLength="170.8" clip-path="url(#terminal-1876533864-line-4)">&#160;test_quality&#160;</text><text class="terminal-1876533864-r10" x="390.4" y="117.6" textLength="280.6" clip-path="url(#terminal-1876533864-line-4)">&#160;src/comp-a/impl.py:42&#160;</text><text class="terminal-1876533864-r10" x="671" y="117.6" textLength="85.4" clip-path="url(#terminal-1876533864-line-4)">&#160;-&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1876533864-r10" x="756.4" y="117.6" textLength="61" clip-path="url(#terminal-1876533864-line-4)">&#160;1&#160;&#160;&#160;</text><text class="terminal-1876533864-r5" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-4)">
-</text><text class="terminal-1876533864-r11" x="0" y="142" textLength="1464" clip-path="url(#terminal-1876533864-line-5)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1876533864-r5" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-1876533864-line-5)">
-</text><text class="terminal-1876533864-r5" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-6)">
-</text><text class="terminal-1876533864-r5" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-7)">
-</text><text class="terminal-1876533864-r5" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-8)">
-</text><text class="terminal-1876533864-r5" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-9)">
-</text><text class="terminal-1876533864-r5" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-1876533864-line-10)">
-</text><text class="terminal-1876533864-r5" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-11)">
-</text><text class="terminal-1876533864-r5" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-12)">
-</text><text class="terminal-1876533864-r5" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-13)">
-</text><text class="terminal-1876533864-r5" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-14)">
-</text><text class="terminal-1876533864-r5" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-1876533864-line-15)">
-</text><text class="terminal-1876533864-r5" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-16)">
-</text><text class="terminal-1876533864-r5" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-17)">
-</text><text class="terminal-1876533864-r5" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-18)">
-</text><text class="terminal-1876533864-r5" x="1464" y="483.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-19)">
-</text><text class="terminal-1876533864-r5" x="1464" y="508" textLength="12.2" clip-path="url(#terminal-1876533864-line-20)">
-</text><text class="terminal-1876533864-r5" x="1464" y="532.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-21)">
-</text><text class="terminal-1876533864-r5" x="1464" y="556.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-22)">
-</text><text class="terminal-1876533864-r5" x="1464" y="581.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-23)">
-</text><text class="terminal-1876533864-r5" x="1464" y="605.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-24)">
-</text><text class="terminal-1876533864-r5" x="1464" y="630" textLength="12.2" clip-path="url(#terminal-1876533864-line-25)">
-</text><text class="terminal-1876533864-r5" x="1464" y="654.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-26)">
-</text><text class="terminal-1876533864-r5" x="1464" y="678.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-27)">
-</text><text class="terminal-1876533864-r5" x="1464" y="703.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-28)">
-</text><text class="terminal-1876533864-r5" x="1464" y="727.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-29)">
-</text><text class="terminal-1876533864-r5" x="1464" y="752" textLength="12.2" clip-path="url(#terminal-1876533864-line-30)">
-</text><text class="terminal-1876533864-r5" x="1464" y="776.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-31)">
-</text><text class="terminal-1876533864-r5" x="1464" y="800.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-32)">
-</text><text class="terminal-1876533864-r5" x="1464" y="825.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-33)">
-</text><text class="terminal-1876533864-r4" x="12.2" y="849.6" textLength="146.4" clip-path="url(#terminal-1876533864-line-34)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;pr&#160;&#160;</text><text class="terminal-1876533864-r2" x="158.6" y="849.6" textLength="439.2" clip-path="url(#terminal-1876533864-line-34)">https://example.test/pr/100&#160;(merged)</text><text class="terminal-1876533864-r5" x="1464" y="849.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-34)">
-</text><text class="terminal-1876533864-r12" x="0" y="874" textLength="61" clip-path="url(#terminal-1876533864-line-35)">&#160;esc&#160;</text><text class="terminal-1876533864-r9" x="61" y="874" textLength="61" clip-path="url(#terminal-1876533864-line-35)">Back&#160;</text><text class="terminal-1876533864-r12" x="122" y="874" textLength="36.6" clip-path="url(#terminal-1876533864-line-35)">&#160;f&#160;</text><text class="terminal-1876533864-r9" x="158.6" y="874" textLength="85.4" clip-path="url(#terminal-1876533864-line-35)">Follow&#160;</text><text class="terminal-1876533864-r12" x="244" y="874" textLength="36.6" clip-path="url(#terminal-1876533864-line-35)">&#160;q&#160;</text><text class="terminal-1876533864-r9" x="280.6" y="874" textLength="85.4" clip-path="url(#terminal-1876533864-line-35)">Detach&#160;</text><text class="terminal-1876533864-r13" x="1317.6" y="874" textLength="12.2" clip-path="url(#terminal-1876533864-line-35)">▏</text><text class="terminal-1876533864-r12" x="1329.8" y="874" textLength="24.4" clip-path="url(#terminal-1876533864-line-35)">^p</text><text class="terminal-1876533864-r9" x="1354.2" y="874" textLength="97.6" clip-path="url(#terminal-1876533864-line-35)">&#160;palette</text>
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1103601350-clip-terminal)">
+    <rect fill="#e0e0e0" x="0" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="97.6" y="1.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="256.2" y="1.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="390.4" y="1.5" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="561.2" y="1.5" width="902.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="12.2" y="25.9" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="170.8" y="25.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="219.6" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="292.8" y="25.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="427" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="463.6" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="536.8" y="25.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="671" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="707.6" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="780.8" y="25.9" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="939.4" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="976" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1049.2" y="25.9" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1195.6" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1232.2" y="25.9" width="231.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="0" y="74.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="97.6" y="74.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="219.6" y="74.7" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="390.4" y="74.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="671" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="756.4" y="74.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2b3339" x="817.4" y="74.7" width="646.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="0" y="99.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="97.6" y="99.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="219.6" y="99.1" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="390.4" y="99.1" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="671" y="99.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="756.4" y="99.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="817.4" y="99.1" width="646.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="587.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="587.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="611.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="635.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="660.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="684.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="709.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="709.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="733.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="733.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="757.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="757.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="782.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="782.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="806.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="806.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="831.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="12.2" y="831.1" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="158.6" y="831.1" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="597.8" y="831.1" width="866.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="855.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="61" y="855.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="122" y="855.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="158.6" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="244" y="855.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="280.6" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="366" y="855.5" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1317.6" y="855.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1329.8" y="855.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1354.2" y="855.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1451.8" y="855.5" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-1103601350-matrix">
+    <text class="terminal-1103601350-r1" x="0" y="20" textLength="97.6" clip-path="url(#terminal-1103601350-line-0)">&#160;comp-a&#160;</text><text class="terminal-1103601350-r2" x="97.6" y="20" textLength="158.6" clip-path="url(#terminal-1103601350-line-0)">&#160;&#160;Component&#160;A</text><text class="terminal-1103601350-r3" x="256.2" y="20" textLength="134.2" clip-path="url(#terminal-1103601350-line-0)">&#160;&#160;completed</text><text class="terminal-1103601350-r4" x="390.4" y="20" textLength="170.8" clip-path="url(#terminal-1103601350-line-0)">&#160;&#160;1&#160;finding(s)</text><text class="terminal-1103601350-r5" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-1103601350-line-0)">
+</text><text class="terminal-1103601350-r6" x="12.2" y="44.4" textLength="158.6" clip-path="url(#terminal-1103601350-line-1)">engineer&#160;pass</text><text class="terminal-1103601350-r7" x="170.8" y="44.4" textLength="48.8" clip-path="url(#terminal-1103601350-line-1)">&#160;25s</text><text class="terminal-1103601350-r7" x="219.6" y="44.4" textLength="73.2" clip-path="url(#terminal-1103601350-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1103601350-r6" x="292.8" y="44.4" textLength="134.2" clip-path="url(#terminal-1103601350-line-1)">verify&#160;pass</text><text class="terminal-1103601350-r7" x="427" y="44.4" textLength="36.6" clip-path="url(#terminal-1103601350-line-1)">&#160;8s</text><text class="terminal-1103601350-r7" x="463.6" y="44.4" textLength="73.2" clip-path="url(#terminal-1103601350-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1103601350-r6" x="536.8" y="44.4" textLength="134.2" clip-path="url(#terminal-1103601350-line-1)">review&#160;pass</text><text class="terminal-1103601350-r7" x="671" y="44.4" textLength="36.6" clip-path="url(#terminal-1103601350-line-1)">&#160;8s</text><text class="terminal-1103601350-r7" x="707.6" y="44.4" textLength="73.2" clip-path="url(#terminal-1103601350-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1103601350-r6" x="780.8" y="44.4" textLength="158.6" clip-path="url(#terminal-1103601350-line-1)">security&#160;pass</text><text class="terminal-1103601350-r7" x="939.4" y="44.4" textLength="36.6" clip-path="url(#terminal-1103601350-line-1)">&#160;8s</text><text class="terminal-1103601350-r7" x="976" y="44.4" textLength="73.2" clip-path="url(#terminal-1103601350-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1103601350-r6" x="1049.2" y="44.4" textLength="146.4" clip-path="url(#terminal-1103601350-line-1)">distill&#160;pass</text><text class="terminal-1103601350-r7" x="1195.6" y="44.4" textLength="36.6" clip-path="url(#terminal-1103601350-line-1)">&#160;8s</text><text class="terminal-1103601350-r5" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-1103601350-line-1)">
+</text><text class="terminal-1103601350-r8" x="0" y="68.8" textLength="1464" clip-path="url(#terminal-1103601350-line-2)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1103601350-r5" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-1103601350-line-2)">
+</text><text class="terminal-1103601350-r2" x="0" y="93.2" textLength="97.6" clip-path="url(#terminal-1103601350-line-3)">&#160;phase&#160;&#160;</text><text class="terminal-1103601350-r2" x="97.6" y="93.2" textLength="122" clip-path="url(#terminal-1103601350-line-3)">&#160;severity&#160;</text><text class="terminal-1103601350-r2" x="219.6" y="93.2" textLength="170.8" clip-path="url(#terminal-1103601350-line-3)">&#160;category&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1103601350-r2" x="390.4" y="93.2" textLength="280.6" clip-path="url(#terminal-1103601350-line-3)">&#160;location&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1103601350-r2" x="671" y="93.2" textLength="85.4" clip-path="url(#terminal-1103601350-line-3)">&#160;model&#160;</text><text class="terminal-1103601350-r2" x="756.4" y="93.2" textLength="61" clip-path="url(#terminal-1103601350-line-3)">&#160;att&#160;</text><text class="terminal-1103601350-r5" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-1103601350-line-3)">
+</text><text class="terminal-1103601350-r10" x="0" y="117.6" textLength="97.6" clip-path="url(#terminal-1103601350-line-4)">&#160;review&#160;</text><text class="terminal-1103601350-r10" x="97.6" y="117.6" textLength="122" clip-path="url(#terminal-1103601350-line-4)">&#160;advisory&#160;</text><text class="terminal-1103601350-r10" x="219.6" y="117.6" textLength="170.8" clip-path="url(#terminal-1103601350-line-4)">&#160;test_quality&#160;</text><text class="terminal-1103601350-r10" x="390.4" y="117.6" textLength="280.6" clip-path="url(#terminal-1103601350-line-4)">&#160;src/comp-a/impl.py:42&#160;</text><text class="terminal-1103601350-r10" x="671" y="117.6" textLength="85.4" clip-path="url(#terminal-1103601350-line-4)">&#160;-&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1103601350-r10" x="756.4" y="117.6" textLength="61" clip-path="url(#terminal-1103601350-line-4)">&#160;1&#160;&#160;&#160;</text><text class="terminal-1103601350-r5" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-1103601350-line-4)">
+</text><text class="terminal-1103601350-r11" x="0" y="142" textLength="1464" clip-path="url(#terminal-1103601350-line-5)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1103601350-r5" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-1103601350-line-5)">
+</text><text class="terminal-1103601350-r5" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-1103601350-line-6)">
+</text><text class="terminal-1103601350-r5" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-1103601350-line-7)">
+</text><text class="terminal-1103601350-r5" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-1103601350-line-8)">
+</text><text class="terminal-1103601350-r5" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-1103601350-line-9)">
+</text><text class="terminal-1103601350-r5" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-1103601350-line-10)">
+</text><text class="terminal-1103601350-r5" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-1103601350-line-11)">
+</text><text class="terminal-1103601350-r5" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-1103601350-line-12)">
+</text><text class="terminal-1103601350-r5" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-1103601350-line-13)">
+</text><text class="terminal-1103601350-r5" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-1103601350-line-14)">
+</text><text class="terminal-1103601350-r5" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-1103601350-line-15)">
+</text><text class="terminal-1103601350-r5" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-1103601350-line-16)">
+</text><text class="terminal-1103601350-r5" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-1103601350-line-17)">
+</text><text class="terminal-1103601350-r5" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-1103601350-line-18)">
+</text><text class="terminal-1103601350-r5" x="1464" y="483.6" textLength="12.2" clip-path="url(#terminal-1103601350-line-19)">
+</text><text class="terminal-1103601350-r5" x="1464" y="508" textLength="12.2" clip-path="url(#terminal-1103601350-line-20)">
+</text><text class="terminal-1103601350-r5" x="1464" y="532.4" textLength="12.2" clip-path="url(#terminal-1103601350-line-21)">
+</text><text class="terminal-1103601350-r5" x="1464" y="556.8" textLength="12.2" clip-path="url(#terminal-1103601350-line-22)">
+</text><text class="terminal-1103601350-r5" x="1464" y="581.2" textLength="12.2" clip-path="url(#terminal-1103601350-line-23)">
+</text><text class="terminal-1103601350-r5" x="1464" y="605.6" textLength="12.2" clip-path="url(#terminal-1103601350-line-24)">
+</text><text class="terminal-1103601350-r5" x="1464" y="630" textLength="12.2" clip-path="url(#terminal-1103601350-line-25)">
+</text><text class="terminal-1103601350-r5" x="1464" y="654.4" textLength="12.2" clip-path="url(#terminal-1103601350-line-26)">
+</text><text class="terminal-1103601350-r5" x="1464" y="678.8" textLength="12.2" clip-path="url(#terminal-1103601350-line-27)">
+</text><text class="terminal-1103601350-r5" x="1464" y="703.2" textLength="12.2" clip-path="url(#terminal-1103601350-line-28)">
+</text><text class="terminal-1103601350-r5" x="1464" y="727.6" textLength="12.2" clip-path="url(#terminal-1103601350-line-29)">
+</text><text class="terminal-1103601350-r5" x="1464" y="752" textLength="12.2" clip-path="url(#terminal-1103601350-line-30)">
+</text><text class="terminal-1103601350-r5" x="1464" y="776.4" textLength="12.2" clip-path="url(#terminal-1103601350-line-31)">
+</text><text class="terminal-1103601350-r5" x="1464" y="800.8" textLength="12.2" clip-path="url(#terminal-1103601350-line-32)">
+</text><text class="terminal-1103601350-r5" x="1464" y="825.2" textLength="12.2" clip-path="url(#terminal-1103601350-line-33)">
+</text><text class="terminal-1103601350-r4" x="12.2" y="849.6" textLength="146.4" clip-path="url(#terminal-1103601350-line-34)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;pr&#160;&#160;</text><text class="terminal-1103601350-r2" x="158.6" y="849.6" textLength="439.2" clip-path="url(#terminal-1103601350-line-34)">https://example.test/pr/100&#160;(merged)</text><text class="terminal-1103601350-r5" x="1464" y="849.6" textLength="12.2" clip-path="url(#terminal-1103601350-line-34)">
+</text><text class="terminal-1103601350-r12" x="0" y="874" textLength="61" clip-path="url(#terminal-1103601350-line-35)">&#160;esc&#160;</text><text class="terminal-1103601350-r9" x="61" y="874" textLength="61" clip-path="url(#terminal-1103601350-line-35)">Back&#160;</text><text class="terminal-1103601350-r12" x="122" y="874" textLength="36.6" clip-path="url(#terminal-1103601350-line-35)">&#160;f&#160;</text><text class="terminal-1103601350-r9" x="158.6" y="874" textLength="85.4" clip-path="url(#terminal-1103601350-line-35)">Follow&#160;</text><text class="terminal-1103601350-r12" x="244" y="874" textLength="36.6" clip-path="url(#terminal-1103601350-line-35)">&#160;q&#160;</text><text class="terminal-1103601350-r9" x="280.6" y="874" textLength="85.4" clip-path="url(#terminal-1103601350-line-35)">Detach&#160;</text><text class="terminal-1103601350-r13" x="1317.6" y="874" textLength="12.2" clip-path="url(#terminal-1103601350-line-35)">▏</text><text class="terminal-1103601350-r12" x="1329.8" y="874" textLength="24.4" clip-path="url(#terminal-1103601350-line-35)">^p</text><text class="terminal-1103601350-r9" x="1354.2" y="874" textLength="97.6" clip-path="url(#terminal-1103601350-line-35)">&#160;palette</text>
     </g>
     </g>
 </svg>

--- a/tests/__snapshots__/test_tui_snapshots/test_component_detail_snapshot.raw
+++ b/tests/__snapshots__/test_tui_snapshots/test_component_detail_snapshot.raw
@@ -1,0 +1,209 @@
+<svg class="rich-terminal" viewBox="0 0 1482 928.4" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1876533864-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1876533864-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1876533864-r1 { fill: #242f38;font-weight: bold }
+.terminal-1876533864-r2 { fill: #e0e0e0;font-weight: bold }
+.terminal-1876533864-r3 { fill: #fd971f }
+.terminal-1876533864-r4 { fill: #a0a3a6 }
+.terminal-1876533864-r5 { fill: #c5c8c6 }
+.terminal-1876533864-r6 { fill: #98e024 }
+.terminal-1876533864-r7 { fill: #999999 }
+.terminal-1876533864-r8 { fill: #242f38 }
+.terminal-1876533864-r9 { fill: #e0e0e0 }
+.terminal-1876533864-r10 { fill: #ddedf9;font-weight: bold }
+.terminal-1876533864-r11 { fill: #704d1c }
+.terminal-1876533864-r12 { fill: #ffa62b;font-weight: bold }
+.terminal-1876533864-r13 { fill: #495259 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1876533864-clip-terminal">
+      <rect x="0" y="0" width="1463.0" height="877.4" />
+    </clipPath>
+    <clipPath id="terminal-1876533864-line-0">
+    <rect x="0" y="1.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-1">
+    <rect x="0" y="25.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-2">
+    <rect x="0" y="50.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-3">
+    <rect x="0" y="74.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-4">
+    <rect x="0" y="99.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-5">
+    <rect x="0" y="123.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-6">
+    <rect x="0" y="147.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-7">
+    <rect x="0" y="172.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-8">
+    <rect x="0" y="196.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-9">
+    <rect x="0" y="221.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-10">
+    <rect x="0" y="245.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-11">
+    <rect x="0" y="269.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-12">
+    <rect x="0" y="294.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-13">
+    <rect x="0" y="318.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-14">
+    <rect x="0" y="343.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-15">
+    <rect x="0" y="367.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-16">
+    <rect x="0" y="391.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-17">
+    <rect x="0" y="416.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-18">
+    <rect x="0" y="440.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-19">
+    <rect x="0" y="465.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-20">
+    <rect x="0" y="489.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-21">
+    <rect x="0" y="513.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-22">
+    <rect x="0" y="538.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-23">
+    <rect x="0" y="562.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-24">
+    <rect x="0" y="587.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-25">
+    <rect x="0" y="611.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-26">
+    <rect x="0" y="635.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-27">
+    <rect x="0" y="660.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-28">
+    <rect x="0" y="684.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-29">
+    <rect x="0" y="709.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-30">
+    <rect x="0" y="733.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-31">
+    <rect x="0" y="757.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-32">
+    <rect x="0" y="782.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-33">
+    <rect x="0" y="806.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1876533864-line-34">
+    <rect x="0" y="831.1" width="1464" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="926.4" rx="8"/><text class="terminal-1876533864-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">ralph</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1876533864-clip-terminal)">
+    <rect fill="#e0e0e0" x="0" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="97.6" y="1.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="256.2" y="1.5" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="390.4" y="1.5" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="561.2" y="1.5" width="902.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="25.9" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="12.2" y="25.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="134.2" y="25.9" width="48.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="183" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="256.2" y="25.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="353.8" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="390.4" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="463.6" y="25.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="561.2" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="597.8" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="671" y="25.9" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="793" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="829.6" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="902.8" y="25.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1012.6" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="1049.2" y="25.9" width="414.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#121212" x="0" y="50.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="0" y="74.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="97.6" y="74.7" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="219.6" y="74.7" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="390.4" y="74.7" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="671" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="756.4" y="74.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2b3339" x="817.4" y="74.7" width="646.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="0" y="99.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="97.6" y="99.1" width="122" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="219.6" y="99.1" width="170.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="390.4" y="99.1" width="280.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="671" y="99.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="756.4" y="99.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="817.4" y="99.1" width="646.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="123.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="147.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="147.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="172.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="172.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="196.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="196.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="221.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="221.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="245.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="245.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="269.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="269.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="294.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="294.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="318.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="318.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="343.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="343.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="367.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="367.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="391.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="391.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="416.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="416.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="440.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="440.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="465.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="465.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="489.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="489.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="513.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="513.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="538.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="538.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="562.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="562.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="587.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="587.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="611.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="611.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="635.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="635.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="660.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="660.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="684.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="684.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="709.1" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="709.1" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="733.5" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="733.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="757.9" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="757.9" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="782.3" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="782.3" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="0" y="806.7" width="1439.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#000000" x="1439.6" y="806.7" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="831.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="12.2" y="831.1" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="158.6" y="831.1" width="439.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="597.8" y="831.1" width="866.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="855.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="61" y="855.5" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="122" y="855.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="158.6" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="244" y="855.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="280.6" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="366" y="855.5" width="951.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1317.6" y="855.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1329.8" y="855.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1354.2" y="855.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1451.8" y="855.5" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-1876533864-matrix">
+    <text class="terminal-1876533864-r1" x="0" y="20" textLength="97.6" clip-path="url(#terminal-1876533864-line-0)">&#160;comp-a&#160;</text><text class="terminal-1876533864-r2" x="97.6" y="20" textLength="158.6" clip-path="url(#terminal-1876533864-line-0)">&#160;&#160;Component&#160;A</text><text class="terminal-1876533864-r3" x="256.2" y="20" textLength="134.2" clip-path="url(#terminal-1876533864-line-0)">&#160;&#160;completed</text><text class="terminal-1876533864-r4" x="390.4" y="20" textLength="170.8" clip-path="url(#terminal-1876533864-line-0)">&#160;&#160;1&#160;finding(s)</text><text class="terminal-1876533864-r5" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-1876533864-line-0)">
+</text><text class="terminal-1876533864-r6" x="12.2" y="44.4" textLength="122" clip-path="url(#terminal-1876533864-line-1)">engineer&#160;✓</text><text class="terminal-1876533864-r7" x="134.2" y="44.4" textLength="48.8" clip-path="url(#terminal-1876533864-line-1)">&#160;25s</text><text class="terminal-1876533864-r7" x="183" y="44.4" textLength="73.2" clip-path="url(#terminal-1876533864-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1876533864-r6" x="256.2" y="44.4" textLength="97.6" clip-path="url(#terminal-1876533864-line-1)">verify&#160;✓</text><text class="terminal-1876533864-r7" x="353.8" y="44.4" textLength="36.6" clip-path="url(#terminal-1876533864-line-1)">&#160;8s</text><text class="terminal-1876533864-r7" x="390.4" y="44.4" textLength="73.2" clip-path="url(#terminal-1876533864-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1876533864-r6" x="463.6" y="44.4" textLength="97.6" clip-path="url(#terminal-1876533864-line-1)">review&#160;✓</text><text class="terminal-1876533864-r7" x="561.2" y="44.4" textLength="36.6" clip-path="url(#terminal-1876533864-line-1)">&#160;8s</text><text class="terminal-1876533864-r7" x="597.8" y="44.4" textLength="73.2" clip-path="url(#terminal-1876533864-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1876533864-r6" x="671" y="44.4" textLength="122" clip-path="url(#terminal-1876533864-line-1)">security&#160;✓</text><text class="terminal-1876533864-r7" x="793" y="44.4" textLength="36.6" clip-path="url(#terminal-1876533864-line-1)">&#160;8s</text><text class="terminal-1876533864-r7" x="829.6" y="44.4" textLength="73.2" clip-path="url(#terminal-1876533864-line-1)">&#160;&#160;-&gt;&#160;&#160;</text><text class="terminal-1876533864-r6" x="902.8" y="44.4" textLength="109.8" clip-path="url(#terminal-1876533864-line-1)">distill&#160;✓</text><text class="terminal-1876533864-r7" x="1012.6" y="44.4" textLength="36.6" clip-path="url(#terminal-1876533864-line-1)">&#160;8s</text><text class="terminal-1876533864-r5" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-1)">
+</text><text class="terminal-1876533864-r8" x="0" y="68.8" textLength="1464" clip-path="url(#terminal-1876533864-line-2)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1876533864-r5" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-2)">
+</text><text class="terminal-1876533864-r2" x="0" y="93.2" textLength="97.6" clip-path="url(#terminal-1876533864-line-3)">&#160;phase&#160;&#160;</text><text class="terminal-1876533864-r2" x="97.6" y="93.2" textLength="122" clip-path="url(#terminal-1876533864-line-3)">&#160;severity&#160;</text><text class="terminal-1876533864-r2" x="219.6" y="93.2" textLength="170.8" clip-path="url(#terminal-1876533864-line-3)">&#160;category&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1876533864-r2" x="390.4" y="93.2" textLength="280.6" clip-path="url(#terminal-1876533864-line-3)">&#160;location&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1876533864-r2" x="671" y="93.2" textLength="85.4" clip-path="url(#terminal-1876533864-line-3)">&#160;model&#160;</text><text class="terminal-1876533864-r2" x="756.4" y="93.2" textLength="61" clip-path="url(#terminal-1876533864-line-3)">&#160;att&#160;</text><text class="terminal-1876533864-r5" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-3)">
+</text><text class="terminal-1876533864-r10" x="0" y="117.6" textLength="97.6" clip-path="url(#terminal-1876533864-line-4)">&#160;review&#160;</text><text class="terminal-1876533864-r10" x="97.6" y="117.6" textLength="122" clip-path="url(#terminal-1876533864-line-4)">&#160;advisory&#160;</text><text class="terminal-1876533864-r10" x="219.6" y="117.6" textLength="170.8" clip-path="url(#terminal-1876533864-line-4)">&#160;test_quality&#160;</text><text class="terminal-1876533864-r10" x="390.4" y="117.6" textLength="280.6" clip-path="url(#terminal-1876533864-line-4)">&#160;src/comp-a/impl.py:42&#160;</text><text class="terminal-1876533864-r10" x="671" y="117.6" textLength="85.4" clip-path="url(#terminal-1876533864-line-4)">&#160;-&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1876533864-r10" x="756.4" y="117.6" textLength="61" clip-path="url(#terminal-1876533864-line-4)">&#160;1&#160;&#160;&#160;</text><text class="terminal-1876533864-r5" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-4)">
+</text><text class="terminal-1876533864-r11" x="0" y="142" textLength="1464" clip-path="url(#terminal-1876533864-line-5)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1876533864-r5" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-1876533864-line-5)">
+</text><text class="terminal-1876533864-r5" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-6)">
+</text><text class="terminal-1876533864-r5" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-7)">
+</text><text class="terminal-1876533864-r5" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-8)">
+</text><text class="terminal-1876533864-r5" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-9)">
+</text><text class="terminal-1876533864-r5" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-1876533864-line-10)">
+</text><text class="terminal-1876533864-r5" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-11)">
+</text><text class="terminal-1876533864-r5" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-12)">
+</text><text class="terminal-1876533864-r5" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-13)">
+</text><text class="terminal-1876533864-r5" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-14)">
+</text><text class="terminal-1876533864-r5" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-1876533864-line-15)">
+</text><text class="terminal-1876533864-r5" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-16)">
+</text><text class="terminal-1876533864-r5" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-17)">
+</text><text class="terminal-1876533864-r5" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-18)">
+</text><text class="terminal-1876533864-r5" x="1464" y="483.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-19)">
+</text><text class="terminal-1876533864-r5" x="1464" y="508" textLength="12.2" clip-path="url(#terminal-1876533864-line-20)">
+</text><text class="terminal-1876533864-r5" x="1464" y="532.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-21)">
+</text><text class="terminal-1876533864-r5" x="1464" y="556.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-22)">
+</text><text class="terminal-1876533864-r5" x="1464" y="581.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-23)">
+</text><text class="terminal-1876533864-r5" x="1464" y="605.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-24)">
+</text><text class="terminal-1876533864-r5" x="1464" y="630" textLength="12.2" clip-path="url(#terminal-1876533864-line-25)">
+</text><text class="terminal-1876533864-r5" x="1464" y="654.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-26)">
+</text><text class="terminal-1876533864-r5" x="1464" y="678.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-27)">
+</text><text class="terminal-1876533864-r5" x="1464" y="703.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-28)">
+</text><text class="terminal-1876533864-r5" x="1464" y="727.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-29)">
+</text><text class="terminal-1876533864-r5" x="1464" y="752" textLength="12.2" clip-path="url(#terminal-1876533864-line-30)">
+</text><text class="terminal-1876533864-r5" x="1464" y="776.4" textLength="12.2" clip-path="url(#terminal-1876533864-line-31)">
+</text><text class="terminal-1876533864-r5" x="1464" y="800.8" textLength="12.2" clip-path="url(#terminal-1876533864-line-32)">
+</text><text class="terminal-1876533864-r5" x="1464" y="825.2" textLength="12.2" clip-path="url(#terminal-1876533864-line-33)">
+</text><text class="terminal-1876533864-r4" x="12.2" y="849.6" textLength="146.4" clip-path="url(#terminal-1876533864-line-34)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;pr&#160;&#160;</text><text class="terminal-1876533864-r2" x="158.6" y="849.6" textLength="439.2" clip-path="url(#terminal-1876533864-line-34)">https://example.test/pr/100&#160;(merged)</text><text class="terminal-1876533864-r5" x="1464" y="849.6" textLength="12.2" clip-path="url(#terminal-1876533864-line-34)">
+</text><text class="terminal-1876533864-r12" x="0" y="874" textLength="61" clip-path="url(#terminal-1876533864-line-35)">&#160;esc&#160;</text><text class="terminal-1876533864-r9" x="61" y="874" textLength="61" clip-path="url(#terminal-1876533864-line-35)">Back&#160;</text><text class="terminal-1876533864-r12" x="122" y="874" textLength="36.6" clip-path="url(#terminal-1876533864-line-35)">&#160;f&#160;</text><text class="terminal-1876533864-r9" x="158.6" y="874" textLength="85.4" clip-path="url(#terminal-1876533864-line-35)">Follow&#160;</text><text class="terminal-1876533864-r12" x="244" y="874" textLength="36.6" clip-path="url(#terminal-1876533864-line-35)">&#160;q&#160;</text><text class="terminal-1876533864-r9" x="280.6" y="874" textLength="85.4" clip-path="url(#terminal-1876533864-line-35)">Detach&#160;</text><text class="terminal-1876533864-r13" x="1317.6" y="874" textLength="12.2" clip-path="url(#terminal-1876533864-line-35)">▏</text><text class="terminal-1876533864-r12" x="1329.8" y="874" textLength="24.4" clip-path="url(#terminal-1876533864-line-35)">^p</text><text class="terminal-1876533864-r9" x="1354.2" y="874" textLength="97.6" clip-path="url(#terminal-1876533864-line-35)">&#160;palette</text>
+    </g>
+    </g>
+</svg>

--- a/tests/__snapshots__/test_tui_snapshots/test_overview_snapshot.raw
+++ b/tests/__snapshots__/test_tui_snapshots/test_overview_snapshot.raw
@@ -19,188 +19,188 @@
         font-weight: 700;
     }
 
-    .terminal-3861803967-matrix {
+    .terminal-4154289677-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3861803967-title {
+    .terminal-4154289677-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3861803967-r1 { fill: #242f38;font-weight: bold }
-.terminal-3861803967-r2 { fill: #e0e0e0 }
-.terminal-3861803967-r3 { fill: #e0e0e0;font-weight: bold }
-.terminal-3861803967-r4 { fill: #c5c8c6 }
-.terminal-3861803967-r5 { fill: #a0a3a6 }
-.terminal-3861803967-r6 { fill: #a0a3a6;font-style: italic; }
-.terminal-3861803967-r7 { fill: #ddedf9;font-weight: bold }
-.terminal-3861803967-r8 { fill: #98e024 }
-.terminal-3861803967-r9 { fill: #ffa62b;font-weight: bold }
-.terminal-3861803967-r10 { fill: #495259 }
+    .terminal-4154289677-r1 { fill: #242f38;font-weight: bold }
+.terminal-4154289677-r2 { fill: #e0e0e0 }
+.terminal-4154289677-r3 { fill: #e0e0e0;font-weight: bold }
+.terminal-4154289677-r4 { fill: #c5c8c6 }
+.terminal-4154289677-r5 { fill: #a0a3a6 }
+.terminal-4154289677-r6 { fill: #a0a3a6;font-style: italic; }
+.terminal-4154289677-r7 { fill: #ddedf9;font-weight: bold }
+.terminal-4154289677-r8 { fill: #98e024 }
+.terminal-4154289677-r9 { fill: #ffa62b;font-weight: bold }
+.terminal-4154289677-r10 { fill: #495259 }
     </style>
 
     <defs>
-    <clipPath id="terminal-3861803967-clip-terminal">
+    <clipPath id="terminal-4154289677-clip-terminal">
       <rect x="0" y="0" width="1463.0" height="877.4" />
     </clipPath>
-    <clipPath id="terminal-3861803967-line-0">
+    <clipPath id="terminal-4154289677-line-0">
     <rect x="0" y="1.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-1">
+<clipPath id="terminal-4154289677-line-1">
     <rect x="0" y="25.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-2">
+<clipPath id="terminal-4154289677-line-2">
     <rect x="0" y="50.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-3">
+<clipPath id="terminal-4154289677-line-3">
     <rect x="0" y="74.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-4">
+<clipPath id="terminal-4154289677-line-4">
     <rect x="0" y="99.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-5">
+<clipPath id="terminal-4154289677-line-5">
     <rect x="0" y="123.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-6">
+<clipPath id="terminal-4154289677-line-6">
     <rect x="0" y="147.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-7">
+<clipPath id="terminal-4154289677-line-7">
     <rect x="0" y="172.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-8">
+<clipPath id="terminal-4154289677-line-8">
     <rect x="0" y="196.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-9">
+<clipPath id="terminal-4154289677-line-9">
     <rect x="0" y="221.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-10">
+<clipPath id="terminal-4154289677-line-10">
     <rect x="0" y="245.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-11">
+<clipPath id="terminal-4154289677-line-11">
     <rect x="0" y="269.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-12">
+<clipPath id="terminal-4154289677-line-12">
     <rect x="0" y="294.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-13">
+<clipPath id="terminal-4154289677-line-13">
     <rect x="0" y="318.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-14">
+<clipPath id="terminal-4154289677-line-14">
     <rect x="0" y="343.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-15">
+<clipPath id="terminal-4154289677-line-15">
     <rect x="0" y="367.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-16">
+<clipPath id="terminal-4154289677-line-16">
     <rect x="0" y="391.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-17">
+<clipPath id="terminal-4154289677-line-17">
     <rect x="0" y="416.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-18">
+<clipPath id="terminal-4154289677-line-18">
     <rect x="0" y="440.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-19">
+<clipPath id="terminal-4154289677-line-19">
     <rect x="0" y="465.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-20">
+<clipPath id="terminal-4154289677-line-20">
     <rect x="0" y="489.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-21">
+<clipPath id="terminal-4154289677-line-21">
     <rect x="0" y="513.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-22">
+<clipPath id="terminal-4154289677-line-22">
     <rect x="0" y="538.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-23">
+<clipPath id="terminal-4154289677-line-23">
     <rect x="0" y="562.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-24">
+<clipPath id="terminal-4154289677-line-24">
     <rect x="0" y="587.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-25">
+<clipPath id="terminal-4154289677-line-25">
     <rect x="0" y="611.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-26">
+<clipPath id="terminal-4154289677-line-26">
     <rect x="0" y="635.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-27">
+<clipPath id="terminal-4154289677-line-27">
     <rect x="0" y="660.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-28">
+<clipPath id="terminal-4154289677-line-28">
     <rect x="0" y="684.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-29">
+<clipPath id="terminal-4154289677-line-29">
     <rect x="0" y="709.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-30">
+<clipPath id="terminal-4154289677-line-30">
     <rect x="0" y="733.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-31">
+<clipPath id="terminal-4154289677-line-31">
     <rect x="0" y="757.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-32">
+<clipPath id="terminal-4154289677-line-32">
     <rect x="0" y="782.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-33">
+<clipPath id="terminal-4154289677-line-33">
     <rect x="0" y="806.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3861803967-line-34">
+<clipPath id="terminal-4154289677-line-34">
     <rect x="0" y="831.1" width="1464" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="926.4" rx="8"/><text class="terminal-3861803967-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">ralph</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="926.4" rx="8"/><text class="terminal-4154289677-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">ralph</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3861803967-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-4154289677-clip-terminal)">
     <rect fill="#e0e0e0" x="0" y="1.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="85.4" y="1.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="109.8" y="1.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="256.2" y="1.5" width="219.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="475.8" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="488" y="1.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="573.4" y="1.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="658.8" y="1.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="817.4" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="915" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="988.2" y="1.5" width="463.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1451.8" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="0" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="36.6" y="25.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="170.8" y="25.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="305" y="25.9" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="390.4" y="25.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="451.4" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="524.6" y="25.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="585.6" y="25.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="695.4" y="25.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2b3339" x="793" y="25.9" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="0" y="50.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="36.6" y="50.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="170.8" y="50.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="305" y="50.3" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="390.4" y="50.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="451.4" y="50.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="524.6" y="50.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="585.6" y="50.3" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="695.4" y="50.3" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="793" y="50.3" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="24.4" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="36.6" y="74.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="170.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="183" y="74.7" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="292.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="305" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="390.4" y="74.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="451.4" y="74.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="524.6" y="74.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="585.6" y="74.7" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="695.4" y="74.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="793" y="74.7" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="24.4" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="36.6" y="99.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="170.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="183" y="99.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="292.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="305" y="99.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="390.4" y="99.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="451.4" y="99.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="524.6" y="99.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="585.6" y="99.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="695.4" y="99.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="793" y="99.1" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="123.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="147.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="172.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="196.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="221.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="245.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="269.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="294.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="318.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="343.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="367.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="391.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="416.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="440.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="465.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="489.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="513.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="538.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="562.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="587.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="611.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="635.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="660.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="684.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="709.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="733.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="757.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="782.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="806.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="831.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="855.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="36.6" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="122" y="855.5" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1317.6" y="855.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1329.8" y="855.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1354.2" y="855.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1451.8" y="855.5" width="12.2" height="24.65" shape-rendering="crispEdges"/>
-    <g class="terminal-3861803967-matrix">
-    <text class="terminal-3861803967-r1" x="0" y="20" textLength="85.4" clip-path="url(#terminal-3861803967-line-0)">&#160;ralph&#160;</text><text class="terminal-3861803967-r3" x="109.8" y="20" textLength="146.4" clip-path="url(#terminal-3861803967-line-0)">fake-project</text><text class="terminal-3861803967-r5" x="488" y="20" textLength="85.4" clip-path="url(#terminal-3861803967-line-0)">tokens&#160;</text><text class="terminal-3861803967-r3" x="573.4" y="20" textLength="85.4" clip-path="url(#terminal-3861803967-line-0)">288.0k+</text><text class="terminal-3861803967-r5" x="658.8" y="20" textLength="158.6" clip-path="url(#terminal-3861803967-line-0)">&#160;/&#160;5.00M&#160;(5%)</text><text class="terminal-3861803967-r5" x="817.4" y="20" textLength="97.6" clip-path="url(#terminal-3861803967-line-0)">&#160;&#160;&#160;cost&#160;</text><text class="terminal-3861803967-r3" x="915" y="20" textLength="73.2" clip-path="url(#terminal-3861803967-line-0)">$4.50+</text><text class="terminal-3861803967-r6" x="988.2" y="20" textLength="463.6" clip-path="url(#terminal-3861803967-line-0)">&#160;&#160;&#160;[3&#160;call(s)&#160;unreported:&#160;lower&#160;bound]</text><text class="terminal-3861803967-r4" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-3861803967-line-0)">
-</text><text class="terminal-3861803967-r3" x="36.6" y="44.4" textLength="134.2" clip-path="url(#terminal-3861803967-line-1)">&#160;component&#160;</text><text class="terminal-3861803967-r3" x="170.8" y="44.4" textLength="134.2" clip-path="url(#terminal-3861803967-line-1)">&#160;status&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r3" x="305" y="44.4" textLength="85.4" clip-path="url(#terminal-3861803967-line-1)">&#160;phase&#160;</text><text class="terminal-3861803967-r3" x="390.4" y="44.4" textLength="61" clip-path="url(#terminal-3861803967-line-1)">&#160;att&#160;</text><text class="terminal-3861803967-r3" x="451.4" y="44.4" textLength="73.2" clip-path="url(#terminal-3861803967-line-1)">&#160;iter&#160;</text><text class="terminal-3861803967-r3" x="524.6" y="44.4" textLength="61" clip-path="url(#terminal-3861803967-line-1)">&#160;age&#160;</text><text class="terminal-3861803967-r3" x="585.6" y="44.4" textLength="109.8" clip-path="url(#terminal-3861803967-line-1)">&#160;tokens&#160;&#160;</text><text class="terminal-3861803967-r3" x="695.4" y="44.4" textLength="97.6" clip-path="url(#terminal-3861803967-line-1)">&#160;cost&#160;&#160;&#160;</text><text class="terminal-3861803967-r4" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-1)">
-</text><text class="terminal-3861803967-r7" x="0" y="68.8" textLength="36.6" clip-path="url(#terminal-3861803967-line-2)">&#160;✓&#160;</text><text class="terminal-3861803967-r7" x="36.6" y="68.8" textLength="134.2" clip-path="url(#terminal-3861803967-line-2)">&#160;comp-a&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r7" x="170.8" y="68.8" textLength="134.2" clip-path="url(#terminal-3861803967-line-2)">&#160;completed&#160;</text><text class="terminal-3861803967-r7" x="305" y="68.8" textLength="85.4" clip-path="url(#terminal-3861803967-line-2)">&#160;done&#160;&#160;</text><text class="terminal-3861803967-r7" x="390.4" y="68.8" textLength="61" clip-path="url(#terminal-3861803967-line-2)">&#160;1&#160;&#160;&#160;</text><text class="terminal-3861803967-r7" x="451.4" y="68.8" textLength="73.2" clip-path="url(#terminal-3861803967-line-2)">&#160;2&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r7" x="524.6" y="68.8" textLength="61" clip-path="url(#terminal-3861803967-line-2)">&#160;0s&#160;&#160;</text><text class="terminal-3861803967-r7" x="585.6" y="68.8" textLength="109.8" clip-path="url(#terminal-3861803967-line-2)">&#160;48000+&#160;&#160;</text><text class="terminal-3861803967-r7" x="695.4" y="68.8" textLength="97.6" clip-path="url(#terminal-3861803967-line-2)">&#160;$0.75+&#160;</text><text class="terminal-3861803967-r4" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-2)">
-</text><text class="terminal-3861803967-r8" x="12.2" y="93.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-3)">✓</text><text class="terminal-3861803967-r2" x="36.6" y="93.2" textLength="134.2" clip-path="url(#terminal-3861803967-line-3)">&#160;comp-b&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r8" x="183" y="93.2" textLength="109.8" clip-path="url(#terminal-3861803967-line-3)">completed</text><text class="terminal-3861803967-r2" x="305" y="93.2" textLength="85.4" clip-path="url(#terminal-3861803967-line-3)">&#160;done&#160;&#160;</text><text class="terminal-3861803967-r2" x="390.4" y="93.2" textLength="61" clip-path="url(#terminal-3861803967-line-3)">&#160;1&#160;&#160;&#160;</text><text class="terminal-3861803967-r2" x="451.4" y="93.2" textLength="73.2" clip-path="url(#terminal-3861803967-line-3)">&#160;2&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r2" x="524.6" y="93.2" textLength="61" clip-path="url(#terminal-3861803967-line-3)">&#160;0s&#160;&#160;</text><text class="terminal-3861803967-r2" x="585.6" y="93.2" textLength="109.8" clip-path="url(#terminal-3861803967-line-3)">&#160;96000+&#160;&#160;</text><text class="terminal-3861803967-r2" x="695.4" y="93.2" textLength="97.6" clip-path="url(#terminal-3861803967-line-3)">&#160;$1.50+&#160;</text><text class="terminal-3861803967-r4" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-3)">
-</text><text class="terminal-3861803967-r8" x="12.2" y="117.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-4)">✓</text><text class="terminal-3861803967-r2" x="36.6" y="117.6" textLength="134.2" clip-path="url(#terminal-3861803967-line-4)">&#160;comp-c&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r8" x="183" y="117.6" textLength="109.8" clip-path="url(#terminal-3861803967-line-4)">completed</text><text class="terminal-3861803967-r2" x="305" y="117.6" textLength="85.4" clip-path="url(#terminal-3861803967-line-4)">&#160;done&#160;&#160;</text><text class="terminal-3861803967-r2" x="390.4" y="117.6" textLength="61" clip-path="url(#terminal-3861803967-line-4)">&#160;1&#160;&#160;&#160;</text><text class="terminal-3861803967-r2" x="451.4" y="117.6" textLength="73.2" clip-path="url(#terminal-3861803967-line-4)">&#160;2&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r2" x="524.6" y="117.6" textLength="61" clip-path="url(#terminal-3861803967-line-4)">&#160;0s&#160;&#160;</text><text class="terminal-3861803967-r2" x="585.6" y="117.6" textLength="109.8" clip-path="url(#terminal-3861803967-line-4)">&#160;144000+&#160;</text><text class="terminal-3861803967-r2" x="695.4" y="117.6" textLength="97.6" clip-path="url(#terminal-3861803967-line-4)">&#160;$2.25+&#160;</text><text class="terminal-3861803967-r4" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-4)">
-</text><text class="terminal-3861803967-r4" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-3861803967-line-5)">
-</text><text class="terminal-3861803967-r4" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-6)">
-</text><text class="terminal-3861803967-r4" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-7)">
-</text><text class="terminal-3861803967-r4" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-8)">
-</text><text class="terminal-3861803967-r4" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-9)">
-</text><text class="terminal-3861803967-r4" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-3861803967-line-10)">
-</text><text class="terminal-3861803967-r4" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-11)">
-</text><text class="terminal-3861803967-r4" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-12)">
-</text><text class="terminal-3861803967-r4" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-13)">
-</text><text class="terminal-3861803967-r4" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-14)">
-</text><text class="terminal-3861803967-r4" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-3861803967-line-15)">
-</text><text class="terminal-3861803967-r4" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-16)">
-</text><text class="terminal-3861803967-r4" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-17)">
-</text><text class="terminal-3861803967-r4" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-18)">
-</text><text class="terminal-3861803967-r4" x="1464" y="483.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-19)">
-</text><text class="terminal-3861803967-r4" x="1464" y="508" textLength="12.2" clip-path="url(#terminal-3861803967-line-20)">
-</text><text class="terminal-3861803967-r4" x="1464" y="532.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-21)">
-</text><text class="terminal-3861803967-r4" x="1464" y="556.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-22)">
-</text><text class="terminal-3861803967-r4" x="1464" y="581.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-23)">
-</text><text class="terminal-3861803967-r4" x="1464" y="605.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-24)">
-</text><text class="terminal-3861803967-r4" x="1464" y="630" textLength="12.2" clip-path="url(#terminal-3861803967-line-25)">
-</text><text class="terminal-3861803967-r4" x="1464" y="654.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-26)">
-</text><text class="terminal-3861803967-r4" x="1464" y="678.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-27)">
-</text><text class="terminal-3861803967-r4" x="1464" y="703.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-28)">
-</text><text class="terminal-3861803967-r4" x="1464" y="727.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-29)">
-</text><text class="terminal-3861803967-r4" x="1464" y="752" textLength="12.2" clip-path="url(#terminal-3861803967-line-30)">
-</text><text class="terminal-3861803967-r4" x="1464" y="776.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-31)">
-</text><text class="terminal-3861803967-r4" x="1464" y="800.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-32)">
-</text><text class="terminal-3861803967-r4" x="1464" y="825.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-33)">
-</text><text class="terminal-3861803967-r4" x="1464" y="849.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-34)">
-</text><text class="terminal-3861803967-r9" x="0" y="874" textLength="36.6" clip-path="url(#terminal-3861803967-line-35)">&#160;q&#160;</text><text class="terminal-3861803967-r2" x="36.6" y="874" textLength="85.4" clip-path="url(#terminal-3861803967-line-35)">Detach&#160;</text><text class="terminal-3861803967-r10" x="1317.6" y="874" textLength="12.2" clip-path="url(#terminal-3861803967-line-35)">▏</text><text class="terminal-3861803967-r9" x="1329.8" y="874" textLength="24.4" clip-path="url(#terminal-3861803967-line-35)">^p</text><text class="terminal-3861803967-r2" x="1354.2" y="874" textLength="97.6" clip-path="url(#terminal-3861803967-line-35)">&#160;palette</text>
+    <g class="terminal-4154289677-matrix">
+    <text class="terminal-4154289677-r1" x="0" y="20" textLength="85.4" clip-path="url(#terminal-4154289677-line-0)">&#160;ralph&#160;</text><text class="terminal-4154289677-r3" x="109.8" y="20" textLength="146.4" clip-path="url(#terminal-4154289677-line-0)">fake-project</text><text class="terminal-4154289677-r5" x="488" y="20" textLength="85.4" clip-path="url(#terminal-4154289677-line-0)">tokens&#160;</text><text class="terminal-4154289677-r3" x="573.4" y="20" textLength="85.4" clip-path="url(#terminal-4154289677-line-0)">288.0k+</text><text class="terminal-4154289677-r5" x="658.8" y="20" textLength="158.6" clip-path="url(#terminal-4154289677-line-0)">&#160;/&#160;5.00M&#160;(5%)</text><text class="terminal-4154289677-r5" x="817.4" y="20" textLength="97.6" clip-path="url(#terminal-4154289677-line-0)">&#160;&#160;&#160;cost&#160;</text><text class="terminal-4154289677-r3" x="915" y="20" textLength="73.2" clip-path="url(#terminal-4154289677-line-0)">$4.50+</text><text class="terminal-4154289677-r6" x="988.2" y="20" textLength="463.6" clip-path="url(#terminal-4154289677-line-0)">&#160;&#160;&#160;[3&#160;call(s)&#160;unreported:&#160;lower&#160;bound]</text><text class="terminal-4154289677-r4" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-4154289677-line-0)">
+</text><text class="terminal-4154289677-r3" x="36.6" y="44.4" textLength="134.2" clip-path="url(#terminal-4154289677-line-1)">&#160;component&#160;</text><text class="terminal-4154289677-r3" x="170.8" y="44.4" textLength="134.2" clip-path="url(#terminal-4154289677-line-1)">&#160;status&#160;&#160;&#160;&#160;</text><text class="terminal-4154289677-r3" x="305" y="44.4" textLength="85.4" clip-path="url(#terminal-4154289677-line-1)">&#160;phase&#160;</text><text class="terminal-4154289677-r3" x="390.4" y="44.4" textLength="61" clip-path="url(#terminal-4154289677-line-1)">&#160;att&#160;</text><text class="terminal-4154289677-r3" x="451.4" y="44.4" textLength="73.2" clip-path="url(#terminal-4154289677-line-1)">&#160;iter&#160;</text><text class="terminal-4154289677-r3" x="524.6" y="44.4" textLength="61" clip-path="url(#terminal-4154289677-line-1)">&#160;age&#160;</text><text class="terminal-4154289677-r3" x="585.6" y="44.4" textLength="109.8" clip-path="url(#terminal-4154289677-line-1)">&#160;tokens&#160;&#160;</text><text class="terminal-4154289677-r3" x="695.4" y="44.4" textLength="97.6" clip-path="url(#terminal-4154289677-line-1)">&#160;cost&#160;&#160;&#160;</text><text class="terminal-4154289677-r4" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-4154289677-line-1)">
+</text><text class="terminal-4154289677-r7" x="0" y="68.8" textLength="36.6" clip-path="url(#terminal-4154289677-line-2)">&#160;+&#160;</text><text class="terminal-4154289677-r7" x="36.6" y="68.8" textLength="134.2" clip-path="url(#terminal-4154289677-line-2)">&#160;comp-a&#160;&#160;&#160;&#160;</text><text class="terminal-4154289677-r7" x="170.8" y="68.8" textLength="134.2" clip-path="url(#terminal-4154289677-line-2)">&#160;completed&#160;</text><text class="terminal-4154289677-r7" x="305" y="68.8" textLength="85.4" clip-path="url(#terminal-4154289677-line-2)">&#160;done&#160;&#160;</text><text class="terminal-4154289677-r7" x="390.4" y="68.8" textLength="61" clip-path="url(#terminal-4154289677-line-2)">&#160;1&#160;&#160;&#160;</text><text class="terminal-4154289677-r7" x="451.4" y="68.8" textLength="73.2" clip-path="url(#terminal-4154289677-line-2)">&#160;2&#160;&#160;&#160;&#160;</text><text class="terminal-4154289677-r7" x="524.6" y="68.8" textLength="61" clip-path="url(#terminal-4154289677-line-2)">&#160;0s&#160;&#160;</text><text class="terminal-4154289677-r7" x="585.6" y="68.8" textLength="109.8" clip-path="url(#terminal-4154289677-line-2)">&#160;48000+&#160;&#160;</text><text class="terminal-4154289677-r7" x="695.4" y="68.8" textLength="97.6" clip-path="url(#terminal-4154289677-line-2)">&#160;$0.75+&#160;</text><text class="terminal-4154289677-r4" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-4154289677-line-2)">
+</text><text class="terminal-4154289677-r8" x="12.2" y="93.2" textLength="12.2" clip-path="url(#terminal-4154289677-line-3)">+</text><text class="terminal-4154289677-r2" x="36.6" y="93.2" textLength="134.2" clip-path="url(#terminal-4154289677-line-3)">&#160;comp-b&#160;&#160;&#160;&#160;</text><text class="terminal-4154289677-r8" x="183" y="93.2" textLength="109.8" clip-path="url(#terminal-4154289677-line-3)">completed</text><text class="terminal-4154289677-r2" x="305" y="93.2" textLength="85.4" clip-path="url(#terminal-4154289677-line-3)">&#160;done&#160;&#160;</text><text class="terminal-4154289677-r2" x="390.4" y="93.2" textLength="61" clip-path="url(#terminal-4154289677-line-3)">&#160;1&#160;&#160;&#160;</text><text class="terminal-4154289677-r2" x="451.4" y="93.2" textLength="73.2" clip-path="url(#terminal-4154289677-line-3)">&#160;2&#160;&#160;&#160;&#160;</text><text class="terminal-4154289677-r2" x="524.6" y="93.2" textLength="61" clip-path="url(#terminal-4154289677-line-3)">&#160;0s&#160;&#160;</text><text class="terminal-4154289677-r2" x="585.6" y="93.2" textLength="109.8" clip-path="url(#terminal-4154289677-line-3)">&#160;96000+&#160;&#160;</text><text class="terminal-4154289677-r2" x="695.4" y="93.2" textLength="97.6" clip-path="url(#terminal-4154289677-line-3)">&#160;$1.50+&#160;</text><text class="terminal-4154289677-r4" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-4154289677-line-3)">
+</text><text class="terminal-4154289677-r8" x="12.2" y="117.6" textLength="12.2" clip-path="url(#terminal-4154289677-line-4)">+</text><text class="terminal-4154289677-r2" x="36.6" y="117.6" textLength="134.2" clip-path="url(#terminal-4154289677-line-4)">&#160;comp-c&#160;&#160;&#160;&#160;</text><text class="terminal-4154289677-r8" x="183" y="117.6" textLength="109.8" clip-path="url(#terminal-4154289677-line-4)">completed</text><text class="terminal-4154289677-r2" x="305" y="117.6" textLength="85.4" clip-path="url(#terminal-4154289677-line-4)">&#160;done&#160;&#160;</text><text class="terminal-4154289677-r2" x="390.4" y="117.6" textLength="61" clip-path="url(#terminal-4154289677-line-4)">&#160;1&#160;&#160;&#160;</text><text class="terminal-4154289677-r2" x="451.4" y="117.6" textLength="73.2" clip-path="url(#terminal-4154289677-line-4)">&#160;2&#160;&#160;&#160;&#160;</text><text class="terminal-4154289677-r2" x="524.6" y="117.6" textLength="61" clip-path="url(#terminal-4154289677-line-4)">&#160;0s&#160;&#160;</text><text class="terminal-4154289677-r2" x="585.6" y="117.6" textLength="109.8" clip-path="url(#terminal-4154289677-line-4)">&#160;144000+&#160;</text><text class="terminal-4154289677-r2" x="695.4" y="117.6" textLength="97.6" clip-path="url(#terminal-4154289677-line-4)">&#160;$2.25+&#160;</text><text class="terminal-4154289677-r4" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-4154289677-line-4)">
+</text><text class="terminal-4154289677-r4" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-4154289677-line-5)">
+</text><text class="terminal-4154289677-r4" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-4154289677-line-6)">
+</text><text class="terminal-4154289677-r4" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-4154289677-line-7)">
+</text><text class="terminal-4154289677-r4" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-4154289677-line-8)">
+</text><text class="terminal-4154289677-r4" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-4154289677-line-9)">
+</text><text class="terminal-4154289677-r4" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-4154289677-line-10)">
+</text><text class="terminal-4154289677-r4" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-4154289677-line-11)">
+</text><text class="terminal-4154289677-r4" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-4154289677-line-12)">
+</text><text class="terminal-4154289677-r4" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-4154289677-line-13)">
+</text><text class="terminal-4154289677-r4" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-4154289677-line-14)">
+</text><text class="terminal-4154289677-r4" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-4154289677-line-15)">
+</text><text class="terminal-4154289677-r4" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-4154289677-line-16)">
+</text><text class="terminal-4154289677-r4" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-4154289677-line-17)">
+</text><text class="terminal-4154289677-r4" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-4154289677-line-18)">
+</text><text class="terminal-4154289677-r4" x="1464" y="483.6" textLength="12.2" clip-path="url(#terminal-4154289677-line-19)">
+</text><text class="terminal-4154289677-r4" x="1464" y="508" textLength="12.2" clip-path="url(#terminal-4154289677-line-20)">
+</text><text class="terminal-4154289677-r4" x="1464" y="532.4" textLength="12.2" clip-path="url(#terminal-4154289677-line-21)">
+</text><text class="terminal-4154289677-r4" x="1464" y="556.8" textLength="12.2" clip-path="url(#terminal-4154289677-line-22)">
+</text><text class="terminal-4154289677-r4" x="1464" y="581.2" textLength="12.2" clip-path="url(#terminal-4154289677-line-23)">
+</text><text class="terminal-4154289677-r4" x="1464" y="605.6" textLength="12.2" clip-path="url(#terminal-4154289677-line-24)">
+</text><text class="terminal-4154289677-r4" x="1464" y="630" textLength="12.2" clip-path="url(#terminal-4154289677-line-25)">
+</text><text class="terminal-4154289677-r4" x="1464" y="654.4" textLength="12.2" clip-path="url(#terminal-4154289677-line-26)">
+</text><text class="terminal-4154289677-r4" x="1464" y="678.8" textLength="12.2" clip-path="url(#terminal-4154289677-line-27)">
+</text><text class="terminal-4154289677-r4" x="1464" y="703.2" textLength="12.2" clip-path="url(#terminal-4154289677-line-28)">
+</text><text class="terminal-4154289677-r4" x="1464" y="727.6" textLength="12.2" clip-path="url(#terminal-4154289677-line-29)">
+</text><text class="terminal-4154289677-r4" x="1464" y="752" textLength="12.2" clip-path="url(#terminal-4154289677-line-30)">
+</text><text class="terminal-4154289677-r4" x="1464" y="776.4" textLength="12.2" clip-path="url(#terminal-4154289677-line-31)">
+</text><text class="terminal-4154289677-r4" x="1464" y="800.8" textLength="12.2" clip-path="url(#terminal-4154289677-line-32)">
+</text><text class="terminal-4154289677-r4" x="1464" y="825.2" textLength="12.2" clip-path="url(#terminal-4154289677-line-33)">
+</text><text class="terminal-4154289677-r4" x="1464" y="849.6" textLength="12.2" clip-path="url(#terminal-4154289677-line-34)">
+</text><text class="terminal-4154289677-r9" x="0" y="874" textLength="36.6" clip-path="url(#terminal-4154289677-line-35)">&#160;q&#160;</text><text class="terminal-4154289677-r2" x="36.6" y="874" textLength="85.4" clip-path="url(#terminal-4154289677-line-35)">Detach&#160;</text><text class="terminal-4154289677-r10" x="1317.6" y="874" textLength="12.2" clip-path="url(#terminal-4154289677-line-35)">▏</text><text class="terminal-4154289677-r9" x="1329.8" y="874" textLength="24.4" clip-path="url(#terminal-4154289677-line-35)">^p</text><text class="terminal-4154289677-r2" x="1354.2" y="874" textLength="97.6" clip-path="url(#terminal-4154289677-line-35)">&#160;palette</text>
     </g>
     </g>
 </svg>

--- a/tests/__snapshots__/test_tui_snapshots/test_overview_snapshot.raw
+++ b/tests/__snapshots__/test_tui_snapshots/test_overview_snapshot.raw
@@ -1,0 +1,206 @@
+<svg class="rich-terminal" viewBox="0 0 1482 928.4" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-3861803967-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-3861803967-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-3861803967-r1 { fill: #242f38;font-weight: bold }
+.terminal-3861803967-r2 { fill: #e0e0e0 }
+.terminal-3861803967-r3 { fill: #e0e0e0;font-weight: bold }
+.terminal-3861803967-r4 { fill: #c5c8c6 }
+.terminal-3861803967-r5 { fill: #a0a3a6 }
+.terminal-3861803967-r6 { fill: #a0a3a6;font-style: italic; }
+.terminal-3861803967-r7 { fill: #ddedf9;font-weight: bold }
+.terminal-3861803967-r8 { fill: #98e024 }
+.terminal-3861803967-r9 { fill: #ffa62b;font-weight: bold }
+.terminal-3861803967-r10 { fill: #495259 }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-3861803967-clip-terminal">
+      <rect x="0" y="0" width="1463.0" height="877.4" />
+    </clipPath>
+    <clipPath id="terminal-3861803967-line-0">
+    <rect x="0" y="1.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-1">
+    <rect x="0" y="25.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-2">
+    <rect x="0" y="50.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-3">
+    <rect x="0" y="74.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-4">
+    <rect x="0" y="99.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-5">
+    <rect x="0" y="123.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-6">
+    <rect x="0" y="147.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-7">
+    <rect x="0" y="172.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-8">
+    <rect x="0" y="196.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-9">
+    <rect x="0" y="221.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-10">
+    <rect x="0" y="245.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-11">
+    <rect x="0" y="269.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-12">
+    <rect x="0" y="294.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-13">
+    <rect x="0" y="318.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-14">
+    <rect x="0" y="343.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-15">
+    <rect x="0" y="367.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-16">
+    <rect x="0" y="391.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-17">
+    <rect x="0" y="416.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-18">
+    <rect x="0" y="440.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-19">
+    <rect x="0" y="465.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-20">
+    <rect x="0" y="489.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-21">
+    <rect x="0" y="513.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-22">
+    <rect x="0" y="538.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-23">
+    <rect x="0" y="562.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-24">
+    <rect x="0" y="587.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-25">
+    <rect x="0" y="611.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-26">
+    <rect x="0" y="635.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-27">
+    <rect x="0" y="660.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-28">
+    <rect x="0" y="684.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-29">
+    <rect x="0" y="709.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-30">
+    <rect x="0" y="733.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-31">
+    <rect x="0" y="757.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-32">
+    <rect x="0" y="782.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-33">
+    <rect x="0" y="806.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3861803967-line-34">
+    <rect x="0" y="831.1" width="1464" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="926.4" rx="8"/><text class="terminal-3861803967-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">ralph</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3861803967-clip-terminal)">
+    <rect fill="#e0e0e0" x="0" y="1.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="85.4" y="1.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="109.8" y="1.5" width="146.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="256.2" y="1.5" width="219.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="475.8" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="488" y="1.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="573.4" y="1.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="658.8" y="1.5" width="158.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="817.4" y="1.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="915" y="1.5" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="988.2" y="1.5" width="463.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1451.8" y="1.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="0" y="25.9" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="36.6" y="25.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="170.8" y="25.9" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="305" y="25.9" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="390.4" y="25.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="451.4" y="25.9" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="524.6" y="25.9" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="585.6" y="25.9" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#2d3740" x="695.4" y="25.9" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#2b3339" x="793" y="25.9" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="0" y="50.3" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="36.6" y="50.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="170.8" y="50.3" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="305" y="50.3" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="390.4" y="50.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="451.4" y="50.3" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="524.6" y="50.3" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="585.6" y="50.3" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#0178d4" x="695.4" y="50.3" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="793" y="50.3" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="12.2" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="24.4" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="36.6" y="74.7" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="170.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="183" y="74.7" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="292.8" y="74.7" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="305" y="74.7" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="390.4" y="74.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="451.4" y="74.7" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="524.6" y="74.7" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="585.6" y="74.7" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="695.4" y="74.7" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="793" y="74.7" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="0" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="12.2" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="24.4" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="36.6" y="99.1" width="134.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="170.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="183" y="99.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="292.8" y="99.1" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="305" y="99.1" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="390.4" y="99.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="451.4" y="99.1" width="73.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="524.6" y="99.1" width="61" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="585.6" y="99.1" width="109.8" height="24.65" shape-rendering="crispEdges"/><rect fill="#1c1c1c" x="695.4" y="99.1" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#1e1e1e" x="793" y="99.1" width="671" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="123.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="147.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="172.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="196.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="221.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="245.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="269.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="294.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="318.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="343.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="367.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="391.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="416.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="440.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="465.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="489.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="513.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="538.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="562.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="587.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="611.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="635.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="660.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="684.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="709.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="733.5" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="757.9" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="782.3" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="806.7" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#272727" x="0" y="831.1" width="1464" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="0" y="855.5" width="36.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="36.6" y="855.5" width="85.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="122" y="855.5" width="1195.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1317.6" y="855.5" width="12.2" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1329.8" y="855.5" width="24.4" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1354.2" y="855.5" width="97.6" height="24.65" shape-rendering="crispEdges"/><rect fill="#242f38" x="1451.8" y="855.5" width="12.2" height="24.65" shape-rendering="crispEdges"/>
+    <g class="terminal-3861803967-matrix">
+    <text class="terminal-3861803967-r1" x="0" y="20" textLength="85.4" clip-path="url(#terminal-3861803967-line-0)">&#160;ralph&#160;</text><text class="terminal-3861803967-r3" x="109.8" y="20" textLength="146.4" clip-path="url(#terminal-3861803967-line-0)">fake-project</text><text class="terminal-3861803967-r5" x="488" y="20" textLength="85.4" clip-path="url(#terminal-3861803967-line-0)">tokens&#160;</text><text class="terminal-3861803967-r3" x="573.4" y="20" textLength="85.4" clip-path="url(#terminal-3861803967-line-0)">288.0k+</text><text class="terminal-3861803967-r5" x="658.8" y="20" textLength="158.6" clip-path="url(#terminal-3861803967-line-0)">&#160;/&#160;5.00M&#160;(5%)</text><text class="terminal-3861803967-r5" x="817.4" y="20" textLength="97.6" clip-path="url(#terminal-3861803967-line-0)">&#160;&#160;&#160;cost&#160;</text><text class="terminal-3861803967-r3" x="915" y="20" textLength="73.2" clip-path="url(#terminal-3861803967-line-0)">$4.50+</text><text class="terminal-3861803967-r6" x="988.2" y="20" textLength="463.6" clip-path="url(#terminal-3861803967-line-0)">&#160;&#160;&#160;[3&#160;call(s)&#160;unreported:&#160;lower&#160;bound]</text><text class="terminal-3861803967-r4" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-3861803967-line-0)">
+</text><text class="terminal-3861803967-r3" x="36.6" y="44.4" textLength="134.2" clip-path="url(#terminal-3861803967-line-1)">&#160;component&#160;</text><text class="terminal-3861803967-r3" x="170.8" y="44.4" textLength="134.2" clip-path="url(#terminal-3861803967-line-1)">&#160;status&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r3" x="305" y="44.4" textLength="85.4" clip-path="url(#terminal-3861803967-line-1)">&#160;phase&#160;</text><text class="terminal-3861803967-r3" x="390.4" y="44.4" textLength="61" clip-path="url(#terminal-3861803967-line-1)">&#160;att&#160;</text><text class="terminal-3861803967-r3" x="451.4" y="44.4" textLength="73.2" clip-path="url(#terminal-3861803967-line-1)">&#160;iter&#160;</text><text class="terminal-3861803967-r3" x="524.6" y="44.4" textLength="61" clip-path="url(#terminal-3861803967-line-1)">&#160;age&#160;</text><text class="terminal-3861803967-r3" x="585.6" y="44.4" textLength="109.8" clip-path="url(#terminal-3861803967-line-1)">&#160;tokens&#160;&#160;</text><text class="terminal-3861803967-r3" x="695.4" y="44.4" textLength="97.6" clip-path="url(#terminal-3861803967-line-1)">&#160;cost&#160;&#160;&#160;</text><text class="terminal-3861803967-r4" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-1)">
+</text><text class="terminal-3861803967-r7" x="0" y="68.8" textLength="36.6" clip-path="url(#terminal-3861803967-line-2)">&#160;✓&#160;</text><text class="terminal-3861803967-r7" x="36.6" y="68.8" textLength="134.2" clip-path="url(#terminal-3861803967-line-2)">&#160;comp-a&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r7" x="170.8" y="68.8" textLength="134.2" clip-path="url(#terminal-3861803967-line-2)">&#160;completed&#160;</text><text class="terminal-3861803967-r7" x="305" y="68.8" textLength="85.4" clip-path="url(#terminal-3861803967-line-2)">&#160;done&#160;&#160;</text><text class="terminal-3861803967-r7" x="390.4" y="68.8" textLength="61" clip-path="url(#terminal-3861803967-line-2)">&#160;1&#160;&#160;&#160;</text><text class="terminal-3861803967-r7" x="451.4" y="68.8" textLength="73.2" clip-path="url(#terminal-3861803967-line-2)">&#160;2&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r7" x="524.6" y="68.8" textLength="61" clip-path="url(#terminal-3861803967-line-2)">&#160;0s&#160;&#160;</text><text class="terminal-3861803967-r7" x="585.6" y="68.8" textLength="109.8" clip-path="url(#terminal-3861803967-line-2)">&#160;48000+&#160;&#160;</text><text class="terminal-3861803967-r7" x="695.4" y="68.8" textLength="97.6" clip-path="url(#terminal-3861803967-line-2)">&#160;$0.75+&#160;</text><text class="terminal-3861803967-r4" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-2)">
+</text><text class="terminal-3861803967-r8" x="12.2" y="93.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-3)">✓</text><text class="terminal-3861803967-r2" x="36.6" y="93.2" textLength="134.2" clip-path="url(#terminal-3861803967-line-3)">&#160;comp-b&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r8" x="183" y="93.2" textLength="109.8" clip-path="url(#terminal-3861803967-line-3)">completed</text><text class="terminal-3861803967-r2" x="305" y="93.2" textLength="85.4" clip-path="url(#terminal-3861803967-line-3)">&#160;done&#160;&#160;</text><text class="terminal-3861803967-r2" x="390.4" y="93.2" textLength="61" clip-path="url(#terminal-3861803967-line-3)">&#160;1&#160;&#160;&#160;</text><text class="terminal-3861803967-r2" x="451.4" y="93.2" textLength="73.2" clip-path="url(#terminal-3861803967-line-3)">&#160;2&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r2" x="524.6" y="93.2" textLength="61" clip-path="url(#terminal-3861803967-line-3)">&#160;0s&#160;&#160;</text><text class="terminal-3861803967-r2" x="585.6" y="93.2" textLength="109.8" clip-path="url(#terminal-3861803967-line-3)">&#160;96000+&#160;&#160;</text><text class="terminal-3861803967-r2" x="695.4" y="93.2" textLength="97.6" clip-path="url(#terminal-3861803967-line-3)">&#160;$1.50+&#160;</text><text class="terminal-3861803967-r4" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-3)">
+</text><text class="terminal-3861803967-r8" x="12.2" y="117.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-4)">✓</text><text class="terminal-3861803967-r2" x="36.6" y="117.6" textLength="134.2" clip-path="url(#terminal-3861803967-line-4)">&#160;comp-c&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r8" x="183" y="117.6" textLength="109.8" clip-path="url(#terminal-3861803967-line-4)">completed</text><text class="terminal-3861803967-r2" x="305" y="117.6" textLength="85.4" clip-path="url(#terminal-3861803967-line-4)">&#160;done&#160;&#160;</text><text class="terminal-3861803967-r2" x="390.4" y="117.6" textLength="61" clip-path="url(#terminal-3861803967-line-4)">&#160;1&#160;&#160;&#160;</text><text class="terminal-3861803967-r2" x="451.4" y="117.6" textLength="73.2" clip-path="url(#terminal-3861803967-line-4)">&#160;2&#160;&#160;&#160;&#160;</text><text class="terminal-3861803967-r2" x="524.6" y="117.6" textLength="61" clip-path="url(#terminal-3861803967-line-4)">&#160;0s&#160;&#160;</text><text class="terminal-3861803967-r2" x="585.6" y="117.6" textLength="109.8" clip-path="url(#terminal-3861803967-line-4)">&#160;144000+&#160;</text><text class="terminal-3861803967-r2" x="695.4" y="117.6" textLength="97.6" clip-path="url(#terminal-3861803967-line-4)">&#160;$2.25+&#160;</text><text class="terminal-3861803967-r4" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-4)">
+</text><text class="terminal-3861803967-r4" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-3861803967-line-5)">
+</text><text class="terminal-3861803967-r4" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-6)">
+</text><text class="terminal-3861803967-r4" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-7)">
+</text><text class="terminal-3861803967-r4" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-8)">
+</text><text class="terminal-3861803967-r4" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-9)">
+</text><text class="terminal-3861803967-r4" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-3861803967-line-10)">
+</text><text class="terminal-3861803967-r4" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-11)">
+</text><text class="terminal-3861803967-r4" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-12)">
+</text><text class="terminal-3861803967-r4" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-13)">
+</text><text class="terminal-3861803967-r4" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-14)">
+</text><text class="terminal-3861803967-r4" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-3861803967-line-15)">
+</text><text class="terminal-3861803967-r4" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-16)">
+</text><text class="terminal-3861803967-r4" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-17)">
+</text><text class="terminal-3861803967-r4" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-18)">
+</text><text class="terminal-3861803967-r4" x="1464" y="483.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-19)">
+</text><text class="terminal-3861803967-r4" x="1464" y="508" textLength="12.2" clip-path="url(#terminal-3861803967-line-20)">
+</text><text class="terminal-3861803967-r4" x="1464" y="532.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-21)">
+</text><text class="terminal-3861803967-r4" x="1464" y="556.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-22)">
+</text><text class="terminal-3861803967-r4" x="1464" y="581.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-23)">
+</text><text class="terminal-3861803967-r4" x="1464" y="605.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-24)">
+</text><text class="terminal-3861803967-r4" x="1464" y="630" textLength="12.2" clip-path="url(#terminal-3861803967-line-25)">
+</text><text class="terminal-3861803967-r4" x="1464" y="654.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-26)">
+</text><text class="terminal-3861803967-r4" x="1464" y="678.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-27)">
+</text><text class="terminal-3861803967-r4" x="1464" y="703.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-28)">
+</text><text class="terminal-3861803967-r4" x="1464" y="727.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-29)">
+</text><text class="terminal-3861803967-r4" x="1464" y="752" textLength="12.2" clip-path="url(#terminal-3861803967-line-30)">
+</text><text class="terminal-3861803967-r4" x="1464" y="776.4" textLength="12.2" clip-path="url(#terminal-3861803967-line-31)">
+</text><text class="terminal-3861803967-r4" x="1464" y="800.8" textLength="12.2" clip-path="url(#terminal-3861803967-line-32)">
+</text><text class="terminal-3861803967-r4" x="1464" y="825.2" textLength="12.2" clip-path="url(#terminal-3861803967-line-33)">
+</text><text class="terminal-3861803967-r4" x="1464" y="849.6" textLength="12.2" clip-path="url(#terminal-3861803967-line-34)">
+</text><text class="terminal-3861803967-r9" x="0" y="874" textLength="36.6" clip-path="url(#terminal-3861803967-line-35)">&#160;q&#160;</text><text class="terminal-3861803967-r2" x="36.6" y="874" textLength="85.4" clip-path="url(#terminal-3861803967-line-35)">Detach&#160;</text><text class="terminal-3861803967-r10" x="1317.6" y="874" textLength="12.2" clip-path="url(#terminal-3861803967-line-35)">▏</text><text class="terminal-3861803967-r9" x="1329.8" y="874" textLength="24.4" clip-path="url(#terminal-3861803967-line-35)">^p</text><text class="terminal-3861803967-r2" x="1354.2" y="874" textLength="97.6" clip-path="url(#terminal-3861803967-line-35)">&#160;palette</text>
+    </g>
+    </g>
+</svg>

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from unittest.mock import PropertyMock, patch
 
 from rich.text import Text
 
@@ -109,6 +110,20 @@ class TestOverview:
             await pilot.pause()
 
             assert app.store.state.total_tokens == initial_tokens
+
+    async def test_timers_ignore_empty_screen_stack_during_teardown(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            with patch.object(
+                RalphTuiApp, "screen_stack", new_callable=PropertyMock,
+                return_value=[],
+            ):
+                app._poll()
+                app._tick_ages()
 
 
 class TestRenderHelpers:

--- a/tests/test_tui_snapshots.py
+++ b/tests/test_tui_snapshots.py
@@ -1,0 +1,53 @@
+"""Stage 3 PR G (TUI rewrite): SVG snapshot tests.
+
+Kept deliberately few (overview, detail, checkpoint modal) at a fixed
+size over the fixed-run_id fixture, so churn stays reviewable. Update
+with: uv run pytest tests/test_tui_snapshots.py --snapshot-update
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ralph_py.tui.app import Mode, RalphTuiApp
+from tests.helpers.fake_run import FakeRunSpec, write_fake_run
+
+SIZE = (120, 36)
+
+
+@pytest.fixture()
+def fixed_run(tmp_path: Path) -> tuple[Path, Path]:
+    run_dir = write_fake_run(tmp_path, FakeRunSpec(components=3))
+    return tmp_path, run_dir
+
+
+def _app(root: Path, run_dir: Path) -> RalphTuiApp:
+    # Poll interval high enough that no timer fires between the pilot
+    # settling and the snapshot capture (determinism).
+    return RalphTuiApp(
+        run_dir=run_dir, root_dir=root, mode=Mode.DASH, poll_interval=60.0,
+    )
+
+
+def test_overview_snapshot(
+    snap_compare: Any, fixed_run: tuple[Path, Path],
+) -> None:
+    root, run_dir = fixed_run
+    assert snap_compare(_app(root, run_dir), terminal_size=SIZE)
+
+
+def test_component_detail_snapshot(
+    snap_compare: Any, fixed_run: tuple[Path, Path],
+) -> None:
+    root, run_dir = fixed_run
+
+    async def open_detail(pilot: Any) -> None:
+        pilot.app.open_component("comp-a")
+        await pilot.pause()
+
+    assert snap_compare(
+        _app(root, run_dir), terminal_size=SIZE, run_before=open_detail,
+    )

--- a/tests/test_tui_snapshots.py
+++ b/tests/test_tui_snapshots.py
@@ -1,7 +1,7 @@
 """Stage 3 PR G (TUI rewrite): SVG snapshot tests.
 
-Kept deliberately few (overview, detail, checkpoint modal) at a fixed
-size over the fixed-run_id fixture, so churn stays reviewable. Update
+Kept deliberately few (overview and detail) at a fixed size over the
+fixed-run_id fixture, so churn stays reviewable. Update
 with: uv run pytest tests/test_tui_snapshots.py --snapshot-update
 """
 

--- a/uv.lock
+++ b/uv.lock
@@ -394,6 +394,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -523,6 +535,80 @@ linkify = [
 ]
 plugins = [
     { name = "mdit-py-plugins" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631 },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058 },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287 },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940 },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887 },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692 },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471 },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923 },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572 },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077 },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876 },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615 },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020 },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332 },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947 },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962 },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760 },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529 },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015 },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540 },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105 },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906 },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622 },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374 },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980 },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990 },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784 },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588 },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041 },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543 },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113 },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911 },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658 },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066 },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639 },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569 },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284 },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801 },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769 },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642 },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612 },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200 },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973 },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619 },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029 },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408 },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005 },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048 },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821 },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606 },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043 },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747 },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341 },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073 },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661 },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069 },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670 },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598 },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261 },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835 },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733 },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672 },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819 },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426 },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146 },
 ]
 
 [[package]]
@@ -862,6 +948,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-textual-snapshot"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pytest" },
+    { name = "rich" },
+    { name = "syrupy" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/75/2ef17ae52fa5bc848ff2d1d7bc317a702cbd6d7ad733ca991b9f899dbbae/pytest_textual_snapshot-1.0.0.tar.gz", hash = "sha256:065217055ed833b8a16f2320a0613f39a0154e8d9fee63535f29f32c6414b9d7", size = 11071 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/2e/4bf16ed78b382b3d7c1e545475ec8cf04346870be662815540faf8f16e8c/pytest_textual_snapshot-1.0.0-py3-none-any.whl", hash = "sha256:dd3a421491a6b1987ee7b4336d7f65299524924d2b0a297e69733b73b01570e1", size = 11171 },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -923,6 +1025,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-textual-snapshot" },
     { name = "ruff" },
 ]
 
@@ -941,6 +1044,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-textual-snapshot", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.6.0" },
 ]
 
@@ -1152,6 +1256,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632 },
+]
+
+[[package]]
+name = "syrupy"
+version = "5.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/39/17dde9f0c76cc5abcdeef1b2243791bb850d498f784147b8e460dd23abe8/syrupy-5.5.3.tar.gz", hash = "sha256:fa21e4ae77c89ec5abfca513338d8a7eb916da6618ca0f8db301476e0768e57a", size = 91614 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/f9/617a194c1a4203279998e1859426cf2635042533a99a93d63d3ee1fb967e/syrupy-5.5.3-py3-none-any.whl", hash = "sha256:0b260a0c9dad55e1fb83818973dc36fbc1aea3fd5381592f442a986686c4171a", size = 54959 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Stage 3 PR G - the final PR of the TUI rewrite plan (stacked on #118).

- **Animation retired**: the 24fps Lissajous `Live` loop becomes a one-line static brand mark (spike: 24fps is the ceiling, not the norm). `ui/animated_art.py` shrinks to `brand_mark()`.
- **SVG snapshots**: `pytest-textual-snapshot` (dev dep, resolves against textual 5.3) with two deliberately-few fixed-size snapshots (overview, component detail) over the fixed-run_id fixture.
- **Docs**: runbook "The dashboard (TUI)" section (keys, per-mode quit semantics, checkpoint modal, notify-capture tradeoff, files-are-the-record); `RALPH_NO_TUI` in env-vars; `ralph status` hints at `ralph dash`. Zero `prompt_toolkit` references remain (grep-verified).
- Noted plan deviation: no `[ui] tui` toml key - the flag + env var are the wired controls; a dead config key would violate the control-plane conventions.

## End-to-end verification (the plan's final gate, real CLI)

On a toy git project: `ralph factory` (plain mode, echo agent) completed 2 components - `events.jsonl` carries `run_plan` + phase brackets, worker `engineer.jsonl` + transcript captured, `ralph status` renders from the Events source with authoritative phase; `ralph run 1` smoke passed; **`ralph dash` driven in a real pty**: board rendered (components, project, ✓ glyphs), `q` exited 0, alt screen + cursor restored.

Gates: fast 1657 passed, spine 25 passed, `mypy --strict` clean, ruff clean.

## The whole stack

#101 spike -> #102 events -> #103 reducer -> #104 dual-write -> #105 semantic events -> #106 bridge UI -> #107 worker channel -> #109 renderer inversion -> #110 status -> #112 interaction seam -> #113 shutdown -> #114 tailing -> #115 dashboard + dash -> #117 detail + modal -> #118 embedded -> this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)