### PR TITLE
feat: universal run substrate + generalized embed + OptionsModal (TUI surface A3)

### DIFF
--- a/kstrl/commandrun.py
+++ b/kstrl/commandrun.py
@@ -1,0 +1,223 @@
+"""Universal run substrate: any command as an event-stream run.
+
+``open_command_run`` gives decompose/feature/understand the same disk
+contract the factory has - ``.kstrl/runs/<run_id>/events.jsonl`` plus
+per-component transcripts - so the dashboard, home shell, and replay
+work identically for every kind. It mirrors the factory's sink-attach
+block with two deliberate differences:
+
+- No V1CompatSink: ``.kstrl/progress.jsonl`` is a factory-only
+  contract with its own consumers (v1 status, the Linear ProgressSink).
+  Non-factory commands never wrote it; starting now would surprise
+  both.
+- A stream filter keeps full agent output OUT of events.jsonl: those
+  bytes are teed to the per-component transcript file instead (the
+  spike's lean-stream rule - flooding the event stream starves the
+  TUI input loop).
+
+Gating matches the factory exactly: ``[factory] progress_log_enabled``
+(env or kstrl.toml) turns recording off, in which case the bus still
+renders to the terminal but nothing lands on disk.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, TextIO
+
+from kstrl.events import (
+    Event,
+    EventBus,
+    EventSink,
+    JsonlSink,
+    Log,
+    RunPaths,
+    WorkerHeartbeat,
+)
+from kstrl.runid import mint_run_id
+from kstrl.ui.bridge import EventBridgeUI
+
+if TYPE_CHECKING:
+    from kstrl.ui.base import UI
+
+HEARTBEAT_INTERVAL_SECONDS = 15.0
+
+
+def start_heartbeat(
+    bus: EventBus, interval: float | None = None,
+) -> Callable[[], None]:
+    """Emit WorkerHeartbeat every ``interval`` seconds on a daemon
+    thread until the returned stop callable runs. JsonlSink's lock
+    makes the cross-thread emit safe. (Moved from factory.py so every
+    run kind keeps its liveness window fresh during long agent calls.)
+    """
+    stop_event = threading.Event()
+    period = HEARTBEAT_INTERVAL_SECONDS if interval is None else interval
+    started = time.monotonic()
+    pid = os.getpid()
+
+    def _beat() -> None:
+        while not stop_event.wait(period):
+            bus.emit(WorkerHeartbeat(
+                pid=pid,
+                elapsed_seconds=round(time.monotonic() - started, 1),
+            ))
+
+    thread = threading.Thread(target=_beat, daemon=True, name="ralph-heartbeat")
+    thread.start()
+
+    def _stop() -> None:
+        stop_event.set()
+        thread.join(timeout=1.0)
+
+    return _stop
+
+
+class _StreamFilterSink:
+    """Drops ``Log(kind="stream")`` lines for the given keys before the
+    inner sink sees them. Only keys that are teed to a transcript file
+    belong here - filtering anything else would silently lose record.
+    """
+
+    def __init__(
+        self, inner: EventSink,
+        drop_stream_keys: frozenset[str] = frozenset({"AI"}),
+    ) -> None:
+        self._inner = inner
+        self._drop = drop_stream_keys
+
+    def emit(self, event: Event) -> None:
+        if (
+            isinstance(event, Log)
+            and event.kind == "stream"
+            and event.key in self._drop
+        ):
+            return
+        self._inner.emit(event)
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+@dataclass
+class CommandRun:
+    """One command execution's recording session. ``paths`` is None
+    when recording is disabled - every accessor degrades to None and
+    ``close()`` stays safe to call."""
+
+    run_id: str
+    kind: str
+    bus: EventBus
+    paths: RunPaths | None
+    _sinks: list[EventSink] = field(default_factory=list)
+    _stop_heartbeat: Callable[[], None] | None = None
+    _transcripts: dict[str, TextIO] = field(default_factory=dict)
+    _restore_component: str | None = None
+
+    @property
+    def recording(self) -> bool:
+        return self.paths is not None
+
+    def transcript_path(self, component_id: str) -> Path | None:
+        if self.paths is None:
+            return None
+        return self.paths.engineer_log(component_id)
+
+    def transcript_writer(
+        self, component_id: str,
+    ) -> Callable[[str], None] | None:
+        """Line-buffered appender onto the component's transcript file
+        (the file the dashboard's transcript pane tails); None when
+        recording is disabled. The handle closes with the run."""
+        path = self.transcript_path(component_id)
+        if path is None:
+            return None
+        handle = self._transcripts.get(component_id)
+        if handle is None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            handle = open(path, "a", buffering=1, encoding="utf-8")
+            self._transcripts[component_id] = handle
+
+        def _write(line: str) -> None:
+            handle.write(line if line.endswith("\n") else line + "\n")
+
+        return _write
+
+    def close(self) -> None:
+        """Stop the heartbeat, detach and close the run's file sinks,
+        close transcripts, and un-stamp the shared console bus so
+        post-run narration reads run-level again."""
+        if self._stop_heartbeat is not None:
+            self._stop_heartbeat()
+            self._stop_heartbeat = None
+        for sink in self._sinks:
+            self.bus.remove_sink(sink)
+            sink.close()
+        self._sinks.clear()
+        for handle in self._transcripts.values():
+            try:
+                handle.close()
+            except OSError:
+                pass
+        self._transcripts.clear()
+        if self._restore_component is not None:
+            self.bus.component = self._restore_component
+            self._restore_component = None
+
+
+def open_command_run(
+    ui: UI,
+    root_dir: Path,
+    kind: str,
+    *,
+    component: str = "",
+    run_id: str | None = None,
+    enabled: bool | None = None,
+    heartbeat: bool = True,
+) -> CommandRun:
+    """Open a recording session for one command execution.
+
+    Reuses the console's bus when ``ui`` is the event bridge (so every
+    imperative narration line lands in the run's stream, exactly like
+    the factory's chunk-7 wiring); a bare UI gets a private bus.
+    ``component`` becomes the bus's default stamp - the pseudo-component
+    the reducer projects this command's work onto. ``enabled=None``
+    resolves the factory's ``progress_log_enabled`` (env + kstrl.toml).
+    """
+    if enabled is None:
+        from kstrl.factory import FactoryConfig
+
+        enabled = FactoryConfig.load(root_dir).progress_log_enabled
+    rid = run_id or mint_run_id(kind)
+
+    restore_component: str | None = None
+    if isinstance(ui, EventBridgeUI):
+        bus = ui.bus
+        bus.run_id = rid
+        if component:
+            restore_component = bus.component
+            bus.component = component
+    else:
+        bus = EventBus(run_id=rid, component=component)
+
+    run = CommandRun(
+        run_id=rid, kind=kind, bus=bus, paths=None,
+        _restore_component=restore_component,
+    )
+    if not enabled:
+        return run
+
+    paths = RunPaths.for_run(root_dir, rid)
+    paths.root.mkdir(parents=True, exist_ok=True)
+    sink: EventSink = _StreamFilterSink(JsonlSink(paths.events_file))
+    bus.add_sink(sink)
+    run.paths = paths
+    run._sinks.append(sink)
+    if heartbeat:
+        run._stop_heartbeat = start_heartbeat(bus)
+    return run

--- a/kstrl/commandrun.py
+++ b/kstrl/commandrun.py
@@ -117,6 +117,7 @@ class CommandRun:
     _sinks: list[EventSink] = field(default_factory=list)
     _stop_heartbeat: Callable[[], None] | None = None
     _transcripts: dict[str, TextIO] = field(default_factory=dict)
+    _restore_run_id: str | None = None
     _restore_component: str | None = None
 
     @property
@@ -165,6 +166,9 @@ class CommandRun:
             except OSError:
                 pass
         self._transcripts.clear()
+        if self._restore_run_id is not None:
+            self.bus.run_id = self._restore_run_id
+            self._restore_run_id = None
         if self._restore_component is not None:
             self.bus.component = self._restore_component
             self._restore_component = None
@@ -195,18 +199,20 @@ def open_command_run(
         enabled = FactoryConfig.load(root_dir).progress_log_enabled
     rid = run_id or mint_run_id(kind)
 
+    restore_run_id: str | None = None
     restore_component: str | None = None
     if isinstance(ui, EventBridgeUI):
         bus = ui.bus
+        restore_run_id = bus.run_id
+        restore_component = bus.component
         bus.run_id = rid
-        if component:
-            restore_component = bus.component
-            bus.component = component
+        bus.component = component
     else:
         bus = EventBus(run_id=rid, component=component)
 
     run = CommandRun(
         run_id=rid, kind=kind, bus=bus, paths=None,
+        _restore_run_id=restore_run_id,
         _restore_component=restore_component,
     )
     if not enabled:

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -21,6 +21,7 @@ from kstrl import envcompat
 from kstrl.agents.base import UsageTotals, collect_usage
 from kstrl.agents.proc import kill_active_process_groups
 from kstrl.breaker import BreakerConfig
+from kstrl.commandrun import start_heartbeat as _start_heartbeat
 from kstrl.config import KstrlConfig
 from kstrl.context import IterationContext
 from kstrl.contract import (
@@ -43,7 +44,6 @@ from kstrl.events import (
     RunPlan,
     RunStarted,
     V1CompatSink,
-    WorkerHeartbeat,
 )
 from kstrl.events import (
     ContractResult as ContractResultEvent,
@@ -1213,9 +1213,6 @@ def _run_component(
                 pass
 
 
-_HEARTBEAT_INTERVAL_SECONDS = 15.0
-
-
 def _install_worker_signal_forwarding() -> None:
     """Pool-worker SIGTERM handler: kill the agent's process group,
     then exit 130. Installed only on a worker's main thread."""
@@ -1249,34 +1246,6 @@ def _redirect_worker_output(log_path: Path) -> None:
         sys.stderr = f
     except OSError:
         pass
-
-
-def _start_heartbeat(
-    bus: EventBus, interval: float | None = None,
-) -> Callable[[], None]:
-    """Emit WorkerHeartbeat every ``interval`` seconds on a daemon
-    thread until the returned stop callable runs. JsonlSink's lock
-    makes the cross-thread emit safe."""
-    stop_event = threading.Event()
-    period = _HEARTBEAT_INTERVAL_SECONDS if interval is None else interval
-    started = time.monotonic()
-    pid = os.getpid()
-
-    def _beat() -> None:
-        while not stop_event.wait(period):
-            bus.emit(WorkerHeartbeat(
-                pid=pid,
-                elapsed_seconds=round(time.monotonic() - started, 1),
-            ))
-
-    thread = threading.Thread(target=_beat, daemon=True, name="ralph-heartbeat")
-    thread.start()
-
-    def _stop() -> None:
-        stop_event.set()
-        thread.join(timeout=1.0)
-
-    return _stop
 
 
 class _InlineExecutor:

--- a/kstrl/tui/app.py
+++ b/kstrl/tui/app.py
@@ -17,11 +17,13 @@ graceful-shutdown flow.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import StrEnum
 from pathlib import Path
 
 from textual.app import App
 from textual.binding import Binding
+from textual.screen import Screen
 from textual.widgets import DataTable
 
 from kstrl.interaction import (
@@ -33,6 +35,7 @@ from kstrl.tui.bridge import OrchestratorHandle
 from kstrl.tui.messages import StateChanged
 from kstrl.tui.screens.checkpoint import CheckpointModal
 from kstrl.tui.screens.component import ComponentScreen
+from kstrl.tui.screens.options import OptionsModal
 from kstrl.tui.screens.overview import OverviewScreen
 from kstrl.tui.screens.quit import QuitModal
 from kstrl.tui.state import StateStore
@@ -40,6 +43,9 @@ from kstrl.tui.tail import RunTailer, TextTailer
 from kstrl.tui.theme import KSTRL_THEME
 
 DEFAULT_POLL_INTERVAL = 0.2  # measured, spike G1
+
+# Bottom-first initial screen stack; None = the default overview.
+ScreenStackFactory = Callable[[], list[Screen[None]]]
 
 
 class Mode(StrEnum):
@@ -67,6 +73,7 @@ class KstrlTuiApp(App[int]):
         poll_interval: float = DEFAULT_POLL_INTERVAL,
         channel: QueueInteractionChannel | None = None,
         orchestrator: OrchestratorHandle | None = None,
+        screen_factory: ScreenStackFactory | None = None,
     ) -> None:
         super().__init__()
         self.run_dir = run_dir
@@ -75,6 +82,7 @@ class KstrlTuiApp(App[int]):
         self.poll_interval = poll_interval
         self.channel = channel
         self.orchestrator = orchestrator
+        self.screen_factory = screen_factory
         self.tailer = RunTailer(run_dir)
         self.store = StateStore(root_dir, run_id=run_dir.name)
         self._transcript_tailers: dict[str, TextTailer] = {}
@@ -84,9 +92,13 @@ class KstrlTuiApp(App[int]):
     def on_mount(self) -> None:
         self.register_theme(KSTRL_THEME)
         self.theme = "kstrl"
-        self.push_screen(OverviewScreen(
-            observe_only=self.mode is Mode.DASH,
-        ))
+        if self.screen_factory is not None:
+            for screen in self.screen_factory():
+                self.push_screen(screen)
+        else:
+            self.push_screen(OverviewScreen(
+                observe_only=self.mode is Mode.DASH,
+            ))
         self.set_interval(self.poll_interval, self._poll)
         self.set_interval(1.0, self._tick_ages)
         if self.mode is Mode.EMBEDDED:
@@ -107,6 +119,19 @@ class KstrlTuiApp(App[int]):
     # -- data flow -----------------------------------------------------------
 
     def _poll(self) -> None:
+        """Screen dispatch is duck-typed on a small contract so any
+        screen (component detail, decompose, home-launched views) can
+        opt in without the app enumerating types:
+
+        - ``transcript_component`` (str): a detail screen; when
+          ``ready``, gets ``refresh_state(state, manifest)`` directly
+          and a bounded transcript tail for that ONE component
+          (finding 3 - never all components at once).
+        - otherwise: receives the StateChanged message.
+        - ``feed_events(batch)``: narrated event batches (curated by
+          humanize(); truncation rebuilds replay history into state
+          but must not re-narrate it into the feed).
+        """
         chunk = self.tailer.poll_events()
         if chunk.truncated:
             self.store.reset()
@@ -115,23 +140,25 @@ class KstrlTuiApp(App[int]):
         if not screen_stack:
             return
         screen = screen_stack[-1]
+        component_id = str(getattr(screen, "transcript_component", ""))
+        ready = bool(getattr(screen, "ready", True))
         if changed:
-            if isinstance(screen, ComponentScreen) and screen.ready:
-                screen.refresh_state(self.store.state, self.store.manifest())
-            elif not isinstance(screen, ComponentScreen):
+            if component_id:
+                if ready:
+                    screen.refresh_state(  # type: ignore[attr-defined]
+                        self.store.state, self.store.manifest(),
+                    )
+            else:
                 screen.post_message(StateChanged(self.store.state))
-            if isinstance(screen, OverviewScreen) and not chunk.truncated:
-                # The feed narrates the run (design pass); humanize()
-                # curates, so raw Log noise and heartbeats never land.
-                # A truncation rebuild replays history into the state
-                # but must not re-narrate it into the feed.
-                screen.feed_events(chunk.events)
-        # Transcript: ONLY the top component screen's component
-        # (finding 3 - never all components at once).
-        if isinstance(screen, ComponentScreen) and screen.ready:
-            screen.feed_transcript(
-                self._transcript_tailer(screen.component_id).poll(),
-            )
+            feed = getattr(screen, "feed_events", None)
+            if feed is not None and not chunk.truncated:
+                feed(chunk.events)
+        if component_id and ready:
+            feed_transcript = getattr(screen, "feed_transcript", None)
+            if feed_transcript is not None:
+                feed_transcript(
+                    self._transcript_tailer(component_id).poll(),
+                )
 
     def _transcript_tailer(self, component_id: str) -> TextTailer:
         tailer = self._transcript_tailers.get(component_id)
@@ -146,9 +173,9 @@ class KstrlTuiApp(App[int]):
         screen_stack = self.screen_stack
         if not screen_stack:
             return
-        screen = screen_stack[-1]
-        if isinstance(screen, OverviewScreen):
-            screen.tick_ages(self.store.state)
+        tick = getattr(screen_stack[-1], "tick_ages", None)
+        if tick is not None:
+            tick(self.store.state)
 
     # -- navigation ----------------------------------------------------------
 
@@ -201,11 +228,14 @@ class KstrlTuiApp(App[int]):
             ):
                 self._pending_prompts.pop(request.request_id, None)
 
