### PR TITLE
fix: main CI red - complete FakeHandle; re-land stranded docs follow-up

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -207,6 +207,12 @@ dashboard crash all work by construction. Recording obeys the
 `.kstrl/progress.jsonl` keeps being written byte-compatibly by factory
 runs for existing consumers.
 
+The same event bus feeds the optional Linear mirror: a `LinearSink`
+subscribes to progress events and comments on component issues at
+failure and budget-halt moments, while status transitions ride branch
+names and PR trailers with zero API calls
+([docs/linear-integration.md](docs/linear-integration.md)).
+
 Token and cost figures are CLI self-reports: when any call goes
 unreported the meter renders a `+` marker and treats the total as a
 lower bound - an honest number is never turned into a false one.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <h1 align="center">kstrl</h1>
 
-<p align="center"><em>The adversarial software factory. Hand it a spec, walk away, get verified code.</em></p>
+<p align="center"><em>A fleet of AI agents builds your spec in parallel. An adversarial gauntlet attacks every diff. Only code that survives ships - and the factory learns from every run.</em></p>
 
 [![CI](https://github.com/0xfauzi/kstrl/actions/workflows/ci.yml/badge.svg)](https://github.com/0xfauzi/kstrl/actions/workflows/ci.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](pyproject.toml)
@@ -80,9 +80,9 @@ When the agent signals completion, kstrl doesn't just trust it. Every run goes t
 - **Adversarial review** (LLM): an independent reviewer checks the diff against the acceptance criteria, then a security reviewer hunts vulnerabilities - in `hard` mode their failures block.
 - **Contract testing** (multi-component runs): component branches merge tier-by-tier with integration tests at each tier.
 
-When verification fails, kstrl doesn't dump raw stderr into the retry prompt. It parses tool output into structured failures with file paths, source context, and fix hints:
+When verification fails, kstrl doesn't dump raw stderr into the retry prompt. It parses tool output into structured failures with file paths, source context, and fix hints. A sample of the retry context the agent gets back after a failed typecheck:
 
-```
+```text
 [mypy] Found 1 error in 1 file (checked 14 source files)
   src/api/auth.py:23 [arg-type] Argument 1 to "verify_password" has incompatible type "str | None"; expected "str"
     |     21 |     password = request.form.get("password")
@@ -119,6 +119,24 @@ kstrl factory --manifest scripts/kstrl/manifest.json --max-parallel 4
 Each component runs in an isolated git worktree (`.kstrl/worktrees/<run>/<component>`) with its own PRD. `ks run` is actually factory mode with a single component - the same verification pipeline runs whether you're building one feature or twenty.
 
 Scheduling, worktree isolation, merge gating, and the contract-testing bisect are diagrammed in [ARCHITECTURE.md](ARCHITECTURE.md#factory-mode).
+
+## Linear integration - the factory, mirrored into your tracker
+
+Enable the mirror and every factory run shows up in Linear without you lifting a finger:
+
+```toml
+[linear]
+enabled = true
+team_id = "your-team-uuid"
+```
+
+```bash
+export KSTRL_LINEAR_TOKEN="lin_api_..."
+```
+
+`ks decompose` creates a project and one issue per component (user stories as a checklist in the issue body); non-blocker spec findings are filed into Triage. Status transitions ride Linear's own GitHub integration: the component branch carries the issue identifier and the PR body carries a `Fixes ENG-42` trailer, so In Progress on PR-open and Done on merge cost kstrl zero API calls. Failures and budget halts land as a comment on the issue, and retries update the same issues - never duplicates, because issue ids persist in the manifest.
+
+The mirror is observability-only by design: every Linear failure warns and degrades, and nothing in the pipeline ever fails because Linear did. Setup, per-team automation settings, and rate-limit behavior: [docs/linear-integration.md](docs/linear-integration.md).
 
 ## The TUI - the whole surface, not just the factory
 

--- a/docs/linear-integration.md
+++ b/docs/linear-integration.md
@@ -1,6 +1,6 @@
 # Linear Integration (R7.4)
 
-Ralph mirrors a factory run into Linear: one project per manifest, one
+kstrl mirrors a factory run into Linear: one project per manifest, one
 issue per component, spec findings into Triage, and status transitions
 driven entirely by Linear's GitHub integration. The integration is
 observability only - every Linear failure warns and degrades; nothing
@@ -36,7 +36,7 @@ knobs: see `docs/env-vars.md` and `kstrl.toml.example`.
 | Component failure / budget halt | Comment on the issue | `LinearSink` on the progress log |
 | `ks retry` / resume | Same issues updated, never duplicated | ids persisted in the manifest |
 
-Status transitions therefore cost ralph **zero** API calls; the only
+Status transitions therefore cost kstrl **zero** API calls; the only
 mutations are decompose-time creates and failure comments. Per-team
 automation defaults ("In Progress" on PR open, "Done" on merge) are
 configurable in Linear under Team Settings > Workflows and

--- a/tests/test_config_screen.py
+++ b/tests/test_config_screen.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 from unittest.mock import patch
 
 import pytest
@@ -129,7 +129,11 @@ class TestConfigScreen:
             class FakeHandle:
                 finished = False
                 # Read by the HOME session watcher once done() flips.
+                # Keep this in sync with kstrl.tui.bridge's handle
+                # interface: the watcher's completion path reads
+                # exit_code AND error_box unconditionally.
                 exit_code = 0
+                error_box: ClassVar[list[BaseException]] = []
 
                 def done(self) -> bool:
                     return self.finished


### PR DESCRIPTION
Two things, both fallout from the #145 merge timing:

## 1. The CI failure on main (the actual bug)

`tests/test_config_screen.py::test_refresh_refused_while_a_session_is_active` fails with `AttributeError: 'FakeHandle' object has no attribute 'error_box'`.

Root cause: the test's `FakeHandle` predates the bridge handle gaining `error_box` (TUI embed work). The HOME session watcher's completion path reads `run.handle.error_box` unconditionally once `done()` flips - so the moment the watcher fires against this fake, it explodes. Measured: the test fails **in isolation at any recent commit** (3/3 at the pre-merge green commit e89c703 AND at main) - it was a latent bug masked by full-file test ordering, and the #145 merge perturbed the ordering enough to unmask it in CI. Docs-only diffs don't break tests; drifted fakes do.

Fix: the fake now carries `error_box` (ClassVar, mirroring `kstrl/tui/bridge.py`) with a sync-note comment. 7/7 full-file and 3/3 isolated, deterministic.

## 2. Re-land the stranded docs follow-up

#145 was merged before its review-feedback commit landed, so that commit was stranded on the deleted branch. Cherry-picked here: the stronger tagline ("A fleet of AI agents builds your spec in parallel..."), the README **Linear integration** section (enable snippet, what mirrors where, zero-API-call status transitions, observability-only degradation), the LinearSink note in ARCHITECTURE.md, the parsed-failure example explicitly captioned as sample output (it read as a live error), and two stale "Ralph" words in docs/linear-integration.md.

## Tested

Fast tier 1910 passed / 28 skipped (the previously-failing test now green), spine 25 passed, mypy --strict clean, ruff clean, gen_docs --check current. The failing test was verified red 3/3 isolated before the fix and green 3/3 after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)