### PR TITLE
feat: EvolveScreen - proposals, patterns, trends (TUI surface D4)

### DIFF
--- a/kstrl/tui/screens/evolve.py
+++ b/kstrl/tui/screens/evolve.py
@@ -1,0 +1,283 @@
+"""Evolve screen: proposals, failure patterns, experiment trends (D4).
+
+Three tabs over the evolution layer's on-disk records:
+- proposals: master-detail over .kstrl/proposals/prop-*.md with the
+  REAL apply path (B1's engine). `a` opens the confirm modal; the
+  modal IS the confirmation, so apply_proposal runs with an
+  always-yes seam. Non-convention proposals keep the honest manual
+  message - no false "applied" claims (R6.3).
+- patterns: get_cross_run_patterns over the journal.
+- trends: the last experiments.tsv rows with retry-rate bars and
+  R3.1 lower-bound markers on token/cost cells.
+
+Propose-from-TUI is deliberately absent in v1: `ks evolve` remains
+the generator; this screen reads, triages, and applies.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Static, TabbedContent, TabPane
+
+from kstrl.evolution import EvolutionConfig, EvolutionJournal
+from kstrl.interaction import PromptKind, PromptRequest
+from kstrl.proposals import Proposal, apply_proposal, list_proposals
+from kstrl.tui import theme
+from kstrl.tui.screens.options import OptionsModal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+TREND_ROWS = 14
+_BAR_BLOCKS = "▁▂▃▄▅▆▇"
+
+
+def retry_bar(rate: float) -> str:
+    """A one-cell bar for a 0..1 retry rate; empty stays empty."""
+    if rate <= 0:
+        return theme.EMPTY_CELL
+    index = min(len(_BAR_BLOCKS) - 1, int(rate * len(_BAR_BLOCKS)))
+    return _BAR_BLOCKS[index]
+
+
+def _proposal_detail(proposal: Proposal) -> Text:
+    text = Text()
+    text.append(f"{proposal.display_id} ", style=f"bold {theme.ACCENT}")
+    text.append(proposal.title, style="bold")
+    text.append(f"\n{proposal.path}", style=theme.MUTED)
+    text.append("\ntype ", style=theme.MUTED)
+    text.append(proposal.type or "?")
+    text.append("  target ", style=theme.MUTED)
+    text.append(proposal.target or "?")
+    if proposal.convention:
+        text.append("\n\nsuggested change\n", style=f"bold {theme.ACCENT}")
+        text.append(proposal.convention)
+    if proposal.applied:
+        text.append(f"\n\n✓ applied {proposal.applied}",
+                    style=f"bold {theme.SUCCESS}")
+    elif proposal.is_convention:
+        text.append("\n\n(a) apply - appends to CLAUDE.md Agent Learnings",
+                    style=theme.MUTED)
+    else:
+        text.append(
+            "\n\nautomated apply only covers convention-type proposals "
+            "(target claude_md); review the file and apply manually",
+            style=theme.WARNING,
+        )
+    return text
+
+
+class EvolveScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "app.pop_screen", "Back"),
+        Binding("a", "apply_selected", "Apply"),
+        Binding("r", "reload", "Reload", show=False),
+    ]
+
+    PROPOSAL_COLUMNS = ("id", "title", "type", "target", "applied")
+    PATTERN_COLUMNS = ("check", "code", "runs", "components", "category")
+    TREND_COLUMNS = ("run", "done", "failed", "retry", "tok", "cost")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._proposals: list[Proposal] = []
+
+    def compose(self) -> ComposeResult:
+        with TabbedContent(id="evolve-tabs"):
+            with TabPane("proposals", id="tab-proposals"):
+                with Horizontal(id="proposals-split"):
+                    yield DataTable(id="proposals-table")
+                    yield Static(id="proposal-detail")
+            with TabPane("patterns", id="tab-patterns"):
+                yield DataTable(id="patterns-table")
+            with TabPane("trends", id="tab-trends"):
+                yield DataTable(id="trends-table")
+        yield Footer()
+
+    @property
+    def ready(self) -> bool:
+        return next(iter(self.query(TabbedContent)), None) is not None
+
+    def on_mount(self) -> None:
+        for table_id, columns in (
+            ("#proposals-table", self.PROPOSAL_COLUMNS),
+            ("#patterns-table", self.PATTERN_COLUMNS),
+            ("#trends-table", self.TREND_COLUMNS),
+        ):
+            table = self.query_one(table_id, DataTable)
+            table.cursor_type = "row"
+            table.zebra_stripes = False
+            for column in columns:
+                table.add_column(column, key=column)
+        self.reload()
+
+    def _root_dir(self) -> Path:
+        from pathlib import Path as _Path
+
+        root = getattr(self.app, "root_dir", None)
+        return root if root is not None else _Path.cwd()
+
+    def reload(self) -> None:
+        root_dir = self._root_dir()
+        self._load_proposals(root_dir)
+        self._load_patterns_and_trends(root_dir)
+
+    def _load_proposals(self, root_dir: Path) -> None:
+        self._proposals = list_proposals(root_dir / ".kstrl" / "proposals")
+        table = self.query_one("#proposals-table", DataTable)
+        table.clear()
+        for proposal in self._proposals:
+            applied = (
+                Text("✓", style=f"bold {theme.SUCCESS}")
+                if proposal.applied
+                else Text(theme.EMPTY_CELL, style=theme.MUTED)
+            )
+            table.add_row(
+                Text(proposal.display_id, style="bold"),
+                proposal.title,
+                proposal.type or Text(theme.EMPTY_CELL, style=theme.MUTED),
+                proposal.target or Text(theme.EMPTY_CELL, style=theme.MUTED),
+                applied,
+                key=proposal.path.name,
+            )
+        detail = self.query_one("#proposal-detail", Static)
+        if self._proposals:
+            self._show_detail(0)
+        else:
+            detail.update(Text(
+                "no proposals yet - run `ks evolve` after a few factory "
+                "runs to generate them",
+                style=theme.MUTED,
+            ))
+
+    def _load_patterns_and_trends(self, root_dir: Path) -> None:
+        journal = EvolutionJournal(EvolutionConfig.load(root_dir))
+        patterns_table = self.query_one("#patterns-table", DataTable)
+        patterns_table.clear()
+        for pattern in journal.get_cross_run_patterns():
+            patterns_table.add_row(
+                Text(pattern.check_name, style="bold"),
+                pattern.error_signature,
+                Text(str(pattern.frequency), justify="right"),
+                Text(str(len(pattern.affected_components)), justify="right"),
+                Text(pattern.category, style=theme.MUTED),
+            )
+        trends_table = self.query_one("#trends-table", DataTable)
+        trends_table.clear()
+        for row in journal.get_experiment_trends(last_n=TREND_ROWS):
+            trends_table.add_row(*self._trend_cells(row))
+
+    @staticmethod
+    def _trend_cells(row: dict[str, Any]) -> tuple[Text | str, ...]:
+        def _num(key: str) -> Text:
+            value = str(row.get(key, "") or "")
+            if not value:
+                return Text(theme.EMPTY_CELL, style=theme.MUTED,
+                            justify="right")
+            return Text(value, justify="right")
+
+        run_id = str(row.get("run_id", ""))
+        short = run_id.rsplit("-", 1)[-1] if run_id else theme.EMPTY_CELL
+        try:
+            rate = float(row.get("retry_rate", "") or 0)
+        except ValueError:
+            rate = 0.0
+        # Unreported calls make token/cost totals lower bounds (R3.1).
+        try:
+            unreported = int(float(row.get("unreported_calls", "") or 0))
+        except ValueError:
+            unreported = 0
+        marker = "+" if unreported else ""
+        tokens = str(row.get("total_tokens", "") or "")
+        cost = str(row.get("total_cost_usd", "") or "")
+        return (
+            Text(short, style="bold"),
+            _num("completed"),
+            _num("failed"),
+            Text(f"{retry_bar(rate)} {rate:.2f}" if rate else theme.EMPTY_CELL,
+                 justify="right"),
+            Text(f"{tokens}{marker}", justify="right") if tokens
+            else Text(theme.EMPTY_CELL, style=theme.MUTED, justify="right"),
+            Text(f"${cost}{marker}", justify="right") if cost
+            else Text(theme.EMPTY_CELL, style=theme.MUTED, justify="right"),
+        )
+
+    # -- proposals master-detail + apply ------------------------------------
+
+    def _selected_proposal(self) -> Proposal | None:
+        table = self.query_one("#proposals-table", DataTable)
+        if not table.row_count or table.cursor_row is None:
+            return None
+        index = table.cursor_row
+        if 0 <= index < len(self._proposals):
+            return self._proposals[index]
+        return None
+
+    def _show_detail(self, index: int) -> None:
+        if 0 <= index < len(self._proposals):
+            self.query_one("#proposal-detail", Static).update(
+                _proposal_detail(self._proposals[index]),
+            )
+
+    def on_data_table_row_highlighted(
+        self, event: DataTable.RowHighlighted,
+    ) -> None:
+        if event.data_table.id != "proposals-table":
+            return
+        if event.cursor_row is not None and event.cursor_row >= 0:
+            self._show_detail(event.cursor_row)
+
+    def action_reload(self) -> None:
+        self.reload()
+
+    def action_apply_selected(self) -> None:
+        proposal = self._selected_proposal()
+        if proposal is None:
+            return
+        if proposal.applied:
+            self.app.notify(
+                f"{proposal.display_id} already applied at "
+                f"{proposal.applied}",
+            )
+            return
+        if not proposal.is_convention:
+            self.app.notify(
+                "automated apply only covers convention-type proposals "
+                f"(target claude_md); review {proposal.path} and apply "
+                "manually",
+                severity="warning",
+            )
+            return
+
+        def _resolved(choice: int | None) -> None:
+            if choice != 0:
+                return
+            # The modal WAS the confirmation.
+            outcome = apply_proposal(
+                proposal, self._root_dir(), confirm=lambda _: True,
+            )
+            self.app.notify(
+                outcome.message,
+                severity="information" if outcome.status == "applied"
+                else "error",
+            )
+            self._load_proposals(self._root_dir())
+
+        self.app.push_screen(
+            OptionsModal(PromptRequest(
+                kind=PromptKind.CONFIRM,
+                header=(
+                    f"{proposal.display_id}: append this convention to "
+                    f"CLAUDE.md Agent Learnings?  \"{proposal.convention}\""
+                ),
+                options=("Apply", "Cancel"),
+                default=1,
+            )),
+            _resolved,
+        )

--- a/kstrl/tui/screens/evolve.py
+++ b/kstrl/tui/screens/evolve.py
@@ -16,6 +16,7 @@ the generator; this screen reads, triages, and applies.
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, Any
 
 from rich.text import Text
@@ -40,7 +41,7 @@ _BAR_BLOCKS = "▁▂▃▄▅▆▇"
 
 def retry_bar(rate: float) -> str:
     """A one-cell bar for a 0..1 retry rate; empty stays empty."""
-    if rate <= 0:
+    if not math.isfinite(rate) or rate <= 0:
         return theme.EMPTY_CELL
     index = min(len(_BAR_BLOCKS) - 1, int(rate * len(_BAR_BLOCKS)))
     return _BAR_BLOCKS[index]
@@ -140,9 +141,11 @@ class EvolveScreen(Screen[None]):
             )
             table.add_row(
                 Text(proposal.display_id, style="bold"),
-                proposal.title,
-                proposal.type or Text(theme.EMPTY_CELL, style=theme.MUTED),
-                proposal.target or Text(theme.EMPTY_CELL, style=theme.MUTED),
+                Text(proposal.title),
+                Text(proposal.type) if proposal.type
+                else Text(theme.EMPTY_CELL, style=theme.MUTED),
+                Text(proposal.target) if proposal.target
+                else Text(theme.EMPTY_CELL, style=theme.MUTED),
                 applied,
                 key=proposal.path.name,
             )
@@ -163,7 +166,7 @@ class EvolveScreen(Screen[None]):
         for pattern in journal.get_cross_run_patterns():
             patterns_table.add_row(
                 Text(pattern.check_name, style="bold"),
-                pattern.error_signature,
+                Text(pattern.error_signature),
                 Text(str(pattern.frequency), justify="right"),
                 Text(str(len(pattern.affected_components)), justify="right"),
                 Text(pattern.category, style=theme.MUTED),
@@ -188,10 +191,12 @@ class EvolveScreen(Screen[None]):
             rate = float(row.get("retry_rate", "") or 0)
         except ValueError:
             rate = 0.0
+        if not math.isfinite(rate):
+            rate = 0.0
         # Unreported calls make token/cost totals lower bounds (R3.1).
         try:
             unreported = int(float(row.get("unreported_calls", "") or 0))
-        except ValueError:
+        except (OverflowError, ValueError):
             unreported = 0
         marker = "+" if unreported else ""
         tokens = str(row.get("total_tokens", "") or "")
@@ -237,6 +242,8 @@ class EvolveScreen(Screen[None]):
         self.reload()
 
     def action_apply_selected(self) -> None:
+        if self.query_one(TabbedContent).active != "tab-proposals":
+            return
         proposal = self._selected_proposal()
         if proposal is None:
             return

--- a/kstrl/tui/screens/home.py
+++ b/kstrl/tui/screens/home.py
@@ -59,6 +59,10 @@ HOME_COMMANDS: list[HomeCommand] = [
         "config", "config",
         "resolved configuration with per-value sources",
     ),
+    HomeCommand(
+        "evolve", "evolve",
+        "harness proposals, failure patterns, experiment trends",
+    ),
 ]
 
 
@@ -262,3 +266,7 @@ class HomeScreen(Screen[None]):
             from kstrl.tui.screens.config import ConfigScreen
 
             self.app.push_screen(ConfigScreen())
+        elif event.option_id == "evolve":
+            from kstrl.tui.screens.evolve import EvolveScreen
+
+            self.app.push_screen(EvolveScreen())

--- a/kstrl/tui/screens/options.py
+++ b/kstrl/tui/screens/options.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from rich.text import Text
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
@@ -47,12 +48,13 @@ class OptionsModal(ModalScreen[int | None]):
         dialog = Vertical(id="options-dialog")
         dialog.border_title = self.request.kind.value
         with dialog:
-            yield Label(self.request.header, id="options-question")
+            yield Label(Text(self.request.header), id="options-question")
             with Horizontal(id="options-buttons"):
                 for index, option in enumerate(self.request.options):
                     label = option.split(" (")[0]
                     button = Button(
-                        f"{label} ({index + 1})", id=f"choice-{index}",
+                        Text(f"{label} ({index + 1})"),
+                        id=f"choice-{index}",
                     )
                     if index == self.request.default:
                         button.add_class("default-choice")

--- a/kstrl/tui/styles.tcss
+++ b/kstrl/tui/styles.tcss
@@ -292,6 +292,32 @@ CheckpointModal {
     padding: 0 1;
 }
 
+/* ---- evolve screen ------------------------------------------------------- */
+
+#evolve-tabs {
+    height: 1fr;
+}
+
+#proposals-split {
+    height: 1fr;
+}
+
+#proposals-table {
+    width: 55%;
+    background: $background;
+}
+
+#proposal-detail {
+    width: 1fr;
+    padding: 1 2;
+    background: $surface;
+}
+
+#patterns-table, #trends-table {
+    height: 1fr;
+    background: $background;
+}
+
 /* ---- decompose screen ---------------------------------------------------- */
 /* Same register as the component screen: strips are 1 line, panel
  * titles 2 (the border-bottom needs its own row), the transcript

--- a/tests/test_evolve_screen.py
+++ b/tests/test_evolve_screen.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 from typing import cast
+
+from rich.text import Text
+from textual.coordinate import Coordinate
+from textual.widgets import TabbedContent
 
 from kstrl.tui import theme
 from kstrl.tui.app import KstrlTuiApp, Mode
@@ -82,6 +87,8 @@ class TestRetryBar:
         assert retry_bar(0) == theme.EMPTY_CELL
         assert retry_bar(0.5) in "▃▄▅"
         assert retry_bar(1.0) == "▇"
+        assert retry_bar(math.nan) == theme.EMPTY_CELL
+        assert retry_bar(math.inf) == theme.EMPTY_CELL
 
 
 class TestEvolveScreen:
@@ -105,6 +112,47 @@ class TestEvolveScreen:
             second = trends.get_row_at(1)  # type: ignore[attr-defined]
             second_cells = [str(cell) for cell in second]
             assert theme.EMPTY_CELL in second_cells  # empty tokens honest
+
+            # Non-finite data is invalid, but must degrade to an empty
+            # cell rather than crashing the whole screen.
+            cells = screen._trend_cells({
+                "retry_rate": "nan", "unreported_calls": "inf",
+            })
+            assert str(cells[3]) == theme.EMPTY_CELL
+
+    async def test_repository_text_is_literal_and_apply_is_tab_scoped(
+        self, tmp_path: Path,
+    ) -> None:
+        _seed(tmp_path)
+        proposal_path = tmp_path / ".kstrl" / "proposals" / "prop-001.md"
+        proposal_path.write_text(
+            proposal_path.read_text()
+            .replace("Always pin versions", "[/bold]")
+            .replace("Pin every dependency", "[/bold] every dependency"),
+        )
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            screen = await _open(app, pilot)
+            table = screen.query_one("#proposals-table")
+            title = table.get_cell_at(Coordinate(0, 1))  # type: ignore[attr-defined]
+            assert isinstance(title, Text)
+            assert title.plain == "[/bold]"
+
+            tabs = screen.query_one(TabbedContent)
+            tabs.active = "tab-patterns"
+            screen.action_apply_selected()
+            await pilot.pause()
+            assert isinstance(app.screen, EvolveScreen)
+
+            tabs.active = "tab-proposals"
+            screen.action_apply_selected()
+            await pilot.pause()
+            assert isinstance(app.screen, OptionsModal)
+            question = app.screen.query_one("#options-question")
+            assert isinstance(question.renderable, Text)
+            assert "[/bold]" in question.renderable.plain
+            await pilot.press("escape")
 
     async def test_apply_via_modal_mutates_and_stamps(
         self, tmp_path: Path,

--- a/tests/test_evolve_screen.py
+++ b/tests/test_evolve_screen.py
@@ -1,0 +1,176 @@
+"""TUI surface D4: the evolve screen - proposals, patterns, trends."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+from kstrl.tui import theme
+from kstrl.tui.app import KstrlTuiApp, Mode
+from kstrl.tui.screens.evolve import EvolveScreen, retry_bar
+from kstrl.tui.screens.options import OptionsModal
+
+CONVENTION_PROP = """# PROP-001: Always pin versions
+**Type**: computational
+**Target**: claude_md
+
+Suggested change:
+
+> Pin every dependency version in pyproject.toml.
+"""
+
+MANUAL_PROP = """# PROP-002: Bump feedforward budget
+**Type**: inferential
+**Target**: feedforward_config
+
+Suggested change:
+
+> Raise max_context_tokens to 12000.
+"""
+
+CLAUDE_MD = """# CLAUDE.md
+
+## Agent Learnings
+
+- existing bullet
+"""
+
+TSV_HEADER = (
+    "run_id\ttimestamp\tproject\tcomponents_total\tcompleted\tfailed\t"
+    "skipped\tavg_iterations\tavg_duration_s\tretry_rate\tcommon_failure\t"
+    "total_tokens\ttotal_cost_usd\tunreported_calls"
+)
+
+
+def _seed(tmp_path: Path) -> None:
+    proposals_dir = tmp_path / ".kstrl" / "proposals"
+    proposals_dir.mkdir(parents=True)
+    (proposals_dir / "prop-001.md").write_text(CONVENTION_PROP)
+    (proposals_dir / "prop-002.md").write_text(MANUAL_PROP)
+    (tmp_path / "CLAUDE.md").write_text(CLAUDE_MD)
+    (tmp_path / ".kstrl" / "experiments.tsv").write_text(
+        TSV_HEADER + "\n"
+        + "factory-20260718-100000.000000-aaa\t2026-07-18\tdemo\t3\t3\t0\t0"
+          "\t2.0\t120\t0.33\t\t144000\t2.25\t2\n"
+        + "factory-20260719-100000.000000-bbb\t2026-07-19\tdemo\t2\t1\t1\t0"
+          "\t3.0\t150\t0\ttest_suite:assert\t\t\t0\n",
+    )
+    entries = [
+        {"event_type": "component_result", "run_id": run,
+         "component_id": comp,
+         "failure_signatures": ["test_suite:assert"]}
+        for run, comp in (("r1", "c1"), ("r2", "c2"))
+    ]
+    (tmp_path / ".kstrl" / "evolution.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in entries) + "\n",
+    )
+
+
+async def _open(app: KstrlTuiApp, pilot: object) -> EvolveScreen:
+    app.push_screen(EvolveScreen())
+    await pilot.pause(0.2)  # type: ignore[attr-defined]
+    return cast(EvolveScreen, app.screen)
+
+
+def _home_app(tmp_path: Path) -> KstrlTuiApp:
+    return KstrlTuiApp(root_dir=tmp_path, mode=Mode.HOME, poll_interval=0.05)
+
+
+class TestRetryBar:
+    def test_scaling(self) -> None:
+        assert retry_bar(0) == theme.EMPTY_CELL
+        assert retry_bar(0.5) in "▃▄▅"
+        assert retry_bar(1.0) == "▇"
+
+
+class TestEvolveScreen:
+    async def test_tabs_render_all_three_datasets(
+        self, tmp_path: Path,
+    ) -> None:
+        _seed(tmp_path)
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            screen = await _open(app, pilot)
+            proposals = screen.query_one("#proposals-table")
+            assert proposals.row_count == 2  # type: ignore[attr-defined]
+            patterns = screen.query_one("#patterns-table")
+            assert patterns.row_count == 1  # type: ignore[attr-defined]
+            trends = screen.query_one("#trends-table")
+            assert trends.row_count == 2  # type: ignore[attr-defined]
+            row = trends.get_row_at(0)  # type: ignore[attr-defined]
+            cells = " ".join(str(cell) for cell in row)
+            assert "144000+" in cells  # unreported -> lower bound
+            second = trends.get_row_at(1)  # type: ignore[attr-defined]
+            second_cells = [str(cell) for cell in second]
+            assert theme.EMPTY_CELL in second_cells  # empty tokens honest
+
+    async def test_apply_via_modal_mutates_and_stamps(
+        self, tmp_path: Path,
+    ) -> None:
+        _seed(tmp_path)
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            screen = await _open(app, pilot)
+            await pilot.press("a")
+            await pilot.pause()
+            assert isinstance(app.screen, OptionsModal)
+            assert "PROP-001" in app.screen.request.header
+            await pilot.press("1")  # Apply
+            await pilot.pause(0.2)
+            content = (tmp_path / "CLAUDE.md").read_text()
+            assert "Pin every dependency version" in content
+            assert "applied from PROP-001" in content
+            prop = (
+                tmp_path / ".kstrl" / "proposals" / "prop-001.md"
+            ).read_text()
+            assert "**Applied**:" in prop
+            detail = str(
+                screen.query_one("#proposal-detail").renderable,
+            )
+            assert "✓ applied" in detail
+
+    async def test_cancel_writes_nothing(self, tmp_path: Path) -> None:
+        _seed(tmp_path)
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            await _open(app, pilot)
+            await pilot.press("a")
+            await pilot.pause()
+            assert isinstance(app.screen, OptionsModal)
+            await pilot.press("2")  # Cancel
+            await pilot.pause()
+            assert (tmp_path / "CLAUDE.md").read_text() == CLAUDE_MD
+            prop = (
+                tmp_path / ".kstrl" / "proposals" / "prop-001.md"
+            ).read_text()
+            assert "**Applied**:" not in prop
+
+    async def test_manual_proposal_never_opens_the_modal(
+        self, tmp_path: Path,
+    ) -> None:
+        _seed(tmp_path)
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            screen = await _open(app, pilot)
+            table = screen.query_one("#proposals-table")
+            table.focus()
+            await pilot.press("down")  # PROP-002, the inferential one
+            await pilot.press("a")
+            await pilot.pause()
+            assert isinstance(app.screen, EvolveScreen)  # no modal
+            assert (tmp_path / "CLAUDE.md").read_text() == CLAUDE_MD
+
+    async def test_empty_state(self, tmp_path: Path) -> None:
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            screen = await _open(app, pilot)
+            detail = str(
+                screen.query_one("#proposal-detail").renderable,
+            )
+            assert "no proposals yet" in detail


