### PR TITLE
feat: understand as an event-stream run (TUI surface C1)

### DIFF
--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -7,7 +7,7 @@ import json
 import os
 import sys
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import fields as dataclass_fields
 from datetime import datetime
 from pathlib import Path
@@ -17,6 +17,7 @@ from kstrl import envcompat
 
 if TYPE_CHECKING:
     from kstrl.evolution import EvolutionConfig
+    from kstrl.interaction import InteractionChannel
 
 import click
 from click.core import ParameterSource
@@ -30,10 +31,22 @@ from kstrl.agents import (
 )
 from kstrl.agents.base import Agent, UsageRecord
 from kstrl.breaker import BreakerConfig
+from kstrl.commandrun import CommandRun, open_command_run
 from kstrl.config import KstrlConfig, _parse_paths, resolve_config_file
 from kstrl.config_report import build_config_report
 from kstrl.config_report import normalize_ui_mode as _normalize_ui_mode
 from kstrl.decompose import SpecBlockerError, decompose_spec
+from kstrl.events import (
+    ArtifactWritten,
+    ComponentCompleted,
+    ComponentFailed,
+    ComponentStarted,
+    PhaseCompleted,
+    PhaseStarted,
+    RunCompleted,
+    RunPlan,
+    RunStarted,
+)
 from kstrl.factory import FactoryConfig, run_factory
 from kstrl.init_cmd import DEFAULT_FEATURE_UNDERSTAND, run_init
 from kstrl.interaction import (
@@ -717,6 +730,13 @@ def init(directory: Path, ui: str, no_color: bool) -> None:
     is_flag=True,
     help="Use ASCII characters only",
 )
