### PR TITLE
feat: decompose rich screens + kind dispatch + status TTY board (TUI surface C5)

### DIFF
--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -1470,9 +1470,8 @@ def decompose(
             )
             sys.exit(2)
         from kstrl.runid import mint_run_id
+        from kstrl.tui.dispatch import initial_screens_for_kind
         from kstrl.tui.embed import EmbeddedContext, run_embedded
-        from kstrl.tui.screens.component import ComponentScreen
-        from kstrl.tui.screens.overview import OverviewScreen
 
         def _target(embed_ctx: EmbeddedContext) -> int:
             command_run = open_command_run(
@@ -1487,10 +1486,9 @@ def decompose(
         sys.exit(run_embedded(
             _target, root_dir=root_dir,
             run_id=mint_run_id("decompose"),
-            screen_factory=lambda: [
-                OverviewScreen(observe_only=False),
-                ComponentScreen("architect"),
-            ],
+            screen_factory=initial_screens_for_kind(
+                "decompose", observe_only=False,
+            ),
         ))
 
     command_run = open_command_run(
@@ -2473,10 +2471,14 @@ def dash(root: Path | None, run_id: str | None, poll: float) -> None:
         _sys.exit(1)
 
     from kstrl.tui.app import KstrlTuiApp, Mode
+    from kstrl.tui.dispatch import initial_screens_for_kind
 
     app = KstrlTuiApp(
         run_dir=ref.run_dir, root_dir=root_dir,
         mode=Mode.DASH, poll_interval=poll,
+        screen_factory=initial_screens_for_kind(
+            ref.kind, observe_only=True,
+        ),
     )
     try:
         code = app.run()
@@ -2530,6 +2532,14 @@ def dash(root: Path | None, run_id: str | None, poll: float) -> None:
     is_flag=True,
     help="Disable colors",
 )
+@click.option(
+    "--tui/--no-tui",
+    "tui",
+    default=None,
+    help="Open the dashboard for the newest run (default: auto - on "
+         "when stdin/stdout are TTYs, --ui is not plain, and --watch "
+         "is not set; KSTRL_NO_TUI=1 forces off)",
+)
 def status(
     root: Path | None,
     manifest_path: Path | None,
@@ -2538,20 +2548,55 @@ def status(
     interval: float,
     ui: str,
     no_color: bool,
+    tui: bool | None,
 ) -> None:
     """Show per-component status from the manifest + progress log.
 
-    R3.2: joins the factory manifest with the ProgressLog (default
-    .kstrl/progress.jsonl): per component status, retries, branch,
-    timestamps, plus phase, attempt, last-event age, usage totals and
-    evidence paths for the latest run found in the log. Works
-    manifest-only when no log exists.
+    On a TTY this opens the dashboard for the newest run of any kind
+    (post-mortem or live); the plain text report remains the contract
+    for pipes/CI, --no-tui, --watch, and KSTRL_NO_TUI=1.
+
+    R3.2 (plain report): joins the factory manifest with the
+    ProgressLog (default .kstrl/progress.jsonl): per component status,
+    retries, branch, timestamps, plus phase, attempt, last-event age,
+    usage totals and evidence paths for the latest run found in the
+    log. Works manifest-only when no log exists.
     """
     import time as _time
 
     root_dir = root.resolve() if root else Path.cwd()
     force_rich = os.environ.get("GUM_FORCE") == "1"
     ui_impl = _console_ui(_normalize_ui_mode(ui), no_color, force_rich=force_rich)
+
+    use_tui = tui if tui is not None else (
+        sys.stdout.isatty()
+        and sys.stdin.isatty()
+        and envcompat.get("KSTRL_NO_TUI") != "1"
+        and _normalize_ui_mode(ui) != "plain"
+        and not watch
+    )
+    if use_tui:
+        from kstrl.tui.runs import latest_run
+
+        ref = latest_run(root_dir)
+        if ref is not None:
+            from kstrl.tui.app import KstrlTuiApp, Mode
+            from kstrl.tui.dispatch import initial_screens_for_kind
+
+            app = KstrlTuiApp(
+                run_dir=ref.run_dir, root_dir=root_dir, mode=Mode.DASH,
+                screen_factory=initial_screens_for_kind(
+                    ref.kind, observe_only=True,
+                ),
+            )
+            try:
+                code = app.run()
+            finally:
+                sys.stdout.write("\x1b[?1049l\x1b[?25h\x1b[0m")
+                sys.stdout.flush()
+            sys.exit(code or 0)
+        # No run dirs yet: fall through to the plain report, whose
+        # missing-manifest guidance is the useful answer here.
 
     if manifest_path is not None:
         candidates = [manifest_path]

--- a/kstrl/tui/dispatch.py
+++ b/kstrl/tui/dispatch.py
@@ -1,0 +1,42 @@
+"""Kind-aware initial screen stacks (TUI surface C5).
+
+One helper shared by `ks dash`, `ks status --tui`, the embedded
+command paths, and the home shell: which screens a run of a given
+kind opens with. Factory runs get the board; decompose runs get the
+architect view over the board; single-loop kinds get their
+pseudo-component's detail screen when its id is known.
+"""
+
+from __future__ import annotations
+
+from kstrl.tui.app import ScreenStackFactory
+from kstrl.tui.screens.component import ComponentScreen
+from kstrl.tui.screens.decompose import DecomposeScreen
+from kstrl.tui.screens.overview import OverviewScreen
+
+
+def initial_screens_for_kind(
+    kind: str,
+    *,
+    observe_only: bool,
+    component: str = "",
+) -> ScreenStackFactory:
+    """Bottom-first stack for a run of ``kind``.
+
+    ``component`` names the pseudo-component detail screen to open for
+    single-loop kinds; "understand" is implied for understand runs.
+    Unknown kinds degrade to the plain board - a forward-compatible
+    default, never an error.
+    """
+    if kind == "decompose":
+        return lambda: [
+            OverviewScreen(observe_only=observe_only),
+            DecomposeScreen(),
+        ]
+    detail = component or ("understand" if kind == "understand" else "")
+    if detail:
+        return lambda: [
+            OverviewScreen(observe_only=observe_only),
+            ComponentScreen(detail),
+        ]
+    return lambda: [OverviewScreen(observe_only=observe_only)]

--- a/kstrl/tui/screens/decompose.py
+++ b/kstrl/tui/screens/decompose.py
@@ -1,0 +1,300 @@
+"""Decompose run screens: the live architect view + spec triage (C5).
+
+DecomposeScreen is the decompose-kind counterpart of ComponentScreen:
+attempt strip, the forming DAG (rows appear as the RunPlan folds),
+the architect's streaming transcript, and a spec-issue strip that
+deepens into SpecTriageScreen. Everything renders from the folded
+RunState - files are the record.
+
+SpecTriageScreen is read-only in v1: blockers already halted the run
+(the banner says so and points at the durable artifact); non-blockers
+never gate, so there is no decision to prompt for.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Static
+
+from kstrl.tui import theme
+from kstrl.tui.messages import StateChanged
+from kstrl.tui.widgets.dag_table import ARCHITECT_ID, DagTable
+from kstrl.tui.widgets.header import RunHeader
+from kstrl.tui.widgets.transcript import TranscriptTail
+
+if TYPE_CHECKING:
+    from kstrl.manifest import Manifest
+    from kstrl.reducer import RunState
+
+_SEVERITY_ORDER = {"blocker": 0, "major": 1, "minor": 2}
+_SEVERITY_STYLES = {
+    "blocker": f"bold {theme.ERROR}",
+    "major": theme.ERROR,
+    "minor": theme.WARNING,
+}
+
+
+def _issue_strip(state: RunState) -> Text:
+    text = Text()
+    counts = state.spec_issue_counts
+    architect = state.components.get(ARCHITECT_ID)
+    audit_ran = architect is not None and any(
+        p.get("phase") == "audit" for p in architect.phase_history
+    )
+    if not counts:
+        if audit_ran:
+            text.append("✓ clean audit", style=f"bold {theme.SUCCESS}")
+            text.append("  no spec issues", style=theme.MUTED)
+        else:
+            text.append("spec audit pending", style=theme.MUTED)
+        return text
+    text.append("▲ ", style=f"bold {theme.WARNING}")
+    text.append("spec issues  ", style="bold")
+    parts: list[tuple[str, str]] = []
+    for severity in ("blocker", "major", "minor"):
+        if counts.get(severity):
+            parts.append((
+                f"{counts[severity]} {severity}",
+                _SEVERITY_STYLES[severity],
+            ))
+    for other, n in sorted(counts.items()):
+        if other not in _SEVERITY_ORDER:
+            parts.append((f"{n} {other}", theme.MUTED))
+    for index, (label, style) in enumerate(parts):
+        if index:
+            text.append(" · ", style=theme.MUTED)
+        text.append(label, style=style)
+    text.append("   (i) triage", style=theme.MUTED)
+    return text
+
+
+def _attempt_strip(state: RunState) -> Text:
+    text = Text()
+    architect = state.components.get(ARCHITECT_ID)
+    if architect is None:
+        text.append("waiting for the architect...", style=theme.MUTED)
+        return text
+    glyph, color = theme.status_glyph(architect.status)
+    text.append(f"{glyph} ", style=f"bold {color}")
+    text.append("architect ", style="bold")
+    text.append(architect.status, style=color)
+    attempts = [
+        p for p in architect.phase_history
+        if p.get("phase") == "decompose"
+    ]
+    failed = sum(1 for p in attempts if not p.get("passed"))
+    attempt = max(architect.attempt, 1)
+    text.append(
+        f"  attempt {attempt}",
+        style=theme.WARNING if failed else theme.MUTED,
+    )
+    if failed:
+        text.append(f"  · {failed} failed", style=theme.WARNING)
+    return text
+
+
+def _summary(state: RunState) -> Text | None:
+    if not state.finished:
+        return None
+    text = Text()
+    architect = state.components.get(ARCHITECT_ID)
+    if architect is None or architect.status != "completed":
+        text.append("✗ decompose did not complete", style=f"bold {theme.ERROR}")
+        return text
+    planned = [c for c in state.plan_order if c != ARCHITECT_ID]
+    prds = [a for a in state.artifacts if a.get("label") == "prd"]
+    manifest = next(
+        (a for a in state.artifacts if a.get("label") == "manifest"), None,
+    )
+    text.append("✓ ", style=f"bold {theme.SUCCESS}")
+    text.append(f"{len(planned)} component(s)", style="bold")
+    text.append(f" · {len(prds)} PRD(s)", style=theme.MUTED)
+    if manifest is not None:
+        text.append(f" · manifest {manifest.get('path', '')}",
+                    style=theme.MUTED)
+    return text
+
+
+class DecomposeScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "app.pop_screen", "Back"),
+        Binding("i", "open_triage", "Triage"),
+        Binding("f", "toggle_follow", "Follow"),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        # The app's duck-typed poll contract (A3): refresh_state +
+        # the architect's bounded transcript tail.
+        self.transcript_component = ARCHITECT_ID
+        self._following = True
+
+    def compose(self) -> ComposeResult:
+        yield RunHeader(id="decompose-header")
+        yield Static(id="attempt-strip")
+        yield Static("plan", id="dag-title")
+        yield DagTable(id="dag-table")
+        yield Static(id="issues-strip")
+        yield Static(id="decompose-summary")
+        yield Static(id="decompose-transcript-title")
+        yield TranscriptTail(id="transcript")
+        yield Footer()
+
+    @property
+    def ready(self) -> bool:
+        return next(iter(self.query(TranscriptTail)), None) is not None
+
+    def on_mount(self) -> None:
+        self._update_transcript_title()
+        store = getattr(self.app, "store", None)
+        if store is not None:
+            self.refresh_state(store.state, store.manifest())
+
+    def refresh_state(
+        self, state: RunState, manifest: Manifest | None,
+    ) -> None:
+        del manifest  # the folded plan is the source; no manifest join
+        if not self.ready:
+            return
+        self.query_one(RunHeader).update_state(state)
+        self.query_one("#attempt-strip", Static).update(_attempt_strip(state))
+        self.query_one(DagTable).update_state(state)
+        self.query_one("#issues-strip", Static).update(_issue_strip(state))
+        summary = _summary(state)
+        summary_widget = self.query_one("#decompose-summary", Static)
+        summary_widget.display = summary is not None
+        if summary is not None:
+            summary_widget.update(summary)
+
+    def tick_ages(self, state: RunState) -> None:
+        if self.ready:
+            self.query_one(RunHeader).update_state(state)
+
+    def feed_transcript(self, lines: list[str]) -> None:
+        self.query_one(TranscriptTail).feed_lines(lines)
+
+    def _update_transcript_title(self) -> None:
+        title = Text("architect transcript", style="bold")
+        if self._following:
+            title.append("  ● following", style=theme.ACCENT)
+        else:
+            title.append("  ⏸ paused", style=theme.MUTED)
+        title.append("  (f toggles)", style=theme.MUTED)
+        self.query_one(
+            "#decompose-transcript-title", Static,
+        ).update(title)
+
+    def action_toggle_follow(self) -> None:
+        self._following = self.query_one(TranscriptTail).toggle_follow()
+        self._update_transcript_title()
+
+    def action_open_triage(self) -> None:
+        self.app.push_screen(SpecTriageScreen())
+
+
+class SpecTriageScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "app.pop_screen", "Back"),
+    ]
+
+    COLUMNS = ("severity", "kind", "summary", "location")
+
+    def compose(self) -> ComposeResult:
+        yield Static(id="triage-banner")
+        yield Static("spec issues", id="triage-title")
+        yield DataTable(id="triage-table")
+        yield Static(id="triage-detail")
+        yield Footer()
+
+    @property
+    def ready(self) -> bool:
+        return next(iter(self.query(DataTable)), None) is not None
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.cursor_type = "row"
+        table.zebra_stripes = False
+        for column in self.COLUMNS:
+            table.add_column(column, key=column)
+        store = getattr(self.app, "store", None)
+        if store is not None:
+            self._refresh(store.state)
+
+    def on_state_changed(self, message: StateChanged) -> None:
+        self._refresh(message.state)
+
+    def _refresh(self, state: RunState) -> None:
+        if not self.ready:
+            return
+        self._issues = sorted(
+            state.spec_issues,
+            key=lambda i: _SEVERITY_ORDER.get(i.get("severity", ""), 9),
+        )
+        banner = self.query_one("#triage-banner", Static)
+        architect = state.components.get(ARCHITECT_ID)
+        halted = (
+            bool(state.spec_issue_counts.get("blocker"))
+            and architect is not None and architect.status == "failed"
+        )
+        if halted:
+            artifact = next(
+                (a.get("path", "") for a in state.artifacts
+                 if a.get("label") == "spec_issues"),
+                "scripts/kstrl/spec-issues.json",
+            )
+            banner.display = True
+            banner.update(Text(
+                f"✗ decompose halted - resolve the spec and re-run · {artifact}",
+                style=f"bold {theme.ERROR}",
+            ))
+        else:
+            banner.display = False
+        table = self.query_one(DataTable)
+        table.clear()
+        for issue in self._issues:
+            severity = issue.get("severity", "")
+            table.add_row(
+                Text(severity,
+                     style=_SEVERITY_STYLES.get(severity, theme.MUTED)),
+                issue.get("kind", "") or Text(theme.EMPTY_CELL,
+                                              style=theme.MUTED),
+                issue.get("summary", ""),
+                issue.get("location", "") or Text(theme.EMPTY_CELL,
+                                                  style=theme.MUTED),
+            )
+        if self._issues:
+            self._show_detail(0)
+        else:
+            self.query_one("#triage-detail", Static).update(
+                Text("no spec issues recorded", style=theme.MUTED),
+            )
+
+    def on_data_table_row_highlighted(
+        self, event: DataTable.RowHighlighted,
+    ) -> None:
+        if event.cursor_row is not None and event.cursor_row >= 0:
+            self._show_detail(event.cursor_row)
+
+    def _show_detail(self, index: int) -> None:
+        issues = getattr(self, "_issues", [])
+        if not issues or index >= len(issues):
+            return
+        issue = issues[index]
+        detail = Text()
+        severity = issue.get("severity", "")
+        detail.append(
+            f"[{severity}] ",
+            style=_SEVERITY_STYLES.get(severity, theme.MUTED),
+        )
+        detail.append(issue.get("summary", ""), style="bold")
+        if issue.get("location"):
+            detail.append(f"\nat {issue['location']}", style=theme.MUTED)
+        if issue.get("suggestion"):
+            detail.append("\nsuggestion  ", style=f"bold {theme.ACCENT}")
+            detail.append(issue["suggestion"])
+        self.query_one("#triage-detail", Static).update(detail)

--- a/kstrl/tui/screens/decompose.py
+++ b/kstrl/tui/screens/decompose.py
@@ -261,11 +261,11 @@ class SpecTriageScreen(Screen[None]):
             table.add_row(
                 Text(severity,
                      style=_SEVERITY_STYLES.get(severity, theme.MUTED)),
-                issue.get("kind", "") or Text(theme.EMPTY_CELL,
-                                              style=theme.MUTED),
-                issue.get("summary", ""),
-                issue.get("location", "") or Text(theme.EMPTY_CELL,
-                                                  style=theme.MUTED),
+                Text(issue["kind"]) if issue.get("kind")
+                else Text(theme.EMPTY_CELL, style=theme.MUTED),
+                Text(issue.get("summary", "")),
+                Text(issue["location"]) if issue.get("location")
+                else Text(theme.EMPTY_CELL, style=theme.MUTED),
             )
         if self._issues:
             self._show_detail(0)

--- a/kstrl/tui/styles.tcss
+++ b/kstrl/tui/styles.tcss
@@ -232,6 +232,69 @@ CheckpointModal {
     color: $warning;
 }
 
+/* ---- decompose screen ---------------------------------------------------- */
+/* Same register as the component screen: strips are 1 line, panel
+ * titles 2 (the border-bottom needs its own row), the transcript
+ * fills what remains. */
+
+#decompose-header {
+    height: 1;
+    padding: 0 1;
+}
+
+#attempt-strip {
+    height: 1;
+    padding: 0 1;
+}
+
+#dag-title, #triage-title {
+    height: 2;
+    padding: 0 1;
+    color: $text-muted;
+    text-style: bold;
+    border-bottom: solid $panel;
+}
+
+#dag-table {
+    height: auto;
+    max-height: 40%;
+    background: $background;
+}
+
+#issues-strip {
+    height: 1;
+    padding: 0 1;
+}
+
+#decompose-summary {
+    height: 1;
+    padding: 0 1;
+}
+
+#decompose-transcript-title {
+    height: 2;
+    padding: 0 1;
+    border-bottom: solid $panel;
+}
+
+/* ---- spec triage --------------------------------------------------------- */
+
+#triage-banner {
+    height: 1;
+    padding: 0 1;
+}
+
+#triage-table {
+    height: 1fr;
+    background: $background;
+}
+
+#triage-detail {
+    height: 6;
+    padding: 1 2;
+    background: $surface;
+}
+
 /* ---- options modal ------------------------------------------------------- */
 /* Lean prompt surface for every non-checkpoint request (feature gate,
  * apply/retry confirms). Same chrome family as the checkpoint modal;

--- a/kstrl/tui/widgets/dag_table.py
+++ b/kstrl/tui/widgets/dag_table.py
@@ -1,0 +1,108 @@
+"""Forming-DAG table for the decompose screen (TUI surface C5).
+
+Rows appear as the architect's RunPlan folds - no manifest read
+needed. Tiers come from a local cycle-tolerant Kahn over the folded
+deps (mirrors Manifest.compute_tiers but works before the manifest
+exists); a component caught in a dependency cycle renders a warning
+marker instead of failing the screen - the plain-mode DAG validation
+warnings remain the authoritative complaint.
+
+Same render policy as the component board: diff row updates, never
+clear()+rebuild per poll (spike finding 3).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.widgets import DataTable
+
+from kstrl.tui import theme
+
+if TYPE_CHECKING:
+    from kstrl.reducer import ComponentState, RunState
+
+ARCHITECT_ID = "architect"
+COLUMNS = ("component", "tier", "deps", "prd")
+_CYCLE_TIER = -1
+
+
+def compute_tiers(components: dict[str, tuple[str, ...]]) -> dict[str, int]:
+    """Kahn layering over {id: deps}; cycle members get _CYCLE_TIER.
+
+    Deps pointing outside the mapping are ignored (a forming plan can
+    reference components whose rows have not folded yet)."""
+    remaining = {
+        cid: {d for d in deps if d in components and d != cid}
+        for cid, deps in components.items()
+    }
+    tiers: dict[str, int] = {}
+    tier = 0
+    while remaining:
+        ready = sorted(
+            cid for cid, deps in remaining.items()
+            if not (deps - set(tiers))
+        )
+        if not ready:
+            for cid in remaining:
+                tiers[cid] = _CYCLE_TIER
+            break
+        for cid in ready:
+            tiers[cid] = tier
+            del remaining[cid]
+        tier += 1
+    return tiers
+
+
+def _row_values(
+    comp: ComponentState,
+    tier: int,
+    prd_written: bool,
+) -> tuple[Text | str, ...]:
+    name = Text(comp.component_id)
+    if comp.title:
+        name.append(f"  {comp.title}", style=theme.MUTED)
+    if tier == _CYCLE_TIER:
+        tier_cell = Text("cycle!", style=f"bold {theme.WARNING}",
+                         justify="right")
+    else:
+        tier_cell = Text(str(tier), justify="right")
+    deps = ", ".join(comp.deps)
+    return (
+        name,
+        tier_cell,
+        Text(deps) if deps else Text(theme.EMPTY_CELL, style=theme.MUTED),
+        Text("✓", style=theme.SUCCESS) if prd_written
+        else Text(theme.EMPTY_CELL, style=theme.MUTED),
+    )
+
+
+class DagTable(DataTable[Text | str]):
+    def on_mount(self) -> None:
+        self.cursor_type = "row"
+        self.zebra_stripes = False
+        for column in COLUMNS:
+            self.add_column(column, key=column)
+
+    def update_state(self, state: RunState) -> None:
+        order = [cid for cid in state.plan_order if cid != ARCHITECT_ID]
+        deps_map = {
+            cid: state.components[cid].deps
+            for cid in order if cid in state.components
+        }
+        tiers = compute_tiers(deps_map)
+        prds = {
+            a["component"]
+            for a in state.artifacts if a.get("label") == "prd"
+        }
+        for cid in order:
+            comp = state.components.get(cid)
+            if comp is None:
+                continue
+            values = _row_values(comp, tiers.get(cid, 0), cid in prds)
+            if cid in self.rows:
+                for key, value in zip(COLUMNS, values, strict=True):
+                    self.update_cell(cid, key, value)
+            else:
+                self.add_row(*values, key=cid)

--- a/kstrl/tui/widgets/dag_table.py
+++ b/kstrl/tui/widgets/dag_table.py
@@ -34,7 +34,7 @@ def compute_tiers(components: dict[str, tuple[str, ...]]) -> dict[str, int]:
     Deps pointing outside the mapping are ignored (a forming plan can
     reference components whose rows have not folded yet)."""
     remaining = {
-        cid: {d for d in deps if d in components and d != cid}
+        cid: {d for d in deps if d in components}
         for cid, deps in components.items()
     }
     tiers: dict[str, int] = {}
@@ -96,6 +96,18 @@ class DagTable(DataTable[Text | str]):
             a["component"]
             for a in state.artifacts if a.get("label") == "prd"
         }
+        desired = [cid for cid in order if cid in state.components]
+        current = [str(key.value) for key in self.rows]
+
+        # A rewritten event stream can replace the plan. Remove rows that
+        # disappeared, and rebuild only when surviving rows changed order.
+        # The normal forming-plan path remains append/update-only.
+        for cid in current:
+            if cid not in desired:
+                self.remove_row(cid)
+        current = [str(key.value) for key in self.rows]
+        if current != desired[:len(current)]:
+            self.clear()
         for cid in order:
             comp = state.components.get(cid)
             if comp is None:

--- a/tests/test_decompose_screens.py
+++ b/tests/test_decompose_screens.py
@@ -7,6 +7,9 @@ from typing import Any
 from unittest.mock import patch
 
 from click.testing import CliRunner
+from rich.text import Text
+from textual.coordinate import Coordinate
+from textual.widgets import DataTable
 
 from kstrl.cli import cli
 from kstrl.tui.app import KstrlTuiApp, Mode
@@ -36,6 +39,9 @@ class TestComputeTiers:
         tiers = compute_tiers({"a": ("b",), "b": ("a",), "c": ()})
         assert tiers["c"] == 0
         assert tiers["a"] == -1 and tiers["b"] == -1
+
+    def test_self_dependency_is_a_cycle(self) -> None:
+        assert compute_tiers({"a": ("a",)}) == {"a": -1}
 
 
 class TestDispatch:
@@ -87,6 +93,13 @@ class TestDecomposeScreen:
             assert summary.display
             assert "2 component(s)" in str(summary.renderable)
 
+            # A replaced event stream may contain a smaller plan; rows
+            # from the old fold must not survive the rebuild.
+            app.store.state.plan_order = ["architect", "database"]
+            app.store.state.components.pop("api")
+            table.update_state(app.store.state)
+            assert {key.value for key in table.rows} == {"database"}
+
     async def test_triage_shows_blocker_banner_and_detail(
         self, tmp_path: Path,
     ) -> None:
@@ -106,6 +119,21 @@ class TestDecomposeScreen:
             text = str(detail.renderable)
             assert "[blocker]" in text
             assert "Resolve it" in text
+
+            # Spec text is untrusted content, not Rich markup. Keeping
+            # every cell as Text prevents tags from being interpreted.
+            app.store.state.spec_issues[0]["summary"] = "[/bold]"
+            app.store.state.spec_issues[0]["location"] = (
+                "[link=https://example.invalid]location[/link]"
+            )
+            app.screen._refresh(app.store.state)
+            table = app.screen.query_one(DataTable)
+            summary_cell = table.get_cell_at(Coordinate(0, 2))
+            location_cell = table.get_cell_at(Coordinate(0, 3))
+            assert isinstance(summary_cell, Text)
+            assert summary_cell.plain == "[/bold]"
+            assert isinstance(location_cell, Text)
+            assert location_cell.plain.startswith("[link=")
             await pilot.press("escape")
             await pilot.pause()
             assert isinstance(app.screen, DecomposeScreen)

--- a/tests/test_decompose_screens.py
+++ b/tests/test_decompose_screens.py
@@ -1,0 +1,171 @@
+"""TUI surface C5: decompose screens, kind dispatch, status --tui."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from kstrl.cli import cli
+from kstrl.tui.app import KstrlTuiApp, Mode
+from kstrl.tui.dispatch import initial_screens_for_kind
+from kstrl.tui.screens.component import ComponentScreen
+from kstrl.tui.screens.decompose import DecomposeScreen, SpecTriageScreen
+from kstrl.tui.screens.overview import OverviewScreen
+from kstrl.tui.widgets.dag_table import DagTable, compute_tiers
+from tests.helpers.fake_run import (
+    write_fake_decompose_run,
+    write_fake_run,
+)
+
+
+class TestComputeTiers:
+    def test_chain_and_diamond(self) -> None:
+        assert compute_tiers({
+            "a": (), "b": ("a",), "c": ("a",), "d": ("b", "c"),
+        }) == {"a": 0, "b": 1, "c": 1, "d": 2}
+
+    def test_unknown_deps_ignored(self) -> None:
+        assert compute_tiers({"a": ("ghost",), "b": ("a",)}) == {
+            "a": 0, "b": 1,
+        }
+
+    def test_cycle_marks_members_not_raises(self) -> None:
+        tiers = compute_tiers({"a": ("b",), "b": ("a",), "c": ()})
+        assert tiers["c"] == 0
+        assert tiers["a"] == -1 and tiers["b"] == -1
+
+
+class TestDispatch:
+    def test_kinds_map_to_stacks(self) -> None:
+        decompose = initial_screens_for_kind("decompose", observe_only=True)()
+        assert [type(s) for s in decompose] == [OverviewScreen, DecomposeScreen]
+        understand = initial_screens_for_kind("understand", observe_only=True)()
+        assert isinstance(understand[-1], ComponentScreen)
+        assert understand[-1].component_id == "understand"
+        feature = initial_screens_for_kind(
+            "feature", observe_only=False, component="demo",
+        )()
+        assert isinstance(feature[-1], ComponentScreen)
+        assert feature[-1].component_id == "demo"
+        factory = initial_screens_for_kind("factory", observe_only=True)()
+        assert [type(s) for s in factory] == [OverviewScreen]
+        unknown = initial_screens_for_kind("someday", observe_only=True)()
+        assert [type(s) for s in unknown] == [OverviewScreen]
+
+
+def _decompose_app(root: Path, run_dir: Path) -> KstrlTuiApp:
+    return KstrlTuiApp(
+        run_dir=run_dir, root_dir=root, mode=Mode.DASH,
+        poll_interval=0.05,
+        screen_factory=initial_screens_for_kind(
+            "decompose", observe_only=True,
+        ),
+    )
+
+
+class TestDecomposeScreen:
+    async def test_success_run_renders_dag_and_summary(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = write_fake_decompose_run(tmp_path, attempts=2)
+        app = _decompose_app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            assert isinstance(app.screen, DecomposeScreen)
+            table = app.screen.query_one(DagTable)
+            assert list(table.rows) != []
+            row_keys = {key.value for key in table.rows}
+            assert row_keys == {"database", "api"}  # architect excluded
+            strip = app.screen.query_one("#issues-strip")
+            assert "minor" in str(strip.renderable)
+            attempt = app.screen.query_one("#attempt-strip")
+            assert "attempt 2" in str(attempt.renderable)
+            summary = app.screen.query_one("#decompose-summary")
+            assert summary.display
+            assert "2 component(s)" in str(summary.renderable)
+
+    async def test_triage_shows_blocker_banner_and_detail(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = write_fake_decompose_run(tmp_path, blockers=1, minors=1)
+        app = _decompose_app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            await pilot.press("i")
+            await pilot.pause()
+            assert isinstance(app.screen, SpecTriageScreen)
+            banner = app.screen.query_one("#triage-banner")
+            assert banner.display
+            assert "halted" in str(banner.renderable)
+            # Blockers sort first; the detail pane carries the
+            # suggestion for the highlighted row.
+            detail = app.screen.query_one("#triage-detail")
+            text = str(detail.renderable)
+            assert "[blocker]" in text
+            assert "Resolve it" in text
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, DecomposeScreen)
+
+    async def test_escape_pops_to_overview(self, tmp_path: Path) -> None:
+        run_dir = write_fake_decompose_run(tmp_path)
+        app = _decompose_app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, OverviewScreen)
+
+
+class TestStatusTui:
+    def _capture_app(self) -> tuple[list[KstrlTuiApp], Any]:
+        captured: list[KstrlTuiApp] = []
+
+        def fake_run(self: KstrlTuiApp) -> int:
+            captured.append(self)
+            return 0
+
+        return captured, fake_run
+
+    def test_explicit_tui_opens_the_newest_run_with_kind_dispatch(
+        self, tmp_path: Path,
+    ) -> None:
+        write_fake_run(tmp_path, run_id="factory-20260718-100000.000000-old")
+        write_fake_decompose_run(tmp_path)
+        captured, fake_run = self._capture_app()
+        runner = CliRunner()
+        with patch.object(KstrlTuiApp, "run", fake_run):
+            result = runner.invoke(
+                cli, ["status", "--root", str(tmp_path), "--tui"],
+            )
+        assert result.exit_code == 0
+        assert len(captured) == 1
+        app = captured[0]
+        assert app.run_dir.name.startswith("decompose-")  # newest wins
+        assert app.screen_factory is not None
+        stack = app.screen_factory()
+        assert isinstance(stack[-1], DecomposeScreen)
+
+    def test_tui_with_no_runs_falls_back_to_plain_guidance(
+        self, tmp_path: Path,
+    ) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["status", "--root", str(tmp_path), "--tui"],
+        )
+        assert result.exit_code == 1
+        assert "No manifest found" in result.output
+
+    def test_non_tty_default_stays_plain(self, tmp_path: Path) -> None:
+        """CliRunner is non-TTY: the auto rule must never open the
+        dashboard - the pinned plain report is the CI contract."""
+        write_fake_run(tmp_path)
+        captured, fake_run = self._capture_app()
+        runner = CliRunner()
+        with patch.object(KstrlTuiApp, "run", fake_run):
+            result = runner.invoke(cli, ["status", "--root", str(tmp_path)])
+        assert captured == []
+        assert "No manifest found" in result.output


### PR DESCRIPTION
Stacks on #135. Completes the decompose experience and lands the user's status decision.

## What
- **DecomposeScreen** (`tui/screens/decompose.py`): attempt strip with honest failure count, forming-DAG table (`widgets/dag_table.py` - rows appear as the RunPlan folds, tiers via a cycle-tolerant Kahn that marks cycle members instead of raising, PRD ✓ from artifact events), spec-issue strip (clean-audit / pending / severity counts), streaming architect transcript (A3 duck contract), post-run summary line.
- **SpecTriageScreen**: blockers-first table + detail pane (kind/location/suggestion); halted runs get the ERROR banner pointing at `scripts/kstrl/spec-issues.json`. Read-only v1 - blockers already halted the run and non-blockers never gate, so there is no decision to invent.
- **`tui/dispatch.py::initial_screens_for_kind`**: one stack-picker for dash, `status --tui`, embed, and (later) the home shell; unknown kinds degrade to the board.
- **`ks status` TTY auto-launch** (user decision): on a TTY, status opens the dashboard for the newest run of ANY kind; plain report retained for non-TTY/`--no-tui`/`--watch`/KSTRL_NO_TUI=1. CliRunner is non-TTY, so the ~40 pinned substrings in `test_status_cmd.py` hold untouched.
- `ks dash` dispatches by run kind; the embedded decompose path opens the rich screen.

## Tested (new `tests/test_decompose_screens.py`)
- `compute_tiers`: chain/diamond, unknown deps ignored, cycle-tolerance.
- Dispatch mapping for all kinds incl. unknown.
- Pilot: DAG rows (architect excluded), attempt/issue strips, summary; triage banner + blocker-first detail + escape stack; escape to overview.
- status: `--tui` opens the NEWEST run with kind dispatch (captured app), no-runs falls back to plain guidance, non-TTY default stays plain.

No new SVG snapshots (deliberate two-snapshot churn discipline); Pilot assertions carry the coverage. Fast tier 1829 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)