### PR TITLE
feat: ConfigScreen over the precomputed report (TUI surface D3)

### DIFF
--- a/kstrl/tui/app.py
+++ b/kstrl/tui/app.py
@@ -81,9 +81,13 @@ class KstrlTuiApp(App[int]):
         channel: QueueInteractionChannel | None = None,
         orchestrator: OrchestratorHandle | None = None,
         screen_factory: ScreenStackFactory | None = None,
+        config_report: object | None = None,
     ) -> None:
         super().__init__()
         self.root_dir = root_dir
+        # Precomputed by run_home_shell BEFORE app.run() - the source
+        # detection scrubs os.environ process-wide (see config_report).
+        self.config_report = config_report
         self.mode = mode
         self.poll_interval = poll_interval
         self.channel = channel

--- a/kstrl/tui/home.py
+++ b/kstrl/tui/home.py
@@ -15,9 +15,20 @@ ANSI_RESTORE = "\x1b[?1049l\x1b[?25h\x1b[0m"
 
 
 def run_home_shell(root_dir: Path) -> int:
+    from kstrl.config_report import ConfigReport, build_config_report
     from kstrl.tui.app import KstrlTuiApp, Mode
 
-    app = KstrlTuiApp(root_dir=root_dir, mode=Mode.HOME)
+    # Computed BEFORE app.run(): source detection scrubs os.environ
+    # process-wide, which must never race a running session's thread.
+    config_report: ConfigReport | None
+    try:
+        config_report = build_config_report(root_dir)
+    except ValueError:
+        config_report = None  # the screen renders the guidance line
+
+    app = KstrlTuiApp(
+        root_dir=root_dir, mode=Mode.HOME, config_report=config_report,
+    )
     try:
         code = app.run()
     finally:

--- a/kstrl/tui/screens/config.py
+++ b/kstrl/tui/screens/config.py
@@ -93,7 +93,7 @@ class ConfigScreen(Screen[None]):
             table.add_row(
                 Text(row.section, style=theme.MUTED),
                 Text(row.key, style="bold"),
-                row.value,
+                Text(row.value),
                 Text(row.source, style=SOURCE_STYLES.get(row.source, "")),
                 key=f"{row.section}.{row.key}",
             )
@@ -144,7 +144,7 @@ class ConfigScreen(Screen[None]):
 
     def action_back_or_clear(self) -> None:
         filter_input = self.query_one(Input)
-        if filter_input.has_focus and filter_input.value:
+        if filter_input.value:
             filter_input.value = ""
             return
         self.app.pop_screen()
@@ -153,7 +153,8 @@ class ConfigScreen(Screen[None]):
         # The env-scrub is process-wide: never while a launched
         # session's thread could be reading os.environ.
         run_context = getattr(self.app, "run_context", None)
