### PR TITLE
feat: home run summaries + quick stats (TUI surface D2)

### DIFF
--- a/kstrl/tui/home_data.py
+++ b/kstrl/tui/home_data.py
@@ -2,9 +2,10 @@
 
 Summarizing a run is a full reducer fold (file IO + fold), so the
 home screen computes these on a worker thread, renders honest "·"
-cells until they land, and caches by (run_id, events mtime) so only
-movers recompute. Numbers keep R3.1 semantics: whenever a run has
-unreported calls, its totals are LOWER BOUNDS and carry the "+".
+cells until they land, and caches by every folded stream's identity,
+mtime, and size so only movers recompute. Numbers keep R3.1 semantics:
+whenever a run has unreported calls, its totals are LOWER BOUNDS and
+carry the "+".
 """
 
 from __future__ import annotations
@@ -64,22 +65,60 @@ def summarize_run(ref: RunRef) -> RunSummary:
 
 
 class SummaryCache:
-    """(run_id, events mtime) -> RunSummary; recompute only movers."""
+    """Run-stream signature -> RunSummary; recompute only movers."""
 
     def __init__(self) -> None:
-        self._cache: dict[str, tuple[float, RunSummary]] = {}
+        self._cache: dict[
+            str,
+            tuple[tuple[tuple[str, int, int, int, int], ...], RunSummary],
+        ] = {}
 
     def refresh(self, refs: list[RunRef]) -> dict[str, RunSummary]:
         out: dict[str, RunSummary] = {}
+        active = {ref.run_id for ref in refs}
+        for stale in self._cache.keys() - active:
+            del self._cache[stale]
         for ref in refs:
+            signature = _run_stream_signature(ref)
             hit = self._cache.get(ref.run_id)
-            if hit is not None and hit[0] == ref.mtime:
+            if hit is not None and hit[0] == signature:
                 out[ref.run_id] = hit[1]
                 continue
             summary = summarize_run(ref)
-            self._cache[ref.run_id] = (ref.mtime, summary)
+            self._cache[ref.run_id] = (signature, summary)
             out[ref.run_id] = summary
         return out
+
+
+def _run_stream_signature(
+    ref: RunRef,
+) -> tuple[tuple[str, int, int, int, int], ...]:
+    """Identity for every stream consumed by ``read_run_dir``."""
+    paths = [ref.events_path]
+    components_dir = ref.run_dir / "components"
+    try:
+        component_dirs = sorted(components_dir.iterdir())
+    except OSError:
+        component_dirs = []
+    paths.extend(
+        component_dir / "engineer.jsonl"
+        for component_dir in component_dirs
+        if component_dir.is_dir()
+    )
+    signature: list[tuple[str, int, int, int, int]] = []
+    for path in paths:
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        signature.append((
+            str(path.relative_to(ref.run_dir)),
+            stat.st_dev,
+            stat.st_ino,
+            stat.st_mtime_ns,
+            stat.st_size,
+        ))
+    return tuple(signature)
 
 
 def pending_proposal_count(root_dir: Path) -> int:

--- a/kstrl/tui/home_data.py
+++ b/kstrl/tui/home_data.py
@@ -1,0 +1,100 @@
+"""Home shell data: run summaries + quick stats (TUI surface D2).
+
+Summarizing a run is a full reducer fold (file IO + fold), so the
+home screen computes these on a worker thread, renders honest "·"
+cells until they land, and caches by (run_id, events mtime) so only
+movers recompute. Numbers keep R3.1 semantics: whenever a run has
+unreported calls, its totals are LOWER BOUNDS and carry the "+".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from kstrl.proposals import list_proposals
+from kstrl.reducer import fold, read_run_dir
+from kstrl.tui.runs import RunRef
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    run_id: str
+    outcome: str  # live | done | failed | stale
+    components_done: int
+    components_failed: int
+    components_total: int
+    total_tokens: int
+    tokens_lower_bound: bool
+    cost_usd: float
+
+
+@dataclass(frozen=True)
+class HomeStats:
+    last: RunSummary | None
+    pending_proposals: int
+
+
+def summarize_run(ref: RunRef) -> RunSummary:
+    state = fold(read_run_dir(ref.run_dir))
+    done = sum(
+        1 for comp in state.components.values()
+        if comp.status == "completed"
+    )
+    failed = sum(
+        1 for comp in state.components.values() if comp.status == "failed"
+    )
+    total = len(state.plan_order) or len(state.components)
+    if ref.live:
+        outcome = "live"
+    elif state.finished:
+        outcome = "failed" if failed else "done"
+    else:
+        outcome = "stale"
+    return RunSummary(
+        run_id=ref.run_id,
+        outcome=outcome,
+        components_done=done,
+        components_failed=failed,
+        components_total=total,
+        total_tokens=state.total_tokens,
+        tokens_lower_bound=state.unreported_calls > 0,
+        cost_usd=state.cost_usd,
+    )
+
+
+class SummaryCache:
+    """(run_id, events mtime) -> RunSummary; recompute only movers."""
+
+    def __init__(self) -> None:
+        self._cache: dict[str, tuple[float, RunSummary]] = {}
+
+    def refresh(self, refs: list[RunRef]) -> dict[str, RunSummary]:
+        out: dict[str, RunSummary] = {}
+        for ref in refs:
+            hit = self._cache.get(ref.run_id)
+            if hit is not None and hit[0] == ref.mtime:
+                out[ref.run_id] = hit[1]
+                continue
+            summary = summarize_run(ref)
+            self._cache[ref.run_id] = (ref.mtime, summary)
+            out[ref.run_id] = summary
+        return out
+
+
+def pending_proposal_count(root_dir: Path) -> int:
+    proposals_dir = root_dir / ".kstrl" / "proposals"
+    return sum(
+        1 for proposal in list_proposals(proposals_dir)
+        if not proposal.applied
+    )
+
+
+def gather_stats(
+    root_dir: Path, summaries: dict[str, RunSummary],
+    newest_run_id: str,
+) -> HomeStats:
+    return HomeStats(
+        last=summaries.get(newest_run_id),
+        pending_proposals=pending_proposal_count(root_dir),
+    )

