### PR TITLE
feat: init wizard + shared form widgets (TUI surface D5)

### DIFF
--- a/kstrl/init_wizard.py
+++ b/kstrl/init_wizard.py
@@ -1,0 +1,100 @@
+"""Init wizard logic layer (TUI surface D5) - Textual-free.
+
+The wizard never generates content itself: scaffolding is run_init's
+job (templates byte-identical, _create_if_missing non-destructive).
+This module answers "what WOULD init touch" for the preview, exposes
+the project-context detection, and offers exactly one write of its
+own: substituting the STOCK commented [agent] lines that
+DEFAULT_KSTRL_TOML ships - and refusing (False, no write) whenever
+those exact lines are not found, because a user-edited file is never
+something to guess inside.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from kstrl.init_cmd import _detect_project_context
+
+# The documented kstrl.toml [agent] type vocabulary (empty = auto).
+AGENT_TYPES = ("", "claude-code", "claude-sdk", "codex")
+
+# The stock commented lines DEFAULT_KSTRL_TOML scaffolds, keyed by the
+# toml key they set. Substitution is line-targeted on these prefixes.
+_AGENT_STOCK_PREFIXES = {
+    "type": '# type = ""',
+    "model": '# model = ""',
+    "reasoning_effort": '# reasoning_effort = ""',
+}
+
+
+@dataclass(frozen=True)
+class ScaffoldEntry:
+    path: Path
+    exists: bool  # True -> "exists - kept"; False -> "will create"
+
+
+def plan_scaffold(root: Path) -> list[ScaffoldEntry]:
+    """The exact file set run_init touches, with existence markers."""
+    kstrl_dir = root / "scripts" / "kstrl"
+    paths = [
+        root / "kstrl.toml",
+        kstrl_dir / "prompt.md",
+        kstrl_dir / "prd.json",
+        kstrl_dir / "progress.txt",
+        kstrl_dir / "codebase_map.md",
+        kstrl_dir / "understand_prompt.md",
+        kstrl_dir / "feature_understand_prompt.md",
+        root / "CLAUDE.md",
+        root / "AGENTS.md",
+    ]
+    return [ScaffoldEntry(path=p, exists=p.exists()) for p in paths]
+
+
+def detect_context(root: Path) -> dict[str, str]:
+    """Public wrapper over init_cmd's project-context detection."""
+    return _detect_project_context(root)
+
+
+def apply_agent_settings(
+    toml_path: Path,
+    *,
+    agent_type: str = "",
+    model: str = "",
+    reasoning: str = "",
+) -> bool:
+    """Substitute the stock commented [agent] lines with real values.
+
+    All-or-nothing: if any requested key's stock line is missing (a
+    user-edited or pre-existing file), NOTHING is written and False
+    returns - the wizard reports it honestly instead of guessing.
+    Empty values are skipped; all-empty is a no-op False.
+    """
+    wanted = {
+        key: value
+        for key, value in (
+            ("type", agent_type),
+            ("model", model),
+            ("reasoning_effort", reasoning),
+        )
+        if value
+    }
+    if not wanted:
+        return False
+    try:
+        content = toml_path.read_text()
+    except OSError:
+        return False
+    lines = content.splitlines(keepends=True)
+    for key, value in wanted.items():
+        prefix = _AGENT_STOCK_PREFIXES[key]
+        for index, line in enumerate(lines):
+            if line.startswith(prefix):
+                ending = "\n" if line.endswith("\n") else ""
+                lines[index] = f'{key} = "{value}"{ending}'
+                break
+        else:
+            return False  # stock line missing: never guess
+    toml_path.write_text("".join(lines))
+    return True

--- a/kstrl/init_wizard.py
+++ b/kstrl/init_wizard.py
@@ -12,6 +12,7 @@ something to guess inside.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -92,7 +93,8 @@ def apply_agent_settings(
         for index, line in enumerate(lines):
             if line.startswith(prefix):
                 ending = "\n" if line.endswith("\n") else ""
-                lines[index] = f'{key} = "{value}"{ending}'
+                encoded = json.dumps(value, ensure_ascii=False)
+                lines[index] = f"{key} = {encoded}{ending}"
                 break
         else:
             return False  # stock line missing: never guess

--- a/kstrl/tui/app.py
+++ b/kstrl/tui/app.py
@@ -308,6 +308,13 @@ class KstrlTuiApp(App[int]):
 
     def action_quit_or_detach(self) -> None:
         if self.mode is Mode.HOME:
+            if bool(getattr(self.screen, "navigation_blocked", False)):
+                self.notify(
+                    "this operation is still writing files; wait for it "
+                    "to finish",
+                    severity="warning",
+                )
+                return
             if isinstance(self.screen, HomeScreen):
                 self.exit(0)
                 return

--- a/kstrl/tui/screens/home.py
+++ b/kstrl/tui/screens/home.py
@@ -63,6 +63,10 @@ HOME_COMMANDS: list[HomeCommand] = [
         "evolve", "evolve",
         "harness proposals, failure patterns, experiment trends",
     ),
+    HomeCommand(
+        "init", "init",
+        "scaffold kstrl into a project (wizard)",
+    ),
 ]
 
 