+@click.option(
+    "--tui/--no-tui",
+    "tui",
+    default=None,
+    help="Embedded dashboard (default: auto - on when stdin/stdout are "
+         "TTYs and --ui is not plain; KSTRL_NO_TUI=1 forces off)",
+)
 def understand(
     max_iterations: int,
     root: Path | None,
@@ -732,6 +752,7 @@ def understand(
     ui: str,
     no_color: bool,
     ascii: bool,
+    tui: bool | None,
 ) -> None:
     """Run codebase understanding loop (read-only mode).
 
@@ -849,12 +870,131 @@ def understand(
         max_budget_usd=config.agent_budget_usd,
     )
 
+    use_tui = tui if tui is not None else (
+        sys.stdout.isatty()
+        and sys.stdin.isatty()
+        and envcompat.get("KSTRL_NO_TUI") != "1"
+        and config.ui_mode != "plain"
+    )
+    if use_tui:
+        if not (sys.stdout.isatty() and sys.stdin.isatty()):
+            click.echo(
+                "--tui requires an interactive terminal; use --no-tui "
+                "for non-interactive execution.",
+                err=True,
+            )
+            sys.exit(2)
+        from kstrl.runid import mint_run_id
+        from kstrl.tui.embed import EmbeddedContext, run_embedded
+        from kstrl.tui.screens.component import ComponentScreen
+        from kstrl.tui.screens.overview import OverviewScreen
+
+        def _target(embed_ctx: EmbeddedContext) -> int:
+            command_run = open_command_run(
+                embed_ctx.ui, root_dir, "understand",
+                component="understand", run_id=embed_ctx.run_id,
+            )
+            try:
+                return _understand_core(
+                    config, agent, root_dir, embed_ctx.ui,
+                    run=command_run,
+                    interaction=embed_ctx.channel,
+                    stop_check=embed_ctx.stop.is_set,
+                )
+            finally:
+                command_run.close()
+
+        sys.exit(run_embedded(
+            _target, root_dir=root_dir,
+            run_id=mint_run_id("understand"),
+            screen_factory=lambda: [
+                OverviewScreen(observe_only=False),
+                ComponentScreen("understand"),
+            ],
+        ))
+
+    command_run = open_command_run(
+        ui_impl, root_dir, "understand", component="understand",
+    )
+    try:
+        code = _understand_core(
+            config, agent, root_dir, ui_impl, run=command_run,
+        )
+    finally:
+        command_run.close()
+    sys.exit(code)
+
+
+def _understand_core(
+    config: KstrlConfig,
+    agent: Agent,
+    root_dir: Path,
+    ui_impl: UI,
+    *,
+    run: CommandRun,
+    interaction: InteractionChannel | None = None,
+    stop_check: Callable[[], bool] | None = None,
+) -> int:
+    """The understand loop as an event-stream run (TUI surface C1).
+
+    The reducer projects the work onto the pseudo-component
+    "understand": one plan row, one phase, the loop's iterations. When
+    recording, the agent is wrapped so its transcript lands where the
+    dashboard's transcript pane tails.
+    """
+    bus = run.bus
+    component = "understand"
+    loop_agent = agent
+    transcript = run.transcript_path(component)
+    if transcript is not None:
+        loop_agent = LoggingAgent(agent, transcript)
+
+    started = time.monotonic()
+    bus.emit(RunStarted(project=root_dir.name, components=1))
+    bus.emit(RunPlan(components=(
+        {"id": component, "title": "Codebase understanding", "deps": []},
+    )))
+    bus.emit(ComponentStarted(component=component))
+    bus.emit(PhaseStarted(component=component, phase="understand", attempt=1))
+
     result = run_loop(
-        config, ui_impl, agent, root_dir,
+        config, ui_impl, loop_agent, root_dir,
         timeouts=TimeoutConfig.load(root_dir),
         breaker_config=BreakerConfig.load(root_dir),
+        bus=bus,
+        interaction=interaction,
+        stop_check=stop_check,
     )
-    sys.exit(result.exit_code)
+
+    duration = round(time.monotonic() - started, 2)
+    passed = result.exit_code == 0
+    bus.emit(PhaseCompleted(
+        component=component, phase="understand", passed=passed,
+        detail="" if passed else f"exit {result.exit_code}",
+        duration_seconds=duration,
+    ))
+    if passed:
+        map_path = config.codebase_map_file
+        try:
+            map_display = str(map_path.relative_to(root_dir))
+        except ValueError:
+            map_display = str(map_path)
+        bus.emit(ArtifactWritten(label="codebase_map", path=map_display))
+        bus.emit(ComponentCompleted(
+            component=component, duration_seconds=duration,
+            iterations=result.iterations,
+        ))
+    else:
+        bus.emit(ComponentFailed(
+            component=component,
+            error=f"understand loop exited {result.exit_code}",
+        ))
+    bus.emit(RunCompleted(
+        completed=1 if passed else 0,
+        failed=0 if passed else 1,
+        duration_seconds=duration,
+    ))
+    return result.exit_code
 
 
 @cli.command()

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -957,20 +957,38 @@ def _understand_core(
     bus.emit(ComponentStarted(component=component))
     bus.emit(PhaseStarted(component=component, phase="understand", attempt=1))
 
-    result = run_loop(
-        config, ui_impl, loop_agent, root_dir,
-        timeouts=TimeoutConfig.load(root_dir),
-        breaker_config=BreakerConfig.load(root_dir),
-        bus=bus,
-        interaction=interaction,
-        stop_check=stop_check,
-    )
+    try:
+        result = run_loop(
+            config, ui_impl, loop_agent, root_dir,
+            timeouts=TimeoutConfig.load(root_dir),
+            breaker_config=BreakerConfig.load(root_dir),
+            bus=bus,
+            interaction=interaction,
+            stop_check=stop_check,
+        )
+    except Exception as exc:
+        duration = round(time.monotonic() - started, 2)
+        detail = f"{type(exc).__name__}: {exc}"
+        bus.emit(PhaseCompleted(
+            component=component, phase="understand", passed=False,
+            detail=detail, duration_seconds=duration,
+        ))
+        bus.emit(ComponentFailed(component=component, error=detail))
+        bus.emit(RunCompleted(
+            completed=0, failed=1, duration_seconds=duration,
+        ))
+        raise
 
     duration = round(time.monotonic() - started, 2)
-    passed = result.exit_code == 0
+    passed = result.completed and result.exit_code == 0
+    failure_detail = (
+        f"exit {result.exit_code}"
+        if result.exit_code != 0
+        else "ended before completion"
+    )
     bus.emit(PhaseCompleted(
         component=component, phase="understand", passed=passed,
-        detail="" if passed else f"exit {result.exit_code}",
+        detail="" if passed else failure_detail,
         duration_seconds=duration,
     ))
     if passed:
@@ -987,7 +1005,7 @@ def _understand_core(
     else:
         bus.emit(ComponentFailed(
             component=component,
-            error=f"understand loop exited {result.exit_code}",
+            error=f"understand loop {failure_detail}",
         ))
     bus.emit(RunCompleted(
         completed=1 if passed else 0,

--- a/tests/helpers/fake_run.py
+++ b/tests/helpers/fake_run.py
@@ -153,3 +153,48 @@ def stream_fake_run(
 ) -> Iterator[None]:
     """Step the fake run forward one write-batch per iteration."""
     return _emit_run(root, spec or FakeRunSpec(), run_id)
+
+
+def write_fake_understand_run(
+    root: Path, *,
+    complete: bool = True,
+    run_id: str = "understand-20260720-130000.000000-fake",
+) -> Path:
+    """A complete understand-kind run: one pseudo-component, one phase,
+    a transcript, the codebase-map artifact (TUI surface C1)."""
+    paths = ev.RunPaths.for_run(root, run_id)
+    bus = ev.EventBus(
+        ev.JsonlSink(paths.events_file), run_id=run_id,
+        component="understand",
+    )
+    bus.emit(ev.RunStarted(project="fake-project", components=1))
+    bus.emit(ev.RunPlan(components=(
+        {"id": "understand", "title": "Codebase understanding", "deps": []},
+    )))
+    bus.emit(ev.ComponentStarted(component="understand"))
+    bus.emit(ev.PhaseStarted(component="understand", phase="understand",
+                             attempt=1))
+    log_path = paths.engineer_log("understand")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a", encoding="utf-8") as log:
+        log.write("[understand] reading src/\n")
+        log.write("[understand] editing scripts/kstrl/codebase_map.md\n")
+    for iteration in (1, 2):
+        bus.emit(ev.IterationStarted(component="understand",
+                                     iteration=iteration, max_iterations=10))
+        bus.emit(ev.IterationCompleted(
+            component="understand", iteration=iteration,
+            duration_seconds=8.0, completed=iteration == 2,
+        ))
+    if complete:
+        bus.emit(ev.PhaseCompleted(component="understand", phase="understand",
+                                   passed=True, duration_seconds=16.0))
+        bus.emit(ev.ArtifactWritten(component="understand",
+                                    label="codebase_map",
+                                    path="scripts/kstrl/codebase_map.md"))
+        bus.emit(ev.ComponentCompleted(component="understand",
+                                       duration_seconds=16.0, iterations=2))
+        bus.emit(ev.RunCompleted(completed=1, failed=0, skipped=0,
+                                 duration_seconds=16.0))
+    bus.close()
+    return paths.root

--- a/tests/test_understand_run.py
+++ b/tests/test_understand_run.py
@@ -34,7 +34,10 @@ class StubAgent:
         yield "editing codebase_map.md"
 
 
-def _fake_run_loop(record: dict[str, Any], exit_code: int = 0) -> Any:
+def _fake_run_loop(
+    record: dict[str, Any], exit_code: int = 0, *,
+    completed: bool | None = None,
+) -> Any:
     def fake(
         config: Any, ui: Any, agent: Any, cwd: Any = None,
         context_prefix: Any = None, timeouts: Any = None,
@@ -50,7 +53,9 @@ def _fake_run_loop(record: dict[str, Any], exit_code: int = 0) -> Any:
                 iteration=1, duration_seconds=5.0, completed=exit_code == 0,
             ))
         return LoopResult(
-            completed=exit_code == 0, iterations=1, exit_code=exit_code,
+            completed=exit_code == 0 if completed is None else completed,
+            iterations=1,
+            exit_code=exit_code,
         )
 
     return fake
@@ -121,6 +126,52 @@ class TestUnderstandRun:
         comp = state.components["understand"]
         assert comp.status == "failed"
         assert state.artifacts == []
+
+    def test_incomplete_zero_exit_folds_as_failure(self, tmp_path: Path) -> None:
+        """Choosing interactive Quit is successful at the shell but did
+        not complete the understand work."""
+        runner = CliRunner()
+        with (
+            patch("kstrl.cli.get_agent", return_value=StubAgent()),
+            patch("kstrl.cli._check_agent_preflight"),
+            patch(
+                "kstrl.cli.run_loop",
+                _fake_run_loop({}, exit_code=0, completed=False),
+            ),
+        ):
+            result = runner.invoke(
+                cli, ["understand", "--root", str(tmp_path)],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 0
+        state, _ = load_run_state(tmp_path)
+        assert state.finished
+        comp = state.components["understand"]
+        assert comp.status == "failed"
+        assert comp.error == "understand loop ended before completion"
+        assert state.artifacts == []
+
+    def test_exception_records_terminal_failure(self, tmp_path: Path) -> None:
+        def explode(*args: Any, **kwargs: Any) -> LoopResult:
+            raise RuntimeError("agent exploded")
+
+        runner = CliRunner()
+        with (
+            patch("kstrl.cli.get_agent", return_value=StubAgent()),
+            patch("kstrl.cli._check_agent_preflight"),
+            patch("kstrl.cli.run_loop", explode),
+        ):
+            result = runner.invoke(
+                cli, ["understand", "--root", str(tmp_path)],
+            )
+        assert result.exit_code == 1
+        assert isinstance(result.exception, RuntimeError)
+        state, _ = load_run_state(tmp_path)
+        assert state.finished
+        comp = state.components["understand"]
+        assert comp.status == "failed"
+        assert comp.error == "RuntimeError: agent exploded"
+        assert comp.phase_history[-1]["passed"] is False
 
     def test_disabled_gating_leaves_no_run_dir(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_understand_run.py
+++ b/tests/test_understand_run.py
@@ -1,0 +1,165 @@
+"""TUI surface C1: `ks understand` as an event-stream run."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from kstrl import events as ev
+from kstrl.cli import cli
+from kstrl.loop import LoopResult
+from kstrl.reducer import load_run_state
+from kstrl.runid import run_kind
+from kstrl.tui.app import KstrlTuiApp, Mode
+from kstrl.tui.screens.component import ComponentScreen
+from kstrl.tui.screens.overview import OverviewScreen
+from tests.helpers.fake_run import write_fake_understand_run
+
+
+class StubAgent:
+    name = "stub"
+    final_message: str | None = None
+    usage_records: list[Any] = []
+
+    def run(
+        self, prompt: str, cwd: Path | None = None,
+        timeout: float | None = None,
+    ) -> Iterator[str]:
+        yield "understanding the codebase"
+        yield "editing codebase_map.md"
+
+
+def _fake_run_loop(record: dict[str, Any], exit_code: int = 0) -> Any:
+    def fake(
+        config: Any, ui: Any, agent: Any, cwd: Any = None,
+        context_prefix: Any = None, timeouts: Any = None,
+        breaker_config: Any = None, *, bus: Any = None,
+        interaction: Any = None, stop_check: Any = None,
+    ) -> LoopResult:
+        record.update(bus=bus, interaction=interaction, agent=agent)
+        for _ in agent.run("prompt", cwd):
+            pass
+        if bus is not None:
+            bus.emit(ev.IterationStarted(iteration=1, max_iterations=3))
+            bus.emit(ev.IterationCompleted(
+                iteration=1, duration_seconds=5.0, completed=exit_code == 0,
+            ))
+        return LoopResult(
+            completed=exit_code == 0, iterations=1, exit_code=exit_code,
+        )
+
+    return fake
+
+
+def _invoke_understand(tmp_path: Path, record: dict[str, Any]) -> Any:
+    runner = CliRunner()
+    with (
+        patch("kstrl.cli.get_agent", return_value=StubAgent()),
+        patch("kstrl.cli._check_agent_preflight"),
+        patch("kstrl.cli.run_loop", _fake_run_loop(record)),
+    ):
+        return runner.invoke(
+            cli, ["understand", "--root", str(tmp_path)],
+            catch_exceptions=False,
+        )
+
+
+class TestUnderstandRun:
+    def test_writes_a_foldable_run_dir(self, tmp_path: Path) -> None:
+        record: dict[str, Any] = {}
+        result = _invoke_understand(tmp_path, record)
+        assert result.exit_code == 0
+
+        runs_root = tmp_path / ".kstrl" / "runs"
+        run_dirs = list(runs_root.iterdir())
+        assert len(run_dirs) == 1
+        assert run_kind(run_dirs[0].name) == "understand"
+
+        state, source = load_run_state(tmp_path)
+        assert source is not None
+        assert state.kind == "understand"
+        assert state.finished
+        assert state.plan_order == ["understand"]
+        comp = state.components["understand"]
+        assert comp.status == "completed"
+        assert comp.iteration == 1
+        assert [p["phase"] for p in comp.phase_history] == ["understand"]
+        assert comp.phase_history[0]["passed"] is True
+        assert [a["label"] for a in state.artifacts] == ["codebase_map"]
+        # run_loop received the run's bus (Iteration* came through it).
+        assert record["bus"] is not None
+
+    def test_transcript_lands_in_engineer_log(self, tmp_path: Path) -> None:
+        record: dict[str, Any] = {}
+        _invoke_understand(tmp_path, record)
+        runs_root = tmp_path / ".kstrl" / "runs"
+        run_dir = next(iter(runs_root.iterdir()))
+        transcript = run_dir / "components" / "understand" / "engineer.log"
+        content = transcript.read_text()
+        assert "understanding the codebase" in content
+        assert "editing codebase_map.md" in content
+
+    def test_failed_loop_folds_as_failure(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        with (
+            patch("kstrl.cli.get_agent", return_value=StubAgent()),
+            patch("kstrl.cli._check_agent_preflight"),
+            patch("kstrl.cli.run_loop", _fake_run_loop({}, exit_code=1)),
+        ):
+            result = runner.invoke(
+                cli, ["understand", "--root", str(tmp_path)],
+                catch_exceptions=False,
+            )
+        assert result.exit_code == 1
+        state, _ = load_run_state(tmp_path)
+        assert state.finished
+        comp = state.components["understand"]
+        assert comp.status == "failed"
+        assert state.artifacts == []
+
+    def test_disabled_gating_leaves_no_run_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("KSTRL_FACTORY_PROGRESS_LOG_ENABLED", "0")
+        record: dict[str, Any] = {}
+        result = _invoke_understand(tmp_path, record)
+        assert result.exit_code == 0
+        assert not (tmp_path / ".kstrl" / "runs").exists()
+
+    def test_terminal_output_identical_with_recording_off(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Recording is silent: the plain terminal bytes must not
+        change when the run dir is being written."""
+        on = _invoke_understand(tmp_path, {})
+        monkeypatch.setenv("KSTRL_FACTORY_PROGRESS_LOG_ENABLED", "0")
+        off = _invoke_understand(tmp_path, {})
+        assert on.output == off.output
+
+
+class TestUnderstandDashboard:
+    async def test_component_screen_renders_understand_run(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = write_fake_understand_run(tmp_path)
+        app = KstrlTuiApp(
+            run_dir=run_dir, root_dir=tmp_path, mode=Mode.DASH,
+            poll_interval=0.05,
+            screen_factory=lambda: [
+                OverviewScreen(observe_only=True),
+                ComponentScreen("understand"),
+            ],
+        )
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            assert isinstance(app.screen, ComponentScreen)
+            comp = app.store.state.components["understand"]
+            assert comp.status == "completed"
+            assert comp.phase_history
+            transcript = app.screen.query_one("#transcript")
+            assert transcript is not None


### PR DESCRIPTION
Stacks on #131. First command onto the A3 substrate - deliberately the smallest one, proving the pattern end to end.

## What
- `ks understand` opens `open_command_run(kind="understand", component="understand")`: an `understand-*` run dir, typed events, heartbeats, and the agent transcript teed to `components/understand/engineer.log` via `LoggingAgent`.
- `_understand_core(...) -> int` emits RunStarted / 1-component RunPlan / ComponentStarted / PhaseStarted("understand") around `run_loop(bus=...)` (Iteration* events now flow), then PhaseCompleted / ArtifactWritten("codebase_map") / ComponentCompleted-or-Failed / RunCompleted. Cores return exit codes - no sys.exit inside.
- `--tui/--no-tui` mirrors factory's auto rule (TTYs + KSTRL_NO_TUI + ui!=plain); embedded mode runs the core through `run_embedded` with an overview + ComponentScreen("understand") stack - the component screen IS the rich understand view (phase chip, live transcript, iteration counter).

## Tested (new `tests/test_understand_run.py`)
- Run dir folds correctly: kind/plan/phase/iterations/artifact/completion; failed loop folds as failure with no artifact.
- Transcript lands in engineer.log.
- `KSTRL_FACTORY_PROGRESS_LOG_ENABLED=0` leaves no run dir.
- **Byte parity**: terminal output identical with recording on vs off.
- Pilot: ComponentScreen renders a fake understand run (`write_fake_understand_run` helper added).

Fast tier 1801 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)