### PR TITLE
fix: enforce max_total_tokens during the engineer loop, not just after it

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ merge_timeout = 300.0              # seconds to wait for PR merge confirmation
 max_adversarial_calls = 0          # cap on review+security+distill LLM calls; 0 = unbounded
 max_total_tokens = 0               # run-level token budget; 0 = unbounded. Halts before the next engineer iteration or phase, never mid-call (docs/env-vars.md)
 pause_before_pr_merge = false      # human checkpoint before each PR (E6)
-progress_log_enabled = true        # JSONL event log at .kstrl/progress.jsonl (R3.2)
+progress_log_enabled = true        # JSONL event log at .kstrl/progress.jsonl (R3.2); usage accounting is written either way (docs/env-vars.md)
 keep_worktrees_on_failure = false  # keep failed components' worktrees for post-mortem (R3.3)
 
 # No-progress circuit breaker (R7.5; 0 iterations disables)

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ create_prs = true                  # push + merge PRs via gh
 review_mode = "hard"               # hard | advisory | skip (Phase 2)
 merge_timeout = 300.0              # seconds to wait for PR merge confirmation
 max_adversarial_calls = 0          # cap on review+security+distill LLM calls; 0 = unbounded
-max_total_tokens = 0               # run-level token budget; 0 = unbounded
+max_total_tokens = 0               # run-level token budget; 0 = unbounded. Halts before the next engineer iteration or phase, never mid-call (docs/env-vars.md)
 pause_before_pr_merge = false      # human checkpoint before each PR (E6)
 progress_log_enabled = true        # JSONL event log at .kstrl/progress.jsonl (R3.2)
 keep_worktrees_on_failure = false  # keep failed components' worktrees for post-mortem (R3.3)

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -90,17 +90,40 @@ What is **not** bounded:
 | Unreported spend | Every token figure is a CLI self-report. Calls that report nothing count as zero, so totals are lower bounds whenever `unreported_calls > 0` and the halt can arrive late. A loop that reports *nothing* is a separate case and halts outright - see below |
 
 Unknown usage is deliberately **not** silently treated as zero in the one case
-where that would make the cap undeliverable: if the cap is on and **this
-engineer loop** has reported no tokens at all after two agent calls (a custom
-`agent_cmd` never reports usage), the loop halts with a
-`token budget unenforceable` reason rather than run under a ceiling that can
-provably never trip. One silent call is treated as an incident - the claude
-adapter records no counts for a timed-out or unparseable result - so a single
-bad iteration does not end a capped run.
+where that would make the cap undeliverable. The loop halts with a
+`token budget unenforceable` reason when **both** hold:
+
+1. **this engineer loop** has reported no token count on any of its calls, so
+   the run total cannot grow while it runs (the spend recorded before this
+   worker launched is frozen at launch); **and**
+2. the **run** has now seen two calls that reported no token count - counted
+   run-wide, so the threshold does not reset on every attempt or component.
+
+Reported *cost* is not token evidence: a result carrying `total_cost_usd` with
+no `usage` dict is "known" to the meter but can never move a token total, so
+the rule counts token-bearing calls (`token_calls`), not reporting calls.
+
+The threshold counts only the calls that reported **no tokens**, so a lone
+unparseable result in an otherwise-reporting run is still treated as an
+incident, not a dead adapter. The flip side, on purpose: once a run has
+accumulated one tokenless call anywhere, the engineer's first tokenless
+iteration reaches the threshold and halts. Two independent tokenless calls in
+one run is adapter behavior (a custom `agent_cmd` never reports usage), and a
+loud, recoverable halt beats spending under a ceiling that cannot fire.
 
 `KSTRL_AGENT_BUDGET_USD` is the only genuine in-turn ceiling, and only the
 `claude-sdk` adapter enforces it; `claude-code`, `codex`, and custom commands
 ignore it.
+
+### Usage accounting vs progress logging
+
+`FACTORY_PROGRESS_LOG_ENABLED=0` (or `[factory] progress_log_enabled = false`)
+turns off `progress.jsonl` and the run's `events.jsonl`. It does **not** turn
+off usage accounting: every run still allocates
+`.kstrl/runs/<run_id>/components/<id>/engineer_usage.json`, a small snapshot
+the engineer loop rewrites at each iteration boundary so a worker killed by a
+shutdown does not take its spend to the grave. An observability opt-out may
+drop the narration; it must never drop the meter.
 
 ## BreakerConfig (`[breaker]`)
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -64,6 +64,44 @@ All values are seconds; 0 or less disables that limit.
 
 The two safety knobs (E4 `max_adversarial_calls`, E6 `pause_before_pr_merge`) are reachable via all three surfaces since R2.2: the env vars above, `[factory]` keys in kstrl.toml, and the `--max-adversarial-calls` / `--pause-before-pr-merge` CLI flags.
 
