### PR TITLE
feat: launch sessions, launcher forms, retry surface (TUI surface D6)

### DIFF
--- a/kstrl/tui/app.py
+++ b/kstrl/tui/app.py
@@ -102,6 +102,21 @@ class KstrlTuiApp(App[int]):
         )
         self._pending_prompts: dict[str, PromptRequest] = {}
         self._stopping = False
+        # D6 launch seam: injectable so Pilot tests drive a fake
+        # session; the default binds the real substrate lazily.
+        self.start_session: Callable[[object], object] = (
+            self._default_start_session
+        )
+        self._session: object | None = None
+        self._session_notified = False
+
+    def _default_start_session(self, spec: object) -> object:
+        from typing import cast
+
+        from kstrl.launch import LaunchSpec
+        from kstrl.tui.session import start_run_session
+
+        return start_run_session(cast("LaunchSpec", spec), self.root_dir)
 
     # Compat views for screens and tests that duck-pull off the app.
     @property
@@ -132,6 +147,8 @@ class KstrlTuiApp(App[int]):
             ))
         self.set_interval(self.poll_interval, self._poll)
         self.set_interval(1.0, self._tick_ages)
+        if self.mode is Mode.HOME:
+            self.set_interval(0.5, self._check_session)
         if self.mode is Mode.EMBEDDED:
             self.set_interval(0.5, self._check_orchestrator)
             if self.channel is not None:
@@ -223,8 +240,16 @@ class KstrlTuiApp(App[int]):
     def action_nav_back(self) -> None:
         # The stack floor is 2: Textual's hidden default screen plus
         # the base screen this mode pushed (home, or the dash board).
-        if len(self.screen_stack) > 2:
-            self.pop_screen()
+        if len(self.screen_stack) <= 2:
+            return
+        below = self.screen_stack[-2]
+        if isinstance(below, HomeScreen) and self.session_in_flight():
+            # The run owns its board while in flight; q offers a stop.
+            self.notify(
+                "run in flight - press q to stop it", severity="warning",
+            )
+            return
+        self.pop_screen()
 
     # -- home mode (D1) ------------------------------------------------------
 
@@ -246,13 +271,97 @@ class KstrlTuiApp(App[int]):
 
     def close_run(self) -> None:
         """Tear down the observe context when navigation lands back on
-        home. CLI-scoped contexts (dash/embedded) are never closed."""
+        home. CLI-scoped contexts (dash/embedded) are never closed,
+        and an in-flight launched session keeps running (the nav
+        guards keep its board up; this is only a belt-and-braces
+        no-op for that state)."""
         run = self.run_context
         if run is None or run.owns_app_exit:
             return
-        if run.channel is not None:
+        if run.handle is not None and not run.handle.done():
+            return
+        session = self._session
+        if session is not None:
+            close = getattr(session, "close", None)
+            if close is not None:
+                close()
+            self._session = None
+        elif run.channel is not None:
             run.channel.detach()
+        if run.handle is not None:
+            run.handle.join(timeout=2)
         self.run_context = None
+
+    def session_in_flight(self) -> bool:
+        run = self.run_context
+        return (
+            self.mode is Mode.HOME
+            and run is not None
+            and run.handle is not None
+            and not run.handle.done()
+        )
+
+    def launch(self, spec: object) -> None:
+        """Start a command session (D6) and put its board over home."""
+        if self.session_in_flight():
+            self.notify("a run is already in flight", severity="warning")
+            return
+        from kstrl.tui.session import LaunchError
+
+        try:
+            session = self.start_session(spec)
+        except LaunchError as exc:
+            self.notify(str(exc), severity="error")
+            return
+        # The seam is duck-typed so Pilot tests can inject fakes.
+        from typing import Any, cast
+
+        from kstrl.tui.dispatch import initial_screens_for_kind
+
+        sess = cast(Any, session)
+        run = RunContext.observe(
+            Path(sess.run_dir), self.root_dir, owns_app_exit=False,
+        )
+        run.channel = sess.channel
+        run.handle = sess.handle
+        self.run_context = run
+        self._session = session
+        self._session_notified = False
+        self._stopping = False
+        run.channel.attach(
+            lambda req: self.call_from_thread(self.on_prompt_request, req),
+        )
+        # Replace any form screens with the run's board stack.
+        while len(self.screen_stack) > 2:
+            self.pop_screen()
+        kind = str(getattr(session, "kind", "factory"))
+        for screen in initial_screens_for_kind(
+            kind, observe_only=False,
+        )():
+            self.push_screen(screen)
+        self._poll()
+
+    def _check_session(self) -> None:
+        """HOME-mode counterpart of _check_orchestrator: a finished
+        launched session notifies and keeps the board up (post-mortem
+        reading); escape then pops home and tears it down."""
+        run = self.run_context
+        if (
+            self.mode is not Mode.HOME
+            or run is None
+            or run.handle is None
+            or not run.handle.done()
+            or self._session_notified
+        ):
+            return
+        self._session_notified = True
+        self._poll()  # final drain
+        code = run.handle.exit_code
+        self.notify(
+            f"run finished (exit {code}) - escape returns home",
+            severity="information" if code == 0 else "error",
+            timeout=10,
+        )
 
     # -- embedded mode (PR F) ------------------------------------------------
 
@@ -271,8 +380,16 @@ class KstrlTuiApp(App[int]):
         self._pending_prompts[request.request_id] = request
         self._open_prompt(request)
 
+    def _active_channel(self) -> QueueInteractionChannel | None:
+        """The embedded CLI channel, or the home-launched session's."""
+        if self.channel is not None:
+            return self.channel
+        run = self.run_context
+        return run.channel if run is not None else None
+
     def _open_prompt(self, request: PromptRequest) -> None:
-        if self.channel is None:
+        channel = self._active_channel()
+        if channel is None:
             return
 
         def _resolve(choice: int | None) -> None:
@@ -285,9 +402,7 @@ class KstrlTuiApp(App[int]):
                     severity="warning",
                 )
                 return
-            if self.channel is not None and self.channel.resolve(
-                request.request_id, choice,
-            ):
+            if channel.resolve(request.request_id, choice):
                 self._pending_prompts.pop(request.request_id, None)
 
         if request.kind is PromptKind.CHECKPOINT and request.checkpoint:
@@ -308,6 +423,31 @@ class KstrlTuiApp(App[int]):
 
     def action_quit_or_detach(self) -> None:
         if self.mode is Mode.HOME:
+            if self.session_in_flight():
+                run = self.run_context
+                session_handle = run.handle if run is not None else None
+                if session_handle is None:
+                    return
+                if self._stopping or session_handle.stop.is_set():
+                    # Second request escalates to force + quit, exactly
+                    # like the embedded flow.
+                    session_handle.stop.request("forced from TUI", force=True)
+                    self.exit(130)
+                    return
+
+                def _session_stop(stop_run: bool | None) -> None:
+                    if not stop_run or session_handle is None:
+                        return
+                    self._stopping = True
+                    session_handle.stop.request("stopped from TUI")
+                    self.notify(
+                        "shutting down - the board stays up until the "
+                        "run finishes",
+                        timeout=10,
+                    )
+
+                self.push_screen(QuitModal(), _session_stop)
+                return
             if isinstance(self.screen, HomeScreen):
                 self.exit(0)
                 return

--- a/kstrl/tui/app.py
+++ b/kstrl/tui/app.py
@@ -357,8 +357,12 @@ class KstrlTuiApp(App[int]):
         self._session_notified = True
         self._poll()  # final drain
         code = run.handle.exit_code