-        if run_context is not None and run_context.handle is not None:
+        handle = run_context.handle if run_context is not None else None
+        if handle is not None and not handle.done():
             self.app.notify(
                 "config refresh is disabled while a run is in flight "
                 "(source detection scrubs the environment)",

--- a/kstrl/tui/screens/config.py
+++ b/kstrl/tui/screens/config.py
@@ -1,0 +1,176 @@
+"""Config screen: the resolved-config report as a searchable table (D3).
+
+Renders the SAME dataset `ks config show` prints - built by
+kstrl.config_report - with source-colored cells and a toml-snippet
+hint for the cursor row.
+
+THREAD HAZARD (real, documented on config_report): source detection
+scrubs os.environ process-wide, so the report is computed BEFORE
+app.run() (run_home_shell) and re-computed only while no launched
+session is active. The dataset is static per compute, so the filter
+rebuilds the table wholesale - the never-clear+rebuild render rule is
+about LIVE diff updates starving input, which does not apply here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Input, Static
+
+from kstrl.tui import theme
+
+if TYPE_CHECKING:
+    from kstrl.config_report import ConfigReport
+
+SOURCE_STYLES = {
+    "flag": f"bold {theme.ACCENT}",
+    "env": theme.STEEL,
+    "toml": "",
+    "default": theme.MUTED,
+}
+
+COLUMNS = ("section", "key", "value", "source")
+
+
+class ConfigScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "back_or_clear", "Back"),
+        Binding("slash", "focus_filter", "Filter", key_display="/"),
+        Binding("r", "refresh", "Refresh", show=False),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="config-root"):
+            yield Input(placeholder="filter (key, section, source...)",
+                        id="config-filter")
+            yield Static("resolved config", id="config-title")
+            yield DataTable(id="config-table")
+            yield Static(id="config-hint")
+            yield Footer()
+
+    @property
+    def ready(self) -> bool:
+        return next(iter(self.query(DataTable)), None) is not None
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.cursor_type = "row"
+        table.zebra_stripes = False
+        for column in COLUMNS:
+            table.add_column(column, key=column)
+        self._render_report()
+
+    def _report(self) -> ConfigReport | None:
+        return getattr(self.app, "config_report", None)
+
+    def _render_report(self, needle: str = "") -> None:
+        if not self.ready:
+            return
+        table = self.query_one(DataTable)
+        table.clear()
+        report = self._report()
+        hint = self.query_one("#config-hint", Static)
+        if report is None:
+            hint.update(Text(
+                "config could not be resolved - run `ks config show` "
+                "for the error",
+                style=theme.WARNING,
+            ))
+            return
+        needle = needle.strip().lower()
+        shown = 0
+        for row in report.rows:
+            haystack = f"{row.section} {row.key} {row.value} {row.source}"
+            if needle and needle not in haystack.lower():
+                continue
+            shown += 1
+            table.add_row(
+                Text(row.section, style=theme.MUTED),
+                Text(row.key, style="bold"),
+                row.value,
+                Text(row.source, style=SOURCE_STYLES.get(row.source, "")),
+                key=f"{row.section}.{row.key}",
+            )
+        title = Text("resolved config", style=f"bold {theme.MUTED}")
+        title.append(
+            f"  {shown}/{len(report.rows)} value(s)", style=theme.MUTED,
+        )
+        self.query_one("#config-title", Static).update(title)
+        self._update_hint()
+
+    def _update_hint(self) -> None:
+        report = self._report()
+        hint = self.query_one("#config-hint", Static)
+        if report is None:
+            return
+        text = Text()
+        if report.toml_exists:
+            text.append(str(report.toml_path), style=theme.MUTED)
+        else:
+            text.append(
+                f"{report.toml_path} (absent - run ks init)",
+                style=theme.WARNING,
+            )
+        table = self.query_one(DataTable)
+        if table.row_count and table.cursor_row is not None:
+            try:
+                row_key = list(table.rows)[table.cursor_row]
+            except IndexError:
+                row_key = None
+            if row_key is not None:
+                section, _, key = str(row_key.value).partition(".")
+                text.append(
+                    f"   [{section}] {key} = ...", style=theme.STEEL,
+                )
+        hint.update(text)
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        self._render_report(event.value)
+
+    def on_data_table_row_highlighted(
+        self, event: DataTable.RowHighlighted,
+    ) -> None:
+        del event
+        self._update_hint()
+
+    def action_focus_filter(self) -> None:
+        self.query_one(Input).focus()
+
+    def action_back_or_clear(self) -> None:
+        filter_input = self.query_one(Input)
+        if filter_input.has_focus and filter_input.value:
+            filter_input.value = ""
+            return
+        self.app.pop_screen()
+
+    def action_refresh(self) -> None:
+        # The env-scrub is process-wide: never while a launched
+        # session's thread could be reading os.environ.
+        run_context = getattr(self.app, "run_context", None)
+        if run_context is not None and run_context.handle is not None:
+            self.app.notify(
+                "config refresh is disabled while a run is in flight "
+                "(source detection scrubs the environment)",
+                severity="warning",
+            )
+            return
+        from kstrl.config_report import build_config_report
+
+        root_dir = getattr(self.app, "root_dir", None)
+        if root_dir is None:
+            return
+        try:
+            self.app.config_report = (  # type: ignore[attr-defined]
+                build_config_report(root_dir)
+            )
+        except ValueError as exc:
+            self.app.notify(f"config failed to resolve: {exc}",
+                            severity="error")
+            return
+        self._render_report(self.query_one(Input).value)

--- a/kstrl/tui/screens/home.py
+++ b/kstrl/tui/screens/home.py
@@ -55,6 +55,10 @@ HOME_COMMANDS: list[HomeCommand] = [
         "dash", "dashboard",
         "open the newest run (enter on a row opens that run)",
     ),
+    HomeCommand(
+        "config", "config",
+        "resolved configuration with per-value sources",
+    ),
 ]
 
 
@@ -254,3 +258,7 @@ class HomeScreen(Screen[None]):
                     open_run(refs[0])
             else:
                 self.app.notify("no runs yet", severity="warning")
+        elif event.option_id == "config":
+            from kstrl.tui.screens.config import ConfigScreen
+
+            self.app.push_screen(ConfigScreen())

--- a/kstrl/tui/styles.tcss
+++ b/kstrl/tui/styles.tcss
@@ -265,6 +265,33 @@ CheckpointModal {
     padding: 0 1;
 }
 
+/* ---- config screen ------------------------------------------------------- */
+
+#config-filter {
+    height: 1;
+    border: none;
+    background: $surface;
+    padding: 0 1;
+}
+
+#config-title {
+    height: 2;
+    padding: 0 1;
+    color: $text-muted;
+    text-style: bold;
+    border-bottom: solid $panel;
+}
+
+#config-table {
+    height: 1fr;
+    background: $background;
+}
+
+#config-hint {
+    height: 1;
+    padding: 0 1;
+}
+
 /* ---- decompose screen ---------------------------------------------------- */
 /* Same register as the component screen: strips are 1 line, panel
  * titles 2 (the border-bottom needs its own row), the transcript

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -1,0 +1,131 @@
+"""TUI surface D3: the config screen over the precomputed report."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from kstrl.config_report import build_config_report
+from kstrl.tui.app import KstrlTuiApp, Mode
+from kstrl.tui.runcontext import RunContext
+from kstrl.tui.screens.config import ConfigScreen
+from kstrl.tui.screens.home import HomeScreen
+
+
+def _app(tmp_path: Path, report: Any) -> KstrlTuiApp:
+    return KstrlTuiApp(
+        root_dir=tmp_path, mode=Mode.HOME, poll_interval=0.05,
+        config_report=report,
+    )
+
+
+@pytest.fixture
+def report(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Any:
+    (tmp_path / "kstrl.toml").write_text(
+        "[run]\nmax_iterations = 42\n",
+    )
+    monkeypatch.setenv("SLEEP_SECONDS", "9")
+    return build_config_report(tmp_path)
+
+
+class TestConfigScreen:
+    async def test_rows_sources_and_hint(
+        self, tmp_path: Path, report: Any,
+    ) -> None:
+        app = _app(tmp_path, report)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(ConfigScreen())
+            await pilot.pause(0.2)
+            screen = cast(ConfigScreen, app.screen)
+            table = screen.query_one("#config-table")
+            assert table.row_count == len(report.rows)  # type: ignore[attr-defined]
+            title = str(screen.query_one("#config-title").renderable)
+            assert f"{len(report.rows)}/{len(report.rows)}" in title
+            hint = str(screen.query_one("#config-hint").renderable)
+            assert "kstrl.toml" in hint
+
+    async def test_filter_narrows_and_escape_clears_then_pops(
+        self, tmp_path: Path, report: Any,
+    ) -> None:
+        app = _app(tmp_path, report)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(ConfigScreen())
+            await pilot.pause(0.2)
+            screen = cast(ConfigScreen, app.screen)
+            await pilot.press("slash")
+            from textual.widgets import Input
+
+            filter_input = screen.query_one(Input)
+            assert filter_input.has_focus  # "/" focused it
+            filter_input.value = "max_iterations"
+            await pilot.pause()
+            table = screen.query_one("#config-table")
+            assert table.row_count == 1  # type: ignore[attr-defined]
+            # escape with a filter clears it first...
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfigScreen)
+            assert table.row_count == len(report.rows)  # type: ignore[attr-defined]
+            # ...and out of the input, escape pops the screen.
+            screen.query_one("#config-table").focus()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, HomeScreen)
+
+    async def test_refresh_refused_while_a_session_is_active(
+        self, tmp_path: Path, report: Any,
+    ) -> None:
+        app = _app(tmp_path, report)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            # Fake an in-flight launched session: a context with a
+            # not-done handle.
+            run_dir = tmp_path / ".kstrl" / "runs" / "factory-x"
+            run_dir.mkdir(parents=True)
+
+            class FakeHandle:
+                def done(self) -> bool:
+                    return False
+
+            context = RunContext.observe(
+                run_dir, tmp_path, owns_app_exit=False,
+            )
+            context.handle = cast(Any, FakeHandle())
+            app.run_context = context
+            app.push_screen(ConfigScreen())
+            await pilot.pause(0.2)
+            before = app.config_report
+            await pilot.press("r")
+            await pilot.pause()
+            assert app.config_report is before  # refused, not recomputed
+
+    async def test_missing_report_renders_guidance(
+        self, tmp_path: Path,
+    ) -> None:
+        app = _app(tmp_path, None)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(ConfigScreen())
+            await pilot.pause(0.2)
+            hint = str(app.screen.query_one("#config-hint").renderable)
+            assert "could not be resolved" in hint
+
+    async def test_launcher_entry_opens_the_screen(
+        self, tmp_path: Path, report: Any,
+    ) -> None:
+        app = _app(tmp_path, report)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            commands = app.screen.query_one("#home-commands")
+            commands.focus()
+            deadline = time.monotonic() + 3
+            while not isinstance(app.screen, ConfigScreen):
+                await pilot.press("down")
+                await pilot.press("enter")
+                await pilot.pause(0.1)
+                assert time.monotonic() < deadline, "config never opened"

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 import time
 from pathlib import Path
 from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
