### PR TITLE
chore: open-source community health - CONTRIBUTING, CoC, SECURITY, templates, CHANGELOG, metadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo.
+# Requests review from the maintainer on every pull request.
+* @0xfauzi

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Report something in the kstrl harness that does not work as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. For **security vulnerabilities**, do not use
+        this form - see [SECURITY.md](https://github.com/0xfauzi/kstrl/blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you observe, and what did you expect instead?
+      placeholder: kstrl did X; I expected Y.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands and, if possible, a minimal spec or config.
+      placeholder: |
+        1. `ks init .`
+        2. `ks factory --spec spec.md`
+        3. ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: kstrl version
+      description: Output of `ks --version` (or the installed package version).
+      placeholder: "0.2.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Agent CLI in use
+      options:
+        - Claude Code (claude-code)
+        - Claude SDK (claude-sdk)
+        - Codex (codex)
+        - Custom (agent_cmd)
+        - Not applicable
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / Python
+      placeholder: "macOS 15 / Python 3.11"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output
+      description: |
+        Paste the relevant excerpt from the terminal or from
+        `.kstrl/runs/<run_id>/events.jsonl`. Redact any secrets or tokens.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & ideas
+    url: https://github.com/0xfauzi/kstrl/discussions
+    about: Ask a question, share an idea, or discuss the roadmap in Discussions.
+  - name: Report a security vulnerability
+    url: https://github.com/0xfauzi/kstrl/security/advisories/new
+    about: Please report vulnerabilities privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Propose a capability or improvement for kstrl
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, check the [Dark Factory roadmap](https://github.com/0xfauzi/kstrl/blob/main/docs/dark-factory-roadmap.md)
+        and the [R8 milestone](https://github.com/0xfauzi/kstrl/milestone/1) -
+        your idea may already be planned. For open-ended ideas, consider
+        [Discussions](https://github.com/0xfauzi/kstrl/discussions) instead.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What need or limitation is this solving? Who hits it, and when?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like kstrl to do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, and why this one.
+    validations:
+      required: false
+  - type: dropdown
+    id: build-vs-integrate
+    attributes:
+      label: Build or integrate?
+      description: kstrl prefers integrating existing tools over building in-house. Does an existing tool cover this?
+      options:
+        - Needs to be built into kstrl
+        - Could integrate an existing tool
+        - Not sure
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!-- Thanks for contributing to kstrl. Keep this PR to one coherent change. -->
+
+## Summary
+
+<!-- What does this change do, and why? -->
+
+Closes #<!-- issue number, if any -->
+
+## What was tested vs assumed (H4)
+
+<!-- State what you actually exercised versus what you are assuming.
+     "Ran the full suite" / "drove the factory on examples/uv-python" beats
+     "should work". -->
+
+## Checklist
+
+- [ ] `uv run pytest tests/` passes
+- [ ] `uv run mypy kstrl/ --strict` passes
+- [ ] `uv run ruff check kstrl/ tests/` passes
+- [ ] `uv run python scripts/gen_docs.py --check` passes (if CLI/config changed)
+- [ ] If this maps to a roadmap item, the tracker doc's status is updated in this PR
+
+## Provenance
+
+- [ ] This change was written or substantially assisted by an AI agent
+- [ ] It has been reviewed by a human (AI self-review does not count - H1)
+
+## Prompt changes (only if an adversarial prompt body changed)
+
+- [ ] Calibration re-run and the detection delta recorded (H2)
+- [ ] `*_PROMPT_VERSION` bumped and the snapshot tuple in
+      `tests/test_prompt_versions.py` updated in this diff (H3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Work in progress toward the Dark Factory cycle (continuous intake, a release
+stage, runtime feedback, and an earned-autonomy ladder). See
+[`docs/dark-factory-roadmap.md`](docs/dark-factory-roadmap.md) and the
+[R8 milestone](https://github.com/0xfauzi/kstrl/milestone/1).
+
+## [0.2.0] - 2026-07-21
+
+The first release under the **kstrl** name (the project was formerly "Ralph").
+
+### Added
+
+- **Adversarial factory pipeline**: an architect red-teams the spec and
+  decomposes it into a component DAG; each component is built by a coding agent
+  in an isolated git worktree and gated through mechanical verification, code
+  review, security review, and cross-component contract testing before its PR
+  merges. An optional human checkpoint can pause before merge.
+- **Textual TUI and events substrate**: every run writes a typed
+  `events.jsonl` that every surface projects - a live dashboard, the bare-`ks`
+  home shell with a run browser, `ks dash` (attach read-only to any run), and
+  `ks status` for scripts and CI.
+- **Agent adapters**: `claude-code`, `codex`, `custom`, and an opt-in
+  `claude-sdk` adapter (installed via the `kstrl[sdk]` extra) with in-loop
+  budget enforcement.
+- **Safety systems**: per-phase and per-component timeouts, a no-progress
+  circuit breaker, adversarial-call and token budgets, an OS-level agent
+  sandbox, and a sandboxed approved-fixtures oracle.
+- **Learning loop**: a calibration suite with planted-bug fixtures, an
+  evolution journal, knowledge distillation across runs, and `ks evolve`
+  harness-improvement proposals.
+- **Linear mirror**: an optional one-way outbound sink that reflects factory
+  progress into a Linear tracker.
+- **Dark Factory roadmap**: `docs/dark-factory-roadmap.md` plus the R8 issue
+  set defining the path to a governed autonomous factory.
+
+### Changed
+
+- Renamed the project from Ralph to **kstrl** (CLI `ks`/`kstrl`, config
+  `kstrl.toml`, state `.kstrl/`, env prefix `KSTRL_*`). Legacy `RALPH_*` and
+  `.ralph/` are honored for one release with a deprecation warning.
+
+[Unreleased]: https://github.com/0xfauzi/kstrl/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/0xfauzi/kstrl/releases/tag/v0.2.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainer confidentially through GitHub's private reporting
+([open a private report](https://github.com/0xfauzi/kstrl/security/advisories/new))
+or by contacting the maintainer ([@0xfauzi](https://github.com/0xfauzi))
+directly. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to kstrl
+
+Thank you for considering a contribution. kstrl is run as a formal project:
+the process rules below are the mechanism that keeps an AI-assisted codebase
+trustworthy, so they are requirements, not suggestions.
+
+## Ways to help
+
+- **Report a bug** or **request a feature** through the issue templates.
+- **Ask a question** or **float an idea** in
+  [Discussions](https://github.com/0xfauzi/kstrl/discussions).
+- **Pick up roadmap work**: the current cycle is the Dark Factory roadmap
+  ([`docs/dark-factory-roadmap.md`](docs/dark-factory-roadmap.md), tracking
+  issue [#156](https://github.com/0xfauzi/kstrl/issues/156)). Wave-1 items
+  (policy envelope, health trending, autonomy ladder, exception inbox) are the
+  most self-contained entry points. Comment on an issue before starting so work
+  is not duplicated.
+- **Report a security vulnerability**: do *not* open a public issue. See
+  [SECURITY.md](SECURITY.md).
+
+## AI-assisted contributions
+
+AI-generated pull requests are welcome - this is a tool for building software
+with agents, after all. Two rules apply:
+
+1. **Declare it.** The PR template asks whether an agent wrote the change. Say
+   so honestly.
+2. **It must be human-reviewed.** Per the project's H1 rule, AI-generated code
+   is never gated by AI self-review. A human (you, and then the maintainer)
+   reviews every change. Do not run `/code-review` on your own AI-generated
+   code and present the result as review.
+
+## Development setup
+
+Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/). POSIX (macOS or
+Linux); Windows is unsupported for concurrent worktrees.
+
+```bash
+git clone https://github.com/0xfauzi/kstrl.git
+cd kstrl
+uv sync --all-extras --dev
+uv tool install -e .
+```
+
+There is a runnable end-to-end example under
+[`examples/uv-python/`](examples/uv-python/) - its README shows dry-run and
+fake-agent invocations you can use to exercise the loop without spending
+tokens.
+
+## Verification (run before every PR)
+
+The canonical commands live in [CLAUDE.md](CLAUDE.md); the short version:
+
+```bash
+uv run pytest tests/ -v                 # tests
+uv run mypy kstrl/ --strict             # typecheck
+uv run ruff check kstrl/ tests/         # lint
+uv run python scripts/gen_docs.py --check   # README generated sections in sync
+```
+
+CI runs these plus a coverage ratchet; the test suite must be green. The
+CLI-reference and Configuration sections of `README.md` are generated - edit
+the source (click commands / config dataclasses) or `scripts/gen_docs.py` and
+run `uv run python scripts/gen_docs.py`, never those regions by hand.
+
+## The process rules (H1-H4)
+
+These are the project's standing rules. Full statements are in
+[`docs/adversarial-roadmap.md`](docs/adversarial-roadmap.md) (Phase H) and
+[CLAUDE.md](CLAUDE.md):
+
+- **H1 - No self-review.** AI-generated code is gated by human review, never AI
+  self-review.
+- **H2 - Calibration on prompt change.** Any edit to an adversarial prompt body
+  re-runs the calibration suite and records the detection delta.
+- **H3 - Prompt versioning.** A prompt edit bumps its `*_PROMPT_VERSION` and the
+  snapshot tuple in `tests/test_prompt_versions.py` in the same diff.
+- **H4 - Tested vs assumed.** Every "done" claim states what was actually
+  exercised versus assumed.
+
+## Coding standards
+
+Summarized from [CLAUDE.md](CLAUDE.md):
+
+- `from __future__ import annotations` at the top of every file; type hints on
+  all signatures; `T | None` over `Optional[T]`.
+- `@dataclass` for data containers (`frozen=True` when immutable); `Protocol`
+  for interfaces.
+- snake_case functions, PascalCase classes, UPPER_SNAKE constants; absolute
+  imports grouped stdlib / third-party / local.
+- No bare `except:`; no mutable default arguments; no `pickle` on untrusted
+  data.
+- Match the surrounding code's idiom and comment density. Comments state
+  constraints the code cannot show, nothing else.
+
+## Pull request expectations
+
+- One coherent change per PR. If it maps to a roadmap item, update the tracker
+  doc's status in the same diff (audit-trail doctrine).
+- Fill in the PR template: what changed, what was tested vs assumed (H4),
+  whether an agent wrote it (H1), and - if a prompt changed - the calibration
+  and version-bump boxes (H2/H3).
+- Keep the adversarial mindset: when touching a role or its prompt, ask whether
+  the change makes the role more skeptical or more eager to please. Prefer the
+  former.
+
+By contributing, you agree that your contributions are licensed under the
+project's [MIT License](LICENSE) and that you will uphold the
+[Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 <p align="center"><em>AI agents write the code. kstrl makes sure it actually works.</em></p>
 
 [![CI](https://github.com/0xfauzi/kstrl/actions/workflows/ci.yml/badge.svg)](https://github.com/0xfauzi/kstrl/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/kstrl)](https://pypi.org/project/kstrl/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](pyproject.toml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
@@ -441,6 +442,10 @@ uv run ruff check kstrl/ tests/
 ```
 
 The CLI reference and config reference sections of this README are generated: edit the source (click commands / config dataclasses) or `scripts/gen_docs.py`, then run `uv run python scripts/gen_docs.py`. CI fails if the generated sections are stale.
+
+## Contributing
+
+Contributions are welcome, including AI-assisted ones - but AI-generated code is never gated by AI self-review, so every change is reviewed by a human and PRs should declare whether an agent wrote them. Start with [CONTRIBUTING.md](CONTRIBUTING.md) for the setup, the process rules, and how to pick up roadmap work; the [project wiki](https://github.com/0xfauzi/kstrl/wiki) covers the vision, architecture, and roadmap in depth. To report a vulnerability, see [SECURITY.md](SECURITY.md). Release history is in [CHANGELOG.md](CHANGELOG.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,63 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for security vulnerabilities.
+
+Report privately through GitHub's private vulnerability reporting:
+[**Report a vulnerability**](https://github.com/0xfauzi/kstrl/security/advisories/new).
+This opens a confidential advisory visible only to you and the maintainer.
+
+Please include enough to reproduce: the kstrl version, the agent CLI and model
+in use, your configuration (redact secrets), and the observed vs expected
+behavior. You will get an initial response as soon as reasonably possible for a
+solo-maintained project; please allow time to investigate and prepare a fix
+before any public disclosure.
+
+## Supported versions
+
+kstrl is pre-1.0 and ships from `main`. Security fixes target the latest
+released version (currently the `0.2.x` line) and `main`. Older versions are
+not maintained.
+
+| Version | Supported |
+|---|---|
+| `0.2.x` / `main` | Yes |
+| < `0.2` | No |
+
+## Threat model and scope
+
+kstrl orchestrates AI coding agents that execute code, read and write files,
+run subprocesses, and use API tokens. That makes the trust boundaries unusually
+important. The following are documented in the codebase and are the right
+starting points for any report:
+
+- **Agent sandbox** - what worktree isolation does and does not bound (shell
+  reads/writes, network): module docstring in `kstrl/sandbox.py` and the
+  `[sandbox]` keys in [`docs/env-vars.md`](docs/env-vars.md).
+- **Fixtures sandbox** - PRD-declared fixtures are LLM-emitted and treated as
+  untrusted input; commands run without a shell in a scrubbed environment,
+  functions run in a sandboxed subprocess, paths cannot escape the worktree.
+  See `kstrl/fixtures.py` and
+  [`ARCHITECTURE.md`](ARCHITECTURE.md#the-fixtures-sandbox).
+- **Known limitations** - correlated-failure risk, self-reported flags treated
+  as hints not signals, and the trusted fact-injection prompt: the "Known
+  limitations" section of
+  [`docs/adversarial-design.md`](docs/adversarial-design.md).
+
+**In scope:** vulnerabilities in the kstrl harness itself - sandbox escapes,
+unsafe handling of untrusted agent output, secret/token leakage, path-escape in
+fixtures or worktrees, and injection into the mechanical verifier or PR flow.
+
+**Out of scope:** bugs or vulnerabilities in code that agents write inside your
+own projects (that is the output kstrl is designed to help you review, not a
+flaw in kstrl); vulnerabilities in third-party agent CLIs (Claude Code, Codex)
+or their models; and issues that require an already-compromised host or
+maliciously configured `kstrl.toml`.
+
+## Handling secrets
+
+kstrl reads provider tokens from the environment (for example
+`KSTRL_LINEAR_TOKEN`). Do not paste real tokens into issues, discussions, or
+PRs. If you believe a token was exposed through kstrl's logs, events, or PR
+bodies, report it privately as above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,31 @@ description = "Lightweight agentic loop harness for autonomous AI-driven develop
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
+keywords = [
+    "ai-agents",
+    "coding-agent",
+    "claude-code",
+    "codex",
+    "autonomous-agents",
+    "llm",
+    "code-review",
+    "software-factory",
+    "devsecops",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Environment :: Console",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Testing",
+]
 dependencies = [
     "rich>=13.0.0",
     "click>=8.0.0",
@@ -26,8 +51,10 @@ sdk = [
 [project.urls]
 Homepage = "https://github.com/0xfauzi/kstrl"
 Repository = "https://github.com/0xfauzi/kstrl"
-Documentation = "https://github.com/0xfauzi/kstrl#readme"
+Documentation = "https://github.com/0xfauzi/kstrl/wiki"
 Architecture = "https://github.com/0xfauzi/kstrl/blob/main/ARCHITECTURE.md"
+Changelog = "https://github.com/0xfauzi/kstrl/blob/main/CHANGELOG.md"
+Issues = "https://github.com/0xfauzi/kstrl/issues"
 
 [project.scripts]
 ks = "kstrl.cli:main"


### PR DESCRIPTION
## Summary

Closes the open-source community-health and discoverability gaps so kstrl reads as a formal, contributable project. Companion repo-settings changes (description, topics, homepage, Discussions, private vulnerability reporting) were applied directly and are already live.

### New files
- **CONTRIBUTING.md** - setup, verification commands, the H1-H4 process rules (referencing CLAUDE.md and `docs/adversarial-roadmap.md`), the norm that AI-assisted PRs are welcome but must be human-reviewed and declared, and how to pick up roadmap work.
- **CODE_OF_CONDUCT.md** - Contributor Covenant 2.1; reporting routed to GitHub private reporting / the maintainer (no public email).
- **SECURITY.md** - private vulnerability reporting, supported versions, and a kstrl-specific threat-model scope (harness in scope; agent-written user code and third-party agent CLIs out), referencing the sandbox/fixtures threat models and `docs/adversarial-design.md` known limitations.
- **CHANGELOG.md** - Keep a Changelog format; `0.2.0` entry + `Unreleased`.
- **.github/** - PR template (encodes tested-vs-assumed, AI-provenance, and prompt-change H2/H3 boxes), bug/feature issue forms + config (Discussions + security links, blank issues off), `dependabot.yml` (uv + github-actions), `CODEOWNERS`.

### Edited
- **pyproject.toml** - `classifiers`, `keywords`, and `Changelog`/`Issues` project URLs; `Documentation` now points at the wiki.
- **README.md** - PyPI version badge and a short Contributing section (generated regions untouched).

## What was tested vs assumed (H4)

Verified locally: `pyproject.toml` parses (12 classifiers, 9 keywords, 6 URLs); all `.github` YAML parses; `uv run python scripts/gen_docs.py --check` passes (README generated regions untouched). Docs + packaging metadata only - no `kstrl/` Python logic changed, so ruff/mypy/tests are unaffected. H2/H3 N/A (no prompt changes). Not yet observed: GitHub's server-side rendering of the issue forms and Community Standards page (will confirm post-merge).

## Follow-ups (not in this PR)
- A TUI demo GIF for the README (needs a real terminal recording).
- After merge: tag `v0.2.0` + publish a GitHub Release from the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)