### PR TITLE
rename: PR 2/4 - KSTRL_* env namespace + kstrl.toml, legacy dual-read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,8 @@ scripts/ralph/understand_prompt.md
 # Ralph - runtime state (journals, worktrees, knowledge, locks; R3.4)
 .ralph/
 
-# Live per-checkout config; ralph.toml.example is the tracked template (R3.4)
+# Live per-checkout config; kstrl.toml.example is the tracked template (R3.4)
+/kstrl.toml
 /ralph.toml
 
 # Claude Code session dir: personal settings + live session worktrees (R3.4)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 ## Verification commands
 
 - **Test**: `uv run pytest tests/ -v`
-- **Calibration (opt-in, real LLMs)**: `RALPH_RUN_CALIBRATION=1 uv run pytest tests/test_calibration.py -v`
+- **Calibration (opt-in, real LLMs)**: `KSTRL_RUN_CALIBRATION=1 uv run pytest tests/test_calibration.py -v`
 - **Typecheck**: `uv run mypy kstrl/ --strict`
 - **Lint**: `uv run ruff check kstrl/ tests/`
 

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ hook_timeout = 30.0    # seconds before a hook command is killed
 [linear]
 enabled = false                             # mirror runs into Linear (project/issues/status via GitHub linking)
 team_id = ""                                # Linear team UUID (required when enabled)
-token_env = "RALPH_LINEAR_TOKEN"            # NAME of the env var holding the API token
+token_env = "KSTRL_LINEAR_TOKEN"            # NAME of the env var holding the API token
 auth_mode = "auto"                          # auto | api_key | oauth (auto sniffs the lin_api_ prefix)
 api_url = "https://api.linear.app/graphql"  # GraphQL endpoint
 dry_run = false                             # record mutations instead of sending them
@@ -451,7 +451,7 @@ timeout_seconds = 30.0                      # per-request timeout
 min_request_interval = 0.5                  # client-side throttle between requests (seconds)
 ```
 
-Environment variables override ralph.toml, and CLI flags override both.
+Environment variables override kstrl.toml, and CLI flags override both.
 See [docs/env-vars.md](docs/env-vars.md) for the full env-var mapping.
 <!-- END GENERATED: config-reference -->
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -1,4 +1,9 @@
-# Ralph Environment Variables Reference
+# kstrl Environment Variables Reference
+
+> Rename note (2026-07-20): ``KSTRL_*`` is the primary namespace. The
+> legacy ``RALPH_*`` spelling of every variable below is honored for one
+> release with a DeprecationWarning (see ``kstrl/envcompat.py``). Bare
+> ``FACTORY_*`` names remain accepted for the factory family.
 
 Every config dataclass has a `from_env()` classmethod that reads env vars, and a `load(root_dir)` classmethod that overlays env on top of `ralph.toml` (env wins). This doc enumerates every variable the harness consults.
 
@@ -16,17 +21,17 @@ Precedence: **CLI flag > env var > `ralph.toml` > dataclass default**.
 | `SLEEP_SECONDS` | float | 2.0 | Inter-iteration sleep |
 | `INTERACTIVE` | bool | false | Pause between iterations for human input |
 | `ALLOWED_PATHS` | comma-list | empty | Restrict agent writes to these prefixes |
-| `RALPH_BRANCH` | str | unset | Override branch checkout; `""` means skip checkout |
-| `RALPH_AUTO_CHECKOUT` | bool | true | When false, run loop skips branch resolution |
+| `KSTRL_BRANCH` | str | unset | Override branch checkout; `""` means skip checkout |
+| `KSTRL_AUTO_CHECKOUT` | bool | true | When false, run loop skips branch resolution |
 | `AGENT_CMD` | str | unset | Custom shell command for the agent (overrides type) |
 | `MODEL` | str | unset | Model name passed to the agent |
 | `MODEL_REASONING_EFFORT` | str | unset | `low\|medium\|high\|max` |
-| `RALPH_AGENT_TYPE` | str | unset | `claude-code\|claude-sdk\|codex\|auto` (`claude-sdk` needs the `sdk` extra: `uv sync --extra sdk`) |
-| `RALPH_AGENT_BUDGET_USD` | float | unset | In-loop USD budget ceiling; enforced per turn by the `claude-sdk` adapter only (R7.6). Non-positive or unparseable values are ignored |
-| `RALPH_UI` | str | auto | `auto\|rich\|plain` |
-| `RALPH_NO_TUI` | bool | unset | `1` disables the embedded factory dashboard (plain output) |
+| `KSTRL_AGENT_TYPE` | str | unset | `claude-code\|claude-sdk\|codex\|auto` (`claude-sdk` needs the `sdk` extra: `uv sync --extra sdk`) |
+| `KSTRL_AGENT_BUDGET_USD` | float | unset | In-loop USD budget ceiling; enforced per turn by the `claude-sdk` adapter only (R7.6). Non-positive or unparseable values are ignored |
+| `KSTRL_UI` | str | auto | `auto\|rich\|plain` |
+| `KSTRL_NO_TUI` | bool | unset | `1` disables the embedded factory dashboard (plain output) |
 | `NO_COLOR` | bool flag | false | Disables colors |
-| `RALPH_ASCII` | bool | false | ASCII-only UI |
+| `KSTRL_ASCII` | bool | false | ASCII-only UI |
 
 ## TimeoutConfig (`[timeout]`)
 
@@ -34,14 +39,14 @@ All values are seconds; 0 or less disables that limit.
 
 | Env var | Type | Default | Notes |
 |---|---|---|---|
-| `RALPH_TIMEOUT_GIT` | float | 30 | Per git subprocess |
-| `RALPH_TIMEOUT_AGENT_ITERATION` | float | 1800 | One engineer iteration |
-| `RALPH_TIMEOUT_COMPONENT` | float | 7200 | Wall clock per component across iterations |
-| `RALPH_TIMEOUT_VERIFY` | float | 300 | Each Phase 1 check subprocess (also read by `VerifyConfig.subprocess_timeout`) |
-| `RALPH_TIMEOUT_REVIEW` | float | 600 | Phase 2 reviewer call |
-| `RALPH_TIMEOUT_CONTRACT` | float | 600 | Phase 3 contract test run (also read by `ContractConfig.timeout`) |
-| `RALPH_TIMEOUT_DEFAULT` | float | 60 | Any other subprocess |
-| `RALPH_TIMEOUT_BACKSTOP_MARGIN` | float | 60 | Extra slack before the scheduler declares a worker dead |
+| `KSTRL_TIMEOUT_GIT` | float | 30 | Per git subprocess |
+| `KSTRL_TIMEOUT_AGENT_ITERATION` | float | 1800 | One engineer iteration |
+| `KSTRL_TIMEOUT_COMPONENT` | float | 7200 | Wall clock per component across iterations |
+| `KSTRL_TIMEOUT_VERIFY` | float | 300 | Each Phase 1 check subprocess (also read by `VerifyConfig.subprocess_timeout`) |
+| `KSTRL_TIMEOUT_REVIEW` | float | 600 | Phase 2 reviewer call |
+| `KSTRL_TIMEOUT_CONTRACT` | float | 600 | Phase 3 contract test run (also read by `ContractConfig.timeout`) |
+| `KSTRL_TIMEOUT_DEFAULT` | float | 60 | Any other subprocess |
+| `KSTRL_TIMEOUT_BACKSTOP_MARGIN` | float | 60 | Extra slack before the scheduler declares a worker dead |
 
 ## FactoryConfig (`[factory]`)
 
@@ -51,11 +56,11 @@ All values are seconds; 0 or less disables that limit.
 | `FACTORY_MAX_RETRIES` | int | 3 |
 | `FACTORY_RETRY_DELAY` | float | 5.0 |
 | `FACTORY_MERGE_TIMEOUT` | float | 300.0 |
-| `RALPH_FACTORY_MAX_ADVERSARIAL_CALLS` | int | 0 (unbounded) |
-| `RALPH_FACTORY_MAX_TOTAL_TOKENS` | int | 0 (unbounded) |
-| `RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE` | bool (`1`/`true`/`yes`) | false |
-| `RALPH_FACTORY_PROGRESS_LOG_ENABLED` | bool | true |
-| `RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE` | bool | false |
+| `KSTRL_FACTORY_MAX_ADVERSARIAL_CALLS` | int | 0 (unbounded) |
+| `KSTRL_FACTORY_MAX_TOTAL_TOKENS` | int | 0 (unbounded) |
+| `KSTRL_FACTORY_PAUSE_BEFORE_PR_MERGE` | bool (`1`/`true`/`yes`) | false |
+| `KSTRL_FACTORY_PROGRESS_LOG_ENABLED` | bool | true |
+| `KSTRL_FACTORY_KEEP_WORKTREES_ON_FAILURE` | bool | false |
 
 The two safety knobs (E4 `max_adversarial_calls`, E6 `pause_before_pr_merge`) are reachable via all three surfaces since R2.2: the env vars above, `[factory]` keys in ralph.toml, and the `--max-adversarial-calls` / `--pause-before-pr-merge` CLI flags.
 
@@ -67,9 +72,9 @@ test-failure signature.
 
 | Env var | Type | Default | Notes |
 |---|---|---|---|
-| `RALPH_BREAKER_ITERATIONS` | int | 3 | Consecutive no-progress iterations before the halt; 0 disables |
-| `RALPH_BREAKER_TEST_CMD` | str | unset | Stall-probe command; unset falls back to the explicit `[verify]` test_command, else diff-hash only |
-| `RALPH_BREAKER_TEST_TIMEOUT` | float | 300 | Seconds before the stall probe is killed |
+| `KSTRL_BREAKER_ITERATIONS` | int | 3 | Consecutive no-progress iterations before the halt; 0 disables |
+| `KSTRL_BREAKER_TEST_CMD` | str | unset | Stall-probe command; unset falls back to the explicit `[verify]` test_command, else diff-hash only |
+| `KSTRL_BREAKER_TEST_TIMEOUT` | float | 300 | Seconds before the stall probe is killed |
 
 ## SandboxConfig (`[sandbox]`)
 
@@ -79,25 +84,25 @@ agent's worktree by construction on both CLIs.
 
 | Env var | Type | Default | Notes |
 |---|---|---|---|
-| `RALPH_SANDBOX_ENABLED` | bool | false | Opt-in OS sandbox for agent subprocesses |
-| `RALPH_SANDBOX_ALLOW_NETWORK` | bool | false | Re-open outbound network inside the sandbox |
+| `KSTRL_SANDBOX_ENABLED` | bool | false | Opt-in OS sandbox for agent subprocesses |
+| `KSTRL_SANDBOX_ALLOW_NETWORK` | bool | false | Re-open outbound network inside the sandbox |
 
 ## VerifyConfig (`[verify]`)
 
 | Env var | Type | Default |
 |---|---|---|
-| `RALPH_VERIFY_TEST_CMD` | str | unset (uses `uv run pytest`) |
-| `RALPH_VERIFY_TYPECHECK_CMD` | str | unset (uses `uv run mypy .`) |
-| `RALPH_VERIFY_LINT_CMD` | str | unset (uses `uv run ruff check .`) |
-| `RALPH_DEAD_CODE_CLEANUP` | bool (`1`) | false |
-| `RALPH_DEAD_CODE_CMD` | str | unset |
-| `RALPH_MUTATION_TESTING` | bool (`1`) | false |
-| `RALPH_MUTATION_THRESHOLD` | float | 50 |
-| `RALPH_MUTATION_TIMEOUT` | float | 600 |
-| `RALPH_TIMEOUT_VERIFY` | float | 300 |
-| `RALPH_VERIFY_REQUIRE_SELF_CRITIQUE` | bool (`1`) | false |
-| `RALPH_VERIFY_SELF_CRITIQUE_MIN_BULLETS` | int | 3 |
-| `RALPH_VERIFY_PROGRESS_FILE` | path | `scripts/ralph/progress.txt` |
+| `KSTRL_VERIFY_TEST_CMD` | str | unset (uses `uv run pytest`) |
+| `KSTRL_VERIFY_TYPECHECK_CMD` | str | unset (uses `uv run mypy .`) |
+| `KSTRL_VERIFY_LINT_CMD` | str | unset (uses `uv run ruff check .`) |
+| `KSTRL_DEAD_CODE_CLEANUP` | bool (`1`) | false |
+| `KSTRL_DEAD_CODE_CMD` | str | unset |
+| `KSTRL_MUTATION_TESTING` | bool (`1`) | false |
+| `KSTRL_MUTATION_THRESHOLD` | float | 50 |
+| `KSTRL_MUTATION_TIMEOUT` | float | 600 |
+| `KSTRL_TIMEOUT_VERIFY` | float | 300 |
+| `KSTRL_VERIFY_REQUIRE_SELF_CRITIQUE` | bool (`1`) | false |
+| `KSTRL_VERIFY_SELF_CRITIQUE_MIN_BULLETS` | int | 3 |
+| `KSTRL_VERIFY_PROGRESS_FILE` | path | `scripts/ralph/progress.txt` |
 
 ## FixturesConfig (`[fixtures]`)
 
@@ -105,18 +110,18 @@ Phase 1 approved-fixtures oracle (R7.2). Off by default: fixtures execute PRD-su
 
 | Env var | Type | Default |
 |---|---|---|
-| `RALPH_FIXTURES_ENABLED` | bool | false |
-| `RALPH_FIXTURES_SNAPSHOT_ON_SUCCESS` | bool | true |
-| `RALPH_FIXTURES_SNAPSHOT_DIR` | path | `.ralph/snapshots` (relative = against the repo root) |
-| `RALPH_FIXTURES_TIMEOUT` | float | 30 |
+| `KSTRL_FIXTURES_ENABLED` | bool | false |
+| `KSTRL_FIXTURES_SNAPSHOT_ON_SUCCESS` | bool | true |
+| `KSTRL_FIXTURES_SNAPSHOT_DIR` | path | `.ralph/snapshots` (relative = against the repo root) |
+| `KSTRL_FIXTURES_TIMEOUT` | float | 30 |
 
 ## ContractConfig (`[contract]`)
 
 | Env var | Type | Default |
 |---|---|---|
-| `RALPH_CONTRACT_MODE` | str | `tier` (`tier\|final\|skip`) |
-| `RALPH_CONTRACT_TEST_CMD` | str | `uv run pytest` |
-| `RALPH_TIMEOUT_CONTRACT` | float | 600 |
+| `KSTRL_CONTRACT_MODE` | str | `tier` (`tier\|final\|skip`) |
+| `KSTRL_CONTRACT_TEST_CMD` | str | `uv run pytest` |
+| `KSTRL_TIMEOUT_CONTRACT` | float | 600 |
 
 Invalid mode raises ValueError (Phase B8).
 
@@ -124,12 +129,12 @@ Invalid mode raises ValueError (Phase B8).
 
 | Env var | Type | Default |
 |---|---|---|
-| `RALPH_SECURITY_MODE` | str | `skip` (`skip\|advisory\|hard`) |
-| `RALPH_SECURITY_AGENT_CMD` | str | unset |
-| `RALPH_SECURITY_AGENT_TYPE` | str | unset |
-| `RALPH_SECURITY_MODEL` | str | unset |
-| `RALPH_SECURITY_TIMEOUT` | float | 600 |
-| `RALPH_SECURITY_FAIL_THRESHOLD` | str | `high` (`critical\|high\|medium\|low`) |
+| `KSTRL_SECURITY_MODE` | str | `skip` (`skip\|advisory\|hard`) |
+| `KSTRL_SECURITY_AGENT_CMD` | str | unset |
+| `KSTRL_SECURITY_AGENT_TYPE` | str | unset |
+| `KSTRL_SECURITY_MODEL` | str | unset |
+| `KSTRL_SECURITY_TIMEOUT` | float | 600 |
+| `KSTRL_SECURITY_FAIL_THRESHOLD` | str | `high` (`critical\|high\|medium\|low`) |
 
 Invalid mode or threshold raises ValueError (Phase B8). The default mode is `skip` everywhere (dataclass, env, CLI); enable the pass with `advisory` or `hard`.
 
@@ -137,14 +142,14 @@ Invalid mode or threshold raises ValueError (Phase B8). The default mode is `ski
 
 | Env var | Type | Default |
 |---|---|---|
-| `RALPH_KNOWLEDGE_ENABLED` | bool (`1`/`true`) | true |
-| `RALPH_KNOWLEDGE_MAX_CORE_TOKENS` | int | 2000 |
-| `RALPH_KNOWLEDGE_MAX_DEPENDENCY_TOKENS` | int | 1000 |
-| `RALPH_KNOWLEDGE_MAX_SIBLING_TOKENS` | int | 500 |
-| `RALPH_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS` | float | 300 |
-| `RALPH_KNOWLEDGE_DISTILL_MODEL` | str | falls back to `MODEL` |
-| `RALPH_KNOWLEDGE_MAX_FACTS_PER_DISTILL` | int | 7 |
-| `RALPH_KNOWLEDGE_DEPENDENCY_SCOPE` | str | `direct` (`direct\|transitive`) |
+| `KSTRL_KNOWLEDGE_ENABLED` | bool (`1`/`true`) | true |
+| `KSTRL_KNOWLEDGE_MAX_CORE_TOKENS` | int | 2000 |
+| `KSTRL_KNOWLEDGE_MAX_DEPENDENCY_TOKENS` | int | 1000 |
+| `KSTRL_KNOWLEDGE_MAX_SIBLING_TOKENS` | int | 500 |
+| `KSTRL_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS` | float | 300 |
+| `KSTRL_KNOWLEDGE_DISTILL_MODEL` | str | falls back to `MODEL` |
+| `KSTRL_KNOWLEDGE_MAX_FACTS_PER_DISTILL` | int | 7 |
+| `KSTRL_KNOWLEDGE_DEPENDENCY_SCOPE` | str | `direct` (`direct\|transitive`) |
 
 `dependency_scope` (E8) controls whether the full-text "Dependencies" tier in `build_knowledge_context` surfaces only direct manifest dependencies (`direct`, default) or the transitive closure (`transitive`). Transitive deps excluded from the full-text tier still appear in the sibling first-sentence summary tier - downgraded, not hidden. Invalid values raise ValueError.
 
