### PR TITLE
feat: decompose event vocabulary + reducer folds (TUI surface A2)

### DIFF
--- a/kstrl/events.py
+++ b/kstrl/events.py
@@ -401,6 +401,32 @@ class FindingRecorded(Event):
 
 
 @dataclass(frozen=True, kw_only=True)
+class SpecIssueRecorded(Event):
+    """One architect spec issue, streamed as decompose parses it.
+
+    Mirrors decompose.SpecIssue; ``kind`` is the architect's issue
+    taxonomy (ambiguity, contradiction, ...), not a run kind.
+    """
+
+    type: ClassVar[str] = "spec_issue_recorded"
+    severity: str = ""  # blocker | major | minor
+    kind: str = ""
+    summary: str = ""
+    location: str = ""
+    suggestion: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class ArtifactWritten(Event):
+    """A durable output landed on disk (prd, manifest, spec-issues,
+    codebase map...). ``path`` is root-relative when possible."""
+
+    type: ClassVar[str] = "artifact_written"
+    label: str = ""
+    path: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
 class Log(Event):
     """The escape hatch for imperative narration (the old UI protocol).
 

--- a/kstrl/reducer.py
+++ b/kstrl/reducer.py
@@ -32,6 +32,8 @@ from kstrl.observability import latest_run_id, parse_event_ts, read_progress_eve
 
 # Bounded so a security-heavy run cannot bloat the state.
 MAX_RECENT_FINDINGS = 50
+MAX_SPEC_ISSUES = 100
+MAX_ARTIFACTS = 100
 
 
 @dataclass
@@ -89,6 +91,12 @@ class RunState:
     max_total_tokens: int = 0
     max_adversarial_calls: int = 0
     unknown_events: int = 0
+    # Decompose vocabulary (run-scoped). Counts are complete; the lists
+    # are FIFO-bounded so a pathological stream cannot grow state.
+    spec_issue_counts: dict[str, int] = field(default_factory=dict)
+    spec_issues: list[dict[str, str]] = field(default_factory=list)
+    # {"label", "path", "component"} per artifact_written.
+    artifacts: list[dict[str, str]] = field(default_factory=list)
 
     @property
     def kind(self) -> str:
@@ -179,6 +187,33 @@ def apply(state: RunState, event: ev.Event) -> None:  # noqa: C901 - flat dispat
             comp.last_event_ts = event.ts or comp.last_event_ts
             if not event.passed:
                 comp.error = f"contract failed at tier {event.tier}"
+        return
+
+    if isinstance(event, ev.SpecIssueRecorded):
+        severity = event.severity or "unknown"
+        state.spec_issue_counts[severity] = (
+            state.spec_issue_counts.get(severity, 0) + 1
+        )
+        state.spec_issues.append({
+            "severity": event.severity,
+            "kind": event.kind,
+            "summary": event.summary,
+            "location": event.location,
+            "suggestion": event.suggestion,
+        })
+        if len(state.spec_issues) > MAX_SPEC_ISSUES:
+            del state.spec_issues[0]
+        return
+    if isinstance(event, ev.ArtifactWritten):
+        # Run-scoped even when a component is stamped (per-component
+        # PRDs): artifacts are a run-level record.
+        state.artifacts.append({
+            "label": event.label,
+            "path": event.path,
+            "component": event.component,
+        })
+        if len(state.artifacts) > MAX_ARTIFACTS:
+            del state.artifacts[0]
         return
 
     if not event.component:

--- a/kstrl/reducer.py
+++ b/kstrl/reducer.py
@@ -34,6 +34,7 @@ from kstrl.observability import latest_run_id, parse_event_ts, read_progress_eve
 MAX_RECENT_FINDINGS = 50
 MAX_SPEC_ISSUES = 100
 MAX_ARTIFACTS = 100
+SPEC_ISSUE_SEVERITIES = frozenset({"blocker", "major", "minor"})
 
 
 @dataclass
@@ -190,12 +191,16 @@ def apply(state: RunState, event: ev.Event) -> None:  # noqa: C901 - flat dispat
         return
 
     if isinstance(event, ev.SpecIssueRecorded):
-        severity = event.severity or "unknown"
+        severity = (
+            event.severity
+            if event.severity in SPEC_ISSUE_SEVERITIES
+            else "unknown"
+        )
         state.spec_issue_counts[severity] = (
             state.spec_issue_counts.get(severity, 0) + 1
         )
         state.spec_issues.append({
-            "severity": event.severity,
+            "severity": severity,
             "kind": event.kind,
             "summary": event.summary,
             "location": event.location,

--- a/kstrl/tui/widgets/activity.py
+++ b/kstrl/tui/widgets/activity.py
@@ -126,14 +126,19 @@ def humanize(event: ev.Event) -> Text | None:  # noqa: C901 - flat dispatch
         if event.breaker:
             line.append(f" · breaker {event.breaker}", style=theme.MUTED)
     elif isinstance(event, ev.SpecIssueRecorded):
-        severe = event.severity == "blocker"
+        severity = (
+            event.severity
+            if event.severity in {"blocker", "major", "minor"}
+            else "unknown"
+        )
+        severe = severity == "blocker"
         line.append(
             "▲ ",
             style=f"bold {theme.ERROR}" if severe else theme.WARNING,
         )
         line.append("spec issue ", style="bold" if severe else "")
         line.append(
-            f"[{event.severity}] ",
+            f"[{severity}] ",
             style=theme.ERROR if severe else theme.WARNING,
         )
         line.append(event.summary[:90])
@@ -141,7 +146,7 @@ def humanize(event: ev.Event) -> Text | None:  # noqa: C901 - flat dispatch
             line.append(f" at {event.location}", style=theme.MUTED)
     elif isinstance(event, ev.ArtifactWritten):
         line.append("⇣ ", style=theme.MUTED)
-        line.append(f"{event.label} written", style=theme.MUTED)
+        line.append(f"{event.label or 'artifact'} written", style=theme.MUTED)
         if event.path:
             line.append(f" · {event.path}", style=theme.MUTED)
     elif isinstance(event, ev.RunCompleted):

--- a/kstrl/tui/widgets/activity.py
+++ b/kstrl/tui/widgets/activity.py
@@ -125,6 +125,25 @@ def humanize(event: ev.Event) -> Text | None:  # noqa: C901 - flat dispatch
         line.append("passed" if event.passed else "failed", style=style)
         if event.breaker:
             line.append(f" · breaker {event.breaker}", style=theme.MUTED)
+    elif isinstance(event, ev.SpecIssueRecorded):
+        severe = event.severity == "blocker"
+        line.append(
+            "▲ ",
+            style=f"bold {theme.ERROR}" if severe else theme.WARNING,
+        )
+        line.append("spec issue ", style="bold" if severe else "")
+        line.append(
+            f"[{event.severity}] ",
+            style=theme.ERROR if severe else theme.WARNING,
+        )
+        line.append(event.summary[:90])
+        if event.location:
+            line.append(f" at {event.location}", style=theme.MUTED)
+    elif isinstance(event, ev.ArtifactWritten):
+        line.append("⇣ ", style=theme.MUTED)
+        line.append(f"{event.label} written", style=theme.MUTED)
+        if event.path:
+            line.append(f" · {event.path}", style=theme.MUTED)
     elif isinstance(event, ev.RunCompleted):
         line.append("■ ", style="bold")
         line.append(

--- a/tests/test_activity_feed.py
+++ b/tests/test_activity_feed.py
@@ -36,6 +36,11 @@ class TestSpecIssueLines:
         assert line is not None
         assert "x" * 200 not in line.plain
 
+    def test_unknown_severity_is_named(self) -> None:
+        line = humanize(ev.SpecIssueRecorded(severity="future", summary="s"))
+        assert line is not None
+        assert "[unknown]" in line.plain
+
 
 class TestArtifactLines:
     def test_label_and_path(self) -> None:
@@ -50,6 +55,11 @@ class TestArtifactLines:
         line = humanize(ev.ArtifactWritten(label="spec_issues"))
         assert line is not None
         assert "spec_issues written" in line.plain
+
+    def test_unlabelled_artifact_has_readable_fallback(self) -> None:
+        line = humanize(ev.ArtifactWritten())
+        assert line is not None
+        assert "artifact written" in line.plain
 
 
 class TestCurationControl:

--- a/tests/test_activity_feed.py
+++ b/tests/test_activity_feed.py
@@ -1,0 +1,57 @@
+"""TUI surface A2: activity-feed lines for the decompose vocabulary."""
+
+from __future__ import annotations
+
+from kstrl import events as ev
+from kstrl.tui import theme
+from kstrl.tui.widgets.activity import humanize
+
+
+class TestSpecIssueLines:
+    def test_blocker_reads_as_error(self) -> None:
+        line = humanize(ev.SpecIssueRecorded(
+            severity="blocker", kind="ambiguity",
+            summary="Spec contradicts itself", location="spec.md:12",
+        ))
+        assert line is not None
+        text = line.plain
+        assert "spec issue" in text
+        assert "[blocker]" in text
+        assert "Spec contradicts itself" in text
+        assert "at spec.md:12" in text
+        styles = " ".join(str(span.style) for span in line.spans)
+        assert theme.ERROR in styles
+
+    def test_minor_reads_as_warning_not_error(self) -> None:
+        line = humanize(ev.SpecIssueRecorded(severity="minor", summary="nit"))
+        assert line is not None
+        assert "[minor]" in line.plain
+        styles = " ".join(str(span.style) for span in line.spans)
+        assert theme.WARNING in styles
+        assert theme.ERROR not in styles
+
+    def test_long_summary_truncated(self) -> None:
+        line = humanize(ev.SpecIssueRecorded(severity="major",
+                                             summary="x" * 200))
+        assert line is not None
+        assert "x" * 200 not in line.plain
+
+
+class TestArtifactLines:
+    def test_label_and_path(self) -> None:
+        line = humanize(ev.ArtifactWritten(
+            label="manifest", path="scripts/kstrl/manifest.json",
+        ))
+        assert line is not None
+        assert "manifest written" in line.plain
+        assert "scripts/kstrl/manifest.json" in line.plain
+
+    def test_pathless_artifact_still_renders(self) -> None:
+        line = humanize(ev.ArtifactWritten(label="spec_issues"))
+        assert line is not None
+        assert "spec_issues written" in line.plain
+
+
+class TestCurationControl:
+    def test_heartbeats_stay_out_of_the_feed(self) -> None:
+        assert humanize(ev.WorkerHeartbeat(pid=1, elapsed_seconds=1.0)) is None

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -78,6 +78,11 @@ def _sample_events() -> list[ev.Event]:
         ev.FindingRecorded(component="comp-a", phase="review", category="test_quality",
                            severity="fail", location="a.py:10",
                            explanation="weak assert", attempt=1),
+        ev.SpecIssueRecorded(severity="blocker", kind="ambiguity",
+                             summary="Spec contradicts itself",
+                             location="spec.md:12", suggestion="pick one"),
+        ev.ArtifactWritten(component="comp-a", label="prd",
+                           path="scripts/kstrl/feature/comp-a/prd.json"),
         ev.Log(severity="warn", kind="kv", key="Root", text="/tmp/x"),
     ]
 
@@ -353,6 +358,8 @@ class TestV1CompatGoldenParity:
         bus.emit(ev.WorkerHeartbeat(component="a", pid=1, elapsed_seconds=1.0))
         bus.emit(ev.Log(text="narration"))
         bus.emit(ev.PrMerged(component="a", pr_number=1, pr_url="u"))
+        bus.emit(ev.SpecIssueRecorded(severity="blocker", summary="s"))
+        bus.emit(ev.ArtifactWritten(label="manifest", path="m.json"))
         assert read_progress_events(compat_path) == []
 
     def test_progress_sinks_still_fed(self, tmp_path: Path) -> None:

--- a/tests/test_reducer.py
+++ b/tests/test_reducer.py
@@ -185,6 +185,58 @@ class TestLifecycleFold:
         assert "b" not in state.components
 
 
+class TestDecomposeVocabulary:
+    def test_spec_issues_folded_with_counts(self) -> None:
+        state = reducer.fold(_stamped([
+            ev.SpecIssueRecorded(severity="blocker", kind="ambiguity",
+                                 summary="A or B?", location="spec.md:3",
+                                 suggestion="pick one"),
+            ev.SpecIssueRecorded(severity="minor", kind="style",
+                                 summary="nit"),
+            ev.SpecIssueRecorded(severity="minor", kind="style",
+                                 summary="nit 2"),
+        ]))
+        assert state.spec_issue_counts == {"blocker": 1, "minor": 2}
+        assert state.spec_issues[0] == {
+            "severity": "blocker", "kind": "ambiguity",
+            "summary": "A or B?", "location": "spec.md:3",
+            "suggestion": "pick one",
+        }
+
+    def test_artifacts_recorded_run_level_with_component(self) -> None:
+        state = reducer.fold(_stamped([
+            ev.ArtifactWritten(label="spec_issues",
+                               path="scripts/kstrl/spec-issues.json"),
+            ev.ArtifactWritten(component="comp-a", label="prd",
+                               path="scripts/kstrl/feature/comp-a/prd.json"),
+        ]))
+        assert [a["label"] for a in state.artifacts] == [
+            "spec_issues", "prd",
+        ]
+        assert state.artifacts[1]["component"] == "comp-a"
+        # Run-scoped: the component stamp does not create a component.
+        assert "comp-a" not in state.components
+
+    def test_lists_bounded_counts_complete(self) -> None:
+        overflow = reducer.MAX_SPEC_ISSUES + 20
+        pool: list[ev.Event] = [
+            ev.SpecIssueRecorded(severity="minor", summary=f"issue {i}")
+            for i in range(overflow)
+        ]
+        pool.extend(ev.ArtifactWritten(label="prd", path=f"p{i}.json")
+                    for i in range(reducer.MAX_ARTIFACTS + 20))
+        state = reducer.fold(_stamped(pool))
+        assert len(state.spec_issues) == reducer.MAX_SPEC_ISSUES
+        # FIFO trim: the oldest fell off, the count stays honest.
+        assert state.spec_issues[0]["summary"] == "issue 20"
+        assert state.spec_issue_counts == {"minor": overflow}
+        assert len(state.artifacts) == reducer.MAX_ARTIFACTS
+
+    def test_defaulted_severity_counts_as_unknown(self) -> None:
+        state = reducer.fold(_stamped([ev.SpecIssueRecorded(summary="s")]))
+        assert state.spec_issue_counts == {"unknown": 1}
+
+
 class TestFoldApplyEquivalence:
     def test_fold_equals_incremental_apply_at_random_splits(self) -> None:
         rng = random.Random(7)
@@ -204,6 +256,11 @@ class TestFoldApplyEquivalence:
                 ev.ComponentCompleted(component=c, iterations=rng.randint(1, 5)),
                 ev.ComponentFailed(component=c, error="err"),
                 ev.WorkerHeartbeat(component=c, pid=1, elapsed_seconds=1.0),
+                ev.SpecIssueRecorded(
+                    severity=rng.choice(["blocker", "major", "minor"]),
+                    kind="ambiguity", summary="s", location="spec.md:1",
+                ),
+                ev.ArtifactWritten(component=c, label="prd", path="p.json"),
             ]))
         stamped = _stamped(pool)
         folded = reducer.fold(stamped, run_id="run-1")

--- a/tests/test_reducer.py
+++ b/tests/test_reducer.py
@@ -235,6 +235,15 @@ class TestDecomposeVocabulary:
     def test_defaulted_severity_counts_as_unknown(self) -> None:
         state = reducer.fold(_stamped([ev.SpecIssueRecorded(summary="s")]))
         assert state.spec_issue_counts == {"unknown": 1}
+        assert state.spec_issues[0]["severity"] == "unknown"
+
+    def test_unrecognised_severities_share_the_unknown_bucket(self) -> None:
+        state = reducer.fold(_stamped([
+            ev.SpecIssueRecorded(severity=f"future-{i}", summary="s")
+            for i in range(200)
+        ]))
+        assert state.spec_issue_counts == {"unknown": 200}
+        assert {i["severity"] for i in state.spec_issues} == {"unknown"}
 
 
 class TestFoldApplyEquivalence:


### PR DESCRIPTION
Stacks on #127.

## What
- `kstrl/events.py`: two new v2-only events - `SpecIssueRecorded{severity,kind,summary,location,suggestion}` (mirrors `decompose.SpecIssue`) and `ArtifactWritten{label,path}`. Every payload field defaulted, so the total-decode contract holds; `V1CompatSink` drops both (progress.jsonl and the Linear sink untouched - covered by the extended v2-drop test).
- `kstrl/reducer.py`: run-scoped folds - `spec_issue_counts` (complete), `spec_issues` + `artifacts` (FIFO-bounded at 100). A component-stamped artifact (per-component PRD) records run-level and never creates a component row.
- `kstrl/tui/widgets/activity.py`: feed lines - blocker spec issues styled as errors, other severities warnings; artifact writes as muted lines.

## Tested
- Round-trip + registry-coverage samples extended (the registry test fails loudly if an event lacks a sample).
- New `TestDecomposeVocabulary`: counts vs bounded lists (FIFO trim keeps counts honest), run-level attribution, defaulted severity -> "unknown".
- fold==apply equivalence pool extended with both events.
- New `tests/test_activity_feed.py`: blocker vs minor styling, truncation, artifact lines, heartbeat-curation control.
- Fast tier 1764 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)