### PR TITLE
refactor: pure-data extractions - config report, proposals, retry plan, launch (TUI surface B1)

### DIFF
--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 import copy
 import json
 import os
-import re
 import sys
 import time
 from collections.abc import Iterator
-from contextlib import contextmanager
 from dataclasses import fields as dataclass_fields
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -32,7 +30,9 @@ from kstrl.agents import (
 )
 from kstrl.agents.base import Agent, UsageRecord
 from kstrl.breaker import BreakerConfig
-from kstrl.config import KstrlConfig, _parse_paths, load_toml_section, resolve_config_file
+from kstrl.config import KstrlConfig, _parse_paths, resolve_config_file
+from kstrl.config_report import build_config_report
+from kstrl.config_report import normalize_ui_mode as _normalize_ui_mode
 from kstrl.decompose import SpecBlockerError, decompose_spec
 from kstrl.factory import FactoryConfig, run_factory
 from kstrl.init_cmd import DEFAULT_FEATURE_UNDERSTAND, run_init
@@ -41,6 +41,7 @@ from kstrl.interaction import (
     PromptRequest,
     UiInteractionChannel,
 )
+from kstrl.launch import assemble_factory_configs
 from kstrl.loop import run_loop
 from kstrl.manifest import Manifest
 from kstrl.observability import (
@@ -51,7 +52,11 @@ from kstrl.observability import (
 )
 from kstrl.output import build_console
 from kstrl.prd import PRD
+from kstrl.proposals import append_to_agent_learnings as _append_to_agent_learnings
+from kstrl.proposals import existing_proposal_titles as _existing_proposal_titles
+from kstrl.proposals import mark_applied, parse_proposal_file
 from kstrl.reducer import ComponentState, RunState, fold, load_run_state, upconvert_v1
+from kstrl.retry_plan import RetryError, prepare_retry
 from kstrl.sandbox import SandboxConfig
 from kstrl.shutdown import StopController, install_signal_handlers
 from kstrl.timeout import TimeoutConfig
@@ -283,28 +288,6 @@ def _apply_cli_overrides(
     return overridden
 
 
-@contextmanager
-def _scrubbed_environ() -> Iterator[None]:
-    """Temporarily clear os.environ so a loader sees toml + defaults only.
-
-    Used by ``config show`` to isolate the env contribution: a field
-    whose value changes when the environment disappears was env-set.
-    """
-    saved = dict(os.environ)
-    os.environ.clear()
-    try:
-        yield
-    finally:
-        os.environ.clear()
-        os.environ.update(saved)
-
-
-def _format_config_value(value: Any) -> str:
-    if isinstance(value, Path):
-        return str(value)
-    return repr(value)
-
-
 def _collect_toml_notes(
     notes: list[str],
     section: str,
@@ -358,17 +341,6 @@ def _resolve_path(root: Path, value: str | None, default: Path) -> Path:
     if path.is_absolute():
         return path
     return root / path
-
-
-def _normalize_ui_mode(value: str) -> str:
-    normalized = (value or "auto").strip().lower()
-    if normalized == "gum":
-        return "rich"
-    if normalized in {"plain", "off", "no", "0"}:
-        return "plain"
-    if normalized not in {"auto", "rich", "plain"}:
-        return "auto"
-    return normalized
 
 
 def _derive_feature_name(prd_path: Path, root: Path) -> str:
@@ -2111,47 +2083,6 @@ def factory(
 # Display structure for the KstrlConfig-backed ralph.toml sections:
 # section -> [(toml_key, dataclass_field)]. Mirrors DEFAULT_KSTRL_TOML in
 # init_cmd.py plus the env/flag-only UI knobs (ui_mode, no_color).
-_KSTRL_SHOW_SECTIONS: list[tuple[str, list[tuple[str, str]]]] = [
-    ("agent", [
-        ("type", "agent_type"),
-        ("command", "agent_cmd"),
-        ("model", "model"),
-        ("reasoning_effort", "model_reasoning_effort"),
-    ]),
-    ("run", [
-        ("max_iterations", "max_iterations"),
-        ("sleep_seconds", "sleep_seconds"),
-        ("interactive", "interactive"),
-    ]),
-    ("paths", [
-        ("prompt", "prompt_file"),
-        ("prd", "prd_file"),
-        ("progress", "progress_file"),
-        ("codebase_map", "codebase_map_file"),
-        ("allowed", "allowed_paths"),
-    ]),
-    ("git", [
-        ("branch", "kstrl_branch"),
-        ("auto_checkout", "auto_checkout"),
-    ]),
-    ("ui", [
-        ("ascii", "ascii_only"),
-        ("ui_mode", "ui_mode"),
-        ("no_color", "no_color"),
-    ]),
-]
-
-
-def _ralph_config_defaults(root_dir: Path) -> KstrlConfig:
-    """Built-in KstrlConfig defaults with paths anchored like load()."""
-    config = KstrlConfig()
-    config.prompt_file = root_dir / "scripts/kstrl/prompt.md"
-    config.prd_file = root_dir / "scripts/kstrl/prd.json"
-    config.progress_file = root_dir / "scripts/kstrl/progress.txt"
-    config.codebase_map_file = root_dir / "scripts/kstrl/codebase_map.md"
-    return config
-
-
 @cli.group(name="config")
 def config_group() -> None:
     """Inspect Ralph configuration."""
@@ -2214,132 +2145,34 @@ def config_show(
     """
     ctx = click.get_current_context()
     root_dir = root.resolve() if root else Path.cwd()
-    toml_path = resolve_config_file(root_dir)
 
-    from kstrl.contract import ContractConfig
-    from kstrl.evolution import EvolutionConfig
-    from kstrl.feedforward import FeedforwardConfig
-    from kstrl.knowledge import KnowledgeConfig
-    from kstrl.linear import LinearConfig
-    from kstrl.observability import NotifyConfig
-    from kstrl.security import SecurityConfig
-    from kstrl.verify import VerifyConfig
-
-    # (section, loader, knob fields) - the documented ralph.toml surface.
-    phase_sections: list[tuple[str, Any, list[str]]] = [
-        ("factory", FactoryConfig.load, [
-            "max_parallel", "max_retries", "retry_delay", "use_worktrees",
-            "single_pr", "create_prs", "review_mode", "merge_timeout",
-            "max_adversarial_calls", "max_total_tokens",
-            "pause_before_pr_merge", "progress_log_enabled",
-            "keep_worktrees_on_failure",
-        ]),
-        ("verify", VerifyConfig.load, [
-            "test_command", "typecheck_command", "lint_command",
-            "check_diff_scope", "check_bad_patterns", "dead_code_cleanup",
-            "dead_code_command", "mutation_testing", "mutation_threshold",
-            "mutation_timeout", "subprocess_timeout", "require_self_critique",
-            "self_critique_min_bullets", "progress_file_path",
-        ]),
-        ("security", SecurityConfig.load, [
-            "mode", "fail_threshold", "timeout_seconds", "agent_cmd",
-            "agent_type", "model",
-        ]),
-        ("contract", ContractConfig.load, ["mode", "test_command", "timeout"]),
-        ("feedforward", FeedforwardConfig.load, [
-            "enabled", "module_map", "public_interfaces", "dependency_graph",
-            "conventions", "max_context_tokens",
-        ]),
-        ("knowledge", KnowledgeConfig.load, [
-            "enabled", "max_core_tokens", "max_dependency_tokens",
-            "max_sibling_tokens", "distill_timeout_seconds", "distill_model",
-            "max_facts_per_distill", "dependency_scope",
-        ]),
-        ("evolution", EvolutionConfig.load, [
-            "enabled", "journal_path", "experiments_path",
-            "min_pattern_frequency", "lookback_runs", "auto_propose",
-            "auto_apply_computational",
-        ]),
-        ("timeout", TimeoutConfig.load, [
-            f.name for f in dataclass_fields(TimeoutConfig)
-        ]),
-        ("notify", NotifyConfig.load, [
-            "on_complete", "on_first_failure", "hook_timeout",
-        ]),
-        ("linear", LinearConfig.load, [
-            "enabled", "team_id", "token_env", "auth_mode", "api_url",
-            "dry_run", "timeout_seconds", "min_request_interval",
-        ]),
-    ]
+    def _overlay(config: KstrlConfig) -> set[str]:
+        return _apply_cli_overrides(
+            ctx, config, root_dir,
+            prompt_default=root_dir / "scripts/kstrl/prompt.md",
+            prd_default=root_dir / "scripts/kstrl/prd.json",
+        )
 
     try:
-        resolved_ralph = KstrlConfig.load(root_dir)
-        phase_resolved = {name: loader(root_dir) for name, loader, _ in phase_sections}
-        with _scrubbed_environ():
-            noenv_ralph = KstrlConfig.load(root_dir)
-            phase_noenv = {
-                name: loader(root_dir) for name, loader, _ in phase_sections
-            }
-        phase_toml_keys = {
-            name: set(load_toml_section(toml_path, name).keys())
-            for name, _, _ in phase_sections
-        }
+        report = build_config_report(root_dir, overlay=_overlay)
     except ValueError as exc:
         click.echo(f"error: {exc}", err=True)
         sys.exit(1)
 
-    defaults_ralph = _ralph_config_defaults(root_dir)
-
-    # Per-field sources for KstrlConfig, computed BEFORE flag overlay.
-    ralph_sources: dict[str, str] = {}
-    for f in dataclass_fields(KstrlConfig):
-        if getattr(resolved_ralph, f.name) != getattr(noenv_ralph, f.name):
-            ralph_sources[f.name] = "env"
-        elif getattr(noenv_ralph, f.name) != getattr(defaults_ralph, f.name):
-            ralph_sources[f.name] = "toml"
-        else:
-            ralph_sources[f.name] = "default"
-
-    flag_fields = _apply_cli_overrides(
-        ctx, resolved_ralph, root_dir,
-        prompt_default=root_dir / "scripts/kstrl/prompt.md",
-        prd_default=root_dir / "scripts/kstrl/prd.json",
-    )
-    for name in flag_fields:
-        ralph_sources[name] = "flag"
-    resolved_ralph.ui_mode = _normalize_ui_mode(resolved_ralph.ui_mode)
-
+    toml_path = report.toml_path
     click.echo(f"# Resolved kstrl config for {root_dir}")
-    click.echo(f"# ralph.toml: {toml_path if toml_path.exists() else '(absent)'}")
+    click.echo(f"# ralph.toml: {toml_path if report.toml_exists else '(absent)'}")
     click.echo("")
 
-    for section, keys in _KSTRL_SHOW_SECTIONS:
-        click.echo(f"[{section}]")
-        for toml_key, field_name in keys:
-            value = getattr(resolved_ralph, field_name)
-            source = ralph_sources[field_name]
-            click.echo(
-                f"  {toml_key} = {_format_config_value(value)}  ({source})"
-            )
-        click.echo("")
-
-    for section, _, knob_fields in phase_sections:
-        resolved = phase_resolved[section]
-        noenv = phase_noenv[section]
-        toml_keys = phase_toml_keys[section]
-        click.echo(f"[{section}]")
-        for field_name in knob_fields:
-            value = getattr(resolved, field_name)
-            if value != getattr(noenv, field_name):
-                source = "env"
-            elif field_name in toml_keys:
-                source = "toml"
-            else:
-                source = "default"
-            click.echo(
-                f"  {field_name} = {_format_config_value(value)}  ({source})"
-            )
-        click.echo("")
+    section = ""
+    for row in report.rows:
+        if row.section != section:
+            if section:
+                click.echo("")
+            section = row.section
+            click.echo(f"[{section}]")
+        click.echo(f"  {row.key} = {row.value}  ({row.source})")
+    click.echo("")
 
     sys.exit(0)
 
@@ -2770,9 +2603,6 @@ def retry(
     exactly like `ralph factory` invoked without flags. The run-level
     factory lock applies as usual.
     """
-    import shutil as _shutil
-    import subprocess as _sp
-
     root_dir = root.resolve() if root else Path.cwd()
     force_rich = os.environ.get("GUM_FORCE") == "1"
     ui_impl = _console_ui(_normalize_ui_mode(ui), no_color, force_rich=force_rich)
@@ -2791,78 +2621,13 @@ def retry(
         ui_impl.err(f"Failed to load manifest {manifest_file}: {exc}")
         sys.exit(1)
 
-    comp = manifest.get_component(component_id)
-    evidence_worktree = comp.evidence_worktree if comp else ""
-    failed_branch = comp.branch_name if comp else ""
-
     try:
-        reset_dependents = manifest.reset_for_retry(component_id)
+        prepare_retry(manifest, component_id, manifest_file, root_dir, ui_impl)
     except ValueError as exc:
         ui_impl.err(str(exc))
         sys.exit(2)
-
-    ui_impl.section("Retry plan")
-    ui_impl.kv("Component", component_id)
-    ui_impl.kv(
-        "Cascade-skipped dependents reset",
-        ", ".join(reset_dependents) if reset_dependents else "(none)",
-    )
-    ui_impl.kv("Manifest", str(manifest_file))
-
-    # The failed attempt's worktree and branch are superseded by the
-    # fresh attempt; remove them so provisioning and the stale-branch
-    # preflight start clean. In single_pr mode every component shares
-    # one branch carrying completed components' commits - never delete
-    # it here.
-    if evidence_worktree and Path(evidence_worktree).exists():
-        _sp.run(
-            ["git", "worktree", "remove", "--force", evidence_worktree],
-            cwd=root_dir, capture_output=True, timeout=30,
-        )
-        _shutil.rmtree(evidence_worktree, ignore_errors=True)
-        _sp.run(
-            ["git", "worktree", "prune"],
-            cwd=root_dir, capture_output=True, timeout=30,
-        )
-        ui_impl.info(
-            f"Removed the failed attempt's evidence worktree: "
-            f"{evidence_worktree}"
-        )
-    if failed_branch and not manifest.single_pr:
-        branch_exists = _sp.run(
-            ["git", "rev-parse", "--verify", "--quiet",
-             f"refs/heads/{failed_branch}"],
-            cwd=root_dir, capture_output=True, timeout=30,
-        )
-        if branch_exists.returncode == 0:
-            deleted = _sp.run(
-                ["git", "branch", "-D", failed_branch],
-                cwd=root_dir, capture_output=True, text=True, timeout=30,
-            )
-            if deleted.returncode == 0:
-                ui_impl.info(
-                    f"Deleted branch '{failed_branch}' from the failed "
-                    f"attempt; the retry recreates it from "
-                    f"'{manifest.base_branch}'"
-                )
-            else:
-                ui_impl.err(
-                    f"Could not delete branch '{failed_branch}': "
-                    f"{deleted.stderr.strip()}"
-                )
-                ui_impl.info(
-                    "Delete it manually (git branch -D "
-                    f"{failed_branch}) and re-run; the factory refuses "
-                    "to silently reuse stale branches (R0.5)."
-                )
-                sys.exit(1)
-    elif manifest.single_pr:
-        ui_impl.warn(
-            "single_pr mode: the shared branch is left in place; if the "
-            "run is refused at branch preflight, resolve it manually"
-        )
-
-    manifest.save(manifest_file)
+    except RetryError:
+        sys.exit(1)
 
     _retry_channel = UiInteractionChannel(ui_impl)
     if not yes and _retry_channel.can_prompt():
@@ -2877,34 +2642,14 @@ def retry(
 
     # Config assembly mirrors `ralph factory` with no flags: every phase
     # config resolves env > ralph.toml > defaults (R2.1 control plane).
-    from kstrl.contract import ContractConfig
-    from kstrl.feedforward import FeedforwardConfig
-    from kstrl.security import SecurityConfig
-    from kstrl.verify import VerifyConfig
-
-    base_config = KstrlConfig.load(root_dir)
-    base_config.ui_mode = "plain"
-    base_config.no_color = True
-    if not base_config.prompt_file.exists():
-        default_prompt = root_dir / "scripts" / "kstrl" / "prompt.md"
-        if default_prompt.exists():
-            base_config.prompt_file = default_prompt
-    _check_agent_preflight(base_config, ui_impl)
-
-    factory_config = FactoryConfig.load(root_dir)
-    factory_config.single_pr = manifest.single_pr
-    factory_config.verify_config = VerifyConfig.load(root_dir)
-    factory_config.security_config = SecurityConfig.load(root_dir)
-    contract_resolved = ContractConfig.load(root_dir)
-    factory_config.contract_config = (
-        contract_resolved if contract_resolved.mode != "skip" else None
+    factory_config, base_config = assemble_factory_configs(
+        root_dir,
+        single_pr=manifest.single_pr,
+        progress_log_path=progress_log,
+        force_lock=force_lock,
+        keep_worktrees_on_failure=keep_worktrees_on_failure,
     )
-    factory_config.feedforward_config = FeedforwardConfig.load(root_dir)
-    factory_config.timeout_config = TimeoutConfig.load(root_dir)
-    factory_config.progress_log_path = progress_log
-    factory_config.force_lock = force_lock
-    if keep_worktrees_on_failure:
-        factory_config.keep_worktrees_on_failure = True
+    _check_agent_preflight(base_config, ui_impl)
 
     stop = StopController()
     uninstall = install_signal_handlers(stop)
@@ -3067,84 +2812,6 @@ def evolve(
     sys.exit(0)
 
 
-_PROPOSAL_TITLE_RE = re.compile(r"^# (PROP-\d+): (.+)$")
-_PROPOSAL_FIELD_RE = re.compile(r"^\*\*(Type|Target)\*\*: (.+)$")
-_PROPOSAL_APPLIED_RE = re.compile(r"^\*\*Applied\*\*: (.+)$")
-
-
-def _existing_proposal_titles(proposals_dir: Path) -> set[str]:
-    """Titles of every proposal already saved to disk."""
-    titles: set[str] = set()
-    if not proposals_dir.is_dir():
-        return titles
-    for path in sorted(proposals_dir.glob("prop-*.md")):
-        try:
-            first_line = path.read_text().splitlines()[0]
-        except (OSError, IndexError):
-            continue
-        m = _PROPOSAL_TITLE_RE.match(first_line)
-        if m:
-            titles.add(m.group(2))
-    return titles
-
-
-def _parse_proposal_file(path: Path) -> dict[str, str]:
-    """Parse the structured fields save_proposals writes.
-
-    Returns keys: id, title, type, target, convention (the blockquote
-    body of the suggested change, "" when none), applied (timestamp or
-    "")."""
-    parsed = {
-        "id": "", "title": "", "type": "", "target": "",
-        "convention": "", "applied": "",
-    }
-    convention_lines: list[str] = []
-    for line in path.read_text().splitlines():
-        m = _PROPOSAL_TITLE_RE.match(line)
-        if m and not parsed["id"]:
-            parsed["id"], parsed["title"] = m.group(1), m.group(2)
-            continue
-        m = _PROPOSAL_FIELD_RE.match(line)
-        if m:
-            parsed[m.group(1).lower()] = m.group(2).strip()
-            continue
-        m = _PROPOSAL_APPLIED_RE.match(line)
-        if m:
-            parsed["applied"] = m.group(1).strip()
-            continue
-        if line.startswith("> "):
-            convention_lines.append(line[2:].strip())
-    parsed["convention"] = " ".join(convention_lines).strip()
-    return parsed
-
-
-def _append_to_agent_learnings(
-    claude_md: Path, proposal_id: str, convention: str,
-) -> bool:
-    """Append one convention bullet to the end of the "## Agent
-    Learnings" section of the project CLAUDE.md. Returns False (no
-    write) when the file or the section is missing - the caller then
-    falls back to honest manual instructions instead of guessing a
-    location."""
-    try:
-        content = claude_md.read_text()
-    except OSError:
-        return False
-    marker = "## Agent Learnings"
-    idx = content.find(marker)
-    if idx == -1:
-        return False
-    # End of the section = next level-2 header after it, else EOF.
-    next_header = content.find("\n## ", idx + len(marker))
-    insert_at = len(content) if next_header == -1 else next_header
-    entry = f"- {convention} (applied from {proposal_id} by ralph evolve)\n"
-    head = content[:insert_at]
-    if not head.endswith("\n"):
-        head += "\n"
-    claude_md.write_text(head + entry + content[insert_at:])
-    return True
-
-
 def _evolve_apply(
     apply_id: str,
     proposals_dir: Path,
@@ -3157,7 +2824,9 @@ def _evolve_apply(
     Agent Learnings section after explicit confirmation
     (auto_apply_computational=true skips the prompt); every other
     proposal type prints honest manual instructions - no false
-    "applied" claims."""
+    "applied" claims. Mechanics live in kstrl.proposals (shared with
+    the evolve screen); narration and the click.confirm wrapper stay
+    here."""
     if apply_id.lower() == "all":
         paths = sorted(proposals_dir.glob("prop-*.md"))
         if not paths:
@@ -3176,29 +2845,24 @@ def _evolve_apply(
     claude_md = root_dir / "CLAUDE.md"
     failures = 0
     for path in paths:
-        proposal = _parse_proposal_file(path)
-        pid = proposal["id"] or path.stem.upper()
-        if proposal["applied"]:
+        proposal = parse_proposal_file(path)
+        pid = proposal.display_id
+        if proposal.applied:
             ui_impl.info(
-                f"{pid} already applied at {proposal['applied']}; skipping."
+                f"{pid} already applied at {proposal.applied}; skipping."
             )
             continue
-        is_convention = (
-            proposal["type"] == "computational"
-            and proposal["target"] == "claude_md"
-            and bool(proposal["convention"])
-        )
-        if not is_convention:
-            ui_impl.info(f"{pid}: {proposal['title']}")
+        if not proposal.is_convention:
+            ui_impl.info(f"{pid}: {proposal.title}")
             ui_impl.warn(
                 f"  Automated apply only covers convention-type proposals "
                 f"(target claude_md). This one targets "
-                f"'{proposal['target'] or 'unknown'}': review {path} and "
+                f"'{proposal.target or 'unknown'}': review {path} and "
                 f"apply it manually."
             )
             continue
-        ui_impl.info(f"{pid}: {proposal['title']}")
-        ui_impl.info(f"  Convention: {proposal['convention']}")
+        ui_impl.info(f"{pid}: {proposal.title}")
+        ui_impl.info(f"  Convention: {proposal.convention}")
         if not evo_config.auto_apply_computational:
             # PR A: the old bare click.confirm raised click.Abort on
             # non-TTY EOF and crashed the command. Piped input
@@ -3216,7 +2880,7 @@ def _evolve_apply(
                 ui_impl.info(f"  {pid} not applied (declined).")
                 continue
         if not _append_to_agent_learnings(
-            claude_md, pid, proposal["convention"],
+            claude_md, pid, proposal.convention,
         ):
             ui_impl.err(
                 f"  Could not apply {pid}: {claude_md} is missing or has "
@@ -3225,9 +2889,7 @@ def _evolve_apply(
             )
             failures += 1
             continue
-        applied_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        with open(path, "a") as f:
-            f.write(f"\n**Applied**: {applied_at}\n")
+        mark_applied(path)
         ui_impl.ok(f"  {pid} appended to {claude_md}.")
     return 1 if failures else 0
 

--- a/kstrl/config_report.py
+++ b/kstrl/config_report.py
@@ -1,0 +1,261 @@
+"""Resolved-config reporting: (section, key, value, source) rows.
+
+Extracted from ``cli.config_show`` (TUI surface B1) so the plain
+command and the config screen render the SAME dataset. This module is
+click-free on purpose; presentation (click.echo lines, DataTable rows)
+stays with the callers.
+
+Source detection for env is behavioral: a value is tagged (env) when
+removing the environment changes it. That requires temporarily
+clearing ``os.environ`` - a PROCESS-WIDE side effect. Never call
+``build_config_report`` while another thread is running a live
+command; the TUI computes its report before app.run() and refreshes
+only when no session is active.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from dataclasses import fields as dataclass_fields
+from pathlib import Path
+from typing import Any
+
+from kstrl.config import KstrlConfig, load_toml_section, resolve_config_file
+
+
+@dataclass(frozen=True)
+class ConfigRow:
+    section: str
+    key: str
+    value: str  # pre-formatted via format_config_value
+    source: str  # flag | env | toml | default
+
+
+@dataclass(frozen=True)
+class ConfigReport:
+    root_dir: Path
+    toml_path: Path
+    toml_exists: bool
+    rows: tuple[ConfigRow, ...]
+
+
+# (toml section, [(toml key, KstrlConfig field)]) - the documented
+# kstrl.toml surface for the base config.
+SHOW_SECTIONS: list[tuple[str, list[tuple[str, str]]]] = [
+    ("agent", [
+        ("type", "agent_type"),
+        ("command", "agent_cmd"),
+        ("model", "model"),
+        ("reasoning_effort", "model_reasoning_effort"),
+    ]),
+    ("run", [
+        ("max_iterations", "max_iterations"),
+        ("sleep_seconds", "sleep_seconds"),
+        ("interactive", "interactive"),
+    ]),
+    ("paths", [
+        ("prompt", "prompt_file"),
+        ("prd", "prd_file"),
+        ("progress", "progress_file"),
+        ("codebase_map", "codebase_map_file"),
+        ("allowed", "allowed_paths"),
+    ]),
+    ("git", [
+        ("branch", "kstrl_branch"),
+        ("auto_checkout", "auto_checkout"),
+    ]),
+    ("ui", [
+        ("ascii", "ascii_only"),
+        ("ui_mode", "ui_mode"),
+        ("no_color", "no_color"),
+    ]),
+]
+
+
+def normalize_ui_mode(value: str) -> str:
+    normalized = (value or "auto").strip().lower()
+    if normalized == "gum":
+        return "rich"
+    if normalized in {"plain", "off", "no", "0"}:
+        return "plain"
+    if normalized not in {"auto", "rich", "plain"}:
+        return "auto"
+    return normalized
+
+
+@contextmanager
+def scrubbed_environ() -> Iterator[None]:
+    """Temporarily clear os.environ so a loader sees toml + defaults only.
+
+    A field whose value changes when the environment disappears was
+    env-set. PROCESS-WIDE: see the module docstring's thread warning.
+    """
+    saved = dict(os.environ)
+    os.environ.clear()
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+def format_config_value(value: Any) -> str:
+    if isinstance(value, Path):
+        return str(value)
+    return repr(value)
+
+
+def kstrl_config_defaults(root_dir: Path) -> KstrlConfig:
+    """Built-in KstrlConfig defaults with paths anchored like load()."""
+    config = KstrlConfig()
+    config.prompt_file = root_dir / "scripts/kstrl/prompt.md"
+    config.prd_file = root_dir / "scripts/kstrl/prd.json"
+    config.progress_file = root_dir / "scripts/kstrl/progress.txt"
+    config.codebase_map_file = root_dir / "scripts/kstrl/codebase_map.md"
+    return config
+
+
+def _phase_sections() -> list[tuple[str, Any, list[str]]]:
+    """(section, loader, knob fields) - the documented kstrl.toml
+    surface for the factory-phase configs. Loaders import lazily; the
+    report is not on any hot path."""
+    from kstrl.contract import ContractConfig
+    from kstrl.evolution import EvolutionConfig
+    from kstrl.factory import FactoryConfig
+    from kstrl.feedforward import FeedforwardConfig
+    from kstrl.knowledge import KnowledgeConfig
+    from kstrl.linear import LinearConfig
+    from kstrl.observability import NotifyConfig
+    from kstrl.security import SecurityConfig
+    from kstrl.timeout import TimeoutConfig
+    from kstrl.verify import VerifyConfig
+
+    return [
+        ("factory", FactoryConfig.load, [
+            "max_parallel", "max_retries", "retry_delay", "use_worktrees",
+            "single_pr", "create_prs", "review_mode", "merge_timeout",
+            "max_adversarial_calls", "max_total_tokens",
+            "pause_before_pr_merge", "progress_log_enabled",
+            "keep_worktrees_on_failure",
+        ]),
+        ("verify", VerifyConfig.load, [
+            "test_command", "typecheck_command", "lint_command",
+            "check_diff_scope", "check_bad_patterns", "dead_code_cleanup",
+            "dead_code_command", "mutation_testing", "mutation_threshold",
+            "mutation_timeout", "subprocess_timeout", "require_self_critique",
+            "self_critique_min_bullets", "progress_file_path",
+        ]),
+        ("security", SecurityConfig.load, [
+            "mode", "fail_threshold", "timeout_seconds", "agent_cmd",
+            "agent_type", "model",
+        ]),
+        ("contract", ContractConfig.load, ["mode", "test_command", "timeout"]),
+        ("feedforward", FeedforwardConfig.load, [
+            "enabled", "module_map", "public_interfaces", "dependency_graph",
+            "conventions", "max_context_tokens",
+        ]),
+        ("knowledge", KnowledgeConfig.load, [
+            "enabled", "max_core_tokens", "max_dependency_tokens",
+            "max_sibling_tokens", "distill_timeout_seconds", "distill_model",
+            "max_facts_per_distill", "dependency_scope",
+        ]),
+        ("evolution", EvolutionConfig.load, [
+            "enabled", "journal_path", "experiments_path",
+            "min_pattern_frequency", "lookback_runs", "auto_propose",
+            "auto_apply_computational",
+        ]),
+        ("timeout", TimeoutConfig.load, [
+            f.name for f in dataclass_fields(TimeoutConfig)
+        ]),
+        ("notify", NotifyConfig.load, [
+            "on_complete", "on_first_failure", "hook_timeout",
+        ]),
+        ("linear", LinearConfig.load, [
+            "enabled", "team_id", "token_env", "auth_mode", "api_url",
+            "dry_run", "timeout_seconds", "min_request_interval",
+        ]),
+    ]
+
+
+def build_config_report(
+    root_dir: Path,
+    *,
+    overlay: Callable[[KstrlConfig], set[str]] | None = None,
+) -> ConfigReport:
+    """Resolve every documented config value with its source.
+
+    ``overlay`` is the CLI's flag layer: it mutates the resolved
+    KstrlConfig and returns the field names it overrode (tagged
+    ``flag``). Raises ValueError when a loader rejects the config -
+    presentation of that error is the caller's job.
+    """
+    toml_path = resolve_config_file(root_dir)
+    phase_sections = _phase_sections()
+
+    resolved_base = KstrlConfig.load(root_dir)
+    phase_resolved = {name: loader(root_dir) for name, loader, _ in phase_sections}
+    with scrubbed_environ():
+        noenv_base = KstrlConfig.load(root_dir)
+        phase_noenv = {
+            name: loader(root_dir) for name, loader, _ in phase_sections
+        }
+    phase_toml_keys = {
+        name: set(load_toml_section(toml_path, name).keys())
+        for name, _, _ in phase_sections
+    }
+
+    defaults_base = kstrl_config_defaults(root_dir)
+
+    # Per-field sources for KstrlConfig, computed BEFORE the flag
+    # overlay (a flag replaces whatever source the value had).
+    base_sources: dict[str, str] = {}
+    for f in dataclass_fields(KstrlConfig):
+        if getattr(resolved_base, f.name) != getattr(noenv_base, f.name):
+            base_sources[f.name] = "env"
+        elif getattr(noenv_base, f.name) != getattr(defaults_base, f.name):
+            base_sources[f.name] = "toml"
+        else:
+            base_sources[f.name] = "default"
+
+    if overlay is not None:
+        for name in overlay(resolved_base):
+            base_sources[name] = "flag"
+    resolved_base.ui_mode = normalize_ui_mode(resolved_base.ui_mode)
+
+    rows: list[ConfigRow] = []
+    for section, keys in SHOW_SECTIONS:
+        for toml_key, field_name in keys:
+            rows.append(ConfigRow(
+                section=section,
+                key=toml_key,
+                value=format_config_value(getattr(resolved_base, field_name)),
+                source=base_sources[field_name],
+            ))
+    for section, _, knob_fields in phase_sections:
+        resolved = phase_resolved[section]
+        noenv = phase_noenv[section]
+        toml_keys = phase_toml_keys[section]
+        for field_name in knob_fields:
+            value = getattr(resolved, field_name)
+            if value != getattr(noenv, field_name):
+                source = "env"
+            elif field_name in toml_keys:
+                source = "toml"
+            else:
+                source = "default"
+            rows.append(ConfigRow(
+                section=section,
+                key=field_name,
+                value=format_config_value(value),
+                source=source,
+            ))
+
+    return ConfigReport(
+        root_dir=root_dir,
+        toml_path=toml_path,
+        toml_exists=toml_path.exists(),
+        rows=tuple(rows),
+    )

--- a/kstrl/launch.py
+++ b/kstrl/launch.py
@@ -1,0 +1,99 @@
+"""Launch specs + factory config assembly (TUI surface B1).
+
+The home shell's launcher forms produce a LaunchSpec - the HEADLINE
+options only; everything else resolves env > kstrl.toml > defaults,
+i.e. "the CLI invoked with just these flags". The session layer (D6)
+maps each spec onto its command core.
+
+``assemble_factory_configs`` is the extracted mirror-of-`ks factory`-
+with-no-flags block that cli.retry grew; retry and the launcher share
+it so the two paths can never drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from kstrl.config import KstrlConfig
+from kstrl.factory import FactoryConfig
+from kstrl.timeout import TimeoutConfig
+
+
+@dataclass(frozen=True)
+class FactoryLaunch:
+    """`ks factory` from an existing manifest (or a spec to decompose
+    first - the D6 session layer chains DecomposeLaunch for that)."""
+
+    manifest_path: Path | None = None
+    max_parallel: int | None = None
+    review_mode: str | None = None
+
+
+@dataclass(frozen=True)
+class DecomposeLaunch:
+    spec_path: Path = Path("scripts/kstrl/spec.md")
+    project_name: str = ""
+    base_branch: str = "main"
+    single_pr: bool = False
+
+
+@dataclass(frozen=True)
+class FeatureLaunch:
+    prd_path: Path = Path("scripts/kstrl/prd.json")
+    iterations: int | None = None
+
+
+@dataclass(frozen=True)
+class LoopLaunch:
+    """`ks run` / `ks understand` - the single-loop commands."""
+
+    command: str = "run"  # run | understand
+    iterations: int | None = None
+
+
+LaunchSpec = FactoryLaunch | DecomposeLaunch | FeatureLaunch | LoopLaunch
+
+
+def assemble_factory_configs(
+    root_dir: Path,
+    *,
+    single_pr: bool | None = None,
+    progress_log_path: Path | None = None,
+    force_lock: bool = False,
+    keep_worktrees_on_failure: bool = False,
+) -> tuple[FactoryConfig, KstrlConfig]:
+    """Config assembly mirroring `ks factory` with no flags: every
+    phase config resolves env > kstrl.toml > defaults (R2.1 control
+    plane). The base config is forced plain - factory narration goes
+    through the caller's console/bridge, never a nested rich UI.
+    """
+    from kstrl.contract import ContractConfig
+    from kstrl.feedforward import FeedforwardConfig
+    from kstrl.security import SecurityConfig
+    from kstrl.verify import VerifyConfig
+
+    base_config = KstrlConfig.load(root_dir)
+    base_config.ui_mode = "plain"
+    base_config.no_color = True
+    if not base_config.prompt_file.exists():
+        default_prompt = root_dir / "scripts" / "kstrl" / "prompt.md"
+        if default_prompt.exists():
+            base_config.prompt_file = default_prompt
+
+    factory_config = FactoryConfig.load(root_dir)
+    if single_pr is not None:
+        factory_config.single_pr = single_pr
+    factory_config.verify_config = VerifyConfig.load(root_dir)
+    factory_config.security_config = SecurityConfig.load(root_dir)
+    contract_resolved = ContractConfig.load(root_dir)
+    factory_config.contract_config = (
+        contract_resolved if contract_resolved.mode != "skip" else None
+    )
+    factory_config.feedforward_config = FeedforwardConfig.load(root_dir)
+    factory_config.timeout_config = TimeoutConfig.load(root_dir)
+    factory_config.progress_log_path = progress_log_path
+    factory_config.force_lock = force_lock
+    if keep_worktrees_on_failure:
+        factory_config.keep_worktrees_on_failure = True
+    return factory_config, base_config

--- a/kstrl/proposals.py
+++ b/kstrl/proposals.py
@@ -135,11 +135,17 @@ def append_to_agent_learnings(
     # End of the section = next level-2 header after it, else EOF.
     next_header = content.find("\n## ", idx + len(marker))
     insert_at = len(content) if next_header == -1 else next_header
+    application_marker = f"(applied from {proposal_id} by ralph evolve)"
+    if application_marker in content[idx:insert_at]:
+        return True
     entry = f"- {convention} (applied from {proposal_id} by ralph evolve)\n"
     head = content[:insert_at]
     if not head.endswith("\n"):
         head += "\n"
-    claude_md.write_text(head + entry + content[insert_at:])
+    try:
+        claude_md.write_text(head + entry + content[insert_at:])
+    except OSError:
+        return False
     return True
 
 
@@ -187,5 +193,12 @@ def apply_proposal(
             f"'## Agent Learnings' section. Add the section or apply "
             f"manually from {proposal.path}.",
         )
-    mark_applied(proposal.path)
+    try:
+        mark_applied(proposal.path)
+    except OSError as exc:
+        return ApplyOutcome(
+            "error",
+            f"{pid} was appended to {claude_md}, but the proposal file "
+            f"could not be marked applied: {exc}. Retrying is safe.",
+        )
     return ApplyOutcome("applied", f"{pid} appended to {claude_md}.")

--- a/kstrl/proposals.py
+++ b/kstrl/proposals.py
@@ -1,0 +1,191 @@
+"""Harness-proposal files: parsing and the convention apply path.
+
+Extracted from cli's evolve helpers (TUI surface B1) so the plain
+``ks evolve --apply`` flow and the evolve screen share one engine.
+The proposal file format is what ``evolution.save_proposals`` writes:
+a ``# PROP-NNN: title`` heading, ``**Type**``/``**Target**`` fields,
+the suggested change as a ``> `` blockquote, and an ``**Applied**``
+stamp once applied.
+
+Only convention-type proposals (computational, target claude_md) have
+an automated apply; everything else honestly requires manual review -
+``apply_proposal`` never fakes an "applied" claim (R6.3).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+PROPOSAL_TITLE_RE = re.compile(r"^# (PROP-\d+): (.+)$")
+PROPOSAL_FIELD_RE = re.compile(r"^\*\*(Type|Target)\*\*: (.+)$")
+PROPOSAL_APPLIED_RE = re.compile(r"^\*\*Applied\*\*: (.+)$")
+
+
+@dataclass(frozen=True)
+class Proposal:
+    path: Path
+    id: str
+    title: str
+    type: str
+    target: str
+    convention: str  # blockquote body of the suggested change; "" = none
+    applied: str  # timestamp, "" = not applied
+
+    @property
+    def display_id(self) -> str:
+        return self.id or self.path.stem.upper()
+
+    @property
+    def is_convention(self) -> bool:
+        """Whether the automated apply path covers this proposal."""
+        return (
+            self.type == "computational"
+            and self.target == "claude_md"
+            and bool(self.convention)
+        )
+
+
+@dataclass(frozen=True)
+class ApplyOutcome:
+    status: str  # applied | declined | already_applied | manual_required | error
+    message: str = ""
+
+
+def existing_proposal_titles(proposals_dir: Path) -> set[str]:
+    """Titles of every proposal already saved to disk."""
+    titles: set[str] = set()
+    if not proposals_dir.is_dir():
+        return titles
+    for path in sorted(proposals_dir.glob("prop-*.md")):
+        try:
+            first_line = path.read_text().splitlines()[0]
+        except (OSError, IndexError):
+            continue
+        m = PROPOSAL_TITLE_RE.match(first_line)
+        if m:
+            titles.add(m.group(2))
+    return titles
+
+
+def parse_proposal_file(path: Path) -> Proposal:
+    """Parse the structured fields save_proposals writes."""
+    parsed = {
+        "id": "", "title": "", "type": "", "target": "",
+        "applied": "",
+    }
+    convention_lines: list[str] = []
+    for line in path.read_text().splitlines():
+        m = PROPOSAL_TITLE_RE.match(line)
+        if m and not parsed["id"]:
+            parsed["id"], parsed["title"] = m.group(1), m.group(2)
+            continue
+        m = PROPOSAL_FIELD_RE.match(line)
+        if m:
+            parsed[m.group(1).lower()] = m.group(2).strip()
+            continue
+        m = PROPOSAL_APPLIED_RE.match(line)
+        if m:
+            parsed["applied"] = m.group(1).strip()
+            continue
+        if line.startswith("> "):
+            convention_lines.append(line[2:].strip())
+    return Proposal(
+        path=path,
+        id=parsed["id"],
+        title=parsed["title"],
+        type=parsed["type"],
+        target=parsed["target"],
+        convention=" ".join(convention_lines).strip(),
+        applied=parsed["applied"],
+    )
+
+
+def list_proposals(proposals_dir: Path) -> list[Proposal]:
+    if not proposals_dir.is_dir():
+        return []
+    proposals: list[Proposal] = []
+    for path in sorted(proposals_dir.glob("prop-*.md")):
+        try:
+            proposals.append(parse_proposal_file(path))
+        except OSError:
+            continue
+    return proposals
+
+
+def append_to_agent_learnings(
+    claude_md: Path, proposal_id: str, convention: str,
+) -> bool:
+    """Append one convention bullet to the end of the "## Agent
+    Learnings" section of the project CLAUDE.md. Returns False (no
+    write) when the file or the section is missing - the caller then
+    falls back to honest manual instructions instead of guessing a
+    location."""
+    try:
+        content = claude_md.read_text()
+    except OSError:
+        return False
+    marker = "## Agent Learnings"
+    idx = content.find(marker)
+    if idx == -1:
+        return False
+    # End of the section = next level-2 header after it, else EOF.
+    next_header = content.find("\n## ", idx + len(marker))
+    insert_at = len(content) if next_header == -1 else next_header
+    entry = f"- {convention} (applied from {proposal_id} by ralph evolve)\n"
+    head = content[:insert_at]
+    if not head.endswith("\n"):
+        head += "\n"
+    claude_md.write_text(head + entry + content[insert_at:])
+    return True
+
+
+def mark_applied(path: Path, when: str | None = None) -> str:
+    """Stamp the proposal file as applied; returns the timestamp."""
+    applied_at = when or datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    with open(path, "a") as f:
+        f.write(f"\n**Applied**: {applied_at}\n")
+    return applied_at
+
+
+def apply_proposal(
+    proposal: Proposal,
+    root_dir: Path,
+    *,
+    confirm: Callable[[str], bool],
+) -> ApplyOutcome:
+    """Apply one proposal through the confirm seam.
+
+    ``confirm`` receives the prompt text and answers yes/no - the CLI
+    wraps click.confirm (piped-stdin semantics preserved), the TUI's
+    modal has ALREADY confirmed and passes ``lambda _: True``.
+    """
+    pid = proposal.display_id
+    claude_md = root_dir / "CLAUDE.md"
+    if proposal.applied:
+        return ApplyOutcome(
+            "already_applied",
+            f"{pid} already applied at {proposal.applied}; skipping.",
+        )
+    if not proposal.is_convention:
+        return ApplyOutcome(
+            "manual_required",
+            f"Automated apply only covers convention-type proposals "
+            f"(target claude_md). This one targets "
+            f"'{proposal.target or 'unknown'}': review {proposal.path} "
+            f"and apply it manually.",
+        )
+    if not confirm(f"Append this convention to {claude_md}?"):
+        return ApplyOutcome("declined", f"{pid} not applied (declined).")
+    if not append_to_agent_learnings(claude_md, pid, proposal.convention):
+        return ApplyOutcome(
+            "error",
+            f"Could not apply {pid}: {claude_md} is missing or has no "
+            f"'## Agent Learnings' section. Add the section or apply "
+            f"manually from {proposal.path}.",
+        )
+    mark_applied(proposal.path)
+    return ApplyOutcome("applied", f"{pid} appended to {claude_md}.")

--- a/kstrl/retry_plan.py
+++ b/kstrl/retry_plan.py
@@ -1,0 +1,149 @@
+"""Retry planning and preparation (extracted from cli.retry, B1).
+
+``preview_retry`` answers "what WOULD a retry do" without touching
+anything - the retry screen renders it in its confirm modal.
+``prepare_retry`` is the real mutation: reset statuses, remove the
+failed attempt's worktree and branch, save the manifest. Narration
+stays byte-identical to the original command; the only behavior
+change is RetryError instead of sys.exit so a TUI caller can surface
+the failure without the process dying.
+"""
+
+from __future__ import annotations
+
+import copy
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kstrl.manifest import Manifest
+    from kstrl.ui.base import UI
+
+
+class RetryError(Exception):
+    """A retry preparation step failed after narrating the details."""
+
+
+@dataclass(frozen=True)
+class RetryPreview:
+    component_id: str
+    reset_dependents: list[str]
+    evidence_worktree: str
+    failed_branch: str
+    single_pr: bool
+
+
+def preview_retry(manifest: Manifest, component_id: str) -> RetryPreview:
+    """Non-mutating preview: runs reset_for_retry on a deep copy.
+
+    Raises ValueError exactly as reset_for_retry does (unknown
+    component, component not failed).
+    """
+    comp = manifest.get_component(component_id)
+    scratch = copy.deepcopy(manifest)
+    reset_dependents = scratch.reset_for_retry(component_id)
+    return RetryPreview(
+        component_id=component_id,
+        reset_dependents=reset_dependents,
+        evidence_worktree=comp.evidence_worktree if comp else "",
+        failed_branch=comp.branch_name if comp else "",
+        single_pr=manifest.single_pr,
+    )
+
+
+def prepare_retry(
+    manifest: Manifest,
+    component_id: str,
+    manifest_file: Path,
+    root_dir: Path,
+    ui: UI,
+) -> RetryPreview:
+    """Mutate the manifest for a retry and clean up the failed attempt.
+
+    Verbatim move of the cli.retry block: reset statuses, narrate the
+    plan, remove the kept evidence worktree, delete the failed branch
+    (never in single_pr mode - the shared branch carries completed
+    components' commits), save. ValueError propagates from
+    reset_for_retry; a branch-delete failure raises RetryError after
+    narrating the manual fix.
+    """
+    comp = manifest.get_component(component_id)
+    evidence_worktree = comp.evidence_worktree if comp else ""
+    failed_branch = comp.branch_name if comp else ""
+
+    reset_dependents = manifest.reset_for_retry(component_id)
+
+    ui.section("Retry plan")
+    ui.kv("Component", component_id)
+    ui.kv(
+        "Cascade-skipped dependents reset",
+        ", ".join(reset_dependents) if reset_dependents else "(none)",
+    )
+    ui.kv("Manifest", str(manifest_file))
+
+    # The failed attempt's worktree and branch are superseded by the
+    # fresh attempt; remove them so provisioning and the stale-branch
+    # preflight start clean. In single_pr mode every component shares
+    # one branch carrying completed components' commits - never delete
+    # it here.
+    if evidence_worktree and Path(evidence_worktree).exists():
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", evidence_worktree],
+            cwd=root_dir, capture_output=True, timeout=30,
+        )
+        shutil.rmtree(evidence_worktree, ignore_errors=True)
+        subprocess.run(
+            ["git", "worktree", "prune"],
+            cwd=root_dir, capture_output=True, timeout=30,
+        )
+        ui.info(
+            f"Removed the failed attempt's evidence worktree: "
+            f"{evidence_worktree}"
+        )
+    if failed_branch and not manifest.single_pr:
+        branch_exists = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet",
+             f"refs/heads/{failed_branch}"],
+            cwd=root_dir, capture_output=True, timeout=30,
+        )
+        if branch_exists.returncode == 0:
+            deleted = subprocess.run(
+                ["git", "branch", "-D", failed_branch],
+                cwd=root_dir, capture_output=True, text=True, timeout=30,
+            )
+            if deleted.returncode == 0:
+                ui.info(
+                    f"Deleted branch '{failed_branch}' from the failed "
+                    f"attempt; the retry recreates it from "
+                    f"'{manifest.base_branch}'"
+                )
+            else:
+                ui.err(
+                    f"Could not delete branch '{failed_branch}': "
+                    f"{deleted.stderr.strip()}"
+                )
+                ui.info(
+                    "Delete it manually (git branch -D "
+                    f"{failed_branch}) and re-run; the factory refuses "
+                    "to silently reuse stale branches (R0.5)."
+                )
+                raise RetryError(
+                    f"could not delete branch '{failed_branch}'"
+                )
+    elif manifest.single_pr:
+        ui.warn(
+            "single_pr mode: the shared branch is left in place; if the "
+            "run is refused at branch preflight, resolve it manually"
+        )
+
+    manifest.save(manifest_file)
+    return RetryPreview(
+        component_id=component_id,
+        reset_dependents=reset_dependents,
+        evidence_worktree=evidence_worktree,
+        failed_branch=failed_branch,
+        single_pr=manifest.single_pr,
+    )

--- a/tests/test_config_report.py
+++ b/tests/test_config_report.py
@@ -1,0 +1,96 @@
+"""TUI surface B1: the click-free config report engine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kstrl.config import KstrlConfig
+from kstrl.config_report import (
+    ConfigRow,
+    build_config_report,
+    normalize_ui_mode,
+)
+
+
+def _row(report_rows: tuple[ConfigRow, ...], section: str, key: str) -> ConfigRow:
+    for row in report_rows:
+        if row.section == section and row.key == key:
+            return row
+    raise AssertionError(f"row [{section}] {key} missing")
+
+
+class TestBuildConfigReport:
+    def test_sources_default_toml_env_flag(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text(
+            "[run]\nmax_iterations = 42\n"
+            "[factory]\nmax_parallel = 3\n",
+        )
+        monkeypatch.setenv("SLEEP_SECONDS", "9")
+
+        def overlay(config: KstrlConfig) -> set[str]:
+            config.model = "test-model"
+            return {"model"}
+
+        report = build_config_report(tmp_path, overlay=overlay)
+
+        assert report.toml_exists
+        assert report.toml_path == tmp_path / "kstrl.toml"
+        assert _row(report.rows, "run", "max_iterations") == ConfigRow(
+            "run", "max_iterations", "42", "toml",
+        )
+        assert _row(report.rows, "run", "sleep_seconds").source == "env"
+        assert _row(report.rows, "agent", "model") == ConfigRow(
+            "agent", "model", "'test-model'", "flag",
+        )
+        assert _row(report.rows, "run", "interactive").source == "default"
+        assert _row(report.rows, "factory", "max_parallel") == ConfigRow(
+            "factory", "max_parallel", "3", "toml",
+        )
+        assert _row(report.rows, "factory", "max_retries").source == "default"
+
+    def test_phase_env_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("FACTORY_MAX_PARALLEL", "5")
+        report = build_config_report(tmp_path)
+        assert _row(report.rows, "factory", "max_parallel") == ConfigRow(
+            "factory", "max_parallel", "5", "env",
+        )
+
+    def test_absent_toml(self, tmp_path: Path) -> None:
+        report = build_config_report(tmp_path)
+        assert not report.toml_exists
+        # Every documented section is present in order.
+        sections = list(dict.fromkeys(row.section for row in report.rows))
+        assert sections[:5] == ["agent", "run", "paths", "git", "ui"]
+        assert sections[5] == "factory"
+        assert sections[-1] == "linear"
+
+    def test_loader_valueerror_propagates(self, tmp_path: Path) -> None:
+        (tmp_path / "kstrl.toml").write_text("not [valid toml\n")
+        with pytest.raises(ValueError):
+            build_config_report(tmp_path)
+
+    def test_environ_restored_after_report(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("SLEEP_SECONDS", "9")
+        import os
+
+        before = dict(os.environ)
+        build_config_report(tmp_path)
+        assert dict(os.environ) == before
+
+
+class TestNormalizeUiMode:
+    def test_cases(self) -> None:
+        assert normalize_ui_mode("gum") == "rich"
+        assert normalize_ui_mode("off") == "plain"
+        assert normalize_ui_mode("0") == "plain"
+        assert normalize_ui_mode("") == "auto"
+        assert normalize_ui_mode("RICH ") == "rich"
+        assert normalize_ui_mode("garbage") == "auto"

--- a/tests/test_proposals.py
+++ b/tests/test_proposals.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 from kstrl.proposals import (
     apply_proposal,
@@ -135,6 +136,39 @@ class TestApply:
         (tmp_path / "CLAUDE.md").write_text("# CLAUDE.md\n\nno section\n")
         proposal = parse_proposal_file(proposals_dir / "prop-001.md")
         outcome = apply_proposal(proposal, tmp_path, confirm=lambda _: True)
+        assert outcome.status == "error"
+        assert "**Applied**:" not in proposal.path.read_text()
+
+    def test_stamp_failure_is_reported_and_retry_is_idempotent(
+        self, tmp_path: Path,
+    ) -> None:
+        proposals_dir = _write_props(tmp_path)
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(CLAUDE_MD)
+        proposal = parse_proposal_file(proposals_dir / "prop-001.md")
+
+        with patch("kstrl.proposals.mark_applied", side_effect=OSError("full")):
+            outcome = apply_proposal(
+                proposal, tmp_path, confirm=lambda _: True,
+            )
+
+        assert outcome.status == "error"
+        assert "Retrying is safe" in outcome.message
+        retry = apply_proposal(proposal, tmp_path, confirm=lambda _: True)
+        assert retry.status == "applied"
+        assert claude_md.read_text().count("applied from PROP-001") == 1
+
+    def test_claude_write_failure_is_an_error(self, tmp_path: Path) -> None:
+        proposals_dir = _write_props(tmp_path)
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(CLAUDE_MD)
+        proposal = parse_proposal_file(proposals_dir / "prop-001.md")
+
+        with patch.object(Path, "write_text", side_effect=OSError("read-only")):
+            outcome = apply_proposal(
+                proposal, tmp_path, confirm=lambda _: True,
+            )
+
         assert outcome.status == "error"
         assert "**Applied**:" not in proposal.path.read_text()
 

--- a/tests/test_proposals.py
+++ b/tests/test_proposals.py
@@ -1,0 +1,146 @@
+"""TUI surface B1: the proposal engine shared by cli and the screen."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kstrl.proposals import (
+    apply_proposal,
+    existing_proposal_titles,
+    list_proposals,
+    mark_applied,
+    parse_proposal_file,
+)
+
+CONVENTION_PROP = """# PROP-001: Always pin versions
+**Type**: computational
+**Target**: claude_md
+
+Suggested change:
+
+> Pin every dependency version in pyproject.toml.
+"""
+
+MANUAL_PROP = """# PROP-002: Bump feedforward budget
+**Type**: inferential
+**Target**: feedforward_config
+
+Suggested change:
+
+> Raise max_context_tokens to 12000.
+"""
+
+APPLIED_PROP = CONVENTION_PROP.replace("PROP-001", "PROP-003") + (
+    "\n**Applied**: 2026-07-19T00:00:00Z\n"
+)
+
+CLAUDE_MD = """# CLAUDE.md
+
+## Agent Learnings
+
+- existing bullet
+
+## Other Section
+"""
+
+
+def _write_props(tmp_path: Path) -> Path:
+    proposals_dir = tmp_path / ".kstrl" / "proposals"
+    proposals_dir.mkdir(parents=True)
+    (proposals_dir / "prop-001.md").write_text(CONVENTION_PROP)
+    (proposals_dir / "prop-002.md").write_text(MANUAL_PROP)
+    (proposals_dir / "prop-003.md").write_text(APPLIED_PROP)
+    return proposals_dir
+
+
+class TestParsing:
+    def test_parse_fields(self, tmp_path: Path) -> None:
+        proposals_dir = _write_props(tmp_path)
+        proposal = parse_proposal_file(proposals_dir / "prop-001.md")
+        assert proposal.id == "PROP-001"
+        assert proposal.title == "Always pin versions"
+        assert proposal.type == "computational"
+        assert proposal.target == "claude_md"
+        assert proposal.convention == (
+            "Pin every dependency version in pyproject.toml."
+        )
+        assert proposal.applied == ""
+        assert proposal.is_convention
+
+    def test_applied_stamp_and_classification(self, tmp_path: Path) -> None:
+        proposals_dir = _write_props(tmp_path)
+        applied = parse_proposal_file(proposals_dir / "prop-003.md")
+        assert applied.applied == "2026-07-19T00:00:00Z"
+        manual = parse_proposal_file(proposals_dir / "prop-002.md")
+        assert not manual.is_convention
+        assert manual.display_id == "PROP-002"
+
+    def test_list_and_titles(self, tmp_path: Path) -> None:
+        proposals_dir = _write_props(tmp_path)
+        proposals = list_proposals(proposals_dir)
+        assert [p.id for p in proposals] == ["PROP-001", "PROP-002", "PROP-003"]
+        assert existing_proposal_titles(proposals_dir) == {
+            "Always pin versions", "Bump feedforward budget",
+        }
+        assert list_proposals(tmp_path / "nope") == []
+
+
+class TestApply:
+    def test_applied_path_writes_bullet_and_stamp(self, tmp_path: Path) -> None:
+        proposals_dir = _write_props(tmp_path)
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(CLAUDE_MD)
+        proposal = parse_proposal_file(proposals_dir / "prop-001.md")
+
+        outcome = apply_proposal(proposal, tmp_path, confirm=lambda _: True)
+
+        assert outcome.status == "applied"
+        content = claude_md.read_text()
+        learnings = content.split("## Other Section")[0]
+        assert (
+            "- Pin every dependency version in pyproject.toml. "
+            "(applied from PROP-001 by ralph evolve)" in learnings
+        )
+        assert "**Applied**:" in proposal.path.read_text()
+        assert parse_proposal_file(proposal.path).applied
+
+    def test_declined_writes_nothing(self, tmp_path: Path) -> None:
+        proposals_dir = _write_props(tmp_path)
+        claude_md = tmp_path / "CLAUDE.md"
+        claude_md.write_text(CLAUDE_MD)
+        proposal = parse_proposal_file(proposals_dir / "prop-001.md")
+
+        outcome = apply_proposal(proposal, tmp_path, confirm=lambda _: False)
+
+        assert outcome.status == "declined"
+        assert claude_md.read_text() == CLAUDE_MD
+        assert "**Applied**:" not in proposal.path.read_text()
+
+    def test_manual_and_already_applied(self, tmp_path: Path) -> None:
+        proposals_dir = _write_props(tmp_path)
+        (tmp_path / "CLAUDE.md").write_text(CLAUDE_MD)
+        manual = parse_proposal_file(proposals_dir / "prop-002.md")
+        assert apply_proposal(
+            manual, tmp_path, confirm=lambda _: True,
+        ).status == "manual_required"
+        applied = parse_proposal_file(proposals_dir / "prop-003.md")
+        assert apply_proposal(
+            applied, tmp_path, confirm=lambda _: True,
+        ).status == "already_applied"
+
+    def test_missing_learnings_section_is_an_error(
+        self, tmp_path: Path,
+    ) -> None:
+        proposals_dir = _write_props(tmp_path)
+        (tmp_path / "CLAUDE.md").write_text("# CLAUDE.md\n\nno section\n")
+        proposal = parse_proposal_file(proposals_dir / "prop-001.md")
+        outcome = apply_proposal(proposal, tmp_path, confirm=lambda _: True)
+        assert outcome.status == "error"
+        assert "**Applied**:" not in proposal.path.read_text()
+
+    def test_mark_applied_explicit_timestamp(self, tmp_path: Path) -> None:
+        proposals_dir = _write_props(tmp_path)
+        path = proposals_dir / "prop-001.md"
+        stamp = mark_applied(path, "2026-07-20T12:00:00Z")
+        assert stamp == "2026-07-20T12:00:00Z"
+        assert parse_proposal_file(path).applied == "2026-07-20T12:00:00Z"

--- a/tests/test_retry_plan.py
+++ b/tests/test_retry_plan.py
@@ -1,0 +1,100 @@
+"""TUI surface B1: non-mutating retry preview + prepare extraction."""
+
+from __future__ import annotations
+
+import copy
+import io
+from pathlib import Path
+
+import pytest
+
+from kstrl.manifest import Component, ComponentStatus, Manifest
+from kstrl.retry_plan import prepare_retry, preview_retry
+from kstrl.ui.plain import PlainUI
+
+
+def _failed_manifest() -> Manifest:
+    manifest = Manifest(
+        version="1", spec_file="s", project_name="t",
+        base_branch="main", single_pr=False,
+        components=[
+            Component(
+                id=i, title=i, description="", dependencies=[],
+                prd_path=f"scripts/kstrl/feature/{i}/prd.json",
+                branch_name=f"kstrl/{i}",
+            )
+            for i in ("comp-a", "comp-b", "comp-c")
+        ],
+    )
+    a, b, _ = manifest.components
+    b.dependencies = ["comp-a"]
+    a.status = ComponentStatus.FAILED.value
+    a.error = "boom"
+    b.status = ComponentStatus.SKIPPED.value
+    b.error = "Dependency 'comp-a' failed"
+    manifest.components[2].status = ComponentStatus.COMPLETED.value
+    return manifest
+
+
+class TestPreview:
+    def test_preview_leaves_manifest_untouched(self) -> None:
+        manifest = _failed_manifest()
+        snapshot = copy.deepcopy(manifest)
+
+        preview = preview_retry(manifest, "comp-a")
+
+        assert preview.component_id == "comp-a"
+        assert preview.reset_dependents == ["comp-b"]
+        assert preview.failed_branch == "kstrl/comp-a"
+        assert preview.single_pr is False
+        assert manifest == snapshot  # the deep-copy did the mutation
+
+    def test_preview_propagates_reset_errors(self) -> None:
+        manifest = _failed_manifest()
+        with pytest.raises(ValueError):
+            preview_retry(manifest, "comp-c")  # completed, not failed
+        with pytest.raises(ValueError):
+            preview_retry(manifest, "nope")
+
+
+class TestPrepare:
+    def test_prepare_mutates_saves_and_narrates(
+        self, tmp_path: Path,
+    ) -> None:
+        manifest = _failed_manifest()
+        manifest_file = tmp_path / "manifest.json"
+        stream = io.StringIO()
+        ui = PlainUI(no_color=True, file=stream)
+
+        preview = prepare_retry(
+            manifest, "comp-a", manifest_file, tmp_path, ui,
+        )
+
+        assert preview.reset_dependents == ["comp-b"]
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.status == ComponentStatus.PENDING.value
+        loaded = Manifest.load(manifest_file)
+        reloaded = loaded.get_component("comp-b")
+        assert reloaded is not None
+        assert reloaded.status == ComponentStatus.PENDING.value
+        out = stream.getvalue()
+        assert "Retry plan" in out
+        assert "comp-a" in out
+        assert "comp-b" in out
+
+    def test_single_pr_leaves_branch_and_warns(
+        self, tmp_path: Path,
+    ) -> None:
+        manifest = _failed_manifest()
+        manifest.single_pr = True
+        manifest_file = tmp_path / "manifest.json"
+        stream = io.StringIO()
+
+        prepare_retry(
+            manifest, "comp-a", manifest_file, tmp_path,
+            PlainUI(no_color=True, file=stream),
+        )
+
+        out = stream.getvalue()
+        assert "single_pr mode: the shared branch is left in place" in out


### PR DESCRIPTION
Stacks on #129.

## What
Four new click-free modules extracted from `cli.py` so the plain commands and the upcoming TUI screens share one engine each:

- **`kstrl/config_report.py`**: `build_config_report(root, overlay=)` -> `(section, key, value, source)` rows. Verbatim move of `config show`'s section tables, env-scrub source detection, and value formatting; `cli.config_show` becomes a thin `click.echo` loop. The env-scrub thread hazard (process-wide `os.environ` mutation) is documented on the module - the TUI will precompute before `app.run()`.
- **`kstrl/proposals.py`**: `Proposal`/`parse_proposal_file`/`list_proposals`/`append_to_agent_learnings`/`mark_applied` + `apply_proposal(confirm=seam)` for the evolve screen. cli keeps its exact narration and the `click.confirm`-with-`Abort`->declined wrapper.
- **`kstrl/retry_plan.py`**: `preview_retry` (deep-copy, provably non-mutating) + `prepare_retry` (verbatim narration; `RetryError` instead of `sys.exit`).
- **`kstrl/launch.py`**: frozen `FactoryLaunch`/`DecomposeLaunch`/`FeatureLaunch`/`LoopLaunch` specs + `assemble_factory_configs` (the mirror-of-`factory`-with-no-flags block from retry); retry rewired onto it.

## Byte gates (tests passing UNCHANGED)
`test_config_show.py`, `test_evolve_apply.py` (incl. piped stdin), the retry-path suites. `test_evolve_apply` still imports `_append_to_agent_learnings` from `kstrl.cli` - kept as an import alias.

## New tests
`test_config_report.py` (default/toml/env/flag sources incl. phase sections, environ restoration, ValueError propagation), `test_proposals.py` (parse/classify/apply/decline/manual/already-applied/missing-section), `test_retry_plan.py` (preview non-mutation + error propagation, prepare narration + save, single_pr warn).

Fast tier 1795 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)