### PR TITLE
feat: decompose as an event-stream run (TUI surface C4)

### DIFF
--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -1374,6 +1374,13 @@ def feature(
     is_flag=True,
     help="Disable colors",
 )
+@click.option(
+    "--tui/--no-tui",
+    "tui",
+    default=None,
+    help="Embedded dashboard (default: auto - on when stdin/stdout are "
+         "TTYs and --ui is not plain; KSTRL_NO_TUI=1 forces off)",
+)
 def decompose(
     spec: Path,
     root: Path | None,
@@ -1386,6 +1393,7 @@ def decompose(
     agent_type: str,
     ui: str,
     no_color: bool,
+    tui: bool | None,
 ) -> None:
     """Decompose a spec into components and generate PRDs."""
     ctx = click.get_current_context()
@@ -1421,27 +1429,78 @@ def decompose(
 
     agent = get_agent(effective_cmd, effective_model, effective_reasoning, effective_type)
 
+    def _decompose_core(core_ui: UI, command_run: CommandRun) -> int:
+        try:
+            manifest = decompose_spec(
+                spec_path=spec,
+                project_name=project_name,
+                base_branch=base_branch,
+                single_pr=single_pr,
+                agent=agent,
+                ui=core_ui,
+                root_dir=root_dir,
+                bus=command_run.bus,
+                transcript=command_run.transcript_writer("architect"),
+            )
+            core_ui.ok(f"Decomposed into {len(manifest.components)} components")
+            return 0
+        except SpecBlockerError as exc:
+            core_ui.err(str(exc))
+            # R1.7: point at the durable artifact so the user iterates
+            # against a file, not scrollback.
+            if exc.artifact_path is not None:
+                core_ui.info(f"Spec issues written to: {exc.artifact_path}")
+            return 2
+        except ValueError as exc:
+            core_ui.err(str(exc))
+            return 1
+
+    use_tui = tui if tui is not None else (
+        sys.stdout.isatty()
+        and sys.stdin.isatty()
+        and envcompat.get("KSTRL_NO_TUI") != "1"
+        and _normalize_ui_mode(ui) != "plain"
+    )
+    if use_tui:
+        if not (sys.stdout.isatty() and sys.stdin.isatty()):
+            click.echo(
+                "--tui requires an interactive terminal; use --no-tui "
+                "for non-interactive execution.",
+                err=True,
+            )
+            sys.exit(2)
+        from kstrl.runid import mint_run_id
+        from kstrl.tui.embed import EmbeddedContext, run_embedded
+        from kstrl.tui.screens.component import ComponentScreen
+        from kstrl.tui.screens.overview import OverviewScreen
+
+        def _target(embed_ctx: EmbeddedContext) -> int:
+            command_run = open_command_run(
+                embed_ctx.ui, root_dir, "decompose",
+                component="architect", run_id=embed_ctx.run_id,
+            )
+            try:
+                return _decompose_core(embed_ctx.ui, command_run)
+            finally:
+                command_run.close()
+
+        sys.exit(run_embedded(
+            _target, root_dir=root_dir,
+            run_id=mint_run_id("decompose"),
+            screen_factory=lambda: [
+                OverviewScreen(observe_only=False),
+                ComponentScreen("architect"),
+            ],
+        ))
+
+    command_run = open_command_run(
+        ui_impl, root_dir, "decompose", component="architect",
+    )
     try:
-        manifest = decompose_spec(
-            spec_path=spec,
-            project_name=project_name,
-            base_branch=base_branch,
-            single_pr=single_pr,
-            agent=agent,
-            ui=ui_impl,
-            root_dir=root_dir,
-        )
-        ui_impl.ok(f"Decomposed into {len(manifest.components)} components")
-    except SpecBlockerError as exc:
-        ui_impl.err(str(exc))
-        # R1.7: point at the durable artifact so the user iterates
-        # against a file, not scrollback.
-        if exc.artifact_path is not None:
-            ui_impl.info(f"Spec issues written to: {exc.artifact_path}")
-        sys.exit(2)
-    except ValueError as exc:
-        ui_impl.err(str(exc))
-        sys.exit(1)
+        code = _decompose_core(ui_impl, command_run)
+    finally:
+        command_run.close()
+    sys.exit(code)
 
 
 @cli.command()

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -965,7 +965,7 @@ def _generate_component_prd(
 ARCHITECT_COMPONENT = "architect"
 
 
-def decompose_spec(
+def _decompose_spec_impl(
     spec_path: Path,
     project_name: str,
     base_branch: str,
@@ -1063,19 +1063,26 @@ def decompose_spec(
         output_lines: list[str] = []
         total_bytes = 0
         too_large = False
-        for line in agent.run(retry_prompt, cwd=root_dir):
-            output_lines.append(line)
-            ui.stream_line("AI", line)
-            if transcript is not None:
-                transcript(line)
-            total_bytes += len(line) + 1
-            if total_bytes > MAX_AGENT_OUTPUT_BYTES:
-                too_large = True
-                ui.warn(
-                    f"Decompose agent emitted >{MAX_AGENT_OUTPUT_BYTES // 1024 // 1024}MB; "
-                    "aborting this attempt."
-                )
-                break
+        try:
+            for line in agent.run(retry_prompt, cwd=root_dir):
+                output_lines.append(line)
+                ui.stream_line("AI", line)
+                if transcript is not None:
+                    transcript(line)
+                total_bytes += len(line) + 1
+                if total_bytes > MAX_AGENT_OUTPUT_BYTES:
+                    too_large = True
+                    ui.warn(
+                        "Decompose agent emitted "
+                        f">{MAX_AGENT_OUTPUT_BYTES // 1024 // 1024}MB; "
+                        "aborting this attempt."
+                    )
+                    break
+        except BaseException as exc:
+            attempt_failed(
+                f"{type(exc).__name__}: {exc}", started_at=phase_start,
+            )
+            raise
 
         if too_large:
             last_error = "agent output exceeded size cap"
@@ -1128,14 +1135,6 @@ def decompose_spec(
     if data is None:
         # No files were written in the retry loop, so terminal failure
         # leaves no partial state behind (R1.8).
-        emit(ComponentFailed(
-            component=ARCHITECT_COMPONENT,
-            error=f"decompose failed after {max_retries} attempts",
-        ))
-        emit(RunCompleted(
-            completed=0, failed=1,
-            duration_seconds=round(time.monotonic() - run_started, 2),
-        ))
         raise ValueError(
             f"Failed to decompose spec after {max_retries} attempts. "
             f"Last error: {last_error}"
@@ -1330,9 +1329,6 @@ def decompose_spec(
                 )
             )
             ui.ok(f"  {comp_id}: {len(comp_data['userStories'])} stories")
-            emit(ArtifactWritten(
-                component=comp_id, label="prd", path=rel_prd,
-            ))
 
         manifest = Manifest(
             version="1",
@@ -1361,9 +1357,6 @@ def decompose_spec(
         manifest_path = root_dir / "scripts" / "kstrl" / "manifest.json"
         manifest.save(manifest_path)
         ui.ok(f"Manifest saved: {manifest_path}")
-        emit(ArtifactWritten(
-            label="manifest", path=rel_display(manifest_path),
-        ))
     except BaseException:
         for prd_file in written_prds:
             try:
@@ -1380,6 +1373,20 @@ def decompose_spec(
             except OSError:
                 pass
         raise
+
+    # Publish transactional artifacts only after the PRD + manifest
+    # write set commits. If a later write failed, the cleanup above
+    # removed the PRDs and the event stream must not claim they exist.
+    for component_data, prd_file in zip(
+        data["components"], written_prds, strict=True,
+    ):
+        emit(ArtifactWritten(
+            component=component_data["id"], label="prd",
+            path=rel_display(prd_file),
+        ))
+    emit(ArtifactWritten(
+        label="manifest", path=rel_display(manifest_path),
+    ))
 
     ui.section("Decomposition Summary")
     ui.kv("Components", str(len(manifest.components)))
@@ -1399,3 +1406,48 @@ def decompose_spec(
     emit(RunCompleted(completed=1, duration_seconds=duration))
 
     return manifest
+
+
+def decompose_spec(
+    spec_path: Path,
+    project_name: str,
+    base_branch: str,
+    single_pr: bool,
+    agent: Agent,
+    ui: UI,
+    root_dir: Path,
+    max_retries: int = 3,
+    *,
+    bus: EventBus | None = None,
+    transcript: Callable[[str], None] | None = None,
+) -> Manifest:
+    """Run decomposition and guarantee a terminal event on every exit."""
+    started = time.monotonic()
+    try:
+        return _decompose_spec_impl(
+            spec_path=spec_path,
+            project_name=project_name,
+            base_branch=base_branch,
+            single_pr=single_pr,
+            agent=agent,
+            ui=ui,
+            root_dir=root_dir,
+            max_retries=max_retries,
+            bus=bus,
+            transcript=transcript,
+        )
+    except SpecBlockerError:
+        # Blocker halts are deliberately finalized at the audit site so
+        # the durable artifact path can be attached to the exception.
+        raise
+    except BaseException as exc:
+        if bus is not None:
+            detail = f"{type(exc).__name__}: {exc}"
+            bus.emit(ComponentFailed(
+                component=ARCHITECT_COMPONENT, error=detail,
+            ))
+            bus.emit(RunCompleted(
+                failed=1,
+                duration_seconds=round(time.monotonic() - started, 2),
+            ))
+        raise

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -13,6 +13,20 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
+from kstrl.events import (
+    ArtifactWritten,
+    ComponentCompleted,
+    ComponentFailed,
+    ComponentStarted,
+    Event,
+    EventBus,
+    PhaseCompleted,
+    PhaseStarted,
+    RunCompleted,
+    RunPlan,
+    RunStarted,
+    SpecIssueRecorded,
+)
 from kstrl.linear import (
     LinearClient,
     LinearConfig,
@@ -948,6 +962,9 @@ def _generate_component_prd(
     return prd_path
 
 
+ARCHITECT_COMPONENT = "architect"
+
+
 def decompose_spec(
     spec_path: Path,
     project_name: str,
@@ -957,6 +974,9 @@ def decompose_spec(
     ui: UI,
     root_dir: Path,
     max_retries: int = 3,
+    *,
+    bus: EventBus | None = None,
+    transcript: Callable[[str], None] | None = None,
 ) -> Manifest:
     """Decompose a spec into components and generate PRDs.
 
@@ -969,10 +989,36 @@ def decompose_spec(
         ui: UI for output
         root_dir: Project root directory
         max_retries: Max attempts for JSON parsing
+        bus: Optional run event bus (TUI surface C4): the work is
+            projected onto the pseudo-component "architect" - attempts
+            as decompose phases, the red-team pass as an audit phase,
+            spec issues and artifacts as typed events. None = today's
+            behavior exactly.
+        transcript: Optional sink for the architect's streamed lines
+            (the run's transcript file); terminal streaming through
+            ``ui`` is unchanged either way.
 
     Returns:
         Manifest with generated components and PRD files
     """
+    def emit(event: Event) -> None:
+        if bus is not None:
+            bus.emit(event)
+
+    def rel_display(path: Path) -> str:
+        try:
+            return path.relative_to(root_dir).as_posix()
+        except ValueError:
+            return str(path)
+
+    run_started = time.monotonic()
+    emit(RunStarted(project=project_name, components=0))
+    emit(RunPlan(components=(
+        {"id": ARCHITECT_COMPONENT, "title": "Architect / PRD red-team",
+         "deps": []},
+    )))
+    emit(ComponentStarted(component=ARCHITECT_COMPONENT))
+
     ui.section("Spec Decomposition")
     ui.kv("Spec", str(spec_path))
     if spec_path.is_dir():
@@ -988,9 +1034,22 @@ def decompose_spec(
 
     data = None
     last_error: str | None = None
+    attempts_used = 0
 
     for attempt in range(1, max_retries + 1):
+        attempts_used = attempt
         ui.info(f"Decomposition attempt {attempt}/{max_retries}")
+        emit(PhaseStarted(
+            component=ARCHITECT_COMPONENT, phase="decompose", attempt=attempt,
+        ))
+        phase_start = time.monotonic()
+
+        def attempt_failed(detail: str, *, started_at: float) -> None:
+            emit(PhaseCompleted(
+                component=ARCHITECT_COMPONENT, phase="decompose",
+                passed=False, detail=detail[:200],
+                duration_seconds=round(time.monotonic() - started_at, 2),
+            ))
 
         if last_error:
             retry_prompt = (
@@ -1007,6 +1066,8 @@ def decompose_spec(
         for line in agent.run(retry_prompt, cwd=root_dir):
             output_lines.append(line)
             ui.stream_line("AI", line)
+            if transcript is not None:
+                transcript(line)
             total_bytes += len(line) + 1
             if total_bytes > MAX_AGENT_OUTPUT_BYTES:
                 too_large = True
@@ -1018,6 +1079,7 @@ def decompose_spec(
 
         if too_large:
             last_error = "agent output exceeded size cap"
+            attempt_failed(last_error, started_at=phase_start)
             continue
 
         try:
@@ -1025,12 +1087,14 @@ def decompose_spec(
         except ValueError as exc:
             last_error = str(exc)
             ui.warn(f"JSON extraction failed: {last_error}")
+            attempt_failed(last_error, started_at=phase_start)
             continue
 
         validation_errors = _validate_decompose_output(data)
         if validation_errors:
             last_error = "; ".join(validation_errors)
             ui.warn(f"Validation failed: {last_error}")
+            attempt_failed(last_error, started_at=phase_start)
             data = None
             continue
 
@@ -1050,15 +1114,28 @@ def decompose_spec(
         if prd_errors:
             last_error = "; ".join(prd_errors)
             ui.warn(f"PRD validation failed: {last_error}")
+            attempt_failed(last_error, started_at=phase_start)
             data = None
             continue
 
         last_error = None
+        emit(PhaseCompleted(
+            component=ARCHITECT_COMPONENT, phase="decompose", passed=True,
+            duration_seconds=round(time.monotonic() - phase_start, 2),
+        ))
         break
 
     if data is None:
         # No files were written in the retry loop, so terminal failure
         # leaves no partial state behind (R1.8).
+        emit(ComponentFailed(
+            component=ARCHITECT_COMPONENT,
+            error=f"decompose failed after {max_retries} attempts",
+        ))
+        emit(RunCompleted(
+            completed=0, failed=1,
+            duration_seconds=round(time.monotonic() - run_started, 2),
+        ))
         raise ValueError(
             f"Failed to decompose spec after {max_retries} attempts. "
             f"Last error: {last_error}"
@@ -1069,8 +1146,18 @@ def decompose_spec(
     # success, and clean-audit outcomes alike. If any issue is a
     # blocker, halt before generating PRDs - the architect explicitly
     # judged the spec un-decomposable.
+    emit(PhaseStarted(
+        component=ARCHITECT_COMPONENT, phase="audit", attempt=1,
+    ))
+    audit_start = time.monotonic()
     spec_issues = _parse_spec_issues(data)
     _surface_spec_issues(spec_issues, ui)
+    for issue in spec_issues:
+        emit(SpecIssueRecorded(
+            severity=issue.severity, kind=issue.kind,
+            summary=issue.summary, location=issue.location,
+            suggestion=issue.suggestion,
+        ))
     blockers = [i for i in spec_issues if i.severity == "blocker"]
     artifact_path: Path | None = None
     try:
@@ -1082,6 +1169,9 @@ def decompose_spec(
             halted=bool(blockers),
         )
         ui.ok(f"Spec audit written: {artifact_path}")
+        emit(ArtifactWritten(
+            label="spec_issues", path=rel_display(artifact_path),
+        ))
     except OSError as exc:
         # Loud but non-masking: the blocker halt (or the decompose
         # result) matters more than the artifact write failing.
@@ -1094,8 +1184,36 @@ def decompose_spec(
         halted=bool(blockers),
         ui=ui,
     )
+    emit(PhaseCompleted(
+        component=ARCHITECT_COMPONENT, phase="audit",
+        passed=not blockers,
+        detail=f"{len(blockers)} blocker(s)" if blockers else "",
+        duration_seconds=round(time.monotonic() - audit_start, 2),
+    ))
     if blockers:
+        # The run dir must read as FINISHED, not dead: the halt is the
+        # architect's judgment, delivered before the error propagates.
+        emit(ComponentFailed(
+            component=ARCHITECT_COMPONENT,
+            error=f"spec halted: {len(blockers)} blocker-severity issue(s)",
+        ))
+        emit(RunCompleted(
+            completed=0, failed=1,
+            duration_seconds=round(time.monotonic() - run_started, 2),
+        ))
         raise SpecBlockerError(blockers, artifact_path=artifact_path)
+
+    # The forming DAG, the moment it is known (C5's board draws from
+    # this - no manifest read needed). The architect row stays first.
+    emit(RunPlan(components=(
+        {"id": ARCHITECT_COMPONENT, "title": "Architect / PRD red-team",
+         "deps": []},
+        *(
+            {"id": comp_data["id"], "title": comp_data["title"],
+             "deps": comp_data.get("dependencies", [])}
+            for comp_data in data["components"]
+        ),
+    )))
 
     # R7.4: Linear hook - one project per manifest, one issue per
     # component, non-blocker spec findings into Triage. Runs BEFORE
@@ -1212,6 +1330,9 @@ def decompose_spec(
                 )
             )
             ui.ok(f"  {comp_id}: {len(comp_data['userStories'])} stories")
+            emit(ArtifactWritten(
+                component=comp_id, label="prd", path=rel_prd,
+            ))
 
         manifest = Manifest(
             version="1",
@@ -1240,6 +1361,9 @@ def decompose_spec(
         manifest_path = root_dir / "scripts" / "kstrl" / "manifest.json"
         manifest.save(manifest_path)
         ui.ok(f"Manifest saved: {manifest_path}")
+        emit(ArtifactWritten(
+            label="manifest", path=rel_display(manifest_path),
+        ))
     except BaseException:
         for prd_file in written_prds:
             try:
@@ -1264,5 +1388,14 @@ def decompose_spec(
         for comp_data in data["components"]
     )
     ui.kv("Total stories", str(total_stories))
+
+    duration = round(time.monotonic() - run_started, 2)
+    emit(ComponentCompleted(
+        component=ARCHITECT_COMPONENT, duration_seconds=duration,
+        iterations=attempts_used,
+    ))
+    # completed counts THIS run's work item (the architect); the
+    # planned components are the FACTORY run's job.
+    emit(RunCompleted(completed=1, duration_seconds=duration))
 
     return manifest

--- a/tests/helpers/fake_run.py
+++ b/tests/helpers/fake_run.py
@@ -257,3 +257,90 @@ def write_fake_feature_run(
                                  duration_seconds=110.0))
     bus.close()
     return paths.root
+
+
+def write_fake_decompose_run(
+    root: Path, *,
+    run_id: str = "decompose-20260720-150000.000000-fake",
+    blockers: int = 0,
+    minors: int = 1,
+    attempts: int = 1,
+    components: tuple[str, ...] = ("database", "api"),
+) -> Path:
+    """A decompose-kind run: architect attempts, spec issues, the
+    forming DAG, per-component PRD artifacts (TUI surface C4).
+    ``blockers`` > 0 makes it a halted run (no plan, no PRDs)."""
+    paths = ev.RunPaths.for_run(root, run_id)
+    bus = ev.EventBus(
+        ev.JsonlSink(paths.events_file), run_id=run_id,
+        component="architect",
+    )
+    bus.emit(ev.RunStarted(project="fake-project", components=0))
+    bus.emit(ev.RunPlan(components=(
+        {"id": "architect", "title": "Architect / PRD red-team",
+         "deps": []},
+    )))
+    bus.emit(ev.ComponentStarted(component="architect"))
+    log_path = paths.engineer_log("architect")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    for attempt in range(1, attempts + 1):
+        bus.emit(ev.PhaseStarted(component="architect", phase="decompose",
+                                 attempt=attempt))
+        with open(log_path, "a", encoding="utf-8") as log:
+            log.write(f'{{"components": [... attempt {attempt} ...]}}\n')
+        bus.emit(ev.PhaseCompleted(
+            component="architect", phase="decompose",
+            passed=attempt == attempts, duration_seconds=30.0,
+            detail="" if attempt == attempts else "JSON extraction failed",
+        ))
+    bus.emit(ev.PhaseStarted(component="architect", phase="audit", attempt=1))
+    for n in range(blockers):
+        bus.emit(ev.SpecIssueRecorded(
+            severity="blocker", kind="ambiguity",
+            summary=f"Blocking ambiguity {n + 1}",
+            location="spec.md", suggestion="Resolve it",
+        ))
+    for n in range(minors):
+        bus.emit(ev.SpecIssueRecorded(
+            severity="minor", kind="missing_detail",
+            summary=f"Minor gap {n + 1}",
+        ))
+    bus.emit(ev.ArtifactWritten(label="spec_issues",
+                                path="scripts/kstrl/spec-issues.json"))
+    bus.emit(ev.PhaseCompleted(
+        component="architect", phase="audit", passed=blockers == 0,
+        detail=f"{blockers} blocker(s)" if blockers else "",
+        duration_seconds=1.0,
+    ))
+    if blockers:
+        bus.emit(ev.ComponentFailed(
+            component="architect",
+            error=f"spec halted: {blockers} blocker-severity issue(s)",
+        ))
+        bus.emit(ev.RunCompleted(completed=0, failed=1, skipped=0,
+                                 duration_seconds=31.0))
+        bus.close()
+        return paths.root
+    bus.emit(ev.RunPlan(components=(
+        {"id": "architect", "title": "Architect / PRD red-team",
+         "deps": []},
+        *(
+            {"id": cid, "title": cid.title(),
+             "deps": [components[i - 1]] if i else []}
+            for i, cid in enumerate(components)
+        ),
+    )))
+    for cid in components:
+        bus.emit(ev.ArtifactWritten(
+            component=cid, label="prd",
+            path=f"scripts/kstrl/feature/{cid}/prd.json",
+        ))
+    bus.emit(ev.ArtifactWritten(label="manifest",
+                                path="scripts/kstrl/manifest.json"))
+    bus.emit(ev.ComponentCompleted(component="architect",
+                                   duration_seconds=35.0,
+                                   iterations=attempts))
+    bus.emit(ev.RunCompleted(completed=1, failed=0, skipped=0,
+                             duration_seconds=35.0))
+    bus.close()
+    return paths.root

--- a/tests/test_decompose_run.py
+++ b/tests/test_decompose_run.py
@@ -6,6 +6,7 @@ import io
 import json
 from collections.abc import Iterator
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -58,6 +59,15 @@ class TwoShotAgent:
             return
         yield from self._good.splitlines()
         self.final_message = self._good.splitlines()[-1]
+
+
+class ExplodingAgent:
+    name = "exploding"
+    final_message: str | None = None
+
+    def run(self, prompt: str, cwd: Path | None = None) -> Iterator[str]:
+        raise RuntimeError("architect exploded")
+        yield  # pragma: no cover - makes this an iterator
 
 
 def _spec_root(tmp_path: Path) -> Path:
@@ -177,6 +187,37 @@ class TestDecomposeRun:
         run_dir = next(iter(runs_root.iterdir()))
         transcript = run_dir / "components" / "architect" / "engineer.log"
         assert "spec_issues" in transcript.read_text()
+
+    def test_agent_exception_finishes_the_run(self, tmp_path: Path) -> None:
+        with pytest.raises(RuntimeError, match="architect exploded"):
+            _decompose(tmp_path, ExplodingAgent())
+        state, _ = load_run_state(tmp_path)
+        assert state.finished
+        architect = state.components["architect"]
+        assert architect.status == "failed"
+        assert architect.error == "RuntimeError: architect exploded"
+        assert architect.phase_history[-1]["phase"] == "decompose"
+        assert architect.phase_history[-1]["passed"] is False
+
+    def test_rolled_back_prds_are_not_published_as_artifacts(
+        self, tmp_path: Path,
+    ) -> None:
+        with (
+            patch(
+                "kstrl.decompose.Manifest.save",
+                side_effect=OSError("manifest disk full"),
+            ),
+            pytest.raises(OSError, match="manifest disk full"),
+        ):
+            _decompose(tmp_path, MockDecomposeAgent(MINOR_ISSUE_OUTPUT))
+
+        state, _ = load_run_state(tmp_path)
+        assert state.finished
+        architect = state.components["architect"]
+        assert architect.status == "failed"
+        assert architect.error == "OSError: manifest disk full"
+        assert [a["label"] for a in state.artifacts] == ["spec_issues"]
+        assert list((tmp_path / "scripts" / "kstrl").rglob("prd.json")) == []
 
     def test_without_bus_no_run_dir_and_same_result(
         self, tmp_path: Path,

--- a/tests/test_decompose_run.py
+++ b/tests/test_decompose_run.py
@@ -1,0 +1,196 @@
+"""TUI surface C4: decompose as an event-stream run."""
+
+from __future__ import annotations
+
+import io
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from kstrl.commandrun import open_command_run
+from kstrl.decompose import SpecBlockerError, decompose_spec
+from kstrl.reducer import load_run_state
+from kstrl.ui.plain import PlainUI
+from tests.test_decompose import VALID_DECOMPOSE_OUTPUT, MockDecomposeAgent
+
+MINOR_ISSUE_OUTPUT = json.dumps({
+    **json.loads(VALID_DECOMPOSE_OUTPUT),
+    "spec_issues": [{
+        "severity": "minor",
+        "kind": "missing_detail",
+        "summary": "Edge case unspecified",
+        "location": "spec.md:9",
+        "suggestion": "Name the edge case",
+    }],
+})
+
+BLOCKER_OUTPUT = json.dumps({
+    "spec_issues": [{
+        "severity": "blocker",
+        "kind": "ambiguity",
+        "summary": "Spec is empty",
+        "location": "everywhere",
+        "suggestion": "Write actual requirements",
+    }],
+    "components": [],
+})
+
+
+class TwoShotAgent:
+    """Garbage on the first attempt, valid JSON on the second."""
+
+    def __init__(self, good_output: str) -> None:
+        self._good = good_output
+        self._calls = 0
+        self.final_message: str | None = None
+
+    @property
+    def name(self) -> str:
+        return "two-shot"
+
+    def run(self, prompt: str, cwd: Path | None = None) -> Iterator[str]:
+        self._calls += 1
+        if self._calls == 1:
+            yield "this is not json at all"
+            self.final_message = "this is not json at all"
+            return
+        yield from self._good.splitlines()
+        self.final_message = self._good.splitlines()[-1]
+
+
+def _spec_root(tmp_path: Path) -> Path:
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("# Spec\nBuild it.")
+    (tmp_path / "scripts" / "kstrl").mkdir(parents=True)
+    return spec_file
+
+
+def _decompose(tmp_path: Path, agent: object) -> object:
+    spec_file = _spec_root(tmp_path)
+    ui = PlainUI(no_color=True, file=io.StringIO())
+    run = open_command_run(
+        ui, tmp_path, "decompose", component="architect",
+        enabled=True, heartbeat=False,
+    )
+    try:
+        return decompose_spec(
+            spec_path=spec_file,
+            project_name="test",
+            base_branch="main",
+            single_pr=False,
+            agent=agent,  # type: ignore[arg-type]
+            ui=ui,
+            root_dir=tmp_path,
+            bus=run.bus,
+            transcript=run.transcript_writer("architect"),
+        )
+    finally:
+        run.close()
+
+
+class TestDecomposeRun:
+    def test_success_run_folds_with_plan_and_artifacts(
+        self, tmp_path: Path,
+    ) -> None:
+        manifest = _decompose(
+            tmp_path, MockDecomposeAgent(MINOR_ISSUE_OUTPUT),
+        )
+
+        state, _ = load_run_state(tmp_path)
+        assert state.kind == "decompose"
+        assert state.finished
+        # The forming DAG: architect first, then the manifest order.
+        assert state.plan_order == [
+            "architect",
+            *[c.id for c in manifest.components],  # type: ignore[attr-defined]
+        ]
+        architect = state.components["architect"]
+        assert architect.status == "completed"
+        assert [p["phase"] for p in architect.phase_history] == [
+            "decompose", "audit",
+        ]
+        assert all(p["passed"] for p in architect.phase_history)
+        assert [a["label"] for a in state.artifacts] == [
+            "spec_issues", "prd", "prd", "manifest",
+        ]
+        # Planned components carry their deps for the DAG view.
+        assert state.components["api"].deps == ("database",)
+
+    def test_folded_issues_match_the_disk_artifact(
+        self, tmp_path: Path,
+    ) -> None:
+        _decompose(tmp_path, MockDecomposeAgent(MINOR_ISSUE_OUTPUT))
+        state, _ = load_run_state(tmp_path)
+        payload = json.loads(
+            (tmp_path / "scripts" / "kstrl" / "spec-issues.json").read_text(),
+        )
+        disk_issues = [
+            {
+                "severity": i["severity"], "kind": i["kind"],
+                "summary": i["summary"], "location": i.get("location", ""),
+                "suggestion": i.get("suggestion", ""),
+            }
+            for i in payload["issues"]
+        ]
+        assert state.spec_issues == disk_issues
+        assert state.spec_issue_counts == {"minor": 1}
+
+    def test_retry_folds_a_failed_then_passed_attempt(
+        self, tmp_path: Path,
+    ) -> None:
+        _decompose(tmp_path, TwoShotAgent(VALID_DECOMPOSE_OUTPUT))
+        state, _ = load_run_state(tmp_path)
+        architect = state.components["architect"]
+        decompose_phases = [
+            p for p in architect.phase_history if p["phase"] == "decompose"
+        ]
+        assert [p["passed"] for p in decompose_phases] == [False, True]
+        assert architect.attempt == 2
+        assert architect.status == "completed"
+
+    def test_blocker_halt_finishes_the_run_before_raising(
+        self, tmp_path: Path,
+    ) -> None:
+        with pytest.raises(SpecBlockerError):
+            _decompose(tmp_path, MockDecomposeAgent(BLOCKER_OUTPUT))
+
+        state, _ = load_run_state(tmp_path)
+        assert state.finished  # not dead - the architect judged and halted
+        architect = state.components["architect"]
+        assert architect.status == "failed"
+        audit = [
+            p for p in architect.phase_history if p["phase"] == "audit"
+        ]
+        assert audit and audit[0]["passed"] is False
+        assert state.spec_issue_counts == {"blocker": 1}
+        assert [a["label"] for a in state.artifacts] == ["spec_issues"]
+        # No plan beyond the architect: nothing was decomposed.
+        assert state.plan_order == ["architect"]
+
+    def test_transcript_captures_the_architect_stream(
+        self, tmp_path: Path,
+    ) -> None:
+        _decompose(tmp_path, MockDecomposeAgent(MINOR_ISSUE_OUTPUT))
+        runs_root = tmp_path / ".kstrl" / "runs"
+        run_dir = next(iter(runs_root.iterdir()))
+        transcript = run_dir / "components" / "architect" / "engineer.log"
+        assert "spec_issues" in transcript.read_text()
+
+    def test_without_bus_no_run_dir_and_same_result(
+        self, tmp_path: Path,
+    ) -> None:
+        """bus=None is exactly the pre-C4 behavior."""
+        spec_file = _spec_root(tmp_path)
+        manifest = decompose_spec(
+            spec_path=spec_file,
+            project_name="test",
+            base_branch="main",
+            single_pr=False,
+            agent=MockDecomposeAgent(MINOR_ISSUE_OUTPUT),  # type: ignore[arg-type]
+            ui=PlainUI(no_color=True, file=io.StringIO()),
+            root_dir=tmp_path,
+        )
+        assert len(manifest.components) == 2
+        assert not (tmp_path / ".kstrl" / "runs").exists()


### PR DESCRIPTION
Stacks on #134.

## What
- `decompose_spec(bus=None, transcript=None)` - None is the pre-C4 behavior exactly (the UNTOUCHED `test_decompose.py` suite, 45 tests, is the parity proof). With a bus, the work projects onto pseudo-component `architect`:
  - attempts as `decompose` phases (failed attempts carry the extraction/validation error as detail),
  - the red-team pass as an `audit` phase with every `SpecIssue` emitted as `spec_issue_recorded` (folded issues byte-match the `spec-issues.json` artifact - tested),
  - the forming DAG as a second `RunPlan` the moment validation succeeds (architect row first; C5's DagTable draws from this without reading the manifest),
  - `artifact_written` for spec-issues.json, each PRD, and the manifest,
  - **blocker halts finish the run before raising**: audit-failed + ComponentFailed + RunCompleted precede `SpecBlockerError`, so the run dir reads finished, never dead.
- Architect stream lines tee to `components/architect/engineer.log` via `transcript=`; terminal streaming unchanged.
- `cli.decompose`: `--tui/--no-tui` (factory's auto rule). Embedded v1 = overview + ComponentScreen("architect") via `run_embedded`; the rich DecomposeScreen + spec triage arrive in C5. Exit codes 0/1/2 unchanged in both modes.

## Tested (new `tests/test_decompose_run.py` + `write_fake_decompose_run` helper)
- Success fold: plan order (architect + manifest components with deps), phase chips decompose/audit, artifact labels, completion.
- Folded issues == disk artifact payload; counts.
- Two-shot retry folds failed-then-passed decompose phases, attempt=2.
- Blocker halt: finished run, failed architect, failed audit, blocker counts, no plan beyond architect.
- Transcript capture; `bus=None` leaves no run dir with an identical result.

Fast tier 1819 + spine 25 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)