+### What `max_total_tokens` guarantees (R8)
+
+It is a **stop-before-the-next-unit-of-work** limit, not a hard cap. It is
+evaluated in two places:
+
+- **Between engineer iterations** (`kstrl/loop.py`, `LoopBudget.halt_reason`).
+  The worker is launched with the cap plus the run's spend as of that moment,
+  so the loop refuses to start another iteration once the total reaches the
+  cap. This is the only check that fires while the spend is being incurred.
+- **At phase boundaries** in the parent (`pipeline.process_result`, the review
+  / security / distill gates, and the scheduling gate). These stop the next
+  phase or the next component.
+
+Either route halts the component loudly and identically: a
+`budget_exceeded` event, a typed `infrastructure_error` finding, and exactly
+one `budget_overrun` inbox item.
+
+What is **not** bounded:
+
+| Gap | Why |
+|---|---|
+| The iteration already running | Nothing interrupts a single agent call mid-flight. Overshoot is up to one iteration per running worker; `KSTRL_TIMEOUT_AGENT_ITERATION` bounds that in wall clock, never in tokens |
+| Concurrent workers | Each worker sees the run total as of its own launch. With `FACTORY_MAX_PARALLEL = N`, up to N iterations can be in flight past the cap |
+| Unreported spend | Every token figure is a CLI self-report. Calls that report nothing count as zero, so totals are lower bounds whenever `unreported_calls > 0` and the halt can arrive late |
+
+Unknown usage is deliberately **not** silently treated as zero in the one case
+where that would make the cap undeliverable: if the cap is on and no call in
+the whole run has reported a single token after two agent calls (a custom
+`agent_cmd` never reports usage), the loop halts with a
+`token budget unenforceable` reason rather than run under a ceiling that can
+provably never trip. One silent call is treated as an incident - the claude
+adapter records no counts for a timed-out or unparseable result - so a single
+bad iteration does not end a capped run.
+
+`KSTRL_AGENT_BUDGET_USD` is the only genuine in-turn ceiling, and only the
+`claude-sdk` adapter enforces it; `claude-code`, `codex`, and custom commands
+ignore it.
+
 ## BreakerConfig (`[breaker]`)
 
 No-progress circuit breaker (R7.5): the engineer loop halts loudly when N

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -101,6 +101,13 @@ where that would make the cap undeliverable. The loop halts with a
    every attempt or component, while another role's timed-out call never
    counts (it is no evidence about the engineer's adapter).
 
+A loop that emits the completion marker returns before its own budget check,
+so a component that finishes on a single tokenless call cannot halt itself. The
+scheduling gate catches that case instead: once the engineer has made two
+tokenless calls with no token report, the run refuses to start further
+components. Spend is therefore bounded by the component already in flight, not
+by zero.
+
 Reported *cost* is not token evidence: a result carrying `total_cost_usd` with
 no `usage` dict is "known" to the meter but can never move a token total, so
 the rule counts token-bearing calls (`token_calls`), not reporting calls.

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -96,8 +96,10 @@ where that would make the cap undeliverable. The loop halts with a
 1. **this engineer loop** has reported no token count on any of its calls, so
    the run total cannot grow while it runs (the spend recorded before this
    worker launched is frozen at launch); **and**
-2. the **run** has now seen two calls that reported no token count - counted
-   run-wide, so the threshold does not reset on every attempt or component.
+2. the **engineer** has now made two calls that reported no token count -
+   counted across the run's engineer loops, so the threshold does not reset on
+   every attempt or component, while another role's timed-out call never
+   counts (it is no evidence about the engineer's adapter).
 
 Reported *cost* is not token evidence: a result carrying `total_cost_usd` with
 no `usage` dict is "known" to the meter but can never move a token total, so

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -87,11 +87,11 @@ What is **not** bounded:
 |---|---|
 | The iteration already running | Nothing interrupts a single agent call mid-flight. Overshoot is up to one iteration per running worker; `KSTRL_TIMEOUT_AGENT_ITERATION` bounds that in wall clock, never in tokens |
 | Concurrent workers | Each worker sees the run total as of its own launch. With `FACTORY_MAX_PARALLEL = N`, up to N iterations can be in flight past the cap |
-| Unreported spend | Every token figure is a CLI self-report. Calls that report nothing count as zero, so totals are lower bounds whenever `unreported_calls > 0` and the halt can arrive late |
+| Unreported spend | Every token figure is a CLI self-report. Calls that report nothing count as zero, so totals are lower bounds whenever `unreported_calls > 0` and the halt can arrive late. A loop that reports *nothing* is a separate case and halts outright - see below |
 
 Unknown usage is deliberately **not** silently treated as zero in the one case
-where that would make the cap undeliverable: if the cap is on and no call in
-the whole run has reported a single token after two agent calls (a custom
+where that would make the cap undeliverable: if the cap is on and **this
+engineer loop** has reported no tokens at all after two agent calls (a custom
 `agent_cmd` never reports usage), the loop halts with a
 `token budget unenforceable` reason rather than run under a ceiling that can
 provably never trip. One silent call is treated as an incident - the claude

--- a/docs/sdk-spike.md
+++ b/docs/sdk-spike.md
@@ -58,10 +58,13 @@ produce. This is prevention where the current design has detection.
 
 ### 3. Budget enforcement
 
-CLI subprocess today: `max_total_tokens` (R3.1) is enforced at PHASE
-boundaries from CLI self-reports; an in-flight engineer loop can
-overshoot by a whole phase, and unreported calls make totals lower
-bounds.
+CLI subprocess today: `max_total_tokens` is enforced at PHASE
+boundaries (R3.1) AND between engineer iterations (R8), both from CLI
+self-reports. The in-loop check narrowed the worst case from "a whole
+phase" - one component's entire engineer loop - to "the iteration
+already in flight"; a single call still cannot be interrupted,
+concurrent workers each see only the run total as of their own launch,
+and unreported calls still make totals lower bounds.
 
 SDK, measured: `max_budget_usd=0.00001` halted the run in-loop with a
 typed result - `subtype="error_max_budget_usd"`, `is_error=true`,

--- a/kstrl.toml.example
+++ b/kstrl.toml.example
@@ -101,7 +101,24 @@ create_prs = true                  # call `gh` to push + merge per component
 review_mode = "hard"               # hard | advisory | skip
 merge_timeout = 300.0              # seconds to wait for PR merge confirmation (R0.2)
 max_adversarial_calls = 0          # 0 = unbounded; otherwise cap review+security+distill calls per run
-max_total_tokens = 0               # run-level token budget; 0 = unbounded (R3.1)
+max_total_tokens = 0               # run-level token budget; 0 = unbounded (R3.1/R8)
+# What max_total_tokens actually guarantees (read this before trusting it):
+#   Checked BETWEEN engineer iterations and at every phase boundary. Once the
+#   run's reported spend reaches the cap, no NEW iteration and no new phase
+#   starts, and the component halts loudly (budget_overrun inbox item).
+#   It is NOT a hard cap. What stays unbounded:
+#     - the iteration already in flight: nothing interrupts a single agent call
+#       mid-run, so overshoot is up to one iteration (bounded in wall clock by
+#       [timeout] agent_iteration, not in tokens);
+#     - concurrent workers: each one sees the run total as of ITS launch, so
+#       with max_parallel = N the overshoot scales with N;
+#     - unreported spend: every figure is a CLI self-report, so totals are
+#       lower bounds whenever unreported_calls > 0. If nothing in the run has
+#       reported usage after two agent calls (a custom agent_cmd never does),
+#       the cap provably cannot trip and the loop halts on THAT rather than
+#       pretending to enforce.
+#   [agent] budget_usd is the only genuine per-turn ceiling, and only the
+#   claude-sdk adapter enforces it.
 pause_before_pr_merge = false      # opt-in HITL checkpoint before each PR push+merge
 progress_log_enabled = true        # JSONL event log at .kstrl/progress.jsonl (R3.2)
 keep_worktrees_on_failure = false  # keep failed components' worktrees for post-mortem (R3.3)

--- a/kstrl.toml.example
+++ b/kstrl.toml.example
@@ -113,14 +113,19 @@ max_total_tokens = 0               # run-level token budget; 0 = unbounded (R3.1
 #     - concurrent workers: each one sees the run total as of ITS launch, so
 #       with max_parallel = N the overshoot scales with N;
 #     - unreported spend: every figure is a CLI self-report, so totals are
-#       lower bounds whenever unreported_calls > 0. If nothing in the run has
-#       reported usage after two agent calls (a custom agent_cmd never does),
-#       the cap provably cannot trip and the loop halts on THAT rather than
-#       pretending to enforce.
+#       lower bounds whenever unreported_calls > 0. When THIS engineer loop
+#       reports no token count at all AND the run has now seen two calls that
+#       reported none (a custom agent_cmd never does), the cap provably cannot
+#       trip and the loop halts on THAT rather than pretending to enforce.
+#       Reported cost is not token evidence - a result with a cost but no
+#       usage dict cannot move a token total.
 #   [agent] budget_usd is the only genuine per-turn ceiling, and only the
 #   claude-sdk adapter enforces it.
 pause_before_pr_merge = false      # opt-in HITL checkpoint before each PR push+merge
 progress_log_enabled = true        # JSONL event log at .kstrl/progress.jsonl (R3.2)
+# Disabling progress_log_enabled drops progress.jsonl AND events.jsonl. It does
+# NOT drop usage accounting: engineer_usage.json is still written per component
+# under .kstrl/runs/<run_id>/ so a killed worker's spend still reaches the meter.
 keep_worktrees_on_failure = false  # keep failed components' worktrees for post-mortem (R3.3)
 
 # Phase 1 mechanical verification.

--- a/kstrl/agents/__init__.py
+++ b/kstrl/agents/__init__.py
@@ -40,10 +40,13 @@ def get_agent(
             command has no generic sandbox surface, so the setting is
             ignored there and callers that enable it with a custom
             command must warn.
-        max_budget_usd: In-loop USD budget ceiling (R7.6). Only the
+        max_budget_usd: Per-turn USD budget ceiling (R7.6). Only the
             claude-sdk adapter has an enforcement surface for it; the
-            subprocess adapters ignore it (phase-boundary token budgets
-            from R3.1 still apply to them).
+            subprocess adapters ignore it. Their ceiling is the
+            run-level ``[factory] max_total_tokens``, enforced between
+            engineer iterations (R8) and at phase boundaries (R3.1) -
+            adapter-agnostic, but coarser: it cannot interrupt a call
+            already in flight.
     """
     if agent_cmd:
         return CustomAgent(agent_cmd)

--- a/kstrl/agents/base.py
+++ b/kstrl/agents/base.py
@@ -53,10 +53,25 @@ class UsageTotals:
     wall time, so every token/cost total is a LOWER BOUND whenever
     ``unreported_calls > 0`` (H4: totals are only as honest as their
     coverage, and the rollup renders that gap explicitly).
+
+    ``token_calls`` is the STRICTER coverage signal: invocations that
+    reported an actual token figure. It is deliberately separate from
+    ``known_calls`` because a record carrying only ``cost_usd`` (the
+    claude adapter emits ``total_cost_usd`` even when the ``usage`` dict
+    is missing or drifted) is "known" for cost purposes yet contributes
+    nothing to ``total_tokens``. Anything reasoning about a TOKEN
+    ceiling - see ``kstrl.loop.LoopBudget`` - must read ``token_calls``,
+    not ``known_calls``; a review of R8 found the cost-only case makes a
+    token cap silently unenforceable while ``known_calls`` says coverage
+    is perfect.
     """
 
     calls: int = 0
     known_calls: int = 0
+    #: Invocations that reported at least one TOKEN figure. Always
+    #: <= known_calls. Serialized (to_dict) so the on-disk audit trail
+    #: keeps the distinction; absent in payloads written before R8.
+    token_calls: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
     cache_read_tokens: int = 0
@@ -70,6 +85,17 @@ class UsageTotals:
         """Invocations that reported no token/cost data at all."""
         return self.calls - self.known_calls
 
+    @property
+    def tokenless_calls(self) -> int:
+        """Invocations that reported no TOKEN figure.
+
+        Superset of ``unreported_calls``: a cost-only record is counted
+        here but not there. This is the number a token ceiling has to
+        reason about, because these calls can never move
+        ``total_tokens``.
+        """
+        return self.calls - self.token_calls
+
     def add_record(self, record: object) -> None:
         """Fold one usage record into the totals.
 
@@ -80,6 +106,10 @@ class UsageTotals:
         """
         self.calls += 1
         known = False
+        # Tracked separately from ``known``: a cost-only record is known
+        # but tokenless, and a token cap must not mistake it for
+        # coverage (R8 review, P1-b).
+        token_known = False
         token_fields = (
             "input_tokens",
             "output_tokens",
@@ -95,10 +125,12 @@ class UsageTotals:
                 part_sum += value
                 parts_seen = True
                 known = True
+                token_known = True
         total = _as_int(getattr(record, "total_tokens", None))
         if total is not None:
             self.total_tokens += total
             known = True
+            token_known = True
         elif parts_seen:
             self.total_tokens += part_sum
         cost = _as_float(getattr(record, "cost_usd", None))
@@ -110,11 +142,14 @@ class UsageTotals:
             self.duration_seconds += duration
         if known:
             self.known_calls += 1
+        if token_known:
+            self.token_calls += 1
 
     def merge(self, other: UsageTotals) -> None:
         """Fold another totals object into this one."""
         self.calls += other.calls
         self.known_calls += other.known_calls
+        self.token_calls += other.token_calls
         self.input_tokens += other.input_tokens
         self.output_tokens += other.output_tokens
         self.cache_read_tokens += other.cache_read_tokens
@@ -128,6 +163,7 @@ class UsageTotals:
         return {
             "calls": self.calls,
             "known_calls": self.known_calls,
+            "token_calls": self.token_calls,
             "unreported_calls": self.unreported_calls,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,

--- a/kstrl/events.py
+++ b/kstrl/events.py
@@ -190,12 +190,18 @@ class ReviewResultEvent(Event):
 class ComponentUsage(Event):
     """R3.1 cost meter capture: mirror of ``UsageTotals.to_dict()`` plus
     the phase. Token/cost figures are CLI self-reports - lower bounds
-    whenever ``unreported_calls`` > 0."""
+    whenever ``unreported_calls`` > 0.
+
+    R8: ``token_calls`` is the narrower coverage figure - calls that
+    reported an actual token count, as opposed to cost alone. Payloads
+    written before R8 omit it and decode to 0; the decoder reads only
+    keys it knows, so old and new readers interoperate both ways."""
 
     type: ClassVar[str] = "component_usage"
     phase: str = ""
     calls: int = 0
     known_calls: int = 0
+    token_calls: int = 0
     unreported_calls: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
@@ -710,6 +716,7 @@ class V1CompatSink:
             log.component_usage(comp, event.phase, {
                 "calls": event.calls,
                 "known_calls": event.known_calls,
+                "token_calls": event.token_calls,
                 "unreported_calls": event.unreported_calls,
                 "input_tokens": event.input_tokens,
                 "output_tokens": event.output_tokens,

--- a/kstrl/events.py
+++ b/kstrl/events.py
@@ -858,5 +858,17 @@ class RunPaths:
     def engineer_log(self, component_id: str) -> Path:
         return self.component_dir(component_id) / "engineer.log"
 
+    def engineer_usage(self, component_id: str) -> Path:
+        """Latest engineer-loop usage snapshot (R8).
+
+        Deliberately NOT an event: the worker rewrites this file at every
+        iteration boundary, and the reducer sums ``component_usage``
+        events, so streaming cumulative snapshots would double count in
+        every rollup. It exists so a worker killed by a shutdown does
+        not take its spend with it - the parent reads it only for
+        futures that never delivered a result.
+        """
+        return self.component_dir(component_id) / "engineer_usage.json"
+
     def phase_log(self, component_id: str, phase: str) -> Path:
         return self.component_dir(component_id) / f"{phase}.log"

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -978,8 +978,14 @@ def _read_partial_usage(path: Path) -> UsageTotals | None:
 
     Returns None when the file is absent, unreadable, or not a usage
     dict - the abort path then records nothing rather than guessing.
-    ``unreported_calls`` is a derived property and is deliberately not
-    read back.
+    ``unreported_calls`` and ``tokenless_calls`` are derived properties
+    and are deliberately not read back.
+
+    Backward compatible on read: ``token_calls`` (added in R8 after the
+    review) is optional and defaults to 0 when the payload predates it.
+    That under-reports token coverage rather than inventing it, and the
+    file is rewritten at the next iteration boundary anyway - it is a
+    per-run, per-attempt scratch file, never a long-lived record.
     """
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -989,8 +995,9 @@ def _read_partial_usage(path: Path) -> UsageTotals | None:
         return None
     totals = UsageTotals()
     int_fields = (
-        "calls", "known_calls", "input_tokens", "output_tokens",
-        "cache_read_tokens", "cache_creation_tokens", "total_tokens",
+        "calls", "known_calls", "token_calls", "input_tokens",
+        "output_tokens", "cache_read_tokens", "cache_creation_tokens",
+        "total_tokens",
     )
     for name in int_fields:
         value = data.get(name)
@@ -1007,6 +1014,27 @@ def _read_partial_usage(path: Path) -> UsageTotals | None:
     if totals.calls == 0:
         return None
     return totals
+
+
+def _clear_partial_usage(path: Path) -> None:
+    """Retire the previous attempt's usage snapshot (R8 review, P2-c).
+
+    The snapshot is keyed by run + component only, and a normal result
+    leaves the file on disk, so without this the NEXT attempt inherits
+    it: a retry cancelled before its own first iteration boundary got
+    salvaged with the previous attempt's tokens, which
+    ``process_result`` had already recorded - a clean double count.
+
+    Called by the scheduler in the PARENT immediately before every
+    submission, not by the worker, because the window that matters is
+    exactly the one where the worker never starts (cancelled or killed
+    during pool startup). Best effort: a snapshot we failed to delete is
+    an accounting risk, never a reason to fail a component.
+    """
+    try:
+        path.unlink()
+    except OSError:
+        return
 
 
 def _run_component(
@@ -1039,6 +1067,7 @@ def _run_component(
     sandbox_allow_network: bool = False,
     agent_budget_usd: float | None = None,
     events_dir_str: str | None = None,
+    usage_dir_str: str | None = None,
     run_id: str = "",
     token_budget: LoopBudget | None = None,
     redirect_output: bool = True,
@@ -1059,6 +1088,14 @@ def _run_component(
     the parent's UI so sequential runs keep live engineer output.
     Without ``events_dir_str`` the legacy PlainUI-on-stderr behavior is
     preserved for direct callers.
+
+    R8: ``usage_dir_str`` is where the per-iteration usage snapshot is
+    published so a killed worker's spend is recoverable. It is a
+    SEPARATE argument from ``events_dir_str`` on purpose - the factory
+    always sets it, including when progress logging is off, because
+    accounting must not be switchable off by an observability setting
+    (review finding P2-d). Direct callers that leave it None simply do
+    not publish snapshots.
 
     R8: ``token_budget`` carries the run-level ``max_total_tokens`` plus
     the spend recorded before this worker launched, so the engineer loop
@@ -1251,9 +1288,13 @@ def _run_component(
     # R8: durable per-iteration usage snapshot. The parent reads it only
     # when a worker was killed before it could return a ComponentResult
     # (PR B abort path), so it can never double count with result.usage.
+    # Keyed off usage_dir_str, NOT events_dir_str: the accounting file
+    # is written even when progress logging is disabled (P2-d).
     on_iteration_usage: Callable[[UsageTotals], None] | None = None
-    if run_paths is not None:
-        usage_path = run_paths.engineer_usage(component_id)
+    if usage_dir_str is not None:
+        usage_path = RunPaths(root=Path(usage_dir_str)).engineer_usage(
+            component_id,
+        )
         on_iteration_usage = functools.partial(
             _write_partial_usage, usage_path,
         )
@@ -1519,6 +1560,17 @@ def _salvage_aborted_usage(
       killed yields a complete (if slightly stale) snapshot. Spend
       inside the interrupted iteration is NOT recoverable - it was never
       reported to anyone before the kill.
+
+    The snapshot is attempt-scoped by the scheduler, which deletes it
+    immediately before every submission (``_clear_partial_usage``). That
+    is what makes this route safe: without it a completed attempt left
+    its file behind and a later attempt aborted before its own first
+    iteration boundary salvaged the PREVIOUS attempt's tokens on top of
+    the ones ``process_result`` had already recorded (review finding
+    P2-c, reproduced as a clean 2x double count).
+
+    Reads ``pipeline.usage_paths``, not ``run_paths``: accounting
+    storage exists even when progress logging is off (P2-d).
     """
     if future.done() and not future.cancelled():
         try:
@@ -1528,10 +1580,10 @@ def _salvage_aborted_usage(
         if result is not None and result.usage is not None:
             pipeline.record_engineer_usage(comp_id, result.usage)
         return
-    run_paths = pipeline.run_paths
-    if run_paths is None:
+    usage_paths = pipeline.usage_paths
+    if usage_paths is None:
         return
-    totals = _read_partial_usage(run_paths.engineer_usage(comp_id))
+    totals = _read_partial_usage(usage_paths.engineer_usage(comp_id))
     if totals is not None:
         pipeline.record_engineer_usage(comp_id, totals)
 
@@ -1848,6 +1900,17 @@ def _run_factory_locked(
     journal_path: Path | None = None
     run_paths: RunPaths | None = None
     run_file_sinks: list[EventSink] = []
+    # R8 (review finding P2-d): accounting storage is allocated for
+    # EVERY run, including progress_log_enabled = false. It used to be
+    # `run_paths`, which is gated on progress logging, so turning the
+    # observability opt-out on also deleted the only place a worker
+    # could publish its spend - a killed worker then recorded nothing
+    # and the run silently under-reported. Money is not observability:
+    # an opt-out may drop the narration, never the meter. This is the
+    # same directory as `run_paths` when progress logging is on; when it
+    # is off the run writes exactly one small JSON file per component
+    # attempt under .kstrl/runs/<run_id>/ and no events at all.
+    usage_paths = RunPaths.for_run(root_dir, run_id)
     if not factory_config.progress_log_enabled:
         progress_log = NullProgressLog()
     else:
@@ -2079,6 +2142,7 @@ def _run_factory_locked(
         bus=bus,
         journal_path=journal_path,
         run_paths=run_paths,
+        usage_paths=usage_paths,
         interaction=interaction,
         notify=notify,
         review_selection=review_selection,
@@ -2299,16 +2363,24 @@ def _run_factory_locked(
             # Chunk 6: worker event channel (None when progress logging
             # is disabled - transcripts and events off together).
             str(run_paths.root) if run_paths is not None else None,
+            # R8: accounting channel. Always set, precisely because the
+            # line above may be None (review finding P2-d).
+            str(usage_paths.root),
             run_id,
             # R8: run-level token ceiling + the spend recorded so far,
             # snapshotted AT LAUNCH so the engineer loop can halt itself
             # between iterations. With max_parallel > 1 a worker cannot
             # see a concurrent sibling's spend, only what the parent had
             # recorded when this worker started.
+            # prior_calls/prior_token_calls carry the run-wide tokenless
+            # call count down so the unenforceable rule does not reset on
+            # every attempt and component (review finding P1-a).
             LoopBudget(
                 max_total_tokens=factory_config.max_total_tokens,
                 prior_total_tokens=pipeline.run_usage.total_tokens,
                 prior_known_calls=pipeline.run_usage.known_calls,
+                prior_calls=pipeline.run_usage.calls,
+                prior_token_calls=pipeline.run_usage.token_calls,
             ),
         )
 
@@ -2384,6 +2456,12 @@ def _run_factory_locked(
                         attempt=comp.retries + 1,
                     ))
                     args = _submit_args(comp, wt_path)
+                    # R8 (P2-c): the usage snapshot is attempt-scoped by
+                    # deletion, and the deletion happens HERE - before
+                    # the worker exists - so an attempt cancelled during
+                    # pool startup cannot salvage its predecessor's
+                    # tokens on top of the ones already on the meter.
+                    _clear_partial_usage(usage_paths.engineer_usage(comp.id))
                     if isinstance(executor, _InlineExecutor):
                         # In-process worker: no fd redirection (it would
                         # hijack the parent terminal), and each transcript

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -1016,7 +1016,7 @@ def _read_partial_usage(path: Path) -> UsageTotals | None:
     return totals
 
 
-def _clear_partial_usage(path: Path) -> None:
+def _clear_partial_usage(path: Path) -> bool:
     """Retire the previous attempt's usage snapshot (R8 review, P2-c).
 
     The snapshot is keyed by run + component only, and a normal result
@@ -1028,13 +1028,27 @@ def _clear_partial_usage(path: Path) -> None:
     Called by the scheduler in the PARENT immediately before every
     submission, not by the worker, because the window that matters is
     exactly the one where the worker never starts (cancelled or killed
-    during pool startup). Best effort: a snapshot we failed to delete is
-    an accounting risk, never a reason to fail a component.
+    during pool startup).
+
+    Returns True when the slot is provably clean - deleted, or already
+    absent. Returns False when a snapshot may still be on disk, and the
+    caller must then refuse disk salvage for that attempt: deletion IS
+    the attempt-scoping invariant, so swallowing the error left the
+    previous attempt's totals addressable as the current one and
+    re-counted them (review finding on 22e99b4). A worker that cannot
+    delete the file generally cannot overwrite it either, so "we failed
+    to clear it" and "what is there is stale" travel together.
+
+    Never fails the component: an accounting risk is not a reason to
+    stop work, but it IS a reason to distrust the number.
     """
     try:
         path.unlink()
+    except FileNotFoundError:
+        return True          # nothing to retire; the slot is clean
     except OSError:
-        return
+        return False
+    return True
 
 
 def _run_component(
@@ -1582,6 +1596,8 @@ def _salvage_aborted_usage(
         return
     usage_paths = pipeline.usage_paths
     if usage_paths is None:
+        return
+    if not pipeline.usage_salvage_is_safe(comp_id):
         return
     totals = _read_partial_usage(usage_paths.engineer_usage(comp_id))
     if totals is not None:
@@ -2443,6 +2459,19 @@ def _run_factory_locked(
                         pipeline.fail_for_budget(comp, "scheduling")
                         transitioned_without_launch += 1
                         continue
+                    # R8 review: a loop that emits COMPLETE returns before
+                    # its own budget check, so an adapter that finishes on
+                    # its first tokenless call never halts itself - the
+                    # ordinary success path for a custom agent_cmd. This
+                    # gate is what stops the run handing out NEW work
+                    # under a cap that can no longer fire.
+                    unenforceable = pipeline.token_budget_unenforceable()
+                    if unenforceable is not None:
+                        pipeline.fail_for_budget(
+                            comp, "scheduling", reason=unenforceable,
+                        )
+                        transitioned_without_launch += 1
+                        continue
                     pipeline.begin_attempt(comp)
                     manifest.save(manifest_path)
                     bus.emit(ComponentStarted(component=comp.id))
@@ -2466,7 +2495,24 @@ def _run_factory_locked(
                     # the worker exists - so an attempt cancelled during
                     # pool startup cannot salvage its predecessor's
                     # tokens on top of the ones already on the meter.
-                    _clear_partial_usage(usage_paths.engineer_usage(comp.id))
+                    if _clear_partial_usage(
+                        usage_paths.engineer_usage(comp.id)
+                    ):
+                        pipeline.mark_usage_salvage_safe(comp.id)
+                    else:
+                        # A snapshot we could not delete may still hold
+                        # the PREVIOUS attempt's totals, which
+                        # process_result already counted. Refuse disk
+                        # salvage for this attempt rather than risk
+                        # counting them twice - losing an aborted
+                        # attempt's spend understates a total; salvaging
+                        # a stale one corrupts it.
+                        pipeline.mark_usage_salvage_unsafe(comp.id)
+                        ui.warn(
+                            f"  Could not retire the previous usage "
+                            f"snapshot for {comp.id}; disk salvage is "
+                            f"disabled for this attempt"
+                        )
                     if isinstance(executor, _InlineExecutor):
                         # In-process worker: no fd redirection (it would
                         # hijack the parent terminal), and each transcript

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -2324,6 +2324,7 @@ def _run_factory_locked(
 
     def _submit_args(comp: Component, wt_path: Path) -> tuple[Any, ...]:
         ctx_json = component_contexts.get(comp.id)
+        engineer_usage = pipeline.engineer_usage_totals()
         knowledge_prefix = ""
         if knowledge_config.enabled:
             try:
@@ -2372,15 +2373,19 @@ def _run_factory_locked(
             # between iterations. With max_parallel > 1 a worker cannot
             # see a concurrent sibling's spend, only what the parent had
             # recorded when this worker started.
-            # prior_calls/prior_token_calls carry the run-wide tokenless
+            # prior_calls/prior_token_calls carry the ENGINEER's tokenless
             # call count down so the unenforceable rule does not reset on
-            # every attempt and component (review finding P1-a).
+            # every attempt and component (review finding P1-a), while
+            # staying blind to other roles' timeouts - those say nothing
+            # about whether the engineer's adapter reports tokens.
+            # prior_total_tokens stays run-wide: the overrun check asks
+            # what the RUN has spent against the cap.
             LoopBudget(
                 max_total_tokens=factory_config.max_total_tokens,
                 prior_total_tokens=pipeline.run_usage.total_tokens,
                 prior_known_calls=pipeline.run_usage.known_calls,
-                prior_calls=pipeline.run_usage.calls,
-                prior_token_calls=pipeline.run_usage.token_calls,
+                prior_calls=engineer_usage.calls,
+                prior_token_calls=engineer_usage.token_calls,
             ),
         )
 

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -9,6 +9,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from collections.abc import Callable, Mapping
@@ -72,6 +73,7 @@ from kstrl.knowledge import (
     measure_fact_utilization,
 )
 from kstrl.linear import LinearConfig, build_linear_sink
+from kstrl.loop import LoopBudget
 from kstrl.manifest import Component, ComponentStatus, Manifest
 from kstrl.observability import (
     NotifyConfig,
@@ -504,6 +506,11 @@ class ComponentResult:
     # prompt against the same state is the exact spend the breaker
     # exists to stop) with a distinct journal event.
     no_progress: bool = False
+    # R8: the engineer loop halted ITSELF on the run-level token budget
+    # (between iterations). Routed to pipeline.fail_for_budget so the
+    # audit trail is identical to a breach caught at a phase boundary;
+    # ``error`` carries which budget condition fired.
+    budget_exceeded: bool = False
 
 
 @dataclass
@@ -933,6 +940,75 @@ def _preflight_component_branches(
     return errors
 
 
+def _write_partial_usage(path: Path, totals: UsageTotals) -> None:
+    """Publish the engineer loop's usage-so-far, atomically (R8).
+
+    The worker owns its UsageRecords in memory; the abort path
+    (``_abort_inflight``) SIGKILLs the process, so without this file the
+    spend of a killed worker is simply lost. mkstemp + os.replace is the
+    repo's atomic-write convention (manifest.py:381) and is what makes
+    the file safe to read from a process that may be killing the writer:
+    a reader sees the previous complete snapshot or the new one, never a
+    torn one.
+
+    Accounting only - every failure is swallowed. A worker must not die
+    because its usage file could not be written.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(path.parent), suffix=".tmp", prefix=".usage-",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(totals.to_dict(), fh)
+            os.replace(tmp_path, str(path))
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except (OSError, TypeError, ValueError):
+        return
+
+
+def _read_partial_usage(path: Path) -> UsageTotals | None:
+    """Rehydrate a killed worker's last usage snapshot (R8).
+
+    Returns None when the file is absent, unreadable, or not a usage
+    dict - the abort path then records nothing rather than guessing.
+    ``unreported_calls`` is a derived property and is deliberately not
+    read back.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    totals = UsageTotals()
+    int_fields = (
+        "calls", "known_calls", "input_tokens", "output_tokens",
+        "cache_read_tokens", "cache_creation_tokens", "total_tokens",
+    )
+    for name in int_fields:
+        value = data.get(name)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            setattr(totals, name, value)
+    for name in ("cost_usd", "duration_seconds"):
+        value = data.get(name)
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and value >= 0
+        ):
+            setattr(totals, name, float(value))
+    if totals.calls == 0:
+        return None
+    return totals
+
+
 def _run_component(
     component_id: str,
     prd_path_str: str,
@@ -964,6 +1040,7 @@ def _run_component(
     agent_budget_usd: float | None = None,
     events_dir_str: str | None = None,
     run_id: str = "",
+    token_budget: LoopBudget | None = None,
     redirect_output: bool = True,
     live_line: Callable[[str], None] | None = None,
     stop_check: Callable[[], bool] | None = None,
@@ -982,6 +1059,11 @@ def _run_component(
     the parent's UI so sequential runs keep live engineer output.
     Without ``events_dir_str`` the legacy PlainUI-on-stderr behavior is
     preserved for direct callers.
+
+    R8: ``token_budget`` carries the run-level ``max_total_tokens`` plus
+    the spend recorded before this worker launched, so the engineer loop
+    can halt itself BETWEEN iterations instead of waiting for the
+    parent's next phase boundary. None disables the in-loop check.
     """
     from kstrl.agents import get_agent
     from kstrl.loop import run_loop
@@ -1166,6 +1248,16 @@ def _run_component(
         )
         stop_heartbeat = _start_heartbeat(worker_bus)
 
+    # R8: durable per-iteration usage snapshot. The parent reads it only
+    # when a worker was killed before it could return a ComponentResult
+    # (PR B abort path), so it can never double count with result.usage.
+    on_iteration_usage: Callable[[UsageTotals], None] | None = None
+    if run_paths is not None:
+        usage_path = run_paths.engineer_usage(component_id)
+        on_iteration_usage = functools.partial(
+            _write_partial_usage, usage_path,
+        )
+
     try:
         result = run_loop(
             config, ui, agent, worktree_path,
@@ -1173,11 +1265,19 @@ def _run_component(
             breaker_config=breaker_config,
             bus=worker_bus,
             stop_check=stop_check,
+            budget=token_budget,
+            on_iteration_usage=on_iteration_usage,
         )
         # Report which limit fired so the retry/fail path can act on it
         # (timeout errors trigger the recreate-from-base retry hygiene).
         if result.completed:
             error = None
+        elif result.budget_halt_reason:
+            # First in the chain: the budget halt is the reason the loop
+            # stopped short, and its message carries the numbers the
+            # pipeline needs when its own totals do not yet show a
+            # breach (unreported-usage case).
+            error = result.budget_halt_reason
         elif result.no_progress:
             error = (
                 "no-progress circuit breaker tripped: "
@@ -1205,6 +1305,7 @@ def _run_component(
             context_json=previous_context_json,
             usage=result.usage,
             no_progress=result.no_progress,
+            budget_exceeded=bool(result.budget_halt_reason),
         )
     except Exception as exc:
         return ComponentResult(
@@ -1385,10 +1486,54 @@ def _abort_inflight(
         if killed:
             ui.warn(f"  Terminated {killed} in-flight agent process group(s)")
     for future, comp_id in list(running_futures.items()):
+        _salvage_aborted_usage(future, comp_id, pipeline)
         pipeline.fail_aborted(comp_id, stop.reason)
         running_futures.pop(future, None)
     ui.warn(f"  Aborted in-flight work: {stop.reason}")
     executor.shutdown(wait=False, cancel_futures=True)
+
+
+def _salvage_aborted_usage(
+    future: Future[ComponentResult],
+    comp_id: str,
+    pipeline: ComponentPipeline,
+) -> None:
+    """Record what an aborted worker spent before it was stopped (R8).
+
+    Organic failures carry usage back on the ComponentResult
+    (``pipeline.process_result`` records it before the success branch -
+    "failed attempts cost real tokens too"). The abort path used to lose
+    it: the worker is killed and its future is cancelled without anyone
+    reading a result, so the tokens vanished from the meter and the run
+    under-reported its own spend.
+
+    Two recovery routes, deliberately exclusive so nothing is counted
+    twice:
+    - The future already carries a result (inline executor, or a pool
+      worker that finished as the stop landed): that result is
+      authoritative. ``result()`` cannot block here - the future is
+      done.
+    - Otherwise the worker was killed mid-loop: fall back to the
+      iteration-boundary snapshot it wrote to disk. That file is
+      rewritten atomically, so reading it while the writer is being
+      killed yields a complete (if slightly stale) snapshot. Spend
+      inside the interrupted iteration is NOT recoverable - it was never
+      reported to anyone before the kill.
+    """
+    if future.done() and not future.cancelled():
+        try:
+            result = future.result(timeout=0)
+        except Exception:  # noqa: BLE001 - a crashed worker reported nothing
+            return
+        if result is not None and result.usage is not None:
+            pipeline.record_engineer_usage(comp_id, result.usage)
+        return
+    run_paths = pipeline.run_paths
+    if run_paths is None:
+        return
+    totals = _read_partial_usage(run_paths.engineer_usage(comp_id))
+    if totals is not None:
+        pipeline.record_engineer_usage(comp_id, totals)
 
 
 def _next_backstop_wait(
@@ -2155,6 +2300,16 @@ def _run_factory_locked(
             # is disabled - transcripts and events off together).
             str(run_paths.root) if run_paths is not None else None,
             run_id,
+            # R8: run-level token ceiling + the spend recorded so far,
+            # snapshotted AT LAUNCH so the engineer loop can halt itself
+            # between iterations. With max_parallel > 1 a worker cannot
+            # see a concurrent sibling's spend, only what the parent had
+            # recorded when this worker started.
+            LoopBudget(
+                max_total_tokens=factory_config.max_total_tokens,
+                prior_total_tokens=pipeline.run_usage.total_tokens,
+                prior_known_calls=pipeline.run_usage.known_calls,
+            ),
         )
 
     def _run_scheduling_pass() -> None:
@@ -2238,7 +2393,7 @@ def _run_factory_locked(
                         # TIME, so tests patching it still intercept.
                         # mypy cannot prove the unknown-length *args
                         # tuple stops before the kwargs; _submit_args
-                        # ends at run_id by construction.
+                        # ends at token_budget by construction.
                         task = functools.partial(
                             _run_component, *args,
                             redirect_output=False,  # type: ignore[misc]

--- a/kstrl/loop.py
+++ b/kstrl/loop.py
@@ -32,14 +32,21 @@ logger = logging.getLogger(__name__)
 
 COMPLETION_MARKER = "<promise>COMPLETE</promise>"
 
-# How many agent calls must report NOTHING before an enabled token cap
-# is declared unenforceable (see LoopBudget.halt_reason). A judgment
-# call, not a measurement: one silent call is an incident (the claude
-# adapter records source="timeout" / "parse-error" with no counts), two
-# in a row with nothing reported anywhere in the run is a property of
-# the adapter. The cost of the extra call is one iteration of overshoot
-# on an adapter that reports nothing; the cost of setting it to 1 is
+# How many TOKENLESS agent calls the RUN must accumulate before an
+# enabled token cap is declared unenforceable (see
+# LoopBudget.halt_reason). A judgment call, not a measurement: one
+# tokenless call is an incident (the claude adapter records
+# source="timeout" / "parse-error" with no counts, and a cost-only
+# result event is tokenless too), two in one run is a property of the
+# adapter. The cost of the extra call is one iteration of overshoot on
+# an adapter that reports no tokens; the cost of setting it to 1 is
 # killing a capped run over a single timed-out first iteration.
+#
+# Counted RUN-WIDE (prior_calls/prior_token_calls carry the parent's
+# figures down), because a per-loop counter resets on every attempt and
+# every component: with max_iterations = 1, or a retry that dies after
+# one call, no single loop ever reached the threshold and the rule was
+# decorative. Review finding P1-a reproduced exactly that.
 _UNENFORCEABLE_CALLS = 2
 
 
@@ -80,11 +87,18 @@ class LoopBudget:
     # whole object pickles cleanly to a pool worker.
     max_total_tokens: int = 0
     prior_total_tokens: int = 0
-    #: Reporting calls the run had made before this worker launched.
-    #: Recorded for provenance (it says whether the run's prior total is
-    #: a real figure or an artefact of a silent adapter) and NOT used to
-    #: decide the unenforceable halt - see :meth:`halt_reason`.
+    #: Reporting calls (token OR cost) the run had made before this
+    #: worker launched. Provenance only - it says whether the run's
+    #: prior total is a real figure or an artefact of a silent adapter -
+    #: and NOT part of any decision; see :meth:`halt_reason`.
     prior_known_calls: int = 0
+    #: Agent calls the run had made before this worker launched, and how
+    #: many of them reported a TOKEN figure. Their difference is the
+    #: run's tokenless-call count, which is what the unenforceable rule
+    #: counts (R8 review P1-a: a per-loop counter resets on every
+    #: attempt/component, so short loops never reached the threshold).
+    prior_calls: int = 0
+    prior_token_calls: int = 0
 
     @property
     def enabled(self) -> bool:
@@ -97,30 +111,71 @@ class LoopBudget:
 
         1. OVERRUN - the run total (spend before this worker launched
            plus what this loop has reported) has reached the cap.
-        2. UNENFORCEABLE - THIS loop has made ``_UNENFORCEABLE_CALLS``
-           agent calls and reported no tokens at all. The cap then
-           provably cannot trip, because the only term that can still
-           grow is this loop's own spend: ``prior_total_tokens`` is
-           frozen at launch, so a silent engineer leaves the total
-           fixed below the ceiling forever. Continuing means spending
-           under a cap that can never fire - the exact defect this check
-           exists to remove. Halting loudly beats a decorative cap.
+        2. UNENFORCEABLE - the cap provably cannot trip. Two facts have
+           to hold together, and they are deliberately measured over
+           different scopes:
 
-           Deliberately judged on this loop ALONE, not on the run.
-           Summing in ``prior_known_calls`` looked stricter but was
-           weaker: a reporting architect (or a previous component) made
-           ``known_calls`` nonzero, which suppressed the halt for a
-           silent engineer and handed back the decorative cap in exactly
-           the configuration where it is easiest to hit - ``[agent]
-           command`` sets a custom engineer command while the
-           adversarial roles keep a reporting adapter.
+           (a) TOKEN EVIDENCE, judged on THIS loop: not one of this
+               loop's calls reported a token figure
+               (``loop_usage.token_calls == 0``). That is what makes the
+               cap dead rather than merely slow, because
+               ``prior_total_tokens`` is frozen at this worker's launch:
+               if this loop never reports tokens, the run total stays
+               fixed below the ceiling forever no matter how long the
+               engineer runs.
 
-        An iteration that reports nothing WHILE other calls do report
-        counts as zero tokens: the running total stays a lower bound
-        (see ``UsageTotals.unreported_calls``) that still grows toward
-        the cap, so the halt arrives late rather than never. Charging
-        unknown iterations a guessed amount would invent numbers the CLI
-        never gave us.
+               Judged on the loop ALONE, never on the run. Summing the
+               run's reported calls in looked stricter but was weaker: a
+               reporting architect (or a previous component) suppressed
+               the halt for a silent engineer and handed back the
+               decorative cap in exactly the configuration where it is
+               easiest to hit - ``[agent] command`` sets a custom
+               engineer command while the adversarial roles keep a
+               reporting adapter.
+
+               Reads ``token_calls``, not ``known_calls``: a record
+               carrying only ``cost_usd`` sets ``known_calls`` while
+               contributing nothing to ``total_tokens``, so
+               ``known_calls`` reported perfect coverage for a cap that
+               could never advance (review finding P1-b).
+
+           (b) CALL THRESHOLD, counted RUN-WIDE: the run has now seen
+               ``_UNENFORCEABLE_CALLS`` tokenless calls in total
+               (``prior_calls - prior_token_calls`` plus this loop's
+               own). This is the "have we seen enough to conclude?"
+               half, and it must not reset per attempt or per component
+               - with ``max_iterations = 1``, or a retry that dies after
+               one call, a per-loop counter never reached 2 and the rule
+               was decorative (review finding P1-a).
+
+               Tokenless calls, not all calls: a call that DID report
+               tokens is evidence the adapter works, so counting it
+               toward "this adapter never reports" would be backwards
+               and would make a single unparseable result fatal in an
+               otherwise healthy run.
+
+        CONSEQUENCE, stated plainly: in a run where every prior call
+        reported tokens, a lone unparseable engineer call still does not
+        halt - the run-wide tokenless count is 1. But once a run has
+        accumulated one tokenless call ANYWHERE (including in a
+        different role's adapter), the engineer's first tokenless
+        iteration does trip the halt. That is the deliberate trade: two
+        independent tokenless calls in one run is adapter behavior, not
+        an incident, and the failure is loud, recorded, and recoverable
+        (raise or clear ``max_total_tokens``), whereas the alternative
+        is unbounded spend under a ceiling that cannot fire.
+
+        A loop that has made no calls at all can never halt here: with
+        ``loop_usage.calls == 0`` there is no token evidence either way,
+        so a worker launched into a run with a high ``prior_calls`` must
+        still get to run its engineer.
+
+        An iteration that reports nothing WHILE other calls in the same
+        loop do report counts as zero tokens: the running total stays a
+        lower bound (see ``UsageTotals.unreported_calls``) that still
+        grows toward the cap, so the halt arrives late rather than
+        never. Charging unknown iterations a guessed amount would invent
+        numbers the CLI never gave us.
         """
         if not self.enabled:
             return None
@@ -131,13 +186,20 @@ class LoopBudget:
                 f"max_total_tokens ({self.max_total_tokens}); halting the "
                 "engineer loop instead of starting another iteration (R8)"
             )
-        if loop_usage.calls >= _UNENFORCEABLE_CALLS and loop_usage.known_calls == 0:
+        prior_tokenless = max(0, self.prior_calls - self.prior_token_calls)
+        run_tokenless = prior_tokenless + loop_usage.tokenless_calls
+        if (
+            loop_usage.calls > 0
+            and loop_usage.token_calls == 0
+            and run_tokenless >= _UNENFORCEABLE_CALLS
+        ):
             return (
                 f"token budget unenforceable: none of this loop's "
-                f"{loop_usage.calls} agent call(s) reported any token usage, "
-                f"so max_total_tokens ({self.max_total_tokens}) can never "
-                "trip on this adapter; halting rather than spending under a "
-                "cap that cannot fire (R8)"
+                f"{loop_usage.calls} agent call(s) reported a token count "
+                f"and {run_tokenless} call(s) in this run have now reported "
+                f"none, so max_total_tokens ({self.max_total_tokens}) can "
+                "never trip on this adapter; halting rather than spending "
+                "under a cap that cannot fire (R8)"
             )
         return None
 

--- a/kstrl/loop.py
+++ b/kstrl/loop.py
@@ -80,6 +80,10 @@ class LoopBudget:
     # whole object pickles cleanly to a pool worker.
     max_total_tokens: int = 0
     prior_total_tokens: int = 0
+    #: Reporting calls the run had made before this worker launched.
+    #: Recorded for provenance (it says whether the run's prior total is
+    #: a real figure or an artefact of a silent adapter) and NOT used to
+    #: decide the unenforceable halt - see :meth:`halt_reason`.
     prior_known_calls: int = 0
 
     @property
@@ -93,13 +97,23 @@ class LoopBudget:
 
         1. OVERRUN - the run total (spend before this worker launched
            plus what this loop has reported) has reached the cap.
-        2. UNENFORCEABLE - the loop has made ``_UNENFORCEABLE_CALLS``
-           agent calls and NOTHING in the run has reported a single
-           token: not the phases before it, not this loop. The cap then
-           provably cannot trip on this adapter (a CustomAgent command
-           never reports usage), so continuing means spending under a
-           ceiling that can never fire - the exact defect this check
+        2. UNENFORCEABLE - THIS loop has made ``_UNENFORCEABLE_CALLS``
+           agent calls and reported no tokens at all. The cap then
+           provably cannot trip, because the only term that can still
+           grow is this loop's own spend: ``prior_total_tokens`` is
+           frozen at launch, so a silent engineer leaves the total
+           fixed below the ceiling forever. Continuing means spending
+           under a cap that can never fire - the exact defect this check
            exists to remove. Halting loudly beats a decorative cap.
+
+           Deliberately judged on this loop ALONE, not on the run.
+           Summing in ``prior_known_calls`` looked stricter but was
+           weaker: a reporting architect (or a previous component) made
+           ``known_calls`` nonzero, which suppressed the halt for a
+           silent engineer and handed back the decorative cap in exactly
+           the configuration where it is easiest to hit - ``[agent]
+           command`` sets a custom engineer command while the
+           adversarial roles keep a reporting adapter.
 
         An iteration that reports nothing WHILE other calls do report
         counts as zero tokens: the running total stays a lower bound
@@ -117,14 +131,13 @@ class LoopBudget:
                 f"max_total_tokens ({self.max_total_tokens}); halting the "
                 "engineer loop instead of starting another iteration (R8)"
             )
-        known_calls = self.prior_known_calls + loop_usage.known_calls
-        if loop_usage.calls >= _UNENFORCEABLE_CALLS and known_calls == 0:
+        if loop_usage.calls >= _UNENFORCEABLE_CALLS and loop_usage.known_calls == 0:
             return (
-                "token budget unenforceable: none of the "
-                f"{loop_usage.calls} agent call(s) in this run reported any "
-                f"token usage, so max_total_tokens ({self.max_total_tokens}) "
-                "can never trip on this adapter; halting rather than "
-                "spending under a cap that cannot fire (R8)"
+                f"token budget unenforceable: none of this loop's "
+                f"{loop_usage.calls} agent call(s) reported any token usage, "
+                f"so max_total_tokens ({self.max_total_tokens}) can never "
+                "trip on this adapter; halting rather than spending under a "
+                "cap that cannot fire (R8)"
             )
         return None
 

--- a/kstrl/loop.py
+++ b/kstrl/loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -27,7 +28,105 @@ if TYPE_CHECKING:
     from kstrl.config import KstrlConfig
     from kstrl.ui.base import UI
 
+logger = logging.getLogger(__name__)
+
 COMPLETION_MARKER = "<promise>COMPLETE</promise>"
+
+# How many agent calls must report NOTHING before an enabled token cap
+# is declared unenforceable (see LoopBudget.halt_reason). A judgment
+# call, not a measurement: one silent call is an incident (the claude
+# adapter records source="timeout" / "parse-error" with no counts), two
+# in a row with nothing reported anywhere in the run is a property of
+# the adapter. The cost of the extra call is one iteration of overshoot
+# on an adapter that reports nothing; the cost of setting it to 1 is
+# killing a capped run over a single timed-out first iteration.
+_UNENFORCEABLE_CALLS = 2
+
+
+@dataclass(frozen=True)
+class LoopBudget:
+    """Run-level token ceiling pushed DOWN into the engineer loop (R8).
+
+    ``[factory] max_total_tokens`` was, until R8, consulted only at
+    parent-process phase boundaries (pipeline.process_result, the review
+    / security / distill gates, the scheduling gate). Those checks can
+    stop the NEXT phase; they can never stop the iteration already
+    running, so a single component could spend for ``max_iterations x
+    agent_iteration`` seconds before the cap was consulted once.
+
+    This object is the loop-side half. It is evaluated BETWEEN
+    iterations, which is the tightest bound available without a
+    streaming token feed from the adapter.
+
+    WHAT IT GUARANTEES: the engineer loop starts no NEW iteration once
+    the run's reported spend has reached the cap. Overshoot is bounded
+    by the work already in flight - roughly one iteration per running
+    worker - not by zero.
+
+    WHAT STAYS UNBOUNDED:
+    - A single runaway iteration. Nothing here interrupts an agent call
+      mid-flight; only ``[timeout] agent_iteration`` bounds that, and it
+      bounds wall clock, not tokens.
+    - Concurrent siblings. ``prior_total_tokens`` is the run total as of
+      THIS worker's launch; spend by workers running in parallel is
+      invisible until they report back to the parent. With
+      ``max_parallel = N`` the overshoot scales with N.
+    - Unreported spend. Every figure here is a CLI self-report; see
+      :meth:`halt_reason` for how unknown usage is treated.
+    """
+
+    # Copies of the parent's FactoryConfig.max_total_tokens and the run
+    # usage accumulated before this worker launched. Plain ints so the
+    # whole object pickles cleanly to a pool worker.
+    max_total_tokens: int = 0
+    prior_total_tokens: int = 0
+    prior_known_calls: int = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.max_total_tokens > 0
+
+    def halt_reason(self, loop_usage: UsageTotals) -> str | None:
+        """Why this loop must stop now, or None to keep iterating.
+
+        Two conditions, both computed from CLI self-reported usage:
+
+        1. OVERRUN - the run total (spend before this worker launched
+           plus what this loop has reported) has reached the cap.
+        2. UNENFORCEABLE - the loop has made ``_UNENFORCEABLE_CALLS``
+           agent calls and NOTHING in the run has reported a single
+           token: not the phases before it, not this loop. The cap then
+           provably cannot trip on this adapter (a CustomAgent command
+           never reports usage), so continuing means spending under a
+           ceiling that can never fire - the exact defect this check
+           exists to remove. Halting loudly beats a decorative cap.
+
+        An iteration that reports nothing WHILE other calls do report
+        counts as zero tokens: the running total stays a lower bound
+        (see ``UsageTotals.unreported_calls``) that still grows toward
+        the cap, so the halt arrives late rather than never. Charging
+        unknown iterations a guessed amount would invent numbers the CLI
+        never gave us.
+        """
+        if not self.enabled:
+            return None
+        total = self.prior_total_tokens + loop_usage.total_tokens
+        if total >= self.max_total_tokens:
+            return (
+                f"token budget exceeded: {total} total tokens recorded >= "
+                f"max_total_tokens ({self.max_total_tokens}); halting the "
+                "engineer loop instead of starting another iteration (R8)"
+            )
+        known_calls = self.prior_known_calls + loop_usage.known_calls
+        if loop_usage.calls >= _UNENFORCEABLE_CALLS and known_calls == 0:
+            return (
+                "token budget unenforceable: none of the "
+                f"{loop_usage.calls} agent call(s) in this run reported any "
+                f"token usage, so max_total_tokens ({self.max_total_tokens}) "
+                "can never trip on this adapter; halting rather than "
+                "spending under a cap that cannot fire (R8)"
+            )
+        return None
 
 
 @dataclass
@@ -55,6 +154,11 @@ class LoopResult:
     # signature). Typed so the factory can route it distinctly instead
     # of string-matching the error.
     no_progress: bool = False
+    # R8: non-empty when the run-level token budget halted the loop
+    # between iterations. The string is the human-readable reason (see
+    # LoopBudget.halt_reason) and becomes the component's error, so the
+    # audit trail records WHICH budget condition fired.
+    budget_halt_reason: str = ""
 
 
 def run_loop(
@@ -70,6 +174,8 @@ def run_loop(
     interaction: InteractionChannel | None = None,
     stop_check: Callable[[], bool] | None = None,
     guard_ignored_paths: list[str] | None = None,
+    budget: LoopBudget | None = None,
+    on_iteration_usage: Callable[[UsageTotals], None] | None = None,
 ) -> LoopResult:
     """Run the main agentic loop.
 
@@ -84,6 +190,14 @@ def run_loop(
             across iterations). Defaults to TimeoutConfig.from_env().
         breaker_config: No-progress circuit breaker limits (R7.5).
             Defaults to BreakerConfig.from_env().
+        budget: Run-level token ceiling (R8), checked between
+            iterations. None (the default, and every non-factory
+            caller) means no in-loop token limit.
+        on_iteration_usage: Called with this loop's usage-so-far at
+            every iteration boundary. The factory uses it to persist a
+            durable copy, so a worker killed by a shutdown does not
+            take its spend to the grave. Accounting only: an exception
+            here is logged, never raised into the loop.
 
     Returns:
         LoopResult with completion status and exit code
@@ -279,6 +393,17 @@ def run_loop(
                     timed_out=iteration_timed_out,
                 ))
 
+        # One usage snapshot per iteration, taken before any early
+        # return below so a timed-out or guard-failing iteration is
+        # accounted for too. Published first (durability), then used for
+        # the budget decision.
+        loop_usage = collect_usage(agent)
+        if on_iteration_usage is not None:
+            try:
+                on_iteration_usage(loop_usage)
+            except Exception as exc:  # noqa: BLE001 - accounting never gates
+                logger.warning("Failed to publish iteration usage: %s", exc)
+
         if iteration_timed_out:
             timed_out_iterations += 1
             ui.warn(
@@ -323,6 +448,28 @@ def run_loop(
                 timed_out_iterations=timed_out_iterations,
                 usage=collect_usage(agent),
             )
+
+        # R8 run-level token budget: the ONLY in-loop enforcement point
+        # for [factory] max_total_tokens. Checked here - after the
+        # completion return, before the breaker's stall probe - so a
+        # blown budget never pays for another agent call or another
+        # breaker test command. This bounds overshoot to the work
+        # already in flight (about one iteration per running worker); it
+        # cannot interrupt a call mid-flight. See LoopBudget.
+        if budget is not None:
+            halt_reason = budget.halt_reason(loop_usage)
+            if halt_reason is not None:
+                ui.err(halt_reason)
+                return LoopResult(
+                    completed=False,
+                    iterations=iteration,
+                    exit_code=1,
+                    duration_seconds=time.monotonic() - loop_start,
+                    iteration_durations=iteration_durations,
+                    timed_out_iterations=timed_out_iterations,
+                    usage=loop_usage,
+                    budget_halt_reason=halt_reason,
+                )
 
         # R7.5 no-progress circuit breaker: the iteration finished
         # without completing AND without changing the tree or the test

--- a/kstrl/loop.py
+++ b/kstrl/loop.py
@@ -55,7 +55,8 @@ COMPLETION_MARKER = "<promise>COMPLETE</promise>"
 # while the halt message asserted the cap could "never trip". The
 # question this threshold asks is whether the ENGINEER's adapter reports
 # tokens, so only engineer calls are evidence about it.
-_UNENFORCEABLE_CALLS = 2
+UNENFORCEABLE_CALLS = 2
+_UNENFORCEABLE_CALLS = UNENFORCEABLE_CALLS  # back-compat alias
 
 
 @dataclass(frozen=True)
@@ -88,6 +89,13 @@ class LoopBudget:
       ``max_parallel = N`` the overshoot scales with N.
     - Unreported spend. Every figure here is a CLI self-report; see
       :meth:`halt_reason` for how unknown usage is treated.
+    - Loops that COMPLETE. The completion return fires before this check
+      is evaluated, so an adapter that finishes on its first tokenless
+      call never halts itself - the ordinary success path for a custom
+      ``agent_cmd``. That bypass is closed in the PARENT by
+      ``ComponentPipeline.token_budget_unenforceable`` at the scheduling
+      gate, which stops the run handing out new work; this object cannot
+      see it, and pretending otherwise is how it went unnoticed.
     """
 
     # Copies of the parent's FactoryConfig.max_total_tokens and the run

--- a/kstrl/loop.py
+++ b/kstrl/loop.py
@@ -42,11 +42,19 @@ COMPLETION_MARKER = "<promise>COMPLETE</promise>"
 # an adapter that reports no tokens; the cost of setting it to 1 is
 # killing a capped run over a single timed-out first iteration.
 #
-# Counted RUN-WIDE (prior_calls/prior_token_calls carry the parent's
-# figures down), because a per-loop counter resets on every attempt and
-# every component: with max_iterations = 1, or a retry that dies after
-# one call, no single loop ever reached the threshold and the rule was
-# decorative. Review finding P1-a reproduced exactly that.
+# Counted across the RUN'S ENGINEER LOOPS (prior_calls/prior_token_calls
+# carry the parent's engineer-only figures down), because a per-loop
+# counter resets on every attempt and every component: with
+# max_iterations = 1, or a retry that dies after one call, no single loop
+# ever reached the threshold and the rule was decorative (review finding
+# P1-a).
+#
+# Engineer-scoped, NOT run-wide across roles: a timed-out architect or
+# reviewer call is tokenless too, and counting those let two unrelated
+# timeouts condemn an engineer adapter that had been reporting fine -
+# while the halt message asserted the cap could "never trip". The
+# question this threshold asks is whether the ENGINEER's adapter reports
+# tokens, so only engineer calls are evidence about it.
 _UNENFORCEABLE_CALLS = 2
 
 
@@ -92,11 +100,13 @@ class LoopBudget:
     #: prior total is a real figure or an artefact of a silent adapter -
     #: and NOT part of any decision; see :meth:`halt_reason`.
     prior_known_calls: int = 0
-    #: Agent calls the run had made before this worker launched, and how
-    #: many of them reported a TOKEN figure. Their difference is the
-    #: run's tokenless-call count, which is what the unenforceable rule
-    #: counts (R8 review P1-a: a per-loop counter resets on every
+    #: ENGINEER-loop calls the run had made before this worker launched,
+    #: and how many reported a TOKEN figure. Their difference is the
+    #: engineer's tokenless-call count, which is what the unenforceable
+    #: rule counts (R8 review P1-a: a per-loop counter resets on every
     #: attempt/component, so short loops never reached the threshold).
+    #: Engineer-scoped on purpose - another role's timeout is not
+    #: evidence about the engineer's adapter.
     prior_calls: int = 0
     prior_token_calls: int = 0
 
@@ -139,11 +149,12 @@ class LoopBudget:
                ``known_calls`` reported perfect coverage for a cap that
                could never advance (review finding P1-b).
 
-           (b) CALL THRESHOLD, counted RUN-WIDE: the run has now seen
-               ``_UNENFORCEABLE_CALLS`` tokenless calls in total
-               (``prior_calls - prior_token_calls`` plus this loop's
-               own). This is the "have we seen enough to conclude?"
-               half, and it must not reset per attempt or per component
+           (b) CALL THRESHOLD, counted across the run's ENGINEER loops:
+               the engineer has now made ``_UNENFORCEABLE_CALLS``
+               tokenless calls in total (``prior_calls -
+               prior_token_calls`` plus this loop's own). This is the
+               "have we seen enough to conclude?" half, and it must not
+               reset per attempt or per component
                - with ``max_iterations = 1``, or a retry that dies after
                one call, a per-loop counter never reached 2 and the rule
                was decorative (review finding P1-a).
@@ -154,12 +165,11 @@ class LoopBudget:
                and would make a single unparseable result fatal in an
                otherwise healthy run.
 
-        CONSEQUENCE, stated plainly: in a run where every prior call
-        reported tokens, a lone unparseable engineer call still does not
-        halt - the run-wide tokenless count is 1. But once a run has
-        accumulated one tokenless call ANYWHERE (including in a
-        different role's adapter), the engineer's first tokenless
-        iteration does trip the halt. That is the deliberate trade: two
+        CONSEQUENCE, stated plainly: in a run whose engineer calls have
+        all reported tokens, a lone unparseable engineer call does not
+        halt - the tokenless count is 1. A second tokenless ENGINEER
+        call does. Other roles' timeouts never contribute. That is the
+        deliberate trade: two
         independent tokenless calls in one run is adapter behavior, not
         an incident, and the failure is loud, recorded, and recoverable
         (raise or clear ``max_total_tokens``), whereas the alternative
@@ -195,11 +205,13 @@ class LoopBudget:
         ):
             return (
                 f"token budget unenforceable: none of this loop's "
-                f"{loop_usage.calls} agent call(s) reported a token count "
-                f"and {run_tokenless} call(s) in this run have now reported "
-                f"none, so max_total_tokens ({self.max_total_tokens}) can "
-                "never trip on this adapter; halting rather than spending "
-                "under a cap that cannot fire (R8)"
+                f"{loop_usage.calls} agent call(s) reported a token count, "
+                f"and the engineer has now made {run_tokenless} tokenless "
+                f"call(s) this run. Spend before this worker launched is "
+                f"frozen at {self.prior_total_tokens}, so max_total_tokens "
+                f"({self.max_total_tokens}) cannot advance from this loop; "
+                "halting rather than spending under a cap that cannot fire "
+                "(R8)"
             )
         return None
 

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -57,6 +57,7 @@ from kstrl.interaction import (
     PromptRequest,
     UiInteractionChannel,
 )
+from kstrl.loop import UNENFORCEABLE_CALLS
 from kstrl.manifest import Component, ComponentStatus, Manifest
 from kstrl.observability import NotifyHooks
 from kstrl.policy import PolicyConfig
@@ -321,6 +322,10 @@ class ComponentPipeline:
         # accumulate: every attempt cost real tokens, so the meter never
         # forgets a failed attempt.
         self.usage_meter: dict[str, dict[str, UsageTotals]] = {}
+        # Components whose usage snapshot could not be retired
+        # before this attempt launched; disk salvage is refused
+        # for them (R8 review P2 on 22e99b4).
+        self._usage_salvage_unsafe: set[str] = set()
         self.run_usage = UsageTotals()
 
         # E4: adversarial-call counter shared across review / security /
@@ -384,6 +389,20 @@ class ComponentPipeline:
         never double count with the normal path."""
         self._record_usage(comp_id, "engineer", totals)
 
+    def mark_usage_salvage_safe(self, comp_id: str) -> None:
+        """The attempt's usage snapshot slot is provably clean."""
+        self._usage_salvage_unsafe.discard(comp_id)
+
+    def mark_usage_salvage_unsafe(self, comp_id: str) -> None:
+        """A stale snapshot may survive for this attempt, so disk
+        salvage must not run for it (R8 review: deletion IS the
+        attempt-scoping invariant; when it fails, what is on disk may
+        already have been counted by ``process_result``)."""
+        self._usage_salvage_unsafe.add(comp_id)
+
+    def usage_salvage_is_safe(self, comp_id: str) -> bool:
+        return comp_id not in self._usage_salvage_unsafe
+
     def engineer_usage_totals(self) -> UsageTotals:
         """Engineer-loop spend across every component and attempt.
 
@@ -419,6 +438,43 @@ class ComponentPipeline:
     def token_budget_exceeded(self) -> bool:
         cap = self.factory_config.max_total_tokens
         return cap > 0 and self.run_usage.total_tokens >= cap
+
+    def token_budget_unenforceable(self) -> str | None:
+        """Why the cap can no longer fire at all, or None.
+
+        The parent-side twin of :meth:`LoopBudget.halt_reason`'s
+        unenforceable branch, and it exists because the in-loop check has
+        a blind spot the loop cannot cover itself: a loop that emits
+        COMPLETE returns BEFORE evaluating its budget, so an adapter that
+        finishes on its first tokenless call never reaches the halt.
+        That is the ordinary success path for a custom ``agent_cmd``, not
+        an artificial case - each component completes, the engineer's
+        tokenless count climbs, and the cap never fires (review finding
+        on 22e99b4; the previous docstring's "the halt lands on the next
+        loop" was simply false when the next loop also completes).
+
+        Checked at the scheduling gate, so the run stops handing out NEW
+        work under a dead cap. Deliberately does not retroactively fail
+        components that already completed: their work is valid, and the
+        cap's job is to stop spending, not to destroy what was bought.
+        Bound: at most the component in flight when the determination
+        lands.
+        """
+        cap = self.factory_config.max_total_tokens
+        if cap <= 0:
+            return None
+        engineer = self.engineer_usage_totals()
+        if engineer.token_calls > 0:
+            return None
+        if engineer.tokenless_calls < UNENFORCEABLE_CALLS:
+            return None
+        return (
+            f"token budget unenforceable: the engineer has made "
+            f"{engineer.tokenless_calls} agent call(s) this run and none "
+            f"reported a token count, so max_total_tokens ({cap}) cannot "
+            "advance; refusing to schedule further components rather than "
+            "spending under a cap that cannot fire (R8)"
+        )
 
     # ------------------------------------------------------------------
     # Attempt lifecycle + evidence pointers (R3.3)

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -384,6 +384,30 @@ class ComponentPipeline:
         never double count with the normal path."""
         self._record_usage(comp_id, "engineer", totals)
 
+    def engineer_usage_totals(self) -> UsageTotals:
+        """Engineer-loop spend across every component and attempt.
+
+        Feeds the loop-side budget's tokenless-call threshold (R8). That
+        threshold asks "does the ENGINEER's adapter report tokens?", so
+        it must not be answered with run-wide totals: a timed-out
+        architect or reviewer call is tokenless too, and counting those
+        let two unrelated timeouts condemn an engineer adapter that had
+        been reporting perfectly well - while the halt message asserted
+        the cap "can never trip on this adapter". Engineer-scoped, the
+        counter still survives the case it exists for
+        (``max_iterations = 1`` and retries, where a per-loop counter
+        resets before it can conclude anything).
+
+        The OVERRUN half stays run-wide: that one asks what the RUN has
+        spent against the cap, which is every phase's business.
+        """
+        totals = UsageTotals()
+        for phases in self.usage_meter.values():
+            engineer = phases.get("engineer")
+            if engineer is not None:
+                totals.merge(engineer)
+        return totals
+
     def usage_totals_for(self, comp_id: str) -> UsageTotals:
         """One component's spend across all phases (PR A: shown at the
         E6 checkpoint so the human sees what the attempt cost)."""

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -262,6 +262,7 @@ class ComponentPipeline:
         bus: ev.EventBus,
         journal_path: Path | None,
         run_paths: ev.RunPaths | None = None,
+        usage_paths: ev.RunPaths | None = None,
         interaction: InteractionChannel | None = None,
         notify: NotifyHooks,
         review_selection: AdversarialAgentSelection,
@@ -284,6 +285,12 @@ class ComponentPipeline:
         self.bus = bus
         self.journal_path = journal_path
         self.run_paths = run_paths
+        # R8: where engineer-loop usage snapshots live. Deliberately
+        # SEPARATE from run_paths, which is None when progress logging
+        # is off: accounting must survive the observability opt-out
+        # (review finding P2-d). None only for callers that never run
+        # the abort-salvage path (tests, embedded pipelines).
+        self.usage_paths = usage_paths
         # PR A: the interaction seam. Defaults to today's terminal
         # behavior; embedded mode (PR F) injects a QueueInteractionChannel.
         self.interaction: InteractionChannel = (

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -367,6 +367,16 @@ class ComponentPipeline:
             component=comp_id, phase=phase, **totals.to_dict(),
         ))
 
+    def record_engineer_usage(
+        self, comp_id: str, totals: UsageTotals,
+    ) -> None:
+        """Record engineer spend that never came back through
+        process_result (R8 abort path). The worker was killed, so its
+        records reach the meter here or not at all; the caller
+        guarantees the matching future produced no result, so this can
+        never double count with the normal path."""
+        self._record_usage(comp_id, "engineer", totals)
+
     def usage_totals_for(self, comp_id: str) -> UsageTotals:
         """One component's spend across all phases (PR A: shown at the
         E6 checkpoint so the human sees what the attempt cost)."""
@@ -695,13 +705,22 @@ class ComponentPipeline:
         self.manifest.save(self.manifest_path)
         return Transition.FAILED
 
-    def fail_for_budget(self, comp: Component, phase: str) -> Transition:
+    def fail_for_budget(
+        self, comp: Component, phase: str, reason: str = "",
+    ) -> Transition:
         """R3.1: halt LOUDLY on a blown token budget. Mirrors the R1.2/
         R1.4 synthetic-finding pattern (chunk_budget_insufficient): a
         typed Finding in the stream, a progress-log event, and a FAILED
         component - never a silent degrade. Retrying cannot un-spend
-        tokens, so this fails directly instead of burning retries."""
-        error = (
+        tokens, so this fails directly instead of burning retries.
+
+        ``reason`` (R8) overrides the derived message when the breach
+        was detected somewhere the parent's own totals do not describe -
+        specifically the engineer loop's in-loop halt on unreportable
+        usage, where ``run_usage.total_tokens >= cap`` is false and
+        stating it would put a false number in the audit trail. Every
+        other side effect is identical wherever the breach is caught."""
+        error = reason or (
             f"token budget exceeded: {self.run_usage.total_tokens} total "
             f"tokens recorded >= max_total_tokens "
             f"({self.factory_config.max_total_tokens}); halting instead of "
@@ -1163,9 +1182,22 @@ class ComponentPipeline:
         # R3.1 budget checkpoint: the engineer loop just reported the
         # dominant spend; halt before starting adversarial phases (or a
         # retry) when the run-level cap is blown.
-        if self.token_budget_exceeded():
+        #
+        # R8: the loop can also halt ITSELF between iterations, which is
+        # the only enforcement that happens while the spend is being
+        # incurred. Both routes land here, so the audit trail (typed
+        # finding, BudgetExceeded event, single budget_overrun inbox
+        # item, no duplicate halted_run) is identical either way. The
+        # worker's reason is used only when the parent's own totals do
+        # not show a breach - the unreportable-usage case, where the
+        # derived "N >= cap" sentence would be false.
+        if comp_result.budget_exceeded or self.token_budget_exceeded():
+            reason = (
+                "" if self.token_budget_exceeded()
+                else (comp_result.error or "")
+            )
             return PipelineOutcome(
-                transition=self.fail_for_budget(comp, "engineer"),
+                transition=self.fail_for_budget(comp, "engineer", reason),
             )
 
         if not comp_result.success:

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -366,7 +366,8 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
         "iteration or phase, never mid-call (docs/env-vars.md)",
     ("factory", "pause_before_pr_merge"): "human checkpoint before each PR (E6)",
     ("factory", "progress_log_enabled"):
-        "JSONL event log at .kstrl/progress.jsonl (R3.2)",
+        "JSONL event log at .kstrl/progress.jsonl (R3.2); usage accounting is "
+        "written either way (docs/env-vars.md)",
     ("factory", "keep_worktrees_on_failure"):
         "keep failed components' worktrees for post-mortem (R3.3)",
     ("breaker", "no_progress_iterations"):

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -361,7 +361,9 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("factory", "review_mode"): "hard | advisory | skip (Phase 2)",
     ("factory", "merge_timeout"): "seconds to wait for PR merge confirmation",
     ("factory", "max_adversarial_calls"): "cap on review+security+distill LLM calls; 0 = unbounded",
-    ("factory", "max_total_tokens"): "run-level token budget; 0 = unbounded",
+    ("factory", "max_total_tokens"):
+        "run-level token budget; 0 = unbounded. Halts before the next engineer "
+        "iteration or phase, never mid-call (docs/env-vars.md)",
     ("factory", "pause_before_pr_merge"): "human checkpoint before each PR (E6)",
     ("factory", "progress_log_enabled"):
         "JSONL event log at .kstrl/progress.jsonl (R3.2)",

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -300,7 +300,13 @@ class TestV1CompatGoldenParity:
             component="comp-a", passed=False, mode="hard", fail_count=2,
             advisory_count=1, duration_seconds=60.0))
 
-        usage = {"calls": 3, "known_calls": 2, "unreported_calls": 1,
+        # Mirrors UsageTotals.to_dict() verbatim, which is the documented
+        # contract of ProgressLog.component_usage. R8 added token_calls
+        # (calls that reported a TOKEN figure, as opposed to cost alone),
+        # so both sides of the parity carry it. Every reader of this
+        # payload looks keys up defensively, so older files simply lack it.
+        usage = {"calls": 3, "known_calls": 2, "token_calls": 1,
+                 "unreported_calls": 1,
                  "input_tokens": 100, "output_tokens": 50,
                  "cache_read_tokens": 10, "cache_creation_tokens": 5,
                  "total_tokens": 165, "cost_usd": 0.123456,

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -23,7 +23,7 @@ import time
 from collections.abc import Callable, Iterator
 from concurrent.futures import Future
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1297,17 +1297,22 @@ class TestInLoopTokenBudget:
     def test_a_tokenless_call_after_an_earlier_one_halts_immediately(
         self, tmp_path: Path,
     ) -> None:
-        """The deliberate cost of counting the threshold run-wide.
+        """The deliberate cost of counting the threshold across attempts.
 
-        Once a run has accumulated one tokenless call ANYWHERE - a
-        timed-out reviewer call, a previous component's last iteration -
-        the engineer's first tokenless iteration reaches the threshold
-        and halts, where an isolated loop would have given it a second
-        chance. Accepted on purpose: two independent tokenless calls in
-        one run is adapter behavior rather than an incident, and the
+        Once the ENGINEER has accumulated one tokenless call earlier in
+        the run - a previous component's last iteration, or a retry that
+        died after one call - its next tokenless iteration reaches the
+        threshold and halts, where an isolated loop would have given it a
+        second chance. Accepted on purpose: two tokenless engineer calls
+        in one run is adapter behavior rather than an incident, and the
         failure is loud, recorded and recoverable (raise or clear
-        max_total_tokens), whereas the alternative is a per-loop
-        counter that never fires at all (P1-a).
+        max_total_tokens), whereas the alternative is a per-loop counter
+        that never fires at all (P1-a).
+
+        Scoped to engineer calls, so another role's timeout cannot get
+        here: `prior_calls`/`prior_token_calls` come from
+        `pipeline.engineer_usage_totals()`, not run-wide totals. See
+        TestUnenforceableHaltIsEngineerScoped.
         """
         agent = SequenceUsageAgent([_UNREPORTED, _REPORTED])
         result = run_loop(
@@ -1319,7 +1324,7 @@ class TestInLoopTokenBudget:
         )
         assert result.iterations == 1
         assert "unenforceable" in result.budget_halt_reason
-        assert "2 call(s) in this run" in result.budget_halt_reason
+        assert "2 tokenless call(s) this run" in result.budget_halt_reason
 
     def test_iteration_usage_callback_sees_cumulative_totals(
         self, tmp_path: Path,
@@ -2032,3 +2037,91 @@ class TestMaxTotalTokensConfig:
         assert FactoryConfig.load(tmp_path).max_total_tokens == 111
         monkeypatch.setenv("KSTRL_FACTORY_MAX_TOTAL_TOKENS", "222")
         assert FactoryConfig.load(tmp_path).max_total_tokens == 222
+
+
+class TestUnenforceableHaltIsEngineerScoped:
+    """The tokenless threshold asks whether the ENGINEER's adapter
+    reports tokens, so only engineer calls may answer it.
+
+    Review regression: the counter was first sourced from
+    `pipeline.run_usage`, which aggregates every role. Two unrelated
+    timeouts (say an architect call plus the engineer's first iteration)
+    then halted a run whose engineer adapter had been reporting fine -
+    and the message asserted the cap could "never trip on this adapter"
+    while the run sat at half the ceiling with four reporting calls
+    behind it.
+    """
+
+    def test_other_roles_timeouts_do_not_condemn_a_healthy_engineer(
+        self,
+    ) -> None:
+        # 4 engineer calls, all reported; the run also had an architect
+        # timeout, which is NOT engineer evidence and must not count.
+        budget = LoopBudget(
+            max_total_tokens=500_000, prior_total_tokens=250_000,
+            prior_known_calls=5, prior_calls=4, prior_token_calls=4,
+        )
+        assert budget.halt_reason(
+            UsageTotals(calls=1, known_calls=0, token_calls=0, total_tokens=0),
+        ) is None
+
+    def test_silent_engineer_across_attempts_still_halts(self) -> None:
+        # P1-a must stay fixed: one tokenless engineer call already
+        # recorded, this loop's first is the second.
+        budget = LoopBudget(
+            max_total_tokens=500_000, prior_total_tokens=0,
+            prior_known_calls=0, prior_calls=1, prior_token_calls=0,
+        )
+        reason = budget.halt_reason(
+            UsageTotals(calls=1, known_calls=0, token_calls=0, total_tokens=0),
+        )
+        assert reason is not None
+        assert "unenforceable" in reason
+
+    def test_halt_message_does_not_claim_the_adapter_never_reports(
+        self,
+    ) -> None:
+        # The message must not assert something false about an adapter
+        # that demonstrably reported; it states what is actually true -
+        # prior spend is frozen, so the cap cannot advance from here.
+        budget = LoopBudget(
+            max_total_tokens=500_000, prior_total_tokens=250_000,
+            prior_known_calls=4, prior_calls=2, prior_token_calls=0,
+        )
+        reason = budget.halt_reason(
+            UsageTotals(calls=1, known_calls=0, token_calls=0, total_tokens=0),
+        )
+        assert reason is not None
+        assert "never trip on this adapter" not in reason
+        assert "cannot advance from this loop" in reason
+        assert "frozen at 250000" in reason
+
+    def test_pipeline_engineer_totals_exclude_other_phases(self) -> None:
+        """The source of prior_calls: engineer phase only.
+
+        Exercises the real ``engineer_usage_totals`` fold over the
+        usage_meter shape ``{comp_id: {phase: UsageTotals}}`` without
+        standing up a whole pipeline.
+        """
+        from kstrl.pipeline import ComponentPipeline
+
+        pipeline = cast(Any, ComponentPipeline.__new__(ComponentPipeline))
+        pipeline.usage_meter = {
+            "comp-a": {
+                "review": UsageTotals(
+                    calls=3, known_calls=3, token_calls=3, total_tokens=900,
+                ),
+                "engineer": UsageTotals(
+                    calls=2, known_calls=0, token_calls=0, total_tokens=0,
+                ),
+            },
+            "comp-b": {
+                "engineer": UsageTotals(
+                    calls=1, known_calls=1, token_calls=1, total_tokens=50,
+                ),
+            },
+        }
+        engineer = ComponentPipeline.engineer_usage_totals(pipeline)
+        assert engineer.calls == 3          # 2 + 1, review excluded
+        assert engineer.token_calls == 1
+        assert engineer.total_tokens == 50

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -1076,22 +1076,53 @@ class TestInLoopTokenBudget:
         assert result.usage.unreported_calls == 1
         assert result.usage.total_tokens == 600
 
-    def test_prior_reported_calls_disarm_the_unenforceable_halt(
+    def test_prior_reported_calls_do_not_disarm_the_unenforceable_halt(
         self, tmp_path: Path,
     ) -> None:
-        """An earlier phase reported usage, so the cap CAN trip; this
-        loop's unreported iteration is a lower-bound gap, not proof of a
-        dead cap."""
+        """A silent ENGINEER is a dead cap even when earlier phases
+        reported.
+
+        Review regression: the halt used to be judged on the whole run
+        (`prior_known_calls + loop known_calls`), so a reporting
+        architect suppressed it and a silent engineer then spent
+        unbounded under a nominal cap. `prior_total_tokens` is frozen at
+        launch, so once this loop reports nothing the total can never
+        grow toward the ceiling - the cap is exactly as dead as in the
+        all-silent case. That configuration is easy to reach: `[agent]
+        command` sets a custom engineer command while the adversarial
+        roles keep a reporting adapter.
+        """
         agent = SequenceUsageAgent([_UNREPORTED])
         result = run_loop(
-            _loop_config(tmp_path, 3), PlainUI(no_color=True), agent, tmp_path,
+            _loop_config(tmp_path, 5), PlainUI(no_color=True), agent, tmp_path,
             budget=LoopBudget(
                 max_total_tokens=500, prior_total_tokens=100,
                 prior_known_calls=1,
             ),
         )
-        assert result.iterations == 3
+        assert result.iterations == 2      # halts at _UNENFORCEABLE_CALLS
+        assert "unenforceable" in result.budget_halt_reason
+        assert not result.completed
+
+    def test_one_silent_call_alongside_prior_reporting_keeps_going(
+        self, tmp_path: Path,
+    ) -> None:
+        """A single unparseable result is an incident, not a dead cap.
+
+        The threshold is what separates "this adapter never reports"
+        from "one call came back unreadable"; a lone silent iteration
+        must not kill a capped run.
+        """
+        agent = SequenceUsageAgent([_UNREPORTED, _REPORTED, _REPORTED])
+        result = run_loop(
+            _loop_config(tmp_path, 3), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(
+                max_total_tokens=500_000, prior_total_tokens=100,
+                prior_known_calls=1,
+            ),
+        )
         assert result.budget_halt_reason == ""
+        assert result.iterations == 3
 
     def test_iteration_usage_callback_sees_cumulative_totals(
         self, tmp_path: Path,
@@ -1272,8 +1303,8 @@ class TestInLoopHaltAuditState:
         manifest = _make_manifest([_component("comp-a")])
         config = _factory_config(root, max_total_tokens=1_000_000)
         reason = (
-            "token budget unenforceable: none of the 1 agent call(s) in "
-            "this run reported any token usage, so max_total_tokens "
+            "token budget unenforceable: none of this loop's 1 agent "
+            "call(s) reported any token usage, so max_total_tokens "
             "(1000000) can never trip on this adapter; halting rather "
             "than spending under a cap that cannot fire (R8)"
         )

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -20,7 +20,7 @@ import io
 import json
 import logging
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from concurrent.futures import Future
 from pathlib import Path
 from typing import Any
@@ -37,6 +37,7 @@ from kstrl.events import RunPaths
 from kstrl.factory import (
     ComponentResult,
     FactoryConfig,
+    _clear_partial_usage,
     _format_usage_rollup,
     _read_partial_usage,
     _run_component,
@@ -130,6 +131,60 @@ class TestUsageTotalsMath:
         a.merge(b)
         assert a.calls == 2
         assert a.total_tokens == (9 + 42 + 17418 + 10371) + 1000
+        assert a.known_calls == 2
+        assert a.token_calls == 2
+
+    def test_cost_only_record_is_known_but_tokenless(self) -> None:
+        """Review regression (P1-b): ``known_calls`` is not token evidence.
+
+        ``add_record`` sets ``known`` for a COST figure alone, and the
+        claude adapter reports ``total_cost_usd`` even when the ``usage``
+        dict is absent or drifted. Two such records therefore look like
+        perfect coverage (calls == known_calls) while ``total_tokens``
+        stays 0 forever - so anything gating on a TOKEN ceiling has to
+        read ``token_calls``, which counts only calls that reported an
+        actual token figure.
+
+        Built with the real ``add_record``, not a hand-assembled totals
+        object: the defect lives in that method's ``known`` flag.
+        """
+        totals = UsageTotals()
+        totals.add_record(UsageRecord(
+            cost_usd=0.0227028, duration_seconds=1.8,
+            source="claude-stream-json",
+        ))
+        totals.add_record(UsageRecord(
+            cost_usd=0.0104, duration_seconds=2.1,
+            source="claude-stream-json",
+        ))
+        assert totals.calls == 2
+        assert totals.known_calls == 2      # unchanged semantics
+        assert totals.unreported_calls == 0  # unchanged semantics
+        assert totals.token_calls == 0       # the honest token coverage
+        assert totals.tokenless_calls == 2
+        assert totals.total_tokens == 0
+        assert totals.cost_usd == pytest.approx(0.0331028)
+
+    def test_token_calls_counts_only_token_bearing_records(self) -> None:
+        totals = UsageTotals()
+        totals.add_record(_claude_record())                        # parts
+        totals.add_record(UsageRecord(total_tokens=10))            # total
+        totals.add_record(UsageRecord(cost_usd=0.5))               # cost
+        totals.add_record(UsageRecord(duration_seconds=1.0))       # silence
+        assert totals.calls == 4
+        assert totals.known_calls == 3
+        assert totals.token_calls == 2
+        assert totals.tokenless_calls == 2
+        assert totals.unreported_calls == 1
+
+    def test_token_calls_round_trips_through_to_dict(self) -> None:
+        """Serialized so the audit trail keeps the distinction; readers
+        of older payloads see the key missing and decode it as 0."""
+        totals = UsageTotals()
+        totals.add_record(_claude_record())
+        totals.add_record(UsageRecord(cost_usd=0.5))
+        assert totals.to_dict()["token_calls"] == 1
+        assert totals.to_dict()["known_calls"] == 2
 
     def test_malformed_records_never_raise(self) -> None:
         totals = UsageTotals()
@@ -571,6 +626,19 @@ def _engineer_usage(total: int, cost: float = 0.0) -> UsageTotals:
     return totals
 
 
+def _engineer_usage_events(root: Path) -> list[int]:
+    """Every engineer-phase usage total the run recorded, in order.
+
+    A list (not a sum) on purpose: a double count and a correct total
+    are the same number of tokens but a different number of events.
+    """
+    events = ProgressLog(root / "progress.jsonl").read_events()
+    return [
+        int(e["data"]["total_tokens"]) for e in events
+        if e["event"] == "component_usage" and e["data"]["phase"] == "engineer"
+    ]
+
+
 def _read_journal(tmp_path: Path) -> list[dict[str, Any]]:
     journal_path = tmp_path / ".kstrl" / "evolution.jsonl"
     entries = []
@@ -937,6 +1005,27 @@ class SequenceUsageAgent:
 
 _REPORTED = UsageRecord(total_tokens=300, source="codex-text")
 _UNREPORTED = UsageRecord(duration_seconds=5.0, source="unavailable")
+# Reports a cost but no tokens: "known" to the meter, invisible to a
+# token ceiling (review finding P1-b).
+_COST_ONLY = UsageRecord(
+    cost_usd=0.0227028, duration_seconds=1.8, source="claude-stream-json",
+)
+
+
+def _budget_for(run_total: UsageTotals, cap: int) -> LoopBudget:
+    """Exactly the LoopBudget ``_submit_args`` hands a worker.
+
+    Threading the run totals through this helper is what makes the
+    run-wide half of the unenforceable rule testable: the priors are the
+    only channel by which one loop's tokenless calls reach the next.
+    """
+    return LoopBudget(
+        max_total_tokens=cap,
+        prior_total_tokens=run_total.total_tokens,
+        prior_known_calls=run_total.known_calls,
+        prior_calls=run_total.calls,
+        prior_token_calls=run_total.token_calls,
+    )
 
 
 class TestInLoopTokenBudget:
@@ -966,7 +1055,7 @@ class TestInLoopTokenBudget:
             _loop_config(tmp_path, 10), PlainUI(no_color=True), agent, tmp_path,
             budget=LoopBudget(
                 max_total_tokens=500, prior_total_tokens=450,
-                prior_known_calls=1,
+                prior_known_calls=1, prior_calls=1, prior_token_calls=1,
             ),
         )
         assert result.iterations == 1
@@ -1091,13 +1180,20 @@ class TestInLoopTokenBudget:
         all-silent case. That configuration is easy to reach: `[agent]
         command` sets a custom engineer command while the adversarial
         roles keep a reporting adapter.
+
+        Still true after the run-wide threshold landed (P1-a): the
+        TOKEN-EVIDENCE half of the rule is still judged on this loop
+        alone, so the reporting prior below (one call, one token call)
+        cannot suppress anything - it only keeps the run's tokenless
+        count at 0, which is why the halt lands on this loop's OWN
+        second tokenless call.
         """
         agent = SequenceUsageAgent([_UNREPORTED])
         result = run_loop(
             _loop_config(tmp_path, 5), PlainUI(no_color=True), agent, tmp_path,
             budget=LoopBudget(
                 max_total_tokens=500, prior_total_tokens=100,
-                prior_known_calls=1,
+                prior_known_calls=1, prior_calls=1, prior_token_calls=1,
             ),
         )
         assert result.iterations == 2      # halts at _UNENFORCEABLE_CALLS
@@ -1112,17 +1208,118 @@ class TestInLoopTokenBudget:
         The threshold is what separates "this adapter never reports"
         from "one call came back unreadable"; a lone silent iteration
         must not kill a capped run.
+
+        This is the case the run-wide threshold (P1-a) had to preserve:
+        the prior call reported tokens, so the run's tokenless count is
+        1 after this loop's silent first iteration - below the
+        threshold - and the loop keeps going. Counting ALL prior calls
+        instead of only the tokenless ones would have halted here, which
+        is why the counter is tokenless-scoped.
         """
         agent = SequenceUsageAgent([_UNREPORTED, _REPORTED, _REPORTED])
         result = run_loop(
             _loop_config(tmp_path, 3), PlainUI(no_color=True), agent, tmp_path,
             budget=LoopBudget(
                 max_total_tokens=500_000, prior_total_tokens=100,
-                prior_known_calls=1,
+                prior_known_calls=1, prior_calls=1, prior_token_calls=1,
             ),
         )
         assert result.budget_halt_reason == ""
         assert result.iterations == 3
+
+    def test_cost_only_reporting_is_not_token_evidence(
+        self, tmp_path: Path,
+    ) -> None:
+        """Review regression (P1-b): an adapter that reports cost but no
+        tokens moved ``known_calls`` and so looked fully instrumented,
+        while ``total_tokens`` stayed 0 and the cap could never trip.
+        The loop ran to max_iterations under a dead ceiling. It now
+        halts at the threshold like any other tokenless adapter.
+        """
+        agent = SequenceUsageAgent([_COST_ONLY])
+        result = run_loop(
+            _loop_config(tmp_path, 10), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(max_total_tokens=500),
+        )
+        assert result.iterations == 2      # not the configured 10
+        assert "unenforceable" in result.budget_halt_reason
+        assert result.usage.known_calls == 2   # the misleading signal
+        assert result.usage.token_calls == 0   # the honest one
+        assert result.usage.total_tokens == 0
+
+    def test_unenforceable_threshold_does_not_reset_per_loop(
+        self, tmp_path: Path,
+    ) -> None:
+        """Review regression (P1-a): the threshold is run-wide.
+
+        Reproduced by the reviewer: with ``max_iterations = 1`` (or a
+        retry that dies after one call) no single loop ever reached
+        ``_UNENFORCEABLE_CALLS``, so three sequential one-iteration
+        loops reached calls=3 / token_calls=0 / total_tokens=0 with
+        every ``budget_halt_reason`` empty. The cap was decorative
+        whenever work was split into short loops.
+
+        The priors are threaded exactly as ``_submit_args`` threads
+        them, so this pins the whole channel, not just the arithmetic.
+        """
+        run_total = UsageTotals()
+        reasons: list[str] = []
+        for _ in range(3):
+            agent = SequenceUsageAgent([_UNREPORTED])
+            result = run_loop(
+                _loop_config(tmp_path, 1), PlainUI(no_color=True), agent,
+                tmp_path, budget=_budget_for(run_total, 500),
+            )
+            run_total.merge(result.usage)
+            reasons.append(result.budget_halt_reason)
+
+        assert reasons[0] == ""                    # one is an incident
+        assert "unenforceable" in reasons[1]       # two is the adapter
+        assert "unenforceable" in reasons[2]
+        assert run_total.calls == 3
+        assert run_total.token_calls == 0
+
+    def test_a_high_prior_call_count_cannot_halt_a_loop_that_has_not_run(
+        self,
+    ) -> None:
+        """The run-wide threshold must not pre-empt the engineer.
+
+        A worker launched into a run that already has tokenless calls on
+        its meter has made no calls of its own yet, so there is no
+        token evidence either way and nothing to conclude. Halting here
+        would fail a component that never got to run.
+        """
+        budget = LoopBudget(
+            max_total_tokens=500, prior_calls=20, prior_token_calls=0,
+        )
+        assert budget.halt_reason(UsageTotals()) is None
+
+    def test_a_tokenless_call_after_an_earlier_one_halts_immediately(
+        self, tmp_path: Path,
+    ) -> None:
+        """The deliberate cost of counting the threshold run-wide.
+
+        Once a run has accumulated one tokenless call ANYWHERE - a
+        timed-out reviewer call, a previous component's last iteration -
+        the engineer's first tokenless iteration reaches the threshold
+        and halts, where an isolated loop would have given it a second
+        chance. Accepted on purpose: two independent tokenless calls in
+        one run is adapter behavior rather than an incident, and the
+        failure is loud, recorded and recoverable (raise or clear
+        max_total_tokens), whereas the alternative is a per-loop
+        counter that never fires at all (P1-a).
+        """
+        agent = SequenceUsageAgent([_UNREPORTED, _REPORTED])
+        result = run_loop(
+            _loop_config(tmp_path, 5), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(
+                max_total_tokens=500_000, prior_total_tokens=900,
+                prior_known_calls=2, prior_calls=3, prior_token_calls=2,
+            ),
+        )
+        assert result.iterations == 1
+        assert "unenforceable" in result.budget_halt_reason
+        assert "2 call(s) in this run" in result.budget_halt_reason
 
     def test_iteration_usage_callback_sees_cumulative_totals(
         self, tmp_path: Path,
@@ -1203,22 +1400,58 @@ class TestWorkerPropagatesInLoopHalt:
     def test_worker_persists_usage_at_every_iteration_boundary(
         self, tmp_path: Path,
     ) -> None:
-        """The durable snapshot the abort path reads back."""
+        """The durable snapshot the abort path reads back.
+
+        Keyed off ``usage_dir_str``, not ``events_dir_str``: review
+        finding P2-d showed the snapshot dying with the observability
+        opt-out, so the accounting channel is now its own argument.
+        """
         root = _setup_project(tmp_path, ["comp-a"])
-        events_dir = root / ".kstrl" / "runs" / "run-b"
+        usage_dir = root / ".kstrl" / "runs" / "run-b"
         agent = FakeUsageAgent(outputs=[["working..."]], record=_REPORTED)
 
         with patch("kstrl.agents.get_agent", return_value=agent):
             _run_component(**self._worker_args(
-                root, max_iterations=2, events_dir_str=str(events_dir),
+                root, max_iterations=2,
+                events_dir_str=str(usage_dir), usage_dir_str=str(usage_dir),
             ))
 
         snapshot = _read_partial_usage(
-            RunPaths(root=events_dir).engineer_usage("comp-a")
+            RunPaths(root=usage_dir).engineer_usage("comp-a")
         )
         assert snapshot is not None
         assert snapshot.total_tokens == 600
         assert snapshot.calls == 2
+
+    def test_worker_persists_usage_without_an_events_dir(
+        self, tmp_path: Path,
+    ) -> None:
+        """Review regression (P2-d), worker half.
+
+        ``progress_log_enabled = false`` makes the parent pass
+        ``events_dir_str=None``. That used to skip installing
+        ``on_iteration_usage`` entirely, so a killed worker recorded
+        nothing in a fully supported configuration: an observability
+        opt-out silently disabled the meter. The accounting channel is
+        now independent of the event channel.
+        """
+        root = _setup_project(tmp_path, ["comp-a"])
+        usage_dir = root / ".kstrl" / "accounting-only"
+        agent = FakeUsageAgent(outputs=[["working..."]], record=_REPORTED)
+
+        with patch("kstrl.agents.get_agent", return_value=agent):
+            _run_component(**self._worker_args(
+                root, max_iterations=2,
+                events_dir_str=None, usage_dir_str=str(usage_dir),
+            ))
+
+        snapshot = _read_partial_usage(
+            RunPaths(root=usage_dir).engineer_usage("comp-a")
+        )
+        assert snapshot is not None
+        assert snapshot.total_tokens == 600
+        # No events were written: the opt-out is still honored.
+        assert not (usage_dir / "events.jsonl").exists()
 
 
 class TestSchedulerHandsDownTheBudget:
@@ -1257,12 +1490,46 @@ class TestSchedulerHandsDownTheBudget:
         assert all(isinstance(b, LoopBudget) for b in budgets)
         assert budgets[0] == LoopBudget(
             max_total_tokens=100_000, prior_total_tokens=0,
-            prior_known_calls=0,
+            prior_known_calls=0, prior_calls=0, prior_token_calls=0,
         )
+        # prior_calls / prior_token_calls are the channel that stops the
+        # unenforceable threshold resetting per component (P1-a).
         assert budgets[1] == LoopBudget(
             max_total_tokens=100_000, prior_total_tokens=700,
-            prior_known_calls=1,
+            prior_known_calls=1, prior_calls=1, prior_token_calls=1,
         )
+
+    def test_tokenless_prior_calls_reach_the_next_worker(
+        self, tmp_path: Path,
+    ) -> None:
+        """Review regression (P1-a), scheduler half: a component whose
+        engineer reported nothing must leave that fact on the NEXT
+        worker's budget, or the run-wide threshold cannot exist."""
+        root = _setup_project(tmp_path, ["comp-a", "comp-b"])
+        manifest = _make_manifest([
+            _component("comp-a"), _component("comp-b", deps=["comp-a"]),
+        ])
+        config = _factory_config(root, max_total_tokens=100_000)
+        budgets: list[Any] = []
+        silent = UsageTotals()
+        silent.add_record(_UNREPORTED)
+
+        def fake_run_component(*args: Any, **kwargs: Any) -> ComponentResult:
+            budgets.append(args[-1])
+            return ComponentResult(
+                str(args[0]), success=True, iterations=1, usage=silent,
+            )
+
+        with patch(
+            "kstrl.factory._run_component", side_effect=fake_run_component,
+        ), patch("kstrl.git.get_diff_content", return_value=""):
+            run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert budgets[1].prior_calls == 1
+        assert budgets[1].prior_token_calls == 0
 
     def test_no_cap_still_hands_down_a_disabled_budget(
         self, tmp_path: Path,
@@ -1382,6 +1649,62 @@ class TestInLoopHaltAuditState:
         assert comp_a.retries == 0
 
 
+def _pending_executor(
+    sync_calls: int, on_pending: Callable[[tuple[Any, ...]], None],
+) -> type:
+    """Executor stand-in whose LATER submissions never resolve.
+
+    Why this exists (review finding P2-e): ``_factory_config`` sets
+    ``use_worktrees=False``, which forces ``max_parallel=1``, which
+    selects ``_InlineExecutor`` - and that executor runs the worker
+    synchronously inside ``submit()``. By the time a stop is observed
+    the future is therefore already done, and ``_salvage_aborted_usage``
+    takes the already-delivered route. Every test of the DISK route has
+    to inject a genuinely pending future at the executor seam, or it
+    passes with the snapshot write/read entirely broken.
+
+    ``on_pending`` receives the submit arguments, which is how a test
+    learns the run-scoped usage directory the worker would have been
+    told to write to (the run id is minted inside ``run_factory``).
+    """
+    state = {"n": 0}
+
+    class _PendingExecutor:
+        def submit(
+            self, fn: Callable[..., ComponentResult], /, *args: Any,
+        ) -> Future[ComponentResult]:
+            state["n"] += 1
+            future: Future[ComponentResult] = Future()
+            # Inline mode binds the args into a functools.partial; pool
+            # mode passes them through. Accept both.
+            submit_args = args or tuple(getattr(fn, "args", ()))
+            if state["n"] > sync_calls:
+                on_pending(submit_args)
+                return future  # never resolves: the worker was killed
+            try:
+                future.set_result(fn(*args))
+            except Exception as exc:  # noqa: BLE001 - mirrors the real one
+                future.set_exception(exc)
+            return future
+
+        def shutdown(
+            self, wait: bool = True, cancel_futures: bool = False,
+        ) -> None:
+            """Nothing to shut down."""
+
+    return _PendingExecutor
+
+
+def _usage_dir_from_args(args: tuple[Any, ...]) -> Path:
+    """The accounting directory ``_submit_args`` hands the worker.
+
+    Pins the positional contract from the other end: the submit tuple
+    ends with (events_dir, usage_dir, run_id, token_budget).
+    """
+    assert isinstance(args[-1], LoopBudget)
+    return Path(str(args[-3]))
+
+
 class TestAbortedWorkerUsage:
     def test_snapshot_roundtrips(self, tmp_path: Path) -> None:
         totals = _engineer_usage(1234, cost=0.5)
@@ -1408,15 +1731,25 @@ class TestAbortedWorkerUsage:
         blocker.write_text("not a directory")
         _write_partial_usage(blocker / "sub" / "usage.json", _engineer_usage(1))
 
+    def test_clearing_a_snapshot_is_idempotent(self, tmp_path: Path) -> None:
+        """The scheduler clears before every submission, including the
+        first, when there is nothing to clear."""
+        path = tmp_path / "engineer_usage.json"
+        _clear_partial_usage(path)              # absent: no error
+        _write_partial_usage(path, _engineer_usage(700))
+        _clear_partial_usage(path)
+        assert _read_partial_usage(path) is None
+        _clear_partial_usage(tmp_path)          # a directory: swallowed
+
     def test_killed_worker_spend_recovered_from_the_snapshot(
         self, tmp_path: Path,
     ) -> None:
-        run_paths = RunPaths(root=tmp_path)
+        usage_paths = RunPaths(root=tmp_path)
         _write_partial_usage(
-            run_paths.engineer_usage("comp-a"), _engineer_usage(700),
+            usage_paths.engineer_usage("comp-a"), _engineer_usage(700),
         )
         pipeline = MagicMock()
-        pipeline.run_paths = run_paths
+        pipeline.usage_paths = usage_paths
         future: Future[ComponentResult] = Future()  # never completes
 
         _salvage_aborted_usage(future, "comp-a", pipeline)
@@ -1431,12 +1764,12 @@ class TestAbortedWorkerUsage:
     ) -> None:
         """No double counting: a future that DID deliver is
         authoritative and the (staler) snapshot is ignored."""
-        run_paths = RunPaths(root=tmp_path)
+        usage_paths = RunPaths(root=tmp_path)
         _write_partial_usage(
-            run_paths.engineer_usage("comp-a"), _engineer_usage(700),
+            usage_paths.engineer_usage("comp-a"), _engineer_usage(700),
         )
         pipeline = MagicMock()
-        pipeline.run_paths = run_paths
+        pipeline.usage_paths = usage_paths
         future: Future[ComponentResult] = Future()
         future.set_result(ComponentResult(
             "comp-a", success=False, usage=_engineer_usage(900),
@@ -1449,7 +1782,7 @@ class TestAbortedWorkerUsage:
 
     def test_crashed_worker_records_nothing(self, tmp_path: Path) -> None:
         pipeline = MagicMock()
-        pipeline.run_paths = RunPaths(root=tmp_path)
+        pipeline.usage_paths = RunPaths(root=tmp_path)
         future: Future[ComponentResult] = Future()
         future.set_exception(RuntimeError("worker died"))
 
@@ -1461,7 +1794,17 @@ class TestAbortedWorkerUsage:
         self, tmp_path: Path,
     ) -> None:
         """End to end: the shutdown path used to drop the worker's
-        usage on the floor. Now it lands on the meter."""
+        usage on the floor. Now it lands on the meter.
+
+        SCOPE (review finding P2-e): this covers the ALREADY-DELIVERED
+        route only. ``_factory_config`` sets use_worktrees=False, which
+        forces max_parallel=1 and the synchronous ``_InlineExecutor``,
+        so the future is done before the stop is observed and the disk
+        snapshot is never read. It passed with snapshot write/read
+        entirely broken. The disk route is covered by the pending-future
+        tests below; both routes need their own test because they are
+        mutually exclusive branches of ``_salvage_aborted_usage``.
+        """
         root = _setup_project(tmp_path, ["comp-a"])
         manifest = _make_manifest([_component("comp-a")])
         stop = StopController()
@@ -1486,13 +1829,147 @@ class TestAbortedWorkerUsage:
         comp_a = manifest.get_component("comp-a")
         assert comp_a is not None
         assert comp_a.failed_phase == "aborted"
-        events = ProgressLog(root / "progress.jsonl").read_events()
-        usage_events = [
-            e for e in events
-            if e["event"] == "component_usage" and e["data"]["phase"] == "engineer"
+        assert _engineer_usage_events(root) == [4242]
+
+    def test_pending_worker_spend_is_salvaged_from_disk_end_to_end(
+        self, tmp_path: Path,
+    ) -> None:
+        """Review regression (P2-e): the disk route, exercised for real.
+
+        The future is still PENDING when the stop lands - the worker was
+        killed mid-loop - so the only surviving record of its spend is
+        the snapshot it published at its last iteration boundary. Break
+        ``_write_partial_usage`` or ``_read_partial_usage`` and this
+        test fails; the pre-existing abort test does not.
+        """
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        stop = StopController()
+
+        def worker_published_then_died(args: tuple[Any, ...]) -> None:
+            _write_partial_usage(
+                RunPaths(root=_usage_dir_from_args(args))
+                .engineer_usage("comp-a"),
+                _engineer_usage(700),
+            )
+            stop.request("mid-run test stop")
+
+        with patch(
+            "kstrl.factory._InlineExecutor",
+            _pending_executor(0, worker_published_then_died),
+        ), patch(
+            "kstrl.factory._run_component",
+            side_effect=AssertionError("the worker never returned"),
+        ), patch("kstrl.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, _factory_config(root), _make_base_config(root),
+                PlainUI(no_color=True, file=io.StringIO()), root, stop=stop,
+            )
+
+        assert result.exit_code == 130
+        comp_a = manifest.get_component("comp-a")
+        assert comp_a is not None
+        assert comp_a.failed_phase == "aborted"
+        assert _engineer_usage_events(root) == [700]
+
+    def test_a_stale_snapshot_from_a_finished_attempt_is_not_recounted(
+        self, tmp_path: Path,
+    ) -> None:
+        """Review regression (P2-c): the snapshot is attempt-scoped.
+
+        The file is keyed by run + component only, and a normal result
+        leaves it on disk. Attempt 1 here completes with 700 tokens
+        (recorded by ``process_result``) and leaves its snapshot behind;
+        attempt 2 is cancelled before its own first iteration boundary,
+        so it has no spend of its own. Before the fix, salvage read the
+        stale file and the run reported 1400 for 700 tokens of work.
+
+        The scheduler now clears the snapshot immediately before every
+        submission - in the PARENT, so the window where the worker never
+        starts is covered too.
+        """
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root, max_retries=1)
+        stop = StopController()
+
+        def fake_run_component(*args: Any, **kwargs: Any) -> ComponentResult:
+            # Attempt 1: a real worker publishing its boundary snapshot,
+            # then failing organically with the same spend on the result.
+            _write_partial_usage(
+                RunPaths(root=_usage_dir_from_args(args))
+                .engineer_usage("comp-a"),
+                _engineer_usage(700),
+            )
+            return ComponentResult(
+                "comp-a", success=False, iterations=1, error="tests failed",
+                usage=_engineer_usage(700),
+            )
+
+        with patch(
+            "kstrl.factory._InlineExecutor",
+            # Attempt 1 runs; attempt 2's future hangs and is aborted.
+            _pending_executor(1, lambda args: stop.request("mid-run stop")),
+        ), patch(
+            "kstrl.factory._run_component", side_effect=fake_run_component,
+        ), patch("kstrl.git.get_diff_content", return_value=""):
+            run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True, file=io.StringIO()), root, stop=stop,
+            )
+
+        assert _engineer_usage_events(root) == [700]
+
+    def test_pending_worker_spend_survives_progress_log_disabled(
+        self, tmp_path: Path,
+    ) -> None:
+        """Review regression (P2-d): accounting is not observability.
+
+        With ``progress_log_enabled = false`` the parent had no
+        ``run_paths``, so it passed the worker no place to publish
+        usage and then had no place to read one back: a killed worker
+        recorded nothing at all, in a supported configuration. The
+        accounting directory is now allocated for every run.
+
+        Asserted through the end-of-run usage rollup because the opt-out
+        means there is no progress log to read - and the rollup is what
+        a human actually sees.
+        """
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root, progress_log_enabled=False)
+        stop = StopController()
+        out = io.StringIO()
+
+        def worker_published_then_died(args: tuple[Any, ...]) -> None:
+            usage_dir = _usage_dir_from_args(args)
+            _write_partial_usage(
+                RunPaths(root=usage_dir).engineer_usage("comp-a"),
+                _engineer_usage(700),
+            )
+            stop.request("mid-run test stop")
+
+        with patch(
+            "kstrl.factory._InlineExecutor",
+            _pending_executor(0, worker_published_then_died),
+        ), patch(
+            "kstrl.factory._run_component",
+            side_effect=AssertionError("the worker never returned"),
+        ), patch("kstrl.git.get_diff_content", return_value=""):
+            run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True, file=out), root, stop=stop,
+            )
+
+        rollup = [
+            line for line in out.getvalue().splitlines()
+            if "comp-a" in line and "engineer" in line
         ]
-        assert len(usage_events) == 1
-        assert usage_events[0]["data"]["total_tokens"] == 4242
+        assert rollup, "the aborted worker's spend never reached the meter"
+        assert "700" in rollup[0]
+        # The opt-out is still honored: no progress log, no event stream.
+        assert not (root / "progress.jsonl").exists()
+        assert not list((root / ".kstrl" / "runs").glob("*/events.jsonl"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -2125,3 +2125,132 @@ class TestUnenforceableHaltIsEngineerScoped:
         assert engineer.calls == 3          # 2 + 1, review excluded
         assert engineer.token_calls == 1
         assert engineer.total_tokens == 50
+
+
+class TestCompletionBoundaryBypass:
+    """A loop that emits COMPLETE returns before its own budget check.
+
+    Review regression on 22e99b4: that is the ORDINARY success path for a
+    custom `agent_cmd` - each component finishes on its first tokenless
+    call, the in-loop halt is never reached, and the engineer's tokenless
+    count climbs across components while the cap never fires. The
+    docstring's old claim that "the halt lands on the next loop" was
+    false when the next loop also completes.
+
+    The parent-side gate is what closes it: the run stops handing out NEW
+    work once the cap provably cannot advance.
+    """
+
+    @staticmethod
+    def _pipeline_with_engineer_usage(
+        tmp_path: Path, calls: int, token_calls: int, cap: int,
+    ) -> Any:
+        from kstrl.pipeline import ComponentPipeline
+
+        pipeline = cast(Any, ComponentPipeline.__new__(ComponentPipeline))
+        pipeline.usage_meter = {
+            "comp-a": {
+                "engineer": UsageTotals(
+                    calls=calls, known_calls=0, token_calls=token_calls,
+                    total_tokens=0,
+                ),
+            },
+        }
+        pipeline.factory_config = _factory_config(
+            tmp_path, max_total_tokens=cap,
+        )
+        return pipeline
+
+    def test_completed_tokenless_components_trip_the_parent_gate(self, tmp_path: Path) -> None:
+        from kstrl.pipeline import ComponentPipeline
+
+        pipeline = self._pipeline_with_engineer_usage(
+            tmp_path, calls=2, token_calls=0, cap=500_000,
+        )
+        reason = ComponentPipeline.token_budget_unenforceable(pipeline)
+        assert reason is not None
+        assert "cannot advance" in reason
+        assert "refusing to schedule further components" in reason
+
+    def test_one_completed_tokenless_component_is_not_enough(self, tmp_path: Path) -> None:
+        from kstrl.pipeline import ComponentPipeline
+
+        pipeline = self._pipeline_with_engineer_usage(
+            tmp_path, calls=1, token_calls=0, cap=500_000,
+        )
+        assert ComponentPipeline.token_budget_unenforceable(pipeline) is None
+
+    def test_a_reporting_engineer_never_trips_the_gate(self, tmp_path: Path) -> None:
+        from kstrl.pipeline import ComponentPipeline
+
+        pipeline = self._pipeline_with_engineer_usage(
+            tmp_path, calls=9, token_calls=9, cap=500_000,
+        )
+        assert ComponentPipeline.token_budget_unenforceable(pipeline) is None
+
+    def test_gate_is_inert_without_a_cap(self, tmp_path: Path) -> None:
+        from kstrl.pipeline import ComponentPipeline
+
+        pipeline = self._pipeline_with_engineer_usage(
+            tmp_path, calls=5, token_calls=0, cap=0,
+        )
+        assert ComponentPipeline.token_budget_unenforceable(pipeline) is None
+
+
+class TestFailedSnapshotDeletionInvalidates:
+    """Deletion IS the attempt-scoping invariant.
+
+    Review regression on 22e99b4: `_clear_partial_usage` swallowed every
+    OSError, so a snapshot that could not be deleted stayed addressable
+    as the current attempt and was salvaged again on top of the totals
+    `process_result` had already recorded.
+    """
+
+    def test_missing_file_is_the_clean_case(self, tmp_path: Path) -> None:
+        assert _clear_partial_usage(tmp_path / "nope.json") is True
+
+    def test_successful_delete_reports_clean(self, tmp_path: Path) -> None:
+        target = tmp_path / "usage.json"
+        target.write_text("{}")
+        assert _clear_partial_usage(target) is True
+        assert not target.exists()
+
+    def test_failed_delete_reports_unsafe(self, tmp_path: Path) -> None:
+        target = tmp_path / "usage.json"
+        target.write_text("{}")
+        with patch.object(
+            Path, "unlink", side_effect=PermissionError("read-only"),
+        ):
+            assert _clear_partial_usage(target) is False
+        assert target.exists()      # still there, hence unsafe
+
+    def test_unsafe_attempt_refuses_disk_salvage(self, tmp_path: Path) -> None:
+        """The point of the flag: a stale 700 must not be recounted."""
+        from concurrent.futures import Future
+
+        from kstrl.pipeline import ComponentPipeline
+
+        pipeline = cast(Any, ComponentPipeline.__new__(ComponentPipeline))
+        pipeline.usage_meter = {}
+        pipeline.run_usage = UsageTotals()
+        pipeline._usage_salvage_unsafe = set()
+        pipeline.usage_paths = RunPaths.for_run(tmp_path, "run-1")
+        recorded: list[UsageTotals] = []
+        pipeline.record_engineer_usage = lambda _c, totals: recorded.append(totals)
+
+        snapshot = pipeline.usage_paths.engineer_usage("comp-a")
+        snapshot.parent.mkdir(parents=True, exist_ok=True)
+        _write_partial_usage(
+            snapshot,
+            UsageTotals(calls=1, known_calls=1, token_calls=1, total_tokens=700),
+        )
+
+        pending: Future[Any] = Future()      # never completes
+        ComponentPipeline.mark_usage_salvage_unsafe(pipeline, "comp-a")
+        _salvage_aborted_usage(pending, "comp-a", pipeline)
+        assert recorded == [], "a stale snapshot must not be salvaged"
+
+        # And the safe path still salvages, so the guard is not a blanket off.
+        ComponentPipeline.mark_usage_salvage_safe(pipeline, "comp-a")
+        _salvage_aborted_usage(pending, "comp-a", pipeline)
+        assert [t.total_tokens for t in recorded] == [700]

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -19,7 +19,9 @@ from __future__ import annotations
 import io
 import json
 import logging
+import time
 from collections.abc import Iterator
+from concurrent.futures import Future
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -31,15 +33,22 @@ from kstrl.agents.claude_code import ClaudeCodeAgent, _usage_from_result_event
 from kstrl.agents.codex import CodexAgent
 from kstrl.agents.custom import CustomAgent
 from kstrl.config import KstrlConfig
+from kstrl.events import RunPaths
 from kstrl.factory import (
     ComponentResult,
     FactoryConfig,
     _format_usage_rollup,
+    _read_partial_usage,
+    _run_component,
+    _salvage_aborted_usage,
+    _write_partial_usage,
     run_factory,
 )
-from kstrl.loop import COMPLETION_MARKER, run_loop
+from kstrl.inbox import Inbox, InboxConfig
+from kstrl.loop import COMPLETION_MARKER, LoopBudget, run_loop
 from kstrl.manifest import Component, ComponentStatus, Manifest
 from kstrl.observability import ProgressLog
+from kstrl.shutdown import StopController
 from kstrl.ui.plain import PlainUI
 from kstrl.verify import VerifyConfig
 
@@ -878,6 +887,581 @@ class TestTokenBudgetHalt:
             )
 
         assert "comp-a" in result.completed
+
+
+# ---------------------------------------------------------------------------
+# R8: max_total_tokens enforced DURING the engineer loop
+#
+# The R3.1 checks above are post-hoc detectors at parent-process phase
+# boundaries: they stop the NEXT phase, never the iteration already
+# running. These cover the in-loop half - the loop refusing to start
+# another iteration - and the fact that both routes land in the same
+# audit state.
+# ---------------------------------------------------------------------------
+
+
+class SequenceUsageAgent:
+    """Fake agent appending one caller-supplied record per run.
+
+    Unlike FakeUsageAgent's single fixed record, the sequence lets a
+    test mix reporting and non-reporting iterations (the claude adapter
+    records source="timeout"/"parse-error" with no token counts).
+    """
+
+    def __init__(
+        self, records: list[UsageRecord], outputs: list[str] | None = None,
+    ) -> None:
+        self._records = records
+        self._outputs = outputs or ["working..."]
+        self._usage_records: list[UsageRecord] = []
+
+    @property
+    def name(self) -> str:
+        return "sequence-usage"
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        index = min(len(self._usage_records), len(self._records) - 1)
+        self._usage_records.append(self._records[index])
+        yield from self._outputs
+
+    @property
+    def final_message(self) -> str | None:
+        return None
+
+    @property
+    def usage_records(self) -> list[UsageRecord]:
+        return list(self._usage_records)
+
+
+_REPORTED = UsageRecord(total_tokens=300, source="codex-text")
+_UNREPORTED = UsageRecord(duration_seconds=5.0, source="unavailable")
+
+
+class TestInLoopTokenBudget:
+    def test_halt_happens_between_iterations_not_at_max_iterations(
+        self, tmp_path: Path,
+    ) -> None:
+        """The loop must stop ITSELF: 300 tokens/iteration against a 500
+        cap means iteration 3 never starts, even though max_iterations
+        is 10 and no phase boundary has been reached."""
+        agent = FakeUsageAgent(outputs=[["working..."]], record=_REPORTED)
+        result = run_loop(
+            _loop_config(tmp_path, 10), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(max_total_tokens=500),
+        )
+        assert result.completed is False
+        assert result.iterations == 2
+        assert len(agent.usage_records) == 2  # the agent really stopped
+        assert "token budget exceeded" in result.budget_halt_reason
+        assert "600" in result.budget_halt_reason
+        assert result.usage.total_tokens == 600
+
+    def test_spend_from_earlier_components_counts(self, tmp_path: Path) -> None:
+        """The cap is run-level: a worker launched with 450 tokens
+        already on the run's meter has 50 left, not 500."""
+        agent = FakeUsageAgent(outputs=[["working..."]], record=_REPORTED)
+        result = run_loop(
+            _loop_config(tmp_path, 10), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(
+                max_total_tokens=500, prior_total_tokens=450,
+                prior_known_calls=1,
+            ),
+        )
+        assert result.iterations == 1
+        assert len(agent.usage_records) == 1
+        assert "750" in result.budget_halt_reason
+
+    def test_zero_cap_is_unbounded(self, tmp_path: Path) -> None:
+        agent = FakeUsageAgent(outputs=[["working..."]], record=_REPORTED)
+        result = run_loop(
+            _loop_config(tmp_path, 3), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(max_total_tokens=0),
+        )
+        assert result.iterations == 3
+        assert result.budget_halt_reason == ""
+
+    def test_no_budget_argument_keeps_pre_r8_behaviour(
+        self, tmp_path: Path,
+    ) -> None:
+        """`ks run` / `ks feature` pass no budget; nothing changes."""
+        agent = FakeUsageAgent(outputs=[["working..."]], record=_REPORTED)
+        result = run_loop(
+            _loop_config(tmp_path, 3), PlainUI(no_color=True), agent, tmp_path,
+        )
+        assert result.iterations == 3
+        assert result.budget_halt_reason == ""
+
+    def test_completion_in_the_breaching_iteration_still_completes(
+        self, tmp_path: Path,
+    ) -> None:
+        """Ordering: an iteration that finished the work is a success.
+        The overrun is then caught by the phase-boundary check, which is
+        exactly the pre-R8 path - the loop does not retro-fail work that
+        is already done."""
+        agent = FakeUsageAgent(
+            outputs=[[COMPLETION_MARKER]], record=_REPORTED,
+        )
+        result = run_loop(
+            _loop_config(tmp_path, 5), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(max_total_tokens=100),
+        )
+        assert result.completed is True
+        assert result.budget_halt_reason == ""
+
+    def test_wholly_unreported_usage_halts_as_unenforceable(
+        self, tmp_path: Path,
+    ) -> None:
+        """Unknown usage is NOT treated as zero when nothing at all has
+        reported: a cap that provably cannot trip is the defect being
+        fixed, so the loop halts loudly instead of running to
+        max_iterations under a dead ceiling."""
+        agent = SequenceUsageAgent([_UNREPORTED])
+        result = run_loop(
+            _loop_config(tmp_path, 10), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(max_total_tokens=500),
+        )
+        assert result.completed is False
+        assert result.iterations == 2  # _UNENFORCEABLE_CALLS
+        assert "unenforceable" in result.budget_halt_reason
+        assert result.usage.total_tokens == 0
+        assert result.usage.unreported_calls == 2
+
+    def test_one_silent_call_is_an_incident_not_a_dead_cap(
+        self, tmp_path: Path,
+    ) -> None:
+        """A single non-reporting call (a timed-out or unparseable
+        iteration on an adapter that normally reports) must not kill the
+        run: iteration 2 reports, the cap is demonstrably alive, and the
+        loop continues until the arithmetic trips it."""
+        agent = SequenceUsageAgent([_UNREPORTED, _REPORTED])
+        result = run_loop(
+            _loop_config(tmp_path, 10), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(max_total_tokens=500),
+        )
+        assert result.iterations == 3  # 0 + 300 + 300 >= 500
+        assert "token budget exceeded" in result.budget_halt_reason
+        assert result.usage.unreported_calls == 1
+
+    def test_unreported_usage_is_free_when_the_cap_is_off(
+        self, tmp_path: Path,
+    ) -> None:
+        """The unenforceable halt is a property of an ENABLED cap. With
+        no cap there is nothing to enforce and a non-reporting adapter
+        (CustomAgent) runs exactly as before."""
+        agent = SequenceUsageAgent([_UNREPORTED])
+        result = run_loop(
+            _loop_config(tmp_path, 3), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(max_total_tokens=0),
+        )
+        assert result.iterations == 3
+        assert result.budget_halt_reason == ""
+
+    def test_mixed_reporting_counts_unknown_as_zero_and_keeps_going(
+        self, tmp_path: Path,
+    ) -> None:
+        """One unreported iteration among reporting ones does not halt:
+        the total stays a documented lower bound that still grows toward
+        the cap. Here 300 (reported) + unknown + 300 trips at iteration
+        3, one iteration later than the true spend would have."""
+        agent = SequenceUsageAgent([_REPORTED, _UNREPORTED, _REPORTED])
+        result = run_loop(
+            _loop_config(tmp_path, 10), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(max_total_tokens=500),
+        )
+        assert result.iterations == 3
+        assert "token budget exceeded" in result.budget_halt_reason
+        assert result.usage.calls == 3
+        assert result.usage.unreported_calls == 1
+        assert result.usage.total_tokens == 600
+
+    def test_prior_reported_calls_disarm_the_unenforceable_halt(
+        self, tmp_path: Path,
+    ) -> None:
+        """An earlier phase reported usage, so the cap CAN trip; this
+        loop's unreported iteration is a lower-bound gap, not proof of a
+        dead cap."""
+        agent = SequenceUsageAgent([_UNREPORTED])
+        result = run_loop(
+            _loop_config(tmp_path, 3), PlainUI(no_color=True), agent, tmp_path,
+            budget=LoopBudget(
+                max_total_tokens=500, prior_total_tokens=100,
+                prior_known_calls=1,
+            ),
+        )
+        assert result.iterations == 3
+        assert result.budget_halt_reason == ""
+
+    def test_iteration_usage_callback_sees_cumulative_totals(
+        self, tmp_path: Path,
+    ) -> None:
+        seen: list[int] = []
+        agent = FakeUsageAgent(outputs=[["working..."]], record=_REPORTED)
+        run_loop(
+            _loop_config(tmp_path, 3), PlainUI(no_color=True), agent, tmp_path,
+            on_iteration_usage=lambda totals: seen.append(totals.total_tokens),
+        )
+        assert seen == [300, 600, 900]
+
+    def test_iteration_usage_callback_failure_never_breaks_the_loop(
+        self, tmp_path: Path,
+    ) -> None:
+        def explode(totals: UsageTotals) -> None:
+            raise OSError("disk full")
+
+        agent = FakeUsageAgent(outputs=[["working..."]], record=_REPORTED)
+        result = run_loop(
+            _loop_config(tmp_path, 2), PlainUI(no_color=True), agent, tmp_path,
+            on_iteration_usage=explode,
+        )
+        assert result.iterations == 2
+
+
+class TestWorkerPropagatesInLoopHalt:
+    def _worker_args(self, root: Path, **overrides: Any) -> dict[str, Any]:
+        args: dict[str, Any] = dict(
+            component_id="comp-a",
+            prd_path_str="scripts/kstrl/feature/comp-a/prd.json",
+            worktree_path_str=str(root),
+            root_dir_str=str(root),
+            prompt_file_str="scripts/kstrl/prompt.md",
+            agent_cmd="echo hi",
+            model=None, reasoning=None, agent_type=None,
+            sleep_seconds=0.0,
+            max_iterations=10,
+            events_dir_str=None,
+            run_id="run-b",
+            redirect_output=False,  # NEVER dup2 inside the test process
+        )
+        args.update(overrides)
+        return args
+
+    def test_worker_reports_budget_exceeded_and_stops_early(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _setup_project(tmp_path, ["comp-a"])
+        agent = FakeUsageAgent(outputs=[["working..."]], record=_REPORTED)
+
+        with patch("kstrl.agents.get_agent", return_value=agent):
+            result = _run_component(**self._worker_args(
+                root, token_budget=LoopBudget(max_total_tokens=500),
+            ))
+
+        assert result.success is False
+        assert result.budget_exceeded is True
+        assert result.iterations == 2  # not the configured 10
+        assert "token budget exceeded" in (result.error or "")
+        assert result.usage is not None
+        assert result.usage.total_tokens == 600
+
+    def test_worker_without_a_budget_runs_to_max_iterations(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _setup_project(tmp_path, ["comp-a"])
+        agent = FakeUsageAgent(outputs=[["working..."]], record=_REPORTED)
+
+        with patch("kstrl.agents.get_agent", return_value=agent):
+            result = _run_component(**self._worker_args(
+                root, max_iterations=3,
+            ))
+
+        assert result.budget_exceeded is False
+        assert result.iterations == 3
+
+    def test_worker_persists_usage_at_every_iteration_boundary(
+        self, tmp_path: Path,
+    ) -> None:
+        """The durable snapshot the abort path reads back."""
+        root = _setup_project(tmp_path, ["comp-a"])
+        events_dir = root / ".kstrl" / "runs" / "run-b"
+        agent = FakeUsageAgent(outputs=[["working..."]], record=_REPORTED)
+
+        with patch("kstrl.agents.get_agent", return_value=agent):
+            _run_component(**self._worker_args(
+                root, max_iterations=2, events_dir_str=str(events_dir),
+            ))
+
+        snapshot = _read_partial_usage(
+            RunPaths(root=events_dir).engineer_usage("comp-a")
+        )
+        assert snapshot is not None
+        assert snapshot.total_tokens == 600
+        assert snapshot.calls == 2
+
+
+class TestSchedulerHandsDownTheBudget:
+    def test_worker_is_told_the_cap_and_what_the_run_already_spent(
+        self, tmp_path: Path,
+    ) -> None:
+        """The cap is run-level, so the second worker must launch with
+        the first component's spend already on its meter - otherwise the
+        in-loop check degrades to a per-component budget. Also pins the
+        positional contract between _submit_args and _run_component: the
+        budget is the last element of the submit tuple, which is how the
+        process-pool path passes it."""
+        root = _setup_project(tmp_path, ["comp-a", "comp-b"])
+        manifest = _make_manifest([
+            _component("comp-a"), _component("comp-b", deps=["comp-a"]),
+        ])
+        config = _factory_config(root, max_total_tokens=100_000)
+        budgets: list[Any] = []
+
+        def fake_run_component(*args: Any, **kwargs: Any) -> ComponentResult:
+            budgets.append(args[-1])
+            return ComponentResult(
+                str(args[0]), success=True, iterations=1,
+                usage=_engineer_usage(700),
+            )
+
+        with patch(
+            "kstrl.factory._run_component", side_effect=fake_run_component,
+        ), patch("kstrl.git.get_diff_content", return_value=""):
+            run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert len(budgets) == 2
+        assert all(isinstance(b, LoopBudget) for b in budgets)
+        assert budgets[0] == LoopBudget(
+            max_total_tokens=100_000, prior_total_tokens=0,
+            prior_known_calls=0,
+        )
+        assert budgets[1] == LoopBudget(
+            max_total_tokens=100_000, prior_total_tokens=700,
+            prior_known_calls=1,
+        )
+
+    def test_no_cap_still_hands_down_a_disabled_budget(
+        self, tmp_path: Path,
+    ) -> None:
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        budgets: list[Any] = []
+
+        def fake_run_component(*args: Any, **kwargs: Any) -> ComponentResult:
+            budgets.append(args[-1])
+            return ComponentResult(str(args[0]), success=True, iterations=1)
+
+        with patch(
+            "kstrl.factory._run_component", side_effect=fake_run_component,
+        ), patch("kstrl.git.get_diff_content", return_value=""):
+            run_factory(
+                manifest, _factory_config(root), _make_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert [b.enabled for b in budgets] == [False]
+
+
+class TestInLoopHaltAuditState:
+    def test_same_audit_state_as_a_phase_boundary_breach(
+        self, tmp_path: Path,
+    ) -> None:
+        """An in-loop halt must be indistinguishable, downstream, from
+        the R3.1 phase-boundary halt: BudgetExceeded event, one typed
+        infrastructure_error finding, exactly one budget_overrun inbox
+        item, and no duplicate halted_run.
+
+        The cap here is huge and the reported spend tiny, so ONLY the
+        typed flag can route this - the parent's own totals show no
+        breach (the unreportable-usage case).
+        """
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root, max_total_tokens=1_000_000)
+        reason = (
+            "token budget unenforceable: none of the 1 agent call(s) in "
+            "this run reported any token usage, so max_total_tokens "
+            "(1000000) can never trip on this adapter; halting rather "
+            "than spending under a cap that cannot fire (R8)"
+        )
+        halted = ComponentResult(
+            "comp-a", success=False, iterations=1, error=reason,
+            usage=_engineer_usage(10), budget_exceeded=True,
+        )
+
+        with patch(
+            "kstrl.factory._run_component", return_value=halted,
+        ), patch("kstrl.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert "comp-a" in result.failed
+        comp_a = manifest.get_component("comp-a")
+        assert comp_a is not None
+        assert comp_a.status == ComponentStatus.FAILED.value
+        assert comp_a.failed_phase == "engineer"
+        assert comp_a.failed_check == "token_budget"
+        # The recorded error is the loop's reason, not a derived
+        # "10 >= 1000000" sentence that would be false.
+        assert comp_a.error == reason
+        budget_findings = [
+            f for f in comp_a.findings
+            if f.is_infrastructure_error and "token budget" in f.explanation
+        ]
+        assert len(budget_findings) == 1
+        assert budget_findings[0].phase == "engineer"
+
+        events = ProgressLog(root / "progress.jsonl").read_events()
+        breaches = [e for e in events if e["event"] == "budget_exceeded"]
+        assert len(breaches) == 1
+        assert breaches[0]["data"]["max_total_tokens"] == 1_000_000
+
+        kinds = [str(i.kind) for i in Inbox(root, InboxConfig()).open_items()]
+        assert kinds == ["budget_overrun"]
+
+        # The spend that got us here is still on the meter.
+        entries = _read_journal(root)
+        comp_entry = next(e for e in entries if e["component_id"] == "comp-a")
+        assert comp_entry["usage"]["engineer"]["total_tokens"] == 10
+
+    def test_no_retry_is_burned_on_an_in_loop_halt(
+        self, tmp_path: Path,
+    ) -> None:
+        """Retrying cannot un-spend tokens; the component fails outright
+        even with retries available."""
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        config = _factory_config(root, max_total_tokens=1_000_000, max_retries=3)
+        calls: list[str] = []
+
+        def fake_run_component(*args: Any, **kwargs: Any) -> ComponentResult:
+            calls.append(str(args[0]))
+            return ComponentResult(
+                "comp-a", success=False, iterations=1,
+                error="token budget unenforceable (R8)",
+                usage=_engineer_usage(10), budget_exceeded=True,
+            )
+
+        with patch(
+            "kstrl.factory._run_component", side_effect=fake_run_component,
+        ), patch("kstrl.git.get_diff_content", return_value=""):
+            run_factory(
+                manifest, config, _make_base_config(root),
+                PlainUI(no_color=True), root,
+            )
+
+        assert calls == ["comp-a"]
+        comp_a = manifest.get_component("comp-a")
+        assert comp_a is not None
+        assert comp_a.retries == 0
+
+
+class TestAbortedWorkerUsage:
+    def test_snapshot_roundtrips(self, tmp_path: Path) -> None:
+        totals = _engineer_usage(1234, cost=0.5)
+        path = tmp_path / "engineer_usage.json"
+        _write_partial_usage(path, totals)
+        back = _read_partial_usage(path)
+        assert back is not None
+        assert back.to_dict() == totals.to_dict()
+
+    def test_unusable_snapshots_read_as_none(self, tmp_path: Path) -> None:
+        assert _read_partial_usage(tmp_path / "missing.json") is None
+        torn = tmp_path / "torn.json"
+        torn.write_text('{"calls": 2, "total_tok')
+        assert _read_partial_usage(torn) is None
+        listy = tmp_path / "list.json"
+        listy.write_text("[1, 2]")
+        assert _read_partial_usage(listy) is None
+        empty = tmp_path / "empty.json"
+        empty.write_text('{"calls": 0, "total_tokens": 0}')
+        assert _read_partial_usage(empty) is None  # nothing ran
+
+    def test_unwritable_snapshot_path_is_swallowed(self, tmp_path: Path) -> None:
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        _write_partial_usage(blocker / "sub" / "usage.json", _engineer_usage(1))
+
+    def test_killed_worker_spend_recovered_from_the_snapshot(
+        self, tmp_path: Path,
+    ) -> None:
+        run_paths = RunPaths(root=tmp_path)
+        _write_partial_usage(
+            run_paths.engineer_usage("comp-a"), _engineer_usage(700),
+        )
+        pipeline = MagicMock()
+        pipeline.run_paths = run_paths
+        future: Future[ComponentResult] = Future()  # never completes
+
+        _salvage_aborted_usage(future, "comp-a", pipeline)
+
+        pipeline.record_engineer_usage.assert_called_once()
+        comp_id, totals = pipeline.record_engineer_usage.call_args[0]
+        assert comp_id == "comp-a"
+        assert totals.total_tokens == 700
+
+    def test_a_delivered_result_wins_over_the_snapshot(
+        self, tmp_path: Path,
+    ) -> None:
+        """No double counting: a future that DID deliver is
+        authoritative and the (staler) snapshot is ignored."""
+        run_paths = RunPaths(root=tmp_path)
+        _write_partial_usage(
+            run_paths.engineer_usage("comp-a"), _engineer_usage(700),
+        )
+        pipeline = MagicMock()
+        pipeline.run_paths = run_paths
+        future: Future[ComponentResult] = Future()
+        future.set_result(ComponentResult(
+            "comp-a", success=False, usage=_engineer_usage(900),
+        ))
+
+        _salvage_aborted_usage(future, "comp-a", pipeline)
+
+        pipeline.record_engineer_usage.assert_called_once()
+        assert pipeline.record_engineer_usage.call_args[0][1].total_tokens == 900
+
+    def test_crashed_worker_records_nothing(self, tmp_path: Path) -> None:
+        pipeline = MagicMock()
+        pipeline.run_paths = RunPaths(root=tmp_path)
+        future: Future[ComponentResult] = Future()
+        future.set_exception(RuntimeError("worker died"))
+
+        _salvage_aborted_usage(future, "comp-a", pipeline)
+
+        pipeline.record_engineer_usage.assert_not_called()
+
+    def test_stop_mid_run_keeps_the_aborted_component_spend(
+        self, tmp_path: Path,
+    ) -> None:
+        """End to end: the shutdown path used to drop the worker's
+        usage on the floor. Now it lands on the meter."""
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+        stop = StopController()
+
+        def slow_component(comp_id: str, *a: Any, **k: Any) -> ComponentResult:
+            stop.request("mid-run test stop")
+            time.sleep(0.2)
+            return ComponentResult(
+                comp_id, success=True, iterations=1,
+                usage=_engineer_usage(4242),
+            )
+
+        with patch(
+            "kstrl.factory._run_component", side_effect=slow_component,
+        ), patch("kstrl.git.get_diff_content", return_value=""):
+            result = run_factory(
+                manifest, _factory_config(root), _make_base_config(root),
+                PlainUI(no_color=True, file=io.StringIO()), root, stop=stop,
+            )
+
+        assert result.exit_code == 130
+        comp_a = manifest.get_component("comp-a")
+        assert comp_a is not None
+        assert comp_a.failed_phase == "aborted"
+        events = ProgressLog(root / "progress.jsonl").read_events()
+        usage_events = [
+            e for e in events
+            if e["event"] == "component_usage" and e["data"]["phase"] == "engineer"
+        ]
+        assert len(usage_events) == 1
+        assert usage_events[0]["data"]["total_tokens"] == 4242
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The defect

`[factory] max_total_tokens` was a **post-hoc detector, not a limiter**. It was consulted only at parent-process phase boundaries:

- `kstrl/pipeline.py` - after the engineer returns, before review, before security, before distill
- `kstrl/factory.py` - the scheduling gate and the end-of-run summary

`grep max_total_tokens kstrl/loop.py kstrl/agents/*.py` returned empty: the engineer loop and every adapter were structurally unaware of the run-level cap. With `[run] max_iterations = 10` and a 1800s per-iteration timeout, ONE component could spend for hours before the cap was consulted even once. It could stop the next phase; it could never stop the current one.

The only genuine in-loop control, `max_budget_usd`, is claude-sdk only. On the claude-code adapter there was no in-loop limit at all.

## The fix

**Loop side** (`kstrl/loop.py`): a new `LoopBudget` carries the cap plus the run's spend as of the worker's launch. It is evaluated BETWEEN iterations - after the completion return, before the no-progress breaker's stall probe - so a blown budget pays for neither another agent call nor another breaker test command.

**Unknown usage is not silently zero.** Calls that report nothing count as zero while *other* calls do report (the total stays a documented lower bound that still grows toward the cap). But if nothing in the whole run has reported after two agent calls, the cap provably cannot trip - a custom `agent_cmd` never reports usage - and the loop halts on *that* instead of pretending to enforce. One silent call stays an incident: the claude adapter records no counts for a timed-out or unparseable result, and a single bad iteration must not end a capped run. The threshold of 2 is a judgment call, documented as such next to the constant.

**Wiring**: `_submit_args` snapshots the budget per launch, `_run_component` forwards it and reports `ComponentResult.budget_exceeded`, and `process_result` routes that flag into the **existing** `fail_for_budget`. The audit trail is therefore identical wherever the breach is caught: `BudgetExceeded` event, typed `infrastructure_error` finding, exactly one `budget_overrun` inbox item, no duplicate `halted_run`. `fail_for_budget` gained a `reason` override so the unenforceable case does not record a false "N >= cap" sentence.

## What the cap actually guarantees now

**It is not a hard cap.** The engineer loop starts no new iteration once the run's reported spend reaches the cap. What stays unbounded, stated in the code, `kstrl.toml.example`, `docs/env-vars.md`, and `docs/sdk-spike.md`:

| Gap | Why |
|---|---|
| The iteration already in flight | Nothing interrupts a single agent call mid-run. Overshoot is up to one iteration per running worker; `agent_iteration` bounds that in wall clock, never in tokens |
| Concurrent workers | Each sees the run total as of its own launch. With `max_parallel = N`, up to N iterations can be in flight past the cap |
| Unreported spend | Every figure is a CLI self-report; totals are lower bounds whenever `unreported_calls > 0` |

`[agent] budget_usd` remains the only genuine per-turn ceiling, and only the claude-sdk adapter enforces it.

## Secondary: abort-path usage loss (fixed)

`_abort_inflight` killed the worker and cancelled its future without reading a result, so `usage_records` died with the process while organic failures carried usage correctly. Workers now publish an atomic per-iteration usage snapshot (mkstemp + `os.replace`). It is deliberately a **file, not an event**: the reducer sums `component_usage`, so streaming cumulative snapshots would double count in every rollup. On abort, a future that already delivered is authoritative; otherwise the snapshot is read back. The two routes are exclusive by construction. Spend inside the interrupted iteration remains unrecoverable - it was never reported to anyone before the kill.

## Behavior change to be aware of

A run with `max_total_tokens` set **and** a non-reporting agent (`agent_cmd`) now halts after two iterations with `token budget unenforceable`, where previously it ran to completion under a decorative cap. Runs without a cap (`= 0`, the default) are unaffected.

## Tests

26 new behavioral tests in `tests/test_usage_meter.py`: the loop stops early (iteration count asserted, not just the flag), prior-component spend counts, the unenforceable / mixed-reporting / one-silent-call policies, the scheduler hands down the right budget with the right prior spend, the in-loop halt produces the same audit state as the phase-boundary halt, and the abort path keeps the spend.

Verified by mutation, not by presence: disabling the in-loop check fails 5 tests, reverting the pipeline routing fails 2, removing the abort salvage fails 1. Existing budget tests are unmodified.

## Gates

- `uv run pytest tests/ -q` - **2200 passed, 28 skipped, 0 failed** (baseline 2174 passed)
- `uv run mypy kstrl/ --strict` - clean, 107 source files
- `uv run ruff check kstrl/ tests/ scripts/` - clean

No adversarial prompt was touched, so no calibration run is implicated (H2/H3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)