### PR TITLE
R8.3: Exception inbox - one surface for human decisions (closes #150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ ks decompose                    Decompose a spec into components and generate PR
 ks evolve                       Analyze factory runs and propose harness improvements.
 ks factory                      Run the software factory - decompose and execute a spec.
 ks feature                      Run feature understanding, then implementation.
+ks inbox approve ITEM_ID        Accept the exception and close the item.
+ks inbox ls                     List items awaiting a decision.
+ks inbox reject ITEM_ID         Refuse the exception, recording why.
+ks inbox retry ITEM_ID          Requeue the item's component and close the item.
+ks inbox show ITEM_ID           Show one item in full, including its evidence.
+ks inbox snooze ITEM_ID         Defer an item; it returns when the TTL lapses.
 ks init [DIRECTORY]             Initialize kstrl in a project directory.
 ks retry COMPONENT_ID           Retry a FAILED component from the factory manifest (R3.3).
 ks run [MAX_ITERATIONS]         Run the agentic loop as a single-component factory invocation.
@@ -353,6 +359,13 @@ deploy = false                                                                  
 [autonomy]
 enabled = false  # derive run permissions from the ladder level (opt-in)
 max_level = 4    # hard ceiling: never run above this level (1-4)
+
+# Exception inbox (R8.3)
+[inbox]
+enabled = true                 # record exceptions awaiting a human decision
+open_item_cap = 50             # open items after which queue intake pauses; 0 = unbounded
+snooze_hours = 24.0            # default snooze TTL in hours; snoozed items return
+notify_action_required = true  # notify on action-required items and demotions only
 
 # Phase 2.5 security review
 [security]

--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ auto_apply_computational = false             # auto-apply computational proposal
 [notify]
 on_complete = ""       # shell hook fired once when the run finishes; empty = disabled
 on_first_failure = ""  # shell hook fired once on the first component failure
+on_inbox_item = ""     # shell hook fired per R8.3 inbox item kind; empty = disabled
 hook_timeout = 30.0    # seconds before a hook command is killed
 
 # Linear integration (R7.4; default off)

--- a/docs/dark-factory-roadmap.md
+++ b/docs/dark-factory-roadmap.md
@@ -377,7 +377,36 @@ exists and its output over historical `experiments.tsv` is captured here.
 
 ## R8.3 Exception inbox (L) - [#150](https://github.com/0xfauzi/kstrl/issues/150)
 
-Status: `[ ]` - Depends on: R8.1/R8.2 item types (can land with today's subset)
+Status: `[x]` - Shipped in `kstrl/inbox.py` + `ks inbox` +
+`kstrl/tui/screens/inbox.py`. Append-only `.kstrl/inbox.jsonl` folded on
+read; item kinds policy_exception / merge_gate / halted_run /
+budget_overrun / demotion_notice / calibration_drift; dedupe by key,
+snooze with a TTL that RETURNS the item, and an open-item cap that R8.6
+will consult before admitting queue work.
+
+**Emitters are wired, not declared.** Every existing halt path feeds it:
+component FAILED and PR-flow failure (halted_run), MERGE_PENDING
+(merge_gate), token-budget halt (budget_overrun), R8.1 policy findings
+(policy_exception, advisories excluded), and R8.2 demotions
+(demotion_notice, carrying the triggering evidence - the item R8.2
+promised). Verified end-to-end: a run with a planted policy violation
+produces a policy_exception, a halted_run, AND a demotion_notice while
+the ladder drops L3 -> L2.
+
+Closes three IOUs left by earlier items: R8.1's "violations route to the
+inbox", R8.2's "every demotion emits an inbox item", and the surface R8.6
+needs for `stop_at_pr`.
+
+Notification stays one-way, as specified: `notifiable()` selects
+action-required kinds plus demotions, so successes are silent; kstrl runs
+no inbound HTTP surface, and items are actioned in `ks inbox` or the TUI
+screen. An ntfy.sh example is documented in `docs/env-vars.md` under the
+existing `[notify]` hook.
+
+Not built: `approve-and-amend-policy` (widening the R8.1 envelope from a
+repeated approval) and the daily digest. Both are learning-loop
+refinements that want real inbox traffic to design against, and neither
+is load-bearing for R8.6.
 
 **Why.** Over-the-loop operation needs one surface for everything awaiting a
 human decision. Today: SpecBlocker exit codes, FAILED components,

--- a/docs/dark-factory-roadmap.md
+++ b/docs/dark-factory-roadmap.md
@@ -384,14 +384,21 @@ budget_overrun / demotion_notice / calibration_drift; dedupe by key,
 snooze with a TTL that RETURNS the item, and an open-item cap that R8.6
 will consult before admitting queue work.
 
-**Emitters are wired, not declared.** Every existing halt path feeds it:
-component FAILED and PR-flow failure (halted_run), MERGE_PENDING
-(merge_gate), token-budget halt (budget_overrun), R8.1 policy findings
+**Emitters are wired, not declared.** The halt paths that feed it:
+component FAILED and PR-flow failure (halted_run), MERGE_PENDING and the
+pre-merge checkpoint that no interactive UI can answer (merge_gate),
+token-budget halt (budget_overrun), R8.1 policy findings
 (policy_exception, advisories excluded), and R8.2 demotions
 (demotion_notice, carrying the triggering evidence - the item R8.2
 promised). Verified end-to-end: a run with a planted policy violation
 produces a policy_exception, a halted_run, AND a demotion_notice while
 the ladder drops L3 -> L2.
+
+`pause_before_pr_merge` on an unattended run no longer proceeds. It
+returns `CheckpointDecision.PARKED`: the merge is withheld, the
+component fails at `phase=pr / check=merge_gate`, and the decision goes
+to the inbox. Proceeding defeated the gate in exactly the unattended
+case R8.2's L1/L2 forces it on for.
 
 Closes three IOUs left by earlier items: R8.1's "violations route to the
 inbox", R8.2's "every demotion emits an inbox item", and the surface R8.6
@@ -400,13 +407,21 @@ needs for `stop_at_pr`.
 Notification stays one-way, as specified: `notifiable()` selects
 action-required kinds plus demotions, so successes are silent; kstrl runs
 no inbound HTTP surface, and items are actioned in `ks inbox` or the TUI
-screen. An ntfy.sh example is documented in `docs/env-vars.md` under the
-existing `[notify]` hook.
+screen. The push itself is a dedicated `[notify].on_inbox_item` command,
+empty by default: a failing component already fires `on_first_failure`
+and raises an item for the same event, so sharing one command would page
+twice for one thing. An ntfy.sh example is in `docs/env-vars.md`.
 
-Not built: `approve-and-amend-policy` (widening the R8.1 envelope from a
-repeated approval) and the daily digest. Both are learning-loop
-refinements that want real inbox traffic to design against, and neither
-is load-bearing for R8.6.
+Not built, and NOT claimed as done:
+
+- `approve-and-amend-policy` (widening the R8.1 envelope from a repeated
+  approval) and the daily digest. Both are learning-loop refinements that
+  want real inbox traffic to design against, and neither is load-bearing
+  for R8.6.
+- Inbox emission from `SpecBlockerError` exits and from terminal contract
+  failures. Review of PR #175 established that the original "every halt
+  path feeds it" claim was too broad: those two paths still bypass the
+  inbox.
 
 **Why.** Over-the-loop operation needs one surface for everything awaiting a
 human decision. Today: SpecBlocker exit codes, FAILED components,

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -144,6 +144,28 @@ Promotion requires evidence **and** a recorded human ack (`ks autonomy promote -
 | `KSTRL_AUTONOMY_ENABLED` | bool (`1`) | false |
 | `KSTRL_AUTONOMY_MAX_LEVEL` | int (1-4) | 4 |
 
+## InboxConfig (`[inbox]`)
+
+Exception inbox (R8.3): one surface for everything awaiting a human - policy exceptions (R8.1), halted runs, unconfirmed merges, budget overruns, and autonomy demotions (R8.2). On by default, because recording an exception changes no behaviour and an inbox that is off silently loses the record of decisions you still had to make.
+
+Items are append-only in `.kstrl/inbox.jsonl` and actioned with `ks inbox approve|reject|snooze|retry`. Notifications are one-way (kstrl runs no inbound HTTP surface); only action-required kinds and demotions notify, so success stays silent.
+
+| Env var | Type | Default |
+|---|---|---|
+| `KSTRL_INBOX_ENABLED` | bool (`1`) | true |
+| `KSTRL_INBOX_OPEN_CAP` | int (0 = unbounded) | 50 |
+| `KSTRL_INBOX_SNOOZE_HOURS` | float | 24.0 |
+| `KSTRL_INBOX_NOTIFY` | bool (`1`) | true |
+
+Push notifications reuse the existing `[notify]` hook rather than adding a service. An ntfy.sh example (self-hostable, priority tiers, no inbound surface on your side):
+
+```toml
+[notify]
+on_first_failure = "curl -fsS -H 'Priority: high' -d \"$KSTRL_NOTIFY_EVENT $KSTRL_NOTIFY_COMPONENT\" https://ntfy.sh/your-topic"
+```
+
+Then triage with `ks inbox ls`. Notifications never carry an action link: decisions happen locally, which is what keeps kstrl free of an inbound HTTP endpoint.
+
 ## ContractConfig (`[contract]`)
 
 | Env var | Type | Default |

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -157,12 +157,16 @@ Items are append-only in `.kstrl/inbox.jsonl` and actioned with `ks inbox approv
 | `KSTRL_INBOX_SNOOZE_HOURS` | float | 24.0 |
 | `KSTRL_INBOX_NOTIFY` | bool (`1`) | true |
 
-Push notifications reuse the existing `[notify]` hook rather than adding a service. An ntfy.sh example (self-hostable, priority tiers, no inbound surface on your side):
+`KSTRL_INBOX_NOTIFY` gates whether an item is *offered* to the notifier at all; the push itself only happens if `[notify].on_inbox_item` is set. Both are required, so the default is silent.
+
+Push notifications reuse the existing `[notify]` machinery rather than adding a service, but get their own command. An ntfy.sh example (self-hostable, priority tiers, no inbound surface on your side):
 
 ```toml
 [notify]
-on_first_failure = "curl -fsS -H 'Priority: high' -d \"$KSTRL_NOTIFY_EVENT $KSTRL_NOTIFY_COMPONENT\" https://ntfy.sh/your-topic"
+on_inbox_item = "curl -fsS -H 'Priority: high' -d \"$KSTRL_NOTIFY_EVENT $KSTRL_NOTIFY_COMPONENT\" https://ntfy.sh/your-topic"
 ```
+
+`KSTRL_NOTIFY_EVENT` arrives as `inbox_<kind>` (for example `inbox_merge_gate`), so one command can route by kind. It is a separate key from `on_first_failure` on purpose: a failing component fires the failure hook and raises an inbox item for the same event, and one event must not page twice.
 
 Then triage with `ks inbox ls`. Notifications never carry an action link: decisions happen locally, which is what keeps kstrl free of an inbound HTTP endpoint.
 
@@ -225,13 +229,16 @@ Invalid mode or threshold raises ValueError (Phase B8). The default mode is `ski
 
 ## NotifyConfig (`[notify]`)
 
-Run-milestone shell hooks (R3.2), each fired at most once per run. The hook command runs via the shell with `KSTRL_NOTIFY_EVENT` (`run_complete` | `first_failure` | `merge_pending`), `KSTRL_NOTIFY_RUN_ID`, `KSTRL_NOTIFY_PROJECT`, `KSTRL_NOTIFY_COMPONENT` and `KSTRL_NOTIFY_DETAIL` set in its environment.
+Run-milestone shell hooks (R3.2), each condition fired at most once per run. The hook command runs via the shell with `KSTRL_NOTIFY_EVENT` (`run_complete` | `first_failure` | `merge_pending` | `inbox_<kind>`), `KSTRL_NOTIFY_RUN_ID`, `KSTRL_NOTIFY_PROJECT`, `KSTRL_NOTIFY_COMPONENT` and `KSTRL_NOTIFY_DETAIL` set in its environment.
 
 | Env var | Type | Default |
 |---|---|---|
 | `KSTRL_NOTIFY_ON_COMPLETE` | str | unset (hook disabled) |
 | `KSTRL_NOTIFY_ON_FIRST_FAILURE` | str | unset (hook disabled) |
+| `KSTRL_NOTIFY_ON_INBOX_ITEM` | str | unset (hook disabled) |
 | `KSTRL_NOTIFY_HOOK_TIMEOUT` | float | 30 |
+
+`on_inbox_item` (R8.3) fires once per inbox item *kind* raised during a run, and is deliberately NOT a reuse of `on_first_failure`: a failing component fires the failure hook and raises an inbox item for the same event, so one shared command would page twice for one thing. Leave it empty unless you want per-item pushes; see `[inbox]` above for an ntfy.sh example.
 
 ## LinearConfig (`[linear]`)
 

--- a/kstrl.toml.example
+++ b/kstrl.toml.example
@@ -146,6 +146,17 @@ license_unresolved = "block"       # block | advisory - what to do when no sourc
 license_use_network = true         # false = uv cache only (offline); part of the envelope hash
 deploy = false                     # reserved for the R8.7 release gate; stored + hashed, not yet enforced
 
+# Exception inbox (R8.3): one surface for everything awaiting a human -
+# policy exceptions, halted runs, unconfirmed merges, budget overruns, autonomy
+# demotions. On by default: recording an exception changes no behaviour, and
+# what you lose by having it off is the record of a decision you already made.
+# Triage with `ks inbox ls|show|approve|reject|snooze|retry`.
+[inbox]
+enabled = true
+open_item_cap = 50                 # open items after which queue intake pauses (R8.6); 0 = unbounded
+snooze_hours = 24.0                # default snooze TTL; a snoozed item RETURNS
+notify_action_required = true      # notify on action-required items and demotions only
+
 # Autonomy ladder (R8.2): one ordered level (L1-L4) replaces the scatter of
 # independent autonomy flags. The level derives a flag bundle at run start and
 # WINS over contradicting flags here (contradictions are logged, not honored).

--- a/kstrl.toml.example
+++ b/kstrl.toml.example
@@ -213,11 +213,15 @@ auto_apply_computational = false   # auto-apply computational proposals
 
 # Run-milestone notification hooks (R3.2). Shell commands fired at most
 # once per run, with KSTRL_NOTIFY_EVENT (run_complete | first_failure |
-# merge_pending), KSTRL_NOTIFY_RUN_ID, KSTRL_NOTIFY_PROJECT,
+# merge_pending | inbox_<kind>), KSTRL_NOTIFY_RUN_ID, KSTRL_NOTIFY_PROJECT,
 # KSTRL_NOTIFY_COMPONENT and KSTRL_NOTIFY_DETAIL set in their environment.
+# on_inbox_item is a separate command on purpose: an R8.3 inbox item is
+# usually raised for the same event that already fired on_first_failure,
+# so sharing one command would notify twice for one thing.
 [notify]
 on_complete = ""                   # e.g. "printf '\\a'" for a terminal bell
 on_first_failure = ""              # e.g. a curl webhook one-liner
+on_inbox_item = ""                 # per R8.3 inbox item kind; opt-in
 hook_timeout = 30.0                # seconds before a hook command is killed
 
 # Linear integration (R7.4). Off by default. When enabled, decompose

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -3310,6 +3310,228 @@ def autonomy_replay_cmd(
     sys.exit(0 if report.sufficient_data else 2)
 
 
+@cli.group(name="inbox")
+def inbox_group() -> None:
+    """Triage what is waiting on a human (R8.3).
+
+    One surface for policy exceptions, halted runs, unconfirmed merges,
+    budget overruns, and autonomy demotions - the things that used to be
+    discoverable only if you already knew where to look.
+    """
+
+
+_inbox_root_option = click.option(
+    "--root", type=click.Path(path_type=Path),
+    help="Project root path (defaults to current directory)",
+)
+_inbox_ui_option = click.option(
+    "--ui", type=click.Choice(["auto", "rich", "plain", "gum"]),
+    default="auto", help="UI mode",
+)
+_inbox_no_color_option = click.option(
+    "--no-color", is_flag=True, help="Disable colors",
+)
+
+
+def _inbox_for(root: Path | None) -> tuple[Path, Any]:
+    from kstrl.inbox import Inbox, InboxConfig
+
+    root_dir = (root or Path.cwd()).resolve()
+    return root_dir, Inbox(root_dir, InboxConfig.load(root_dir))
+
+
+def _actor() -> str:
+    """Who is deciding. Best-effort identity for the audit trail."""
+    return os.environ.get("USER") or os.environ.get("USERNAME") or "operator"
+
+
+@inbox_group.command(name="ls")
+@click.option("--all", "show_all", is_flag=True, help="Include decided items")
+@_inbox_root_option
+@_inbox_ui_option
+@_inbox_no_color_option
+def inbox_ls(
+    show_all: bool, root: Path | None, ui: str, no_color: bool,
+) -> None:
+    """List items awaiting a decision."""
+    from kstrl.inbox import summarize
+
+    _root_dir, box = _inbox_for(root)
+    ui_impl = _autonomy_ui(ui, no_color)
+    items = box.items() if show_all else box.open_items()
+    if not items:
+        ui_impl.ok("Inbox clear: nothing is waiting on you.")
+        sys.exit(0)
+    ui_impl.section("Inbox")
+    for item in items:
+        marker = {"high": "!", "normal": " ", "low": "."}.get(str(item.priority), " ")
+        repeat = f" x{item.occurrences}" if item.occurrences > 1 else ""
+        state = "" if item.is_open else f" [{item.status}]"
+        ui_impl.info(
+            f"  {marker} {item.id[:8]}  {str(item.kind):<18}"
+            f"{item.title}{repeat}{state}"
+        )
+    ui_impl.info("")
+    ui_impl.kv("summary", summarize(box.items()))
+    if box.over_cap():
+        ui_impl.warn(
+            f"  Open items have reached the cap ({box.config.open_item_cap}); "
+            "queue intake pauses here (R8.6)."
+        )
+    sys.exit(0)
+
+
+@inbox_group.command(name="show")
+@click.argument("item_id")
+@_inbox_root_option
+@_inbox_ui_option
+@_inbox_no_color_option
+def inbox_show(
+    item_id: str, root: Path | None, ui: str, no_color: bool,
+) -> None:
+    """Show one item in full, including its evidence."""
+    import json as _json
+
+    _root_dir, box = _inbox_for(root)
+    ui_impl = _autonomy_ui(ui, no_color)
+    item = box.get(item_id)
+    if item is None:
+        ui_impl.err(f"No inbox item matching {item_id!r}")
+        sys.exit(1)
+    ui_impl.section(item.title)
+    ui_impl.kv("id", item.id)
+    ui_impl.kv("kind", str(item.kind))
+    ui_impl.kv("priority", str(item.priority))
+    ui_impl.kv("status", str(item.status))
+    ui_impl.kv("created", item.created_at)
+    if item.component:
+        ui_impl.kv("component", item.component)
+    if item.run_id:
+        ui_impl.kv("run", item.run_id)
+    if item.occurrences > 1:
+        ui_impl.kv("occurrences", str(item.occurrences))
+    if item.decided_by:
+        ui_impl.kv("decided by", f"{item.decided_by} at {item.decided_at}")
+    if item.decision_comment:
+        ui_impl.kv("comment", item.decision_comment)
+    if item.detail:
+        ui_impl.subsection("Detail")
+        for line in item.detail.splitlines():
+            ui_impl.info(f"  {line}")
+    if item.evidence:
+        ui_impl.subsection("Evidence")
+        for line in _json.dumps(item.evidence, indent=2).splitlines():
+            ui_impl.info(f"  {line}")
+    sys.exit(0)
+
+
+def _decide_and_report(
+    action: str, item_id: str, root: Path | None, ui: str, no_color: bool,
+    comment: str = "", hours: float | None = None,
+) -> None:
+    from kstrl.inbox import InboxError
+
+    _root_dir, box = _inbox_for(root)
+    ui_impl = _autonomy_ui(ui, no_color)
+    try:
+        if action == "approve":
+            item = box.approve(item_id, actor=_actor(), comment=comment)
+        elif action == "reject":
+            item = box.reject(item_id, actor=_actor(), comment=comment)
+        elif action == "snooze":
+            item = box.snooze(item_id, actor=_actor(), hours=hours)
+        else:
+            item = box.resolve(item_id, actor=_actor(), comment=comment)
+    except InboxError as exc:
+        ui_impl.err(str(exc))
+        sys.exit(1)
+    ui_impl.ok(f"{action}d {item.id[:8]}: {item.title}")
+    sys.exit(0)
+
+
+@inbox_group.command(name="approve")
+@click.argument("item_id")
+@click.option("--comment", default="", help="Why (recorded in the audit trail)")
+@_inbox_root_option
+@_inbox_ui_option
+@_inbox_no_color_option
+def inbox_approve(
+    item_id: str, comment: str, root: Path | None, ui: str, no_color: bool,
+) -> None:
+    """Accept the exception and close the item."""
+    _decide_and_report("approve", item_id, root, ui, no_color, comment=comment)
+
+
+@inbox_group.command(name="reject")
+@click.argument("item_id")
+@click.option("--comment", required=True, help="Why it was rejected")
+@_inbox_root_option
+@_inbox_ui_option
+@_inbox_no_color_option
+def inbox_reject(
+    item_id: str, comment: str, root: Path | None, ui: str, no_color: bool,
+) -> None:
+    """Refuse the exception, recording why."""
+    _decide_and_report("reject", item_id, root, ui, no_color, comment=comment)
+
+
+@inbox_group.command(name="snooze")
+@click.argument("item_id")
+@click.option("--hours", type=float, help="TTL (default: [inbox] snooze_hours)")
+@_inbox_root_option
+@_inbox_ui_option
+@_inbox_no_color_option
+def inbox_snooze(
+    item_id: str, hours: float | None, root: Path | None, ui: str, no_color: bool,
+) -> None:
+    """Defer an item; it returns when the TTL lapses."""
+    _decide_and_report("snooze", item_id, root, ui, no_color, hours=hours)
+
+
+@inbox_group.command(name="retry")
+@click.argument("item_id")
+@_inbox_root_option
+@_inbox_ui_option
+@_inbox_no_color_option
+def inbox_retry(
+    item_id: str, root: Path | None, ui: str, no_color: bool,
+) -> None:
+    """Requeue the item's component and close the item.
+
+    A real round-trip, not a status change: the component is reset to
+    PENDING in the manifest (with its dependents un-skipped), so the next
+    `ks factory` run picks it up.
+    """
+    from kstrl.manifest import Manifest
+
+    root_dir, box = _inbox_for(root)
+    ui_impl = _autonomy_ui(ui, no_color)
+    item = box.get(item_id)
+    if item is None:
+        ui_impl.err(f"No inbox item matching {item_id!r}")
+        sys.exit(1)
+    if not item.component:
+        ui_impl.err(f"{item.id[:8]} has no component to requeue")
+        sys.exit(1)
+    manifest_path = root_dir / "scripts" / "kstrl" / "manifest.json"
+    if not manifest_path.exists():
+        ui_impl.err(f"No manifest at {manifest_path}")
+        sys.exit(1)
+    manifest = Manifest.load(manifest_path)
+    try:
+        reset = manifest.reset_for_retry(item.component)
+    except (ValueError, KeyError) as exc:
+        ui_impl.err(f"Could not requeue {item.component}: {exc}")
+        sys.exit(1)
+    manifest.save(manifest_path)
+    box.resolve(item.id, actor=_actor(), comment="requeued via ks inbox retry")
+    ui_impl.ok(
+        f"Requeued {item.component} (reset: {', '.join(reset) or item.component}); "
+        "run `ks factory` to pick it up."
+    )
+    sys.exit(0)
+
+
 def main() -> None:
     """Main entry point."""
     cli()

--- a/kstrl/config_report.py
+++ b/kstrl/config_report.py
@@ -171,7 +171,8 @@ def _phase_sections() -> list[tuple[str, Any, list[str]]]:
             f.name for f in dataclass_fields(TimeoutConfig)
         ]),
         ("notify", NotifyConfig.load, [
-            "on_complete", "on_first_failure", "hook_timeout",
+            "on_complete", "on_first_failure", "on_inbox_item",
+            "hook_timeout",
         ]),
         ("linear", LinearConfig.load, [
             "enabled", "team_id", "token_env", "auth_mode", "api_url",

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -62,6 +62,7 @@ from kstrl.feedforward import FeedforwardConfig, build_feedforward_context
 from kstrl.findings import POLICY_CATEGORY_PREFIX
 from kstrl.fixtures import FixturesConfig
 from kstrl.git import fetch_base_branch, resolve_base_ref
+from kstrl.inbox import Inbox, InboxConfig, ItemKind
 from kstrl.interaction import InteractionChannel
 from kstrl.knowledge import (
     KnowledgeConfig,
@@ -1565,6 +1566,27 @@ def _record_autonomy_outcome(
         )
         return
     commit_transition(state, record, root_dir, bus=bus, run_id=run_id)
+    # R8.2 promised this and R8.3 delivers it: a demotion is exactly the
+    # boundary condition an over-the-loop operator must see, and the
+    # triggering evidence is perishable - it belongs on the item.
+    try:
+        inbox_config = InboxConfig.load(root_dir)
+        if inbox_config.enabled:
+            Inbox(root_dir, inbox_config).add(
+                ItemKind.DEMOTION_NOTICE,
+                f"Autonomy demoted L{record.from_level} -> L{record.to_level}",
+                detail=record.reason,
+                run_id=run_id,
+                dedupe_key=f"demotion:{run_id}:{record.to_level}",
+                evidence={
+                    "trigger": record.trigger,
+                    "from_level": record.from_level,
+                    "to_level": record.to_level,
+                    **record.evidence,
+                },
+            )
+    except (OSError, ValueError) as exc:
+        ui.warn(f"Inbox write failed (non-fatal): {exc}")
     ui.warn(
         f"Autonomy DEMOTED L{before} -> L{state.level} "
         f"({state.autonomy_level.label}) on policy violation; cool-down "

--- a/kstrl/inbox.py
+++ b/kstrl/inbox.py
@@ -1,0 +1,568 @@
+"""R8.3 exception inbox: one surface for everything awaiting a human.
+
+Over-the-loop operation needs a single place to look. Today the things
+that want a decision are scattered across surfaces that share nothing: a
+FAILED component lives in the manifest, a MERGE_PENDING park lives in a
+status string, an R8.1 policy violation lives in a finding, an R8.2
+demotion lives in the evolution journal, a budget overrun lives in a log
+line. Each is discoverable only if you already know to look for it, which
+is the opposite of what "humans handle exceptions" requires.
+
+This module is the thin substrate: an append-only ``.kstrl/inbox.jsonl``
+plus the fold that turns it into a current view. Deliberately small - the
+value is in the emitters that feed it and the actions that resolve it,
+not in the store.
+
+**Append-only, never rewritten.** Every emission and every decision is one
+appended line; the current state of an item is the fold of its lines in
+order. A crash mid-write can lose at most the last line, never corrupt a
+prior decision, and "what did I approve and when?" is answerable by
+reading the file rather than trusting a mutated record.
+
+Design notes that carry weight:
+
+- **The open-item cap is a real backstop, not decoration.** An inbox that
+  grows without bound is a second job, and the roadmap's own failure mode.
+  ``InboxConfig.open_item_cap`` is what R8.6 will consult before admitting
+  more queue work.
+- **Snooze has a TTL, not a hide button.** A snoozed item returns; that is
+  the difference between deferring a decision and losing one.
+- **Notifications are one-way.** Items are actioned in ``ks inbox``, never
+  by a callback into the harness, so kstrl runs no inbound HTTP surface.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import uuid
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+INBOX_FILENAME = ".kstrl/inbox.jsonl"
+INBOX_SCHEMA_VERSION = 1
+
+
+class ItemKind(StrEnum):
+    """What kind of decision an item is asking for.
+
+    The kinds map one-to-one onto the halt paths that existed before this
+    module; adding a kind means adding an emitter, never just a label.
+    """
+
+    POLICY_EXCEPTION = "policy_exception"      # R8.1 envelope violation
+    MERGE_GATE = "merge_gate"                  # a merge awaiting approval
+    HALTED_RUN = "halted_run"                  # a component/run stopped
+    BUDGET_OVERRUN = "budget_overrun"          # a cap was hit
+    DEMOTION_NOTICE = "demotion_notice"        # R8.2 autonomy revoked
+    CALIBRATION_DRIFT = "calibration_drift"    # detection rate moved
+
+    @property
+    def action_required(self) -> bool:
+        """Whether this kind blocks on a human, as opposed to informing.
+
+        Drives notification: action-required kinds and demotions notify;
+        informational kinds stay silent and batch into a digest. Alert
+        fatigue is the failure mode being defended against - a surface
+        that pages on success trains you to ignore it.
+        """
+        return self in {
+            ItemKind.POLICY_EXCEPTION,
+            ItemKind.MERGE_GATE,
+            ItemKind.HALTED_RUN,
+            ItemKind.BUDGET_OVERRUN,
+        }
+
+
+class ItemStatus(StrEnum):
+    OPEN = "open"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    SNOOZED = "snoozed"
+    RESOLVED = "resolved"     # actioned elsewhere / no longer relevant
+
+
+class Priority(StrEnum):
+    """Notification tier. Not a sort key alone - age matters too."""
+
+    HIGH = "high"
+    NORMAL = "normal"
+    LOW = "low"
+
+
+#: Default priority per kind. A demotion is high because autonomy was
+#: revoked and the evidence is perishable; drift is low because it is a
+#: trend, not an event.
+DEFAULT_PRIORITY: dict[ItemKind, Priority] = {
+    ItemKind.POLICY_EXCEPTION: Priority.HIGH,
+    ItemKind.MERGE_GATE: Priority.NORMAL,
+    ItemKind.HALTED_RUN: Priority.NORMAL,
+    ItemKind.BUDGET_OVERRUN: Priority.HIGH,
+    ItemKind.DEMOTION_NOTICE: Priority.HIGH,
+    ItemKind.CALIBRATION_DRIFT: Priority.LOW,
+}
+
+_PRIORITY_ORDER = {Priority.HIGH: 0, Priority.NORMAL: 1, Priority.LOW: 2}
+
+
+class InboxError(RuntimeError):
+    """An inbox action was refused (unknown id, already decided, cap hit)."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def _iso(moment: datetime) -> str:
+    return moment.isoformat()
+
+
+def _parse_iso(value: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+@dataclass
+class InboxItem:
+    """One decision awaiting (or having received) a human.
+
+    ``dedupe_key`` collapses repeats: the same component failing the same
+    way across three retries is one item with a bumped count, not three
+    items. Without it the inbox becomes noise on exactly the runs where it
+    matters most.
+    """
+
+    id: str
+    kind: ItemKind
+    title: str
+    created_at: str
+    detail: str = ""
+    priority: Priority = Priority.NORMAL
+    component: str = ""
+    run_id: str = ""
+    dedupe_key: str = ""
+    evidence: dict[str, Any] = field(default_factory=dict)
+    status: ItemStatus = ItemStatus.OPEN
+    occurrences: int = 1
+    last_seen_at: str = ""
+    decided_at: str = ""
+    decided_by: str = ""
+    decision_comment: str = ""
+    snooze_until: str = ""
+
+    @property
+    def is_open(self) -> bool:
+        """Open now: never decided, or snoozed past its TTL.
+
+        A lapsed snooze reads as open rather than needing a sweeper - the
+        deferral expires by the clock, so nothing has to remember to
+        un-hide it.
+        """
+        if self.status is ItemStatus.OPEN:
+            return True
+        if self.status is ItemStatus.SNOOZED:
+            until = _parse_iso(self.snooze_until)
+            return until is None or until <= _utc_now()
+        return False
+
+    @property
+    def snooze_active(self) -> bool:
+        return self.status is ItemStatus.SNOOZED and not self.is_open
+
+    def sort_key(self) -> tuple[int, str]:
+        return (_PRIORITY_ORDER.get(self.priority, 1), self.created_at)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": str(self.kind),
+            "title": self.title,
+            "created_at": self.created_at,
+            "detail": self.detail,
+            "priority": str(self.priority),
+            "component": self.component,
+            "run_id": self.run_id,
+            "dedupe_key": self.dedupe_key,
+            "evidence": self.evidence,
+            "status": str(self.status),
+            "occurrences": self.occurrences,
+            "last_seen_at": self.last_seen_at,
+            "decided_at": self.decided_at,
+            "decided_by": self.decided_by,
+            "decision_comment": self.decision_comment,
+            "snooze_until": self.snooze_until,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> InboxItem | None:
+        """Rebuild an item, returning None for anything unrecognizable.
+
+        Tolerant by design: one malformed line must not make the whole
+        inbox unreadable, because an unreadable inbox is an invisible
+        backlog. The line is skipped, not fatal.
+        """
+        item_id = data.get("id")
+        if not isinstance(item_id, str) or not item_id:
+            return None
+        try:
+            kind = ItemKind(str(data.get("kind", "")))
+            status = ItemStatus(str(data.get("status", ItemStatus.OPEN)))
+            priority = Priority(str(data.get("priority", Priority.NORMAL)))
+        except ValueError:
+            return None
+        evidence = data.get("evidence", {})
+        if not isinstance(evidence, dict):
+            evidence = {}
+        occurrences = data.get("occurrences", 1)
+        if not isinstance(occurrences, int) or isinstance(occurrences, bool):
+            occurrences = 1
+        return cls(
+            id=item_id,
+            kind=kind,
+            title=str(data.get("title", "")),
+            created_at=str(data.get("created_at", "")),
+            detail=str(data.get("detail", "")),
+            priority=priority,
+            component=str(data.get("component", "")),
+            run_id=str(data.get("run_id", "")),
+            dedupe_key=str(data.get("dedupe_key", "")),
+            evidence=evidence,
+            status=status,
+            occurrences=occurrences,
+            last_seen_at=str(data.get("last_seen_at", "")),
+            decided_at=str(data.get("decided_at", "")),
+            decided_by=str(data.get("decided_by", "")),
+            decision_comment=str(data.get("decision_comment", "")),
+            snooze_until=str(data.get("snooze_until", "")),
+        )
+
+
+@dataclass(frozen=True)
+class InboxConfig:
+    """``[inbox]`` config. On by default - unlike the R8.1/R8.2 gates.
+
+    Recording an exception changes no behaviour: nothing blocks, nothing
+    merges differently, a file gains a line. The thing an operator can
+    lose by having it off is the record of a decision they already had to
+    make, so the safe default is on. ``open_item_cap`` is the backstop
+    R8.6 consults before admitting more queue work.
+    """
+
+    enabled: bool = True
+    open_item_cap: int = 50
+    snooze_hours: float = 24.0
+    notify_action_required: bool = True
+
+    @classmethod
+    def from_env(cls) -> InboxConfig:
+        defaults = cls()
+        enabled = os.environ.get("KSTRL_INBOX_ENABLED")
+        cap = os.environ.get("KSTRL_INBOX_OPEN_CAP")
+        snooze = os.environ.get("KSTRL_INBOX_SNOOZE_HOURS")
+        notify = os.environ.get("KSTRL_INBOX_NOTIFY")
+        return cls(
+            enabled=defaults.enabled if enabled is None else enabled == "1",
+            open_item_cap=defaults.open_item_cap if cap is None else int(cap),
+            snooze_hours=(
+                defaults.snooze_hours if snooze is None else float(snooze)
+            ),
+            notify_action_required=(
+                defaults.notify_action_required if notify is None else notify == "1"
+            ),
+        )
+
+    @classmethod
+    def load(cls, root_dir: Path | None = None) -> InboxConfig:
+        """Precedence: env > toml > defaults; reads ``[inbox]``."""
+        from kstrl.config import load_toml_section, resolve_config_file
+
+        if root_dir is None:
+            root_dir = Path.cwd()
+        section = load_toml_section(resolve_config_file(root_dir), "inbox")
+        defaults = cls()
+        enabled = (
+            bool(section["enabled"]) if "enabled" in section else defaults.enabled
+        )
+        open_item_cap = (
+            int(section["open_item_cap"])
+            if "open_item_cap" in section
+            else defaults.open_item_cap
+        )
+        snooze_hours = (
+            float(section["snooze_hours"])
+            if "snooze_hours" in section
+            else defaults.snooze_hours
+        )
+        notify_action_required = (
+            bool(section["notify_action_required"])
+            if "notify_action_required" in section
+            else defaults.notify_action_required
+        )
+        if "KSTRL_INBOX_ENABLED" in os.environ:
+            enabled = os.environ["KSTRL_INBOX_ENABLED"] == "1"
+        if "KSTRL_INBOX_OPEN_CAP" in os.environ:
+            open_item_cap = int(os.environ["KSTRL_INBOX_OPEN_CAP"])
+        if "KSTRL_INBOX_SNOOZE_HOURS" in os.environ:
+            snooze_hours = float(os.environ["KSTRL_INBOX_SNOOZE_HOURS"])
+        if "KSTRL_INBOX_NOTIFY" in os.environ:
+            notify_action_required = os.environ["KSTRL_INBOX_NOTIFY"] == "1"
+        return cls(
+            enabled=enabled,
+            open_item_cap=open_item_cap,
+            snooze_hours=snooze_hours,
+            notify_action_required=notify_action_required,
+        )
+
+
+class Inbox:
+    """Append-only store over ``.kstrl/inbox.jsonl``.
+
+    Reads fold the log into current items; writes append one line. No
+    method rewrites history - ``compact`` exists but writes a fresh file
+    from the folded state and is never called implicitly.
+    """
+
+    def __init__(self, root_dir: Path, config: InboxConfig | None = None) -> None:
+        self.root_dir = root_dir
+        self.config = config or InboxConfig()
+
+    @property
+    def path(self) -> Path:
+        return self.root_dir / INBOX_FILENAME
+
+    # -- reading -----------------------------------------------------------
+    def _read_lines(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        records: list[dict[str, Any]] = []
+        try:
+            text = self.path.read_text(encoding="utf-8")
+        except OSError:
+            return []
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue          # tolerate a torn tail; skip, never raise
+            if isinstance(record, dict):
+                records.append(record)
+        return records
+
+    def items(self) -> list[InboxItem]:
+        """Every item, latest state per id, newest-first by priority/age."""
+        folded: dict[str, InboxItem] = {}
+        for record in self._read_lines():
+            item = InboxItem.from_dict(record)
+            if item is None:
+                continue
+            folded[item.id] = item     # later lines supersede earlier ones
+        return sorted(folded.values(), key=lambda i: i.sort_key())
+
+    def open_items(self) -> list[InboxItem]:
+        return [item for item in self.items() if item.is_open]
+
+    def get(self, item_id: str) -> InboxItem | None:
+        """Find by exact id or unique short prefix (ids are uuid4 hex)."""
+        items = self.items()
+        for item in items:
+            if item.id == item_id:
+                return item
+        matches = [item for item in items if item.id.startswith(item_id)]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise InboxError(
+                f"ambiguous item id {item_id!r}: matches "
+                + ", ".join(m.id[:8] for m in matches[:5])
+            )
+        return None
+
+    def find_by_dedupe_key(self, key: str) -> InboxItem | None:
+        if not key:
+            return None
+        for item in self.items():
+            if item.dedupe_key == key:
+                return item
+        return None
+
+    # -- writing -----------------------------------------------------------
+    def _append(self, item: InboxItem) -> None:
+        """Append one line, creating the file atomically on first write."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"schema_version": INBOX_SCHEMA_VERSION, **item.to_dict()}
+        line = json.dumps(payload, separators=(",", ":"), default=str) + "\n"
+        with open(self.path, "a", encoding="utf-8") as handle:
+            handle.write(line)
+
+    def add(
+        self,
+        kind: ItemKind,
+        title: str,
+        *,
+        detail: str = "",
+        component: str = "",
+        run_id: str = "",
+        dedupe_key: str = "",
+        evidence: dict[str, Any] | None = None,
+        priority: Priority | None = None,
+    ) -> InboxItem:
+        """Record an exception, collapsing repeats onto one item.
+
+        A repeat of a still-open item bumps its occurrence count instead of
+        adding a row. A repeat of a DECIDED item opens a fresh one: you
+        approved that failure once, and its recurrence is new information.
+        """
+        now = _utc_now()
+        existing = self.find_by_dedupe_key(dedupe_key)
+        if existing is not None and existing.status is ItemStatus.OPEN:
+            existing.occurrences += 1
+            existing.last_seen_at = _iso(now)
+            if detail:
+                existing.detail = detail
+            self._append(existing)
+            return existing
+        item = InboxItem(
+            id=uuid.uuid4().hex,
+            kind=kind,
+            title=title,
+            created_at=_iso(now),
+            detail=detail,
+            priority=priority or DEFAULT_PRIORITY.get(kind, Priority.NORMAL),
+            component=component,
+            run_id=run_id,
+            dedupe_key=dedupe_key,
+            evidence=evidence or {},
+            last_seen_at=_iso(now),
+        )
+        self._append(item)
+        return item
+
+    def _decide(
+        self,
+        item_id: str,
+        status: ItemStatus,
+        *,
+        actor: str,
+        comment: str = "",
+        snooze_until: datetime | None = None,
+    ) -> InboxItem:
+        item = self.get(item_id)
+        if item is None:
+            raise InboxError(f"no inbox item matching {item_id!r}")
+        item.status = status
+        item.decided_at = _iso(_utc_now())
+        item.decided_by = actor
+        item.decision_comment = comment
+        item.snooze_until = _iso(snooze_until) if snooze_until else ""
+        self._append(item)
+        return item
+
+    def approve(self, item_id: str, *, actor: str, comment: str = "") -> InboxItem:
+        return self._decide(
+            item_id, ItemStatus.APPROVED, actor=actor, comment=comment,
+        )
+
+    def reject(self, item_id: str, *, actor: str, comment: str) -> InboxItem:
+        """Reject. A comment is required: a bare "no" is not a decision
+        anyone can act on later, least of all the person who made it."""
+        if not comment.strip():
+            raise InboxError("rejection requires a comment explaining why")
+        return self._decide(
+            item_id, ItemStatus.REJECTED, actor=actor, comment=comment,
+        )
+
+    def resolve(self, item_id: str, *, actor: str = "system", comment: str = "") -> InboxItem:
+        return self._decide(
+            item_id, ItemStatus.RESOLVED, actor=actor, comment=comment,
+        )
+
+    def snooze(
+        self, item_id: str, *, actor: str, hours: float | None = None,
+    ) -> InboxItem:
+        ttl = self.config.snooze_hours if hours is None else hours
+        if ttl <= 0:
+            raise InboxError("snooze needs a positive TTL; use approve/reject to close")
+        return self._decide(
+            item_id,
+            ItemStatus.SNOOZED,
+            actor=actor,
+            comment=f"snoozed {ttl}h",
+            snooze_until=_utc_now() + timedelta(hours=ttl),
+        )
+
+    # -- capacity ----------------------------------------------------------
+    def over_cap(self) -> bool:
+        """Whether the open backlog has reached its cap.
+
+        R8.6 consults this before admitting queue work: an operator who is
+        already behind should not be handed more to be behind on.
+        """
+        cap = self.config.open_item_cap
+        return cap > 0 and len(self.open_items()) >= cap
+
+    def compact(self) -> int:
+        """Rewrite the log as one line per item from the folded state.
+
+        Never called implicitly - history is the audit trail. Returns the
+        number of items retained. Atomic (mkstemp + os.replace), matching
+        the manifest pattern.
+        """
+        items = self.items()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(self.path.parent), suffix=".tmp", prefix=".inbox-",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                for item in items:
+                    payload = {
+                        "schema_version": INBOX_SCHEMA_VERSION, **item.to_dict(),
+                    }
+                    handle.write(
+                        json.dumps(payload, separators=(",", ":"), default=str) + "\n"
+                    )
+            os.replace(tmp_path, str(self.path))
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        return len(items)
+
+
+def summarize(items: Sequence[InboxItem]) -> str:
+    """One-line summary for run epilogues and notifications."""
+    open_items = [item for item in items if item.is_open]
+    if not open_items:
+        return "inbox clear"
+    by_kind: dict[str, int] = {}
+    for item in open_items:
+        by_kind[str(item.kind)] = by_kind.get(str(item.kind), 0) + 1
+    parts = ", ".join(f"{count} {kind}" for kind, count in sorted(by_kind.items()))
+    return f"{len(open_items)} open ({parts})"
+
+
+def notifiable(items: Iterable[InboxItem]) -> list[InboxItem]:
+    """Items worth interrupting a human for.
+
+    Action-required kinds and demotion notices only: successes stay
+    silent, and informational kinds batch into a digest instead of
+    paging. Silence on success is what keeps the signal worth reading.
+    """
+    return [
+        item for item in items
+        if item.is_open
+        and (item.kind.action_required or item.kind is ItemKind.DEMOTION_NOTICE)
+    ]

--- a/kstrl/inbox.py
+++ b/kstrl/inbox.py
@@ -359,15 +359,25 @@ class Inbox:
                 records.append(record)
         return records
 
-    def items(self) -> list[InboxItem]:
-        """Every item, latest state per id, newest-first by priority/age."""
+    def _folded(self) -> list[InboxItem]:
+        """Latest state per id, in the order the ids first appeared.
+
+        Log order is a total order; ``created_at`` is not (it is rounded
+        to the second, so two items raised in the same second tie). Any
+        "which generation is newer?" question has to be answered here,
+        not from the timestamp.
+        """
         folded: dict[str, InboxItem] = {}
         for record in self._read_lines():
             item = InboxItem.from_dict(record)
             if item is None:
                 continue
             folded[item.id] = item     # later lines supersede earlier ones
-        return sorted(folded.values(), key=lambda i: i.sort_key())
+        return list(folded.values())
+
+    def items(self) -> list[InboxItem]:
+        """Every item, latest state per id, newest-first by priority/age."""
+        return sorted(self._folded(), key=lambda i: i.sort_key())
 
     def open_items(self) -> list[InboxItem]:
         return [item for item in self.items() if item.is_open]
@@ -389,12 +399,28 @@ class Inbox:
         return None
 
     def find_by_dedupe_key(self, key: str) -> InboxItem | None:
+        """The generation of ``key`` that a repeat should collapse onto.
+
+        An OPEN generation always wins; otherwise the NEWEST decided one.
+        Returning the oldest match (which ``items()`` yields first, being
+        sorted ascending by age) meant a second repeat after a decision
+        re-found the decided original and opened yet another item, so a
+        recurring failure fanned out into one item per occurrence -
+        exactly the noise dedupe exists to prevent.
+
+        "Newest" is by log position, not ``created_at``: timestamps are
+        second-resolution and two generations of the same key can share
+        one, which would put the tie-break back where the bug was.
+        """
         if not key:
             return None
-        for item in self.items():
-            if item.dedupe_key == key:
+        matches = [item for item in self._folded() if item.dedupe_key == key]
+        if not matches:
+            return None
+        for item in matches:
+            if item.status is ItemStatus.OPEN:
                 return item
-        return None
+        return matches[-1]
 
     # -- writing -----------------------------------------------------------
     def _append(self, item: InboxItem) -> None:

--- a/kstrl/init_cmd.py
+++ b/kstrl/init_cmd.py
@@ -448,6 +448,14 @@ DEFAULT_KSTRL_TOML = """\
 # license_use_network = true       # false = uv cache only; part of the envelope hash
 # deploy = false                   # reserved for the R8.7 release gate
 
+# Exception inbox (R8.3): one surface for everything awaiting a human.
+# On by default; triage with `ks inbox ls`.
+[inbox]
+# enabled = true
+# open_item_cap = 50               # open items after which queue intake pauses
+# snooze_hours = 24.0              # default snooze TTL
+# notify_action_required = true    # notify only on action-required items
+
 # Autonomy ladder (R8.2): one ordered level (L1-L4) instead of scattered
 # autonomy flags. The level derives a flag bundle at run start and wins over
 # contradicting flags. Opt-in: L1 is stricter than the defaults (merge gate on).

--- a/kstrl/observability.py
+++ b/kstrl/observability.py
@@ -442,13 +442,20 @@ class NotifyConfig:
         on_first_failure = "curl -fsS -X POST -d \\"$KSTRL_NOTIFY_EVENT $KSTRL_NOTIFY_COMPONENT\\" https://example.com/hook"
 
     The commands run via the shell with these context variables set:
-    ``KSTRL_NOTIFY_EVENT`` (run_complete | first_failure | merge_pending),
-    ``KSTRL_NOTIFY_RUN_ID``, ``KSTRL_NOTIFY_PROJECT``,
+    ``KSTRL_NOTIFY_EVENT`` (run_complete | first_failure | merge_pending
+    | inbox_<kind>), ``KSTRL_NOTIFY_RUN_ID``, ``KSTRL_NOTIFY_PROJECT``,
     ``KSTRL_NOTIFY_COMPONENT`` and ``KSTRL_NOTIFY_DETAIL``.
+
+    ``on_inbox_item`` is deliberately its OWN command rather than a reuse
+    of ``on_first_failure``: an R8.3 inbox item is usually raised for the
+    same event that already fired a failure hook, so sharing the command
+    would notify twice for one thing. Empty by default - an operator who
+    wants per-item pushes opts in.
     """
 
     on_complete: str = ""
     on_first_failure: str = ""
+    on_inbox_item: str = ""
     hook_timeout: float = 30.0
 
     @classmethod
@@ -471,6 +478,8 @@ class NotifyConfig:
             config.on_complete = section["on_complete"]
         if isinstance(section.get("on_first_failure"), str):
             config.on_first_failure = section["on_first_failure"]
+        if isinstance(section.get("on_inbox_item"), str):
+            config.on_inbox_item = section["on_inbox_item"]
         if "hook_timeout" in section:
             config.hook_timeout = float(section["hook_timeout"])
         _apply_notify_env(config)
@@ -482,6 +491,8 @@ def _apply_notify_env(config: NotifyConfig) -> None:
         config.on_complete = os.environ["KSTRL_NOTIFY_ON_COMPLETE"]
     if "KSTRL_NOTIFY_ON_FIRST_FAILURE" in os.environ:
         config.on_first_failure = os.environ["KSTRL_NOTIFY_ON_FIRST_FAILURE"]
+    if "KSTRL_NOTIFY_ON_INBOX_ITEM" in os.environ:
+        config.on_inbox_item = os.environ["KSTRL_NOTIFY_ON_INBOX_ITEM"]
     if "KSTRL_NOTIFY_HOOK_TIMEOUT" in os.environ:
         config.hook_timeout = float(os.environ["KSTRL_NOTIFY_HOOK_TIMEOUT"])
 
@@ -489,13 +500,17 @@ def _apply_notify_env(config: NotifyConfig) -> None:
 class NotifyHooks:
     """Fires user-configured shell commands on factory-run milestones.
 
-    Three conditions, each fired at most once per run (R3.2):
+    Each condition fires at most once per run (R3.2):
 
     - run completion -> ``on_complete``
     - first component failure -> ``on_first_failure``
     - first MERGE_PENDING park -> ``on_first_failure`` (the attention
       channel: the run is blocked on a human confirming a merge). The
       hook can tell the conditions apart via ``KSTRL_NOTIFY_EVENT``.
+    - first R8.3 inbox item of each kind -> ``on_inbox_item``, which is
+      empty by default. Kept off ``on_first_failure`` on purpose: the
+      item and the failure usually describe the same event, and one
+      event must not page twice.
 
     Hooks are observability, never control flow: a hook that fails to
     launch, exits nonzero, or times out produces a warning and nothing
@@ -528,6 +543,22 @@ class NotifyHooks:
         self._fire(
             "first_failure", self._config.on_first_failure,
             component_id=component_id, detail=error,
+        )
+
+    def fire_inbox_item(self, kind: str, title: str, component_id: str = "") -> None:
+        """R8.3: an exception needs a human. Opt-in via its OWN
+        ``on_inbox_item`` command, empty by default.
+
+        It must not share ``on_first_failure``: a failing component
+        already fires that hook, and the inbox item it raises describes
+        the same event, so reusing the command would notify twice for
+        one thing. One-way as ever - the hook pushes, it never calls
+        back into the harness. Only action-required kinds and demotions
+        reach here, so success stays silent.
+        """
+        self._fire(
+            f"inbox_{kind}", self._config.on_inbox_item,
+            component_id=component_id, detail=title,
         )
 
     def fire_merge_pending(self, component_id: str, detail: str = "") -> None:

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -49,7 +49,7 @@ from kstrl.findings import (
     tag_finding_with_attempt,
 )
 from kstrl.fixtures import FixturesConfig
-from kstrl.inbox import Inbox, InboxConfig, ItemKind
+from kstrl.inbox import Inbox, InboxConfig, InboxError, ItemKind, notifiable
 from kstrl.interaction import (
     CheckpointContext,
     InteractionChannel,
@@ -173,6 +173,9 @@ class CheckpointDecision(Enum):
 
     NOT_PROMPTED = "not_prompted"
     APPROVED = "approved"
+    # R8.3: no interactive UI was available to answer the gate, so the
+    # component is parked for the inbox rather than merged unreviewed.
+    PARKED = "parked"
     REJECTED = "rejected"
     RETRY = "retry"
 
@@ -290,6 +293,8 @@ class ComponentPipeline:
         # R8.3: lazily built so a disabled inbox costs nothing and a
         # broken one can never fail a run (see _inbox_add).
         self._inbox: Inbox | None = None
+        self._inbox_disabled = False
+        self._inbox_typed: set[str] = set()
         self.review_selection = review_selection
         self.security_selection = security_selection
         self.knowledge_config = knowledge_config
@@ -675,14 +680,17 @@ class ComponentPipeline:
         self.factory_result.skipped.extend(skipped)
         self.bus.emit(ev.ComponentFailed(component=comp.id, error=error))
         self.notify.fire_first_failure(comp.id, error)
-        self._inbox_add(
-            ItemKind.HALTED_RUN,
-            f"{comp.id} halted in {phase}",
-            detail=error,
-            component=comp.id,
-            dedupe_key=f"halted:{comp.id}:{phase}:{check}",
-            evidence={"phase": phase, "check": check, "error": error},
-        )
+        if comp.id in self._inbox_typed:
+            self._inbox_typed.discard(comp.id)
+        else:
+            self._inbox_add(
+                ItemKind.HALTED_RUN,
+                f"{comp.id} halted in {phase}",
+                detail=error,
+                component=comp.id,
+                dedupe_key=f"halted:{comp.id}:{phase}:{check}",
+                evidence={"phase": phase, "check": check, "error": error},
+            )
         self.ui.err(f"  Failed: {comp.id}: {error[:80]}")
         self.manifest.save(self.manifest_path)
         return Transition.FAILED
@@ -723,6 +731,7 @@ class ComponentPipeline:
                 "max_total_tokens": self.factory_config.max_total_tokens,
             },
         )
+        self._inbox_suppress_generic(comp.id)
         return self.fail(
             comp, error, phase=phase, check="token_budget",
             signatures=["token_budget:exceeded"],
@@ -751,6 +760,30 @@ class ComponentPipeline:
         self.manifest.save(self.manifest_path)
         return Transition.COMPLETED
 
+    def _inbox_resolve(self, dedupe_key: str, reason: str) -> None:
+        """Close an open item whose question the world has answered."""
+        try:
+            if self._inbox is None:
+                config = InboxConfig.load(self.root_dir)
+                if not config.enabled:
+                    return
+                self._inbox = Inbox(self.root_dir, config)
+            existing = self._inbox.find_by_dedupe_key(dedupe_key)
+            if existing is not None and existing.is_open:
+                self._inbox.resolve(existing.id, comment=reason)
+        except (OSError, ValueError, InboxError) as exc:
+            self.ui.warn(f"  Inbox resolve failed (non-fatal): {exc}")
+
+    def _inbox_suppress_generic(self, comp_id: str) -> None:
+        """Mark that a typed item already covers this component's halt.
+
+        fail() emits a generic halted_run for every terminal failure; a
+        budget halt (or a parked merge gate) has already raised a more
+        specific item, and two items for one event burn two cap slots and
+        bury the reason.
+        """
+        self._inbox_typed.add(comp_id)
+
     def _inbox_add(
         self,
         kind: ItemKind,
@@ -773,9 +806,12 @@ class ComponentPipeline:
             if self._inbox is None:
                 config = InboxConfig.load(self.root_dir)
                 if not config.enabled:
+                    self._inbox_disabled = True
                     return
                 self._inbox = Inbox(self.root_dir, config)
-            self._inbox.add(
+            if self._inbox_disabled:
+                return
+            item = self._inbox.add(
                 kind, title,
                 detail=detail,
                 component=component,
@@ -783,6 +819,13 @@ class ComponentPipeline:
                 dedupe_key=dedupe_key,
                 evidence=evidence or {},
             )
+            # One-way push: only items that actually want a human reach
+            # the hook, and only when the operator asked for it. Without
+            # this the [inbox] notify knob was a documented no-op.
+            if self._inbox.config.notify_action_required and notifiable([item]):
+                self.notify.fire_inbox_item(
+                    str(item.kind), item.title, component_id=component,
+                )
         except (OSError, ValueError) as exc:
             self.ui.warn(f"  Inbox write failed (non-fatal): {exc}")
 
@@ -955,6 +998,17 @@ class ComponentPipeline:
             f"  A worker process for '{comp_id}' may be leaked; "
             f"its worktree is left in place"
         )
+        self._inbox_add(
+            ItemKind.HALTED_RUN,
+            f"{comp_id} abandoned by the scheduler backstop",
+            detail=(
+                f"no result after {backstop_seconds}s; the worker may still "
+                "be alive, so its worktree was left in place"
+            ),
+            component=comp_id,
+            dedupe_key=f"halted:{comp_id}:backstop",
+            evidence={"backstop_seconds": backstop_seconds},
+        )
         self.manifest.save(self.manifest_path)
 
     def repoll_merge_pending(self) -> None:
@@ -1015,10 +1069,30 @@ class ComponentPipeline:
                     self.ui.ok(
                         f"  PR #{pr_number} merged; '{comp.id}' completed"
                     )
+                    # The gate that parked this component is answered by
+                    # reality; leaving it open would hold a cap slot
+                    # forever and ask a human to decide something already
+                    # decided.
+                    self._inbox_resolve(
+                        f"merge:{comp.id}", f"PR #{pr_number} merged",
+                    )
                 elif merge_state == "closed":
                     comp.status = ComponentStatus.FAILED.value
                     comp.error = f"PR #{pr_number} closed without merge"
                     comp.completed_at = _iso_now()
+                    # Not a merge decision any more - it is a halt.
+                    self._inbox_resolve(
+                        f"merge:{comp.id}",
+                        f"PR #{pr_number} closed without merging",
+                    )
+                    self._inbox_add(
+                        ItemKind.HALTED_RUN,
+                        f"{comp.id}: PR closed without merging",
+                        detail=comp.error,
+                        component=comp.id,
+                        dedupe_key=f"halted:{comp.id}:pr-closed",
+                        evidence={"pr_number": pr_number},
+                    )
                     comp.failed_phase = "pr"
                     comp.failed_check = "pr_closed"
                     self.component_failure_signatures[comp.id] = [
@@ -1207,6 +1281,25 @@ class ComponentPipeline:
                     transition=self.fail(
                         comp, "Rejected at HITL checkpoint",
                         phase="pr", check="hitl_reject",
+                    ),
+                    verify=verify, diff=diff, review=review,
+                    security=security, distill=distill,
+                    checkpoint=checkpoint,
+                )
+            if checkpoint == CheckpointDecision.PARKED:
+                # R8.3: the gate could not be answered, so the merge does
+                # NOT happen. Terminal for this run and routed to the
+                # inbox (the item was raised in _phase_checkpoint); the
+                # typed marker stops fail() adding a generic halted_run
+                # on top of it.
+                self._inbox_suppress_generic(comp.id)
+                return PipelineOutcome(
+                    transition=self.fail(
+                        comp,
+                        "Parked awaiting merge approval "
+                        "(pause_before_pr_merge, no interactive UI); "
+                        "approve with `ks inbox retry <id>`",
+                        phase="pr", check="merge_gate",
                     ),
                     verify=verify, diff=diff, review=review,
                     security=security, distill=distill,
@@ -2206,9 +2299,11 @@ class ComponentPipeline:
         loop would re-run the full agent+review cycle and ask the
         human again, once per remaining retry. A human who wants
         a re-run says so explicitly via Retry, which consumes a
-        retry like any other failure. Skip the prompt when no UI
-        is interactive - automation should fail loudly rather
-        than block indefinitely."""
+        retry like any other failure. When no UI is interactive
+        the prompt is skipped but the gate is NOT: R8.3 returns
+        PARKED, which withholds the merge and files a merge_gate
+        inbox item - automation fails loudly rather than blocking
+        indefinitely OR merging something nobody approved."""
         if not self.factory_config.pause_before_pr_merge:
             return CheckpointDecision.NOT_PROMPTED
         question = f"Approve PR creation and merge for {comp.id}?"
@@ -2241,15 +2336,39 @@ class ComponentPipeline:
             ),
         )
         if not self.interaction.can_prompt():
+            # R8.3: the merge gate is the whole point of
+            # pause_before_pr_merge, and proceeding here silently merged
+            # without the approval that was asked for - in exactly the
+            # unattended case R8.2's L1/L2 forces the gate ON for. Park
+            # the component instead and route the decision to the inbox;
+            # `ks inbox retry` requeues it once a human has looked.
             self.ui.warn(
                 f"  pause_before_pr_merge requested but UI is "
-                f"non-interactive; proceeding without prompt for {comp.id}"
+                f"non-interactive; parking {comp.id} for approval "
+                f"(see `ks inbox ls`)"
             )
             self.bus.emit(ev.CheckpointResolved(
                 component=comp.id, kind="pr_merge",
-                decision="not_prompted", decided_by="auto",
+                decision="parked", decided_by="inbox",
             ))
-            return CheckpointDecision.NOT_PROMPTED
+            self._inbox_add(
+                ItemKind.MERGE_GATE,
+                f"{comp.id} awaiting merge approval",
+                detail=(
+                    "pause_before_pr_merge is on but no interactive UI was "
+                    "available, so the merge was NOT performed. Review the "
+                    "component, then `ks inbox retry <id>` to requeue it."
+                ),
+                component=comp.id,
+                dedupe_key=f"merge-gate:{comp.id}",
+                evidence={
+                    "branch": comp.branch_name,
+                    "review_findings": len([
+                        f for f in comp.findings if f.phase == "review"
+                    ]),
+                },
+            )
+            return CheckpointDecision.PARKED
         self.ui.section(f"Human checkpoint: {comp.id}")
         self.ui.info(comp.review_findings or "(no review findings)")
         response = self.interaction.request(request)

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -42,8 +42,14 @@ from kstrl import events as ev
 from kstrl import git
 from kstrl.agents.base import UsageTotals, collect_usage
 from kstrl.context import IterationContext, IterationRecord
-from kstrl.findings import Finding, finding_model, tag_finding_with_attempt
+from kstrl.findings import (
+    POLICY_CATEGORY_PREFIX,
+    Finding,
+    finding_model,
+    tag_finding_with_attempt,
+)
 from kstrl.fixtures import FixturesConfig
+from kstrl.inbox import Inbox, InboxConfig, ItemKind
 from kstrl.interaction import (
     CheckpointContext,
     InteractionChannel,
@@ -281,6 +287,9 @@ class ComponentPipeline:
             interaction if interaction is not None else UiInteractionChannel(ui)
         )
         self.notify = notify
+        # R8.3: lazily built so a disabled inbox costs nothing and a
+        # broken one can never fail a run (see _inbox_add).
+        self._inbox: Inbox | None = None
         self.review_selection = review_selection
         self.security_selection = security_selection
         self.knowledge_config = knowledge_config
@@ -666,6 +675,14 @@ class ComponentPipeline:
         self.factory_result.skipped.extend(skipped)
         self.bus.emit(ev.ComponentFailed(component=comp.id, error=error))
         self.notify.fire_first_failure(comp.id, error)
+        self._inbox_add(
+            ItemKind.HALTED_RUN,
+            f"{comp.id} halted in {phase}",
+            detail=error,
+            component=comp.id,
+            dedupe_key=f"halted:{comp.id}:{phase}:{check}",
+            evidence={"phase": phase, "check": check, "error": error},
+        )
         self.ui.err(f"  Failed: {comp.id}: {error[:80]}")
         self.manifest.save(self.manifest_path)
         return Transition.FAILED
@@ -691,6 +708,21 @@ class ComponentPipeline:
             total_tokens=self.run_usage.total_tokens,
             max_total_tokens=self.factory_config.max_total_tokens,
         ))
+        # Raised BEFORE delegating to fail(): a blown budget is its own
+        # exception kind, and the generic halted_run item fail() adds
+        # would bury why the run stopped.
+        self._inbox_add(
+            ItemKind.BUDGET_OVERRUN,
+            f"{comp.id} exceeded the token budget",
+            detail=error,
+            component=comp.id,
+            dedupe_key=f"budget:{comp.id}",
+            evidence={
+                "phase": phase,
+                "total_tokens": self.run_usage.total_tokens,
+                "max_total_tokens": self.factory_config.max_total_tokens,
+            },
+        )
         return self.fail(
             comp, error, phase=phase, check="token_budget",
             signatures=["token_budget:exceeded"],
@@ -719,6 +751,41 @@ class ComponentPipeline:
         self.manifest.save(self.manifest_path)
         return Transition.COMPLETED
 
+    def _inbox_add(
+        self,
+        kind: ItemKind,
+        title: str,
+        *,
+        detail: str = "",
+        component: str = "",
+        dedupe_key: str = "",
+        evidence: dict[str, Any] | None = None,
+    ) -> None:
+        """Record an exception for a human (R8.3). Never fatal.
+
+        Every terminal halt routes through here, so the inbox reflects
+        what actually happened rather than what someone remembered to
+        report. Bookkeeping must not be able to fail a run, so a broken
+        inbox degrades to a warning - but it warns, because a silently
+        empty inbox reads exactly like a clean run.
+        """
+        try:
+            if self._inbox is None:
+                config = InboxConfig.load(self.root_dir)
+                if not config.enabled:
+                    return
+                self._inbox = Inbox(self.root_dir, config)
+            self._inbox.add(
+                kind, title,
+                detail=detail,
+                component=component,
+                run_id=self.run_id,
+                dedupe_key=dedupe_key,
+                evidence=evidence or {},
+            )
+        except (OSError, ValueError) as exc:
+            self.ui.warn(f"  Inbox write failed (non-fatal): {exc}")
+
     def _park_merge_pending(
         self, comp: Component, error: str,
     ) -> Transition:
@@ -737,6 +804,14 @@ class ComponentPipeline:
             component=comp.id, pr_url=comp.pr_url, error=comp.error,
         ))
         self.notify.fire_merge_pending(comp.id, comp.error)
+        self._inbox_add(
+            ItemKind.MERGE_GATE,
+            f"{comp.id} merge unconfirmed",
+            detail=comp.error,
+            component=comp.id,
+            dedupe_key=f"merge:{comp.id}",
+            evidence={"pr_url": comp.pr_url},
+        )
         self._end_attempt(comp)
         self.ui.warn(
             f"  MERGE PENDING: {comp.id}: {comp.error}; "
@@ -820,6 +895,14 @@ class ComponentPipeline:
         self.factory_result.skipped.extend(skipped)
         self.bus.emit(ev.ComponentFailed(component=comp.id, error=comp.error))
         self.notify.fire_first_failure(comp.id, comp.error)
+        self._inbox_add(
+            ItemKind.HALTED_RUN,
+            f"{comp.id} halted in the PR flow",
+            detail=comp.error,
+            component=comp.id,
+            dedupe_key=f"halted:{comp.id}:pr",
+            evidence={"phase": "pr", "pr_url": comp.pr_url},
+        )
         self.ui.err(f"  Failed: {comp.id}: {comp.error[:120]}")
         self.manifest.save(self.manifest_path)
         return Transition.FAILED
@@ -1304,6 +1387,28 @@ class ComponentPipeline:
         ]
         if check_findings:
             self._add_findings(comp, check_findings)
+            # R8.3: an envelope breach is the archetypal exception - a
+            # machine decision a human may want to approve once, or
+            # convert into a widened policy. Advisories stay out: they
+            # are recorded, not blocking, and the inbox is for decisions.
+            for finding in check_findings:
+                if (
+                    finding.category.startswith(POLICY_CATEGORY_PREFIX)
+                    and finding.severity != "advisory"
+                ):
+                    self._inbox_add(
+                        ItemKind.POLICY_EXCEPTION,
+                        f"{comp.id}: {finding.category}",
+                        detail=finding.explanation,
+                        component=comp.id,
+                        dedupe_key=f"policy:{comp.id}:{finding.category}",
+                        evidence={
+                            "category": finding.category,
+                            "severity": finding.severity,
+                            "location": finding.location,
+                            "suggestion": finding.suggestion,
+                        },
+                    )
         self.bus.emit(ev.VerificationResultEvent(
             component=comp.id, passed=verification.passed,
             checks=tuple(c.name for c in verification.checks),

--- a/kstrl/tui/screens/home.py
+++ b/kstrl/tui/screens/home.py
@@ -54,6 +54,7 @@ HOME_COMMANDS: list[HomeCommand] = [
     HomeCommand("retry", "retry", "rerun a failed component"),
     HomeCommand("dash", "dashboard", "open the newest run"),
     HomeCommand("config", "config", "resolved values + sources"),
+    HomeCommand("inbox", "inbox", "decisions awaiting you"),
     HomeCommand("evolve", "evolve", "proposals and trends"),
     HomeCommand("init", "init", "scaffold a project"),
     HomeCommand("feature", "feature", "via CLI: ks feature --tui"),
@@ -355,6 +356,10 @@ class HomeScreen(Screen[None]):
             from kstrl.tui.screens.config import ConfigScreen
 
             self.app.push_screen(ConfigScreen())
+        elif command_id == "inbox":
+            from kstrl.tui.screens.inbox import InboxScreen
+
+            self.app.push_screen(InboxScreen())
         elif command_id == "evolve":
             from kstrl.tui.screens.evolve import EvolveScreen
 

--- a/kstrl/tui/screens/inbox.py
+++ b/kstrl/tui/screens/inbox.py
@@ -1,0 +1,197 @@
+"""Inbox screen: triage what is waiting on a human (R8.3).
+
+Master-detail over ``.kstrl/inbox.jsonl`` with the REAL decision path -
+the same ``Inbox`` methods ``ks inbox`` calls, so a decision made here is
+indistinguishable from one made at the CLI and lands in the same
+append-only log.
+
+One-key actions in the spirit of a triage queue: ``a`` approve, ``r``
+reject, ``s`` snooze, ``o`` toggle decided items. Reject opens a comment
+prompt rather than accepting a bare "no" - a rejection nobody can explain
+later is not a decision.
+
+Requeue is deliberately CLI-only (``ks inbox retry``): it mutates the
+manifest, and a keystroke away from a component reset is the kind of
+thing that should cost one more deliberate step.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal
+from textual.screen import Screen
+from textual.widgets import DataTable, Footer, Static
+
+from kstrl.inbox import Inbox, InboxConfig, InboxError, InboxItem
+from kstrl.tui.widgets.context_bar import ContextBar
+
+_PRIORITY_STYLE = {"high": "bold red", "normal": "", "low": "dim"}
+
+
+def priority_marker(priority: str) -> Text:
+    """A one-cell severity cue; low priority stays visually quiet."""
+    glyph = {"high": "!", "normal": "•", "low": "·"}.get(priority, "•")
+    return Text(glyph, style=_PRIORITY_STYLE.get(priority, ""))
+
+
+class InboxScreen(Screen[None]):
+    """Triage surface for exceptions awaiting a decision."""
+
+    BINDINGS = [
+        Binding("escape", "app.pop_screen", "back"),
+        Binding("a", "approve", "approve"),
+        Binding("r", "reject", "reject"),
+        Binding("s", "snooze", "snooze"),
+        Binding("o", "toggle_decided", "show/hide decided"),
+        Binding("f5", "refresh", "refresh"),
+    ]
+
+    def __init__(self, root_dir: Any = None) -> None:
+        super().__init__()
+        from pathlib import Path
+
+        self._root = Path(root_dir) if root_dir else Path.cwd()
+        self._show_decided = False
+        self._items: list[InboxItem] = []
+
+    # -- composition -------------------------------------------------------
+    def compose(self) -> ComposeResult:
+        yield ContextBar("inbox")
+        with Horizontal():
+            yield DataTable(id="inbox-table")
+            yield Static("", id="inbox-detail")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one("#inbox-table", DataTable)
+        table.cursor_type = "row"
+        table.add_columns("", "kind", "title", "status")
+        self.action_refresh()
+
+    # -- data --------------------------------------------------------------
+    def _inbox(self) -> Inbox:
+        return Inbox(self._root, InboxConfig.load(self._root))
+
+    def action_refresh(self) -> None:
+        box = self._inbox()
+        self._items = box.items() if self._show_decided else box.open_items()
+        table = self.query_one("#inbox-table", DataTable)
+        table.clear()
+        for item in self._items:
+            repeat = f" x{item.occurrences}" if item.occurrences > 1 else ""
+            table.add_row(
+                priority_marker(str(item.priority)),
+                str(item.kind),
+                f"{item.title}{repeat}",
+                "" if item.is_open else str(item.status),
+            )
+        self._render_detail()
+
+    def action_toggle_decided(self) -> None:
+        self._show_decided = not self._show_decided
+        self.action_refresh()
+
+    def _selected(self) -> InboxItem | None:
+        table = self.query_one("#inbox-table", DataTable)
+        row = table.cursor_row
+        if row is None or not (0 <= row < len(self._items)):
+            return None
+        return self._items[row]
+
+    def _render_detail(self) -> None:
+        detail = self.query_one("#inbox-detail", Static)
+        item = self._selected()
+        if item is None:
+            detail.update(
+                Text("Inbox clear: nothing is waiting on you.", style="dim")
+                if not self._items
+                else Text("")
+            )
+            return
+        lines = Text()
+        lines.append(f"{item.title}\n", style="bold")
+        lines.append(f"{item.kind}  priority={item.priority}\n", style="dim")
+        if item.component:
+            lines.append(f"component: {item.component}\n")
+        if item.occurrences > 1:
+            lines.append(f"seen {item.occurrences}x\n")
+        if item.decided_by:
+            lines.append(
+                f"decided by {item.decided_by} at {item.decided_at}\n", style="dim",
+            )
+        if item.decision_comment:
+            lines.append(f"comment: {item.decision_comment}\n", style="dim")
+        if item.detail:
+            lines.append(f"\n{item.detail}\n")
+        for key, value in item.evidence.items():
+            lines.append(f"  {key}: {value}\n", style="dim")
+        detail.update(lines)
+
+    def on_data_table_row_highlighted(self, _event: object) -> None:
+        self._render_detail()
+
+    # -- actions -----------------------------------------------------------
+    def _decide(self, action: str, comment: str = "") -> None:
+        item = self._selected()
+        if item is None:
+            return
+        box = self._inbox()
+        try:
+            if action == "approve":
+                box.approve(item.id, actor=self._actor(), comment=comment)
+            elif action == "reject":
+                box.reject(item.id, actor=self._actor(), comment=comment)
+            else:
+                box.snooze(item.id, actor=self._actor())
+        except InboxError as exc:
+            self.notify(str(exc), severity="error")
+            return
+        self.notify(f"{action}d: {item.title}")
+        self.action_refresh()
+
+    @staticmethod
+    def _actor() -> str:
+        import os
+
+        return os.environ.get("USER") or os.environ.get("USERNAME") or "operator"
+
+    def action_approve(self) -> None:
+        self._decide("approve")
+
+    def action_snooze(self) -> None:
+        self._decide("snooze")
+
+    def action_reject(self) -> None:
+        """Reject needs a reason, so this prompts rather than acting."""
+        item = self._selected()
+        if item is None:
+            return
+        from kstrl.interaction import PromptKind, PromptRequest
+        from kstrl.tui.screens.options import OptionsModal
+
+        reasons = (
+            "not a real problem",
+            "needs a spec change",
+            "will fix by hand",
+        )
+
+        def _handle(choice: int | None) -> None:
+            if choice is not None and 0 <= choice < len(reasons):
+                self._decide("reject", comment=reasons[choice])
+
+        self.app.push_screen(
+            OptionsModal(PromptRequest(
+                kind=PromptKind.GUARD,
+                header=f"Reject: {item.title}",
+                options=reasons,
+                default=0,
+            )),
+            _handle,
+        )
+
+
+__all__ = ["InboxScreen", "priority_marker"]

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -125,6 +125,7 @@ def _section_specs() -> list[SectionSpec]:
     from kstrl.factory import FactoryConfig
     from kstrl.feedforward import FeedforwardConfig
     from kstrl.fixtures import FixturesConfig
+    from kstrl.inbox import InboxConfig
     from kstrl.knowledge import KnowledgeConfig
     from kstrl.linear import LinearConfig
     from kstrl.observability import NotifyConfig
@@ -257,6 +258,14 @@ def _section_specs() -> list[SectionSpec]:
             ]),
             lambda root: AutonomyConfig.load(root_dir=root),
             AutonomyConfig(), probe_undocumented_fields=True,
+        ),
+        SectionSpec(
+            "inbox", "Exception inbox (R8.3)",
+            identity_keys(InboxConfig, [
+                f.name for f in dataclasses.fields(InboxConfig)
+            ]),
+            lambda root: InboxConfig.load(root_dir=root),
+            InboxConfig(), probe_undocumented_fields=True,
         ),
         SectionSpec(
             "security", "Phase 2.5 security review",
@@ -406,6 +415,10 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("policy", "deploy"): "reserved for the R8.7 release gate; stored + hashed",
     ("autonomy", "enabled"): "derive run permissions from the ladder level (opt-in)",
     ("autonomy", "max_level"): "hard ceiling: never run above this level (1-4)",
+    ("inbox", "enabled"): "record exceptions awaiting a human decision",
+    ("inbox", "open_item_cap"): "open items after which queue intake pauses; 0 = unbounded",
+    ("inbox", "snooze_hours"): "default snooze TTL in hours; snoozed items return",
+    ("inbox", "notify_action_required"): "notify on action-required items and demotions only",
     ("security", "mode"): "skip | advisory | hard",
     ("security", "agent_cmd"): "empty = inherit [agent]",
     ("security", "agent_type"): "empty = inherit [agent]",

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -453,6 +453,8 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
         "shell hook fired once when the run finishes; empty = disabled",
     ("notify", "on_first_failure"):
         "shell hook fired once on the first component failure",
+    ("notify", "on_inbox_item"):
+        "shell hook fired per R8.3 inbox item kind; empty = disabled",
     ("notify", "hook_timeout"): "seconds before a hook command is killed",
     ("linear", "enabled"): "mirror runs into Linear (project/issues/status via GitHub linking)",
     ("linear", "team_id"): "Linear team UUID (required when enabled)",

--- a/tests/test_config_control_plane.py
+++ b/tests/test_config_control_plane.py
@@ -667,7 +667,7 @@ class TestKnowledgeSectionRoundTrip:
 
 EXPECTED_SCAFFOLD_SECTIONS = {
     "agent", "run", "paths", "git", "ui",
-    "factory", "verify", "policy", "autonomy", "security", "contract",
+    "factory", "verify", "policy", "autonomy", "inbox", "security", "contract",
     "feedforward", "knowledge", "evolution", "timeout",
 }
 
@@ -698,6 +698,9 @@ EXPECTED_SCAFFOLD_KEYS = {
         "license_use_network", "deploy",
     },
     "autonomy": {"enabled", "max_level"},
+    "inbox": {
+        "enabled", "open_item_cap", "snooze_hours", "notify_action_required",
+    },
     "security": {
         "mode", "fail_threshold", "timeout_seconds", "agent_cmd",
         "agent_type", "model",

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -315,8 +315,10 @@ class TestSemanticEvents:
         assert comp.phase == "done"
 
     def test_checkpoint_events_auto_resolution(self, tmp_path: Path) -> None:
-        """pause_before_pr_merge on a non-TTY: requested then resolved
-        with decided_by=auto, and the run proceeds (NO_GH path)."""
+        """pause_before_pr_merge on a non-TTY: requested, then resolved
+        as parked with decided_by=inbox (R8.3). The gate is not answered
+        by proceeding - the merge is withheld and the decision is handed
+        to the inbox for a human."""
         root = _setup_project(tmp_path, ["comp-a"])
         manifest = _make_manifest([_component("comp-a")])
         config = _factory_config(
@@ -340,8 +342,8 @@ class TestSemanticEvents:
         assert len(requested) == 1
         assert requested[0].kind == "pr_merge"
         assert len(resolved) == 1
-        assert resolved[0].decision == "not_prompted"
-        assert resolved[0].decided_by == "auto"
+        assert resolved[0].decision == "parked"
+        assert resolved[0].decided_by == "inbox"
 
 
 class TestPhaseTranscripts:

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -1,0 +1,506 @@
+"""R8.3 exception inbox tests.
+
+Covers the substrate (append-only log, decision folding, dedupe, snooze
+TTLs, the open-item cap), the config surface, and - the part that matters
+most after PR #174 - that every halt path ACTUALLY emits an item during a
+real factory run, rather than the store being real but unfed.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kstrl.autonomy import AutonomyLevel, AutonomyState
+from kstrl.findings import Finding
+from kstrl.inbox import (
+    Inbox,
+    InboxConfig,
+    InboxError,
+    InboxItem,
+    ItemKind,
+    ItemStatus,
+    Priority,
+    notifiable,
+    summarize,
+)
+
+
+def _box(tmp_path: Path, **kwargs: object) -> Inbox:
+    return Inbox(tmp_path, InboxConfig(**kwargs))  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Substrate
+# --------------------------------------------------------------------------
+class TestSubstrate:
+    def test_add_and_list(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        item = box.add(ItemKind.HALTED_RUN, "comp-a halted", component="comp-a")
+        assert box.open_items() == [item]
+        assert item.status is ItemStatus.OPEN
+        assert item.occurrences == 1
+
+    def test_empty_inbox_reads_clean(self, tmp_path: Path) -> None:
+        assert _box(tmp_path).items() == []
+        assert summarize([]) == "inbox clear"
+
+    def test_log_is_append_only(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        item = box.add(ItemKind.MERGE_GATE, "m", dedupe_key="k")
+        box.approve(item.id, actor="human")
+        lines = box.path.read_text().strip().splitlines()
+        assert len(lines) == 2          # emission + decision, nothing rewritten
+        assert len(box.items()) == 1    # folded to one current item
+
+    def test_decision_folds_to_latest(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        item = box.add(ItemKind.MERGE_GATE, "m")
+        box.snooze(item.id, actor="h", hours=5)
+        box.approve(item.id, actor="h")
+        assert box.get(item.id).status is ItemStatus.APPROVED  # type: ignore[union-attr]
+
+    def test_torn_line_is_skipped_not_fatal(self, tmp_path: Path) -> None:
+        # An unreadable inbox is an invisible backlog; tolerate the tear.
+        box = _box(tmp_path)
+        box.add(ItemKind.HALTED_RUN, "good")
+        with open(box.path, "a", encoding="utf-8") as handle:
+            handle.write('{"id": "broken", "kind": "nonsense"}\n{not json\n')
+        assert len(box.items()) == 1
+
+    def test_prefix_lookup(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        item = box.add(ItemKind.HALTED_RUN, "x")
+        assert box.get(item.id[:8]) is not None
+        assert box.get("nope") is None
+
+    def test_compact_preserves_state_and_shrinks_log(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        first = box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        box.add(ItemKind.MERGE_GATE, "b", dedupe_key="b")
+        box.approve(first.id, actor="h")
+        before = len(box.path.read_text().strip().splitlines())
+        kept = box.compact()
+        after = len(box.path.read_text().strip().splitlines())
+        assert kept == 2 and after == 2 and after < before
+        assert box.get(first.id).status is ItemStatus.APPROVED  # type: ignore[union-attr]
+
+
+class TestDedupe:
+    def test_repeat_while_open_bumps_occurrences(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        first = box.add(ItemKind.HALTED_RUN, "comp-a halted", dedupe_key="h:comp-a")
+        again = box.add(ItemKind.HALTED_RUN, "comp-a halted", dedupe_key="h:comp-a")
+        assert again.id == first.id
+        assert again.occurrences == 2
+        assert len(box.open_items()) == 1
+
+    def test_repeat_after_decision_opens_a_new_item(self, tmp_path: Path) -> None:
+        # You approved that failure once; its recurrence is new information.
+        box = _box(tmp_path)
+        first = box.add(ItemKind.HALTED_RUN, "comp-a halted", dedupe_key="h:comp-a")
+        box.approve(first.id, actor="h")
+        again = box.add(ItemKind.HALTED_RUN, "comp-a halted", dedupe_key="h:comp-a")
+        assert again.id != first.id
+        assert len(box.open_items()) == 1
+
+    def test_no_dedupe_key_never_collapses(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        box.add(ItemKind.HALTED_RUN, "a")
+        box.add(ItemKind.HALTED_RUN, "a")
+        assert len(box.open_items()) == 2
+
+
+class TestDecisions:
+    def test_reject_requires_a_comment(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        item = box.add(ItemKind.POLICY_EXCEPTION, "x")
+        with pytest.raises(InboxError, match="requires a comment"):
+            box.reject(item.id, actor="h", comment="   ")
+
+    def test_decision_records_actor_and_time(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        item = box.add(ItemKind.POLICY_EXCEPTION, "x")
+        decided = box.approve(item.id, actor="wumpini", comment="once")
+        assert decided.decided_by == "wumpini"
+        assert decided.decision_comment == "once"
+        assert decided.decided_at
+
+    def test_unknown_id_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(InboxError, match="no inbox item"):
+            _box(tmp_path).approve("missing", actor="h")
+
+    def test_ambiguous_prefix_raises(self, tmp_path: Path) -> None:
+        # Two ids sharing a prefix must not silently resolve to one.
+        box = _box(tmp_path)
+        for suffix in ("aa", "bb"):
+            box._append(InboxItem(
+                id=f"abcdef{suffix}",
+                kind=ItemKind.HALTED_RUN,
+                title=f"item {suffix}",
+                created_at="2026-07-27T00:00:00+00:00",
+            ))
+        with pytest.raises(InboxError, match="ambiguous"):
+            box.get("abcdef")
+
+    def test_unambiguous_prefix_still_resolves(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        box._append(InboxItem(
+            id="abcdefaa", kind=ItemKind.HALTED_RUN, title="only",
+            created_at="2026-07-27T00:00:00+00:00",
+        ))
+        assert box.get("abcdef") is not None
+
+
+class TestSnooze:
+    def test_snooze_hides_until_ttl(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        item = box.add(ItemKind.MERGE_GATE, "m")
+        snoozed = box.snooze(item.id, actor="h", hours=5)
+        assert snoozed.status is ItemStatus.SNOOZED
+        assert snoozed.snooze_active
+        assert box.open_items() == []
+
+    def test_lapsed_snooze_reads_open_again(self, tmp_path: Path) -> None:
+        # Deferring a decision must not be the same as losing it.
+        box = _box(tmp_path)
+        item = box.add(ItemKind.MERGE_GATE, "m")
+        box.snooze(item.id, actor="h", hours=1)
+        stored = box.get(item.id)
+        assert stored is not None
+        stored.snooze_until = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        box._append(stored)
+        assert len(box.open_items()) == 1
+
+    def test_non_positive_ttl_refused(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        item = box.add(ItemKind.MERGE_GATE, "m")
+        with pytest.raises(InboxError, match="positive TTL"):
+            box.snooze(item.id, actor="h", hours=0)
+
+
+class TestCapacityAndNotification:
+    def test_open_cap(self, tmp_path: Path) -> None:
+        box = _box(tmp_path, open_item_cap=2)
+        box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        assert box.over_cap() is False
+        box.add(ItemKind.HALTED_RUN, "b", dedupe_key="b")
+        assert box.over_cap() is True
+
+    def test_cap_zero_is_unbounded(self, tmp_path: Path) -> None:
+        box = _box(tmp_path, open_item_cap=0)
+        for i in range(5):
+            box.add(ItemKind.HALTED_RUN, str(i), dedupe_key=str(i))
+        assert box.over_cap() is False
+
+    def test_decided_items_free_capacity(self, tmp_path: Path) -> None:
+        box = _box(tmp_path, open_item_cap=1)
+        item = box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        assert box.over_cap() is True
+        box.approve(item.id, actor="h")
+        assert box.over_cap() is False
+
+    @pytest.mark.parametrize(
+        "kind,expected",
+        [
+            (ItemKind.POLICY_EXCEPTION, True),
+            (ItemKind.MERGE_GATE, True),
+            (ItemKind.HALTED_RUN, True),
+            (ItemKind.BUDGET_OVERRUN, True),
+            (ItemKind.DEMOTION_NOTICE, False),   # informational, but notified
+            (ItemKind.CALIBRATION_DRIFT, False),
+        ],
+    )
+    def test_action_required_taxonomy(self, kind: ItemKind, expected: bool) -> None:
+        assert kind.action_required is expected
+
+    def test_notifiable_covers_demotions_but_not_drift(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        box.add(ItemKind.DEMOTION_NOTICE, "demoted", dedupe_key="d")
+        box.add(ItemKind.CALIBRATION_DRIFT, "drift", dedupe_key="c")
+        kinds = {str(i.kind) for i in notifiable(box.items())}
+        assert kinds == {"demotion_notice"}
+
+    def test_decided_items_are_not_notifiable(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        item = box.add(ItemKind.POLICY_EXCEPTION, "x")
+        box.approve(item.id, actor="h")
+        assert notifiable(box.items()) == []
+
+    def test_priority_defaults_and_ordering(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        box.add(ItemKind.CALIBRATION_DRIFT, "low", dedupe_key="l")
+        box.add(ItemKind.POLICY_EXCEPTION, "high", dedupe_key="h")
+        first = box.open_items()[0]
+        assert first.priority is Priority.HIGH
+
+
+class TestConfig:
+    def test_enabled_by_default(self) -> None:
+        assert InboxConfig().enabled is True
+
+    def test_load_reads_section(self, tmp_path: Path) -> None:
+        (tmp_path / "kstrl.toml").write_text(
+            "[inbox]\nenabled = false\nopen_item_cap = 7\nsnooze_hours = 2.5\n"
+        )
+        config = InboxConfig.load(tmp_path)
+        assert config.enabled is False
+        assert config.open_item_cap == 7
+        assert config.snooze_hours == 2.5
+
+    def test_env_overrides_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text("[inbox]\nopen_item_cap = 7\n")
+        monkeypatch.setenv("KSTRL_INBOX_OPEN_CAP", "3")
+        assert InboxConfig.load(tmp_path).open_item_cap == 3
+
+
+# --------------------------------------------------------------------------
+# Emitters: every halt path must actually feed the inbox (PR #174 lesson)
+# --------------------------------------------------------------------------
+def _init_git_repo(root: Path) -> None:
+    def run(*args: str) -> None:
+        subprocess.run(
+            ["git", *args], cwd=root, check=True, capture_output=True, text=True,
+        )
+
+    run("init")
+    run("symbolic-ref", "HEAD", "refs/heads/main")
+    run("config", "user.email", "t@example.com")
+    run("config", "user.name", "tester")
+    (root / "README.md").write_text("base\n")
+    run("add", ".")
+    run("commit", "-m", "base")
+
+
+def _run_factory(
+    tmp_path: Path,
+    *,
+    verification: object | None = None,
+    level: AutonomyLevel = AutonomyLevel.L1_SUPERVISED,
+    autonomy: bool = False,
+) -> None:
+    from kstrl.config import KstrlConfig
+    from kstrl.factory import ComponentResult, FactoryConfig, run_factory
+    from kstrl.manifest import Component, Manifest
+    from kstrl.review import ReviewResult
+    from kstrl.ui.plain import PlainUI
+    from kstrl.verify import CheckResult, VerificationResult, VerifyConfig
+
+    _init_git_repo(tmp_path)
+    kstrl_dir = tmp_path / "scripts" / "kstrl"
+    kstrl_dir.mkdir(parents=True, exist_ok=True)
+    (kstrl_dir / "prompt.md").write_text("p")
+    (tmp_path / "kstrl.toml").write_text(
+        f"[autonomy]\nenabled = {'true' if autonomy else 'false'}\n"
+        "[policy]\nenabled = true\n[inbox]\nenabled = true\n"
+    )
+    AutonomyState(level=int(level)).save(tmp_path)
+    manifest = Manifest(
+        version="1", spec_file="s", project_name="t", base_branch="main",
+        single_pr=False,
+        components=[Component(
+            "comp-a", "A", "D", [],
+            "scripts/kstrl/feature/comp-a/prd.json", "kstrl/factory/comp-a",
+        )],
+    )
+    config = FactoryConfig(
+        use_worktrees=False, create_prs=False, max_parallel=1, max_retries=0,
+        retry_delay=0, review_mode="skip",
+        verify_config=VerifyConfig(
+            test_command="true", typecheck_command="true", lint_command="true",
+            check_bad_patterns=False, subprocess_timeout=5.0,
+        ),
+    )
+    base = KstrlConfig(
+        prompt_file=kstrl_dir / "prompt.md", prd_file=kstrl_dir / "prd.json",
+        sleep_seconds=0, agent_cmd="echo test", kstrl_branch="",
+        kstrl_branch_explicit=True, ui_mode="plain", no_color=True,
+    )
+    result = verification or VerificationResult(
+        passed=True, checks=[CheckResult("diff_scope", True, "ok")],
+    )
+    with (
+        patch(
+            "kstrl.factory._run_component",
+            return_value=ComponentResult("comp-a", success=True, iterations=1),
+        ),
+        patch("kstrl.factory.run_mechanical_verification", return_value=result),
+        patch(
+            "kstrl.factory.run_review",
+            return_value=ReviewResult(passed=True, mode="hard"),
+        ),
+    ):
+        run_factory(manifest, config, base, PlainUI(no_color=True), tmp_path)
+
+
+class TestEmittersFireDuringRuns:
+    def test_policy_violation_emits_policy_exception(self, tmp_path: Path) -> None:
+        from kstrl.verify import CheckResult, VerificationResult
+
+        violation = Finding.policy_violation(
+            category="paths_deny", explanation="touched .env",
+        )
+        _run_factory(tmp_path, verification=VerificationResult(
+            passed=False,
+            checks=[CheckResult(
+                "policy_envelope", False, "1 violation", findings=[violation],
+            )],
+        ))
+        kinds = {str(i.kind) for i in Inbox(tmp_path, InboxConfig()).items()}
+        assert "policy_exception" in kinds
+
+    def test_failed_component_emits_halted_run(self, tmp_path: Path) -> None:
+        from kstrl.verify import CheckResult, VerificationResult
+
+        _run_factory(tmp_path, verification=VerificationResult(
+            passed=False, checks=[CheckResult("test_suite", False, "boom")],
+        ))
+        items = Inbox(tmp_path, InboxConfig()).items()
+        halted = [i for i in items if i.kind is ItemKind.HALTED_RUN]
+        assert halted
+        assert halted[0].component == "comp-a"
+        assert halted[0].evidence.get("phase") == "verify"
+
+    def test_demotion_emits_notice_with_evidence(self, tmp_path: Path) -> None:
+        from kstrl.verify import CheckResult, VerificationResult
+
+        violation = Finding.policy_violation(
+            category="paths_deny", explanation="touched .env",
+        )
+        _run_factory(
+            tmp_path,
+            verification=VerificationResult(
+                passed=False,
+                checks=[CheckResult(
+                    "policy_envelope", False, "1 violation", findings=[violation],
+                )],
+            ),
+            level=AutonomyLevel.L3_ENVELOPED_AUTO,
+            autonomy=True,
+        )
+        items = Inbox(tmp_path, InboxConfig()).items()
+        notices = [i for i in items if i.kind is ItemKind.DEMOTION_NOTICE]
+        assert notices, [str(i.kind) for i in items]
+        assert notices[0].evidence.get("trigger") == "policy_violation"
+        assert notices[0].priority is Priority.HIGH
+
+    def test_clean_run_emits_nothing(self, tmp_path: Path) -> None:
+        # Silence on success is what keeps the surface worth reading.
+        _run_factory(tmp_path)
+        assert Inbox(tmp_path, InboxConfig()).items() == []
+
+    def test_disabled_inbox_writes_nothing(self, tmp_path: Path) -> None:
+        from kstrl.verify import CheckResult, VerificationResult
+
+        _init_git_repo(tmp_path)
+        (tmp_path / "kstrl.toml").write_text("[inbox]\nenabled = false\n")
+        kstrl_dir = tmp_path / "scripts" / "kstrl"
+        kstrl_dir.mkdir(parents=True, exist_ok=True)
+        (kstrl_dir / "prompt.md").write_text("p")
+        with patch.object(Path, "write_text", Path.write_text):
+            _run_factory(tmp_path, verification=VerificationResult(
+                passed=False, checks=[CheckResult("test_suite", False, "boom")],
+            ))
+        # _run_factory rewrites kstrl.toml with inbox enabled, so assert the
+        # config path directly instead:
+        assert InboxConfig.load(tmp_path).enabled is True
+
+    def test_inbox_write_failure_does_not_fail_the_run(
+        self, tmp_path: Path,
+    ) -> None:
+        from kstrl.verify import CheckResult, VerificationResult
+
+        with patch(
+            "kstrl.pipeline.Inbox.add", side_effect=OSError("disk full"),
+        ):
+            _run_factory(tmp_path, verification=VerificationResult(
+                passed=False, checks=[CheckResult("test_suite", False, "boom")],
+            ))
+        # The run completed; that is the assertion.
+
+
+class TestInboxRetryRoundTrip:
+    def test_retry_resets_the_component_to_pending(self, tmp_path: Path) -> None:
+        from kstrl.manifest import Component, ComponentStatus, Manifest
+
+        manifest_path = tmp_path / "scripts" / "kstrl" / "manifest.json"
+        manifest_path.parent.mkdir(parents=True)
+        manifest = Manifest(
+            version="1", spec_file="s", project_name="t", base_branch="main",
+            single_pr=False,
+            components=[Component(
+                "comp-a", "A", "D", [], "prd.json", "kstrl/comp-a",
+                status=ComponentStatus.FAILED.value,
+            )],
+        )
+        manifest.save(manifest_path)
+        reset = manifest.reset_for_retry("comp-a")
+        manifest.save(manifest_path)
+        reloaded = Manifest.load(manifest_path)
+        assert reloaded.components[0].status == ComponentStatus.PENDING.value
+        assert "comp-a" in reset or reset == []
+
+
+class TestSummaries:
+    def test_summarize_counts_by_kind(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        box.add(ItemKind.HALTED_RUN, "b", dedupe_key="b")
+        box.add(ItemKind.MERGE_GATE, "c", dedupe_key="c")
+        text = summarize(box.items())
+        assert "3 open" in text and "2 halted_run" in text
+
+    def test_schema_version_recorded(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        box.add(ItemKind.HALTED_RUN, "a")
+        record = json.loads(box.path.read_text().strip().splitlines()[0])
+        assert record["schema_version"] == 1
+
+
+# --------------------------------------------------------------------------
+# TUI screen
+# --------------------------------------------------------------------------
+class TestInboxScreen:
+    def test_screen_imports_and_registers(self) -> None:
+        from kstrl.tui.screens.home import HOME_COMMANDS
+        from kstrl.tui.screens.inbox import InboxScreen, priority_marker
+
+        assert InboxScreen is not None
+        assert any(c.command_id == "inbox" for c in HOME_COMMANDS), [
+            c.command_id for c in HOME_COMMANDS
+        ]
+        assert priority_marker("high").plain == "!"
+
+    @pytest.mark.asyncio
+    async def test_screen_renders_and_approves(self, tmp_path: Path) -> None:
+        from textual.app import App, ComposeResult
+
+        from kstrl.tui.screens.inbox import InboxScreen
+
+        box = _box(tmp_path)
+        box.add(
+            ItemKind.POLICY_EXCEPTION, "comp-a: denied path",
+            component="comp-a", dedupe_key="p1",
+        )
+
+        class _Harness(App[None]):
+            def compose(self) -> ComposeResult:
+                yield from ()
+
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await app.push_screen(InboxScreen(tmp_path))
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, InboxScreen)
+            assert len(screen._items) == 1
+            screen.action_approve()
+            await pilot.pause()
+        assert Inbox(tmp_path, InboxConfig()).open_items() == []

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -279,12 +279,31 @@ def _init_git_repo(root: Path) -> None:
     run("commit", "-m", "base")
 
 
+def _usage(total: int) -> object:
+    from kstrl.agents.base import UsageRecord, UsageTotals
+
+    totals = UsageTotals()
+    totals.add_record(UsageRecord(
+        input_tokens=total // 3,
+        output_tokens=total - total // 3,
+        total_tokens=total,
+        duration_seconds=1.0,
+        source="claude-stream-json",
+    ))
+    return totals
+
+
 def _run_factory(
     tmp_path: Path,
     *,
     verification: object | None = None,
     level: AutonomyLevel = AutonomyLevel.L1_SUPERVISED,
     autonomy: bool = False,
+    inbox_enabled: bool = True,
+    max_total_tokens: int = 0,
+    engineer_tokens: int = 0,
+    create_prs: bool = False,
+    pause_before_pr_merge: bool = False,
 ) -> None:
     from kstrl.config import KstrlConfig
     from kstrl.factory import ComponentResult, FactoryConfig, run_factory
@@ -299,7 +318,8 @@ def _run_factory(
     (kstrl_dir / "prompt.md").write_text("p")
     (tmp_path / "kstrl.toml").write_text(
         f"[autonomy]\nenabled = {'true' if autonomy else 'false'}\n"
-        "[policy]\nenabled = true\n[inbox]\nenabled = true\n"
+        "[policy]\nenabled = true\n"
+        f"[inbox]\nenabled = {'true' if inbox_enabled else 'false'}\n"
     )
     AutonomyState(level=int(level)).save(tmp_path)
     manifest = Manifest(
@@ -311,8 +331,10 @@ def _run_factory(
         )],
     )
     config = FactoryConfig(
-        use_worktrees=False, create_prs=False, max_parallel=1, max_retries=0,
-        retry_delay=0, review_mode="skip",
+        use_worktrees=False, create_prs=create_prs, max_parallel=1,
+        max_retries=0, retry_delay=0, review_mode="skip",
+        max_total_tokens=max_total_tokens,
+        pause_before_pr_merge=pause_before_pr_merge,
         verify_config=VerifyConfig(
             test_command="true", typecheck_command="true", lint_command="true",
             check_bad_patterns=False, subprocess_timeout=5.0,
@@ -326,16 +348,20 @@ def _run_factory(
     result = verification or VerificationResult(
         passed=True, checks=[CheckResult("diff_scope", True, "ok")],
     )
+    component_result = ComponentResult(
+        "comp-a", success=True, iterations=1,
+        usage=_usage(engineer_tokens) if engineer_tokens else None,
+    )
     with (
         patch(
-            "kstrl.factory._run_component",
-            return_value=ComponentResult("comp-a", success=True, iterations=1),
+            "kstrl.factory._run_component", return_value=component_result,
         ),
         patch("kstrl.factory.run_mechanical_verification", return_value=result),
         patch(
             "kstrl.factory.run_review",
             return_value=ReviewResult(passed=True, mode="hard"),
         ),
+        patch("kstrl.pr.is_gh_available", return_value=False),
     ):
         run_factory(manifest, config, base, PlainUI(no_color=True), tmp_path)
 
@@ -399,18 +425,14 @@ class TestEmittersFireDuringRuns:
     def test_disabled_inbox_writes_nothing(self, tmp_path: Path) -> None:
         from kstrl.verify import CheckResult, VerificationResult
 
-        _init_git_repo(tmp_path)
-        (tmp_path / "kstrl.toml").write_text("[inbox]\nenabled = false\n")
-        kstrl_dir = tmp_path / "scripts" / "kstrl"
-        kstrl_dir.mkdir(parents=True, exist_ok=True)
-        (kstrl_dir / "prompt.md").write_text("p")
-        with patch.object(Path, "write_text", Path.write_text):
-            _run_factory(tmp_path, verification=VerificationResult(
+        _run_factory(
+            tmp_path,
+            verification=VerificationResult(
                 passed=False, checks=[CheckResult("test_suite", False, "boom")],
-            ))
-        # _run_factory rewrites kstrl.toml with inbox enabled, so assert the
-        # config path directly instead:
-        assert InboxConfig.load(tmp_path).enabled is True
+            ),
+            inbox_enabled=False,
+        )
+        assert Inbox(tmp_path, InboxConfig()).items() == []
 
     def test_inbox_write_failure_does_not_fail_the_run(
         self, tmp_path: Path,
@@ -504,3 +526,131 @@ class TestInboxScreen:
             screen.action_approve()
             await pilot.pause()
         assert Inbox(tmp_path, InboxConfig()).open_items() == []
+
+
+# --------------------------------------------------------------------------
+# Review regressions (PR #175)
+# --------------------------------------------------------------------------
+class TestDedupeAcrossGenerations:
+    """A repeat must collapse onto the OPEN generation, not fan out."""
+
+    def test_two_repeats_after_a_decision_share_one_item(
+        self, tmp_path: Path,
+    ) -> None:
+        box = _box(tmp_path)
+        first = box.add(ItemKind.HALTED_RUN, "x", dedupe_key="k")
+        box.approve(first.id, actor="h")
+        second = box.add(ItemKind.HALTED_RUN, "x", dedupe_key="k")
+        third = box.add(ItemKind.HALTED_RUN, "x", dedupe_key="k")
+        assert second.id == third.id != first.id
+        open_items = box.open_items()
+        assert len(open_items) == 1
+        assert open_items[0].occurrences == 2
+
+    def test_many_repeats_stay_one_open_item(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        first = box.add(ItemKind.HALTED_RUN, "x", dedupe_key="k")
+        box.approve(first.id, actor="h")
+        for _ in range(5):
+            box.add(ItemKind.HALTED_RUN, "x", dedupe_key="k")
+        assert len(box.open_items()) == 1
+        assert box.open_items()[0].occurrences == 5
+
+    def test_open_generation_wins_over_older_decided(
+        self, tmp_path: Path,
+    ) -> None:
+        """The exact regression: two generations of one key exist, and
+        the lookup must return the OPEN one even though the decided one
+        sorts first (items() is ascending by age)."""
+        box = _box(tmp_path)
+        decided = box.add(ItemKind.HALTED_RUN, "x", dedupe_key="k")
+        box.approve(decided.id, actor="h")
+        reopened = box.add(ItemKind.HALTED_RUN, "x", dedupe_key="k")
+        assert reopened.id != decided.id
+        found = box.find_by_dedupe_key("k")
+        assert found is not None
+        assert found.id == reopened.id
+
+    def test_all_decided_falls_back_to_the_newest(
+        self, tmp_path: Path,
+    ) -> None:
+        box = _box(tmp_path)
+        first = box.add(ItemKind.HALTED_RUN, "x", dedupe_key="k")
+        box.approve(first.id, actor="h")
+        second = box.add(ItemKind.HALTED_RUN, "x", dedupe_key="k")
+        box.reject(second.id, actor="h", comment="no")
+        found = box.find_by_dedupe_key("k")
+        assert found is not None
+        # Not the oldest: a decision on the stale generation must not be
+        # what a fresh occurrence collapses onto.
+        assert found.id == second.id
+
+
+class TestBudgetEmitsOneItem:
+    def test_budget_halt_does_not_also_emit_halted_run(
+        self, tmp_path: Path,
+    ) -> None:
+        """One event must not consume two cap slots or bury its reason.
+
+        Drives the REAL halt: the engineer's recorded spend trips
+        max_total_tokens, so fail_for_budget raises budget_overrun and
+        the generic halted_run fail() would otherwise add is suppressed.
+        """
+        _run_factory(tmp_path, max_total_tokens=100, engineer_tokens=500)
+        kinds = [str(i.kind) for i in _box(tmp_path).open_items()]
+        assert kinds == ["budget_overrun"]
+
+
+class TestNotifyWiring:
+    def test_inbox_hook_is_silent_without_its_own_command(
+        self, tmp_path: Path,
+    ) -> None:
+        """Review #5: the knob had no consumer. It has one now, but it
+        must NOT borrow on_first_failure - a failing component already
+        fires that hook and raises an item for the same event."""
+        from kstrl.observability import NotifyConfig, NotifyHooks
+
+        marker = tmp_path / "fired.txt"
+        cmd = f"echo \"$KSTRL_NOTIFY_EVENT\" >> '{marker}'"
+        hooks = NotifyHooks(NotifyConfig(on_first_failure=cmd))
+        hooks.fire_inbox_item("policy_exception", "denied path", "comp-a")
+        assert not marker.exists()
+
+    def test_action_required_item_fires_its_own_command(
+        self, tmp_path: Path,
+    ) -> None:
+        from kstrl.observability import NotifyConfig, NotifyHooks
+
+        marker = tmp_path / "fired.txt"
+        cmd = f"echo \"$KSTRL_NOTIFY_EVENT $KSTRL_NOTIFY_COMPONENT\" >> '{marker}'"
+        hooks = NotifyHooks(NotifyConfig(on_inbox_item=cmd))
+        hooks.fire_inbox_item("policy_exception", "denied path", "comp-a")
+        hooks.fire_inbox_item("policy_exception", "denied again", "comp-b")
+        # Once per condition, as with every other hook.
+        assert marker.read_text().splitlines() == [
+            "inbox_policy_exception comp-a",
+        ]
+
+    def test_notifiable_excludes_low_priority_kinds(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        box.add(ItemKind.CALIBRATION_DRIFT, "drift", dedupe_key="d")
+        assert notifiable(box.items()) == []
+
+
+class TestMergeGateIsTheHumanGate:
+    """The gate is the pre-merge checkpoint, not the post-merge timeout."""
+
+    def test_parked_decision_exists(self) -> None:
+        from kstrl.pipeline import CheckpointDecision
+
+        assert CheckpointDecision.PARKED.value == "parked"
+
+    def test_non_interactive_gate_parks_and_emits(self, tmp_path: Path) -> None:
+        # pause_before_pr_merge with no interactive UI must NOT merge:
+        # it parks the component and files exactly one merge_gate item.
+        _run_factory(
+            tmp_path, create_prs=True, pause_before_pr_merge=True,
+        )
+        items = _box(tmp_path).open_items()
+        assert [str(i.kind) for i in items] == ["merge_gate"]
+        assert items[0].component == "comp-a"

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -59,6 +59,8 @@ class TestNotifyConfig:
         config = NotifyConfig()
         assert config.on_complete == ""
         assert config.on_first_failure == ""
+        # R8.3: opt-in, so an inbox item is silent unless asked for.
+        assert config.on_inbox_item == ""
         assert config.hook_timeout == 30.0
 
     def test_load_reads_notify_section(self, tmp_path: Path) -> None:
@@ -66,11 +68,13 @@ class TestNotifyConfig:
             "[notify]\n"
             "on_complete = \"printf 'a'\"\n"
             'on_first_failure = "curl example.com"\n'
+            'on_inbox_item = "curl example.com/inbox"\n'
             "hook_timeout = 5.0\n"
         )
         config = NotifyConfig.load(tmp_path)
         assert config.on_complete == "printf 'a'"
         assert config.on_first_failure == "curl example.com"
+        assert config.on_inbox_item == "curl example.com/inbox"
         assert config.hook_timeout == 5.0
 
     def test_env_overrides_toml(
@@ -78,12 +82,15 @@ class TestNotifyConfig:
     ) -> None:
         (tmp_path / "kstrl.toml").write_text(
             '[notify]\non_complete = "from-toml"\n'
+            'on_inbox_item = "inbox-toml"\n'
         )
         monkeypatch.setenv("KSTRL_NOTIFY_ON_COMPLETE", "from-env")
         monkeypatch.setenv("KSTRL_NOTIFY_ON_FIRST_FAILURE", "fail-env")
+        monkeypatch.setenv("KSTRL_NOTIFY_ON_INBOX_ITEM", "inbox-env")
         config = NotifyConfig.load(tmp_path)
         assert config.on_complete == "from-env"
         assert config.on_first_failure == "fail-env"
+        assert config.on_inbox_item == "inbox-env"
 
     def test_missing_section_is_defaults(self, tmp_path: Path) -> None:
         config = NotifyConfig.load(tmp_path)
@@ -317,9 +324,69 @@ class TestFactoryFiresHooks:
             )
 
         # Two independent components both failed; the hook fired once.
+        # The R8.3 inbox items raised by those same failures must not
+        # add a second firing: on_inbox_item is a separate, opt-in key.
         assert len(result.failed) == 2
         assert _lines(fail_count) == ["first_failure a"]
         assert _lines(complete_count) == ["run_complete "]
+
+    def test_inbox_hook_is_silent_until_opted_in(
+        self, tmp_path: Path,
+    ) -> None:
+        """R8.3 + review #5: a failing run raises inbox items, but with
+        on_inbox_item unset (the default) nothing extra is pushed."""
+        from kstrl.inbox import Inbox, InboxConfig
+
+        root = _setup_plain_project(tmp_path)
+        inbox_count = tmp_path / "inbox-count.txt"
+        config = _plain_factory_config(notify_config=NotifyConfig(
+            on_first_failure=_count_cmd(tmp_path / "fail-count.txt"),
+        ))
+
+        def fake_run(
+            component_id: str, *args: object, **kwargs: object,
+        ) -> ComponentResult:
+            return ComponentResult(component_id, success=False, error="boom")
+
+        with patch("kstrl.factory._run_component", side_effect=fake_run):
+            run_factory(
+                _two_component_manifest(), config, _plain_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        # Items were genuinely raised, so the silence is a decision and
+        # not an empty code path.
+        assert len(Inbox(root, InboxConfig()).open_items()) == 2
+        assert _lines(inbox_count) == []
+
+    def test_opted_in_inbox_hook_fires_without_doubling_the_failure_hook(
+        self, tmp_path: Path,
+    ) -> None:
+        """Opting in adds an inbox push; it does not fire the failure
+        hook a second time for the same event."""
+        root = _setup_plain_project(tmp_path)
+        fail_count = tmp_path / "fail-count.txt"
+        inbox_count = tmp_path / "inbox-count.txt"
+        config = _plain_factory_config(notify_config=NotifyConfig(
+            on_first_failure=_count_cmd(fail_count),
+            on_inbox_item=_count_cmd(inbox_count),
+        ))
+
+        def fake_run(
+            component_id: str, *args: object, **kwargs: object,
+        ) -> ComponentResult:
+            return ComponentResult(component_id, success=False, error="boom")
+
+        with patch("kstrl.factory._run_component", side_effect=fake_run):
+            run_factory(
+                _two_component_manifest(), config, _plain_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert _lines(fail_count) == ["first_failure a"]
+        # One line per item KIND, not per item: both components raised a
+        # halted_run, and once means once.
+        assert _lines(inbox_count) == ["inbox_halted_run a"]
 
     def test_clean_run_fires_only_complete(self, tmp_path: Path) -> None:
         root = _setup_plain_project(tmp_path)

--- a/tests/test_phase_e.py
+++ b/tests/test_phase_e.py
@@ -183,11 +183,16 @@ class TestE4BudgetCap:
 
 
 class TestE6HitlCheckpoint:
-    def test_non_interactive_ui_warns_and_proceeds(self, tmp_path: Path) -> None:
+    def test_non_interactive_ui_parks_for_approval(self, tmp_path: Path) -> None:
         """When pause_before_pr_merge=True but the UI can't prompt
-        (PlainUI in tests), the factory must log a warning and proceed
-        rather than block indefinitely."""
+        (PlainUI in tests), the factory must NOT merge unapproved. R8.3:
+        it parks the component (fails it at phase=pr/check=merge_gate)
+        and routes the decision to the inbox as a merge_gate item, so a
+        human can approve it later with `ks inbox retry`. Proceeding
+        would defeat the gate in exactly the unattended case R8.2's
+        L1/L2 forces the gate on for."""
         from kstrl.factory import ComponentResult
+        from kstrl.inbox import Inbox, InboxConfig, ItemKind
         scaffold = tmp_path / "scripts" / "kstrl"
         scaffold.mkdir(parents=True)
         (scaffold / "prompt.md").write_text("p")
@@ -238,10 +243,18 @@ class TestE6HitlCheckpoint:
             result = run_factory(
                 manifest, config, base, PlainUI(no_color=True), tmp_path,
             )
-        # PlainUI returns False for can_prompt() so HITL skips and the
-        # component completes (no gh available so no PR is actually
-        # created, but the path executed cleanly).
-        assert "comp-a" in result.completed
+        # PlainUI returns False for can_prompt(), so the gate cannot be
+        # answered: the component is parked, not merged.
+        assert "comp-a" not in result.completed
+        assert "comp-a" in result.failed
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.failed_phase == "pr"
+        assert comp.failed_check == "merge_gate"
+        # ...and the decision is queued for a human, exactly once.
+        items = Inbox(tmp_path, InboxConfig()).open_items()
+        assert [i.kind for i in items] == [ItemKind.MERGE_GATE]
+        assert items[0].component == "comp-a"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -27,6 +27,7 @@ from kstrl.factory import (
     FactoryResult,
 )
 from kstrl.fixtures import FixturesConfig
+from kstrl.inbox import Inbox, InboxConfig, ItemKind
 from kstrl.knowledge import KnowledgeConfig
 from kstrl.manifest import Component, ComponentStatus, Manifest
 from kstrl.observability import NotifyConfig, NotifyHooks, ProgressLog
@@ -830,6 +831,15 @@ class TestMergePendingRepoll:
         comp.pr_url = "https://x/pull/7"
         return pipeline, manifest, result
 
+    def _seed_merge_gate(self, tmp_path: Path) -> Inbox:
+        """The merge_gate item the park itself would have raised."""
+        box = Inbox(tmp_path, InboxConfig())
+        box.add(
+            ItemKind.MERGE_GATE, "comp-a merge unconfirmed",
+            component="comp-a", dedupe_key="merge:comp-a",
+        )
+        return box
+
     def test_repoll_merged_completes(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -841,11 +851,15 @@ class TestMergePendingRepoll:
             "kstrl.git.fetch_base_branch", lambda *a, **k: None,
         )
         pipeline, manifest, result = self._parked(tmp_path)
+        box = self._seed_merge_gate(tmp_path)
         pipeline.repoll_merge_pending()
         comp = manifest.get_component("comp-a")
         assert comp is not None
         assert comp.status == ComponentStatus.COMPLETED.value
         assert result.completed == ["comp-a"]
+        # R8.3: reality answered the gate, so the item must not survive
+        # to hold a cap slot and ask for a decision already made.
+        assert box.open_items() == []
 
     def test_repoll_closed_fails_and_cascade_skips(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
@@ -855,6 +869,7 @@ class TestMergePendingRepoll:
             "kstrl.pr.wait_for_merge", lambda *a, **k: "closed",
         )
         pipeline, manifest, result = self._parked(tmp_path)
+        box = self._seed_merge_gate(tmp_path)
         pipeline.repoll_merge_pending()
         comp = manifest.get_component("comp-a")
         dep = manifest.get_component("comp-b")
@@ -864,6 +879,9 @@ class TestMergePendingRepoll:
         assert dep.status == ComponentStatus.SKIPPED.value
         assert result.failed == ["comp-a"]
         assert result.skipped == ["comp-b"]
+        # R8.3: it stopped being a merge decision and became a halt, so
+        # the merge_gate item is resolved and a halted_run replaces it.
+        assert [str(i.kind) for i in box.open_items()] == ["halted_run"]
 
     def test_repoll_unconfirmed_stays_parked(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Implements **R8.3 Exception inbox** (closes [#150](https://github.com/0xfauzi/kstrl/issues/150)), completing R8 Wave 1 and unblocking Wave 3 (continuous intake, #153).

Over-the-loop operation needs a single place to look. Before this, the things wanting a decision were scattered across surfaces sharing nothing: a FAILED component in the manifest, a MERGE_PENDING park in a status string, an R8.1 policy violation in a finding, an R8.2 demotion in the journal, a budget overrun in a log line. Each was discoverable only if you already knew to look for it — the opposite of what "humans handle exceptions" requires.

## Emitters are wired, not declared

This is the lesson from #174, so I led with it. **Every existing halt path feeds the inbox:**

| Halt path | Item kind |
|---|---|
| component FAILED, PR-flow failure | `halted_run` |
| MERGE_PENDING park | `merge_gate` |
| token-budget halt | `budget_overrun` |
| R8.1 policy findings (advisories excluded) | `policy_exception` |
| R8.2 demotion, with triggering evidence | `demotion_notice` |

Verified end-to-end rather than asserted: a run with a planted policy violation produces a `policy_exception`, a `halted_run`, **and** a `demotion_notice`, while the ladder drops L3 → L2. Inbox writes can never fail a run — but they warn, because a silently empty inbox reads exactly like a clean run.

This closes three IOUs left by earlier items: R8.1's "violations route to the inbox", R8.2's "every demotion emits an inbox item carrying the triggering evidence", and the surface R8.6 needs.

## Substrate

`.kstrl/inbox.jsonl`, append-only, folded on read. Every emission and decision is one appended line; a crash mid-write loses at most the last line and never corrupts a prior decision.

Design choices that carry weight:
- **Dedupe by key** — a component failing the same way across three retries is one item with a bumped count, not three. But a repeat *after* a decision opens a fresh item: you approved that failure once, and its recurrence is new information.
- **Snooze has a TTL, not a hide button.** A lapsed snooze reads as open again by the clock, so nothing has to remember to un-hide it. That is the difference between deferring a decision and losing one.
- **The open-item cap is a real backstop** — R8.6 consults it before admitting queue work. An operator already behind should not be handed more.
- **Reject demands a comment.** A bare "no" is not a decision anyone can act on later, least of all the person who made it.

## Surfaces

- `ks inbox ls | show | approve | reject | snooze | retry` — `retry` is a genuine round-trip, resetting the component to PENDING via the manifest so the next `ks factory` picks it up.
- `kstrl/tui/screens/inbox.py` — master-detail triage screen in the home shell, using the *same* `Inbox` methods the CLI calls, so a decision made in either place is indistinguishable and lands in the same log. Requeue is deliberately CLI-only: it mutates the manifest, and that should cost one more deliberate step than a keystroke.
- Notification stays **one-way**: `notifiable()` selects action-required kinds plus demotions, so successes are silent. kstrl still runs no inbound HTTP surface; an ntfy.sh example reuses the existing `[notify]` hook.

## Deliberately not built

`approve-and-amend-policy` (widening the R8.1 envelope from a repeated approval) and the daily digest. Both are learning-loop refinements that want real inbox traffic to design against, and neither is load-bearing for R8.6. Recorded in the roadmap rather than left implied.

## Tests / gates

- 44 inbox tests: append-only log and decision folding, dedupe semantics both ways, snooze TTL expiry, cap behaviour, torn-line tolerance, ambiguous-prefix refusal, the notification taxonomy, config surface, **end-to-end emitter runs**, and a live Textual screen test that approves an item and asserts the store.
- `mypy --strict` clean (107 files), `ruff` clean, full suite **2162 passed / 28 skipped / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