--- a/kstrl/tui/messages.py
+++ b/kstrl/tui/messages.py
@@ -8,6 +8,7 @@ from textual.message import Message
 
 if TYPE_CHECKING:
     from kstrl.reducer import RunState
+    from kstrl.tui.home_data import HomeStats, RunSummary
 
 
 class StateChanged(Message):
@@ -18,3 +19,14 @@ class StateChanged(Message):
     def __init__(self, state: RunState) -> None:
         super().__init__()
         self.state = state
+
+
+class SummariesReady(Message):
+    """The home worker finished folding run summaries (D2)."""
+
+    def __init__(
+        self, summaries: dict[str, RunSummary], stats: HomeStats,
+    ) -> None:
+        super().__init__()
+        self.summaries = summaries
+        self.stats = stats

--- a/kstrl/tui/screens/home.py
+++ b/kstrl/tui/screens/home.py
@@ -208,8 +208,7 @@ class HomeScreen(Screen[None]):
 
     def on_summaries_ready(self, message: SummariesReady) -> None:
         self._summarizing = False
-        if message.summaries:
-            self._summaries = message.summaries
+        self._summaries = message.summaries
         if self.ready:
             self.query_one(RunTable).update_runs(
                 list(self._refs.values()), self._summaries,

--- a/kstrl/tui/screens/home.py
+++ b/kstrl/tui/screens/home.py
@@ -23,7 +23,15 @@ from textual.widgets.option_list import Option
 
 from kstrl.config import resolve_config_file
 from kstrl.tui import theme
+from kstrl.tui.home_data import (
+    HomeStats,
+    RunSummary,
+    SummaryCache,
+    gather_stats,
+)
+from kstrl.tui.messages import SummariesReady
 from kstrl.tui.runs import RunRef, discover_runs
+from kstrl.tui.widgets.cost_meter import format_tokens
 from kstrl.tui.widgets.run_table import RunTable
 
 if TYPE_CHECKING:
@@ -88,6 +96,41 @@ def _masthead(root_dir: Path, branch: str, project: str) -> Text:
     return text
 
 
+def _stats_line(stats: HomeStats) -> Text:
+    text = Text()
+    last = stats.last
+    if last is None:
+        text.append("no finished runs yet", style=theme.MUTED)
+    else:
+        glyphs = {
+            "live": ("●", theme.ACCENT),
+            "done": ("✓", theme.SUCCESS),
+            "failed": ("✗", theme.ERROR),
+            "stale": (theme.EMPTY_CELL, theme.MUTED),
+        }
+        glyph, color = glyphs.get(last.outcome, (theme.EMPTY_CELL, theme.MUTED))
+        text.append("last run ", style=theme.MUTED)
+        text.append(f"{glyph} {last.outcome}", style=f"bold {color}")
+        text.append(
+            f" {last.components_done}/{last.components_total}",
+            style="bold",
+        )
+        marker = "+" if last.tokens_lower_bound else ""
+        if last.total_tokens:
+            text.append(" · ", style=theme.MUTED)
+            text.append(f"{format_tokens(last.total_tokens)}{marker} tok")
+        if last.cost_usd:
+            text.append(" · ", style=theme.MUTED)
+            text.append(f"${last.cost_usd:.2f}{marker}")
+    if stats.pending_proposals:
+        text.append("   ", style=theme.MUTED)
+        text.append(
+            f"▲ {stats.pending_proposals} proposal(s) pending",
+            style=theme.WARNING,
+        )
+    return text
+
+
 class HomeScreen(Screen[None]):
     BINDINGS = [
         Binding("r", "refresh", "Refresh", show=False),
@@ -96,9 +139,13 @@ class HomeScreen(Screen[None]):
     def __init__(self) -> None:
         super().__init__()
         self._refs: dict[str, RunRef] = {}
+        self._summaries: dict[str, RunSummary] = {}
+        self._cache = SummaryCache()
+        self._summarizing = False
 
     def compose(self) -> ComposeResult:
         yield Static(id="home-masthead")
+        yield Static(id="home-stats")
         yield Static("runs", id="home-runs-title")
         yield RunTable(id="home-runs")
         yield Static("commands", id="home-commands-title")
@@ -128,14 +175,48 @@ class HomeScreen(Screen[None]):
     def refresh_runs(self) -> None:
         if not self.ready:
             return
-        refs = discover_runs(self._root_dir())[:HOME_RUN_LIMIT]
+        root_dir = self._root_dir()
+        refs = discover_runs(root_dir)[:HOME_RUN_LIMIT]
         self._refs = {ref.run_id: ref for ref in refs}
-        self.query_one(RunTable).update_runs(refs)
+        self.query_one(RunTable).update_runs(refs, self._summaries)
         title = Text("runs", style=f"bold {theme.MUTED}")
         if not refs:
             title.append("  none yet - run a command below",
                          style=theme.MUTED)
         self.query_one("#home-runs-title", Static).update(title)
+        if not self._summarizing:
+            # Folding every listed run is file IO + reducer work: off
+            # the UI thread, with "·" cells until the message lands.
+            self._summarizing = True
+            self.run_worker(
+                lambda: self._compute_summaries(list(refs), root_dir),
+                thread=True,
+            )
+
+    def _compute_summaries(
+        self, refs: list[RunRef], root_dir: Path,
+    ) -> None:
+        try:
+            summaries = self._cache.refresh(refs)
+            stats = gather_stats(
+                root_dir, summaries,
+                refs[0].run_id if refs else "",
+            )
+        except Exception:  # noqa: BLE001 - a broken run dir must not kill home
+            summaries, stats = {}, HomeStats(None, 0)
+        self.post_message(SummariesReady(summaries, stats))
+
+    def on_summaries_ready(self, message: SummariesReady) -> None:
+        self._summarizing = False
+        if message.summaries:
+            self._summaries = message.summaries
+        if self.ready:
+            self.query_one(RunTable).update_runs(
+                list(self._refs.values()), self._summaries,
+            )
+            self.query_one("#home-stats", Static).update(
+                _stats_line(message.stats),
+            )
 
     def on_screen_resume(self) -> None:
         # Whatever path popped back here, the observed run is done

--- a/kstrl/tui/styles.tcss
+++ b/kstrl/tui/styles.tcss
@@ -239,6 +239,11 @@ CheckpointModal {
     padding: 0 1;
 }
 
+#home-stats {
+    height: 1;
+    padding: 0 1;
+}
+
 #home-runs-title, #home-commands-title {
     height: 2;
     padding: 0 1;

--- a/kstrl/tui/widgets/cost_meter.py
+++ b/kstrl/tui/widgets/cost_meter.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from kstrl.reducer import RunState
 
 
-def _format_tokens(tokens: int) -> str:
+def format_tokens(tokens: int) -> str:
     if tokens >= 1_000_000:
         return f"{tokens / 1_000_000:.2f}M"
     if tokens >= 1_000:
@@ -35,7 +35,7 @@ def render_cost_meter(state: RunState) -> Text:
     text = Text()
     marker = "+" if state.unreported_calls else ""
     text.append(
-        f"{_format_tokens(state.total_tokens)}{marker}", style="bold",
+        f"{format_tokens(state.total_tokens)}{marker}", style="bold",
     )
     text.append(" tok", style=theme.MUTED)
     text.append(" · ", style=theme.MUTED)

--- a/kstrl/tui/widgets/run_table.py
+++ b/kstrl/tui/widgets/run_table.py
@@ -1,10 +1,11 @@
-"""Run browser table for the home shell (TUI surface D1).
+"""Run browser table for the home shell (TUI surface D1/D2).
 
 One row per discovered run, newest first, diff-updated like the
-component board (never clear()+rebuild). D1 renders what RunRef alone
-knows - kind, liveness, age; D2 joins the folded summaries (comps,
-tokens, cost) into the remaining columns, which render the honest
-dim dot until then.
+component board (never clear()+rebuild). Ref-only columns (kind,
+liveness, age) render immediately; the folded summary columns (comps,
+tok, cost) render the honest dim dot until the D2 worker posts
+SummariesReady - and keep R3.1's "+" lower-bound marker whenever the
+run had unreported calls.
 """
 
 from __future__ import annotations
@@ -16,11 +17,13 @@ from rich.text import Text
 from textual.widgets import DataTable
 
 from kstrl.tui import theme
+from kstrl.tui.widgets.cost_meter import format_tokens
 
 if TYPE_CHECKING:
+    from kstrl.tui.home_data import RunSummary
     from kstrl.tui.runs import RunRef
 
-COLUMNS = ("", "run", "kind", "age")
+COLUMNS = ("", "run", "kind", "age", "comps", "tok", "cost")
 
 
 def _age(mtime: float, now: float) -> str:
@@ -34,20 +37,52 @@ def _age(mtime: float, now: float) -> str:
     return f"{seconds // 86400}d"
 
 
-def _status_cell(ref: RunRef) -> Text:
+def _dot() -> Text:
+    return Text(theme.EMPTY_CELL, style=theme.MUTED, justify="right")
+
+
+def _status_cell(ref: RunRef, summary: RunSummary | None) -> Text:
     if ref.live:
         return Text("●", style=f"bold {theme.ACCENT}")
+    if summary is not None and summary.outcome == "failed":
+        return Text("✗", style=f"bold {theme.ERROR}")
     if ref.completed:
         return Text("✓", style=f"bold {theme.SUCCESS}")
     return Text(theme.EMPTY_CELL, style=theme.MUTED)
 
 
-def _row_values(ref: RunRef, now: float) -> tuple[Text | str, ...]:
+def _summary_cells(summary: RunSummary | None) -> tuple[Text, Text, Text]:
+    if summary is None:
+        return _dot(), _dot(), _dot()
+    comps = Text(
+        f"{summary.components_done}/{summary.components_total}",
+        justify="right",
+        style=theme.ERROR if summary.components_failed else "",
+    )
+    if summary.components_failed:
+        comps.append(f" {summary.components_failed}✗", style=theme.ERROR)
+    marker = "+" if summary.tokens_lower_bound else ""
+    tok = (
+        Text(f"{format_tokens(summary.total_tokens)}{marker}",
+             justify="right")
+        if summary.total_tokens else _dot()
+    )
+    cost = (
+        Text(f"${summary.cost_usd:.2f}{marker}", justify="right")
+        if summary.cost_usd else _dot()
+    )
+    return comps, tok, cost
+
+
+def _row_values(
+    ref: RunRef, summary: RunSummary | None, now: float,
+) -> tuple[Text | str, ...]:
     return (
-        _status_cell(ref),
+        _status_cell(ref, summary),
         Text(theme.short_run_id(ref.run_id), style="bold"),
         Text(ref.kind or "run", style=theme.MUTED),
         Text(_age(ref.mtime, now), style=theme.MUTED, justify="right"),
+        *_summary_cells(summary),
     )
 
 
@@ -58,12 +93,17 @@ class RunTable(DataTable[Text | str]):
         for column in COLUMNS:
             self.add_column(column, key=column or "status")
 
-    def update_runs(self, refs: list[RunRef]) -> None:
+    def update_runs(
+        self,
+        refs: list[RunRef],
+        summaries: dict[str, RunSummary] | None = None,
+    ) -> None:
         now = time.time()
+        summaries = summaries or {}
         seen = set()
         for ref in refs:
             seen.add(ref.run_id)
-            values = _row_values(ref, now)
+            values = _row_values(ref, summaries.get(ref.run_id), now)
             if ref.run_id in self.rows:
                 for key, value in zip(
                     ("status", *COLUMNS[1:]), values, strict=True,

--- a/tests/test_home_data.py
+++ b/tests/test_home_data.py
@@ -8,10 +8,12 @@ from unittest.mock import patch
 
 from kstrl.tui.app import KstrlTuiApp, Mode
 from kstrl.tui.home_data import (
+    HomeStats,
     SummaryCache,
     pending_proposal_count,
     summarize_run,
 )
+from kstrl.tui.messages import SummariesReady
 from kstrl.tui.runs import discover_runs
 from tests.helpers.fake_run import (
     FakeRunSpec,
@@ -98,6 +100,25 @@ class TestSummaryCache:
             cache.refresh(moved)
         assert spy.call_count == 1
 
+    def test_moved_worker_stream_recomputes(self, tmp_path: Path) -> None:
+        write_fake_run(tmp_path, FakeRunSpec(components=1))
+        refs = discover_runs(tmp_path)
+        cache = SummaryCache()
+        cache.refresh(refs)
+        worker = next(
+            (refs[0].run_dir / "components").glob("*/engineer.jsonl"),
+        )
+        worker.write_text(worker.read_text() + "\n")
+        unchanged_orchestrator_mtime = refs[0].mtime
+        moved = discover_runs(tmp_path)
+        assert moved[0].mtime == unchanged_orchestrator_mtime
+        with patch(
+            "kstrl.tui.home_data.summarize_run",
+            wraps=summarize_run,
+        ) as spy:
+            cache.refresh(moved)
+        assert spy.call_count == 1
+
 
 class TestPendingProposals:
     def test_counts_unapplied_only(self, tmp_path: Path) -> None:
@@ -140,3 +161,10 @@ class TestHomeSummariesPilot:
             cells = " ".join(str(cell) for cell in row)
             assert "2/2" in cells
             assert "+" in cells  # lower-bound marker rides along
+
+            app.screen.on_summaries_ready(
+                SummariesReady({}, HomeStats(None, 0)),
+            )
+            assert app.screen._summaries == {}
+            row = table.get_row_at(0)  # type: ignore[attr-defined]
+            assert "2/2" not in " ".join(str(cell) for cell in row)

--- a/tests/test_home_data.py
+++ b/tests/test_home_data.py
@@ -1,0 +1,142 @@
+"""TUI surface D2: run summaries, cache, quick stats."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from kstrl.tui.app import KstrlTuiApp, Mode
+from kstrl.tui.home_data import (
+    SummaryCache,
+    pending_proposal_count,
+    summarize_run,
+)
+from kstrl.tui.runs import discover_runs
+from tests.helpers.fake_run import (
+    FakeRunSpec,
+    write_fake_decompose_run,
+    write_fake_run,
+    write_fake_understand_run,
+)
+
+CONVENTION_PROP = """# PROP-001: Pin versions
+**Type**: computational
+**Target**: claude_md
+
+> Pin them.
+"""
+
+
+class TestSummarizeRun:
+    def test_factory_run_with_lower_bound_marker(
+        self, tmp_path: Path,
+    ) -> None:
+        write_fake_run(
+            tmp_path, FakeRunSpec(components=2, include_unreported_usage=True),
+        )
+        ref = discover_runs(tmp_path)[0]
+        summary = summarize_run(ref)
+        assert summary.outcome == "done"
+        assert summary.components_done == 2
+        assert summary.components_total == 2
+        assert summary.tokens_lower_bound  # unreported calls -> "+"
+        assert summary.total_tokens > 0
+        assert summary.cost_usd > 0
+
+    def test_understand_and_halted_decompose(self, tmp_path: Path) -> None:
+        write_fake_understand_run(tmp_path)
+        write_fake_decompose_run(
+            tmp_path, blockers=1,
+            run_id="decompose-20260720-160000.000000-halt",
+        )
+        by_kind = {ref.kind: ref for ref in discover_runs(tmp_path)}
+        understand = summarize_run(by_kind["understand"])
+        assert understand.outcome == "done"
+        assert understand.components_done == 1
+        halted = summarize_run(by_kind["decompose"])
+        assert halted.outcome == "failed"
+        assert halted.components_failed == 1
+
+    def test_incomplete_stale_run(self, tmp_path: Path) -> None:
+        import os
+
+        write_fake_run(tmp_path, FakeRunSpec(components=1, complete=False))
+        ref = discover_runs(tmp_path)[0]
+        old = time.time() - 3600
+        os.utime(ref.events_path, (old, old))
+        ref = discover_runs(tmp_path)[0]
+        assert summarize_run(ref).outcome == "stale"
+
+
+class TestSummaryCache:
+    def test_unchanged_mtime_hits_cache(self, tmp_path: Path) -> None:
+        write_fake_run(tmp_path, FakeRunSpec(components=1))
+        refs = discover_runs(tmp_path)
+        cache = SummaryCache()
+        with patch(
+            "kstrl.tui.home_data.summarize_run",
+            wraps=summarize_run,
+        ) as spy:
+            cache.refresh(refs)
+            cache.refresh(refs)
+        assert spy.call_count == 1
+
+    def test_moved_mtime_recomputes(self, tmp_path: Path) -> None:
+        import os
+
+        write_fake_run(tmp_path, FakeRunSpec(components=1))
+        refs = discover_runs(tmp_path)
+        cache = SummaryCache()
+        cache.refresh(refs)
+        os.utime(refs[0].events_path, None)
+        moved = discover_runs(tmp_path)
+        with patch(
+            "kstrl.tui.home_data.summarize_run",
+            wraps=summarize_run,
+        ) as spy:
+            cache.refresh(moved)
+        assert spy.call_count == 1
+
+
+class TestPendingProposals:
+    def test_counts_unapplied_only(self, tmp_path: Path) -> None:
+        proposals_dir = tmp_path / ".kstrl" / "proposals"
+        proposals_dir.mkdir(parents=True)
+        (proposals_dir / "prop-001.md").write_text(CONVENTION_PROP)
+        (proposals_dir / "prop-002.md").write_text(
+            CONVENTION_PROP.replace("PROP-001", "PROP-002")
+            + "\n**Applied**: 2026-07-19T00:00:00Z\n",
+        )
+        assert pending_proposal_count(tmp_path) == 1
+        assert pending_proposal_count(tmp_path / "empty") == 0
+
+
+class TestHomeSummariesPilot:
+    async def test_cells_fill_after_the_worker_lands(
+        self, tmp_path: Path,
+    ) -> None:
+        write_fake_run(tmp_path, FakeRunSpec(components=2))
+        proposals_dir = tmp_path / ".kstrl" / "proposals"
+        proposals_dir.mkdir(parents=True)
+        (proposals_dir / "prop-001.md").write_text(CONVENTION_PROP)
+
+        app = KstrlTuiApp(root_dir=tmp_path, mode=Mode.HOME,
+                          poll_interval=0.05)
+        async with app.run_test(size=(130, 40)) as pilot:
+            deadline = time.monotonic() + 5
+            while True:
+                await pilot.pause(0.1)
+                stats = str(
+                    app.screen.query_one("#home-stats").renderable,
+                )
+                if "last run" in stats:
+                    break
+                assert time.monotonic() < deadline, "summaries never landed"
+            assert "✓ done 2/2" in stats
+            assert "proposal(s) pending" in stats
+            table = app.screen.query_one("#home-runs")
+            row = table.get_row_at(0)  # type: ignore[attr-defined]
+            cells = " ".join(str(cell) for cell in row)
+            assert "2/2" in cells
+            assert "+" in cells  # lower-bound marker rides along


### PR DESCRIPTION
Stacks on #137.

## What
- **`tui/home_data.py`**: `RunSummary` (outcome live/done/failed/stale, comps done/failed/total, tokens + `tokens_lower_bound`, cost) via full reducer fold; `SummaryCache` keyed `(run_id, events mtime)` - only movers recompute; `pending_proposal_count` reuses the B1 proposals engine.
- **HomeScreen**: summaries fold on a `run_worker(thread=True)` (bounded by the 15-run browser cap), cells render the honest "·" until `SummariesReady` posts back; one-line quick-stats strip (last run outcome/comps/tokens/cost with R3.1 "+" markers, pending proposals). A broken run dir degrades to empty summaries rather than killing the worker.
- **RunTable**: comps/tok/cost columns; failed runs carry `N✗` in error styling; `format_tokens` made public on the cost meter.

## Tested (new `tests/test_home_data.py`)
- `summarize_run`: factory fixture with unreported usage -> `+` flag; understand done; halted decompose failed; aged incomplete run -> stale.
- Cache: unchanged mtime = zero recomputes (spy), touched mtime recomputes.
- Proposal count: unapplied only; missing dir = 0.
- Pilot: dots -> values after the worker lands; stats strip shows `✓ done 2/2` + pending proposals; the "+" marker rides into the row cells.

Fast tier 1846 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)