@@ -269,3 +273,7 @@ class HomeScreen(Screen[None]):
             from kstrl.tui.screens.evolve import EvolveScreen
 
             self.app.push_screen(EvolveScreen())
+        elif event.option_id == "init":
+            from kstrl.tui.screens.init_wizard import InitWizardScreen
+
+            self.app.push_screen(InitWizardScreen())

--- a/kstrl/tui/screens/init_wizard.py
+++ b/kstrl/tui/screens/init_wizard.py
@@ -54,6 +54,14 @@ class InitWizardScreen(Screen[None]):
         Binding("escape", "back", "Back"),
     ]
 
+    def __init__(self) -> None:
+        super().__init__()
+        self._scaffolding = False
+
+    @property
+    def navigation_blocked(self) -> bool:
+        return self._scaffolding
+
     def compose(self) -> ComposeResult:
         with Vertical(id="wizard-root"):
             yield Static("initialize project", id="wizard-title")
@@ -178,8 +186,11 @@ class InitWizardScreen(Screen[None]):
         button_id = event.button.id or ""
         if button_id == "wizard-preview-btn":
             errors: list[str] = []
-            if not self._directory().exists():
-                errors.append(f"directory not found: {self._directory()}")
+            directory = self._directory()
+            if not directory.exists():
+                errors.append(f"directory not found: {directory}")
+            elif not directory.is_dir():
+                errors.append(f"not a directory: {directory}")
             self.query_one(FormErrors).show(errors)
             if errors:
                 return
@@ -191,41 +202,54 @@ class InitWizardScreen(Screen[None]):
             self._run_scaffold()
 
     def _run_scaffold(self) -> None:
+        if self._scaffolding:
+            return
+        self._scaffolding = True
         directory = self._directory()
         agent_type, model, reasoning = self._agent_values()
         toml_missing_before = not (directory / "kstrl.toml").exists()
 
         def _work() -> None:
             stream = io.StringIO()
-            code = run_init(directory, PlainUI(no_color=True, file=stream))
             note = ""
-            if any((agent_type, model, reasoning)):
-                if not toml_missing_before:
-                    note = (
-                        "agent settings NOT written: kstrl.toml already "
-                        "existed before this run"
-                    )
-                elif code != 0:
-                    note = "agent settings skipped: init did not succeed"
-                elif apply_agent_settings(
-                    directory / "kstrl.toml",
-                    agent_type=agent_type, model=model, reasoning=reasoning,
-                ):
-                    note = "agent settings written to kstrl.toml [agent]"
-                else:
-                    note = (
-                        "agent settings NOT written: the scaffolded "
-                        "[agent] lines were not found"
-                    )
+            try:
+                code = run_init(
+                    directory, PlainUI(no_color=True, file=stream),
+                )
+                if any((agent_type, model, reasoning)):
+                    if not toml_missing_before:
+                        note = (
+                            "agent settings NOT written: kstrl.toml already "
+                            "existed before this run"
+                        )
+                    elif code != 0:
+                        note = "agent settings skipped: init did not succeed"
+                    elif apply_agent_settings(
+                        directory / "kstrl.toml",
+                        agent_type=agent_type, model=model,
+                        reasoning=reasoning,
+                    ):
+                        note = "agent settings written to kstrl.toml [agent]"
+                    else:
+                        note = (
+                            "agent settings NOT written: the scaffolded "
+                            "[agent] lines were not found"
+                        )
+            except (OSError, ValueError) as exc:
+                code = 1
+                stream.write(f"init failed: {exc}\n")
             self.post_message(WizardDone(code, stream.getvalue(), note))
 
         self._show_stage("result")
         self.query_one("#wizard-log", Static).update(
             Text("scaffolding...", style=theme.MUTED),
         )