@@ -152,55 +157,55 @@ Invalid mode or threshold raises ValueError (Phase B8). The default mode is `ski
 
 | Env var | Type | Default |
 |---|---|---|
-| `RALPH_FEEDFORWARD_ENABLED` | bool | true |
-| `RALPH_FEEDFORWARD_MODULE_MAP` | bool | true |
-| `RALPH_FEEDFORWARD_PUBLIC_INTERFACES` | bool | true |
-| `RALPH_FEEDFORWARD_DEPENDENCY_GRAPH` | bool | true |
-| `RALPH_FEEDFORWARD_CONVENTIONS` | bool | true |
-| `RALPH_FEEDFORWARD_MAX_TOKENS` | int | 4000 |
+| `KSTRL_FEEDFORWARD_ENABLED` | bool | true |
+| `KSTRL_FEEDFORWARD_MODULE_MAP` | bool | true |
+| `KSTRL_FEEDFORWARD_PUBLIC_INTERFACES` | bool | true |
+| `KSTRL_FEEDFORWARD_DEPENDENCY_GRAPH` | bool | true |
+| `KSTRL_FEEDFORWARD_CONVENTIONS` | bool | true |
+| `KSTRL_FEEDFORWARD_MAX_TOKENS` | int | 4000 |
 
 ## EvolutionConfig (`[evolution]`)
 
 | Env var | Type | Default |
 |---|---|---|
-| `RALPH_EVOLUTION_ENABLED` | bool | true |
-| `RALPH_EVOLUTION_JOURNAL_PATH` | path | `.ralph/evolution.jsonl` |
-| `RALPH_EVOLUTION_LOOKBACK_RUNS` | int | 10 |
+| `KSTRL_EVOLUTION_ENABLED` | bool | true |
+| `KSTRL_EVOLUTION_JOURNAL_PATH` | path | `.ralph/evolution.jsonl` |
+| `KSTRL_EVOLUTION_LOOKBACK_RUNS` | int | 10 |
 
 ## NotifyConfig (`[notify]`)
 
-Run-milestone shell hooks (R3.2), each fired at most once per run. The hook command runs via the shell with `RALPH_NOTIFY_EVENT` (`run_complete` | `first_failure` | `merge_pending`), `RALPH_NOTIFY_RUN_ID`, `RALPH_NOTIFY_PROJECT`, `RALPH_NOTIFY_COMPONENT` and `RALPH_NOTIFY_DETAIL` set in its environment.
+Run-milestone shell hooks (R3.2), each fired at most once per run. The hook command runs via the shell with `KSTRL_NOTIFY_EVENT` (`run_complete` | `first_failure` | `merge_pending`), `KSTRL_NOTIFY_RUN_ID`, `KSTRL_NOTIFY_PROJECT`, `KSTRL_NOTIFY_COMPONENT` and `KSTRL_NOTIFY_DETAIL` set in its environment.
 
 | Env var | Type | Default |
 |---|---|---|
-| `RALPH_NOTIFY_ON_COMPLETE` | str | unset (hook disabled) |
-| `RALPH_NOTIFY_ON_FIRST_FAILURE` | str | unset (hook disabled) |
-| `RALPH_NOTIFY_HOOK_TIMEOUT` | float | 30 |
+| `KSTRL_NOTIFY_ON_COMPLETE` | str | unset (hook disabled) |
+| `KSTRL_NOTIFY_ON_FIRST_FAILURE` | str | unset (hook disabled) |
+| `KSTRL_NOTIFY_HOOK_TIMEOUT` | float | 30 |
 
 ## LinearConfig (`[linear]`)
 
 | Env var | Type | Default | Notes |
 |---|---|---|---|
-| `RALPH_LINEAR_ENABLED` | bool | false | |
-| `RALPH_LINEAR_TEAM_ID` | str | empty | Linear team UUID; required when enabled |
-| `RALPH_LINEAR_TOKEN_ENV` | str | `RALPH_LINEAR_TOKEN` | NAME of the env var holding the token (indirection so the secret itself never appears in config) |
-| `RALPH_LINEAR_TOKEN` | secret | unset | The API key / OAuth token (default token env var; never logged) |
-| `RALPH_LINEAR_AUTH_MODE` | str | `auto` | `auto\|api_key\|oauth`; auto sniffs the `lin_api_` key prefix |
-| `RALPH_LINEAR_API_URL` | str | `https://api.linear.app/graphql` | |
-| `RALPH_LINEAR_DRY_RUN` | bool | false | Record mutations instead of sending |
-| `RALPH_LINEAR_TIMEOUT` | float | 30 | Per-request timeout (seconds) |
-| `RALPH_LINEAR_MIN_INTERVAL` | float | 0.5 | Client-side throttle between requests |
+| `KSTRL_LINEAR_ENABLED` | bool | false | |
+| `KSTRL_LINEAR_TEAM_ID` | str | empty | Linear team UUID; required when enabled |
+| `KSTRL_LINEAR_TOKEN_ENV` | str | `KSTRL_LINEAR_TOKEN` | NAME of the env var holding the token (indirection so the secret itself never appears in config) |
+| `KSTRL_LINEAR_TOKEN` | secret | unset | The API key / OAuth token (default token env var; never logged) |
+| `KSTRL_LINEAR_AUTH_MODE` | str | `auto` | `auto\|api_key\|oauth`; auto sniffs the `lin_api_` key prefix |
+| `KSTRL_LINEAR_API_URL` | str | `https://api.linear.app/graphql` | |
+| `KSTRL_LINEAR_DRY_RUN` | bool | false | Record mutations instead of sending |
+| `KSTRL_LINEAR_TIMEOUT` | float | 30 | Per-request timeout (seconds) |
+| `KSTRL_LINEAR_MIN_INTERVAL` | float | 0.5 | Client-side throttle between requests |
 
 ## Calibration
 
 | Env var | Default | Notes |
 |---|---|---|
-| `RALPH_RUN_CALIBRATION` | unset | Set to `1` to enable real-LLM calibration tests under `tests/test_calibration.py` |
-| `RALPH_CALIBRATION_MODEL` | `haiku` | Fast model used by the calibration suite. Changing it triggers the R5.5 model-drift warning until a fresh baseline is captured (H2-extended) |
-| `RALPH_CALIBRATION_RUNS` | `3` | Runs per fixture (R5.1). The suite gates on majority-of-runs consistency; use `1` for a cheap smoke, keep `3` for baseline capture |
+| `KSTRL_RUN_CALIBRATION` | unset | Set to `1` to enable real-LLM calibration tests under `tests/test_calibration.py` |
+| `KSTRL_CALIBRATION_MODEL` | `haiku` | Fast model used by the calibration suite. Changing it triggers the R5.5 model-drift warning until a fresh baseline is captured (H2-extended) |
+| `KSTRL_CALIBRATION_RUNS` | `3` | Runs per fixture (R5.1). The suite gates on majority-of-runs consistency; use `1` for a cheap smoke, keep `3` for baseline capture |
 
 ## Patterns
 
 - Boolean env vars accept `1`, `true`, `yes` (case-insensitive). Anything else is false.
 - Path env vars are resolved against the factory's `root_dir`, not the process cwd. If absolute, used as-is.
-- Enum env vars (`RALPH_SECURITY_MODE`, `RALPH_CONTRACT_MODE`, `RALPH_SECURITY_FAIL_THRESHOLD`) validate in `__post_init__`. A typo raises ValueError at startup rather than silently defaulting.
+- Enum env vars (`KSTRL_SECURITY_MODE`, `KSTRL_CONTRACT_MODE`, `KSTRL_SECURITY_FAIL_THRESHOLD`) validate in `__post_init__`. A typo raises ValueError at startup rather than silently defaulting.

--- a/kstrl.toml.example
+++ b/kstrl.toml.example
@@ -1,5 +1,5 @@
-# Ralph configuration
-# Copy to ralph.toml and customize. All values shown are defaults.
+# kstrl configuration
+# Copy to kstrl.toml and customize. All values shown are defaults.
 # Environment variables override these settings (see README for mapping).
 
 [agent]

--- a/kstrl/breaker.py
+++ b/kstrl/breaker.py
@@ -23,11 +23,12 @@ RESETS the stall streak: the breaker fails open, never spuriously.
 from __future__ import annotations
 
 import hashlib
-import os
 import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+
+from kstrl import envcompat
 
 # Distinct, greppable error prefix. loop.py builds its halt message with
 # it and the factory routes on the typed LoopResult/ComponentResult flag
