### PR TITLE
fix: drop late TUI state updates during screen teardown (flaky NoMatches)

### DIFF
--- a/kstrl/tui/screens/decompose.py
+++ b/kstrl/tui/screens/decompose.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.binding import Binding
+from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Static
 
@@ -167,20 +168,33 @@ class DecomposeScreen(Screen[None]):
         del manifest  # the folded plan is the source; no manifest join
         if not self.ready:
             return
-        self.query_one(RunHeader).update_state(state)
-        self.query_one(CostMeter).update_state(state)
-        self.query_one("#attempt-strip", Static).update(_attempt_strip(state))
-        self.query_one(DagTable).update_state(state)
-        self.query_one("#issues-strip", Static).update(_issue_strip(state))
-        summary = _summary(state)
-        summary_widget = self.query_one("#decompose-summary", Static)
-        summary_widget.display = summary is not None
-        if summary is not None:
-            summary_widget.update(summary)
+        try:
+            self.query_one(RunHeader).update_state(state)
+            self.query_one(CostMeter).update_state(state)
+            self.query_one("#attempt-strip", Static).update(_attempt_strip(state))
+            self.query_one(DagTable).update_state(state)
+            self.query_one("#issues-strip", Static).update(_issue_strip(state))
+            summary = _summary(state)
+            summary_widget = self.query_one("#decompose-summary", Static)
+            summary_widget.display = summary is not None
+            if summary is not None:
+                summary_widget.update(summary)
+        except NoMatches:
+            # A late StateChanged can arrive while the screen is tearing
+            # down: `ready` still sees the transcript (composed last) but
+            # RunHeader (composed first) is already gone. Dropping the
+            # update is safe - observability writes, not control flow.
+            return
 
     def tick_ages(self, state: RunState) -> None:
-        if self.ready:
+        if not self.ready:
+            return
+        try:
             self.query_one(RunHeader).update_state(state)
+        except NoMatches:
+            # Same teardown race as refresh_state: a timer-driven tick can
+            # fire after RunHeader is removed. Drop it.
+            return
 
     def feed_transcript(self, lines: list[str]) -> None:
         self.query_one(TranscriptTail).feed_lines(lines)

--- a/kstrl/tui/screens/overview.py
+++ b/kstrl/tui/screens/overview.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal
+from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widgets import Footer, Static
 
@@ -79,12 +80,20 @@ class OverviewScreen(Screen[None]):
     def refresh_state(self, state: RunState) -> None:
         if not self.ready:
             return
-        self.query_one(RunHeader).update_state(state)
-        self.query_one(CostMeter).update_state(state)
-        self.query_one(ComponentTable).update_state(state)
-        self.query_one(CheckpointBanner).update_state(
-            state, observe_only=self.observe_only,
-        )
+        try:
+            self.query_one(RunHeader).update_state(state)
+            self.query_one(CostMeter).update_state(state)
+            self.query_one(ComponentTable).update_state(state)
+            self.query_one(CheckpointBanner).update_state(
+                state, observe_only=self.observe_only,
+            )
+        except NoMatches:
+            # A late StateChanged can arrive while the screen is being torn
+            # down: `ready` still sees the feed (composed last, removed
+            # late) but RunHeader (composed first) is already gone. Dropping
+            # the update is safe - these are observability writes, not
+            # control flow.
+            return
 
     def feed_events(self, batch: list[ev.Event]) -> None:
         feed = next(iter(self.query(ActivityFeed)), None)
@@ -96,8 +105,13 @@ class OverviewScreen(Screen[None]):
     def tick_ages(self, state: RunState) -> None:
         if not self.ready:
             return
-        self.query_one(RunHeader).update_state(state)
-        self.query_one(ComponentTable).tick_ages(state)
+        try:
+            self.query_one(RunHeader).update_state(state)
+            self.query_one(ComponentTable).tick_ages(state)
+        except NoMatches:
+            # Same teardown race as refresh_state: a timer-driven tick can
+            # fire after RunHeader is removed. Drop it.
+            return
 
     def on_state_changed(self, message: StateChanged) -> None:
         self.refresh_state(message.state)

--- a/tests/test_decompose_screens.py
+++ b/tests/test_decompose_screens.py
@@ -18,6 +18,7 @@ from kstrl.tui.screens.component import ComponentScreen
 from kstrl.tui.screens.decompose import DecomposeScreen, SpecTriageScreen
 from kstrl.tui.screens.overview import OverviewScreen
 from kstrl.tui.widgets.dag_table import DagTable, compute_tiers
