### PR TITLE
feat: home shell - bare ks, RunContext, Mode.HOME, HomeScreen v1 (TUI surface D1)

### DIFF
--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -374,11 +374,26 @@ def _timestamp() -> str:
     return datetime.now().strftime("%Y%m%d-%H%M%S")
 
 
-@click.group()
+@click.group(invoke_without_command=True)
 @click.version_option(version=__version__)
-def cli() -> None:
+@click.pass_context
+def cli(ctx: click.Context) -> None:
     """kstrl - Agentic loop harness for AI-driven development."""
-    pass
+    if ctx.invoked_subcommand is not None:
+        return
+    # Bare `ks` on a TTY opens the home shell (D1 user decision);
+    # everywhere else stays byte-identical to click's no-args behavior
+    # (help on stdout, exit 2) - the pipe/CI contract.
+    if (
+        sys.stdout.isatty()
+        and sys.stdin.isatty()
+        and envcompat.get("KSTRL_NO_TUI") != "1"
+    ):
+        from kstrl.tui.home import run_home_shell
+
+        ctx.exit(run_home_shell(Path.cwd()))
+    click.echo(ctx.get_help())
+    ctx.exit(2)
 
 
 @cli.command()

--- a/kstrl/tui/app.py
+++ b/kstrl/tui/app.py
@@ -33,13 +33,14 @@ from kstrl.interaction import (
 )
 from kstrl.tui.bridge import OrchestratorHandle
 from kstrl.tui.messages import StateChanged
+from kstrl.tui.runcontext import RunContext
 from kstrl.tui.screens.checkpoint import CheckpointModal
 from kstrl.tui.screens.component import ComponentScreen
+from kstrl.tui.screens.home import HomeScreen
 from kstrl.tui.screens.options import OptionsModal
 from kstrl.tui.screens.overview import OverviewScreen
 from kstrl.tui.screens.quit import QuitModal
 from kstrl.tui.state import StateStore
-from kstrl.tui.tail import RunTailer, TextTailer
 from kstrl.tui.theme import KSTRL_THEME
 
 DEFAULT_POLL_INTERVAL = 0.2  # measured, spike G1
@@ -51,6 +52,7 @@ ScreenStackFactory = Callable[[], list[Screen[None]]]
 class Mode(StrEnum):
     DASH = "dash"
     EMBEDDED = "embedded"
+    HOME = "home"
 
 
 class KstrlTuiApp(App[int]):
@@ -62,13 +64,18 @@ class KstrlTuiApp(App[int]):
         # it does nothing at all.
         Binding("ctrl+c", "quit_or_detach", show=False),
         Binding("c", "answer_checkpoint", "Checkpoint", show=False),
+        # App-level fallback: screens with their own escape binding
+        # (modals, detail screens) win; on a base screen this pops
+        # toward home when there is anywhere to pop to. (Named
+        # nav_back: Textual's App already owns an async action_back.)
+        Binding("escape", "nav_back", show=False),
     ]
 
     def __init__(
         self,
         *,
-        run_dir: Path,
         root_dir: Path,
+        run_dir: Path | None = None,
         mode: Mode = Mode.DASH,
         poll_interval: float = DEFAULT_POLL_INTERVAL,
         channel: QueueInteractionChannel | None = None,
@@ -76,23 +83,43 @@ class KstrlTuiApp(App[int]):
         screen_factory: ScreenStackFactory | None = None,
     ) -> None:
         super().__init__()
-        self.run_dir = run_dir
         self.root_dir = root_dir
         self.mode = mode
         self.poll_interval = poll_interval
         self.channel = channel
         self.orchestrator = orchestrator
         self.screen_factory = screen_factory