-        if request.kind is PromptKind.CHECKPOINT:
+        if request.kind is PromptKind.CHECKPOINT and request.checkpoint:
             self.push_screen(CheckpointModal(request), _resolve)
         else:
-            # Generic prompts reuse the checkpoint chrome minus context.
-            self.push_screen(CheckpointModal(request), _resolve)
+            # Generic prompts get the lean options modal: the
+            # checkpoint modal's a/r/t bindings hardcode three options
+            # and mis-resolve a 2-option CONFIRM (choice out of range
+            # leaves the prompt pending with the modal gone).
+            self.push_screen(OptionsModal(request), _resolve)
 
     def action_answer_checkpoint(self) -> None:
         if isinstance(self.screen, CheckpointModal):

--- a/kstrl/tui/bridge.py
+++ b/kstrl/tui/bridge.py
@@ -1,17 +1,24 @@
-"""Orchestrator thread handle for embedded mode (stage 3 PR F).
+"""Worker-thread handle for embedded mode.
 
-The orchestrator runs run_factory on a NON-daemon background thread;
-Textual owns the main thread. The only crossings are:
-- QueueInteractionChannel (PR A): orchestrator blocks, TUI resolves
+A command core runs on a NON-daemon background thread; Textual owns
+the main thread. The only crossings are:
+- QueueInteractionChannel (PR A): the core blocks, the TUI resolves
   via App.call_from_thread - the mechanism the spike's G4 soak
   validated (zero deadlocks across 33k events).
 - StopController (PR B): both sides can request a stop.