+from kstrl.tui.widgets.header import RunHeader
 from tests.helpers.fake_run import (
     write_fake_decompose_run,
     write_fake_run,
@@ -99,6 +100,23 @@ class TestDecomposeScreen:
             app.store.state.components.pop("api")
             table.update_state(app.store.state)
             assert {key.value for key in table.rows} == {"database"}
+
+    async def test_state_update_after_header_removed_is_safe(
+        self, tmp_path: Path,
+    ) -> None:
+        # Regression: a late StateChanged or age-tick during teardown finds
+        # RunHeader (composed first) already removed while `ready` (checks
+        # the transcript, composed last) still passes. Must drop, not raise.
+        run_dir = write_fake_decompose_run(tmp_path, attempts=1)
+        app = _decompose_app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            screen = app.screen
+            assert isinstance(screen, DecomposeScreen)
+            await screen.query_one(RunHeader).remove()
+
+            screen.refresh_state(app.store.state, None)
+            screen.tick_ages(app.store.state)
 
     async def test_triage_shows_blocker_banner_and_detail(
         self, tmp_path: Path,

--- a/tests/test_tui_detail.py
+++ b/tests/test_tui_detail.py
@@ -14,6 +14,7 @@ from kstrl.tui.screens.checkpoint import CheckpointModal
 from kstrl.tui.screens.component import ComponentScreen
 from kstrl.tui.screens.overview import OverviewScreen
 from kstrl.tui.widgets.findings_table import FindingsTable
+from kstrl.tui.widgets.header import RunHeader
 from kstrl.tui.widgets.phase_timeline import render_timeline
 from kstrl.tui.widgets.transcript import TranscriptTail
 from tests.helpers.fake_run import FakeRunSpec, write_fake_run
@@ -146,6 +147,27 @@ class TestComponentScreen:
 
             assert table.row_count == 3
             assert str(table.get_row_at(2)[3]) == "3"
+
+
+class TestOverviewScreenTeardown:
+    async def test_state_update_after_header_removed_is_safe(
+        self, tmp_path: Path,
+    ) -> None:
+        # Regression: a late StateChanged or age-tick can arrive while the
+        # screen is tearing down and RunHeader (composed first) has already
+        # been removed, even though `ready` (which checks the feed, composed
+        # last) still passes. Both entry points must drop the update, not
+        # raise textual.css.query.NoMatches.
+        run_dir = write_fake_run(tmp_path, FakeRunSpec(components=1))
+        app = _app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, OverviewScreen)
+            await screen.query_one(RunHeader).remove()
+
+            screen.refresh_state(app.store.state)
+            screen.tick_ages(app.store.state)
 
 
 class TestCheckpointModal:


### PR DESCRIPTION
## Summary

Fixes the intermittent `textual.css.query.NoMatches` failures in the TUI screen tests (tracked in #158). These flakes have been costing false CI reds on unrelated PRs - most recently they made Dependabot PR #161 (setup-uv) look broken when the bump was fine.

## Root cause

`OverviewScreen` and `DecomposeScreen` guard their state-update methods with a `ready` property that checks the **last**-composed widget (`ActivityFeed` / `TranscriptTail`), but the methods then `query_one` the **first**-composed `RunHeader`. During screen teardown the first widgets are removed while the last one still exists, so a late `StateChanged` message or age-tick timer passes the `ready` guard and then raises `NoMatches` on `query_one(RunHeader)`.

Observed failures (both this exact race):
- `test_tui_detail.py::TestCheckpointModal::test_reject_retry_and_escape` -> `NoMatches ... on OverviewScreen()`
- `test_decompose_screens.py::TestDecomposeScreen::test_triage_shows_blocker_banner_and_detail` -> `NoMatches ... on DecomposeScreen()`

## Fix

Wrap the `refresh_state` / `tick_ages` bodies in `try/except NoMatches` and drop the late update. These are observability writes, not control flow, so dropping an update against a dismantling screen is safe and matches the project's doctrine (sinks never gate control flow). Two files, four methods.

## What was tested vs assumed (H4)

- Added a regression test per screen that removes `RunHeader` and calls both `refresh_state` and `tick_ages`; both pass with the fix.
- **Verified the tests bite**: temporarily reverted the `OverviewScreen` guard and confirmed the new test fails with the exact `NoMatches: No nodes match 'RunHeader' on OverviewScreen()`, then restored.
- Full fast tier green locally: `1912 passed, 28 skipped`. `ruff` clean; `mypy --strict` clean (102 files).
- No prompt changes, so H2/H3 do not apply.

Closes #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)