-        self.tailer = RunTailer(run_dir)
-        self.store = StateStore(root_dir, run_id=run_dir.name)
-        self._transcript_tailers: dict[str, TextTailer] = {}
+        # CLI-scoped modes (dash/embedded) are born bound to one run;
+        # HOME opens and closes contexts as the user navigates. Named
+        # run_context because App.run() is Textual's entry point.
+        self.run_context: RunContext | None = (
+            RunContext.observe(run_dir, root_dir)
+            if run_dir is not None else None
+        )
         self._pending_prompts: dict[str, PromptRequest] = {}
         self._stopping = False
+
+    # Compat views for screens and tests that duck-pull off the app.
+    @property
+    def store(self) -> StateStore | None:
+        return (
+            self.run_context.store
+            if self.run_context is not None else None
+        )
+
+    @property
+    def run_dir(self) -> Path | None:
+        return (
+            self.run_context.run_dir
+            if self.run_context is not None else None
+        )
 
     def on_mount(self) -> None:
         self.register_theme(KSTRL_THEME)
         self.theme = "kstrl"
-        if self.screen_factory is not None:
+        if self.mode is Mode.HOME:
+            self.push_screen(HomeScreen())
+        elif self.screen_factory is not None:
             for screen in self.screen_factory():
                 self.push_screen(screen)
         else:
@@ -132,24 +159,29 @@ class KstrlTuiApp(App[int]):
           humanize(); truncation rebuilds replay history into state
           but must not re-narrate it into the feed).
         """
-        chunk = self.tailer.poll_events()
+        run = self.run_context
+        if run is None:
+            return
+        chunk = run.tailer.poll_events()
         if chunk.truncated:
-            self.store.reset()
-        changed = self.store.apply_events(chunk.events)
+            run.store.reset()
+        changed = run.store.apply_events(chunk.events)
         screen_stack = self.screen_stack
         if not screen_stack:
             return
         screen = screen_stack[-1]
+        if isinstance(screen, HomeScreen):
+            return  # home renders discovery, not one run's stream
         component_id = str(getattr(screen, "transcript_component", ""))
         ready = bool(getattr(screen, "ready", True))
         if changed:
             if component_id:
                 if ready:
                     screen.refresh_state(  # type: ignore[attr-defined]
-                        self.store.state, self.store.manifest(),
+                        run.store.state, run.store.manifest(),
                     )
             else:
-                screen.post_message(StateChanged(self.store.state))
+                screen.post_message(StateChanged(run.store.state))
             feed = getattr(screen, "feed_events", None)
             if feed is not None and not chunk.truncated:
                 feed(chunk.events)
@@ -157,25 +189,17 @@ class KstrlTuiApp(App[int]):
             feed_transcript = getattr(screen, "feed_transcript", None)
             if feed_transcript is not None:
                 feed_transcript(
-                    self._transcript_tailer(component_id).poll(),
+                    run.transcript_tailer(component_id).poll(),
                 )
 
-    def _transcript_tailer(self, component_id: str) -> TextTailer:
-        tailer = self._transcript_tailers.get(component_id)
-        if tailer is None:
-            tailer = TextTailer(
-                self.run_dir / "components" / component_id / "engineer.log",
-            )
-            self._transcript_tailers[component_id] = tailer
-        return tailer
-
     def _tick_ages(self) -> None:
+        run = self.run_context
         screen_stack = self.screen_stack
-        if not screen_stack:
+        if run is None or not screen_stack:
             return
         tick = getattr(screen_stack[-1], "tick_ages", None)
         if tick is not None:
-            tick(self.store.state)
+            tick(run.store.state)
 
     # -- navigation ----------------------------------------------------------
 
@@ -191,6 +215,40 @@ class KstrlTuiApp(App[int]):
     def open_component(self, component_id: str) -> None:
         # The screen fills itself in on_mount (compose must run first).
         self.push_screen(ComponentScreen(component_id))
+
+    def action_nav_back(self) -> None:
+        # The stack floor is 2: Textual's hidden default screen plus
+        # the base screen this mode pushed (home, or the dash board).
+        if len(self.screen_stack) > 2:
+            self.pop_screen()
+
+    # -- home mode (D1) ------------------------------------------------------
+
+    def open_run(self, ref: object) -> None:
+        """Open an observe context for a discovered run and push its
+        kind-appropriate screen stack over home."""
+        run_dir = getattr(ref, "run_dir", None)
+        kind = str(getattr(ref, "kind", "factory"))
+        if run_dir is None:
+            return
+        from kstrl.tui.dispatch import initial_screens_for_kind
+
+        self.run_context = RunContext.observe(
+            run_dir, self.root_dir, owns_app_exit=False,
+        )
+        for screen in initial_screens_for_kind(kind, observe_only=True)():
+            self.push_screen(screen)
+        self._poll()
+
+    def close_run(self) -> None:
+        """Tear down the observe context when navigation lands back on
+        home. CLI-scoped contexts (dash/embedded) are never closed."""
+        run = self.run_context
+        if run is None or run.owns_app_exit:
+            return
+        if run.channel is not None:
+            run.channel.detach()
+        self.run_context = None
 
     # -- embedded mode (PR F) ------------------------------------------------
 
@@ -245,6 +303,16 @@ class KstrlTuiApp(App[int]):
             return
 
     def action_quit_or_detach(self) -> None:
+        if self.mode is Mode.HOME:
+            if isinstance(self.screen, HomeScreen):
+                self.exit(0)
+                return
+            # q above home pops back to it (teardown happens on the
+            # home screen's resume); quitting the app is home's call.
+            # Floor 2 = Textual's default screen + HomeScreen.
+            while len(self.screen_stack) > 2:
+                self.pop_screen()
+            return
         if self.mode is Mode.DASH:
             # Detach immediately; the run (if live) is not ours to stop.
             self.exit(0)

--- a/kstrl/tui/home.py
+++ b/kstrl/tui/home.py
@@ -1,0 +1,26 @@
+"""`ks` with no args on a TTY: the home shell (TUI surface D1).
+
+Mirrors dash's wiring: the app owns the terminal; the belt-and-braces
+ANSI restore covers any exit path Textual could not clean up after
+(spike finding 2). Launch-session signal handling arrives with the
+D6 seam - the v1 shell only observes.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ANSI_RESTORE = "\x1b[?1049l\x1b[?25h\x1b[0m"
+
+
+def run_home_shell(root_dir: Path) -> int:
+    from kstrl.tui.app import KstrlTuiApp, Mode
+
+    app = KstrlTuiApp(root_dir=root_dir, mode=Mode.HOME)
+    try:
+        code = app.run()
+    finally:
+        sys.stdout.write(ANSI_RESTORE)
+        sys.stdout.flush()
+    return code or 0