### PR DESCRIPTION
Stacks on #139.

## What
`tui/screens/evolve.py`: TabbedContent with three panes over the evolution layer's records:
- **proposals**: master-detail (id/title/type/target/applied badge; detail shows the suggested-change blockquote and the honest next step). `a` on an unapplied convention proposal opens the **OptionsModal** (default Cancel); on Apply, `apply_proposal(confirm=lambda _: True)` runs - the modal WAS the confirmation - appending to CLAUDE.md's Agent Learnings, stamping `**Applied**`, and refreshing badge + detail. Non-convention targets get the honest manual message and never open the modal (R6.3).
- **patterns**: `get_cross_run_patterns` rows (check/code/runs/components/category).
- **trends**: last 14 `experiments.tsv` rows - retry-rate bar cells (`▁▂▃▄▅▆▇`), "+" lower-bound markers on tokens/cost whenever `unreported_calls` is non-zero, "·" for empty cells.
- No propose-from-TUI in v1 (`ks evolve` stays the generator); home launcher gains the entry.

## Tested (new `tests/test_evolve_screen.py`)
- All three datasets render from fixtures (props + 14-column TSV + journal with a cross-run signature).
- Apply via modal mutates CLAUDE.md + stamps the prop + updates badge/detail; Cancel writes nothing; manual proposal never opens the modal.
- Trends honesty: `144000+` with unreported calls, "·" for empty token cells.
- `retry_bar` scaling unit test; empty proposals state.

Fast tier 1857 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)