@@ -67,15 +68,13 @@ class BreakerConfig:
         config = cls()
         return cls(
             no_progress_iterations=int(
-                os.environ.get(
-                    "RALPH_BREAKER_ITERATIONS",
+                envcompat.get("KSTRL_BREAKER_ITERATIONS",
                     str(config.no_progress_iterations),
                 )
             ),
-            test_command=os.environ.get("RALPH_BREAKER_TEST_CMD") or None,
+            test_command=envcompat.get("KSTRL_BREAKER_TEST_CMD") or None,
             test_timeout=float(
-                os.environ.get(
-                    "RALPH_BREAKER_TEST_TIMEOUT", str(config.test_timeout),
+                envcompat.get("KSTRL_BREAKER_TEST_TIMEOUT", str(config.test_timeout),
                 )
             ),
         )
@@ -86,11 +85,11 @@ class BreakerConfig:
 
         Reads the ``[breaker]`` section from ``<root_dir>/ralph.toml``.
         """
-        from kstrl.config import load_toml_section
+        from kstrl.config import load_toml_section, resolve_config_file
 
         if root_dir is None:
             root_dir = Path.cwd()
-        section = load_toml_section(root_dir / "ralph.toml", "breaker")
+        section = load_toml_section(resolve_config_file(root_dir), "breaker")
         no_progress_iterations = cls.no_progress_iterations
         test_command = cls.test_command
         test_timeout = cls.test_timeout
@@ -100,12 +99,12 @@ class BreakerConfig:
             test_command = str(section["test_command"])
         if "test_timeout" in section:
             test_timeout = float(section["test_timeout"])
-        if "RALPH_BREAKER_ITERATIONS" in os.environ:
-            no_progress_iterations = int(os.environ["RALPH_BREAKER_ITERATIONS"])
-        if os.environ.get("RALPH_BREAKER_TEST_CMD"):
-            test_command = os.environ["RALPH_BREAKER_TEST_CMD"]
-        if "RALPH_BREAKER_TEST_TIMEOUT" in os.environ:
-            test_timeout = float(os.environ["RALPH_BREAKER_TEST_TIMEOUT"])
+        if envcompat.contains("KSTRL_BREAKER_ITERATIONS"):
+            no_progress_iterations = int(envcompat.require("KSTRL_BREAKER_ITERATIONS"))
+        if envcompat.get("KSTRL_BREAKER_TEST_CMD"):
+            test_command = envcompat.require("KSTRL_BREAKER_TEST_CMD")
+        if envcompat.contains("KSTRL_BREAKER_TEST_TIMEOUT"):
+            test_timeout = float(envcompat.require("KSTRL_BREAKER_TEST_TIMEOUT"))
         return cls(
             no_progress_iterations=no_progress_iterations,
             test_command=test_command,

--- a/kstrl/calibration.py
+++ b/kstrl/calibration.py
@@ -617,15 +617,23 @@ def reviewer_override_from_env(
     """(agent_type, model) override for the reviewer and security
     calibration agents (R7.1), read from
     ``RALPH_CALIBRATION_REVIEWER_AGENT_TYPE`` /
-    ``RALPH_CALIBRATION_REVIEWER_MODEL``. Empty values mean unset.
+    ``KSTRL_CALIBRATION_REVIEWER_MODEL``. Empty values mean unset.
 
     The override exists so the calibration suite can measure the
     same-family vs cross-family correlated-miss delta: one baseline with
     no override (same family end to end), one with the reviewer roles on
     the second family. The architect always keeps the base calibration
     agent - rotation applies to reviewers, not the spec red-team."""
-    agent_type = environ.get("RALPH_CALIBRATION_REVIEWER_AGENT_TYPE") or None
-    model = environ.get("RALPH_CALIBRATION_REVIEWER_MODEL") or None
+    agent_type = (
+        environ.get("KSTRL_CALIBRATION_REVIEWER_AGENT_TYPE")
+        or environ.get("RALPH_CALIBRATION_REVIEWER_AGENT_TYPE")
+        or None
+    )
+    model = (
+        environ.get("KSTRL_CALIBRATION_REVIEWER_MODEL")
+        or environ.get("RALPH_CALIBRATION_REVIEWER_MODEL")
+        or None
+    )
     return agent_type, model
 
 
@@ -689,7 +697,7 @@ def model_drift_message(results_dir: Path, configured_model: str) -> str | None:
         f"newest baseline's model {baseline.model!r} ({path.name}). "
         "H2-extended: calibration must be re-run on model change, not just "
         "prompt change - capture a fresh baseline with "
-        "RALPH_RUN_CALIBRATION=1 before trusting detection rates."
+        "KSTRL_RUN_CALIBRATION=1 before trusting detection rates."
     )
 
 

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -15,6 +15,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from kstrl import envcompat
+
 if TYPE_CHECKING:
     from kstrl.evolution import EvolutionConfig
 
@@ -30,7 +32,7 @@ from kstrl.agents import (
 )
 from kstrl.agents.base import Agent, UsageRecord
 from kstrl.breaker import BreakerConfig
-from kstrl.config import KstrlConfig, _parse_paths, load_toml_section
+from kstrl.config import KstrlConfig, _parse_paths, load_toml_section, resolve_config_file
 from kstrl.decompose import SpecBlockerError, decompose_spec
 from kstrl.factory import FactoryConfig, run_factory
 from kstrl.init_cmd import DEFAULT_FEATURE_UNDERSTAND, run_init
@@ -254,9 +256,9 @@ def _apply_cli_overrides(
         config.allowed_paths = _parse_paths(ctx.params["allowed_paths"])
         overridden.add("allowed_paths")
     if passed("branch"):
-        config.ralph_branch = ctx.params["branch"]
-        config.ralph_branch_explicit = True
-        overridden.add("ralph_branch")
+        config.kstrl_branch = ctx.params["branch"]
+        config.kstrl_branch_explicit = True
+        overridden.add("kstrl_branch")
     if passed("agent_cmd"):
         config.agent_cmd = ctx.params["agent_cmd"]
         overridden.add("agent_cmd")
@@ -585,7 +587,7 @@ def run(
     # worth surfacing, not something to swallow.
     prd_branch = PRD.load(config.prd_file).branch_name
 
-    effective_branch = config.ralph_branch or prd_branch or "ralph/run"
+    effective_branch = config.kstrl_branch or prd_branch or "ralph/run"
 
     # Detect base branch from git
     detected_base = "main"
@@ -637,7 +639,7 @@ def run(
     # `ralph run` reviews in advisory mode unless the project's
     # ralph.toml explicitly opts into a different review_mode (there is
     # no review_mode env var, so the toml section check is exhaustive).
-    if "review_mode" not in load_toml_section(root_dir / "ralph.toml", "factory"):
+    if "review_mode" not in load_toml_section(resolve_config_file(root_dir), "factory"):
         factory_cfg.review_mode = "advisory"
 
     # R0.5 (H-15): `ralph run` persists to its own run-manifest.json so
@@ -813,8 +815,8 @@ def understand(
     if _use_cli_value(ctx, "allowed_paths"):
         config.allowed_paths = _parse_paths(allowed_paths)
     if _use_cli_value(ctx, "branch"):
-        config.ralph_branch = branch
-        config.ralph_branch_explicit = True
+        config.kstrl_branch = branch
+        config.kstrl_branch_explicit = True
     if _use_cli_value(ctx, "agent_cmd"):
         config.agent_cmd = agent_cmd
     if _use_cli_value(ctx, "model"):
@@ -835,14 +837,14 @@ def understand(
         config.allowed_paths = ["scripts/ralph/codebase_map.md"]
     # Only fall back to the understand-mode branch default when no other
     # source (CLI / env / TOML) supplied a branch. KstrlConfig.load sets
-    # ralph_branch_explicit=True when TOML provides a non-empty [git].branch.
+    # kstrl_branch_explicit=True when TOML provides a non-empty [git].branch.
     if (
         not _use_cli_value(ctx, "branch")
-        and "RALPH_BRANCH" not in os.environ
-        and not config.ralph_branch_explicit
+        and not envcompat.contains("KSTRL_BRANCH")
+        and not config.kstrl_branch_explicit
     ):
-        config.ralph_branch = "ralph/understanding"
-        config.ralph_branch_explicit = False
+        config.kstrl_branch = "ralph/understanding"
+        config.kstrl_branch_explicit = False
 
     config.ui_mode = _normalize_ui_mode(config.ui_mode)
 
@@ -1205,8 +1207,8 @@ def feature(
     rel_feature_understand = feature_understand.relative_to(root_dir).as_posix()
     understand_config.allowed_paths = [rel_feature_understand]
     if _use_cli_value(ctx, "branch"):
-        understand_config.ralph_branch = branch
-        understand_config.ralph_branch_explicit = True
+        understand_config.kstrl_branch = branch
+        understand_config.kstrl_branch_explicit = True
 
     timeouts = TimeoutConfig.load(root_dir)
     breaker_config = BreakerConfig.load(root_dir)
@@ -1254,8 +1256,8 @@ def feature(
     if _use_cli_value(ctx, "implementation_allowed_paths"):
         run_config.allowed_paths = _parse_paths(implementation_allowed_paths)
     if _use_cli_value(ctx, "branch"):
-        run_config.ralph_branch = branch
-        run_config.ralph_branch_explicit = True
+        run_config.kstrl_branch = branch
+        run_config.kstrl_branch_explicit = True
 
     run_log = log_path("run")
     run_agent = LoggingAgent(agent, run_log)
@@ -1276,8 +1278,8 @@ def feature(
         repair_config.max_iterations = repair_iterations
         if _use_cli_value(ctx, "implementation_allowed_paths"):
             repair_config.allowed_paths = _parse_paths(implementation_allowed_paths)
-        repair_config.ralph_branch = ""
-        repair_config.ralph_branch_explicit = True
+        repair_config.kstrl_branch = ""
+        repair_config.kstrl_branch_explicit = True
 
         repair_log = log_path("repair", attempt)
         repair_agent_base = get_agent(
@@ -1387,7 +1389,7 @@ def decompose(
     )
     effective_type = (
         agent_type if _use_cli_value(ctx, "agent_type")
-        else os.environ.get("RALPH_AGENT_TYPE", "auto")
+        else envcompat.get("KSTRL_AGENT_TYPE", "auto")
     )
 
     # R2.4 mirror (measured 2026-07-20): canonicalize aliases like
@@ -1597,7 +1599,7 @@ def decompose(
     default=None,
     help="Hard cap on adversarial LLM calls (review + security + "
          "distill) per run; 0 = unbounded (default: 0, or "
-         "RALPH_FACTORY_MAX_ADVERSARIAL_CALLS / "
+         "KSTRL_FACTORY_MAX_ADVERSARIAL_CALLS / "
          "[factory].max_adversarial_calls in ralph.toml)",
 )
 @click.option(
@@ -1615,7 +1617,7 @@ def decompose(
     default=None,
     help="Pause for human approval before each component's PR "
          "push+merge (default: off, or "
-         "RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE / "
+         "KSTRL_FACTORY_PAUSE_BEFORE_PR_MERGE / "
          "[factory].pause_before_pr_merge in ralph.toml)",
 )
 @click.option(
@@ -1624,7 +1626,7 @@ def decompose(
     help="Path for the JSONL progress log (default: .ralph/progress.jsonl; "
          "the log is on by default, disable via "
          "[factory].progress_log_enabled = false or "
-         "RALPH_FACTORY_PROGRESS_LOG_ENABLED=0)",
+         "KSTRL_FACTORY_PROGRESS_LOG_ENABLED=0)",
 )
 @click.option(
     "--no-worktrees",
@@ -1763,7 +1765,7 @@ def factory(
     )
     effective_type = (
         agent_type if _use_cli_value(ctx, "agent_type")
-        else os.environ.get("RALPH_AGENT_TYPE", "auto")
+        else envcompat.get("KSTRL_AGENT_TYPE", "auto")
     )
 
     # R2.4 mirror (measured 2026-07-20): canonicalize aliases like
@@ -2072,7 +2074,7 @@ def factory(
     use_tui = tui if tui is not None else (
         sys.stdout.isatty()
         and sys.stdin.isatty()
-        and os.environ.get("RALPH_NO_TUI") != "1"
+        and envcompat.get("KSTRL_NO_TUI") != "1"
         and _normalize_ui_mode(ui) != "plain"
     )
     if use_tui:
@@ -2107,9 +2109,9 @@ def factory(
 
 
 # Display structure for the KstrlConfig-backed ralph.toml sections:
-# section -> [(toml_key, dataclass_field)]. Mirrors DEFAULT_RALPH_TOML in
+# section -> [(toml_key, dataclass_field)]. Mirrors DEFAULT_KSTRL_TOML in
 # init_cmd.py plus the env/flag-only UI knobs (ui_mode, no_color).
-_RALPH_SHOW_SECTIONS: list[tuple[str, list[tuple[str, str]]]] = [
+_KSTRL_SHOW_SECTIONS: list[tuple[str, list[tuple[str, str]]]] = [
     ("agent", [
         ("type", "agent_type"),
         ("command", "agent_cmd"),
@@ -2129,7 +2131,7 @@ _RALPH_SHOW_SECTIONS: list[tuple[str, list[tuple[str, str]]]] = [
         ("allowed", "allowed_paths"),
     ]),
     ("git", [
-        ("branch", "ralph_branch"),
+        ("branch", "kstrl_branch"),
         ("auto_checkout", "auto_checkout"),
     ]),
     ("ui", [
@@ -2212,7 +2214,7 @@ def config_show(
     """
     ctx = click.get_current_context()
     root_dir = root.resolve() if root else Path.cwd()
-    toml_path = root_dir / "ralph.toml"
+    toml_path = resolve_config_file(root_dir)
 
     from kstrl.contract import ContractConfig
     from kstrl.evolution import EvolutionConfig
@@ -2311,7 +2313,7 @@ def config_show(
     click.echo(f"# ralph.toml: {toml_path if toml_path.exists() else '(absent)'}")
     click.echo("")
 
-    for section, keys in _RALPH_SHOW_SECTIONS:
+    for section, keys in _KSTRL_SHOW_SECTIONS:
         click.echo(f"[{section}]")
         for toml_key, field_name in keys:
             value = getattr(resolved_ralph, field_name)
@@ -2722,7 +2724,7 @@ def status(
     is_flag=True,
     help="Keep a failed component's worktree for post-mortem instead of "
          "removing it at cleanup (also via "
-         "RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE / "
+         "KSTRL_FACTORY_KEEP_WORKTREES_ON_FAILURE / "
          "[factory].keep_worktrees_on_failure in ralph.toml)",
 )
 @click.option(

--- a/kstrl/config.py
+++ b/kstrl/config.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import os
 import re
 import tomllib
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+from kstrl import envcompat
 
 
 def _parse_bool(value: str | None) -> bool:
@@ -48,8 +51,8 @@ class KstrlConfig:
     allowed_paths: list[str] = field(default_factory=list)
 
     # Branch config - None means use PRD, "" means skip
-    ralph_branch: str | None = None
-    ralph_branch_explicit: bool = False  # Was RALPH_BRANCH env var set?
+    kstrl_branch: str | None = None
+    kstrl_branch_explicit: bool = False  # Was RALPH_BRANCH env var set?
     auto_checkout: bool = True
 
     # Agent config
@@ -108,13 +111,14 @@ class KstrlConfig:
     ) -> KstrlConfig:
         """Load configuration with precedence: env > toml > dataclass defaults.
 
-        If ``toml_path`` is omitted, ``<root_dir>/ralph.toml`` is auto-discovered.
+        If ``toml_path`` is omitted, ``<root_dir>/kstrl.toml`` is
+        auto-discovered (legacy ``ralph.toml`` honored with a warning).
         Missing TOML file is fine (defaults are used). Malformed TOML raises.
         """
         if root_dir is None:
             root_dir = Path.cwd()
         if toml_path is None:
-            toml_path = root_dir / "ralph.toml"
+            toml_path = resolve_config_file(root_dir)
 
         config = cls()
         config.prompt_file = root_dir / "scripts/ralph/prompt.md"
@@ -138,6 +142,34 @@ class KstrlConfig:
             errors.append(f"Prompt file not found: {self.prompt_file}")
 
         return errors
+
+
+_warned_legacy_toml: set[Path] = set()
+
+
+def resolve_config_file(root_dir: Path) -> Path:
+    """Return the config file for ``root_dir``: kstrl.toml, else ralph.toml.
+
+    ``kstrl.toml`` is the primary name after the rename. When only the
+    legacy ``ralph.toml`` exists it is honored for one release with a
+    once-per-root DeprecationWarning telling the operator to
+    ``mv ralph.toml kstrl.toml``. When neither exists the primary path
+    is returned (loaders no-op on a missing file).
+    """
+    primary = root_dir / "kstrl.toml"
+    if primary.exists():
+        return primary
+    legacy = root_dir / "ralph.toml"
+    if legacy.exists():
+        if root_dir not in _warned_legacy_toml:
+            _warned_legacy_toml.add(root_dir)
+            warnings.warn(
+                f"{legacy} is deprecated; rename it: mv ralph.toml kstrl.toml",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return legacy
+    return primary
 
 
 def _load_toml(path: Path) -> dict[str, Any]:
@@ -231,8 +263,8 @@ def _apply_toml_overrides(
             # var `RALPH_BRANCH=""` (handled below) keeps its historical
             # meaning of "explicit skip".
             if isinstance(branch, str) and branch:
-                config.ralph_branch = branch
-                config.ralph_branch_explicit = True
+                config.kstrl_branch = branch
+                config.kstrl_branch_explicit = True
         if "auto_checkout" in git_section:
             config.auto_checkout = bool(git_section["auto_checkout"])
 
@@ -266,29 +298,29 @@ def _apply_env_overrides(config: KstrlConfig, root_dir: Path) -> None:
         config.interactive = _parse_bool(os.environ.get("INTERACTIVE"))
     if "ALLOWED_PATHS" in os.environ:
         config.allowed_paths = _parse_paths(os.environ.get("ALLOWED_PATHS"))
-    if "RALPH_BRANCH" in os.environ:
-        config.ralph_branch = os.environ["RALPH_BRANCH"]
-        config.ralph_branch_explicit = True
-    if "RALPH_AUTO_CHECKOUT" in os.environ:
-        config.auto_checkout = _parse_bool(os.environ.get("RALPH_AUTO_CHECKOUT"))
+    if envcompat.contains("KSTRL_BRANCH"):
+        config.kstrl_branch = envcompat.require("KSTRL_BRANCH")
+        config.kstrl_branch_explicit = True
+    if envcompat.contains("KSTRL_AUTO_CHECKOUT"):
+        config.auto_checkout = _parse_bool(envcompat.get("KSTRL_AUTO_CHECKOUT"))
     if "AGENT_CMD" in os.environ:
         config.agent_cmd = os.environ["AGENT_CMD"]
     if "MODEL" in os.environ:
         config.model = os.environ["MODEL"]
     if "MODEL_REASONING_EFFORT" in os.environ:
         config.model_reasoning_effort = os.environ["MODEL_REASONING_EFFORT"]
-    if "RALPH_AGENT_TYPE" in os.environ:
-        config.agent_type = os.environ["RALPH_AGENT_TYPE"]
-    if "RALPH_AGENT_BUDGET_USD" in os.environ:
+    if envcompat.contains("KSTRL_AGENT_TYPE"):
+        config.agent_type = envcompat.require("KSTRL_AGENT_TYPE")
+    if envcompat.contains("KSTRL_AGENT_BUDGET_USD"):
         try:
-            budget_value = float(os.environ["RALPH_AGENT_BUDGET_USD"])
+            budget_value = float(envcompat.require("KSTRL_AGENT_BUDGET_USD"))
         except ValueError:
             budget_value = 0.0
         if budget_value > 0:
             config.agent_budget_usd = budget_value
-    if "RALPH_UI" in os.environ:
-        config.ui_mode = os.environ["RALPH_UI"]
+    if envcompat.contains("KSTRL_UI"):
+        config.ui_mode = envcompat.require("KSTRL_UI")
     if "NO_COLOR" in os.environ:
         config.no_color = True
-    if "RALPH_ASCII" in os.environ:
-        config.ascii_only = _parse_bool(os.environ.get("RALPH_ASCII"))
+    if envcompat.contains("KSTRL_ASCII"):
+        config.ascii_only = _parse_bool(envcompat.get("KSTRL_ASCII"))

--- a/kstrl/contract.py
+++ b/kstrl/contract.py
@@ -26,7 +26,6 @@ Blame attribution (bisection) honesty:
 
 from __future__ import annotations
 
-import os
 import secrets
 import subprocess
 import time
@@ -35,7 +34,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from kstrl import git
+from kstrl import envcompat, git
 from kstrl.manifest import Manifest
 from kstrl.verify import run_scrubbed
 
@@ -92,31 +91,31 @@ class ContractConfig:
     def from_env(cls) -> ContractConfig:
         """Load contract config from environment variables."""
         return cls(
-            mode=os.environ.get("RALPH_CONTRACT_MODE", ContractMode.TIER.value),
-            test_command=os.environ.get("RALPH_CONTRACT_TEST_CMD", "uv run pytest"),
-            timeout=float(os.environ.get("RALPH_TIMEOUT_CONTRACT", "600")),
+            mode=envcompat.get("KSTRL_CONTRACT_MODE", ContractMode.TIER.value),
+            test_command=envcompat.get("KSTRL_CONTRACT_TEST_CMD", "uv run pytest"),
+            timeout=float(envcompat.get("KSTRL_TIMEOUT_CONTRACT", "600")),
         )
 
     @classmethod
     def load(cls, root_dir: Path | None = None) -> ContractConfig:
         """Load contract config with precedence: env > toml > defaults."""
-        from kstrl.config import load_toml_section
+        from kstrl.config import load_toml_section, resolve_config_file
         if root_dir is None:
             root_dir = Path.cwd()
         config = cls()
-        section = load_toml_section(root_dir / "ralph.toml", "contract")
+        section = load_toml_section(resolve_config_file(root_dir), "contract")
         if "mode" in section:
             config.mode = str(section["mode"])
         if "test_command" in section:
             config.test_command = str(section["test_command"])
         if "timeout" in section:
             config.timeout = float(section["timeout"])
-        if "RALPH_CONTRACT_MODE" in os.environ:
-            config.mode = os.environ["RALPH_CONTRACT_MODE"]
-        if "RALPH_CONTRACT_TEST_CMD" in os.environ:
-            config.test_command = os.environ["RALPH_CONTRACT_TEST_CMD"]
-        if "RALPH_TIMEOUT_CONTRACT" in os.environ:
-            config.timeout = float(os.environ["RALPH_TIMEOUT_CONTRACT"])
+        if envcompat.contains("KSTRL_CONTRACT_MODE"):
+            config.mode = envcompat.require("KSTRL_CONTRACT_MODE")
+        if envcompat.contains("KSTRL_CONTRACT_TEST_CMD"):
+            config.test_command = envcompat.require("KSTRL_CONTRACT_TEST_CMD")
+        if envcompat.contains("KSTRL_TIMEOUT_CONTRACT"):
+            config.timeout = float(envcompat.require("KSTRL_TIMEOUT_CONTRACT"))
         # Re-validate after assignment (env / toml may have introduced typos)
         config.__post_init__()
         return config

--- a/kstrl/envcompat.py
+++ b/kstrl/envcompat.py
@@ -1,0 +1,78 @@
+"""Environment compatibility layer for the Ralph -> kstrl rename.
+
+``KSTRL_*`` is the primary namespace. For one release the legacy
+``RALPH_*`` spellings are honored with a once-per-variable
+DeprecationWarning so existing setups keep working while announcing the
+rename. ``get``/``contains``/``require`` mirror ``os.environ.get``,
+``name in os.environ`` and ``os.environ[name]`` respectively - call
+sites read exactly like before, just through this module.
+
+The bare ``FACTORY_*`` family is NOT aliased here: it predates the
+rename and its call sites dual-read explicitly (factory config).
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from typing import overload
+
+_KSTRL_PREFIX = "KSTRL_"
+_LEGACY_PREFIX = "RALPH_"
+
+_warned: set[str] = set()
+
+
+def _legacy_name(name: str) -> str | None:
+    if name.startswith(_KSTRL_PREFIX):
+        return _LEGACY_PREFIX + name[len(_KSTRL_PREFIX):]
+    return None
+
+
+def _warn_once(legacy: str, name: str) -> None:
+    if legacy in _warned:
+        return
+    _warned.add(legacy)
+    warnings.warn(
+        f"environment variable {legacy} is deprecated; use {name}",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+@overload
+def get(name: str) -> str | None: ...
+
+
+@overload
+def get(name: str, default: str) -> str: ...
+
+
+def get(name: str, default: str | None = None) -> str | None:
+    """``os.environ.get`` with legacy-name fallback."""
+    if name in os.environ:
+        return os.environ[name]
+    legacy = _legacy_name(name)
+    if legacy is not None and legacy in os.environ:
+        _warn_once(legacy, name)
+        return os.environ[legacy]
+    return default
+
+
+def contains(name: str) -> bool:
+    """``name in os.environ`` with legacy-name fallback."""
+    if name in os.environ:
+        return True
+    legacy = _legacy_name(name)
+    if legacy is not None and legacy in os.environ:
+        _warn_once(legacy, name)
+        return True
+    return False
+
+
+def require(name: str) -> str:
+    """``os.environ[name]`` with legacy-name fallback (KeyError if absent)."""
+    value = get(name)
+    if value is None:
+        raise KeyError(name)
+    return value

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -10,13 +10,14 @@ import csv
 import io
 import json
 import logging
-import os
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from kstrl import envcompat
 
 if TYPE_CHECKING:
     from kstrl.factory import FactoryResult
@@ -66,11 +67,11 @@ class EvolutionConfig:
     @classmethod
     def load(cls, root_dir: Path | None = None) -> EvolutionConfig:
         """Load evolution config with precedence: env > toml > defaults."""
-        from kstrl.config import load_toml_section
+        from kstrl.config import load_toml_section, resolve_config_file
         if root_dir is None:
             root_dir = Path.cwd()
         config = cls()
-        section = load_toml_section(root_dir / "ralph.toml", "evolution")
+        section = load_toml_section(resolve_config_file(root_dir), "evolution")
         if "enabled" in section:
             config.enabled = bool(section["enabled"])
         if "journal_path" in section:
@@ -101,17 +102,17 @@ class EvolutionConfig:
 def _apply_env_overrides(config: EvolutionConfig, root_dir: Path) -> None:
     """Overlay env vars that are explicitly set; unset vars leave the
     existing value untouched (so toml values survive the overlay)."""
-    if "RALPH_EVOLUTION_ENABLED" in os.environ:
-        config.enabled = os.environ["RALPH_EVOLUTION_ENABLED"].lower() in {
+    if envcompat.contains("KSTRL_EVOLUTION_ENABLED"):
+        config.enabled = envcompat.require("KSTRL_EVOLUTION_ENABLED").lower() in {
             "1", "true", "yes",
         }
-    if "RALPH_EVOLUTION_JOURNAL_PATH" in os.environ:
-        raw = os.environ["RALPH_EVOLUTION_JOURNAL_PATH"]
+    if envcompat.contains("KSTRL_EVOLUTION_JOURNAL_PATH"):
+        raw = envcompat.require("KSTRL_EVOLUTION_JOURNAL_PATH")
         config.journal_path = (
             Path(raw) if Path(raw).is_absolute() else root_dir / raw
         )
-    if "RALPH_EVOLUTION_LOOKBACK_RUNS" in os.environ:
-        config.lookback_runs = int(os.environ["RALPH_EVOLUTION_LOOKBACK_RUNS"])
+    if envcompat.contains("KSTRL_EVOLUTION_LOOKBACK_RUNS"):
+        config.lookback_runs = int(envcompat.require("KSTRL_EVOLUTION_LOOKBACK_RUNS"))
 
 
 def _resolve_relative_paths(config: EvolutionConfig, root_dir: Path) -> None:

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, TextIO
 
+from kstrl import envcompat
 from kstrl.agents.base import UsageTotals, collect_usage
 from kstrl.agents.proc import kill_active_process_groups
 from kstrl.breaker import BreakerConfig
@@ -186,19 +187,19 @@ class FactoryConfig:
             retry_delay=float(os.environ.get("FACTORY_RETRY_DELAY", "5.0")),
             merge_timeout=float(os.environ.get("FACTORY_MERGE_TIMEOUT", "300.0")),
             max_adversarial_calls=int(
-                os.environ.get("RALPH_FACTORY_MAX_ADVERSARIAL_CALLS", "0")
+                envcompat.get("KSTRL_FACTORY_MAX_ADVERSARIAL_CALLS", "0")
             ),
             max_total_tokens=int(
-                os.environ.get("RALPH_FACTORY_MAX_TOTAL_TOKENS", "0")
+                envcompat.get("KSTRL_FACTORY_MAX_TOTAL_TOKENS", "0")
             ),
             pause_before_pr_merge=_parse_bool(
-                os.environ.get("RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE")
+                envcompat.get("KSTRL_FACTORY_PAUSE_BEFORE_PR_MERGE")
             ),
             progress_log_enabled=_parse_bool(
-                os.environ.get("RALPH_FACTORY_PROGRESS_LOG_ENABLED", "1")
+                envcompat.get("KSTRL_FACTORY_PROGRESS_LOG_ENABLED", "1")
             ),
             keep_worktrees_on_failure=_parse_bool(
-                os.environ.get("RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE")
+                envcompat.get("KSTRL_FACTORY_KEEP_WORKTREES_ON_FAILURE")
             ),
         )
 
@@ -209,11 +210,11 @@ class FactoryConfig:
         Reads the ``[factory]`` section from ``<root_dir>/ralph.toml`` if
         present, then overlays any matching env vars on top.
         """
-        from kstrl.config import _parse_bool, load_toml_section
+        from kstrl.config import _parse_bool, load_toml_section, resolve_config_file
         if root_dir is None:
             root_dir = Path.cwd()
         config = cls()
-        section = load_toml_section(root_dir / "ralph.toml", "factory")
+        section = load_toml_section(resolve_config_file(root_dir), "factory")
         if "max_parallel" in section:
             config.max_parallel = int(section["max_parallel"])
         if "max_retries" in section:
@@ -253,25 +254,25 @@ class FactoryConfig:
             config.retry_delay = float(os.environ["FACTORY_RETRY_DELAY"])
         if "FACTORY_MERGE_TIMEOUT" in os.environ:
             config.merge_timeout = float(os.environ["FACTORY_MERGE_TIMEOUT"])
-        if "RALPH_FACTORY_MAX_ADVERSARIAL_CALLS" in os.environ:
+        if envcompat.contains("KSTRL_FACTORY_MAX_ADVERSARIAL_CALLS"):
             config.max_adversarial_calls = int(
-                os.environ["RALPH_FACTORY_MAX_ADVERSARIAL_CALLS"]
+                envcompat.require("KSTRL_FACTORY_MAX_ADVERSARIAL_CALLS")
             )
-        if "RALPH_FACTORY_MAX_TOTAL_TOKENS" in os.environ:
+        if envcompat.contains("KSTRL_FACTORY_MAX_TOTAL_TOKENS"):
             config.max_total_tokens = int(
-                os.environ["RALPH_FACTORY_MAX_TOTAL_TOKENS"]
+                envcompat.require("KSTRL_FACTORY_MAX_TOTAL_TOKENS")
             )
-        if "RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE" in os.environ:
+        if envcompat.contains("KSTRL_FACTORY_PAUSE_BEFORE_PR_MERGE"):
             config.pause_before_pr_merge = _parse_bool(
-                os.environ["RALPH_FACTORY_PAUSE_BEFORE_PR_MERGE"]
+                envcompat.require("KSTRL_FACTORY_PAUSE_BEFORE_PR_MERGE")
             )
-        if "RALPH_FACTORY_PROGRESS_LOG_ENABLED" in os.environ:
+        if envcompat.contains("KSTRL_FACTORY_PROGRESS_LOG_ENABLED"):
             config.progress_log_enabled = _parse_bool(
-                os.environ["RALPH_FACTORY_PROGRESS_LOG_ENABLED"]
+                envcompat.require("KSTRL_FACTORY_PROGRESS_LOG_ENABLED")
             )
-        if "RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE" in os.environ:
+        if envcompat.contains("KSTRL_FACTORY_KEEP_WORKTREES_ON_FAILURE"):
             config.keep_worktrees_on_failure = _parse_bool(
-                os.environ["RALPH_FACTORY_KEEP_WORKTREES_ON_FAILURE"]
+                envcompat.require("KSTRL_FACTORY_KEEP_WORKTREES_ON_FAILURE")
             )
         return config
 
@@ -1099,8 +1100,8 @@ def _run_component(
         sleep_seconds=sleep_seconds,
         interactive=interactive,
         allowed_paths=list(allowed_paths) if allowed_paths else [],
-        ralph_branch="",
-        ralph_branch_explicit=True,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
         agent_cmd=agent_cmd,
         model=model,
         model_reasoning_effort=reasoning,

--- a/kstrl/feedforward.py
+++ b/kstrl/feedforward.py
@@ -12,6 +12,8 @@ import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 
+from kstrl import envcompat
+
 # Directories to always skip during tree walks
 _SKIP_DIRS = frozenset({
     "__pycache__", "node_modules", ".git", "venv", ".venv", ".ralph",
@@ -50,11 +52,11 @@ class FeedforwardConfig:
     @classmethod
     def load(cls, root_dir: Path | None = None) -> FeedforwardConfig:
         """Load feedforward config with precedence: env > toml > defaults."""
-        from kstrl.config import load_toml_section
+        from kstrl.config import load_toml_section, resolve_config_file
         if root_dir is None:
             root_dir = Path.cwd()
         config = cls()
-        section = load_toml_section(root_dir / "ralph.toml", "feedforward")
+        section = load_toml_section(resolve_config_file(root_dir), "feedforward")
         for key in (
             "enabled", "module_map", "public_interfaces",
             "dependency_graph", "conventions",
@@ -68,23 +70,22 @@ class FeedforwardConfig:
 
 
 _ENV_MAP: dict[str, tuple[str, type]] = {
-    "RALPH_FEEDFORWARD_ENABLED": ("enabled", bool),
-    "RALPH_FEEDFORWARD_MODULE_MAP": ("module_map", bool),
-    "RALPH_FEEDFORWARD_PUBLIC_INTERFACES": ("public_interfaces", bool),
-    "RALPH_FEEDFORWARD_DEPENDENCY_GRAPH": ("dependency_graph", bool),
-    "RALPH_FEEDFORWARD_CONVENTIONS": ("conventions", bool),
-    "RALPH_FEEDFORWARD_MAX_TOKENS": ("max_context_tokens", int),
+    "KSTRL_FEEDFORWARD_ENABLED": ("enabled", bool),
+    "KSTRL_FEEDFORWARD_MODULE_MAP": ("module_map", bool),
+    "KSTRL_FEEDFORWARD_PUBLIC_INTERFACES": ("public_interfaces", bool),
+    "KSTRL_FEEDFORWARD_DEPENDENCY_GRAPH": ("dependency_graph", bool),
+    "KSTRL_FEEDFORWARD_CONVENTIONS": ("conventions", bool),
+    "KSTRL_FEEDFORWARD_MAX_TOKENS": ("max_context_tokens", int),
 }
 
 
 def _apply_env_overrides(config: FeedforwardConfig) -> None:
     """Overlay env vars that are explicitly set; unset vars leave the
     existing value untouched (so toml values survive the overlay)."""
-    import os
 
     for env_key, (field_name, caster) in _ENV_MAP.items():
-        if env_key in os.environ:
-            raw = os.environ[env_key]
+        if envcompat.contains(env_key):
+            raw = envcompat.require(env_key)
             if caster is bool:
                 setattr(config, field_name, raw.lower() in {"1", "true", "yes"})
             else:

--- a/kstrl/fixtures.py
+++ b/kstrl/fixtures.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from kstrl import envcompat
 from kstrl.prd import PRD
 from kstrl.verify import CheckResult, run_scrubbed
 
@@ -74,14 +75,14 @@ class FixturesConfig:
         from kstrl.config import _parse_bool
 
         return cls(
-            enabled=_parse_bool(os.environ.get("RALPH_FIXTURES_ENABLED")),
+            enabled=_parse_bool(envcompat.get("KSTRL_FIXTURES_ENABLED")),
             snapshot_on_success=_parse_bool(
-                os.environ.get("RALPH_FIXTURES_SNAPSHOT_ON_SUCCESS", "1")
+                envcompat.get("KSTRL_FIXTURES_SNAPSHOT_ON_SUCCESS", "1")
             ),
             snapshot_dir=Path(
-                os.environ.get("RALPH_FIXTURES_SNAPSHOT_DIR", ".ralph/snapshots")
+                envcompat.get("KSTRL_FIXTURES_SNAPSHOT_DIR", ".ralph/snapshots")
             ),
-            timeout=float(os.environ.get("RALPH_FIXTURES_TIMEOUT", "30")),
+            timeout=float(envcompat.get("KSTRL_FIXTURES_TIMEOUT", "30")),
         )
 
     @classmethod
@@ -93,12 +94,12 @@ class FixturesConfig:
         recreated across runs, so a worktree-relative snapshot would be
         wiped before the next run could compare against it.
         """
-        from kstrl.config import _parse_bool, load_toml_section
+        from kstrl.config import _parse_bool, load_toml_section, resolve_config_file
 
         if root_dir is None:
             root_dir = Path.cwd()
         config = cls()
-        section = load_toml_section(root_dir / "ralph.toml", "fixtures")
+        section = load_toml_section(resolve_config_file(root_dir), "fixtures")
         if "enabled" in section:
             config.enabled = bool(section["enabled"])
         if "snapshot_on_success" in section:
@@ -107,16 +108,16 @@ class FixturesConfig:
             config.snapshot_dir = Path(str(section["snapshot_dir"]))
         if "timeout" in section:
             config.timeout = float(section["timeout"])
-        if "RALPH_FIXTURES_ENABLED" in os.environ:
-            config.enabled = _parse_bool(os.environ["RALPH_FIXTURES_ENABLED"])
-        if "RALPH_FIXTURES_SNAPSHOT_ON_SUCCESS" in os.environ:
+        if envcompat.contains("KSTRL_FIXTURES_ENABLED"):
+            config.enabled = _parse_bool(envcompat.require("KSTRL_FIXTURES_ENABLED"))
+        if envcompat.contains("KSTRL_FIXTURES_SNAPSHOT_ON_SUCCESS"):
             config.snapshot_on_success = _parse_bool(
-                os.environ["RALPH_FIXTURES_SNAPSHOT_ON_SUCCESS"]
+                envcompat.require("KSTRL_FIXTURES_SNAPSHOT_ON_SUCCESS")
             )
-        if "RALPH_FIXTURES_SNAPSHOT_DIR" in os.environ:
-            config.snapshot_dir = Path(os.environ["RALPH_FIXTURES_SNAPSHOT_DIR"])
-        if "RALPH_FIXTURES_TIMEOUT" in os.environ:
-            config.timeout = float(os.environ["RALPH_FIXTURES_TIMEOUT"])
+        if envcompat.contains("KSTRL_FIXTURES_SNAPSHOT_DIR"):
+            config.snapshot_dir = Path(envcompat.require("KSTRL_FIXTURES_SNAPSHOT_DIR"))
+        if envcompat.contains("KSTRL_FIXTURES_TIMEOUT"):
+            config.timeout = float(envcompat.require("KSTRL_FIXTURES_TIMEOUT"))
         if not config.snapshot_dir.is_absolute():
             config.snapshot_dir = root_dir / config.snapshot_dir
         return config

--- a/kstrl/init_cmd.py
+++ b/kstrl/init_cmd.py
@@ -368,8 +368,8 @@ Otherwise end normally.
 # scaffolding changes no effective value; uncommenting a line is the
 # explicit opt-in. Content mirrors ralph.toml.example trimmed to keys the
 # loaders actually read, plus the [timeout] section wired in R0.1.
-DEFAULT_RALPH_TOML = """\
-# Ralph configuration (scaffolded by `ralph init`).
+DEFAULT_KSTRL_TOML = """\
+# kstrl configuration (scaffolded by `ks init`).
 # Every key is commented out and shows its built-in default: uncomment a
 # line to override it. Precedence: CLI flag > environment variable > this
 # file > built-in default. See docs/env-vars.md for the env-var mapping.
@@ -524,7 +524,7 @@ def run_init(directory: Path, ui: UI) -> int:
         ui.ok("scripts/ralph/ exists")
 
     ui.section("Create defaults")
-    _create_if_missing(root / "ralph.toml", DEFAULT_RALPH_TOML, ui)
+    _create_if_missing(root / "kstrl.toml", DEFAULT_KSTRL_TOML, ui)
     _create_if_missing(ralph_dir / "prompt.md", DEFAULT_PROMPT, ui)
     _create_if_missing(ralph_dir / "prd.json", json.dumps(DEFAULT_PRD, indent=2) + "\n", ui)
     _create_if_missing(ralph_dir / "progress.txt", DEFAULT_PROGRESS, ui)

--- a/kstrl/knowledge.py
+++ b/kstrl/knowledge.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from kstrl import envcompat
 from kstrl.decompose import (
     AgentOutputTooLarge,
     _extract_json,
@@ -97,7 +98,9 @@ class KnowledgeConfig:
         config = cls()
         config.knowledge_root = root_dir / ".ralph" / "knowledge"
 
-        toml_path = root_dir / "ralph.toml"
+        from kstrl.config import resolve_config_file
+
+        toml_path = resolve_config_file(root_dir)
         data: dict[str, Any] = {}
         if toml_path.exists():
             try:
@@ -152,34 +155,34 @@ def _apply_knowledge_env_overrides(config: KnowledgeConfig) -> None:
     Re-validates dependency_scope afterwards: env can supply a bad value
     that bypassed ``__post_init__`` at construction time.
     """
-    if "RALPH_KNOWLEDGE_ENABLED" in os.environ:
-        config.enabled = _parse_bool(os.environ["RALPH_KNOWLEDGE_ENABLED"])
-    if "RALPH_KNOWLEDGE_MAX_CORE_TOKENS" in os.environ:
-        config.max_core_tokens = int(os.environ["RALPH_KNOWLEDGE_MAX_CORE_TOKENS"])
-    if "RALPH_KNOWLEDGE_MAX_DEPENDENCY_TOKENS" in os.environ:
+    if envcompat.contains("KSTRL_KNOWLEDGE_ENABLED"):
+        config.enabled = _parse_bool(envcompat.require("KSTRL_KNOWLEDGE_ENABLED"))
+    if envcompat.contains("KSTRL_KNOWLEDGE_MAX_CORE_TOKENS"):
+        config.max_core_tokens = int(envcompat.require("KSTRL_KNOWLEDGE_MAX_CORE_TOKENS"))
+    if envcompat.contains("KSTRL_KNOWLEDGE_MAX_DEPENDENCY_TOKENS"):
         config.max_dependency_tokens = int(
-            os.environ["RALPH_KNOWLEDGE_MAX_DEPENDENCY_TOKENS"]
+            envcompat.require("KSTRL_KNOWLEDGE_MAX_DEPENDENCY_TOKENS")
         )
-    if "RALPH_KNOWLEDGE_MAX_SIBLING_TOKENS" in os.environ:
+    if envcompat.contains("KSTRL_KNOWLEDGE_MAX_SIBLING_TOKENS"):
         config.max_sibling_tokens = int(
-            os.environ["RALPH_KNOWLEDGE_MAX_SIBLING_TOKENS"]
+            envcompat.require("KSTRL_KNOWLEDGE_MAX_SIBLING_TOKENS")
         )
-    if "RALPH_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS" in os.environ:
+    if envcompat.contains("KSTRL_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS"):
         config.distill_timeout_seconds = float(
-            os.environ["RALPH_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS"]
+            envcompat.require("KSTRL_KNOWLEDGE_DISTILL_TIMEOUT_SECONDS")
         )
-    if "RALPH_KNOWLEDGE_DISTILL_MODEL" in os.environ:
-        config.distill_model = os.environ["RALPH_KNOWLEDGE_DISTILL_MODEL"]
-    if "RALPH_KNOWLEDGE_MAX_FACTS_PER_DISTILL" in os.environ:
+    if envcompat.contains("KSTRL_KNOWLEDGE_DISTILL_MODEL"):
+        config.distill_model = envcompat.require("KSTRL_KNOWLEDGE_DISTILL_MODEL")
+    if envcompat.contains("KSTRL_KNOWLEDGE_MAX_FACTS_PER_DISTILL"):
         config.max_facts_per_distill = int(
-            os.environ["RALPH_KNOWLEDGE_MAX_FACTS_PER_DISTILL"]
+            envcompat.require("KSTRL_KNOWLEDGE_MAX_FACTS_PER_DISTILL")
         )
-    if "RALPH_KNOWLEDGE_DEPENDENCY_SCOPE" in os.environ:
-        config.dependency_scope = os.environ["RALPH_KNOWLEDGE_DEPENDENCY_SCOPE"]
+    if envcompat.contains("KSTRL_KNOWLEDGE_DEPENDENCY_SCOPE"):
+        config.dependency_scope = envcompat.require("KSTRL_KNOWLEDGE_DEPENDENCY_SCOPE")
 
     if config.dependency_scope not in _VALID_DEPENDENCY_SCOPES:
         raise ValueError(
-            f"RALPH_KNOWLEDGE_DEPENDENCY_SCOPE must be one of "
+            f"KSTRL_KNOWLEDGE_DEPENDENCY_SCOPE must be one of "
             f"{sorted(_VALID_DEPENDENCY_SCOPES)}, "
             f"got {config.dependency_scope!r}"
         )

--- a/kstrl/linear.py
+++ b/kstrl/linear.py
@@ -27,7 +27,7 @@ Design (docs/linear-integration.md has the full rationale):
   sink or the decompose hook.
 
 Auth: the token is read from the env var named by
-``LinearConfig.token_env`` (default ``RALPH_LINEAR_TOKEN``) at call
+``LinearConfig.token_env`` (default ``KSTRL_LINEAR_TOKEN``) at call
 time and never appears in code, config files, logs, or error messages.
 Personal API keys use a bare ``Authorization: <key>`` header; OAuth
 (app-actor) tokens use ``Authorization: Bearer <token>``;
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import time
 import urllib.error
 import urllib.request
@@ -48,7 +47,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from kstrl.config import _parse_bool, load_toml_section
+from kstrl import envcompat
+from kstrl.config import _parse_bool, load_toml_section, resolve_config_file
 
 if TYPE_CHECKING:
     from kstrl.decompose import SpecIssue
@@ -84,7 +84,7 @@ class LinearConfig:
 
     enabled: bool = False
     team_id: str = ""
-    token_env: str = "RALPH_LINEAR_TOKEN"
+    token_env: str = "KSTRL_LINEAR_TOKEN"
     auth_mode: str = "auto"
     api_url: str = "https://api.linear.app/graphql"
     dry_run: bool = False
@@ -117,19 +117,17 @@ class LinearConfig:
     @classmethod
     def from_env(cls) -> LinearConfig:
         return cls(
-            enabled=_parse_bool(os.environ.get("RALPH_LINEAR_ENABLED")),
-            team_id=os.environ.get("RALPH_LINEAR_TEAM_ID", ""),
-            token_env=os.environ.get(
-                "RALPH_LINEAR_TOKEN_ENV", "RALPH_LINEAR_TOKEN"
+            enabled=_parse_bool(envcompat.get("KSTRL_LINEAR_ENABLED")),
+            team_id=envcompat.get("KSTRL_LINEAR_TEAM_ID", ""),
+            token_env=envcompat.get("KSTRL_LINEAR_TOKEN_ENV", "KSTRL_LINEAR_TOKEN"
             ),
-            auth_mode=os.environ.get("RALPH_LINEAR_AUTH_MODE", "auto"),
-            api_url=os.environ.get(
-                "RALPH_LINEAR_API_URL", "https://api.linear.app/graphql"
+            auth_mode=envcompat.get("KSTRL_LINEAR_AUTH_MODE", "auto"),
+            api_url=envcompat.get("KSTRL_LINEAR_API_URL", "https://api.linear.app/graphql"
             ),
-            dry_run=_parse_bool(os.environ.get("RALPH_LINEAR_DRY_RUN")),
-            timeout_seconds=float(os.environ.get("RALPH_LINEAR_TIMEOUT", "30")),
+            dry_run=_parse_bool(envcompat.get("KSTRL_LINEAR_DRY_RUN")),
+            timeout_seconds=float(envcompat.get("KSTRL_LINEAR_TIMEOUT", "30")),
             min_request_interval=float(
-                os.environ.get("RALPH_LINEAR_MIN_INTERVAL", "0.5")
+                envcompat.get("KSTRL_LINEAR_MIN_INTERVAL", "0.5")
             ),
         )
 
@@ -139,7 +137,7 @@ class LinearConfig:
         if root_dir is None:
             root_dir = Path.cwd()
         config = cls()
-        section = load_toml_section(root_dir / "ralph.toml", "linear")
+        section = load_toml_section(resolve_config_file(root_dir), "linear")
         if "enabled" in section:
             config.enabled = bool(section["enabled"])
         if "team_id" in section:
@@ -157,23 +155,23 @@ class LinearConfig:
         if "min_request_interval" in section:
             config.min_request_interval = float(section["min_request_interval"])
         # Env overrides
-        if "RALPH_LINEAR_ENABLED" in os.environ:
-            config.enabled = _parse_bool(os.environ["RALPH_LINEAR_ENABLED"])
-        if "RALPH_LINEAR_TEAM_ID" in os.environ:
-            config.team_id = os.environ["RALPH_LINEAR_TEAM_ID"]
-        if "RALPH_LINEAR_TOKEN_ENV" in os.environ:
-            config.token_env = os.environ["RALPH_LINEAR_TOKEN_ENV"]
-        if "RALPH_LINEAR_AUTH_MODE" in os.environ:
-            config.auth_mode = os.environ["RALPH_LINEAR_AUTH_MODE"]
-        if "RALPH_LINEAR_API_URL" in os.environ:
-            config.api_url = os.environ["RALPH_LINEAR_API_URL"]
-        if "RALPH_LINEAR_DRY_RUN" in os.environ:
-            config.dry_run = _parse_bool(os.environ["RALPH_LINEAR_DRY_RUN"])
-        if "RALPH_LINEAR_TIMEOUT" in os.environ:
-            config.timeout_seconds = float(os.environ["RALPH_LINEAR_TIMEOUT"])
-        if "RALPH_LINEAR_MIN_INTERVAL" in os.environ:
+        if envcompat.contains("KSTRL_LINEAR_ENABLED"):
+            config.enabled = _parse_bool(envcompat.require("KSTRL_LINEAR_ENABLED"))
+        if envcompat.contains("KSTRL_LINEAR_TEAM_ID"):
+            config.team_id = envcompat.require("KSTRL_LINEAR_TEAM_ID")
+        if envcompat.contains("KSTRL_LINEAR_TOKEN_ENV"):
+            config.token_env = envcompat.require("KSTRL_LINEAR_TOKEN_ENV")
+        if envcompat.contains("KSTRL_LINEAR_AUTH_MODE"):
+            config.auth_mode = envcompat.require("KSTRL_LINEAR_AUTH_MODE")
+        if envcompat.contains("KSTRL_LINEAR_API_URL"):
+            config.api_url = envcompat.require("KSTRL_LINEAR_API_URL")
+        if envcompat.contains("KSTRL_LINEAR_DRY_RUN"):
+            config.dry_run = _parse_bool(envcompat.require("KSTRL_LINEAR_DRY_RUN"))
+        if envcompat.contains("KSTRL_LINEAR_TIMEOUT"):
+            config.timeout_seconds = float(envcompat.require("KSTRL_LINEAR_TIMEOUT"))
+        if envcompat.contains("KSTRL_LINEAR_MIN_INTERVAL"):
             config.min_request_interval = float(
-                os.environ["RALPH_LINEAR_MIN_INTERVAL"]
+                envcompat.require("KSTRL_LINEAR_MIN_INTERVAL")
             )
         # Re-validate after assignment - typos in env or TOML must surface
         config.__post_init__()
@@ -242,7 +240,7 @@ class LinearClient:
     # -- auth ---------------------------------------------------------
 
     def _token(self) -> str:
-        token = os.environ.get(self.config.token_env, "")
+        token = envcompat.get(self.config.token_env) or ""
         if not token:
             raise LinearError(
                 f"linear: env var {self.config.token_env} is unset or "
@@ -854,7 +852,7 @@ def build_linear_sink(
             "(decompose ran without the hook?); sink inactive"
         )
         return None
-    if not config.dry_run and not os.environ.get(config.token_env, ""):
+    if not config.dry_run and not (envcompat.get(config.token_env) or ""):
         warn(
             f"linear: env var {config.token_env} is unset; sink inactive"
         )

--- a/kstrl/loop.py
+++ b/kstrl/loop.py
@@ -408,11 +408,11 @@ def _determine_branch(config: KstrlConfig) -> tuple[str | None, str | None]:
         - source: Source description (e.g. "from RALPH_BRANCH", "from PRD")
     """
     # If a branch is configured directly on the config, prefer it.
-    # `ralph_branch_explicit` is used to indicate whether it came from RALPH_BRANCH/--branch.
-    if config.ralph_branch is not None:
-        if config.ralph_branch_explicit:
-            return config.ralph_branch, "from RALPH_BRANCH"
-        return config.ralph_branch, "default"
+    # `kstrl_branch_explicit` is used to indicate whether it came from RALPH_BRANCH/--branch.
+    if config.kstrl_branch is not None:
+        if config.kstrl_branch_explicit:
+            return config.kstrl_branch, "from RALPH_BRANCH"
+        return config.kstrl_branch, "default"
 
     # Try to get from PRD
     if config.prd_file.exists():

--- a/kstrl/observability.py
+++ b/kstrl/observability.py
@@ -12,6 +12,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol
 
+from kstrl import envcompat
+
 
 class ProgressSink(Protocol):
     """Observer of progress-log events (R7.4).
@@ -461,12 +463,12 @@ class NotifyConfig:
     @classmethod
     def load(cls, root_dir: Path | None = None) -> NotifyConfig:
         """Load notify config with precedence: env > toml > defaults."""
-        from kstrl.config import load_toml_section
+        from kstrl.config import load_toml_section, resolve_config_file
 
         if root_dir is None:
             root_dir = Path.cwd()
         config = cls()
-        section = load_toml_section(root_dir / "ralph.toml", "notify")
+        section = load_toml_section(resolve_config_file(root_dir), "notify")
         if isinstance(section.get("on_complete"), str):
             config.on_complete = section["on_complete"]
         if isinstance(section.get("on_first_failure"), str):
@@ -478,12 +480,12 @@ class NotifyConfig:
 
 
 def _apply_notify_env(config: NotifyConfig) -> None:
-    if "RALPH_NOTIFY_ON_COMPLETE" in os.environ:
-        config.on_complete = os.environ["RALPH_NOTIFY_ON_COMPLETE"]
-    if "RALPH_NOTIFY_ON_FIRST_FAILURE" in os.environ:
-        config.on_first_failure = os.environ["RALPH_NOTIFY_ON_FIRST_FAILURE"]
-    if "RALPH_NOTIFY_HOOK_TIMEOUT" in os.environ:
-        config.hook_timeout = float(os.environ["RALPH_NOTIFY_HOOK_TIMEOUT"])
+    if envcompat.contains("KSTRL_NOTIFY_ON_COMPLETE"):
+        config.on_complete = envcompat.require("KSTRL_NOTIFY_ON_COMPLETE")
+    if envcompat.contains("KSTRL_NOTIFY_ON_FIRST_FAILURE"):
+        config.on_first_failure = envcompat.require("KSTRL_NOTIFY_ON_FIRST_FAILURE")
+    if envcompat.contains("KSTRL_NOTIFY_HOOK_TIMEOUT"):
+        config.hook_timeout = float(envcompat.require("KSTRL_NOTIFY_HOOK_TIMEOUT"))
 
 
 class NotifyHooks:
@@ -549,13 +551,18 @@ class NotifyHooks:
         # second chance on the next failure - once means once.
         self._fired.add(condition)
         env = dict(os.environ)
-        env.update({
-            "RALPH_NOTIFY_EVENT": condition,
-            "RALPH_NOTIFY_RUN_ID": self._run_id,
-            "RALPH_NOTIFY_PROJECT": self._project,
-            "RALPH_NOTIFY_COMPONENT": component_id,
-            "RALPH_NOTIFY_DETAIL": detail,
-        })
+        notify_vars = {
+            "NOTIFY_EVENT": condition,
+            "NOTIFY_RUN_ID": self._run_id,
+            "NOTIFY_PROJECT": self._project,
+            "NOTIFY_COMPONENT": component_id,
+            "NOTIFY_DETAIL": detail,
+        }
+        # KSTRL_* is primary; RALPH_* mirrors kept one release so existing
+        # user hooks keep reading their values during the rename.
+        for suffix, value in notify_vars.items():
+            env[f"KSTRL_{suffix}"] = value
+            env[f"RALPH_{suffix}"] = value
         try:
             sink = subprocess.DEVNULL if self.capture_output else None
             proc = subprocess.run(

--- a/kstrl/sandbox.py
+++ b/kstrl/sandbox.py
@@ -48,9 +48,10 @@ denied writes), so the operator opts in per project.
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass
 from pathlib import Path
+
+from kstrl import envcompat
 
 # File-tool allow rules for the claude no-network mode: without
 # --dangerously-skip-permissions these tools are permission-gated in
@@ -84,9 +85,9 @@ class SandboxConfig:
         from kstrl.config import _parse_bool
 
         return cls(
-            enabled=_parse_bool(os.environ.get("RALPH_SANDBOX_ENABLED")),
+            enabled=_parse_bool(envcompat.get("KSTRL_SANDBOX_ENABLED")),
             allow_network=_parse_bool(
-                os.environ.get("RALPH_SANDBOX_ALLOW_NETWORK")
+                envcompat.get("KSTRL_SANDBOX_ALLOW_NETWORK")
             ),
         )
 
@@ -96,22 +97,22 @@ class SandboxConfig:
 
         Reads the ``[sandbox]`` section from ``<root_dir>/ralph.toml``.
         """
-        from kstrl.config import _parse_bool, load_toml_section
+        from kstrl.config import _parse_bool, load_toml_section, resolve_config_file
 
         if root_dir is None:
             root_dir = Path.cwd()
-        section = load_toml_section(root_dir / "ralph.toml", "sandbox")
+        section = load_toml_section(resolve_config_file(root_dir), "sandbox")
         enabled = cls.enabled
         allow_network = cls.allow_network
         if "enabled" in section:
             enabled = bool(section["enabled"])
         if "allow_network" in section:
             allow_network = bool(section["allow_network"])
-        if "RALPH_SANDBOX_ENABLED" in os.environ:
-            enabled = _parse_bool(os.environ.get("RALPH_SANDBOX_ENABLED"))
-        if "RALPH_SANDBOX_ALLOW_NETWORK" in os.environ:
+        if envcompat.contains("KSTRL_SANDBOX_ENABLED"):
+            enabled = _parse_bool(envcompat.get("KSTRL_SANDBOX_ENABLED"))
+        if envcompat.contains("KSTRL_SANDBOX_ALLOW_NETWORK"):
             allow_network = _parse_bool(
-                os.environ.get("RALPH_SANDBOX_ALLOW_NETWORK")
+                envcompat.get("KSTRL_SANDBOX_ALLOW_NETWORK")
             )
         return cls(enabled=enabled, allow_network=allow_network)
 

--- a/kstrl/security.py
+++ b/kstrl/security.py
@@ -15,7 +15,6 @@ them; that is a false positive.
 
 from __future__ import annotations
 
-import os
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -23,7 +22,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from kstrl import git
+from kstrl import envcompat, git
 from kstrl.decompose import (
     AgentOutputTooLarge,
     _extract_json,
@@ -282,22 +281,22 @@ class SecurityConfig:
     @classmethod
     def from_env(cls) -> SecurityConfig:
         return cls(
-            mode=os.environ.get("RALPH_SECURITY_MODE", SecurityMode.SKIP.value),
-            agent_cmd=os.environ.get("RALPH_SECURITY_AGENT_CMD") or None,
-            agent_type=os.environ.get("RALPH_SECURITY_AGENT_TYPE") or None,
-            model=os.environ.get("RALPH_SECURITY_MODEL") or None,
-            timeout_seconds=float(os.environ.get("RALPH_SECURITY_TIMEOUT", "600")),
-            fail_threshold=os.environ.get("RALPH_SECURITY_FAIL_THRESHOLD", "high"),
+            mode=envcompat.get("KSTRL_SECURITY_MODE", SecurityMode.SKIP.value),
+            agent_cmd=envcompat.get("KSTRL_SECURITY_AGENT_CMD") or None,
+            agent_type=envcompat.get("KSTRL_SECURITY_AGENT_TYPE") or None,
+            model=envcompat.get("KSTRL_SECURITY_MODEL") or None,
+            timeout_seconds=float(envcompat.get("KSTRL_SECURITY_TIMEOUT", "600")),
+            fail_threshold=envcompat.get("KSTRL_SECURITY_FAIL_THRESHOLD", "high"),
         )
 
     @classmethod
     def load(cls, root_dir: Path | None = None) -> SecurityConfig:
         """Load security config with precedence: env > toml > defaults."""
-        from kstrl.config import load_toml_section
+        from kstrl.config import load_toml_section, resolve_config_file
         if root_dir is None:
             root_dir = Path.cwd()
         config = cls()
-        section = load_toml_section(root_dir / "ralph.toml", "security")
+        section = load_toml_section(resolve_config_file(root_dir), "security")
         if "mode" in section:
             config.mode = str(section["mode"])
         if "agent_cmd" in section:
@@ -311,18 +310,18 @@ class SecurityConfig:
         if "fail_threshold" in section:
             config.fail_threshold = str(section["fail_threshold"])
         # Env overrides
-        if "RALPH_SECURITY_MODE" in os.environ:
-            config.mode = os.environ["RALPH_SECURITY_MODE"]
-        if "RALPH_SECURITY_AGENT_CMD" in os.environ:
-            config.agent_cmd = os.environ["RALPH_SECURITY_AGENT_CMD"] or None
-        if "RALPH_SECURITY_AGENT_TYPE" in os.environ:
-            config.agent_type = os.environ["RALPH_SECURITY_AGENT_TYPE"] or None
-        if "RALPH_SECURITY_MODEL" in os.environ:
-            config.model = os.environ["RALPH_SECURITY_MODEL"] or None
-        if "RALPH_SECURITY_TIMEOUT" in os.environ:
-            config.timeout_seconds = float(os.environ["RALPH_SECURITY_TIMEOUT"])
-        if "RALPH_SECURITY_FAIL_THRESHOLD" in os.environ:
-            config.fail_threshold = os.environ["RALPH_SECURITY_FAIL_THRESHOLD"]
+        if envcompat.contains("KSTRL_SECURITY_MODE"):
+            config.mode = envcompat.require("KSTRL_SECURITY_MODE")
+        if envcompat.contains("KSTRL_SECURITY_AGENT_CMD"):
+            config.agent_cmd = envcompat.require("KSTRL_SECURITY_AGENT_CMD") or None
+        if envcompat.contains("KSTRL_SECURITY_AGENT_TYPE"):
+            config.agent_type = envcompat.require("KSTRL_SECURITY_AGENT_TYPE") or None
+        if envcompat.contains("KSTRL_SECURITY_MODEL"):
+            config.model = envcompat.require("KSTRL_SECURITY_MODEL") or None
+        if envcompat.contains("KSTRL_SECURITY_TIMEOUT"):
+            config.timeout_seconds = float(envcompat.require("KSTRL_SECURITY_TIMEOUT"))
+        if envcompat.contains("KSTRL_SECURITY_FAIL_THRESHOLD"):
+            config.fail_threshold = envcompat.require("KSTRL_SECURITY_FAIL_THRESHOLD")
         # Re-validate after assignment - typos in env or TOML must surface
         config.__post_init__()
         return config

--- a/kstrl/timeout.py
+++ b/kstrl/timeout.py
@@ -2,23 +2,24 @@
 
 from __future__ import annotations
 
-import os
 import subprocess
 from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
 
+from kstrl import envcompat
+
 # Field name -> environment variable, shared by from_env and load so the
 # two surfaces cannot drift.
 _ENV_VARS: dict[str, str] = {
-    "git_operation": "RALPH_TIMEOUT_GIT",
-    "agent_iteration": "RALPH_TIMEOUT_AGENT_ITERATION",
-    "component_total": "RALPH_TIMEOUT_COMPONENT",
-    "verification_check": "RALPH_TIMEOUT_VERIFY",
-    "review_agent": "RALPH_TIMEOUT_REVIEW",
-    "contract_test": "RALPH_TIMEOUT_CONTRACT",
-    "subprocess_default": "RALPH_TIMEOUT_DEFAULT",
-    "scheduler_backstop_margin": "RALPH_TIMEOUT_BACKSTOP_MARGIN",
+    "git_operation": "KSTRL_TIMEOUT_GIT",
+    "agent_iteration": "KSTRL_TIMEOUT_AGENT_ITERATION",
+    "component_total": "KSTRL_TIMEOUT_COMPONENT",
+    "verification_check": "KSTRL_TIMEOUT_VERIFY",
+    "review_agent": "KSTRL_TIMEOUT_REVIEW",
+    "contract_test": "KSTRL_TIMEOUT_CONTRACT",
+    "subprocess_default": "KSTRL_TIMEOUT_DEFAULT",
+    "scheduler_backstop_margin": "KSTRL_TIMEOUT_BACKSTOP_MARGIN",
 }
 
 
@@ -58,12 +59,12 @@ class TimeoutConfig:
         Reads the ``[timeout]`` section from ``<root_dir>/ralph.toml`` if
         present, then overlays any explicitly-set env vars on top.
         """
-        from kstrl.config import load_toml_section
+        from kstrl.config import load_toml_section, resolve_config_file
 
         if root_dir is None:
             root_dir = Path.cwd()
         config = cls()
-        section = load_toml_section(root_dir / "ralph.toml", "timeout")
+        section = load_toml_section(resolve_config_file(root_dir), "timeout")
         for f in fields(cls):
             if f.name in section:
                 setattr(config, f.name, float(section[f.name]))
@@ -75,8 +76,8 @@ def _apply_env_overrides(config: TimeoutConfig) -> None:
     """Overlay env vars that are explicitly set; unset vars leave the
     existing value untouched (so toml values survive the overlay)."""
     for field_name, env_var in _ENV_VARS.items():
-        if env_var in os.environ:
-            setattr(config, field_name, float(os.environ[env_var]))
+        if envcompat.contains(env_var):
+            setattr(config, field_name, float(envcompat.require(env_var)))
 
 
 def run_with_timeout(

--- a/kstrl/verify.py
+++ b/kstrl/verify.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from kstrl import git
+from kstrl import envcompat, git
 
 if TYPE_CHECKING:
     from kstrl.fixtures import FixturesConfig
@@ -215,29 +215,27 @@ class VerifyConfig:
     def from_env(cls) -> VerifyConfig:
         """Load verify config from environment variables."""
         return cls(
-            test_command=os.environ.get("RALPH_VERIFY_TEST_CMD"),
-            typecheck_command=os.environ.get("RALPH_VERIFY_TYPECHECK_CMD"),
-            lint_command=os.environ.get("RALPH_VERIFY_LINT_CMD"),
-            dead_code_cleanup=os.environ.get("RALPH_DEAD_CODE_CLEANUP", "") == "1",
-            dead_code_command=os.environ.get("RALPH_DEAD_CODE_CMD"),
-            mutation_testing=os.environ.get("RALPH_MUTATION_TESTING", "") == "1",
+            test_command=envcompat.get("KSTRL_VERIFY_TEST_CMD"),
+            typecheck_command=envcompat.get("KSTRL_VERIFY_TYPECHECK_CMD"),
+            lint_command=envcompat.get("KSTRL_VERIFY_LINT_CMD"),
+            dead_code_cleanup=envcompat.get("KSTRL_DEAD_CODE_CLEANUP", "") == "1",
+            dead_code_command=envcompat.get("KSTRL_DEAD_CODE_CMD"),
+            mutation_testing=envcompat.get("KSTRL_MUTATION_TESTING", "") == "1",
             mutation_threshold=float(
-                os.environ.get("RALPH_MUTATION_THRESHOLD", "50")
+                envcompat.get("KSTRL_MUTATION_THRESHOLD", "50")
             ),
             mutation_timeout=float(
-                os.environ.get("RALPH_MUTATION_TIMEOUT", "600")
+                envcompat.get("KSTRL_MUTATION_TIMEOUT", "600")
             ),
             subprocess_timeout=float(
-                os.environ.get("RALPH_TIMEOUT_VERIFY", "300")
+                envcompat.get("KSTRL_TIMEOUT_VERIFY", "300")
             ),
-            require_self_critique=os.environ.get(
-                "RALPH_VERIFY_REQUIRE_SELF_CRITIQUE", "",
+            require_self_critique=envcompat.get("KSTRL_VERIFY_REQUIRE_SELF_CRITIQUE", "",
             ) == "1",
             self_critique_min_bullets=int(
-                os.environ.get("RALPH_VERIFY_SELF_CRITIQUE_MIN_BULLETS", "3"),
+                envcompat.get("KSTRL_VERIFY_SELF_CRITIQUE_MIN_BULLETS", "3"),
             ),
-            progress_file_path=os.environ.get(
-                "RALPH_VERIFY_PROGRESS_FILE",
+            progress_file_path=envcompat.get("KSTRL_VERIFY_PROGRESS_FILE",
                 "scripts/ralph/progress.txt",
             ),
         )
@@ -245,11 +243,11 @@ class VerifyConfig:
     @classmethod
     def load(cls, root_dir: Path | None = None) -> VerifyConfig:
         """Load verify config with precedence: env > toml > defaults."""
-        from kstrl.config import load_toml_section
+        from kstrl.config import load_toml_section, resolve_config_file
         if root_dir is None:
             root_dir = Path.cwd()
         config = cls()
-        section = load_toml_section(root_dir / "ralph.toml", "verify")
+        section = load_toml_section(resolve_config_file(root_dir), "verify")
         if "test_command" in section:
             config.test_command = str(section["test_command"]) or None
         if "typecheck_command" in section:
@@ -283,26 +281,26 @@ class VerifyConfig:
         # Env overrides. Each var is applied only when it is explicitly
         # set in the environment: the previous compare-against-default
         # heuristic silently dropped an env value that happened to equal
-        # the dataclass default (e.g. RALPH_MUTATION_THRESHOLD=50 could
+        # the dataclass default (e.g. KSTRL_MUTATION_THRESHOLD=50 could
         # not override a toml mutation_threshold), breaking the
         # env-beats-toml precedence contract (R2.1).
         env = cls.from_env()
         env_var_to_field = {
-            "RALPH_VERIFY_TEST_CMD": "test_command",
-            "RALPH_VERIFY_TYPECHECK_CMD": "typecheck_command",
-            "RALPH_VERIFY_LINT_CMD": "lint_command",
-            "RALPH_DEAD_CODE_CLEANUP": "dead_code_cleanup",
-            "RALPH_DEAD_CODE_CMD": "dead_code_command",
-            "RALPH_MUTATION_TESTING": "mutation_testing",
-            "RALPH_MUTATION_THRESHOLD": "mutation_threshold",
-            "RALPH_MUTATION_TIMEOUT": "mutation_timeout",
-            "RALPH_TIMEOUT_VERIFY": "subprocess_timeout",
-            "RALPH_VERIFY_REQUIRE_SELF_CRITIQUE": "require_self_critique",
-            "RALPH_VERIFY_SELF_CRITIQUE_MIN_BULLETS": "self_critique_min_bullets",
-            "RALPH_VERIFY_PROGRESS_FILE": "progress_file_path",
+            "KSTRL_VERIFY_TEST_CMD": "test_command",
+            "KSTRL_VERIFY_TYPECHECK_CMD": "typecheck_command",
+            "KSTRL_VERIFY_LINT_CMD": "lint_command",
+            "KSTRL_DEAD_CODE_CLEANUP": "dead_code_cleanup",
+            "KSTRL_DEAD_CODE_CMD": "dead_code_command",
+            "KSTRL_MUTATION_TESTING": "mutation_testing",
+            "KSTRL_MUTATION_THRESHOLD": "mutation_threshold",
+            "KSTRL_MUTATION_TIMEOUT": "mutation_timeout",
+            "KSTRL_TIMEOUT_VERIFY": "subprocess_timeout",
+            "KSTRL_VERIFY_REQUIRE_SELF_CRITIQUE": "require_self_critique",
+            "KSTRL_VERIFY_SELF_CRITIQUE_MIN_BULLETS": "self_critique_min_bullets",
+            "KSTRL_VERIFY_PROGRESS_FILE": "progress_file_path",
         }
         for env_var, field_name in env_var_to_field.items():
-            if env_var in os.environ:
+            if envcompat.contains(env_var):
                 setattr(config, field_name, getattr(env, field_name))
         return config
 

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -14,7 +14,7 @@ documented and a new command cannot be silently omitted.
 
 The config reference is verified behaviorally, not transcribed: for
 every documented ``[section]`` key the script writes a sentinel value
-into a throwaway ralph.toml, runs the real loader, and asserts the
+into a throwaway kstrl.toml, runs the real loader, and asserts the
 resolved config changed. It also probes every *undocumented* dataclass
 field name of the per-section configs and fails if one turns out to be
 a live toml key. Defaults shown in the output come from the dataclass
@@ -182,7 +182,7 @@ def _section_specs() -> list[SectionSpec]:
         ),
         SectionSpec(
             "git", "Branch handling",
-            {"branch": "ralph_branch", "auto_checkout": "auto_checkout"},
+            {"branch": "kstrl_branch", "auto_checkout": "auto_checkout"},
             ralph_loader, ralph_defaults, probe_undocumented_fields=False,
         ),
         SectionSpec(
@@ -519,7 +519,7 @@ def _verify_sections(specs: list[SectionSpec]) -> None:
         # spuriously differ on fields the toml never touched.
         probe_root = Path(tmp) / "probe"
         probe_root.mkdir()
-        toml_path = probe_root / "ralph.toml"
+        toml_path = probe_root / "kstrl.toml"
 
         baselines = {spec.section: spec.loader(probe_root) for spec in specs}
         _write_probe_toml(toml_path, specs, extra)
@@ -531,7 +531,7 @@ def _verify_sections(specs: list[SectionSpec]) -> None:
                 if getattr(probed, field_name) == getattr(baseline, field_name):
                     errors.append(
                         f"[{spec.section}] {key}: documented but setting it in "
-                        f"ralph.toml did not change {type(baseline).__name__}.{field_name}"
+                        f"kstrl.toml did not change {type(baseline).__name__}.{field_name}"
                     )
             for field_name in extra.get(spec.section, ()):
                 if getattr(probed, field_name) != getattr(baseline, field_name):
@@ -570,7 +570,7 @@ def build_config_reference() -> str:
         "<!-- Defaults come from the config dataclasses; every key is probed\n"
         "     against the real loaders before this section is emitted. -->\n\n"
         f"```toml\n{body}\n```\n\n"
-        "Environment variables override ralph.toml, and CLI flags override both.\n"
+        "Environment variables override kstrl.toml, and CLI flags override both.\n"
         "See [docs/env-vars.md](docs/env-vars.md) for the full env-var mapping.\n"
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # SecurityConfig, VerifyConfig, EvolutionConfig, KnowledgeConfig). Cleared
 # by prefix so ambient dev-machine env cannot alter from_env/load tests,
 # and so newly added vars in a family are covered without editing this list.
+# Each family is scrubbed in BOTH namespaces during the rename transition:
+# KSTRL_* is primary, RALPH_* is the deprecated alias envcompat still reads.
 RALPH_ENV_PREFIXES: tuple[str, ...] = (
     "FACTORY_",
     "RALPH_FACTORY_",
@@ -43,6 +45,18 @@ RALPH_ENV_PREFIXES: tuple[str, ...] = (
     "RALPH_MUTATION_",
     "RALPH_DEAD_CODE_",
     "RALPH_LINEAR_",
+    "KSTRL_FACTORY_",
+    "KSTRL_TIMEOUT_",
+    "KSTRL_CONTRACT_",
+    "KSTRL_SECURITY_",
+    "KSTRL_VERIFY_",
+    "KSTRL_EVOLUTION_",
+    "KSTRL_KNOWLEDGE_",
+    "KSTRL_FEEDFORWARD_",
+    "KSTRL_MUTATION_",
+    "KSTRL_DEAD_CODE_",
+    "KSTRL_LINEAR_",
+    "KSTRL_NOTIFY_",
 )
 
 # Legacy single-loop env vars (exact names, no shared prefix).
@@ -56,11 +70,20 @@ _LEGACY_ENV_VARS: tuple[str, ...] = (
     "PROMPT_FILE",
     "ALLOWED_PATHS",
     "RALPH_BRANCH",
+    "KSTRL_BRANCH",
     "PRD_FILE",
     "RALPH_UI",
+    "KSTRL_UI",
     "GUM_FORCE",
     "NO_COLOR",
     "RALPH_ASCII",
+    "KSTRL_ASCII",
+    "RALPH_AGENT_TYPE",
+    "KSTRL_AGENT_TYPE",
+    "RALPH_AUTO_CHECKOUT",
+    "KSTRL_AUTO_CHECKOUT",
+    "RALPH_AGENT_BUDGET_USD",
+    "KSTRL_AGENT_BUDGET_USD",
 )
 
 

--- a/tests/spine_utils.py
+++ b/tests/spine_utils.py
@@ -138,7 +138,7 @@ def base_config(root: Path, agent_cmd: str = COMPLETE_LINE) -> KstrlConfig:
         prompt_file=root / "scripts" / "ralph" / "prompt.md",
         prd_file=root / "scripts" / "ralph" / "prd.json",
         sleep_seconds=0, agent_cmd=agent_cmd,
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     )
 

--- a/tests/test_breaker.py
+++ b/tests/test_breaker.py
@@ -202,8 +202,8 @@ def _loop_config(root: Path, max_iterations: int) -> KstrlConfig:
         prompt_file=ralph_dir / "prompt.md",
         prd_file=ralph_dir / "prd.json",
         sleep_seconds=0,
-        ralph_branch="",
-        ralph_branch_explicit=True,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
     )
 
 

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -10,7 +10,7 @@ When run, the suite iterates over fixtures in
 ``tests/adversarial_fixtures/{security,concerns,specs}/``, feeds each
 fixture's diff or spec to the corresponding role prompt against a
 fast model (Haiku-class), and gates on detection over
-``RALPH_CALIBRATION_RUNS`` runs per fixture (default 3, R5.1): a
+``KSTRL_CALIBRATION_RUNS`` runs per fixture (default 3, R5.1): a
 fixture passes when a majority of its completed runs catch the
 planted issue (``calibration.FIXTURE_DETECTION_THRESHOLD``), so
 single-run LLM variance is reported as consistency instead of
@@ -80,12 +80,19 @@ from kstrl.security import (
     parse_security_output,
 )
 
-CALIBRATION_ENABLED = os.environ.get("RALPH_RUN_CALIBRATION") == "1"
-CALIBRATION_MODEL = os.environ.get("RALPH_CALIBRATION_MODEL", "haiku")
+CALIBRATION_ENABLED = "1" in (
+    os.environ.get("KSTRL_RUN_CALIBRATION"),
+    os.environ.get("RALPH_RUN_CALIBRATION"),
+)
+CALIBRATION_MODEL = (
+    os.environ.get("KSTRL_CALIBRATION_MODEL")
+    or os.environ.get("RALPH_CALIBRATION_MODEL")
+    or "haiku"
+)
 CALIBRATION_RUNS = int(
-    os.environ.get(
-        "RALPH_CALIBRATION_RUNS", str(calibration.DEFAULT_CALIBRATION_RUNS),
-    )
+    os.environ.get("KSTRL_CALIBRATION_RUNS")
+    or os.environ.get("RALPH_CALIBRATION_RUNS")
+    or str(calibration.DEFAULT_CALIBRATION_RUNS)
 )
 # R7.1: optional reviewer-family override so the user can capture
 # same-family vs cross-family baselines with the same tooling. Applies
@@ -157,7 +164,7 @@ def render_verification(meta: dict) -> str:
 # TestFixtureStructure still run without the env var.
 _skip_unless_calibrating = pytest.mark.skipif(
     not CALIBRATION_ENABLED,
-    reason="Calibration suite requires RALPH_RUN_CALIBRATION=1 (makes real LLM calls)",
+    reason="Calibration suite requires KSTRL_RUN_CALIBRATION=1 (makes real LLM calls)",
 )
 
 

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -29,7 +29,10 @@ import pytest
 from kstrl.agents.codex import CodexAgent
 
 CODEX_AVAILABLE = shutil.which("codex") is not None
-LIVE_CONTRACT_ENABLED = os.environ.get("RALPH_RUN_LIVE_CONTRACT") == "1"
+LIVE_CONTRACT_ENABLED = "1" in (
+    os.environ.get("KSTRL_RUN_LIVE_CONTRACT"),
+    os.environ.get("RALPH_RUN_LIVE_CONTRACT"),
+)
 
 
 class TestCodexAgentStructure:
@@ -99,7 +102,7 @@ class TestCodexAgentStructure:
 
 @pytest.mark.skipif(
     not LIVE_CONTRACT_ENABLED,
-    reason="live codex contract tests are opt-in: set RALPH_RUN_LIVE_CONTRACT=1",
+    reason="live codex contract tests are opt-in: set KSTRL_RUN_LIVE_CONTRACT=1",
 )
 @pytest.mark.skipif(not CODEX_AVAILABLE, reason="codex CLI not installed")
 class TestCodexLiveContract:

--- a/tests/test_config_control_plane.py
+++ b/tests/test_config_control_plane.py
@@ -33,7 +33,7 @@ import kstrl.evolution as evolution_mod
 from kstrl.evolution import EvolutionConfig
 from kstrl.factory import FactoryConfig, FactoryResult
 from kstrl.feedforward import FeedforwardConfig
-from kstrl.init_cmd import DEFAULT_RALPH_TOML
+from kstrl.init_cmd import DEFAULT_KSTRL_TOML
 from kstrl.knowledge import KnowledgeConfig
 from kstrl.manifest import Component, Manifest
 from kstrl.verify import VerifyConfig
@@ -732,13 +732,13 @@ def _uncomment_scaffold(text: str) -> str:
 
 
 class TestInitScaffold:
-    def test_init_creates_ralph_toml(self, tmp_path: Path) -> None:
+    def test_init_creates_kstrl_toml(self, tmp_path: Path) -> None:
         runner = CliRunner()
         result = runner.invoke(
             cli_mod.cli, ["init", str(tmp_path), "--ui", "plain"]
         )
         assert result.exit_code == 0, result.output
-        toml_path = tmp_path / "ralph.toml"
+        toml_path = tmp_path / "kstrl.toml"
         assert toml_path.exists()
         data = tomllib.loads(toml_path.read_text())
         assert set(data.keys()) == EXPECTED_SCAFFOLD_SECTIONS
@@ -760,7 +760,7 @@ class TestInitScaffold:
     def test_scaffold_keys_are_real(self) -> None:
         # Uncomment every key and check each against the loader key sets;
         # a scaffold key the loaders do not read fails here.
-        data = tomllib.loads(_uncomment_scaffold(DEFAULT_RALPH_TOML))
+        data = tomllib.loads(_uncomment_scaffold(DEFAULT_KSTRL_TOML))
         assert set(data.keys()) == EXPECTED_SCAFFOLD_SECTIONS
         for section, keys in data.items():
             unexpected = set(keys) - EXPECTED_SCAFFOLD_KEYS[section]
@@ -778,7 +778,7 @@ class TestInitScaffold:
         from kstrl.timeout import TimeoutConfig
 
         (tmp_path / "ralph.toml").write_text(
-            _uncomment_scaffold(DEFAULT_RALPH_TOML)
+            _uncomment_scaffold(DEFAULT_KSTRL_TOML)
         )
         KstrlConfig.load(tmp_path)
         FactoryConfig.load(tmp_path)

--- a/tests/test_config_toml.py
+++ b/tests/test_config_toml.py
@@ -86,8 +86,8 @@ auto_checkout = false
 """,
     )
     config = KstrlConfig.from_toml(toml_path, tmp_path)
-    assert config.ralph_branch == "feature/x"
-    assert config.ralph_branch_explicit is True
+    assert config.kstrl_branch == "feature/x"
+    assert config.kstrl_branch_explicit is True
     assert config.auto_checkout is False
 
 
@@ -215,8 +215,8 @@ def test_load_defaults_when_no_toml_and_no_env(
     assert config.sleep_seconds == 2.0
     assert config.agent_type is None
     assert config.agent_cmd is None
-    assert config.ralph_branch is None
-    assert config.ralph_branch_explicit is False
+    assert config.kstrl_branch is None
+    assert config.kstrl_branch_explicit is False
 
 
 def test_load_auto_discovers_ralph_toml(
@@ -249,8 +249,8 @@ def test_load_env_branch_marks_explicit(
 ) -> None:
     monkeypatch.setenv("RALPH_BRANCH", "")
     config = KstrlConfig.load(tmp_path)
-    assert config.ralph_branch == ""
-    assert config.ralph_branch_explicit is True
+    assert config.kstrl_branch == ""
+    assert config.kstrl_branch_explicit is True
 
 
 def test_load_env_paths_resolved_against_root(
@@ -264,7 +264,7 @@ def test_load_env_paths_resolved_against_root(
 def test_load_toml_empty_branch_does_not_mark_explicit(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """ralph.toml.example documents `branch = ""` as 'empty = use PRD
+    """kstrl.toml.example documents `branch = ""` as 'empty = use PRD
     branchName'. An empty TOML branch must therefore NOT mark explicit,
     so loop._determine_branch falls through to PRD lookup instead of
     skipping checkout. Env var RALPH_BRANCH="" retains its historical
@@ -279,8 +279,8 @@ branch = ""
 """,
     )
     config = KstrlConfig.load(tmp_path)
-    assert config.ralph_branch is None
-    assert config.ralph_branch_explicit is False
+    assert config.kstrl_branch is None
+    assert config.kstrl_branch_explicit is False
 
 
 def test_load_toml_nonempty_branch_marks_explicit(
@@ -296,8 +296,8 @@ branch = "feature/foo"
 """,
     )
     config = KstrlConfig.load(tmp_path)
-    assert config.ralph_branch == "feature/foo"
-    assert config.ralph_branch_explicit is True
+    assert config.kstrl_branch == "feature/foo"
+    assert config.kstrl_branch_explicit is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_contract_safety.py
+++ b/tests/test_contract_safety.py
@@ -266,7 +266,7 @@ class TestContractFailureExitsNonzero:
             prd_file=root / "scripts" / "ralph" / "prd.json",
             sleep_seconds=0,
             agent_cmd="echo unused",
-            ralph_branch="", ralph_branch_explicit=True,
+            kstrl_branch="", kstrl_branch_explicit=True,
             ui_mode="plain", no_color=True,
         )
 
@@ -348,7 +348,7 @@ class TestBreakerRetryReentersScheduling:
             prd_file=root / "scripts" / "ralph" / "prd.json",
             sleep_seconds=0,
             agent_cmd=agent_cmd,
-            ralph_branch="", ralph_branch_explicit=True,
+            kstrl_branch="", kstrl_branch_explicit=True,
             ui_mode="plain", no_color=True,
         )
 
@@ -496,7 +496,7 @@ class TestCleanupFailsLoudly:
             prd_file=root / "scripts" / "ralph" / "prd.json",
             sleep_seconds=0,
             agent_cmd="echo unused",
-            ralph_branch="", ralph_branch_explicit=True,
+            kstrl_branch="", kstrl_branch_explicit=True,
             ui_mode="plain", no_color=True,
         )
 

--- a/tests/test_envcompat.py
+++ b/tests/test_envcompat.py
@@ -1,0 +1,122 @@
+"""PR 2 of the rename: the KSTRL_/RALPH_ env compatibility layer.
+
+Existing suite tests keep setting RALPH_* names, so the legacy fallback
+is exercised hundreds of times for free. What is NOT covered for free is
+the contract itself: new-name precedence, the once-per-variable
+deprecation warning, and the toml filename fallback. That lives here.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+from kstrl import envcompat
+from kstrl.config import KstrlConfig, resolve_config_file
+
+
+@pytest.fixture(autouse=True)
+def _fresh_warn_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(envcompat, "_warned", set())
+
+
+class TestEnvPrecedence:
+    def test_new_name_wins_over_legacy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KSTRL_VERIFY_TEST_CMD", "new")
+        monkeypatch.setenv("RALPH_VERIFY_TEST_CMD", "old")
+        assert envcompat.get("KSTRL_VERIFY_TEST_CMD") == "new"
+
+    def test_legacy_read_when_new_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KSTRL_VERIFY_TEST_CMD", raising=False)
+        monkeypatch.setenv("RALPH_VERIFY_TEST_CMD", "old")
+        with pytest.warns(DeprecationWarning, match="RALPH_VERIFY_TEST_CMD"):
+            assert envcompat.get("KSTRL_VERIFY_TEST_CMD") == "old"
+
+    def test_default_when_both_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KSTRL_VERIFY_TEST_CMD", raising=False)
+        monkeypatch.delenv("RALPH_VERIFY_TEST_CMD", raising=False)
+        assert envcompat.get("KSTRL_VERIFY_TEST_CMD", "dflt") == "dflt"
+
+    def test_contains_covers_both(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KSTRL_UI", raising=False)
+        monkeypatch.setenv("RALPH_UI", "plain")
+        with pytest.warns(DeprecationWarning):
+            assert envcompat.contains("KSTRL_UI")
+
+    def test_require_raises_when_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("KSTRL_UI", raising=False)
+        monkeypatch.delenv("RALPH_UI", raising=False)
+        with pytest.raises(KeyError):
+            envcompat.require("KSTRL_UI")
+
+    def test_warning_fires_once_per_variable(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("KSTRL_UI", raising=False)
+        monkeypatch.setenv("RALPH_UI", "plain")
+        with pytest.warns(DeprecationWarning):
+            envcompat.get("KSTRL_UI")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert envcompat.get("KSTRL_UI") == "plain"
+
+    def test_non_kstrl_name_has_no_fallback(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        assert envcompat.get("NO_COLOR") is None
+
+    @pytest.mark.parametrize(
+        ("new", "legacy"),
+        [
+            ("KSTRL_BRANCH", "RALPH_BRANCH"),
+            ("KSTRL_AGENT_TYPE", "RALPH_AGENT_TYPE"),
+            ("KSTRL_FACTORY_MAX_PARALLEL", "RALPH_FACTORY_MAX_PARALLEL"),
+            ("KSTRL_TIMEOUT_AGENT_ITERATION", "RALPH_TIMEOUT_AGENT_ITERATION"),
+        ],
+    )
+    def test_family_fallback_shape(
+        self, monkeypatch: pytest.MonkeyPatch, new: str, legacy: str,
+    ) -> None:
+        monkeypatch.delenv(new, raising=False)
+        monkeypatch.setenv(legacy, "x")
+        with pytest.warns(DeprecationWarning, match=legacy):
+            assert envcompat.get(new) == "x"
+
+
+class TestConfigThroughCompat:
+    def test_legacy_branch_env_still_lands_in_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("RALPH_BRANCH", "legacy/branch")
+        config = KstrlConfig.from_env(tmp_path)
+        assert config.kstrl_branch == "legacy/branch"
+        assert config.kstrl_branch_explicit is True
+
+    def test_new_branch_env_beats_legacy(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("KSTRL_BRANCH", "new/branch")
+        monkeypatch.setenv("RALPH_BRANCH", "legacy/branch")
+        config = KstrlConfig.from_env(tmp_path)
+        assert config.kstrl_branch == "new/branch"
+
+
+class TestTomlFilenameFallback:
+    def test_kstrl_toml_preferred(self, tmp_path: Path) -> None:
+        (tmp_path / "kstrl.toml").write_text("")
+        (tmp_path / "ralph.toml").write_text("")
+        assert resolve_config_file(tmp_path).name == "kstrl.toml"
+
+    def test_legacy_toml_used_with_warning(self, tmp_path: Path) -> None:
+        (tmp_path / "ralph.toml").write_text('[run]\nmax_iterations = 7\n')
+        with pytest.warns(DeprecationWarning, match="mv ralph.toml kstrl.toml"):
+            resolved = resolve_config_file(tmp_path)
+        assert resolved.name == "ralph.toml"
+        config = KstrlConfig.load(tmp_path)
+        assert config.max_iterations == 7
+
+    def test_neither_present_returns_primary(self, tmp_path: Path) -> None:
+        assert resolve_config_file(tmp_path).name == "kstrl.toml"

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -77,7 +77,7 @@ def _make_base_config(root_dir: Path) -> KstrlConfig:
         prompt_file=root_dir / "scripts" / "ralph" / "prompt.md",
         prd_file=root_dir / "scripts" / "ralph" / "prd.json",
         sleep_seconds=0, agent_cmd="echo test",
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     )
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -41,8 +41,8 @@ def _make_base_config(root_dir: Path) -> KstrlConfig:
         prd_file=prd,
         sleep_seconds=0,
         agent_cmd="echo test",
-        ralph_branch="",
-        ralph_branch_explicit=True,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
         ui_mode="plain",
         no_color=True,
     )

--- a/tests/test_gen_docs.py
+++ b/tests/test_gen_docs.py
@@ -94,13 +94,13 @@ class TestConfigProbing:
             gen_docs._verify_sections([spec])
 
     def test_config_reference_covers_all_example_sections(self, gen_docs: ModuleType) -> None:
-        """Every [section] in ralph.toml.example appears in the generated
+        """Every [section] in kstrl.toml.example appears in the generated
         reference and vice versa - the two surfaces stay in lockstep."""
         import tomllib
 
         reference = gen_docs.build_config_reference()
         example = tomllib.loads(
-            (REPO_ROOT / "ralph.toml.example").read_text(encoding="utf-8")
+            (REPO_ROOT / "kstrl.toml.example").read_text(encoding="utf-8")
         )
         generated_sections = {s.section for s in gen_docs._section_specs()}
         assert set(example) == generated_sections
@@ -108,11 +108,11 @@ class TestConfigProbing:
             assert f"[{section}]" in reference
 
     def test_example_toml_keys_are_all_documented(self, gen_docs: ModuleType) -> None:
-        """ralph.toml.example must not name keys the loaders ignore."""
+        """kstrl.toml.example must not name keys the loaders ignore."""
         import tomllib
 
         example = tomllib.loads(
-            (REPO_ROOT / "ralph.toml.example").read_text(encoding="utf-8")
+            (REPO_ROOT / "kstrl.toml.example").read_text(encoding="utf-8")
         )
         documented = {
             (spec.section, key)
@@ -122,7 +122,7 @@ class TestConfigProbing:
         for section, values in example.items():
             for key in values:
                 assert (section, key) in documented, (
-                    f"ralph.toml.example documents [{section}] {key} "
+                    f"kstrl.toml.example documents [{section}] {key} "
                     "but gen_docs does not know it as a live loader key"
                 )
 

--- a/tests/test_hitl_env_scrub.py
+++ b/tests/test_hitl_env_scrub.py
@@ -89,7 +89,7 @@ def _scaffold(
         prompt_file=scaffold / "prompt.md",
         prd_file=scaffold / "prd.json",
         sleep_seconds=0, agent_cmd="echo test",
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     )
     return manifest, base

--- a/tests/test_instance_safety.py
+++ b/tests/test_instance_safety.py
@@ -135,7 +135,7 @@ def _base_config(root: Path, agent_cmd: str = COMPLETE_LINE) -> KstrlConfig:
         prompt_file=root / "scripts" / "ralph" / "prompt.md",
         prd_file=root / "scripts" / "ralph" / "prd.json",
         sleep_seconds=0, agent_cmd=agent_cmd,
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     )
 

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1693,8 +1693,8 @@ def _factory_base_config(root: Path) -> KstrlConfig:
         prd_file=root / "scripts/ralph/prd.json",
         sleep_seconds=0,
         agent_cmd="echo test",
-        ralph_branch="",
-        ralph_branch_explicit=True,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
         ui_mode="plain",
         no_color=True,
     )

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -89,7 +89,7 @@ class TestLinearConfig:
     def test_defaults_disabled(self) -> None:
         config = LinearConfig()
         assert config.enabled is False
-        assert config.token_env == "RALPH_LINEAR_TOKEN"
+        assert config.token_env == "KSTRL_LINEAR_TOKEN"
         assert config.auth_mode == "auto"
         assert config.dry_run is False
 
@@ -222,9 +222,10 @@ class TestLinearClient:
     def test_missing_token_names_var_not_value(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.delenv("KSTRL_LINEAR_TOKEN", raising=False)
         monkeypatch.delenv("RALPH_LINEAR_TOKEN", raising=False)
         client = LinearClient(dry_config(dry_run=False))
-        with pytest.raises(LinearError, match="RALPH_LINEAR_TOKEN"):
+        with pytest.raises(LinearError, match="KSTRL_LINEAR_TOKEN"):
             client.create_comment("issue-1", "body", deterministic_uuid("c"))
 
     def test_token_value_never_in_errors(
@@ -764,6 +765,7 @@ class TestBuildLinearSink:
     def test_live_mode_without_token_warns_inactive(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        monkeypatch.delenv("KSTRL_LINEAR_TOKEN", raising=False)
         monkeypatch.delenv("RALPH_LINEAR_TOKEN", raising=False)
         manifest = make_manifest([component("comp-a")])
         manifest.components[0].linear_issue_id = "issue-uuid-a"
@@ -772,4 +774,4 @@ class TestBuildLinearSink:
             manifest, dry_config(dry_run=False), run_id="r", warn=warn,
         )
         assert sink is None
-        assert any("RALPH_LINEAR_TOKEN" in m for m in warn.messages)
+        assert any("KSTRL_LINEAR_TOKEN" in m for m in warn.messages)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -51,8 +51,8 @@ class TestRunLoop:
             prompt_file=ralph_dir / "prompt.md",
             prd_file=ralph_dir / "prd.json",
             sleep_seconds=0,
-            ralph_branch="",
-            ralph_branch_explicit=True,
+            kstrl_branch="",
+            kstrl_branch_explicit=True,
         )
         ui = PlainUI(no_color=True)
         agent = MockAgent(["working...", COMPLETION_MARKER])
@@ -79,8 +79,8 @@ class TestRunLoop:
             prompt_file=ralph_dir / "prompt.md",
             prd_file=ralph_dir / "prd.json",
             sleep_seconds=0,
-            ralph_branch="",
-            ralph_branch_explicit=True,
+            kstrl_branch="",
+            kstrl_branch_explicit=True,
         )
         ui = PlainUI(no_color=True)
         agent = MockAgent(["still working"])
@@ -124,8 +124,8 @@ class TestRunLoop:
         config = KstrlConfig(
             max_iterations=2,
             prompt_file=tmp_path / "nonexistent.md",
-            ralph_branch="",
-            ralph_branch_explicit=True,
+            kstrl_branch="",
+            kstrl_branch_explicit=True,
         )
         ui = PlainUI(no_color=True)
 
@@ -154,8 +154,8 @@ class TestRunLoop:
             prompt_file=ralph_dir / "prompt.md",
             prd_file=ralph_dir / "prd.json",
             sleep_seconds=0,
-            ralph_branch="",
-            ralph_branch_explicit=True,
+            kstrl_branch="",
+            kstrl_branch_explicit=True,
         )
         ui = PlainUI(no_color=True)
         agent = MockAgent(["start", COMPLETION_MARKER, "more output"])
@@ -238,8 +238,8 @@ class TestRunLoop:
             prompt_file=ralph_dir / "prompt.md",
             prd_file=ralph_dir / "prd.json",
             sleep_seconds=0,
-            ralph_branch="",
-            ralph_branch_explicit=True,
+            kstrl_branch="",
+            kstrl_branch_explicit=True,
         )
         ui = PlainUI(no_color=True)
         agent = MockAgent(
@@ -324,8 +324,8 @@ class TestGuardsRunBeforeCompletion:
             prompt_file=ralph_dir / "prompt.md",
             prd_file=ralph_dir / "prd.json",
             sleep_seconds=0,
-            ralph_branch="",
-            ralph_branch_explicit=True,
+            kstrl_branch="",
+            kstrl_branch_explicit=True,
             allowed_paths=["src/"],
         )
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -222,7 +222,7 @@ def _plain_base_config(root: Path) -> KstrlConfig:
         prompt_file=root / "scripts" / "ralph" / "prompt.md",
         prd_file=root / "scripts" / "ralph" / "prd.json",
         sleep_seconds=0, agent_cmd="echo test",
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     )
 

--- a/tests/test_phase_c_coverage.py
+++ b/tests/test_phase_c_coverage.py
@@ -106,8 +106,8 @@ def _base_config(root: Path) -> KstrlConfig:
         prd_file=root / "scripts/ralph/prd.json",
         sleep_seconds=0,
         agent_cmd="echo test",
-        ralph_branch="",
-        ralph_branch_explicit=True,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
         ui_mode="plain",
         no_color=True,
     )

--- a/tests/test_phase_e.py
+++ b/tests/test_phase_e.py
@@ -103,7 +103,7 @@ class TestE4BudgetCap:
             prompt_file=root / "scripts/ralph/prompt.md",
             prd_file=root / "scripts/ralph/prd.json",
             sleep_seconds=0, agent_cmd="echo test",
-            ralph_branch="", ralph_branch_explicit=True,
+            kstrl_branch="", kstrl_branch_explicit=True,
             ui_mode="plain", no_color=True,
         )
 
@@ -226,7 +226,7 @@ class TestE6HitlCheckpoint:
             prompt_file=scaffold / "prompt.md",
             prd_file=scaffold / "prd.json",
             sleep_seconds=0, agent_cmd="echo test",
-            ralph_branch="", ralph_branch_explicit=True,
+            kstrl_branch="", kstrl_branch_explicit=True,
             ui_mode="plain", no_color=True,
         )
         success = ComponentResult("comp-a", success=True, iterations=1)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -85,8 +85,8 @@ def _base_config(root: Path) -> KstrlConfig:
         prd_file=root / "scripts" / "ralph" / "prd.json",
         sleep_seconds=0,
         agent_cmd="echo test",
-        ralph_branch="",
-        ralph_branch_explicit=True,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
         ui_mode="plain",
         no_color=True,
     )

--- a/tests/test_pr_outcomes.py
+++ b/tests/test_pr_outcomes.py
@@ -222,7 +222,7 @@ def _base_config(root: Path) -> KstrlConfig:
         prompt_file=root / "scripts" / "ralph" / "prompt.md",
         prd_file=root / "scripts" / "ralph" / "prd.json",
         sleep_seconds=0, agent_cmd="echo test",
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     )
 

--- a/tests/test_provisioning.py
+++ b/tests/test_provisioning.py
@@ -107,7 +107,7 @@ def _base_config(root: Path, agent_cmd: str) -> KstrlConfig:
         prompt_file=root / "scripts" / "ralph" / "prompt.md",
         prd_file=root / "scripts" / "ralph" / "prd.json",
         sleep_seconds=0, agent_cmd=agent_cmd,
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     )
 

--- a/tests/test_resume_ergonomics.py
+++ b/tests/test_resume_ergonomics.py
@@ -87,7 +87,7 @@ def _base_config(root: Path) -> KstrlConfig:
         prompt_file=root / "scripts/ralph/prompt.md",
         prd_file=root / "scripts/ralph/prd.json",
         sleep_seconds=0, agent_cmd="echo test",
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     )
 

--- a/tests/test_review_gates.py
+++ b/tests/test_review_gates.py
@@ -425,7 +425,7 @@ def _base_config(root: Path) -> KstrlConfig:
         prompt_file=root / "scripts/ralph/prompt.md",
         prd_file=root / "scripts/ralph/prd.json",
         sleep_seconds=0, agent_cmd="echo test",
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     )
 

--- a/tests/test_run_honesty.py
+++ b/tests/test_run_honesty.py
@@ -107,7 +107,7 @@ def _base_config(root: Path, agent_cmd: str, **overrides: Any) -> KstrlConfig:
         prompt_file=root / "scripts" / "ralph" / "prompt.md",
         prd_file=root / "scripts" / "ralph" / "prd.json",
         sleep_seconds=0, agent_cmd=agent_cmd,
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     )
     defaults.update(overrides)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -72,8 +72,8 @@ def _base_config(root: Path) -> KstrlConfig:
         prd_file=root / "scripts" / "ralph" / "prd.json",
         sleep_seconds=0,
         agent_cmd="echo test",
-        ralph_branch="",
-        ralph_branch_explicit=True,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
         ui_mode="plain",
         no_color=True,
     )

--- a/tests/test_scope_hardening.py
+++ b/tests/test_scope_hardening.py
@@ -393,8 +393,8 @@ def _factory_fixtures(tmp_path: Path) -> tuple[Manifest, FactoryConfig, KstrlCon
         prd_file=ralph_dir / "prd.json",
         sleep_seconds=0,
         agent_cmd="echo test",
-        ralph_branch="",
-        ralph_branch_explicit=True,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
         ui_mode="plain",
         no_color=True,
     )

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -310,7 +310,7 @@ class TestLoopStopCheck:
             max_iterations=5, sleep_seconds=0,
             prompt_file=tmp_path / "prompt.md",
             prd_file=tmp_path / "prd.json",
-            ralph_branch="", ralph_branch_explicit=True,
+            kstrl_branch="", kstrl_branch_explicit=True,
             ui_mode="plain", no_color=True,
         )
         (tmp_path / "prompt.md").write_text("p")

--- a/tests/test_spine_crash_recovery.py
+++ b/tests/test_spine_crash_recovery.py
@@ -79,7 +79,7 @@ result = run_factory(
         prompt_file=root / "scripts" / "ralph" / "prompt.md",
         prd_file=root / "scripts" / "ralph" / "prd.json",
         sleep_seconds=0, agent_cmd=sys.argv[4],
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     ),
     PlainUI(no_color=True),

--- a/tests/test_timeout_enforcement.py
+++ b/tests/test_timeout_enforcement.py
@@ -488,8 +488,8 @@ def _loop_config(tmp_path: Path, max_iterations: int) -> KstrlConfig:
         prompt_file=ralph_dir / "prompt.md",
         prd_file=ralph_dir / "prd.json",
         sleep_seconds=0,
-        ralph_branch="",
-        ralph_branch_explicit=True,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
     )
 
 
@@ -600,7 +600,7 @@ class TestFactoryComponentTimeout:
             prd_file=ralph_dir / "prd.json",
             sleep_seconds=0,
             agent_cmd=f"echo $$ > {pidfile}; exec sleep 300",
-            ralph_branch="", ralph_branch_explicit=True,
+            kstrl_branch="", kstrl_branch_explicit=True,
             ui_mode="plain", no_color=True,
         )
 
@@ -649,7 +649,7 @@ class TestFactoryComponentTimeout:
             prd_file=tmp_path / "scripts" / "ralph" / "prd.json",
             sleep_seconds=0,
             agent_cmd="exec sleep 300",
-            ralph_branch="", ralph_branch_explicit=True,
+            kstrl_branch="", kstrl_branch_explicit=True,
             ui_mode="plain", no_color=True,
         )
 
@@ -803,7 +803,7 @@ class TestSchedulerBackstop:
             prd_file=tmp_path / "scripts" / "ralph" / "prd.json",
             sleep_seconds=0,
             agent_cmd="echo done",
-            ralph_branch="", ralph_branch_explicit=True,
+            kstrl_branch="", kstrl_branch_explicit=True,
             ui_mode="plain", no_color=True,
         )
 

--- a/tests/test_truncation_policy.py
+++ b/tests/test_truncation_policy.py
@@ -544,7 +544,7 @@ def _base_config(root: Path) -> KstrlConfig:
         prompt_file=root / "scripts/ralph/prompt.md",
         prd_file=root / "scripts/ralph/prd.json",
         sleep_seconds=0, agent_cmd="echo test",
-        ralph_branch="", ralph_branch_explicit=True,
+        kstrl_branch="", kstrl_branch_explicit=True,
         ui_mode="plain", no_color=True,
     )
 

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -401,8 +401,8 @@ def _loop_config(tmp_path: Path, max_iterations: int) -> KstrlConfig:
         prompt_file=ralph_dir / "prompt.md",
         prd_file=ralph_dir / "prd.json",
         sleep_seconds=0,
-        ralph_branch="",
-        ralph_branch_explicit=True,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
     )
 
 
@@ -495,8 +495,8 @@ def _make_base_config(root_dir: Path) -> KstrlConfig:
         prd_file=root_dir / "scripts" / "ralph" / "prd.json",
         sleep_seconds=0,
         agent_cmd="echo test",
-        ralph_branch="",
-        ralph_branch_explicit=True,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
         ui_mode="plain",
         no_color=True,
     )


### PR DESCRIPTION
Second of the rename series, stacked on #122 (retarget to main after #122 merges - GitHub does this automatically when the base branch is deleted).

## Changes

- **`kstrl/envcompat.py`**: `get`/`contains`/`require` reading `KSTRL_X` first, then legacy `RALPH_X` with a once-per-variable DeprecationWarning. Typed with `os.environ.get`-style overloads for `--strict`.
- All 14 direct env-reader modules threaded through it (~145 sites), including the dynamic env-map sites (`timeout`, `feedforward`, `verify`) and calibration's injected-mapping reviewer override (inline dual-read since it takes a mapping, not os.environ).
- Notify hooks export **both** `KSTRL_NOTIFY_*` and `RALPH_NOTIFY_*` so existing hook scripts keep reading their values for one release.
- **Config file**: `resolve_config_file()` prefers `kstrl.toml`, honors `ralph.toml` with a warning instructing `mv ralph.toml kstrl.toml`. All 15 `load_toml_section` call sites + `KstrlConfig.load` + `KnowledgeConfig.load` routed through it. `ralph.toml.example -> kstrl.toml.example`; `ks init` scaffolds `kstrl.toml`.
- `kstrl_branch` field renames, `KSTRL_LINEAR_TOKEN` default (legacy env still works - the token tests that set `RALPH_LINEAR_TOKEN` were deliberately left as-is and pass through the fallback).
- conftest scrubs both namespaces; opt-in gates accept both `KSTRL_RUN_CALIBRATION`/`RALPH_RUN_CALIBRATION` spellings, so your pending calibration commands work unchanged.

## Tested

- Fast tier 1741 passed / 28 skipped; spine 25 passed; mypy --strict clean (73 files); ruff clean; gen_docs --check current.
- New `tests/test_envcompat.py` (16 tests): new-name precedence, legacy fallback + warning, warn-once semantics, KeyError on absence, config-level precedence (`KSTRL_BRANCH` beats `RALPH_BRANCH`), toml filename preference/fallback/warning with a real load.
- The 138 DeprecationWarnings in the suite run are the legacy fallback being exercised by the ~90 untouched RALPH_-setting tests - deliberate coverage of the compat path.

## Assumed

- Bare `FACTORY_*` names keep their existing explicit dual-accept (unchanged behavior, not routed through envcompat).
- Operator-visible paths (`scripts/ralph/`, `.ralph/`) and prompt bodies are untouched here - PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)