+from rich.text import Text
+from textual.coordinate import Coordinate
 
-from kstrl.config_report import build_config_report
+from kstrl.config_report import (
+    ConfigReport,
+    ConfigRow,
+    build_config_report,
+)
 from kstrl.tui.app import KstrlTuiApp, Mode
 from kstrl.tui.runcontext import RunContext
 from kstrl.tui.screens.config import ConfigScreen
@@ -48,6 +55,25 @@ class TestConfigScreen:
             hint = str(screen.query_one("#config-hint").renderable)
             assert "kstrl.toml" in hint
 
+    async def test_values_render_as_literal_text(
+        self, tmp_path: Path,
+    ) -> None:
+        report = ConfigReport(
+            root_dir=tmp_path,
+            toml_path=tmp_path / "kstrl.toml",
+            toml_exists=False,
+            rows=(ConfigRow("run", "value", "[/bold]", "env"),),
+        )
+        app = _app(tmp_path, report)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(ConfigScreen())
+            await pilot.pause(0.2)
+            table = app.screen.query_one("#config-table")
+            value = table.get_cell_at(Coordinate(0, 2))
+            assert isinstance(value, Text)
+            assert value.plain == "[/bold]"
+
     async def test_filter_narrows_and_escape_clears_then_pops(
         self, tmp_path: Path, report: Any,
     ) -> None:
@@ -66,13 +92,14 @@ class TestConfigScreen:
             await pilot.pause()
             table = screen.query_one("#config-table")
             assert table.row_count == 1  # type: ignore[attr-defined]
-            # escape with a filter clears it first...
+            # Escape clears an active filter even after focus moved
+            # into the results table.
+            table.focus()  # type: ignore[attr-defined]
             await pilot.press("escape")
             await pilot.pause()
             assert isinstance(app.screen, ConfigScreen)
             assert table.row_count == len(report.rows)  # type: ignore[attr-defined]
-            # ...and out of the input, escape pops the screen.
-            screen.query_one("#config-table").focus()
+            # The next escape pops the screen.
             await pilot.press("escape")
             await pilot.pause()
             assert isinstance(app.screen, HomeScreen)
@@ -89,20 +116,38 @@ class TestConfigScreen:
             run_dir.mkdir(parents=True)
 
             class FakeHandle:
+                finished = False
+
                 def done(self) -> bool:
-                    return False
+                    return self.finished
 
             context = RunContext.observe(
                 run_dir, tmp_path, owns_app_exit=False,
             )
-            context.handle = cast(Any, FakeHandle())
+            handle = FakeHandle()
+            context.handle = cast(Any, handle)
             app.run_context = context
             app.push_screen(ConfigScreen())
             await pilot.pause(0.2)
+            screen = cast(ConfigScreen, app.screen)
             before = app.config_report
-            await pilot.press("r")
+            screen.action_refresh()
             await pilot.pause()
             assert app.config_report is before  # refused, not recomputed
+
+            # A finished handle no longer has a thread reading the
+            # environment, so refresh is safe again.
+            handle.finished = True
+            refreshed = build_config_report(tmp_path)
+
+            with patch(
+                "kstrl.config_report.build_config_report",
+                return_value=refreshed,
+            ) as build:
+                screen.action_refresh()
+                await pilot.pause()
+            build.assert_called_once_with(tmp_path)
+            assert app.config_report is refreshed
 
     async def test_missing_report_renders_guidance(
         self, tmp_path: Path,


### PR DESCRIPTION
Stacks on #138.

## What
- **`tui/screens/config.py`**: the `ks config show` dataset (B1's `build_config_report`) as a searchable table - source-styled cells (`flag`=accent, `env`=steel, `toml`=plain, `default`=muted), shown/total count in the panel title, footer hint with the toml path (or the `run ks init` warning) plus a `[section] key` snippet for the cursor row. `/` focuses the filter, escape clears-then-pops. The dataset is static per compute, so the filter rebuilds wholesale - documented as exempt from the live-diff render rule.
- **Thread-hazard handling** (the real one found in B1): the report is computed in `run_home_shell` BEFORE `app.run()`; the `r` refresh checks for an in-flight launched session (context handle) and refuses with an explanation rather than scrubbing `os.environ` under a live thread. A `ValueError` from the loaders degrades to a guidance line.
- Home launcher gains the `config` entry.

## Tested (new `tests/test_config_screen.py`)
- Row count == report rows, title count, toml-path hint.
- Filter narrows to 1 row; escape clears the filter first, then pops to home.
- Refresh refused (report object unchanged) while a fake in-flight session handle is attached.
- Missing report renders the guidance line.
- Launcher entry opens the screen.

Fast tier 1851 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)