### PR TITLE
refactor: extract the feature flow to feature_cmd.run_feature (TUI surface C2)

### DIFF
--- a/kstrl/agents/logging.py
+++ b/kstrl/agents/logging.py
@@ -1,0 +1,44 @@
+"""Agent wrapper that tees streamed output to a log file.
+
+Moved from cli.py (TUI surface C2) so command cores outside the CLI
+module can wrap agents; behavior unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from kstrl.agents.base import Agent, UsageRecord
+
+
+class LoggingAgent:
+    """Agent wrapper that appends streamed output to a log file."""
+
+    def __init__(self, agent: Agent, log_path: Path) -> None:
+        self._agent = agent
+        self._log_path = log_path
+
+    @property
+    def name(self) -> str:
+        return self._agent.name
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        self._log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._log_path.open("a") as handle:
+            for line in self._agent.run(prompt, cwd, timeout):
+                handle.write(f"{line}\n")
+                handle.flush()
+                yield line
+
+    @property
+    def final_message(self) -> str | None:
+        return self._agent.final_message
+
+    @property
+    def usage_records(self) -> list[UsageRecord]:
+        """R3.1: forward the wrapped agent's usage records."""
+        records = getattr(self._agent, "usage_records", None)
+        return list(records) if records is not None else []

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import copy
 import json
 import os
 import sys
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from dataclasses import fields as dataclass_fields
 from datetime import datetime
 from pathlib import Path
@@ -29,7 +28,8 @@ from kstrl.agents import (
     CodexAgent,
     get_agent,
 )
-from kstrl.agents.base import Agent, UsageRecord
+from kstrl.agents.base import Agent
+from kstrl.agents.logging import LoggingAgent
 from kstrl.breaker import BreakerConfig
 from kstrl.commandrun import CommandRun, open_command_run
 from kstrl.config import KstrlConfig, _parse_paths, resolve_config_file
@@ -48,6 +48,7 @@ from kstrl.events import (
     RunStarted,
 )
 from kstrl.factory import FactoryConfig, run_factory