-- This handle: the TUI polls done() and reads the result.
+- This handle: the TUI polls done() and reads the exit code.
+
+Generalized from the factory-only orchestrator (TUI surface A3): any
+``Callable[[], int]`` command core runs the same way. Cores must
+RETURN exit codes, not ``sys.exit()`` - a SystemExit raised on the
+thread is boxed as a result (its code, not a crash), but that path is
+a bug's safety net, not the contract.
 """
 
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -20,7 +27,7 @@ from kstrl.factory import run_factory
 
 if TYPE_CHECKING:
     from kstrl.config import KstrlConfig
-    from kstrl.factory import FactoryConfig, FactoryResult
+    from kstrl.factory import FactoryConfig
     from kstrl.interaction import QueueInteractionChannel
     from kstrl.manifest import Manifest
     from kstrl.shutdown import StopController
@@ -28,10 +35,10 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class OrchestratorHandle:
+class CommandHandle:
     thread: threading.Thread
     stop: StopController
-    result_box: list[FactoryResult] = field(default_factory=list)
+    result_box: list[int] = field(default_factory=list)
     error_box: list[BaseException] = field(default_factory=list)
 
     def done(self) -> bool:
@@ -45,8 +52,46 @@ class OrchestratorHandle:
         if self.error_box:
             return 1
         if self.result_box:
-            return self.result_box[0].exit_code
+            return self.result_box[0]
         return 1  # died without a result
+
+
+# Compat alias: the app and tests grew up on the factory-only name.
+OrchestratorHandle = CommandHandle
+
+
+def start_command_thread(
+    target: Callable[[], int],
+    *,
+    stop: StopController,
+    name: str = "kstrl-worker",
+) -> CommandHandle:
+    result_box: list[int] = []
+    error_box: list[BaseException] = []
+
+    def _run() -> None:
+        try:
+            result_box.append(int(target()))
+        except SystemExit as exc:
+            # A missed sys.exit inside a core: honor its code rather
+            # than collapsing every exit to a crash.
+            code = exc.code
+            if isinstance(code, int):
+                result_box.append(code)
+            elif code is None:
+                result_box.append(0)
+            else:
+                result_box.append(1)
+        except BaseException as exc:  # noqa: BLE001 - surfaced via the box
+            error_box.append(exc)
+
+    thread = threading.Thread(target=_run, name=name, daemon=False)
+    handle = CommandHandle(
+        thread=thread, stop=stop,
+        result_box=result_box, error_box=error_box,
+    )
+    thread.start()
+    return handle
 
 
 def start_orchestrator(
@@ -60,29 +105,17 @@ def start_orchestrator(
     run_id: str,
     stop: StopController,
     channel: QueueInteractionChannel,
-) -> OrchestratorHandle:
-    result_box: list[FactoryResult] = []
-    error_box: list[BaseException] = []
+) -> CommandHandle:
+    def _target() -> int:
+        return run_factory(
+            manifest, factory_config, base_config, ui, root_dir,
+            manifest_path=manifest_path,
+            interaction=channel,
+            stop=stop,
+            run_id=run_id,
+            notify_capture_output=True,
+        ).exit_code
 
-    def _target() -> None:
-        try:
-            result_box.append(run_factory(
-                manifest, factory_config, base_config, ui, root_dir,
-                manifest_path=manifest_path,
-                interaction=channel,
-                stop=stop,
-                run_id=run_id,
-                notify_capture_output=True,
-            ))
-        except BaseException as exc:  # noqa: BLE001 - surfaced via the box
-            error_box.append(exc)
-
-    thread = threading.Thread(
-        target=_target, name="ralph-orchestrator", daemon=False,
+    return start_command_thread(
+        _target, stop=stop, name="ralph-orchestrator",
     )
-    handle = OrchestratorHandle(
-        thread=thread, stop=stop,
-        result_box=result_box, error_box=error_box,
-    )
-    thread.start()
-    return handle

--- a/kstrl/tui/embed.py
+++ b/kstrl/tui/embed.py
@@ -1,24 +1,28 @@
-"""Embedded mode: `ralph factory` with the dashboard (stage 3 PR F).
+"""Embedded mode: a command core with the dashboard over it.
 
 Sequence (each step maps to a spike finding or plan decision):
-1.  Mint the run id BEFORE anything starts (PR B's override) so the
-    run dir is known to the TUI from frame one.
-2.  Orchestrator narration renders to <run_dir>/orchestrator.log
-    through the SAME console architecture as the terminal (bridge ->
-    bus -> UIBackedRenderer -> PlainUI-on-a-file); run_factory then
-    attaches the run's file sinks to that bus as usual. A root logging
-    FileHandler catches module loggers (evolution, agents) that would
-    otherwise scribble on the alt screen; notify hooks run
-    output-captured (spike: measured 5-line alt-screen corruption).
+1.  The run id is minted BEFORE anything starts so the run dir is
+    known to the TUI from frame one.
+2.  Core narration renders to <run_dir>/orchestrator.log through the
+    SAME console architecture as the terminal (bridge -> bus ->
+    UIBackedRenderer -> PlainUI-on-a-file); the core then attaches the
+    run's file sinks to that bus as usual. A root logging FileHandler
+    catches module loggers (evolution, agents) that would otherwise
+    scribble on the alt screen; notify hooks run output-captured
+    (spike: measured 5-line alt-screen corruption).
 3.  Signal handlers install BEFORE app.run() (spike finding 2: Textual
     leaves the terminal raw on SIGTERM); a signal requests the same
     graceful stop as the TUI's quit flow.
-4.  The TUI tails the SAME files as `ralph dash` - one data path, so a
-    TUI crash cannot lose orchestrator state: the fallback loop keeps
-    streaming events as plain lines until the run finishes.
+4.  The TUI tails the SAME files as `ks dash` - one data path, so a
+    TUI crash cannot lose run state: the fallback loop keeps streaming
+    events as plain lines until the run finishes.
 5.  finally: detach the channel (pending prompts degrade to their
     non-interactive defaults - a dead TUI never hangs the run), join
-    the orchestrator, restore the terminal.
+    the worker thread, restore the terminal.
+
+Generalized in TUI surface A3: ``run_embedded`` hosts ANY command core
+(a ``Callable[[EmbeddedContext], int]``); ``run_factory_embedded``
+keeps its exact signature and delegates.
 """
 
 from __future__ import annotations
