### PR TITLE
docs: human tagline + current model examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <h1 align="center">kstrl</h1>
 
-<p align="center"><em>A fleet of AI agents builds your spec in parallel. An adversarial gauntlet attacks every diff. Only code that survives ships - and the factory learns from every run.</em></p>
+<p align="center"><em>AI agents write the code. kstrl makes sure it actually works.</em></p>
 
 [![CI](https://github.com/0xfauzi/kstrl/actions/workflows/ci.yml/badge.svg)](https://github.com/0xfauzi/kstrl/actions/workflows/ci.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](pyproject.toml)
@@ -56,9 +56,11 @@ You need at least one AI coding agent CLI:
 
 | Agent | Install | Example models |
 |-------|---------|----------------|
-| Claude Code (recommended) | [claude.ai/code](https://claude.ai/code) | sonnet, opus, haiku |
-| OpenAI Codex | [github.com/openai/codex](https://github.com/openai/codex) | gpt-5, o3 |
+| Claude Code (recommended) | [claude.ai/code](https://claude.ai/code) | `opus`, `sonnet`, `haiku`, `claude-fable-5` |
+| OpenAI Codex | [github.com/openai/codex](https://github.com/openai/codex) | `gpt-5.5`, `gpt-5.4` |
 | Custom | Any command that reads stdin | - |
+
+Model names current as of 2026-07: the claude aliases track the newest release in each tier (today Opus 4.8, Sonnet 5, Haiku 4.5) with `claude-fable-5` as the top-end frontier model, and codex defaults to `gpt-5.5` (the older `gpt-5.x-codex` ids are being retired).
 
 kstrl does not validate model names: `[agent].model` is passed straight through to the CLI (`claude --model` / `codex -m`), so any model the installed CLI accepts works.
 
@@ -237,7 +239,7 @@ kstrl reads `kstrl.toml` at the project root; copy [kstrl.toml.example](kstrl.to
 [agent]
 type = ""              # "claude-code" | "claude-sdk" | "codex"; empty/"auto" = auto-detect
 command = ""           # custom agent shell command; overrides type
-model = ""             # e.g. "sonnet" (claude) or "gpt-5" (codex); empty = agent default
+model = ""             # e.g. "sonnet" (claude) or "gpt-5.5" (codex); empty = agent default
 reasoning_effort = ""  # low | medium | high | max (model-dependent)
 budget_usd = ""        # in-loop USD ceiling; claude-sdk adapter only; empty/0 = unlimited (R7.6)
 

--- a/kstrl.toml.example
+++ b/kstrl.toml.example
@@ -5,7 +5,7 @@
 [agent]
 type = ""                          # "claude-code" | "claude-sdk" | "codex" (empty = auto-detect)
 command = ""                       # custom agent shell command; overrides type
-model = ""                         # e.g., "sonnet" for claude, "gpt-5" for codex (empty = default)
+model = ""                         # e.g., "sonnet" for claude, "gpt-5.5" for codex (empty = default)
 reasoning_effort = ""              # low|medium|high|max
 budget_usd = 0                     # in-loop USD ceiling; claude-sdk adapter only; 0 = unlimited (R7.6)
 

--- a/kstrl/init_cmd.py
+++ b/kstrl/init_cmd.py
@@ -377,7 +377,7 @@ DEFAULT_KSTRL_TOML = """\
 [agent]
 # type = ""                        # "claude-code" | "claude-sdk" | "codex" (empty = auto-detect)
 # command = ""                     # custom agent shell command; overrides type
-# model = ""                       # e.g. "sonnet" for claude, "gpt-5" for codex (empty = agent default)
+# model = ""                       # e.g. "sonnet" for claude, "gpt-5.5" for codex (empty = agent default)
 # reasoning_effort = ""            # low|medium|high|max
 
 [run]

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -301,7 +301,7 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("agent", "type"):
         '"claude-code" | "claude-sdk" | "codex"; empty/"auto" = auto-detect',
     ("agent", "command"): "custom agent shell command; overrides type",
-    ("agent", "model"): 'e.g. "sonnet" (claude) or "gpt-5" (codex); empty = agent default',
+    ("agent", "model"): 'e.g. "sonnet" (claude) or "gpt-5.5" (codex); empty = agent default',
     ("agent", "reasoning_effort"): "low | medium | high | max (model-dependent)",
     ("agent", "budget_usd"):
         "in-loop USD ceiling; claude-sdk adapter only; empty/0 = unlimited (R7.6)",


### PR DESCRIPTION
Two review-feedback fixes:

## Tagline

The previous one read as AI-written (the staccato triple-parallel structure). Now: **"AI agents write the code. kstrl makes sure it actually works."** - plain, honest, and the differentiator (verification, not generation) is the hook. The full pitch stays in the intro paragraph where it belongs.

## Model examples (verified, not recalled)

- **Claude Code**: `opus`, `sonnet`, `haiku`, `claude-fable-5` - the aliases track the newest release per tier (currently Opus 4.8 / Sonnet 5 / Haiku 4.5); Fable 5 is the top-end frontier model.
- **OpenAI Codex**: `gpt-5.5` (current default), `gpt-5.4`. The old examples (`gpt-5`, `o3`) were stale, and the `gpt-5.x-codex` ids are being retired per OpenAI's July 2026 sunset - checked via web search today, sources: [Codex models docs](https://developers.openai.com/codex/models), [Codex model sunset timeline](https://codex.danielvaughan.com/2026/06/02/codex-model-sunset-june-july-2026-deprecation-timeline-migration-paths-config-recipes/).
- Added a dated "current as of 2026-07" note under the table since model names rot quickly.
- The `[agent].model` example comment was fixed at its three sources (gen_docs, kstrl.toml.example, init scaffold) and the README regenerated - that line lives inside the generated config reference, so a direct README edit would have tripped the drift gate.

## Tested

Fast tier 1910 passed; gen_docs --check current; the config/scaffold/gen_docs cross-check tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)