+        self.query_one("#wizard-run-btn", Button).disabled = True
         self.run_worker(_work, thread=True)
 
     def on_wizard_done(self, message: WizardDone) -> None:
+        self._scaffolding = False
+        self.query_one("#wizard-run-btn", Button).disabled = False
         self.query_one("#wizard-log", Static).update(
             Text(message.transcript or "(no output)"),
         )
@@ -242,6 +266,12 @@ class InitWizardScreen(Screen[None]):
         self.query_one("#wizard-outcome", Static).update(outcome)
 
     def action_back(self) -> None:
+        if self._scaffolding:
+            self.app.notify(
+                "init is still writing project files; wait for it to finish",
+                severity="warning",
+            )
+            return
         if getattr(self, "_stage", "form") == "preview":
             self._show_stage("form")
             return

--- a/kstrl/tui/screens/init_wizard.py
+++ b/kstrl/tui/screens/init_wizard.py
@@ -1,0 +1,248 @@
+"""Init wizard: form -> preview -> scaffold (TUI surface D5).
+
+One screen, three progressively revealed sections. All content comes
+from run_init's existing scaffold functions - zero template drift by
+construction (this module never renders a template). The only wizard-
+own write is init_wizard.apply_agent_settings, and only when THIS run
+created the kstrl.toml and the user actually picked agent values; its
+outcome is reported honestly either way.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.message import Message
+from textual.screen import Screen
+from textual.widgets import Button, Footer, Input, Select, Static
+
+from kstrl.init_cmd import run_init
+from kstrl.init_wizard import (
+    AGENT_TYPES,
+    apply_agent_settings,
+    detect_context,
+    plan_scaffold,
+)
+from kstrl.tui import theme
+from kstrl.tui.widgets.form import FormErrors, FormField
+from kstrl.ui.plain import PlainUI
+
+if TYPE_CHECKING:
+    pass
+
+REASONING_LEVELS = ("", "low", "medium", "high", "max")
+
+
+class WizardDone(Message):
+    def __init__(
+        self, exit_code: int, transcript: str, agent_note: str,
+    ) -> None:
+        super().__init__()
+        self.exit_code = exit_code
+        self.transcript = transcript
+        self.agent_note = agent_note
+
+
+class InitWizardScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "back", "Back"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="wizard-root"):
+            yield Static("initialize project", id="wizard-title")
+            with Vertical(id="wizard-form"):
+                yield FormField(
+                    "directory",
+                    Input(id="wizard-directory"),
+                    hint="project root to scaffold",
+                )
+                yield FormField(
+                    "agent type",
+                    Select(
+                        [(t or "auto-detect", t) for t in AGENT_TYPES],
+                        value="", allow_blank=False, id="wizard-agent-type",
+                    ),
+                )
+                yield FormField(
+                    "model",
+                    Input(placeholder="agent default", id="wizard-model"),
+                )
+                yield FormField(
+                    "reasoning",
+                    Select(
+                        [(r or "agent default", r) for r in REASONING_LEVELS],
+                        value="", allow_blank=False, id="wizard-reasoning",
+                    ),
+                )
+                yield Static(id="wizard-detected")
+                yield FormErrors(id="wizard-errors")
+                with Horizontal(classes="wizard-buttons"):
+                    yield Button("preview", id="wizard-preview-btn",
+                                 classes="default-choice")
+            with Vertical(id="wizard-preview"):
+                yield Static("plan", id="wizard-plan-title")
+                yield Static(id="wizard-plan")
+                with Horizontal(classes="wizard-buttons"):
+                    yield Button("run init", id="wizard-run-btn",
+                                 classes="default-choice")
+                    yield Button("back", id="wizard-back-btn")
+            with Vertical(id="wizard-result"):
+                yield Static("init transcript", id="wizard-log-title")
+                with VerticalScroll(id="wizard-log-scroll"):
+                    yield Static(id="wizard-log")
+                yield Static(id="wizard-outcome")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        root = getattr(self.app, "root_dir", Path.cwd())
+        self.query_one("#wizard-directory", Input).value = str(root)
+        context = detect_context(Path(root))
+        detected = Text()
+        detected.append("detected  ", style=f"bold {theme.MUTED}")
+        detected.append(context.get("language", "unknown"))
+        for key in ("test_cmd", "typecheck_cmd", "lint_cmd"):
+            if context.get(key):
+                detected.append(f"  ·  {context[key]}", style=theme.MUTED)
+        self.query_one("#wizard-detected", Static).update(detected)
+        self._show_stage("form")
+
+    # -- stages --------------------------------------------------------------
+
+    def _show_stage(self, stage: str) -> None:
+        self._stage = stage
+        self.query_one("#wizard-form").display = stage == "form"
+        self.query_one("#wizard-preview").display = stage == "preview"
+        self.query_one("#wizard-result").display = stage == "result"
+
+    def _directory(self) -> Path:
+        return Path(
+            self.query_one("#wizard-directory", Input).value.strip()
+            or ".",
+        ).expanduser()
+
+    def _agent_values(self) -> tuple[str, str, str]:
+        agent_type = str(
+            self.query_one("#wizard-agent-type", Select).value or "",
+        )
+        model = self.query_one("#wizard-model", Input).value.strip()
+        reasoning = str(
+            self.query_one("#wizard-reasoning", Select).value or "",
+        )
+        return agent_type, model, reasoning
+
+    def _render_preview(self) -> None:
+        directory = self._directory()
+        plan = Text()
+        for entry in plan_scaffold(directory):
+            try:
+                display = entry.path.relative_to(directory)
+            except ValueError:
+                display = entry.path
+            if entry.exists:
+                plan.append("  · exists - kept   ", style=theme.MUTED)
+                plan.append(f"{display}\n", style=theme.MUTED)
+            else:
+                plan.append("  + will create    ", style=f"bold {theme.ACCENT}")
+                plan.append(f"{display}\n")
+        agent_type, model, reasoning = self._agent_values()
+        if any((agent_type, model, reasoning)):
+            if (directory / "kstrl.toml").exists():
+                plan.append(
+                    "\n  existing kstrl.toml - agent settings will NOT "
+                    "be written",
+                    style=theme.WARNING,
+                )
+            else:
+                chosen = ", ".join(
+                    f"{k}={v}" for k, v in (
+                        ("type", agent_type), ("model", model),
+                        ("reasoning", reasoning),
+                    ) if v
+                )
+                plan.append(
+                    f"\n  [agent] will be set: {chosen}",
+                    style=theme.STEEL,
+                )
+        self.query_one("#wizard-plan", Static).update(plan)
+
+    # -- events --------------------------------------------------------------
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id or ""
+        if button_id == "wizard-preview-btn":
+            errors: list[str] = []
+            if not self._directory().exists():
+                errors.append(f"directory not found: {self._directory()}")
+            self.query_one(FormErrors).show(errors)
+            if errors:
+                return
+            self._render_preview()
+            self._show_stage("preview")
+        elif button_id == "wizard-back-btn":
+            self._show_stage("form")
+        elif button_id == "wizard-run-btn":
+            self._run_scaffold()
+
+    def _run_scaffold(self) -> None:
+        directory = self._directory()
+        agent_type, model, reasoning = self._agent_values()
+        toml_missing_before = not (directory / "kstrl.toml").exists()
+
+        def _work() -> None:
+            stream = io.StringIO()
+            code = run_init(directory, PlainUI(no_color=True, file=stream))
+            note = ""
+            if any((agent_type, model, reasoning)):
+                if not toml_missing_before:
+                    note = (
+                        "agent settings NOT written: kstrl.toml already "
+                        "existed before this run"
+                    )
+                elif code != 0:
+                    note = "agent settings skipped: init did not succeed"
+                elif apply_agent_settings(
+                    directory / "kstrl.toml",
+                    agent_type=agent_type, model=model, reasoning=reasoning,
+                ):
+                    note = "agent settings written to kstrl.toml [agent]"
+                else:
+                    note = (
+                        "agent settings NOT written: the scaffolded "
+                        "[agent] lines were not found"
+                    )
+            self.post_message(WizardDone(code, stream.getvalue(), note))
+
+        self._show_stage("result")
+        self.query_one("#wizard-log", Static).update(
+            Text("scaffolding...", style=theme.MUTED),
+        )
+        self.run_worker(_work, thread=True)
+
+    def on_wizard_done(self, message: WizardDone) -> None:
+        self.query_one("#wizard-log", Static).update(
+            Text(message.transcript or "(no output)"),
+        )
+        outcome = Text()
+        if message.exit_code == 0:
+            outcome.append("✓ init complete", style=f"bold {theme.SUCCESS}")
+        else:
+            outcome.append(
+                f"✗ init exited {message.exit_code}",
+                style=f"bold {theme.ERROR}",
+            )
+        if message.agent_note:
+            outcome.append(f"  ·  {message.agent_note}", style=theme.MUTED)
+        self.query_one("#wizard-outcome", Static).update(outcome)
+
+    def action_back(self) -> None:
+        if getattr(self, "_stage", "form") == "preview":
+            self._show_stage("form")
+            return
+        self.app.pop_screen()

--- a/kstrl/tui/styles.tcss
+++ b/kstrl/tui/styles.tcss
@@ -292,6 +292,103 @@ CheckpointModal {
     padding: 0 1;
 }
 
+/* ---- forms + init wizard ------------------------------------------------- */
+
+.form-field {
+    height: 1;
+    margin-bottom: 1;
+}
+
+.form-label {
+    width: 14;
+    padding: 0 1;
+}
+
+.form-field Input {
+    width: 1fr;
+    height: 1;
+    border: none;
+    background: $surface;
+    padding: 0 1;
+}
+
+.form-field Select {
+    width: 1fr;
+    height: 1;
+}
+
+.form-hint {
+    width: auto;
+    padding: 0 1;
+}
+
+.path-marker {
+    width: 14;
+    padding: 0 1;
+}
+
+#wizard-title {
+    height: 2;
+    padding: 0 1;
+    color: $text-muted;
+    text-style: bold;
+    border-bottom: solid $panel;
+}
+
+#wizard-root {
+    padding: 0 1;
+}
+
+#wizard-detected, #wizard-errors {
+    height: 1;
+    padding: 0 1;
+}
+
+.wizard-buttons {
+    height: 3;
+    margin-top: 1;
+}
+
+.wizard-buttons Button {
+    margin: 0 1;
+    min-width: 14;
+    border: none;
+    height: 1;
+    background: $panel;
+    color: $foreground;
+    text-style: none;
+}
+
+.wizard-buttons .default-choice {
+    background: $accent;
+    color: $background;
+    text-style: bold;
+}
+
+#wizard-plan-title, #wizard-log-title {
+    height: 2;
+    padding: 0 1;
+    color: $text-muted;
+    text-style: bold;
+    border-bottom: solid $panel;
+}
+
+#wizard-plan {
+    height: auto;
+    padding: 0 1;
+}
+
+#wizard-log-scroll {
+    height: 1fr;
+    background: $background;
+    padding: 0 1;
+}
+
+#wizard-outcome {
+    height: 1;
+    padding: 0 1;
+}
+
 /* ---- evolve screen ------------------------------------------------------- */
 
 #evolve-tabs {

--- a/kstrl/tui/widgets/form.py
+++ b/kstrl/tui/widgets/form.py
@@ -1,0 +1,101 @@
+"""Shared form vocabulary for launcher forms and the init wizard (D5).
+
+Thin composition over stock Textual controls - Input/Select/Button
+come from the framework (amber focus arrives free via KSTRL_THEME's
+variables); these widgets only add the dense one-line "label control
+hint" rhythm and a path-existence marker.
+
+Textual >=3,<6 span: only lowest-common APIs (constructor options
+lists, value attributes) - no major-specific keywords.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.widget import Widget
+from textual.widgets import Input, Static
+
+from kstrl.tui import theme
+
+
+class FormField(Horizontal):
+    """One dense form row: muted label, the control, optional hint."""
+
+    DEFAULT_CLASSES = "form-field"
+
+    def __init__(
+        self, label: str, control: Widget, hint: str = "",
+    ) -> None:
+        super().__init__()
+        self._label = label
+        self._control = control
+        self._hint = hint
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            Text(self._label, style=f"bold {theme.MUTED}"),
+            classes="form-label",
+        )
+        yield self._control
+        if self._hint:
+            yield Static(
+                Text(self._hint, style=theme.MUTED),
+                classes="form-hint",
+            )
+
+
+class PathField(Horizontal):
+    """Input + a live exists/absent marker for path values."""
+
+    DEFAULT_CLASSES = "form-field"
+
+    def __init__(
+        self, value: str = "", *, placeholder: str = "",
+        input_id: str = "",
+    ) -> None:
+        super().__init__()
+        self._value = value
+        self._placeholder = placeholder
+        self._input_id = input_id
+
+    def compose(self) -> ComposeResult:
+        kwargs = {"id": self._input_id} if self._input_id else {}
+        yield Input(
+            value=self._value, placeholder=self._placeholder,
+            **kwargs,  # type: ignore[arg-type]
+        )
+        yield Static(classes="path-marker")
+
+    def on_mount(self) -> None:
+        self._update_marker(self.query_one(Input).value)
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        self._update_marker(event.value)
+
+    @property
+    def value(self) -> str:
+        return self.query_one(Input).value
+
+    def _update_marker(self, raw: str) -> None:
+        marker = self.query_one(".path-marker", Static)
+        if not raw.strip():
+            marker.update(Text(theme.EMPTY_CELL, style=theme.MUTED))
+            return
+        if Path(raw).expanduser().exists():
+            marker.update(Text("●", style=theme.SUCCESS))
+        else:
+            marker.update(Text("✗ not found", style=theme.ERROR))
+
+
+class FormErrors(Static):
+    """One-line error strip; empty = valid."""
+
+    def show(self, errors: list[str]) -> None:
+        if errors:
+            self.update(Text(" · ".join(errors), style=f"bold {theme.ERROR}"))
+        else:
+            self.update("")