@@ -26,6 +30,8 @@ from __future__ import annotations
 import logging
 import sys
 import time
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -34,8 +40,8 @@ from kstrl.interaction import QueueInteractionChannel
 from kstrl.knowledge import current_run_id
 from kstrl.render import UIBackedRenderer
 from kstrl.shutdown import StopController, install_signal_handlers
-from kstrl.tui.app import KstrlTuiApp, Mode
-from kstrl.tui.bridge import OrchestratorHandle, start_orchestrator
+from kstrl.tui.app import KstrlTuiApp, Mode, ScreenStackFactory
+from kstrl.tui.bridge import CommandHandle, start_command_thread
 from kstrl.tui.tail import RunTailer
 from kstrl.ui.bridge import EventBridgeUI, NullPrompter
 from kstrl.ui.plain import PlainUI
@@ -46,6 +52,17 @@ if TYPE_CHECKING:
     from kstrl.manifest import Manifest
 
 ANSI_RESTORE = "\x1b[?1049l\x1b[?25h\x1b[0m"
+
+
+@dataclass(frozen=True)
+class EmbeddedContext:
+    """Everything a command core needs from the embed layer."""
+
+    run_id: str
+    run_paths: RunPaths
+    ui: EventBridgeUI
+    channel: QueueInteractionChannel
+    stop: StopController
 
 
 def _install_exclusive_root_handler(
@@ -69,31 +86,34 @@ def _restore_root_handlers(
         root_logger.addHandler(existing)
 
 
-def run_factory_embedded(
-    manifest: Manifest,
-    factory_config: FactoryConfig,
-    base_config: KstrlConfig,
-    root_dir: Path,
-    manifest_path: Path | None,
+def run_embedded(
+    target: Callable[[EmbeddedContext], int],
     *,
+    root_dir: Path,
+    run_id: str,
+    screen_factory: ScreenStackFactory | None = None,
+    thread_name: str = "kstrl-worker",
     poll_interval: float = 0.2,
 ) -> int:
-    run_id = current_run_id()
     run_paths = RunPaths.for_run(root_dir, run_id)
     run_paths.root.mkdir(parents=True, exist_ok=True)
 
-    # Orchestrator narration -> orchestrator.log via the standard
-    # console stack; prompts go through the queue channel, never a TTY.
+    # Core narration -> orchestrator.log via the standard console
+    # stack; prompts go through the queue channel, never a TTY.
     log_fh = open(
         run_paths.root / "orchestrator.log", "a",
         buffering=1, encoding="utf-8",
     )
     renderer = UIBackedRenderer(PlainUI(no_color=True, file=log_fh))
     bus = EventBus(CallbackSink(renderer.handle))
-    orchestrator_ui = EventBridgeUI(bus, prompter=NullPrompter())
+    core_ui = EventBridgeUI(bus, prompter=NullPrompter())
 
     channel = QueueInteractionChannel()
     stop = StopController()
+    context = EmbeddedContext(
+        run_id=run_id, run_paths=run_paths, ui=core_ui,
+        channel=channel, stop=stop,
+    )
 
     # Module loggers (evolution, agents/*) must not hit the alt screen.
     root_logger = logging.getLogger()
@@ -105,17 +125,16 @@ def run_factory_embedded(
     )
 
     uninstall = install_signal_handlers(stop)
-    handle: OrchestratorHandle | None = None
+    handle: CommandHandle | None = None
     try:
-        handle = start_orchestrator(
-            manifest, factory_config, base_config, orchestrator_ui,
-            root_dir, manifest_path,
-            run_id=run_id, stop=stop, channel=channel,
+        handle = start_command_thread(
+            lambda: target(context), stop=stop, name=thread_name,
         )
         app = KstrlTuiApp(
             run_dir=run_paths.root, root_dir=root_dir,
             mode=Mode.EMBEDDED, poll_interval=poll_interval,
             channel=channel, orchestrator=handle,
+            screen_factory=screen_factory,
         )
         # The app attaches the channel itself in on_mount - attaching
         # before app.run() would race call_from_thread on a
@@ -150,7 +169,34 @@ def run_factory_embedded(
         sys.stdout.flush()
 
 
-def _plain_fallback(handle: OrchestratorHandle, run_dir: Path) -> int:
+def run_factory_embedded(
+    manifest: Manifest,
+    factory_config: FactoryConfig,
+    base_config: KstrlConfig,
+    root_dir: Path,
+    manifest_path: Path | None,
+    *,
+    poll_interval: float = 0.2,
+) -> int:
+    from kstrl.factory import run_factory
+
+    def _target(ctx: EmbeddedContext) -> int:
+        return run_factory(
+            manifest, factory_config, base_config, ctx.ui, root_dir,
+            manifest_path=manifest_path,
+            interaction=ctx.channel,
+            stop=ctx.stop,
+            run_id=ctx.run_id,
+            notify_capture_output=True,
+        ).exit_code
+
+    return run_embedded(
+        _target, root_dir=root_dir, run_id=current_run_id(),
+        thread_name="ralph-orchestrator", poll_interval=poll_interval,
+    )
+
+
+def _plain_fallback(handle: CommandHandle, run_dir: Path) -> int:
     """TUI died: stream the run's events as plain lines until done."""
     renderer = UIBackedRenderer(PlainUI(no_color=True))
     tailer = RunTailer(run_dir)

--- a/kstrl/tui/screens/component.py
+++ b/kstrl/tui/screens/component.py
@@ -39,6 +39,10 @@ class ComponentScreen(Screen[None]):
     def __init__(self, component_id: str) -> None:
         super().__init__()
         self.component_id = component_id
+        # The app's duck-typed poll contract: a screen naming a
+        # transcript_component gets refresh_state(state, manifest) and
+        # that ONE component's transcript tail.
+        self.transcript_component = component_id
         self._following = True
 
     def compose(self) -> ComposeResult:

--- a/kstrl/tui/screens/options.py
+++ b/kstrl/tui/screens/options.py
@@ -1,0 +1,85 @@
+"""Lean options modal for generic prompts (TUI surface A3).
+
+Every non-checkpoint PromptRequest (feature review gate, evolve apply,
+retry confirm, guard/iteration prompts) lands here: header + one
+button per option, digits 1..n decide, Enter takes the default,
+Esc leaves the prompt pending (the request stays open; press c to
+reopen - identical semantics to the checkpoint modal).
+
+The checkpoint modal is NOT reused for these: its a/r/t bindings
+hardcode three options, and on a 2-option CONFIRM the third key
+dismissed with an out-of-range choice - the channel rejected it,
+leaving the orchestrator blocked with the modal gone (D9).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label
+
+if TYPE_CHECKING:
+    from kstrl.interaction import PromptRequest
+
+MAX_KEYED_OPTIONS = 9
+
+
+class OptionsModal(ModalScreen[int | None]):
+    # Enter is NOT bound at screen level: the default button holds
+    # focus, so Enter presses it - a screen binding would double-fire.
+    BINDINGS = [
+        Binding("escape", "leave_pending", "Later"),
+        *[
+            Binding(str(n + 1), f"decide({n})", show=False)
+            for n in range(MAX_KEYED_OPTIONS)
+        ],
+    ]
+
+    def __init__(self, request: PromptRequest) -> None:
+        super().__init__()
+        self.request = request
+
+    def compose(self) -> ComposeResult:
+        dialog = Vertical(id="options-dialog")
+        dialog.border_title = self.request.kind.value
+        with dialog:
+            yield Label(self.request.header, id="options-question")
+            with Horizontal(id="options-buttons"):
+                for index, option in enumerate(self.request.options):
+                    label = option.split(" (")[0]
+                    button = Button(
+                        f"{label} ({index + 1})", id=f"choice-{index}",
+                    )
+                    if index == self.request.default:
+                        button.add_class("default-choice")
+                    yield button
+
+    def on_mount(self) -> None:
+        buttons = list(self.query(Button))
+        default = self.request.default
+        if 0 <= default < len(buttons):
+            buttons[default].focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id or ""
+        if not button_id.startswith("choice-"):
+            return
+        try:
+            choice = int(button_id.removeprefix("choice-"))
+        except ValueError:
+            return
+        self.action_decide(choice)
+
+    def action_decide(self, choice: int) -> None:
+        if 0 <= choice < len(self.request.options):
+            self.dismiss(choice)
+
+    def action_take_default(self) -> None:
+        self.action_decide(self.request.default)
+
+    def action_leave_pending(self) -> None:
+        self.dismiss(None)

--- a/kstrl/tui/styles.tcss
+++ b/kstrl/tui/styles.tcss
@@ -232,6 +232,63 @@ CheckpointModal {
     color: $warning;
 }
 
+/* ---- options modal ------------------------------------------------------- */
+/* Lean prompt surface for every non-checkpoint request (feature gate,
+ * apply/retry confirms). Same chrome family as the checkpoint modal;
+ * the accent sits on the REQUEST's default option, which is not
+ * always index 0. */
+
+OptionsModal {
+    align: center middle;
+    background: $background 60%;
+}
+
+#options-dialog {
+    width: 70%;
+    max-width: 90;
+    height: auto;
+    border: round $accent 60%;
+    border-title-color: $accent;
+    border-title-style: bold;
+    background: $surface;
+    padding: 1 2;
+}
+
+#options-question {
+    text-style: bold;
+    color: $foreground;
+}
+
+#options-buttons {
+    height: 3;
+    margin-top: 1;
+    align-horizontal: center;
+}
+
+#options-buttons Button {
+    margin: 0 1;
+    min-width: 16;
+    border: none;
+    height: 1;
+    background: $panel;
+    color: $foreground;
+    text-style: none;
+}
+
+#options-buttons Button:hover {
+    background: $boost;
+}
+
+#options-buttons Button:focus {
+    text-style: bold;
+}
+
+#options-buttons .default-choice {
+    background: $accent;
+    color: $background;
+    text-style: bold;
+}
+
 /* ---- quit modal ---------------------------------------------------------- */
 
 QuitModal {

--- a/tests/test_commandrun.py
+++ b/tests/test_commandrun.py
@@ -1,0 +1,135 @@
+"""TUI surface A3: the universal run substrate (open_command_run)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from kstrl import events as ev
+from kstrl.commandrun import CommandRun, open_command_run
+from kstrl.runid import run_kind
+from kstrl.ui.bridge import EventBridgeUI, NullPrompter
+from kstrl.ui.plain import PlainUI
+
+
+def _events_on_disk(run: CommandRun) -> list[dict[str, Any]]:
+    assert run.paths is not None
+    lines = run.paths.events_file.read_text().splitlines()
+    return [json.loads(line) for line in lines]
+
+
+class TestOpenCommandRun:
+    def test_enabled_records_events_with_component_stamp(
+        self, tmp_path: Path,
+    ) -> None:
+        ui = PlainUI(no_color=True)
+        run = open_command_run(
+            ui, tmp_path, "understand", component="understand",
+            enabled=True, heartbeat=False,
+        )
+        assert run.recording
+        assert run_kind(run.run_id) == "understand"
+        run.bus.emit(ev.RunStarted(project="p", components=1))
+        run.close()
+        events = _events_on_disk(run)
+        assert [e["event"] for e in events] == ["factory_started"]
+        assert events[0]["component"] == "understand"
+        assert events[0]["run_id"] == run.run_id
+
+    def test_disabled_leaves_no_run_dir(self, tmp_path: Path) -> None:
+        run = open_command_run(
+            PlainUI(no_color=True), tmp_path, "understand",
+            enabled=False,
+        )
+        assert not run.recording
+        run.bus.emit(ev.RunStarted(project="p"))
+        assert run.transcript_path("understand") is None
+        assert run.transcript_writer("understand") is None
+        run.close()  # safe when disabled
+        assert not (tmp_path / ".kstrl" / "runs").exists()
+
+    def test_enabled_none_reads_factory_gating(self, tmp_path: Path) -> None:
+        (tmp_path / "kstrl.toml").write_text(
+            "[factory]\nprogress_log_enabled = false\n",
+        )
+        run = open_command_run(
+            PlainUI(no_color=True), tmp_path, "decompose",
+        )
+        assert not run.recording
+        run.close()
+
+    def test_bridge_ui_bus_is_reused_and_restored(
+        self, tmp_path: Path,
+    ) -> None:
+        """Console narration lands in the run stream (chunk-7 wiring),
+        and close() un-stamps the shared bus for post-run lines."""
+        rendered: list[ev.Event] = []
+        bus = ev.EventBus(ev.CallbackSink(rendered.append))
+        ui = EventBridgeUI(bus, prompter=NullPrompter())
+        run = open_command_run(
+            ui, tmp_path, "decompose", component="architect",
+            enabled=True, heartbeat=False,
+        )
+        assert run.bus is bus
+        assert bus.component == "architect"
+        ui.info("resolved spec")
+        run.close()
+        assert bus.component == ""
+        ui.info("post-run narration")
+        events = _events_on_disk(run)
+        assert [e["event"] for e in events] == ["log"]
+        assert events[0]["component"] == "architect"
+        # The post-close line rendered to the console but not the file.
+        assert len(rendered) == 2
+
+    def test_heartbeat_started_when_enabled(self, tmp_path: Path) -> None:
+        run = open_command_run(
+            PlainUI(no_color=True), tmp_path, "feature",
+            component="my-feature", enabled=True, heartbeat=True,
+        )
+        assert run._stop_heartbeat is not None
+        run.close()
+        assert run._stop_heartbeat is None
+
+
+class TestStreamFilter:
+    def test_agent_stream_stays_out_of_events_jsonl(
+        self, tmp_path: Path,
+    ) -> None:
+        bus = ev.EventBus(ev.CallbackSink(lambda e: None))
+        ui = EventBridgeUI(bus, prompter=NullPrompter())
+        run = open_command_run(
+            ui, tmp_path, "understand", component="understand",
+            enabled=True, heartbeat=False,
+        )
+        ui.stream_line("AI", "full agent output line")
+        ui.stream_line("verify", "pytest output line")
+        ui.info("narration")
+        run.close()
+        events = _events_on_disk(run)
+        kinds = [(e["event"], e["data"].get("key", "")) for e in events]
+        assert ("log", "AI") not in kinds
+        assert ("log", "verify") in kinds
+        assert ("log", "") in kinds
+
+
+class TestTranscripts:
+    def test_writer_appends_lines_to_engineer_log(
+        self, tmp_path: Path,
+    ) -> None:
+        run = open_command_run(
+            PlainUI(no_color=True), tmp_path, "understand",
+            component="understand", enabled=True, heartbeat=False,
+        )
+        write = run.transcript_writer("understand")
+        assert write is not None
+        write("first line")
+        write("second line\n")
+        path = run.transcript_path("understand")
+        assert path is not None
+        assert path == (
+            run.paths.root / "components" / "understand" / "engineer.log"  # type: ignore[union-attr]
+        )
+        assert path.read_text() == "first line\nsecond line\n"
+        run.close()

--- a/tests/test_commandrun.py
+++ b/tests/test_commandrun.py
@@ -65,23 +65,44 @@ class TestOpenCommandRun:
         """Console narration lands in the run stream (chunk-7 wiring),
         and close() un-stamps the shared bus for post-run lines."""
         rendered: list[ev.Event] = []
-        bus = ev.EventBus(ev.CallbackSink(rendered.append))
+        bus = ev.EventBus(
+            ev.CallbackSink(rendered.append),
+            run_id="outer-run", component="outer-component",
+        )
         ui = EventBridgeUI(bus, prompter=NullPrompter())
         run = open_command_run(
             ui, tmp_path, "decompose", component="architect",
             enabled=True, heartbeat=False,
         )
         assert run.bus is bus
+        assert bus.run_id == run.run_id
         assert bus.component == "architect"
         ui.info("resolved spec")
         run.close()
-        assert bus.component == ""
+        assert bus.run_id == "outer-run"
+        assert bus.component == "outer-component"
         ui.info("post-run narration")
         events = _events_on_disk(run)
         assert [e["event"] for e in events] == ["log"]
         assert events[0]["component"] == "architect"
         # The post-close line rendered to the console but not the file.
         assert len(rendered) == 2
+
+    def test_bridge_run_level_session_clears_inherited_component(
+        self, tmp_path: Path,
+    ) -> None:
+        bus = ev.EventBus(run_id="outer-run", component="outer-component")
+        ui = EventBridgeUI(bus, prompter=NullPrompter())
+        run = open_command_run(
+            ui, tmp_path, "decompose", enabled=True, heartbeat=False,
+        )
+        assert bus.component == ""
+        run.bus.emit(ev.RunStarted(project="p"))
+        run.close()
+
+        assert bus.run_id == "outer-run"
+        assert bus.component == "outer-component"
+        assert _events_on_disk(run)[0]["component"] == ""
 
     def test_heartbeat_started_when_enabled(self, tmp_path: Path) -> None:
         run = open_command_run(

--- a/tests/test_tui_embed.py
+++ b/tests/test_tui_embed.py
@@ -23,13 +23,20 @@ from kstrl.interaction import (
 from kstrl.observability import NotifyConfig, NotifyHooks
 from kstrl.shutdown import StopController
 from kstrl.tui.app import KstrlTuiApp, Mode
-from kstrl.tui.bridge import OrchestratorHandle, start_orchestrator
+from kstrl.tui.bridge import (
+    OrchestratorHandle,
+    start_command_thread,
+    start_orchestrator,
+)
 from kstrl.tui.embed import (
     _install_exclusive_root_handler,
     _plain_fallback,
     _restore_root_handlers,
 )
 from kstrl.tui.screens.checkpoint import CheckpointModal
+from kstrl.tui.screens.component import ComponentScreen
+from kstrl.tui.screens.options import OptionsModal
+from kstrl.tui.screens.overview import OverviewScreen
 from kstrl.tui.screens.quit import QuitModal
 
 
@@ -94,7 +101,7 @@ def _fake_orchestrator(
 ) -> OrchestratorHandle:
     """A thread standing in for run_factory: optionally asks one
     checkpoint question, then finishes (or waits for stop)."""
-    result_box: list[FactoryResult] = []
+    result_box: list[int] = []
     error_box: list[BaseException] = []
 
     def _target() -> None:
@@ -117,9 +124,7 @@ def _fake_orchestrator(
             decisions.append(response.choice if response.answered else -1)
         if wait_for_stop:
             stop.wait(timeout=30)
-        result = FactoryResult()
-        result.exit_code = 130 if stop.is_set() else 0
-        result_box.append(result)
+        result_box.append(130 if stop.is_set() else 0)
 
     thread = threading.Thread(target=_target, daemon=False)
     handle = OrchestratorHandle(
@@ -271,13 +276,11 @@ class TestEmbeddedApp:
 class TestFallbackAndLogging:
     def test_plain_fallback_accepts_tailer_chunks(self, tmp_path: Path) -> None:
         run_dir = _write_minimal_run(tmp_path, "factory-20260720-fallback")
-        result = FactoryResult()
-        result.exit_code = 7
         thread = threading.Thread(target=lambda: None)
         thread.start()
         thread.join()
         handle = OrchestratorHandle(
-            thread=thread, stop=StopController(), result_box=[result],
+            thread=thread, stop=StopController(), result_box=[7],
         )
 
         assert _plain_fallback(handle, run_dir) == 7
@@ -332,3 +335,150 @@ class TestNotifyCapture:
         src = inspect.getsource(NotifyHooks._fire)
         assert "stdout=sink" in src and "stderr=sink" in src
         assert subprocess.DEVNULL  # imported, used above
+
+
+def _fake_confirm_worker(
+    channel: QueueInteractionChannel,
+    stop: StopController,
+    decisions: list[int],
+) -> OrchestratorHandle:
+    """A command core standing in for the feature review gate: one
+    2-option CONFIRM through the channel, then done."""
+    del stop  # the handle's StopController is unused by this fake
+
+    def _target() -> int:
+        deadline = time.monotonic() + 5
+        while not channel.can_prompt() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        response = channel.request(PromptRequest(
+            kind=PromptKind.CONFIRM,
+            header="Understanding complete. Start implementation?",
+            options=("Start implementation", "Quit"),
+            default=0,
+        ))
+        decisions.append(response.choice if response.answered else -1)
+        return 0
+
+    return start_command_thread(_target, stop=StopController())
+
+
+class TestCommandThread:
+    def test_returned_code_is_boxed(self) -> None:
+        handle = start_command_thread(lambda: 7, stop=StopController())
+        handle.join(timeout=5)
+        assert handle.done()
+        assert handle.exit_code == 7
+        assert not handle.error_box
+
+    def test_system_exit_codes_are_honored_not_crashes(self) -> None:
+        """A missed sys.exit inside a core must keep its exit code."""
+        import sys
+
+        cases: list[tuple[Any, int]] = [(3, 3), (None, 0), ("boom", 1)]
+        for raised, expected in cases:
+            handle = start_command_thread(
+                lambda code=raised: sys.exit(code),  # type: ignore[misc]
+                stop=StopController(),
+            )
+            handle.join(timeout=5)
+            assert not handle.error_box, f"sys.exit({raised!r}) crashed"
+            assert handle.exit_code == expected
+
+    def test_exception_lands_in_error_box(self) -> None:
+        def _boom() -> int:
+            raise RuntimeError("boom")
+
+        handle = start_command_thread(_boom, stop=StopController())
+        handle.join(timeout=5)
+        assert handle.error_box
+        assert handle.exit_code == 1
+
+
+class TestScreenFactory:
+    async def test_custom_stack_pushed_bottom_first(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = _write_minimal_run(tmp_path, "factory-20260720-stack1")
+        app = KstrlTuiApp(
+            run_dir=run_dir, root_dir=tmp_path, mode=Mode.DASH,
+            poll_interval=0.05,
+            screen_factory=lambda: [
+                OverviewScreen(observe_only=True),
+                ComponentScreen("comp-a"),
+            ],
+        )
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            assert isinstance(app.screen, ComponentScreen)
+            assert app.screen.component_id == "comp-a"
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, OverviewScreen)
+
+
+class TestOptionsModal:
+    async def test_confirm_resolves_through_the_channel(
+        self, tmp_path: Path,
+    ) -> None:
+        """D9 regression: a 2-option CONFIRM must open the lean options
+        modal; an out-of-range digit does NOTHING (the checkpoint
+        modal's old 't'/'3' path dismissed with a rejected choice,
+        leaving the core blocked with the modal gone)."""
+        run_dir = _write_minimal_run(tmp_path, "factory-20260720-opts1")
+        channel = QueueInteractionChannel()
+        stop = StopController()
+        decisions: list[int] = []
+        handle = _fake_confirm_worker(channel, stop, decisions)
+        app = KstrlTuiApp(
+            run_dir=run_dir, root_dir=tmp_path, mode=Mode.EMBEDDED,
+            poll_interval=0.05, channel=channel, orchestrator=handle,
+        )
+        async with app.run_test(size=(120, 40)) as pilot:
+            deadline = time.monotonic() + 5
+            while not isinstance(app.screen, OptionsModal):
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline, "modal never opened"
+            await pilot.press("3")  # out of range: still open, unresolved
+            await pilot.pause()
+            assert isinstance(app.screen, OptionsModal)
+            assert not decisions
+            await pilot.press("2")
+            deadline = time.monotonic() + 5
+            while not handle.done():
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline, "core stuck"
+            await pilot.pause(0.6)
+        assert decisions == [1]
+        assert app.return_value == 0
+
+    async def test_escape_leaves_pending_and_c_reopens(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = _write_minimal_run(tmp_path, "factory-20260720-opts2")
+        channel = QueueInteractionChannel()
+        stop = StopController()
+        decisions: list[int] = []
+        handle = _fake_confirm_worker(channel, stop, decisions)
+        app = KstrlTuiApp(
+            run_dir=run_dir, root_dir=tmp_path, mode=Mode.EMBEDDED,
+            poll_interval=0.05, channel=channel, orchestrator=handle,
+        )
+        async with app.run_test(size=(120, 40)) as pilot:
+            deadline = time.monotonic() + 5
+            while not isinstance(app.screen, OptionsModal):
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline, "modal never opened"
+            await pilot.press("escape")
+            await pilot.pause()
+            assert not isinstance(app.screen, OptionsModal)
+            assert not handle.done()  # the core is still waiting
+            await pilot.press("c")
+            await pilot.pause()
+            assert isinstance(app.screen, OptionsModal)
+            await pilot.press("1")
+            deadline = time.monotonic() + 5
+            while not handle.done():
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline, "core stuck"
+            await pilot.pause(0.6)
+        assert decisions == [0]


### PR DESCRIPTION
Stacks on #128.

## What
- **`kstrl/commandrun.py`** (new): `open_command_run(ui, root, kind, component=, run_id=, enabled=, heartbeat=)` -> `CommandRun{run_id, kind, bus, paths}` with `transcript_writer()`/`close()`. Mirrors the factory's sink-attach block minus `V1CompatSink` (progress.jsonl stays a factory-only contract - Linear sink untouched). `_StreamFilterSink` drops `Log(kind="stream", key="AI")` from events.jsonl (transcript files carry those bytes; lean-stream spike rule). `start_heartbeat` moved here from factory.py (import-aliased back, so `patch("kstrl.factory._start_heartbeat")` in existing tests still works).
- **`tui/bridge.py`**: `CommandHandle` (int result box) + `start_command_thread`; SystemExit on the worker thread boxes its code instead of reading as a crash; `start_orchestrator` is now a thin factory wrapper; `OrchestratorHandle` alias kept.
- **`tui/embed.py`**: `run_embedded(target, root_dir=, run_id=, screen_factory=)` generalizes the embed sequence (orchestrator.log console, signals-before-app.run, channel-attach-in-on_mount, plain fallback, ANSI restore); `run_factory_embedded` delegates with its signature unchanged.
- **`tui/app.py`**: `screen_factory` param; poll/tick dispatch duck-typed (`transcript_component`/`feed_events`/`tick_ages` contract documented in `_poll`); prompt routing fix (D9): non-checkpoint prompts open the new **OptionsModal** (`screens/options.py`) - digits 1..n, focused default button, Esc leaves pending. The checkpoint modal's hardcoded 3-option bindings mis-resolved 2-option CONFIRMs (dismissed with a rejected choice, core left blocked).

## Tested
- New `tests/test_commandrun.py`: enabled/disabled/toml-gated matrix, bridge-bus reuse + component stamp restore on close, stream filter, transcript writer, heartbeat lifecycle.
- `test_tui_embed.py` additions: SystemExit boxing cases (3/None/str), screen_factory stack + escape pop, OptionsModal channel round-trip incl. the out-of-range-digit regression and Esc-pending/c-reopen.
- Existing embed/app/detail tests pass with only the `result_box` type adaptation (`list[FactoryResult]` -> `list[int]`) in the fake orchestrator.
- Fast tier 1777 passed; spine tier 25 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)