+        failure = ""
+        if run.handle.error_box:
+            exc = run.handle.error_box[0]
+            failure = f" - {type(exc).__name__}: {exc}"
         self.notify(
-            f"run finished (exit {code}) - escape returns home",
+            f"run finished (exit {code}){failure} - escape returns home",
             severity="information" if code == 0 else "error",
             timeout=10,
         )

--- a/kstrl/tui/home.py
+++ b/kstrl/tui/home.py
@@ -32,6 +32,19 @@ def run_home_shell(root_dir: Path) -> int:
     try:
         code = app.run()
     finally:
+        # A launched session's worker is non-daemon: stop it if the
+        # shell is exiting under it, then join before releasing the
+        # terminal (a dead shell must never orphan a run silently).
+        run = app.run_context
+        if run is not None and run.handle is not None:
+            if not run.handle.done():
+                run.handle.stop.request("home shell exited")
+            if run.channel is not None:
+                run.channel.detach()
+            run.handle.join()
+        session = getattr(app, "_session", None)
+        if session is not None:
+            session.close()
         sys.stdout.write(ANSI_RESTORE)
         sys.stdout.flush()
     return code or 0

--- a/kstrl/tui/screens/home.py
+++ b/kstrl/tui/screens/home.py
@@ -52,6 +52,18 @@ class HomeCommand:
 # D6 launch forms all append here.
 HOME_COMMANDS: list[HomeCommand] = [
     HomeCommand(
+        "factory", "factory",
+        "launch a factory run from the manifest",
+    ),
+    HomeCommand(
+        "decompose", "decompose",
+        "decompose a spec into components + PRDs",
+    ),
+    HomeCommand(
+        "retry", "retry",
+        "retry a failed component from the manifest",
+    ),
+    HomeCommand(
         "dash", "dashboard",
         "open the newest run (enter on a row opens that run)",
     ),
@@ -66,6 +78,14 @@ HOME_COMMANDS: list[HomeCommand] = [
     HomeCommand(
         "init", "init",
         "scaffold kstrl into a project (wizard)",
+    ),
+    HomeCommand(
+        "feature", "feature",
+        "CLI: ks feature --prd <path> (opens the same embedded TUI)",
+    ),
+    HomeCommand(
+        "understand", "understand",
+        "CLI: ks understand (opens the same embedded TUI)",
     ),
 ]
 
@@ -277,3 +297,21 @@ class HomeScreen(Screen[None]):
             from kstrl.tui.screens.init_wizard import InitWizardScreen
 
             self.app.push_screen(InitWizardScreen())
+        elif event.option_id == "factory":
+            from kstrl.tui.screens.launch import FactoryLaunchForm
+
+            self.app.push_screen(FactoryLaunchForm())
+        elif event.option_id == "decompose":
+            from kstrl.tui.screens.launch import DecomposeLaunchForm
+
+            self.app.push_screen(DecomposeLaunchForm())
+        elif event.option_id == "retry":
+            from kstrl.tui.screens.retry import RetryScreen
+
+            self.app.push_screen(RetryScreen())
+        elif event.option_id in ("feature", "understand"):
+            self.app.notify(
+                f"run `ks {event.option_id} --tui` from the CLI - its "
+                "argument resolution lives there and opens the same "
+                "embedded dashboard",
+            )

--- a/kstrl/tui/screens/launch.py
+++ b/kstrl/tui/screens/launch.py
@@ -1,0 +1,170 @@
+"""Launcher forms: factory and decompose (TUI surface D6).
+
+Headline options only - everything else resolves env > kstrl.toml >
+defaults, exactly like the CLI invoked with just these flags (the
+LaunchSpec contract from B1). Submitting hands the spec to
+app.launch, which starts the session and replaces the form with the
+run's board.
+
+Feature and understand keep their full arg-resolution stacks in the
+CLI (where `--tui` already gives them the same embedded experience);
+the home launcher points at them honestly instead of duplicating
+that resolution here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import Screen
+from textual.widgets import Button, Footer, Input, Select, Static, Switch
+
+from kstrl.launch import DecomposeLaunch, FactoryLaunch
+from kstrl.tui import theme
+from kstrl.tui.widgets.form import FormErrors, FormField
+
+REVIEW_MODES = ("", "hard", "advisory", "skip")
+
+
+class FactoryLaunchForm(Screen[None]):
+    BINDINGS = [Binding("escape", "app.pop_screen", "Back")]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="launch-root"):
+            yield Static("launch factory", id="launch-title")
+            yield FormField(
+                "manifest",
+                Input(id="factory-manifest",
+                      placeholder="scripts/kstrl/manifest.json"),
+                hint="existing manifest (decompose writes it)",
+            )
+            yield FormField(
+                "max parallel",
+                Input(id="factory-parallel", placeholder="from config"),
+            )
+            yield FormField(
+                "review mode",
+                Select(
+                    [(m or "from config", m) for m in REVIEW_MODES],
+                    value="", allow_blank=False, id="factory-review",
+                ),
+            )
+            yield Static(
+                Text(
+                    "everything else resolves env > kstrl.toml > defaults",
+                    style=theme.MUTED,
+                ),
+                id="launch-note",
+            )
+            yield FormErrors(id="launch-errors")
+            with Horizontal(classes="wizard-buttons"):
+                yield Button("start factory", id="factory-start",
+                             classes="default-choice")
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id != "factory-start":
+            return
+        root_dir = getattr(self.app, "root_dir", Path.cwd())
+        raw_manifest = self.query_one("#factory-manifest", Input).value.strip()
+        manifest_path = (
+            (root_dir / raw_manifest if not Path(raw_manifest).is_absolute()
+             else Path(raw_manifest))
+            if raw_manifest else None
+        )
+        raw_parallel = self.query_one("#factory-parallel", Input).value.strip()
+        errors: list[str] = []
+        max_parallel: int | None = None
+        if raw_parallel:
+            try:
+                max_parallel = int(raw_parallel)
+            except ValueError:
+                errors.append(f"max parallel must be an integer: {raw_parallel}")
+            else:
+                if max_parallel < 1:
+                    errors.append("max parallel must be >= 1")
+        default_manifest = root_dir / "scripts" / "kstrl" / "manifest.json"
+        if not (manifest_path or default_manifest).exists():
+            errors.append(
+                f"no manifest at {manifest_path or default_manifest} - "
+                "decompose a spec first",
+            )
+        self.query_one(FormErrors).show(errors)
+        if errors:
+            return
+        review = str(self.query_one("#factory-review", Select).value or "")
+        launch = getattr(self.app, "launch", None)
+        if launch is not None:
+            launch(FactoryLaunch(
+                manifest_path=manifest_path,
+                max_parallel=max_parallel,
+                review_mode=review or None,
+            ))
+
+
+class DecomposeLaunchForm(Screen[None]):
+    BINDINGS = [Binding("escape", "app.pop_screen", "Back")]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="launch-root"):
+            yield Static("launch decompose", id="launch-title")
+            yield FormField(
+                "spec",
+                Input(id="decompose-spec",
+                      placeholder="scripts/kstrl/spec.md"),
+                hint="markdown spec or SpecKit directory",
+            )
+            yield FormField(
+                "project name",
+                Input(id="decompose-project"),
+            )
+            yield FormField(
+                "base branch",
+                Input(value="main", id="decompose-branch"),
+            )
+            yield FormField(
+                "single PR",
+                Switch(value=False, id="decompose-single-pr"),
+                hint="one branch for all components",
+            )
+            yield FormErrors(id="launch-errors")
+            with Horizontal(classes="wizard-buttons"):
+                yield Button("start decompose", id="decompose-start",
+                             classes="default-choice")
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id != "decompose-start":
+            return
+        root_dir = getattr(self.app, "root_dir", Path.cwd())
+        raw_spec = self.query_one("#decompose-spec", Input).value.strip()
+        project = self.query_one("#decompose-project", Input).value.strip()
+        branch = (
+            self.query_one("#decompose-branch", Input).value.strip() or "main"
+        )
+        errors: list[str] = []
+        spec_path = (
+            Path(raw_spec) if Path(raw_spec).is_absolute()
+            else root_dir / raw_spec
+        ) if raw_spec else None
+        if spec_path is None:
+            errors.append("spec path is required")
+        elif not spec_path.exists():
+            errors.append(f"spec not found: {spec_path}")
+        if not project:
+            errors.append("project name is required")
+        self.query_one(FormErrors).show(errors)
+        if errors or spec_path is None:
+            return
+        launch = getattr(self.app, "launch", None)
+        if launch is not None:
+            launch(DecomposeLaunch(
+                spec_path=spec_path,
+                project_name=project,
+                base_branch=branch,
+                single_pr=self.query_one("#decompose-single-pr", Switch).value,
+            ))

--- a/kstrl/tui/screens/retry.py
+++ b/kstrl/tui/screens/retry.py
@@ -10,6 +10,7 @@ factory relaunches through the D6 session seam.
 from __future__ import annotations
 
 import io
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -157,20 +158,49 @@ class RetryScreen(Screen[None]):
         def _resolved(choice: int | None) -> None:
             if choice != 0:
                 return
-            # Narration lands in the retry log the new session tails.
+            # Reload at commit time. An external factory or editor can
+            # update the manifest while the confirmation modal is open;
+            # never save the stale object captured by the screen.
+            latest, latest_file = _load_manifest(self._root_dir())
+            if latest is None:
+                self.app.notify(
+                    f"retry failed: cannot load {latest_file}",
+                    severity="error",
+                )
+                self.reload()
+                return
+            try:
+                latest_preview = preview_retry(latest, comp.id)
+            except ValueError as exc:
+                self.app.notify(
+                    f"retry plan changed: {exc}", severity="warning",
+                )
+                self.reload()
+                return
+            if latest_preview != preview:
+                self.app.notify(
+                    "retry plan changed since the preview; review it again",
+                    severity="warning",
+                )
+                self.reload()
+                return
+            # Keep preparation narration off the alternate screen; the
+            # confirmation already presented the same retry plan.
             narration = io.StringIO()
             try:
                 prepare_retry(
-                    manifest, comp.id, self._manifest_file,
+                    latest, comp.id, latest_file,
                     self._root_dir(), PlainUI(no_color=True, file=narration),
                 )
-            except (ValueError, RetryError) as exc:
+            except (
+                OSError, ValueError, RetryError, subprocess.SubprocessError,
+            ) as exc:
                 self.app.notify(f"retry failed: {exc}", severity="error")
                 self.reload()
                 return
             launch = getattr(self.app, "launch", None)
             if launch is not None:
-                launch(FactoryLaunch(manifest_path=self._manifest_file))
+                launch(FactoryLaunch(manifest_path=latest_file))
 
         self.app.push_screen(
             OptionsModal(PromptRequest(

--- a/kstrl/tui/screens/retry.py
+++ b/kstrl/tui/screens/retry.py
@@ -1,0 +1,183 @@
+"""Retry surface: pick a failed component, preview, relaunch (D6).
+
+The table lists the manifest's FAILED components with their evidence
+paths. `r` renders preview_retry (non-mutating) in the confirm modal;
+on confirm, prepare_retry does the real mutation (reset + worktree/
+branch cleanup + save, narrated into the new session's log) and the
+factory relaunches through the D6 session seam.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Static
+
+from kstrl.interaction import PromptKind, PromptRequest
+from kstrl.launch import FactoryLaunch
+from kstrl.retry_plan import RetryError, prepare_retry, preview_retry
+from kstrl.tui import theme
+from kstrl.tui.screens.options import OptionsModal
+from kstrl.ui.plain import PlainUI
+
+if TYPE_CHECKING:
+    from kstrl.manifest import Component, Manifest
+
+
+def _load_manifest(root_dir: Path) -> tuple[Manifest | None, Path]:
+    from kstrl.manifest import Manifest
+
+    manifest_file = root_dir / "scripts" / "kstrl" / "manifest.json"
+    if not manifest_file.exists():
+        return None, manifest_file
+    try:
+        return Manifest.load(manifest_file), manifest_file
+    except (OSError, ValueError):
+        return None, manifest_file
+
+
+def _failed_components(manifest: Manifest) -> list[Component]:
+    return [c for c in manifest.components if c.status == "failed"]
+
+
+class RetryScreen(Screen[None]):
+    BINDINGS = [
+        Binding("escape", "app.pop_screen", "Back"),
+        Binding("r", "retry_selected", "Retry"),
+    ]
+
+    COLUMNS = ("component", "phase", "check", "retries", "evidence")
+
+    def compose(self) -> ComposeResult:
+        yield Static("failed components", id="retry-title")
+        yield DataTable(id="retry-table")
+        yield Static(id="retry-detail")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one(DataTable)
+        table.cursor_type = "row"
+        table.zebra_stripes = False
+        for column in self.COLUMNS:
+            table.add_column(column, key=column)
+        self.reload()
+
+    def _root_dir(self) -> Path:
+        root = getattr(self.app, "root_dir", None)
+        return root if root is not None else Path.cwd()
+
+    def reload(self) -> None:
+        manifest, manifest_file = _load_manifest(self._root_dir())
+        self._manifest = manifest
+        self._manifest_file = manifest_file
+        self._failed = _failed_components(manifest) if manifest else []
+        table = self.query_one(DataTable)
+        table.clear()
+        for comp in self._failed:
+            evidence = comp.evidence_worktree or comp.evidence_debug_dir
+            table.add_row(
+                Text(comp.id, style="bold"),
+                comp.failed_phase or Text(theme.EMPTY_CELL, style=theme.MUTED),
+                comp.failed_check or Text(theme.EMPTY_CELL, style=theme.MUTED),
+                Text(str(comp.retries), justify="right"),
+                evidence or Text(theme.EMPTY_CELL, style=theme.MUTED),
+                key=comp.id,
+            )
+        detail = self.query_one("#retry-detail", Static)
+        if manifest is None:
+            detail.update(Text(
+                f"no manifest at {manifest_file} - nothing to retry",
+                style=theme.MUTED,
+            ))
+        elif not self._failed:
+            detail.update(Text(
+                "no failed components - nothing to retry",
+                style=theme.MUTED,
+            ))
+        elif self._failed:
+            self._show_detail(0)
+
+    def _show_detail(self, index: int) -> None:
+        if not (0 <= index < len(self._failed)):
+            return
+        comp = self._failed[index]
+        detail = Text()
+        detail.append(comp.id, style=f"bold {theme.ERROR}")
+        if comp.error:
+            detail.append(f"  {comp.error[:160]}", style=theme.MUTED)
+        for label, value in (
+            ("worktree", comp.evidence_worktree),
+            ("debug", comp.evidence_debug_dir),
+        ):
+            if value:
+                detail.append(f"\n{label}  ", style=f"bold {theme.ACCENT}")
+                detail.append(value)
+        detail.append("\n(r) retry - resets the component, removes the "
+                      "failed attempt's worktree/branch, re-enters the "
+                      "factory", style=theme.MUTED)
+        self.query_one("#retry-detail", Static).update(detail)
+
+    def on_data_table_row_highlighted(
+        self, event: DataTable.RowHighlighted,
+    ) -> None:
+        if event.cursor_row is not None and event.cursor_row >= 0:
+            self._show_detail(event.cursor_row)
+
+    def action_retry_selected(self) -> None:
+        table = self.query_one(DataTable)
+        if not table.row_count or table.cursor_row is None:
+            return
+        if not (0 <= table.cursor_row < len(self._failed)):
+            return
+        manifest = self._manifest
+        if manifest is None:
+            return
+        comp = self._failed[table.cursor_row]
+        try:
+            preview = preview_retry(manifest, comp.id)
+        except ValueError as exc:
+            self.app.notify(str(exc), severity="error")
+            return
+        dependents = (
+            ", ".join(preview.reset_dependents)
+            if preview.reset_dependents else "none"
+        )
+        header = (
+            f"Retry '{comp.id}'? Resets it (+ dependents: {dependents}), "
+            "removes the failed attempt's worktree and branch, and "
+            "re-enters the factory."
+        )
+
+        def _resolved(choice: int | None) -> None:
+            if choice != 0:
+                return
+            # Narration lands in the retry log the new session tails.
+            narration = io.StringIO()
+            try:
+                prepare_retry(
+                    manifest, comp.id, self._manifest_file,
+                    self._root_dir(), PlainUI(no_color=True, file=narration),
+                )
+            except (ValueError, RetryError) as exc:
+                self.app.notify(f"retry failed: {exc}", severity="error")
+                self.reload()
+                return
+            launch = getattr(self.app, "launch", None)
+            if launch is not None:
+                launch(FactoryLaunch(manifest_path=self._manifest_file))
+
+        self.app.push_screen(
+            OptionsModal(PromptRequest(
+                kind=PromptKind.CONFIRM,
+                header=header,
+                options=("Start retry", "Cancel"),
+                default=1,
+            )),
+            _resolved,
+        )

--- a/kstrl/tui/session.py
+++ b/kstrl/tui/session.py
@@ -1,0 +1,262 @@
+"""Launched-run sessions for the home shell (TUI surface D6).
+
+The pre-App portion of run_embedded, factored so an ALREADY-RUNNING
+app (home) can start a command without owning a new terminal: mint
+the run id, route core narration to <run_dir>/orchestrator.log via
+the standard console stack, take module loggers off the alt screen,
+and put the command core on a worker thread behind the queue channel.
+
+Validation that can fail fast (missing manifest/spec) raises
+LaunchError BEFORE any thread starts - the form shows the message and
+nothing was mutated.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from kstrl.commandrun import open_command_run
+from kstrl.events import CallbackSink, EventBus, RunPaths
+from kstrl.interaction import QueueInteractionChannel
+from kstrl.launch import (
+    DecomposeLaunch,
+    FactoryLaunch,
+    LaunchSpec,
+    assemble_factory_configs,
+)
+from kstrl.render import UIBackedRenderer
+from kstrl.runid import mint_run_id
+from kstrl.shutdown import StopController
+from kstrl.tui.bridge import CommandHandle, start_command_thread
+from kstrl.tui.embed import (
+    _install_exclusive_root_handler,
+    _restore_root_handlers,
+)
+from kstrl.ui.bridge import EventBridgeUI, NullPrompter
+from kstrl.ui.plain import PlainUI
+
+if TYPE_CHECKING:
+    pass
+
+
+class LaunchError(Exception):
+    """A launch failed validation before anything started."""
+
+
+@dataclass
+class RunSession:
+    run_dir: Path
+    kind: str
+    channel: QueueInteractionChannel
+    handle: CommandHandle
+    _cleanups: list[Callable[[], None]] = field(default_factory=list)
+
+    def close(self) -> None:
+        """Detach the channel and restore process-global state. Join
+        the handle FIRST (or stop it) - closing under a live thread
+        only detaches; the run itself keeps its files."""
+        self.channel.detach()
+        for cleanup in reversed(self._cleanups):
+            try:
+                cleanup()
+            except OSError:
+                pass
+        self._cleanups.clear()
+
+
+def start_run_session(
+    spec: LaunchSpec,
+    root_dir: Path,
+    *,
+    stop: StopController | None = None,
+) -> RunSession:
+    """Start ``spec``'s command core on a worker thread; the caller
+    (the app's launch seam) attaches the channel and tails the run
+    dir like any other run."""
+    stop = stop or StopController()
+    # Validate FIRST: a LaunchError must leave zero disk state behind
+    # (no run dir, no open log handle).
+    if isinstance(spec, FactoryLaunch):
+        kind = "factory"
+        prepared = _prepare_factory(spec, root_dir)
+    elif isinstance(spec, DecomposeLaunch):
+        kind = "decompose"
+        prepared = _prepare_decompose(spec, root_dir)
+    else:
+        raise LaunchError(
+            f"the launcher does not support {type(spec).__name__} yet; "
+            "run the command from the CLI (it has the same embedded TUI)",
+        )
+
+    run_id = mint_run_id(kind)
+    run_paths = RunPaths.for_run(root_dir, run_id)
+    run_paths.root.mkdir(parents=True, exist_ok=True)
+
+    log_fh = open(
+        run_paths.root / "orchestrator.log", "a",
+        buffering=1, encoding="utf-8",
+    )
+    renderer = UIBackedRenderer(PlainUI(no_color=True, file=log_fh))
+    bus = EventBus(CallbackSink(renderer.handle))
+    ui = EventBridgeUI(bus, prompter=NullPrompter())
+    channel = QueueInteractionChannel()
+
+    target = prepared(run_id, ui, channel, stop)
+
+    root_logger = logging.getLogger()
+    log_handler = logging.FileHandler(
+        run_paths.root / "orchestrator.log", encoding="utf-8",
+    )
+    previous = _install_exclusive_root_handler(root_logger, log_handler)
+
+    cleanups: list[Callable[[], None]] = [
+        lambda: log_fh.close(),
+        lambda: log_handler.close(),
+        lambda: _restore_root_handlers(root_logger, log_handler, previous),
+    ]
+    try:
+        handle = start_command_thread(
+            target, stop=stop, name=f"kstrl-{kind}",
+        )
+    except BaseException:
+        for cleanup in reversed(cleanups):
+            cleanup()
+        raise
+    return RunSession(
+        run_dir=run_paths.root,
+        kind=kind,
+        channel=channel,
+        handle=handle,
+        _cleanups=cleanups,
+    )
+
+
+# A prepared launch: everything validated, waiting for the session's
+# run_id / console / channel / stop to close over.
+PreparedLaunch = Callable[
+    [str, EventBridgeUI, QueueInteractionChannel, StopController],
+    Callable[[], int],
+]
+
+
+def _prepare_factory(spec: FactoryLaunch, root_dir: Path) -> PreparedLaunch:
+    from kstrl.manifest import Manifest
+
+    manifest_file = (
+        spec.manifest_path
+        or root_dir / "scripts" / "kstrl" / "manifest.json"
+    )
+    if not manifest_file.exists():
+        raise LaunchError(
+            f"no manifest at {manifest_file} - decompose a spec first",
+        )
+    try:
+        manifest = Manifest.load(manifest_file)
+    except (OSError, ValueError) as exc:
+        raise LaunchError(f"failed to load {manifest_file}: {exc}") from exc
+
+    factory_config, base_config = assemble_factory_configs(
+        root_dir, single_pr=manifest.single_pr,
+    )
+    if spec.max_parallel is not None:
+        factory_config.max_parallel = spec.max_parallel
+    if spec.review_mode is not None:
+        factory_config.review_mode = spec.review_mode
+
+    def build(
+        run_id: str,
+        ui: EventBridgeUI,
+        channel: QueueInteractionChannel,
+        stop: StopController,
+    ) -> Callable[[], int]:
+        def target() -> int:
+            from kstrl.factory import run_factory
+
+            return run_factory(
+                manifest, factory_config, base_config, ui, root_dir,
+                manifest_path=manifest_file,
+                interaction=channel,
+                stop=stop,
+                run_id=run_id,
+                notify_capture_output=True,
+            ).exit_code
+
+        return target
+
+    return build
+
+
+def _prepare_decompose(
+    spec: DecomposeLaunch, root_dir: Path,
+) -> PreparedLaunch:
+    from kstrl.agents import get_agent
+    from kstrl.config import KstrlConfig
+
+    spec_path = (
+        spec.spec_path if spec.spec_path.is_absolute()
+        else root_dir / spec.spec_path
+    )
+    if not spec_path.exists():
+        raise LaunchError(f"spec not found: {spec_path}")
+    if not spec.project_name.strip():
+        raise LaunchError("project name is required")
+
+    config = KstrlConfig.load(root_dir)
+    agent = get_agent(
+        config.agent_cmd, config.model, config.model_reasoning_effort,
+        config.agent_type,
+    )
+
+    def build(
+        run_id: str,
+        ui: EventBridgeUI,
+        channel: QueueInteractionChannel,
+        stop: StopController,
+    ) -> Callable[[], int]:
+        del channel, stop  # decompose has no prompts; stop is v2 work
+
+        def target() -> int:
+            from kstrl.decompose import SpecBlockerError, decompose_spec
+
+            command_run = open_command_run(
+                ui, root_dir, "decompose",
+                component="architect", run_id=run_id,
+            )
+            try:
+                try:
+                    manifest = decompose_spec(
+                        spec_path=spec_path,
+                        project_name=spec.project_name,
+                        base_branch=spec.base_branch,
+                        single_pr=spec.single_pr,
+                        agent=agent,
+                        ui=ui,
+                        root_dir=root_dir,
+                        bus=command_run.bus,
+                        transcript=command_run.transcript_writer("architect"),
+                    )
+                    ui.ok(
+                        f"Decomposed into {len(manifest.components)} "
+                        "components"
+                    )
+                    return 0
+                except SpecBlockerError as exc:
+                    ui.err(str(exc))
+                    if exc.artifact_path is not None:
+                        ui.info(
+                            f"Spec issues written to: {exc.artifact_path}"
+                        )
+                    return 2
+                except ValueError as exc:
+                    ui.err(str(exc))
+                    return 1
+            finally:
+                command_run.close()
+
+        return target
+
+    return build

--- a/kstrl/tui/session.py
+++ b/kstrl/tui/session.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from kstrl.commandrun import open_command_run
+from kstrl.config import KstrlConfig
 from kstrl.events import CallbackSink, EventBus, RunPaths
 from kstrl.interaction import QueueInteractionChannel
 from kstrl.launch import (
@@ -45,6 +46,19 @@ if TYPE_CHECKING:
 
 class LaunchError(Exception):
     """A launch failed validation before anything started."""
+
+
+def _preflight_agent(config: KstrlConfig) -> None:
+    """Apply the same agent validation and alias normalization as CLI runs."""
+    from kstrl.cli import _agent_preflight
+
+    canonical, error, hint = _agent_preflight(
+        config.agent_cmd, config.agent_type,
+    )
+    if error is not None:
+        detail = f"{error} - {hint}" if hint is not None else error
+        raise LaunchError(detail)
+    config.agent_type = canonical
 
 
 @dataclass
@@ -118,9 +132,18 @@ def start_run_session(
         lambda: log_handler.close(),
         lambda: _restore_root_handlers(root_logger, log_handler, previous),
     ]
+    def guarded_target() -> int:
+        try:
+            return target()
+        except BaseException:
+            logging.getLogger(__name__).exception(
+                "%s launch worker failed", kind,
+            )
+            raise
+
     try:
         handle = start_command_thread(
-            target, stop=stop, name=f"kstrl-{kind}",
+            guarded_target, stop=stop, name=f"kstrl-{kind}",
         )
     except BaseException:
         for cleanup in reversed(cleanups):
@@ -159,9 +182,13 @@ def _prepare_factory(spec: FactoryLaunch, root_dir: Path) -> PreparedLaunch:
     except (OSError, ValueError) as exc:
         raise LaunchError(f"failed to load {manifest_file}: {exc}") from exc
 
-    factory_config, base_config = assemble_factory_configs(
-        root_dir, single_pr=manifest.single_pr,
-    )
+    try:
+        factory_config, base_config = assemble_factory_configs(
+            root_dir, single_pr=manifest.single_pr,
+        )
+    except (OSError, ValueError) as exc:
+        raise LaunchError(f"failed to load configuration: {exc}") from exc
+    _preflight_agent(base_config)
     if spec.max_parallel is not None:
         factory_config.max_parallel = spec.max_parallel
     if spec.review_mode is not None:
@@ -194,8 +221,6 @@ def _prepare_decompose(
     spec: DecomposeLaunch, root_dir: Path,
 ) -> PreparedLaunch:
     from kstrl.agents import get_agent
-    from kstrl.config import KstrlConfig
-
     spec_path = (
         spec.spec_path if spec.spec_path.is_absolute()
         else root_dir / spec.spec_path
@@ -205,7 +230,11 @@ def _prepare_decompose(
     if not spec.project_name.strip():
         raise LaunchError("project name is required")
 
-    config = KstrlConfig.load(root_dir)
+    try:
+        config = KstrlConfig.load(root_dir)
+    except (OSError, ValueError) as exc:
+        raise LaunchError(f"failed to load configuration: {exc}") from exc
+    _preflight_agent(config)
     agent = get_agent(
         config.agent_cmd, config.model, config.model_reasoning_effort,
         config.agent_type,

--- a/kstrl/tui/styles.tcss
+++ b/kstrl/tui/styles.tcss
@@ -389,6 +389,41 @@ CheckpointModal {
     padding: 0 1;
 }
 
+/* ---- launch forms + retry ------------------------------------------------ */
+
+#launch-root {
+    padding: 0 1;
+}
+
+#launch-title, #retry-title {
+    height: 2;
+    padding: 0 1;
+    color: $text-muted;
+    text-style: bold;
+    border-bottom: solid $panel;
+}
+
+#launch-note {
+    height: 1;
+    padding: 0 1;
+}
+
+#launch-errors {
+    height: 1;
+    padding: 0 1;
+}
+
+#retry-table {
+    height: 1fr;
+    background: $background;
+}
+
+#retry-detail {
+    height: 6;
+    padding: 1 2;
+    background: $surface;
+}
+
 /* ---- evolve screen ------------------------------------------------------- */
 
 #evolve-tabs {

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
@@ -166,11 +165,13 @@ class TestConfigScreen:
         app = _app(tmp_path, report)
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause(0.2)
+            from kstrl.tui.screens.home import HOME_COMMANDS
+
             commands = app.screen.query_one("#home-commands")
             commands.focus()
-            deadline = time.monotonic() + 3
-            while not isinstance(app.screen, ConfigScreen):
-                await pilot.press("down")
-                await pilot.press("enter")
-                await pilot.pause(0.1)
-                assert time.monotonic() < deadline, "config never opened"
+            commands.highlighted = [  # type: ignore[attr-defined]
+                c.command_id for c in HOME_COMMANDS
+            ].index("config")
+            await pilot.press("enter")
+            await pilot.pause(0.2)
+            assert isinstance(app.screen, ConfigScreen)

--- a/tests/test_home_shell.py
+++ b/tests/test_home_shell.py
@@ -133,9 +133,14 @@ class TestHomeScreen:
         app = _home_app(tmp_path)
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause(0.2)
+            from kstrl.tui.screens.home import HOME_COMMANDS
+
             commands = app.screen.query_one("#home-commands")
             commands.focus()
-            await pilot.press("down")  # highlight the first entry
+            dash_index = [
+                c.command_id for c in HOME_COMMANDS
+            ].index("dash")
+            commands.highlighted = dash_index  # type: ignore[attr-defined]
             await pilot.press("enter")
             await pilot.pause(0.2)
             assert isinstance(app.screen, OverviewScreen)

--- a/tests/test_launch_session.py
+++ b/tests/test_launch_session.py
@@ -183,6 +183,80 @@ class TestStartRunSession:
         with pytest.raises(LaunchError, match="does not support"):
             start_run_session(LoopLaunch(), tmp_path)
 
+    def test_invalid_agent_config_fails_before_run_state(
+        self, tmp_path: Path,
+    ) -> None:
+        manifest_dir = tmp_path / "scripts" / "kstrl"
+        manifest_dir.mkdir(parents=True)
+        Manifest(
+            version="1", spec_file="s", project_name="demo",
+            base_branch="main", single_pr=False, components=[],
+        ).save(manifest_dir / "manifest.json")
+        (tmp_path / "kstrl.toml").write_text(
+            '[agent]\ntype = "gemini"\n', encoding="utf-8",
+        )
+
+        with pytest.raises(LaunchError, match="Unknown agent type"):
+            start_run_session(FactoryLaunch(), tmp_path)
+
+        assert not (tmp_path / ".kstrl").exists() or not list(
+            (tmp_path / ".kstrl" / "runs").glob("*"),
+        )
+
+    def test_decompose_canonicalizes_agent_alias(
+        self, tmp_path: Path,
+    ) -> None:
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Spec\nBuild it.", encoding="utf-8")
+        (tmp_path / "scripts" / "kstrl").mkdir(parents=True)
+        (tmp_path / "kstrl.toml").write_text(
+            '[agent]\ntype = "claude"\n', encoding="utf-8",
+        )
+        with (
+            patch("kstrl.cli.ClaudeCodeAgent.is_available", return_value=True),
+            patch(
+                "kstrl.agents.get_agent",
+                return_value=MockDecomposeAgent(VALID_DECOMPOSE_OUTPUT),
+            ) as get_agent,
+        ):
+            session = start_run_session(
+                DecomposeLaunch(spec_path=spec_file, project_name="demo"),
+                tmp_path,
+            )
+        try:
+            session.handle.join(timeout=15)
+            assert session.handle.exit_code == 0
+        finally:
+            session.close()
+        assert get_agent.call_args.args[3] == "claude-code"
+
+    def test_worker_exception_is_written_to_run_log(
+        self, tmp_path: Path,
+    ) -> None:
+        class ExplodingAgent:
+            def run(self, *args: object, **kwargs: object) -> object:
+                del args, kwargs
+                raise RuntimeError("architect exploded")
+
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Spec\nBuild it.", encoding="utf-8")
+        (tmp_path / "scripts" / "kstrl").mkdir(parents=True)
+        (tmp_path / "kstrl.toml").write_text(
+            '[agent]\ncommand = "fake-agent"\n', encoding="utf-8",
+        )
+        with patch("kstrl.agents.get_agent", return_value=ExplodingAgent()):
+            session = start_run_session(
+                DecomposeLaunch(spec_path=spec_file, project_name="demo"),
+                tmp_path,
+            )
+        session.handle.join(timeout=15)
+        session.close()
+
+        assert session.handle.exit_code == 1
+        assert "architect exploded" in (
+            session.run_dir / "orchestrator.log"
+        ).read_text(encoding="utf-8")
+
     def test_decompose_session_runs_end_to_end(self, tmp_path: Path) -> None:
         spec_file = tmp_path / "spec.md"
         spec_file.write_text("# Spec\nBuild it.")
@@ -345,6 +419,37 @@ class TestRetryScreen:
             await pilot.pause(0.2)
             detail = str(app.screen.query_one("#retry-detail").renderable)
             assert "nothing to retry" in detail
+
+    async def test_confirmation_does_not_overwrite_changed_manifest(
+        self, tmp_path: Path,
+    ) -> None:
+        manifest_file = self._failed_manifest(tmp_path)
+        app = _home_app(tmp_path)
+        specs: list[Any] = []
+        app.start_session = lambda spec: (
+            specs.append(spec) or FakeSession(tmp_path)
+        )
+        async with app.run_test(size=(130, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(RetryScreen())
+            await pilot.pause(0.2)
+            await pilot.press("r")
+            await pilot.pause()
+            assert isinstance(app.screen, OptionsModal)
+
+            changed = Manifest.load(manifest_file)
+            comp = changed.get_component("comp-a")
+            assert comp is not None
+            comp.status = ComponentStatus.COMPLETED.value
+            changed.save(manifest_file)
+
+            await pilot.press("1")
+            await pilot.pause(0.2)
+
+        persisted = Manifest.load(manifest_file).get_component("comp-a")
+        assert persisted is not None
+        assert persisted.status == ComponentStatus.COMPLETED.value
+        assert specs == []
 
 
 class TestDecomposeSessionOnBoard:

--- a/tests/test_launch_session.py
+++ b/tests/test_launch_session.py
@@ -1,0 +1,387 @@
+"""TUI surface D6: session seam, launch forms, retry surface."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from kstrl.interaction import (
+    PromptKind,
+    PromptRequest,
+    QueueInteractionChannel,
+)
+from kstrl.launch import DecomposeLaunch, FactoryLaunch, LoopLaunch
+from kstrl.manifest import Component, ComponentStatus, Manifest
+from kstrl.shutdown import StopController
+from kstrl.tui.app import KstrlTuiApp, Mode
+from kstrl.tui.bridge import start_command_thread
+from kstrl.tui.screens.decompose import DecomposeScreen
+from kstrl.tui.screens.home import HomeScreen
+from kstrl.tui.screens.launch import DecomposeLaunchForm, FactoryLaunchForm
+from kstrl.tui.screens.options import OptionsModal
+from kstrl.tui.screens.overview import OverviewScreen
+from kstrl.tui.screens.retry import RetryScreen
+from kstrl.tui.session import LaunchError, start_run_session
+from tests.test_decompose import VALID_DECOMPOSE_OUTPUT, MockDecomposeAgent
+
+
+class FakeSession:
+    """Injected through the app's start_session seam: streams a fake
+    factory run and optionally blocks on one CONFIRM prompt."""
+
+    def __init__(
+        self, root: Path, *, ask: bool = False, exit_code: int = 0,
+        run_id: str = "factory-20260720-170000.000000-fake",
+    ) -> None:
+        from kstrl import events as ev
+
+        self.kind = "factory"
+        self.channel = QueueInteractionChannel()
+        paths = ev.RunPaths.for_run(root, run_id)
+        self.run_dir = paths.root
+        stop = StopController()
+
+        def _target() -> int:
+            bus = ev.EventBus(ev.JsonlSink(paths.events_file), run_id=run_id)
+            bus.emit(ev.RunStarted(project="fake", components=1))
+            bus.emit(ev.ComponentStarted(component="comp-a"))
+            if ask:
+                deadline = time.monotonic() + 5
+                while (
+                    not self.channel.can_prompt()
+                    and time.monotonic() < deadline
+                ):
+                    time.sleep(0.01)
+                self.channel.request(PromptRequest(
+                    kind=PromptKind.CONFIRM,
+                    header="Proceed with the fake run?",
+                    options=("Proceed", "Stop"),
+                    default=0,
+                ))
+            bus.emit(ev.RunCompleted(completed=1))
+            bus.close()
+            return exit_code
+
+        self.handle = start_command_thread(_target, stop=stop)
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+        self.channel.detach()
+
+
+def _home_app(tmp_path: Path) -> KstrlTuiApp:
+    return KstrlTuiApp(root_dir=tmp_path, mode=Mode.HOME, poll_interval=0.05)
+
+
+class TestLaunchSeam:
+    async def test_launch_puts_the_board_up_and_finishes_in_place(
+        self, tmp_path: Path,
+    ) -> None:
+        app = _home_app(tmp_path)
+        sessions: list[FakeSession] = []
+
+        def fake_start(spec: object) -> FakeSession:
+            session = FakeSession(tmp_path, ask=True)
+            sessions.append(session)
+            return session
+
+        app.start_session = fake_start
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.launch(FactoryLaunch())
+            await pilot.pause(0.2)
+            assert isinstance(app.screen, (OverviewScreen, OptionsModal))
+            deadline = time.monotonic() + 5
+            while not isinstance(app.screen, OptionsModal):
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline, "prompt never arrived"
+            await pilot.press("1")
+            deadline = time.monotonic() + 5
+            while not sessions[0].handle.done():
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline, "session stuck"
+            await pilot.pause(0.7)  # _check_session interval
+            # The board stays up (owns_app_exit=False); app still runs.
+            assert app.return_value is None
+            assert isinstance(app.screen, OverviewScreen)
+            # Escape pops home and tears the session down.
+            await pilot.press("escape")
+            await pilot.pause(0.2)
+            assert isinstance(app.screen, HomeScreen)
+            assert app.run_context is None
+            assert sessions[0].closed
+
+    async def test_in_flight_guards_block_escape_and_second_launch(
+        self, tmp_path: Path,
+    ) -> None:
+        app = _home_app(tmp_path)
+        session = FakeSession(tmp_path, ask=True)  # blocks on the prompt
+        app.start_session = lambda spec: session
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.launch(FactoryLaunch())
+            await pilot.pause(0.3)
+            # Dismiss the prompt modal but leave it pending: the run
+            # stays in flight.
+            deadline = time.monotonic() + 5
+            while not isinstance(app.screen, OptionsModal):
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline
+            await pilot.press("escape")
+            await pilot.pause()
+            assert app.session_in_flight()
+            await pilot.press("escape")  # nav guard refuses
+            await pilot.pause()
+            assert not isinstance(app.screen, HomeScreen)
+            before = app.run_context
+            app.launch(FactoryLaunch())  # single-session guard
+            assert app.run_context is before
+            # Answer via c -> reopen so the thread can finish.
+            await pilot.press("c")
+            await pilot.pause()
+            await pilot.press("1")
+            deadline = time.monotonic() + 5
+            while not session.handle.done():
+                await pilot.pause(0.05)
+                assert time.monotonic() < deadline
+        session.handle.join(timeout=2)
+
+    async def test_launch_error_notifies_and_stays_home(
+        self, tmp_path: Path,
+    ) -> None:
+        app = _home_app(tmp_path)
+
+        def failing(spec: object) -> object:
+            raise LaunchError("no manifest - decompose a spec first")
+
+        app.start_session = failing
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.launch(FactoryLaunch())
+            await pilot.pause()
+            assert isinstance(app.screen, HomeScreen)
+            assert app.run_context is None
+
+
+class TestStartRunSession:
+    def test_factory_without_manifest_raises_before_any_thread(
+        self, tmp_path: Path,
+    ) -> None:
+        with pytest.raises(LaunchError, match="no manifest"):
+            start_run_session(FactoryLaunch(), tmp_path)
+        assert not (tmp_path / ".kstrl").exists() or not list(
+            (tmp_path / ".kstrl" / "runs").glob("*"),
+        )
+
+    def test_unsupported_spec_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(LaunchError, match="does not support"):
+            start_run_session(LoopLaunch(), tmp_path)
+
+    def test_decompose_session_runs_end_to_end(self, tmp_path: Path) -> None:
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Spec\nBuild it.")
+        (tmp_path / "scripts" / "kstrl").mkdir(parents=True)
+        with patch(
+            "kstrl.agents.get_agent",
+            return_value=MockDecomposeAgent(VALID_DECOMPOSE_OUTPUT),
+        ):
+            session = start_run_session(
+                DecomposeLaunch(spec_path=spec_file, project_name="demo"),
+                tmp_path,
+            )
+        try:
+            session.handle.join(timeout=15)
+            assert session.handle.exit_code == 0
+        finally:
+            session.close()
+        assert session.kind == "decompose"
+        assert (session.run_dir / "events.jsonl").exists()
+        assert (session.run_dir / "orchestrator.log").exists()
+        manifest = json.loads(
+            (tmp_path / "scripts" / "kstrl" / "manifest.json").read_text(),
+        )
+        assert len(manifest["components"]) == 2
+
+
+class TestLaunchForms:
+    async def test_factory_form_validates_then_launches(
+        self, tmp_path: Path,
+    ) -> None:
+        app = _home_app(tmp_path)
+        specs: list[Any] = []
+
+        def capture(spec: Any) -> FakeSession:
+            specs.append(spec)
+            return FakeSession(tmp_path)
+
+        app.start_session = capture
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(FactoryLaunchForm())
+            await pilot.pause(0.2)
+            from textual.widgets import Button, Input
+
+            form = app.screen
+            form.query_one("#factory-parallel", Input).value = "zebra"
+            form.query_one("#factory-start", Button).press()
+            await pilot.pause()
+            errors = str(form.query_one("#launch-errors").renderable)
+            assert "must be an integer" in errors
+            assert specs == []
+            # Fix the field and provide a manifest.
+            manifest_dir = tmp_path / "scripts" / "kstrl"
+            manifest_dir.mkdir(parents=True)
+            Manifest(
+                version="1", spec_file="s", project_name="demo",
+                base_branch="main", single_pr=False,
+                components=[],
+            ).save(manifest_dir / "manifest.json")
+            form.query_one("#factory-parallel", Input).value = "2"
+            form.query_one("#factory-start", Button).press()
+            await pilot.pause(0.3)
+            assert len(specs) == 1
+            assert specs[0].max_parallel == 2
+
+    async def test_decompose_form_requires_spec_and_project(
+        self, tmp_path: Path,
+    ) -> None:
+        app = _home_app(tmp_path)
+        specs: list[Any] = []
+        app.start_session = lambda spec: (
+            specs.append(spec) or FakeSession(tmp_path)
+        )
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(DecomposeLaunchForm())
+            await pilot.pause(0.2)
+            from textual.widgets import Button, Input
+
+            form = app.screen
+            form.query_one("#decompose-start", Button).press()
+            await pilot.pause()
+            errors = str(form.query_one("#launch-errors").renderable)
+            assert "spec path is required" in errors
+            assert "project name is required" in errors
+            (tmp_path / "spec.md").write_text("# spec")
+            form.query_one("#decompose-spec", Input).value = "spec.md"
+            form.query_one("#decompose-project", Input).value = "demo"
+            form.query_one("#decompose-start", Button).press()
+            await pilot.pause(0.3)
+            assert len(specs) == 1
+            assert specs[0].project_name == "demo"
+
+
+class TestRetryScreen:
+    def _failed_manifest(self, tmp_path: Path) -> Path:
+        manifest_dir = tmp_path / "scripts" / "kstrl"
+        manifest_dir.mkdir(parents=True)
+        manifest = Manifest(
+            version="1", spec_file="s", project_name="demo",
+            base_branch="main", single_pr=False,
+            components=[
+                Component(
+                    id="comp-a", title="A", description="",
+                    dependencies=[], prd_path="p.json",
+                    branch_name="kstrl/comp-a",
+                    status=ComponentStatus.FAILED.value,
+                    failed_phase="review", failed_check="criteria",
+                    error="review found blocking issues",
+                ),
+                Component(
+                    id="comp-b", title="B", description="",
+                    dependencies=[], prd_path="p.json",
+                    branch_name="kstrl/comp-b",
+                    status=ComponentStatus.COMPLETED.value,
+                ),
+            ],
+        )
+        manifest.save(manifest_dir / "manifest.json")
+        return manifest_dir / "manifest.json"
+
+    async def test_lists_failed_and_launches_after_confirm(
+        self, tmp_path: Path,
+    ) -> None:
+        manifest_file = self._failed_manifest(tmp_path)
+        app = _home_app(tmp_path)
+        specs: list[Any] = []
+        app.start_session = lambda spec: (
+            specs.append(spec) or FakeSession(tmp_path)
+        )
+        async with app.run_test(size=(130, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(RetryScreen())
+            await pilot.pause(0.2)
+            screen = app.screen
+            table = screen.query_one("#retry-table")
+            assert table.row_count == 1  # type: ignore[attr-defined]
+            detail = str(screen.query_one("#retry-detail").renderable)
+            assert "review found blocking issues" in detail
+            await pilot.press("r")
+            await pilot.pause()
+            assert isinstance(app.screen, OptionsModal)
+            assert "comp-a" in app.screen.request.header
+            await pilot.press("1")  # Start retry
+            await pilot.pause(0.3)
+            assert len(specs) == 1
+            assert isinstance(specs[0], FactoryLaunch)
+            assert specs[0].manifest_path == manifest_file
+            # prepare_retry really ran: the component is pending again.
+            reloaded = Manifest.load(manifest_file)
+            comp = reloaded.get_component("comp-a")
+            assert comp is not None
+            assert comp.status == ComponentStatus.PENDING.value
+
+    async def test_empty_state(self, tmp_path: Path) -> None:
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(130, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(RetryScreen())
+            await pilot.pause(0.2)
+            detail = str(app.screen.query_one("#retry-detail").renderable)
+            assert "nothing to retry" in detail
+
+
+class TestDecomposeSessionOnBoard:
+    async def test_launched_decompose_opens_the_rich_screen(
+        self, tmp_path: Path,
+    ) -> None:
+        """The real session + the real board, driven by a fake agent."""
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Spec\nBuild it.")
+        (tmp_path / "scripts" / "kstrl").mkdir(parents=True)
+        app = _home_app(tmp_path)
+        with patch(
+            "kstrl.agents.get_agent",
+            return_value=MockDecomposeAgent(VALID_DECOMPOSE_OUTPUT),
+        ):
+            async with app.run_test(size=(130, 45)) as pilot:
+                await pilot.pause(0.2)
+                app.launch(DecomposeLaunch(
+                    spec_path=spec_file, project_name="demo",
+                ))
+                await pilot.pause(0.2)
+                assert isinstance(app.screen, DecomposeScreen)
+                run = app.run_context
+                assert run is not None and run.handle is not None
+                deadline = time.monotonic() + 15
+                while not run.handle.done():
+                    await pilot.pause(0.1)
+                    assert time.monotonic() < deadline, "decompose stuck"
+                assert run.handle.exit_code == 0
+                await pilot.pause(0.7)
+                # Board reflects the finished run.
+                summary = str(
+                    app.screen.query_one("#decompose-summary").renderable,
+                )
+                assert "2 component(s)" in summary
+                await pilot.press("escape")
+                await pilot.pause()
+                await pilot.press("escape")
+                await pilot.pause(0.2)
+                assert isinstance(app.screen, HomeScreen)

--- a/tests/test_launch_session.py
+++ b/tests/test_launch_session.py
@@ -261,6 +261,9 @@ class TestStartRunSession:
         spec_file = tmp_path / "spec.md"
         spec_file.write_text("# Spec\nBuild it.")
         (tmp_path / "scripts" / "kstrl").mkdir(parents=True)
+        (tmp_path / "kstrl.toml").write_text(
+            '[agent]\ncommand = "fake-agent"\n', encoding="utf-8",
+        )
         with patch(
             "kstrl.agents.get_agent",
             return_value=MockDecomposeAgent(VALID_DECOMPOSE_OUTPUT),
@@ -460,6 +463,9 @@ class TestDecomposeSessionOnBoard:
         spec_file = tmp_path / "spec.md"
         spec_file.write_text("# Spec\nBuild it.")
         (tmp_path / "scripts" / "kstrl").mkdir(parents=True)
+        (tmp_path / "kstrl.toml").write_text(
+            '[agent]\ncommand = "fake-agent"\n', encoding="utf-8",
+        )
         app = _home_app(tmp_path)
         with patch(
             "kstrl.agents.get_agent",


### PR DESCRIPTION
Stacks on #141. Closes the loop: the home shell can now RUN the factory and decompose, not just observe them.

## What
- **`tui/session.py`**: `start_run_session(spec, root) -> RunSession{run_dir, kind, channel, handle}` - the pre-App portion of the embed sequence for an already-running app. **Validation precedes all disk state**: a `LaunchError` (missing manifest/spec, empty project name) leaves no run dir and no open handles (the original ordering leaked both - caught by test and restructured into prepare/build phases). Factory + decompose specs supported; feature/understand keep their CLI arg-resolution stacks (`--tui` there opens the same embedded dashboard) and the launcher entries say so instead of duplicating them.
- **App launch seam**: `launch(spec)` via injectable `start_session` (Pilot fakes); session board replaces the form over home, `owns_app_exit=False` - finish notifies and keeps the board for post-mortem; escape then pops home and tears down. **Prompt routing now uses the active channel** (constructor channel OR the session's) - the fake-session Pilot test caught prompts dying in home mode. In-flight guards: nav-to-home and second launches refused; q = QuitModal -> graceful stop, second q forces (exit 130); `run_home_shell` joins a live session before releasing the terminal.
- **Forms** (`screens/launch.py`, on the D5 form widgets): factory (manifest path, max parallel, review mode) and decompose (spec, project, base branch, single-PR) - headline options only per the B1 LaunchSpec contract, with `FormErrors` validation.
- **RetryScreen**: failed components + evidence detail; `r` -> confirm modal rendering `preview_retry` (non-mutating), then `prepare_retry` for real and a `FactoryLaunch` through the seam.

## Tested (new `tests/test_launch_session.py`, 11 tests)
- FakeSession seam: launch -> board -> prompt modal -> finish-in-place -> escape home with teardown; in-flight guards (escape refused, second launch refused, pending prompt reopened with `c`); LaunchError stays home.
- `start_run_session`: validation leaves zero disk state; unsupported spec message; **real decompose session end-to-end** (fake agent): exit 0, events.jsonl + orchestrator.log written, manifest with 2 components.
- Forms: integer validation blocks submit, then a captured `FactoryLaunch(max_parallel=2)`; decompose requires spec+project then captures the spec.
- RetryScreen: failed-only listing, confirm header, `prepare_retry` really resets the manifest, `FactoryLaunch` captured; empty state.
- Real-session board test: launched decompose opens DecomposeScreen, finishes with the summary line, escape x2 home.

Fast tier 1876 + spine 25 passed; mypy --strict clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)