+from kstrl.feature_cmd import FeatureParams, run_feature
 from kstrl.init_cmd import DEFAULT_FEATURE_UNDERSTAND, run_init
 from kstrl.interaction import (
     PromptKind,
@@ -367,38 +368,6 @@ def _derive_feature_name(prd_path: Path, root: Path) -> str:
             return rel.parts[3]
 
     return prd_path.stem
-
-
-class LoggingAgent:
-    """Agent wrapper that appends streamed output to a log file."""
-
-    def __init__(self, agent: Agent, log_path: Path) -> None:
-        self._agent = agent
-        self._log_path = log_path
-
-    @property
-    def name(self) -> str:
-        return self._agent.name
-
-    def run(
-        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
-    ) -> Iterator[str]:
-        self._log_path.parent.mkdir(parents=True, exist_ok=True)
-        with self._log_path.open("a") as handle:
-            for line in self._agent.run(prompt, cwd, timeout):
-                handle.write(f"{line}\n")
-                handle.flush()
-                yield line
-
-    @property
-    def final_message(self) -> str | None:
-        return self._agent.final_message
-
-    @property
-    def usage_records(self) -> list[UsageRecord]:
-        """R3.1: forward the wrapped agent's usage records."""
-        records = getattr(self._agent, "usage_records", None)
-        return list(records) if records is not None else []
 
 
 def _timestamp() -> str:
@@ -1233,61 +1202,6 @@ def feature(
 
     log_dir = root_dir / ".kstrl" / "logs" / f"feature_{feature_name}"
 
-    def log_path(label: str, attempt: int | None = None) -> Path:
-        stamp = _timestamp()
-        if attempt is None:
-            name = f"{label}_{stamp}.log"
-        else:
-            name = f"{label}_{attempt:02d}_{stamp}.log"
-        return log_dir / name
-
-    def build_repair_prd(log_file: Path, attempt: int) -> Path:
-        repair_dir = feature_dir / "repairs"
-        repair_dir.mkdir(parents=True, exist_ok=True)
-        repair_path = repair_dir / f"repair_{_timestamp()}.json"
-        latest_path = repair_dir / "latest.json"
-
-        verification: list[str] = []
-        seen: set[str] = set()
-        for story in prd_doc.user_stories:
-            for item in story.acceptance_criteria:
-                lower = item.lower()
-                has_check = "typecheck" in lower or "tests" in lower or "lint" in lower
-                if has_check and "pass" in lower:
-                    if item not in seen:
-                        seen.add(item)
-                        verification.append(item)
-
-        try:
-            rel_log = log_file.relative_to(root_dir)
-            log_ref = rel_log.as_posix()
-        except ValueError:
-            log_ref = str(log_file)
-
-        criteria = [f"Repair failures reported in {log_ref}"]
-        criteria.extend(verification)
-
-        repair_story = {
-            "id": f"REPAIR-{attempt:02d}",
-            "title": "Repair failures from last run",
-            "acceptanceCriteria": criteria,
-            "priority": 1,
-            "passes": False,
-            "notes": f"Original PRD: {prd_path}",
-        }
-        repair_doc = {
-            "branchName": prd_doc.branch_name,
-            "userStories": [repair_story],
-        }
-        with open(repair_path, "w") as handle:
-            json.dump(repair_doc, handle, indent=2)
-            handle.write("\n")
-        with open(latest_path, "w") as handle:
-            json.dump(repair_doc, handle, indent=2)
-            handle.write("\n")
-
-        return repair_path
-
     # R2.4 preflight: accept whichever agent the resolved config selects.
     _check_agent_preflight(base_config, ui_impl)
 
@@ -1306,111 +1220,37 @@ def feature(
         max_budget_usd=base_config.agent_budget_usd,
     )
 
-    # Feature understanding phase
-    understand_config = copy.deepcopy(base_config)
-    understand_config.max_iterations = understand_iterations_value
     if _use_cli_value(ctx, "understand_prompt"):
-        understand_config.prompt_file = _resolve_path(
+        understand_prompt_file: Path | None = _resolve_path(
             root_dir, understand_prompt, kstrl_dir / "feature_understand_prompt.md"
         )
     elif "PROMPT_FILE" not in os.environ:
-        understand_config.prompt_file = kstrl_dir / "feature_understand_prompt.md"
-    understand_config.prd_file = prd_path
-    rel_feature_understand = feature_understand.relative_to(root_dir).as_posix()
-    understand_config.allowed_paths = [rel_feature_understand]
-    if _use_cli_value(ctx, "branch"):
-        understand_config.kstrl_branch = branch
-        understand_config.kstrl_branch_explicit = True
-
-    timeouts = TimeoutConfig.load(root_dir)
-    breaker_config = BreakerConfig.load(root_dir)
-
-    understand_log = log_path("understand")
-    understand_agent = LoggingAgent(agent, understand_log)
-    understand_result = run_loop(
-        understand_config, ui_impl, understand_agent, root_dir,
-        timeouts=timeouts, breaker_config=breaker_config,
-    )
-    if understand_result.exit_code != 0:
-        sys.exit(understand_result.exit_code)
-
-    # Review gate
-    ui_impl.section("Feature understand review")
-    ui_impl.kv("Understand file", str(feature_understand))
-    if implementation_auto_run:
-        ui_impl.info("IMPLEMENTATION_AUTO_RUN enabled: skipping review gate")
+        understand_prompt_file = kstrl_dir / "feature_understand_prompt.md"
     else:
-        channel = UiInteractionChannel(ui_impl)
-        if not channel.can_prompt():
-            ui_impl.err(
-                "Interactive review required. Re-run with --implementation-auto-run."
-            )
-            sys.exit(2)
+        understand_prompt_file = None
 
-        response = channel.request(PromptRequest(
-            kind=PromptKind.CONFIRM,
-            header="Review the understand file and confirm implementation start:",
-            options=("Start implementation", "Quit to amend"),
-            default=0,
-        ))
-        if not response.answered or response.choice != 0:
-            ui_impl.info("Amend the understand file and re-run `ralph feature`.")
-            sys.exit(0)
-
-    # Implementation phase
-    run_config = copy.deepcopy(base_config)
-    run_config.prd_file = prd_path
-    run_config.max_iterations = len(prd_doc.user_stories)
-    if run_config.max_iterations == 0:
-        ui_impl.warn("PRD has no user stories. Skipping implementation.")
-        sys.exit(0)
-    run_config.prompt_file = root_dir / "scripts/kstrl/prompt.md"
-    if _use_cli_value(ctx, "implementation_allowed_paths"):
-        run_config.allowed_paths = _parse_paths(implementation_allowed_paths)
-    if _use_cli_value(ctx, "branch"):
-        run_config.kstrl_branch = branch
-        run_config.kstrl_branch_explicit = True
-
-    run_log = log_path("run")
-    run_agent = LoggingAgent(agent, run_log)
-    result = run_loop(
-        run_config, ui_impl, run_agent, root_dir,
-        timeouts=timeouts, breaker_config=breaker_config,
+    params = FeatureParams(
+        prd_path=prd_path,
+        prd_doc=prd_doc,
+        feature_name=feature_name,
+        feature_dir=feature_dir,
+        feature_understand=feature_understand,
+        log_dir=log_dir,
+        understand_iterations=understand_iterations_value,
+        understand_prompt_file=understand_prompt_file,
+        implementation_auto_run=implementation_auto_run,
+        repair_max_runs=repair_max_runs,
+        repair_iterations=repair_iterations,
+        repair_agent_cmd=repair_agent_cmd,
+        branch_override=branch if _use_cli_value(ctx, "branch") else None,
+        allowed_paths_override=(
+            _parse_paths(implementation_allowed_paths)
+            if _use_cli_value(ctx, "implementation_allowed_paths")
+            else None
+        ),
+        sandbox=sandbox_cfg,
     )
-    if result.exit_code == 0 or repair_max_runs == 0 or result.iterations == 0:
-        sys.exit(result.exit_code)
-
-    last_log = run_log
-    repair_result = result
-    for attempt in range(1, repair_max_runs + 1):
-        repair_prd = build_repair_prd(last_log, attempt)
-        repair_config = copy.deepcopy(base_config)
-        repair_config.prd_file = repair_prd
-        repair_config.prompt_file = root_dir / "scripts/kstrl/prompt.md"
-        repair_config.max_iterations = repair_iterations
-        if _use_cli_value(ctx, "implementation_allowed_paths"):
-            repair_config.allowed_paths = _parse_paths(implementation_allowed_paths)
-        repair_config.kstrl_branch = ""
-        repair_config.kstrl_branch_explicit = True
-
-        repair_log = log_path("repair", attempt)
-        repair_agent_base = get_agent(
-            repair_agent_cmd or base_config.agent_cmd,
-            base_config.model,
-            base_config.model_reasoning_effort,
-            base_config.agent_type,
-            sandbox=sandbox_cfg,
-        )
-        repair_agent = LoggingAgent(repair_agent_base, repair_log)
-        repair_result = run_loop(
-            repair_config, ui_impl, repair_agent, root_dir,
-            timeouts=timeouts, breaker_config=breaker_config,
-        )
-        if repair_result.exit_code == 0:
-            sys.exit(0)
-        last_log = repair_log
-
-    sys.exit(repair_result.exit_code)
+    sys.exit(run_feature(params, base_config, agent, ui_impl, root_dir))
 
 
 @cli.command()

--- a/kstrl/feature_cmd.py
+++ b/kstrl/feature_cmd.py
@@ -1,0 +1,256 @@
+"""The feature flow: understand -> review gate -> implement -> repairs.
+
+Mechanical extraction from cli.feature (TUI surface C2): the click
+shell resolves configs/paths/validation and builds FeatureParams; this
+module runs the flow and RETURNS the exit code (no sys.exit - the flow
+must be hostable on a worker thread). Narration is byte-identical to
+the pre-extraction command.
+
+The review gate goes through the interaction seam: the terminal wires
+UiInteractionChannel (unchanged semantics incl. the non-TTY
+"Interactive review required" refusal); the embedded TUI (C3) passes
+its queue channel so the gate opens as a modal.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from kstrl.agents import get_agent
+from kstrl.agents.logging import LoggingAgent
+from kstrl.breaker import BreakerConfig
+from kstrl.interaction import (
+    InteractionChannel,
+    PromptKind,
+    PromptRequest,
+    UiInteractionChannel,
+)
+from kstrl.loop import run_loop
+from kstrl.timeout import TimeoutConfig
+
+if TYPE_CHECKING:
+    from kstrl.agents.base import Agent
+    from kstrl.config import KstrlConfig
+    from kstrl.prd import PRD
+    from kstrl.sandbox import SandboxConfig
+    from kstrl.ui.base import UI
+
+
+def _timestamp() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+@dataclass
+class FeatureParams:
+    """The feature command's resolved knobs (CLI/env/toml already
+    collapsed by the shell; None = "not overridden")."""
+
+    prd_path: Path
+    prd_doc: PRD
+    feature_name: str
+    feature_dir: Path
+    feature_understand: Path
+    log_dir: Path
+    understand_iterations: int
+    understand_prompt_file: Path | None
+    implementation_auto_run: bool
+    repair_max_runs: int
+    repair_iterations: int
+    repair_agent_cmd: str | None
+    branch_override: str | None
+    allowed_paths_override: list[str] | None
+    sandbox: SandboxConfig
+
+
+def _log_path(params: FeatureParams, label: str, attempt: int | None = None) -> Path:
+    stamp = _timestamp()
+    if attempt is None:
+        name = f"{label}_{stamp}.log"
+    else:
+        name = f"{label}_{attempt:02d}_{stamp}.log"
+    return params.log_dir / name
+
+
+def _build_repair_prd(
+    params: FeatureParams, root_dir: Path, log_file: Path, attempt: int,
+) -> Path:
+    repair_dir = params.feature_dir / "repairs"
+    repair_dir.mkdir(parents=True, exist_ok=True)
+    repair_path = repair_dir / f"repair_{_timestamp()}.json"
+    latest_path = repair_dir / "latest.json"
+
+    verification: list[str] = []
+    seen: set[str] = set()
+    for story in params.prd_doc.user_stories:
+        for item in story.acceptance_criteria:
+            lower = item.lower()
+            has_check = "typecheck" in lower or "tests" in lower or "lint" in lower
+            if has_check and "pass" in lower:
+                if item not in seen:
+                    seen.add(item)
+                    verification.append(item)
+
+    try:
+        rel_log = log_file.relative_to(root_dir)
+        log_ref = rel_log.as_posix()
+    except ValueError:
+        log_ref = str(log_file)
+
+    criteria = [f"Repair failures reported in {log_ref}"]
+    criteria.extend(verification)
+
+    repair_story = {
+        "id": f"REPAIR-{attempt:02d}",
+        "title": "Repair failures from last run",
+        "acceptanceCriteria": criteria,
+        "priority": 1,
+        "passes": False,
+        "notes": f"Original PRD: {params.prd_path}",
+    }
+    repair_doc = {
+        "branchName": params.prd_doc.branch_name,
+        "userStories": [repair_story],
+    }
+    with open(repair_path, "w") as handle:
+        json.dump(repair_doc, handle, indent=2)
+        handle.write("\n")
+    with open(latest_path, "w") as handle:
+        json.dump(repair_doc, handle, indent=2)
+        handle.write("\n")
+
+    return repair_path
+
+
+def run_feature(
+    params: FeatureParams,
+    base_config: KstrlConfig,
+    agent: Agent,
+    ui: UI,
+    root_dir: Path,
+    *,
+    interaction: InteractionChannel | None = None,
+    stop_check: Callable[[], bool] | None = None,
+) -> int:
+    """Understand -> review gate -> implement -> repair loop.
+
+    Returns the flow's exit code. ``interaction`` defaults to the
+    terminal channel; ``stop_check`` threads into every run_loop.
+    """
+    del stop_check  # C3 wires this into run_loop alongside the bus
+
+    # Feature understanding phase
+    understand_config = copy.deepcopy(base_config)
+    understand_config.max_iterations = params.understand_iterations
+    if params.understand_prompt_file is not None:
+        understand_config.prompt_file = params.understand_prompt_file
+    understand_config.prd_file = params.prd_path
+    rel_feature_understand = (
+        params.feature_understand.relative_to(root_dir).as_posix()
+    )
+    understand_config.allowed_paths = [rel_feature_understand]
+    if params.branch_override is not None:
+        understand_config.kstrl_branch = params.branch_override
+        understand_config.kstrl_branch_explicit = True
+
+    timeouts = TimeoutConfig.load(root_dir)
+    breaker_config = BreakerConfig.load(root_dir)
+
+    understand_log = _log_path(params, "understand")
+    understand_agent = LoggingAgent(agent, understand_log)
+    understand_result = run_loop(
+        understand_config, ui, understand_agent, root_dir,
+        timeouts=timeouts, breaker_config=breaker_config,
+    )
+    if understand_result.exit_code != 0:
+        return understand_result.exit_code
+
+    # Review gate
+    ui.section("Feature understand review")
+    ui.kv("Understand file", str(params.feature_understand))
+    if params.implementation_auto_run:
+        ui.info("IMPLEMENTATION_AUTO_RUN enabled: skipping review gate")
+    else:
+        channel = (
+            interaction if interaction is not None
+            else UiInteractionChannel(ui)
+        )
+        if not channel.can_prompt():
+            ui.err(
+                "Interactive review required. Re-run with --implementation-auto-run."
+            )
+            return 2
+
+        response = channel.request(PromptRequest(
+            kind=PromptKind.CONFIRM,
+            header="Review the understand file and confirm implementation start:",
+            options=("Start implementation", "Quit to amend"),
+            default=0,
+        ))
+        if not response.answered or response.choice != 0:
+            ui.info("Amend the understand file and re-run `ralph feature`.")
+            return 0
+
+    # Implementation phase
+    run_config = copy.deepcopy(base_config)
+    run_config.prd_file = params.prd_path
+    run_config.max_iterations = len(params.prd_doc.user_stories)
+    if run_config.max_iterations == 0:
+        ui.warn("PRD has no user stories. Skipping implementation.")
+        return 0
+    run_config.prompt_file = root_dir / "scripts/kstrl/prompt.md"
+    if params.allowed_paths_override is not None:
+        run_config.allowed_paths = params.allowed_paths_override
+    if params.branch_override is not None:
+        run_config.kstrl_branch = params.branch_override
+        run_config.kstrl_branch_explicit = True
+
+    run_log = _log_path(params, "run")
+    run_agent = LoggingAgent(agent, run_log)
+    result = run_loop(
+        run_config, ui, run_agent, root_dir,
+        timeouts=timeouts, breaker_config=breaker_config,
+    )
+    if (
+        result.exit_code == 0
+        or params.repair_max_runs == 0
+        or result.iterations == 0
+    ):
+        return result.exit_code
+
+    last_log = run_log
+    repair_result = result
+    for attempt in range(1, params.repair_max_runs + 1):
+        repair_prd = _build_repair_prd(params, root_dir, last_log, attempt)
+        repair_config = copy.deepcopy(base_config)
+        repair_config.prd_file = repair_prd
+        repair_config.prompt_file = root_dir / "scripts/kstrl/prompt.md"
+        repair_config.max_iterations = params.repair_iterations
+        if params.allowed_paths_override is not None:
+            repair_config.allowed_paths = params.allowed_paths_override
+        repair_config.kstrl_branch = ""
+        repair_config.kstrl_branch_explicit = True
+
+        repair_log = _log_path(params, "repair", attempt)
+        repair_agent_base = get_agent(
+            params.repair_agent_cmd or base_config.agent_cmd,
+            base_config.model,
+            base_config.model_reasoning_effort,
+            base_config.agent_type,
+            sandbox=params.sandbox,
+        )
+        repair_agent = LoggingAgent(repair_agent_base, repair_log)
+        repair_result = run_loop(
+            repair_config, ui, repair_agent, root_dir,
+            timeouts=timeouts, breaker_config=breaker_config,
+        )
+        if repair_result.exit_code == 0:
+            return 0
+        last_log = repair_log
+
+    return repair_result.exit_code

--- a/kstrl/feature_cmd.py
+++ b/kstrl/feature_cmd.py
@@ -142,8 +142,6 @@ def run_feature(
     Returns the flow's exit code. ``interaction`` defaults to the
     terminal channel; ``stop_check`` threads into every run_loop.
     """
-    del stop_check  # C3 wires this into run_loop alongside the bus
-
     # Feature understanding phase
     understand_config = copy.deepcopy(base_config)
     understand_config.max_iterations = params.understand_iterations
@@ -166,8 +164,9 @@ def run_feature(
     understand_result = run_loop(
         understand_config, ui, understand_agent, root_dir,
         timeouts=timeouts, breaker_config=breaker_config,
+        interaction=interaction, stop_check=stop_check,
     )
-    if understand_result.exit_code != 0:
+    if not understand_result.completed:
         return understand_result.exit_code
 
     # Review gate
@@ -215,6 +214,7 @@ def run_feature(
     result = run_loop(
         run_config, ui, run_agent, root_dir,
         timeouts=timeouts, breaker_config=breaker_config,
+        interaction=interaction, stop_check=stop_check,
     )
     if (
         result.exit_code == 0
@@ -248,6 +248,7 @@ def run_feature(
         repair_result = run_loop(
             repair_config, ui, repair_agent, root_dir,
             timeouts=timeouts, breaker_config=breaker_config,
+            interaction=interaction, stop_check=stop_check,
         )
         if repair_result.exit_code == 0:
             return 0

--- a/tests/test_feature_cmd.py
+++ b/tests/test_feature_cmd.py
@@ -1,0 +1,197 @@
+"""TUI surface C2: run_feature extraction - direct flow tests."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from kstrl.config import KstrlConfig
+from kstrl.feature_cmd import FeatureParams, run_feature
+from kstrl.interaction import (
+    PromptRequest,
+    PromptResponse,
+)
+from kstrl.loop import LoopResult
+from kstrl.prd import PRD, UserStory
+from kstrl.sandbox import SandboxConfig
+from kstrl.ui.plain import PlainUI
+
+
+class StubAgent:
+    name = "stub"
+    final_message: str | None = None
+    usage_records: list[Any] = []
+
+    def run(self, prompt: str, cwd: Path | None = None,
+            timeout: float | None = None) -> Any:
+        yield "line"
+
+
+class ScriptedChannel:
+    """InteractionChannel answering every request with a fixed choice."""
+
+    def __init__(self, choice: int, *, promptable: bool = True) -> None:
+        self.choice = choice
+        self.promptable = promptable
+        self.requests: list[PromptRequest] = []
+
+    def can_prompt(self) -> bool:
+        return self.promptable
+
+    def request(self, req: PromptRequest) -> PromptResponse:
+        self.requests.append(req)
+        return PromptResponse(
+            request_id=req.request_id, choice=self.choice, answered=True,
+        )
+
+
+def _params(tmp_path: Path, *, stories: int = 1,
+            repair_max_runs: int = 0) -> FeatureParams:
+    feature_dir = tmp_path / "scripts" / "kstrl" / "feature" / "demo"
+    feature_dir.mkdir(parents=True, exist_ok=True)
+    understand = feature_dir / "understand.md"
+    understand.write_text("# understanding\n")
+    prd_path = feature_dir / "prd.json"
+    prd_path.write_text("{}")
+    prd_doc = PRD(
+        branch_name="kstrl/demo",
+        user_stories=[
+            UserStory(
+                id=f"US-{n}", title=f"story {n}",
+                acceptance_criteria=["tests pass"], priority=1,
+                passes=False, notes="",
+            )
+            for n in range(stories)
+        ],
+    )
+    return FeatureParams(
+        prd_path=prd_path,
+        prd_doc=prd_doc,
+        feature_name="demo",
+        feature_dir=feature_dir,
+        feature_understand=understand,
+        log_dir=tmp_path / ".kstrl" / "logs" / "feature_demo",
+        understand_iterations=2,
+        understand_prompt_file=None,
+        implementation_auto_run=False,
+        repair_max_runs=repair_max_runs,
+        repair_iterations=2,
+        repair_agent_cmd=None,
+        branch_override=None,
+        allowed_paths_override=None,
+        sandbox=SandboxConfig(),
+    )
+
+
+def _loop_results(*codes: int) -> Any:
+    """run_loop stub returning the given exit codes in order."""
+    remaining = list(codes)
+
+    def fake(config: Any, ui: Any, agent: Any, *args: Any,
+             **kwargs: Any) -> LoopResult:
+        code = remaining.pop(0)
+        return LoopResult(completed=code == 0, iterations=1, exit_code=code)
+
+    return fake
+
+
+def _ui() -> tuple[PlainUI, io.StringIO]:
+    stream = io.StringIO()
+    return PlainUI(no_color=True, file=stream), stream
+
+
+class TestReviewGate:
+    def test_quit_to_amend_exits_zero(self, tmp_path: Path) -> None:
+        ui, stream = _ui()
+        channel = ScriptedChannel(choice=1)
+        with patch("kstrl.feature_cmd.run_loop", _loop_results(0)):
+            code = run_feature(
+                _params(tmp_path), KstrlConfig(), StubAgent(), ui, tmp_path,
+                interaction=channel,
+            )
+        assert code == 0
+        assert "Amend the understand file" in stream.getvalue()
+        assert len(channel.requests) == 1
+        assert channel.requests[0].options == (
+            "Start implementation", "Quit to amend",
+        )
+
+    def test_non_promptable_channel_refuses_with_2(
+        self, tmp_path: Path,
+    ) -> None:
+        ui, stream = _ui()
+        with patch("kstrl.feature_cmd.run_loop", _loop_results(0)):
+            code = run_feature(
+                _params(tmp_path), KstrlConfig(), StubAgent(), ui, tmp_path,
+                interaction=ScriptedChannel(0, promptable=False),
+            )
+        assert code == 2
+        assert "Interactive review required" in stream.getvalue()
+
+    def test_auto_run_skips_the_gate(self, tmp_path: Path) -> None:
+        ui, stream = _ui()
+        params = _params(tmp_path)
+        params.implementation_auto_run = True
+        channel = ScriptedChannel(0)
+        with patch("kstrl.feature_cmd.run_loop", _loop_results(0, 0)):
+            code = run_feature(
+                params, KstrlConfig(), StubAgent(), ui, tmp_path,
+                interaction=channel,
+            )
+        assert code == 0
+        assert channel.requests == []
+        assert "skipping review gate" in stream.getvalue()
+
+
+class TestExitCodes:
+    def test_failed_understand_short_circuits(self, tmp_path: Path) -> None:
+        ui, _ = _ui()
+        with patch("kstrl.feature_cmd.run_loop", _loop_results(3)):
+            code = run_feature(
+                _params(tmp_path), KstrlConfig(), StubAgent(), ui, tmp_path,
+                interaction=ScriptedChannel(0),
+            )
+        assert code == 3
+
+    def test_empty_prd_skips_implementation(self, tmp_path: Path) -> None:
+        ui, stream = _ui()
+        with patch("kstrl.feature_cmd.run_loop", _loop_results(0)):
+            code = run_feature(
+                _params(tmp_path, stories=0), KstrlConfig(), StubAgent(),
+                ui, tmp_path, interaction=ScriptedChannel(0),
+            )
+        assert code == 0
+        assert "PRD has no user stories" in stream.getvalue()
+
+    def test_repair_loop_recovers(self, tmp_path: Path) -> None:
+        """understand ok, implement fails, first repair succeeds -> 0,
+        and the repair PRD lands on disk."""
+        ui, _ = _ui()
+        params = _params(tmp_path, repair_max_runs=2)
+        with (
+            patch("kstrl.feature_cmd.run_loop", _loop_results(0, 1, 0)),
+            patch("kstrl.feature_cmd.get_agent", return_value=StubAgent()),
+        ):
+            code = run_feature(
+                params, KstrlConfig(), StubAgent(), ui, tmp_path,
+                interaction=ScriptedChannel(0),
+            )
+        assert code == 0
+        repairs = list((params.feature_dir / "repairs").glob("repair_*.json"))
+        assert len(repairs) == 1
+        assert (params.feature_dir / "repairs" / "latest.json").exists()
+
+    def test_repairs_exhausted_returns_last_code(self, tmp_path: Path) -> None:
+        ui, _ = _ui()
+        params = _params(tmp_path, repair_max_runs=2)
+        with (
+            patch("kstrl.feature_cmd.run_loop", _loop_results(0, 1, 1, 4)),
+            patch("kstrl.feature_cmd.get_agent", return_value=StubAgent()),
+        ):
+            code = run_feature(
+                params, KstrlConfig(), StubAgent(), ui, tmp_path,
+                interaction=ScriptedChannel(0),
+            )
+        assert code == 4

--- a/tests/test_feature_cmd.py
+++ b/tests/test_feature_cmd.py
@@ -155,6 +155,25 @@ class TestExitCodes:
             )
         assert code == 3
 
+    def test_incomplete_understand_stops_before_review(self, tmp_path: Path) -> None:
+        ui, _ = _ui()
+        channel = ScriptedChannel(0)
+        calls = 0
+
+        def incomplete(*args: Any, **kwargs: Any) -> LoopResult:
+            nonlocal calls
+            calls += 1
+            return LoopResult(completed=False, iterations=1, exit_code=0)
+
+        with patch("kstrl.feature_cmd.run_loop", incomplete):
+            code = run_feature(
+                _params(tmp_path), KstrlConfig(), StubAgent(), ui, tmp_path,
+                interaction=channel,
+            )
+        assert code == 0
+        assert calls == 1
+        assert channel.requests == []
+
     def test_empty_prd_skips_implementation(self, tmp_path: Path) -> None:
         ui, stream = _ui()
         with patch("kstrl.feature_cmd.run_loop", _loop_results(0)):
@@ -195,3 +214,36 @@ class TestExitCodes:
                 interaction=ScriptedChannel(0),
             )
         assert code == 4
+
+
+class TestControlPropagation:
+    def test_interaction_and_stop_reach_every_loop(self, tmp_path: Path) -> None:
+        ui, _ = _ui()
+        params = _params(tmp_path, repair_max_runs=1)
+        params.implementation_auto_run = True
+        channel = ScriptedChannel(0)
+
+        def stop_check() -> bool:
+            return False
+
+        seen: list[tuple[Any, Any]] = []
+        results = iter((
+            LoopResult(completed=True, iterations=1, exit_code=0),
+            LoopResult(completed=False, iterations=1, exit_code=1),
+            LoopResult(completed=True, iterations=1, exit_code=0),
+        ))
+
+        def record(*args: Any, **kwargs: Any) -> LoopResult:
+            seen.append((kwargs.get("interaction"), kwargs.get("stop_check")))
+            return next(results)
+
+        with (
+            patch("kstrl.feature_cmd.run_loop", record),
+            patch("kstrl.feature_cmd.get_agent", return_value=StubAgent()),
+        ):
+            code = run_feature(
+                params, KstrlConfig(), StubAgent(), ui, tmp_path,
+                interaction=channel, stop_check=stop_check,
+            )
+        assert code == 0
+        assert seen == [(channel, stop_check)] * 3


### PR DESCRIPTION
Stacks on #132.

## What
- `kstrl/feature_cmd.py` (new): `FeatureParams` (the shell's resolved knobs, None = not overridden) + `run_feature(params, base_config, agent, ui, root_dir, *, interaction=, stop_check=) -> int` - a mechanical move of the understand -> review gate -> implement -> repair flow with `sys.exit` -> `return` (mandatory before the flow can run on the embed worker thread) and the gate rewired through the interaction seam (default = `UiInteractionChannel`, byte-identical incl. the non-TTY "Interactive review required" refusal).
- `kstrl/agents/logging.py` (new): `LoggingAgent` moved out of cli (unchanged) so cores outside the CLI module can wrap agents.
- `cli.feature` keeps every validation/resolution branch and ends in `FeatureParams` + `run_feature`.

## Tested
- Existing feature CLI tests pass UNCHANGED (byte gate for the mechanical move); full fast tier 1801.
- New `tests/test_feature_cmd.py`: gate quit-to-amend (exit 0 + narration), non-promptable refusal (exit 2), auto-run skips the gate, failed understand short-circuits, empty PRD skip, repair loop recovery (repair PRD + latest.json land on disk), repairs-exhausted returns the last code.
- mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)