### PR TITLE
ci: validate stacked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+  # Stacked PRs target feature branches until the preceding layer lands.
+  # Checking every PR base keeps each layer independently validated.
   pull_request:
-    branches: [main]
 
 # Cancel superseded runs on the same branch.
 concurrency:


### PR DESCRIPTION
## What changed

- Run the CI workflow for pull requests targeting any base branch.
- Keep push-triggered CI limited to `main`.

## Why

PRs #128 and #129 are stacked on feature branches. The existing `pull_request.branches: [main]` filter prevents GitHub Actions from creating any workflow runs for those layers, leaving them unvalidated until they are retargeted.

This keeps the stacked review structure while ensuring every layer can receive CI independently.

## Validation

- Confirmed #127 has a successful CI run while #128 and #129 have no workflow runs.
- Parsed `.github/workflows/ci.yml` successfully with PyYAML.
- `git diff --check` passes.