--- a/kstrl/tui/runcontext.py
+++ b/kstrl/tui/runcontext.py
@@ -1,0 +1,59 @@
+"""Run-scoped data flow for the app (TUI surface D1).
+
+Everything needed to observe (and, for launched sessions, drive) ONE
+run, extracted from KstrlTuiApp so the home shell can open, close,
+and swap runs without the app being born bound to a single run dir.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from kstrl.tui.state import StateStore
+from kstrl.tui.tail import RunTailer, TextTailer
+
+if TYPE_CHECKING:
+    from kstrl.interaction import QueueInteractionChannel
+    from kstrl.tui.bridge import CommandHandle
+
+
+@dataclass
+class RunContext:
+    """One run's tailer + reducer store + transcript tailers.
+
+    ``owns_app_exit`` is True for CLI-scoped runs (dash / embedded):
+    the run finishing exits the app. Home-launched sessions set it
+    False - finishing keeps the board up for post-mortem reading and
+    escape pops back home. ``channel``/``handle`` arrive with the
+    launch seam (D6); observe-only contexts leave them None.
+    """
+
+    run_dir: Path
+    tailer: RunTailer
+    store: StateStore
+    transcript_tailers: dict[str, TextTailer] = field(default_factory=dict)
+    channel: QueueInteractionChannel | None = None
+    handle: CommandHandle | None = None
+    owns_app_exit: bool = True
+
+    @classmethod
+    def observe(
+        cls, run_dir: Path, root_dir: Path, *, owns_app_exit: bool = True,
+    ) -> RunContext:
+        return cls(
+            run_dir=run_dir,
+            tailer=RunTailer(run_dir),
+            store=StateStore(root_dir, run_id=run_dir.name),
+            owns_app_exit=owns_app_exit,
+        )
+
+    def transcript_tailer(self, component_id: str) -> TextTailer:
+        tailer = self.transcript_tailers.get(component_id)
+        if tailer is None:
+            tailer = TextTailer(
+                self.run_dir / "components" / component_id / "engineer.log",
+            )
+            self.transcript_tailers[component_id] = tailer
+        return tailer

--- a/kstrl/tui/screens/home.py
+++ b/kstrl/tui/screens/home.py
@@ -1,0 +1,175 @@
+"""Home screen: project identity, the run browser, and commands (D1).
+
+The `ks` no-args landing surface. Everything renders from disk
+discovery (tui.runs) and the project's own files; opening a run
+delegates to the app's open_run, which builds an observe context and
+pushes the kind-appropriate stack. Returning here (escape/q) tears
+that context down via on_screen_resume - no matter which path popped.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, OptionList, Static
+from textual.widgets.option_list import Option
+
+from kstrl.config import resolve_config_file
+from kstrl.tui import theme
+from kstrl.tui.runs import RunRef, discover_runs
+from kstrl.tui.widgets.run_table import RunTable
+
+if TYPE_CHECKING:
+    pass
+
+HOME_POLL_INTERVAL = 2.0
+HOME_RUN_LIMIT = 15
+
+
+@dataclass(frozen=True)
+class HomeCommand:
+    command_id: str
+    title: str
+    description: str
+
+
+# The launcher grows with the wave: D3 config, D4 evolve, D5 init,
+# D6 launch forms all append here.
+HOME_COMMANDS: list[HomeCommand] = [
+    HomeCommand(
+        "dash", "dashboard",
+        "open the newest run (enter on a row opens that run)",
+    ),
+]
+
+
+def _git_branch(root_dir: Path) -> str:
+    try:
+        probe = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=root_dir, capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    return probe.stdout.strip() if probe.returncode == 0 else ""
+
+
+def _project_name(root_dir: Path) -> str:
+    manifest_path = root_dir / "scripts" / "kstrl" / "manifest.json"
+    if manifest_path.exists():
+        try:
+            from kstrl.manifest import Manifest
+
+            return Manifest.load(manifest_path).project_name
+        except (OSError, ValueError):
+            pass
+    return root_dir.name
+
+
+def _masthead(root_dir: Path, branch: str, project: str) -> Text:
+    text = Text()
+    text.append(" ◍ kstrl ", style=f"bold {theme.BACKGROUND} on {theme.ACCENT}")
+    text.append("  ")
+    text.append(project or "(no project)", style="bold")
+    if branch:
+        text.append(f"  {branch}", style=theme.STEEL)
+    toml_path = resolve_config_file(root_dir)
+    if toml_path.exists():
+        text.append(f"  {toml_path.name} ✓", style=theme.MUTED)
+    else:
+        text.append("  no kstrl.toml - run ks init", style=theme.WARNING)
+    return text
+
+
+class HomeScreen(Screen[None]):
+    BINDINGS = [
+        Binding("r", "refresh", "Refresh", show=False),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._refs: dict[str, RunRef] = {}
+
+    def compose(self) -> ComposeResult:
+        yield Static(id="home-masthead")
+        yield Static("runs", id="home-runs-title")
+        yield RunTable(id="home-runs")
+        yield Static("commands", id="home-commands-title")
+        yield OptionList(id="home-commands")
+        yield Footer()
+
+    @property
+    def ready(self) -> bool:
+        return next(iter(self.query(RunTable)), None) is not None
+
+    def on_mount(self) -> None:
+        root_dir = self._root_dir()
+        self.query_one("#home-masthead", Static).update(_masthead(
+            root_dir, _git_branch(root_dir), _project_name(root_dir),
+        ))
+        commands = self.query_one(OptionList)
+        for command in HOME_COMMANDS:
+            label = Text(command.title, style="bold")
+            label.append(f"  {command.description}", style=theme.MUTED)
+            commands.add_option(Option(label, id=command.command_id))
+        self.refresh_runs()
+        self.set_interval(HOME_POLL_INTERVAL, self.refresh_runs)
+
+    def _root_dir(self) -> Path:
+        return getattr(self.app, "root_dir", Path.cwd())
+
+    def refresh_runs(self) -> None:
+        if not self.ready:
+            return
+        refs = discover_runs(self._root_dir())[:HOME_RUN_LIMIT]
+        self._refs = {ref.run_id: ref for ref in refs}
+        self.query_one(RunTable).update_runs(refs)
+        title = Text("runs", style=f"bold {theme.MUTED}")
+        if not refs:
+            title.append("  none yet - run a command below",
+                         style=theme.MUTED)
+        self.query_one("#home-runs-title", Static).update(title)
+
+    def on_screen_resume(self) -> None:
+        # Whatever path popped back here, the observed run is done
+        # with: tear its context down and re-discover.
+        close_run = getattr(self.app, "close_run", None)
+        if close_run is not None:
+            close_run()
+        self.refresh_runs()
+
+    def action_refresh(self) -> None:
+        self.refresh_runs()
+
+    def on_data_table_row_selected(
+        self, event: DataTable.RowSelected,
+    ) -> None:
+        event.stop()
+        if event.row_key.value is None:
+            return
+        ref = self._refs.get(str(event.row_key.value))
+        if ref is None:
+            return
+        open_run = getattr(self.app, "open_run", None)
+        if open_run is not None:
+            open_run(ref)
+
+    def on_option_list_option_selected(
+        self, event: OptionList.OptionSelected,
+    ) -> None:
+        event.stop()
+        if event.option_id == "dash":
+            refs = list(self._refs.values())
+            if refs:
+                open_run = getattr(self.app, "open_run", None)
+                if open_run is not None:
+                    open_run(refs[0])
+            else:
+                self.app.notify("no runs yet", severity="warning")

--- a/kstrl/tui/styles.tcss
+++ b/kstrl/tui/styles.tcss
@@ -232,6 +232,34 @@ CheckpointModal {
     color: $warning;
 }
 
+/* ---- home shell ---------------------------------------------------------- */
+
+#home-masthead {
+    height: 1;
+    padding: 0 1;
+}
+
+#home-runs-title, #home-commands-title {
+    height: 2;
+    padding: 0 1;
+    color: $text-muted;
+    text-style: bold;
+    border-bottom: solid $panel;
+}
+
+#home-runs {
+    height: auto;
+    max-height: 45%;
+    background: $background;
+}
+
+#home-commands {
+    height: 1fr;
+    background: $background;
+    border: none;
+    padding: 0 1;
+}
+
 /* ---- decompose screen ---------------------------------------------------- */
 /* Same register as the component screen: strips are 1 line, panel
  * titles 2 (the border-bottom needs its own row), the transcript

--- a/kstrl/tui/widgets/run_table.py
+++ b/kstrl/tui/widgets/run_table.py
@@ -1,0 +1,76 @@
+"""Run browser table for the home shell (TUI surface D1).
+
+One row per discovered run, newest first, diff-updated like the
+component board (never clear()+rebuild). D1 renders what RunRef alone
+knows - kind, liveness, age; D2 joins the folded summaries (comps,
+tokens, cost) into the remaining columns, which render the honest
+dim dot until then.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.widgets import DataTable
+
+from kstrl.tui import theme
+
+if TYPE_CHECKING:
+    from kstrl.tui.runs import RunRef
+
+COLUMNS = ("", "run", "kind", "age")
+
+
+def _age(mtime: float, now: float) -> str:
+    seconds = max(0, int(now - mtime))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h{(seconds % 3600) // 60:02d}m"
+    return f"{seconds // 86400}d"
+
+
+def _status_cell(ref: RunRef) -> Text:
+    if ref.live:
+        return Text("●", style=f"bold {theme.ACCENT}")
+    if ref.completed:
+        return Text("✓", style=f"bold {theme.SUCCESS}")
+    return Text(theme.EMPTY_CELL, style=theme.MUTED)
+
+
+def _row_values(ref: RunRef, now: float) -> tuple[Text | str, ...]:
+    return (
+        _status_cell(ref),
+        Text(theme.short_run_id(ref.run_id), style="bold"),
+        Text(ref.kind or "run", style=theme.MUTED),
+        Text(_age(ref.mtime, now), style=theme.MUTED, justify="right"),
+    )
+
+
+class RunTable(DataTable[Text | str]):
+    def on_mount(self) -> None:
+        self.cursor_type = "row"
+        self.zebra_stripes = False
+        for column in COLUMNS:
+            self.add_column(column, key=column or "status")
+
+    def update_runs(self, refs: list[RunRef]) -> None:
+        now = time.time()
+        seen = set()
+        for ref in refs:
+            seen.add(ref.run_id)
+            values = _row_values(ref, now)
+            if ref.run_id in self.rows:
+                for key, value in zip(
+                    ("status", *COLUMNS[1:]), values, strict=True,
+                ):
+                    self.update_cell(ref.run_id, key, value)
+            else:
+                self.add_row(*values, key=ref.run_id)
+        stale = [k for k in self.rows if str(k.value) not in seen]
+        for row_key in stale:
+            self.remove_row(row_key)

--- a/kstrl/tui/widgets/run_table.py
+++ b/kstrl/tui/widgets/run_table.py
@@ -1,10 +1,10 @@
 """Run browser table for the home shell (TUI surface D1).
 
-One row per discovered run, newest first, diff-updated like the
-component board (never clear()+rebuild). D1 renders what RunRef alone
-knows - kind, liveness, age; D2 joins the folded summaries (comps,
-tokens, cost) into the remaining columns, which render the honest
-dim dot until then.
+One row per discovered run, newest first. Stable polls update cells in
+place; structural changes rebuild the row order while retaining the
+selected run. D1 renders what RunRef alone knows - kind, liveness, age;
+D2 joins the folded summaries (comps, tokens, cost) into the remaining
+columns, which render the honest dim dot until then.
 """
 
 from __future__ import annotations
@@ -60,9 +60,16 @@ class RunTable(DataTable[Text | str]):
 
     def update_runs(self, refs: list[RunRef]) -> None:
         now = time.time()
-        seen = set()
+        desired = [ref.run_id for ref in refs]
+        current = [str(key.value) for key in self.rows]
+        selected = (
+            current[self.cursor_row]
+            if 0 <= self.cursor_row < len(current) else None
+        )
+        order_changed = current != desired
+        if order_changed:
+            self.clear()
         for ref in refs:
-            seen.add(ref.run_id)
             values = _row_values(ref, now)
             if ref.run_id in self.rows:
                 for key, value in zip(
@@ -71,6 +78,5 @@ class RunTable(DataTable[Text | str]):
                     self.update_cell(ref.run_id, key, value)
             else:
                 self.add_row(*values, key=ref.run_id)
-        stale = [k for k in self.rows if str(k.value) not in seen]
-        for row_key in stale:
-            self.remove_row(row_key)
+        if order_changed and selected in desired:
+            self.move_cursor(row=desired.index(selected))

--- a/tests/test_home_shell.py
+++ b/tests/test_home_shell.py
@@ -63,6 +63,18 @@ class TestHomeScreen:
             )
             assert "kstrl.toml ✓" in masthead
 
+            # A run discovered after mount belongs at the top, while
+            # the currently selected run stays selected after reorder.
+            table.move_cursor(row=1)  # the older factory run
+            write_fake_run(
+                tmp_path,
+                run_id="factory-20260720-160000.000000-newest",
+            )
+            app.screen.refresh_runs()
+            keys = [str(k.value) for k in table.rows]
+            assert keys[0].endswith("newest")
+            assert table.cursor_row == 2
+
     async def test_missing_toml_warns_in_masthead(
         self, tmp_path: Path,
     ) -> None:

--- a/tests/test_home_shell.py
+++ b/tests/test_home_shell.py
@@ -1,0 +1,161 @@
+"""TUI surface D1: bare-`ks` contract, home shell, esc/q matrix."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from kstrl.cli import cli
+from kstrl.tui.app import KstrlTuiApp, Mode
+from kstrl.tui.screens.decompose import DecomposeScreen
+from kstrl.tui.screens.home import HomeScreen
+from kstrl.tui.screens.overview import OverviewScreen
+from tests.helpers.fake_run import (
+    FakeRunSpec,
+    write_fake_decompose_run,
+    write_fake_run,
+)
+
+
+class TestBareInvocation:
+    def test_non_tty_prints_help_and_exits_2(self) -> None:
+        """The pipe/CI contract: byte-identical to click's no-args
+        behavior from before the group callback existed."""
+        result = CliRunner().invoke(cli, [])
+        assert result.exit_code == 2
+        assert "Usage:" in result.output
+        assert "Commands:" in result.output
+
+    def test_kstrl_no_tui_suppresses_the_shell(self) -> None:
+        result = CliRunner().invoke(cli, [], env={"KSTRL_NO_TUI": "1"})
+        assert result.exit_code == 2
+        assert "Usage:" in result.output
+
+    def test_help_flag_unchanged(self) -> None:
+        result = CliRunner().invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "Usage:" in result.output
+
+
+def _home_app(root: Path) -> KstrlTuiApp:
+    return KstrlTuiApp(root_dir=root, mode=Mode.HOME, poll_interval=0.05)
+
+
+class TestHomeScreen:
+    async def test_renders_runs_and_identity(self, tmp_path: Path) -> None:
+        write_fake_run(
+            tmp_path, FakeRunSpec(components=1),
+            run_id="factory-20260718-100000.000000-old",
+        )
+        write_fake_decompose_run(tmp_path)
+        (tmp_path / "kstrl.toml").write_text("")
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            assert isinstance(app.screen, HomeScreen)
+            table = app.screen.query_one("#home-runs")
+            keys = [str(k.value) for k in table.rows]  # type: ignore[attr-defined]
+            assert keys[0].startswith("decompose-")  # newest first
+            assert len(keys) == 2
+            masthead = str(
+                app.screen.query_one("#home-masthead").renderable,
+            )
+            assert "kstrl.toml ✓" in masthead
+
+    async def test_missing_toml_warns_in_masthead(
+        self, tmp_path: Path,
+    ) -> None:
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            masthead = str(
+                app.screen.query_one("#home-masthead").renderable,
+            )
+            assert "run ks init" in masthead
+
+    async def test_enter_opens_run_with_kind_dispatch_and_escape_returns(
+        self, tmp_path: Path,
+    ) -> None:
+        write_fake_decompose_run(tmp_path)
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            await pilot.press("enter")
+            await pilot.pause(0.2)
+            assert isinstance(app.screen, DecomposeScreen)
+            assert app.run_context is not None
+            assert not app.run_context.owns_app_exit
+            # escape pops the decompose screen to the overview...
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, OverviewScreen)
+            # ...and again back to home, tearing the context down.
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, HomeScreen)
+            assert app.run_context is None
+
+    async def test_q_over_a_run_pops_home_not_exit(
+        self, tmp_path: Path,
+    ) -> None:
+        write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            await pilot.press("enter")
+            await pilot.pause(0.2)
+            assert isinstance(app.screen, OverviewScreen)
+            await pilot.press("q")
+            await pilot.pause()
+            assert isinstance(app.screen, HomeScreen)
+            assert app.return_value is None  # still running
+            await pilot.press("q")
+            await pilot.pause()
+        assert app.return_value == 0
+
+    async def test_dash_command_opens_newest_run(
+        self, tmp_path: Path,
+    ) -> None:
+        write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            commands = app.screen.query_one("#home-commands")
+            commands.focus()
+            await pilot.press("down")  # highlight the first entry
+            await pilot.press("enter")
+            await pilot.pause(0.2)
+            assert isinstance(app.screen, OverviewScreen)
+
+    async def test_empty_state_renders_guidance(
+        self, tmp_path: Path,
+    ) -> None:
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            title = str(
+                app.screen.query_one("#home-runs-title").renderable,
+            )
+            assert "none yet" in title
+
+
+class TestDashUnchanged:
+    async def test_standalone_dash_q_still_detaches(
+        self, tmp_path: Path,
+    ) -> None:
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = KstrlTuiApp(
+            run_dir=run_dir, root_dir=tmp_path, mode=Mode.DASH,
+            poll_interval=0.05,
+        )
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            assert isinstance(app.screen, OverviewScreen)
+            # escape on the base screen is a no-op in standalone dash.
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, OverviewScreen)
+            await pilot.press("q")
+            await pilot.pause()
+        assert app.return_value == 0


### PR DESCRIPTION
Stacks on #136. Opens Wave D: the `ks` home shell.

## What
- **Bare `ks` on a TTY opens the home shell** (user decision); non-TTY and `KSTRL_NO_TUI=1` remain byte-identical to click's no-args behavior (help on stdout, exit 2 - pinned by test). `--help`/`--version` untouched.
- **`tui/runcontext.py`**: the app's run-scoped flow (tailer, reducer store, transcript tailers, later channel/handle) extracted into `RunContext` with `owns_app_exit` semantics. `KstrlTuiApp` gains `Mode.HOME`, `open_run(ref)` (kind-dispatched stack over home), `close_run()` (fires from HomeScreen.on_screen_resume, so teardown is navigation-path-agnostic), and `store`/`run_dir` compat properties for the screens' duck-pull. The attribute is `run_context`, not `run` - `App.run()` is Textual's entry point and shadowing it would break every launch.
- **HomeScreen** (`screens/home.py`) + **RunTable** (`widgets/run_table.py`): masthead (project from manifest, git branch once at mount, kstrl.toml presence with a `run ks init` warning), run browser (glyph/short-id/kind/age, diff updates incl. stale-row removal, 2s poll, enter opens the run), command list (v1: dashboard; D3-D6 append config/evolve/init/launch entries).
- **esc/q matrix**: home q quits; q or escape above home pops toward it; standalone dash unchanged (escape no-op on the base board, q detaches). The stack floor accounts for Textual's hidden default screen - found by the dash regression test.

## Tested (new `tests/test_home_shell.py`)
- Bare-invocation contract: exit 2 + Usage under CliRunner, KSTRL_NO_TUI suppression, --help unchanged.
- Pilot: mixed-kind run browser order + identity, missing-toml warning, enter -> DecomposeScreen (kind dispatch) with a non-owning context -> escape x2 back home with context torn down, q-over-run pops home then q exits 0, launcher dash entry, empty-state guidance.
- Dash regression: standalone board escape no-op + q detach.
- All existing TUI suites green over the re-plumb (delegation proof). Fast tier 1839 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)