--- a/tests/test_init_wizard.py
+++ b/tests/test_init_wizard.py
@@ -1,0 +1,170 @@
+"""TUI surface D5: init wizard logic + screen."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import cast
+
+from kstrl.init_cmd import DEFAULT_KSTRL_TOML
+from kstrl.init_wizard import (
+    apply_agent_settings,
+    plan_scaffold,
+)
+from kstrl.tui.app import KstrlTuiApp, Mode
+from kstrl.tui.screens.init_wizard import InitWizardScreen
+
+
+class TestPlanScaffold:
+    def test_markers_flip_after_init(self, tmp_path: Path) -> None:
+        before = plan_scaffold(tmp_path)
+        assert all(not entry.exists for entry in before)
+        names = [entry.path.name for entry in before]
+        assert "kstrl.toml" in names
+        assert "prompt.md" in names
+        assert "CLAUDE.md" in names
+
+        (tmp_path / "kstrl.toml").write_text("")
+        after = plan_scaffold(tmp_path)
+        by_name = {e.path.name: e.exists for e in after}
+        assert by_name["kstrl.toml"] is True
+        assert by_name["prd.json"] is False
+
+
+class TestApplyAgentSettings:
+    def test_substitutes_stock_lines(self, tmp_path: Path) -> None:
+        toml = tmp_path / "kstrl.toml"
+        toml.write_text(DEFAULT_KSTRL_TOML)
+        assert apply_agent_settings(
+            toml, agent_type="codex", model="gpt-5", reasoning="high",
+        )
+        content = toml.read_text()
+        assert 'type = "codex"' in content
+        assert 'model = "gpt-5"' in content
+        assert 'reasoning_effort = "high"' in content
+        assert '# type = ""' not in content
+        # Untouched sections stay byte-identical.
+        assert "# max_iterations = 10" in content
+
+    def test_refuses_user_edited_files_without_writing(
+        self, tmp_path: Path,
+    ) -> None:
+        toml = tmp_path / "kstrl.toml"
+        edited = DEFAULT_KSTRL_TOML.replace('# model = ""', 'model = "opus"')
+        toml.write_text(edited)
+        assert not apply_agent_settings(
+            toml, agent_type="codex", model="gpt-5",
+        )
+        assert toml.read_text() == edited  # all-or-nothing: no write
+
+    def test_empty_values_are_a_noop(self, tmp_path: Path) -> None:
+        toml = tmp_path / "kstrl.toml"
+        toml.write_text(DEFAULT_KSTRL_TOML)
+        assert not apply_agent_settings(toml)
+        assert toml.read_text() == DEFAULT_KSTRL_TOML
+
+    def test_not_idempotent_reapply_refused(self, tmp_path: Path) -> None:
+        toml = tmp_path / "kstrl.toml"
+        toml.write_text(DEFAULT_KSTRL_TOML)
+        assert apply_agent_settings(toml, agent_type="codex")
+        # The stock line is gone now; a second apply refuses.
+        assert not apply_agent_settings(toml, agent_type="claude-code")
+        assert 'type = "codex"' in toml.read_text()
+
+
+class TestWizardScreen:
+    async def _run_wizard(
+        self, tmp_path: Path, *, agent_type: str = "",
+    ) -> tuple[KstrlTuiApp, InitWizardScreen]:
+        app = KstrlTuiApp(root_dir=tmp_path, mode=Mode.HOME,
+                          poll_interval=0.05)
+        pilot_ctx = app.run_test(size=(120, 45))
+        pilot = await pilot_ctx.__aenter__()
+        self._pilot_ctx = pilot_ctx
+        self._pilot = pilot
+        await pilot.pause(0.2)
+        app.push_screen(InitWizardScreen())
+        await pilot.pause(0.2)
+        screen = cast(InitWizardScreen, app.screen)
+        if agent_type:
+            from textual.widgets import Select
+
+            screen.query_one("#wizard-agent-type", Select).value = agent_type
+        return app, screen
+
+    async def test_happy_path_scaffolds_and_writes_agent(
+        self, tmp_path: Path,
+    ) -> None:
+        app, screen = await self._run_wizard(tmp_path, agent_type="codex")
+        try:
+            from textual.widgets import Button, Static
+
+            screen.query_one("#wizard-preview-btn", Button).press()
+            await self._pilot.pause(0.2)
+            plan = str(screen.query_one("#wizard-plan", Static).renderable)
+            assert "will create" in plan
+            assert "kstrl.toml" in plan
+            assert "type=codex" in plan
+            screen.query_one("#wizard-run-btn", Button).press()
+            deadline = time.monotonic() + 10
+            while True:
+                await self._pilot.pause(0.1)
+                outcome = str(
+                    screen.query_one("#wizard-outcome", Static).renderable,
+                )
+                if outcome:
+                    break
+                assert time.monotonic() < deadline, "wizard never finished"
+            assert "✓ init complete" in outcome
+            assert "agent settings written" in outcome
+            assert (tmp_path / "scripts" / "kstrl" / "prompt.md").exists()
+            content = (tmp_path / "kstrl.toml").read_text()
+            assert 'type = "codex"' in content
+        finally:
+            await self._pilot_ctx.__aexit__(None, None, None)
+
+    async def test_existing_toml_keeps_agent_settings_out(
+        self, tmp_path: Path,
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text("# user file\n")
+        app, screen = await self._run_wizard(tmp_path, agent_type="codex")
+        try:
+            from textual.widgets import Button, Static
+
+            screen.query_one("#wizard-preview-btn", Button).press()
+            await self._pilot.pause(0.2)
+            plan = str(screen.query_one("#wizard-plan", Static).renderable)
+            assert "exists - kept" in plan
+            assert "will NOT be written" in plan
+            screen.query_one("#wizard-run-btn", Button).press()
+            deadline = time.monotonic() + 10
+            while True:
+                await self._pilot.pause(0.1)
+                outcome = str(
+                    screen.query_one("#wizard-outcome", Static).renderable,
+                )
+                if outcome:
+                    break
+                assert time.monotonic() < deadline, "wizard never finished"
+            assert "NOT written" in outcome
+            assert (tmp_path / "kstrl.toml").read_text() == "# user file\n"
+        finally:
+            await self._pilot_ctx.__aexit__(None, None, None)
+
+    async def test_bad_directory_blocks_preview(
+        self, tmp_path: Path,
+    ) -> None:
+        app, screen = await self._run_wizard(tmp_path)
+        try:
+            from textual.widgets import Button, Input
+
+            screen.query_one("#wizard-directory", Input).value = str(
+                tmp_path / "nope",
+            )
+            screen.query_one("#wizard-preview-btn", Button).press()
+            await self._pilot.pause(0.2)
+            errors = str(screen.query_one("#wizard-errors").renderable)
+            assert "not found" in errors
+            assert screen.query_one("#wizard-form").display
+        finally:
+            await self._pilot_ctx.__aexit__(None, None, None)

--- a/tests/test_init_wizard.py
+++ b/tests/test_init_wizard.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import time
+import tomllib
 from pathlib import Path
+from threading import Event
 from typing import cast
+from unittest.mock import patch
 
 from kstrl.init_cmd import DEFAULT_KSTRL_TOML
 from kstrl.init_wizard import (
@@ -45,6 +48,17 @@ class TestApplyAgentSettings:
         assert '# type = ""' not in content
         # Untouched sections stay byte-identical.
         assert "# max_iterations = 10" in content
+
+    def test_escapes_free_form_values_as_toml_strings(
+        self, tmp_path: Path,
+    ) -> None:
+        toml = tmp_path / "kstrl.toml"
+        toml.write_text(DEFAULT_KSTRL_TOML)
+        hostile = 'gpt"\n[factory]\nmax_parallel = 99'
+        assert apply_agent_settings(toml, model=hostile)
+        parsed = tomllib.loads(toml.read_text())
+        assert parsed["agent"]["model"] == hostile
+        assert "max_parallel" not in parsed["factory"]
 
     def test_refuses_user_edited_files_without_writing(
         self, tmp_path: Path,
@@ -166,5 +180,64 @@ class TestWizardScreen:
             errors = str(screen.query_one("#wizard-errors").renderable)
             assert "not found" in errors
             assert screen.query_one("#wizard-form").display
+        finally:
+            await self._pilot_ctx.__aexit__(None, None, None)
+
+    async def test_file_target_blocks_preview(self, tmp_path: Path) -> None:
+        target = tmp_path / "not-a-directory"
+        target.write_text("data")
+        app, screen = await self._run_wizard(tmp_path)
+        try:
+            from textual.widgets import Button, Input
+
+            screen.query_one("#wizard-directory", Input).value = str(target)
+            screen.query_one("#wizard-preview-btn", Button).press()
+            await self._pilot.pause(0.2)
+            errors = str(screen.query_one("#wizard-errors").renderable)
+            assert "not a directory" in errors
+            assert screen.query_one("#wizard-form").display
+        finally:
+            await self._pilot_ctx.__aexit__(None, None, None)
+
+    async def test_worker_error_is_terminal_and_navigation_waits(
+        self, tmp_path: Path,
+    ) -> None:
+        app, screen = await self._run_wizard(tmp_path)
+        try:
+            from textual.widgets import Button, Static
+
+            screen.query_one("#wizard-preview-btn", Button).press()
+            await self._pilot.pause(0.2)
+            release = Event()
+
+            def fail_init(*args: object) -> int:
+                del args
+                assert release.wait(timeout=5)
+                raise OSError("disk unavailable")
+
+            with patch(
+                "kstrl.tui.screens.init_wizard.run_init",
+                side_effect=fail_init,
+            ):
+                screen.query_one("#wizard-run-btn", Button).press()
+                deadline = time.monotonic() + 5
+                while not screen.navigation_blocked:
+                    await self._pilot.pause(0.05)
+                    assert time.monotonic() < deadline
+                screen.action_back()
+                assert isinstance(app.screen, InitWizardScreen)
+                release.set()
+                deadline = time.monotonic() + 5
+                while screen.navigation_blocked:
+                    await self._pilot.pause(0.1)
+                    assert time.monotonic() < deadline
+            outcome = str(
+                screen.query_one("#wizard-outcome", Static).renderable,
+            )
+            transcript = str(
+                screen.query_one("#wizard-log", Static).renderable,
+            )
+            assert "exited 1" in outcome
+            assert "disk unavailable" in transcript
         finally:
             await self._pilot_ctx.__aexit__(None, None, None)


### PR DESCRIPTION
Stacks on #140.

## What
- **`kstrl/init_wizard.py`** (Textual-free, unit-tested): `plan_scaffold` (run_init's exact file set with exists markers), `detect_context` (public wrapper), `apply_agent_settings` - line-targeted substitution of the STOCK commented `[agent]` lines from `DEFAULT_KSTRL_TOML`, all-or-nothing with no write when any stock line is missing (a user-edited file is never something to guess inside).
- **`tui/screens/init_wizard.py`**: form (directory validation via `FormErrors`, agent type/model/reasoning, detected verify commands) -> preview (`+ will create` accent / `· exists - kept` muted, plus the honest agent-settings note) -> run (`run_init` on a worker thread with the plain transcript captured to the screen; `[agent]` written only when this run created the toml). Content renders ONLY through run_init's scaffold functions - zero template drift; `DEFAULT_PROMPT` untouched.
- **`tui/widgets/form.py`**: `FormField`/`PathField`/`FormErrors` - the shared form vocabulary the D6 launcher forms reuse; lowest-common Textual APIs for the >=3,<6 span.
- Home launcher gains the `init` entry.

## Tested (new `tests/test_init_wizard.py`)
- `plan_scaffold` markers flip per file after partial scaffolds.
- `apply_agent_settings`: substitutes all three stock lines (other sections byte-identical), refuses user-edited files without writing, empty no-op, re-apply refused once stock lines are gone.
- Pilot: happy path scaffolds + writes `[agent]` + reports both outcomes; pre-existing toml keeps agent settings out (file byte-identical) with the warning in preview AND result; bad directory blocks preview with the error strip.

Fast tier 1865 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)