### PR TITLE
fix: one agent-type vocabulary; reject unknown types instead of guessing

### DIFF
--- a/kstrl/agents/__init__.py
+++ b/kstrl/agents/__init__.py
@@ -8,6 +8,10 @@ from kstrl.agents.custom import CustomAgent
 from kstrl.sandbox import SandboxConfig
 
 __all__ = [
+    "AGENT_TYPE_ALIASES",
+    "UnknownAgentTypeError",
+    "VALID_AGENT_TYPES",
+    "canonical_agent_type",
     "Agent",
     "ClaudeCodeAgent",
     "ClaudeSdkAgent",
@@ -15,6 +19,46 @@ __all__ = [
     "CustomAgent",
     "get_agent",
 ]
+
+
+class UnknownAgentTypeError(ValueError):
+    """``[agent] type`` names an adapter that does not exist.
+
+    Raised rather than tolerated because the old behavior was the worst
+    possible one: an unrecognized type fell through every branch to the
+    codex fallback, so `type = "claude"` silently ran Codex while the
+    operator believed they were running Claude. A typo changed which
+    model wrote the code and nothing said so.
+    """
+
+
+#: The one agent-type vocabulary, shared with the CLI preflight. Two
+#: layers previously disagreed: the CLI accepted "claude" as an alias for
+#: "claude-code", while get_agent did not and fell through to the codex
+#: fallback, so a programmatic caller passing the DOCUMENTED spelling got
+#: a different model than the CLI would have chosen. One table, one
+#: vocabulary.
+AGENT_TYPE_ALIASES: dict[str, str] = {
+    "": "auto",
+    "auto": "auto",
+    "claude": "claude-code",
+    "claude-code": "claude-code",
+    "claude-sdk": "claude-sdk",
+    "codex": "codex",
+    "custom": "custom",
+}
+
+#: Accepted spellings for ``[agent] type``.
+VALID_AGENT_TYPES: tuple[str, ...] = tuple(
+    sorted(name for name in AGENT_TYPE_ALIASES if name)
+)
+
+
+def canonical_agent_type(agent_type: str | None) -> str | None:
+    """Canonical spelling for a configured type, or None if unknown."""
+    if agent_type is None:
+        return None
+    return AGENT_TYPE_ALIASES.get(agent_type.strip().lower())
 
 
 def get_agent(
@@ -50,6 +94,25 @@ def get_agent(
     """
     if agent_cmd:
         return CustomAgent(agent_cmd)
+    if agent_type is not None:
+        canonical = canonical_agent_type(agent_type)
+        if canonical is None:
+            raise UnknownAgentTypeError(
+                f"unknown [agent] type {agent_type!r}; expected one of "
+                f"{', '.join(VALID_AGENT_TYPES)}. Leave it unset (or use "
+                "'auto') to auto-detect. This raises rather than falling "
+                "back because an unrecognized type used to resolve silently "
+                "to the codex adapter - a typo changed which model wrote "
+                "your code and nothing said so."
+            )
+        if canonical == "custom":
+            raise UnknownAgentTypeError(
+                'agent type "custom" is configured but no agent command is '
+                "set; set [agent] command in kstrl.toml, AGENT_CMD, or "
+                "--agent-cmd. Without one there is nothing to run, and this "
+                "used to fall through to the codex adapter instead of saying so."
+            )
+        agent_type = canonical
     if agent_type == "claude-code":
         return ClaudeCodeAgent(
             model=model, effort=model_reasoning_effort, sandbox=sandbox,

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -21,6 +21,7 @@ from click.core import ParameterSource
 
 from kstrl import __version__
 from kstrl.agents import (
+    AGENT_TYPE_ALIASES,
     ClaudeCodeAgent,
     ClaudeSdkAgent,
     CodexAgent,
@@ -102,15 +103,10 @@ def _use_cli_value(ctx: click.Context, name: str) -> bool:
 # kstrl.toml documents "claude" | "codex" | "custom"; the --agent-type
 # flags and KSTRL_AGENT_TYPE historically use "claude-code" | "codex" |
 # "auto". Both families resolve to get_agent's vocabulary here.
-_AGENT_TYPE_ALIASES: dict[str, str] = {
-    "": "auto",
-    "auto": "auto",
-    "claude": "claude-code",
-    "claude-code": "claude-code",
-    "claude-sdk": "claude-sdk",
-    "codex": "codex",
-    "custom": "custom",
-}
+# One vocabulary, defined next to the adapters it selects (R8 review):
+# the CLI and get_agent previously kept separate tables and disagreed
+# about "claude".
+_AGENT_TYPE_ALIASES = AGENT_TYPE_ALIASES
 
 
 def _agent_preflight(

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -319,14 +319,49 @@ def _cli_family(
     unknown family (None); "claude-sdk" is the Claude family through
     the SDK transport (R7.6 - without this branch it would fall through
     to codex and INVERT the R7.1 rotation for SDK engineers);
-    "auto"/None auto-detects claude-code first; any unrecognized type
-    string falls through to codex."""
+    "auto"/None auto-detects claude-code first.
+
+    Canonicalizes through the SAME table ``get_agent`` uses, and that is
+    load-bearing rather than tidiness. This function decides which family
+    the ENGINEER belongs to, and the R7.1 rotation then picks a reviewer
+    from the other family. If the two disagree - as they did when
+    ``get_agent`` learned the "claude" alias and this mirror did not -
+    a Claude engineer is recorded as codex, the rotation "cross-family"
+    reviewer resolves to claude-code, and the run gets SAME-family review
+    while reporting the opposite. Correlated blind spots are exactly what
+    R7.1 exists to avoid, so a silent mismatch here is worse than a
+    crash: the safety property fails while the audit trail says it held.
+
+    An unrecognized type raises, matching ``get_agent`` - a config that
+    cannot construct an agent must not first be assigned a family.
+    """
+    # Imported here, matching this module's lazy-agent-import pattern.
+    from kstrl.agents import (
+        VALID_AGENT_TYPES,
+        UnknownAgentTypeError,
+        canonical_agent_type,
+    )
+
     if agent_cmd:
         return None
-    if agent_type in ("claude-code", "claude-sdk"):
-        return "claude-code"
-    if agent_type in (None, "auto"):
+    if agent_type is None:
+        # Unset means auto-detect, NOT unknown. canonical_agent_type
+        # returns None for both, so they must be split before the
+        # unknown-type check or the ordinary "no [agent] type
+        # configured" case would raise.
         return "claude-code" if claude_available else "codex"
+    canonical = canonical_agent_type(agent_type)
+    if canonical is None:
+        raise UnknownAgentTypeError(
+            f"unknown agent type {agent_type!r}; expected one of "
+            f"{', '.join(VALID_AGENT_TYPES)}"
+        )
+    if canonical in ("claude-code", "claude-sdk"):
+        return "claude-code"
+    if canonical == "auto":
+        return "claude-code" if claude_available else "codex"
+    if canonical == "custom":
+        return None
     return "codex"
 
 
@@ -1116,7 +1151,9 @@ def _run_component(
     can halt itself BETWEEN iterations instead of waiting for the
     parent's next phase boundary. None disables the in-loop check.
     """
-    from kstrl.agents import get_agent
+    from kstrl.agents import (
+    get_agent,
+)
     from kstrl.loop import run_loop
     from kstrl.ui.bridge import EventBridgeUI, NullPrompter
     from kstrl.ui.plain import PlainUI

--- a/tests/test_agent_type_validation.py
+++ b/tests/test_agent_type_validation.py
@@ -1,0 +1,116 @@
+"""Agent-type resolution: one vocabulary, no silent substitution.
+
+Two layers used to disagree. The CLI preflight canonicalized "claude" to
+"claude-code" via a private alias table; `get_agent` did not, and its
+final fallthrough returned the codex adapter. A caller that did not go
+through the CLI - a test, a programmatic embedder, any future entry
+point - therefore got a DIFFERENT MODEL than the documented spelling
+names, silently.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kstrl.agents import (
+    AGENT_TYPE_ALIASES,
+    VALID_AGENT_TYPES,
+    ClaudeCodeAgent,
+    ClaudeSdkAgent,
+    CodexAgent,
+    CustomAgent,
+    UnknownAgentTypeError,
+    canonical_agent_type,
+    get_agent,
+)
+
+
+class TestDocumentedSpellingsResolve:
+    @pytest.mark.parametrize(
+        "agent_type,expected",
+        [
+            ("claude", ClaudeCodeAgent),      # the alias that used to give Codex
+            ("claude-code", ClaudeCodeAgent),
+            ("claude-sdk", ClaudeSdkAgent),
+            ("codex", CodexAgent),
+        ],
+    )
+    def test_type_selects_its_adapter(
+        self, agent_type: str, expected: type,
+    ) -> None:
+        assert isinstance(get_agent(agent_type=agent_type), expected)
+
+    def test_claude_alias_is_not_codex(self) -> None:
+        # The regression in one line: this returned CodexAgent.
+        assert isinstance(get_agent(agent_type="claude"), ClaudeCodeAgent)
+
+    @pytest.mark.parametrize("spelling", ["CLAUDE", " claude ", "Claude-Code"])
+    def test_case_and_whitespace_tolerated(self, spelling: str) -> None:
+        assert isinstance(get_agent(agent_type=spelling), ClaudeCodeAgent)
+
+    def test_auto_and_none_autodetect(self) -> None:
+        for value in ("auto", None):
+            agent = get_agent(agent_type=value)
+            assert isinstance(agent, (ClaudeCodeAgent, CodexAgent))
+
+
+class TestUnknownTypesRaise:
+    @pytest.mark.parametrize("bad", ["typo-here", "claude4", "gpt", "sonnet"])
+    def test_unknown_type_is_an_error_not_a_fallback(self, bad: str) -> None:
+        with pytest.raises(UnknownAgentTypeError, match="unknown"):
+            get_agent(agent_type=bad)
+
+    def test_error_lists_the_valid_spellings(self) -> None:
+        with pytest.raises(UnknownAgentTypeError) as exc:
+            get_agent(agent_type="nope")
+        message = str(exc.value)
+        for spelling in ("claude-code", "codex", "auto"):
+            assert spelling in message
+
+    def test_error_does_not_advertise_the_empty_alias(self) -> None:
+        # "" maps to auto internally; showing it in a list of valid
+        # values would be nonsense to read.
+        assert "" not in VALID_AGENT_TYPES
+        with pytest.raises(UnknownAgentTypeError) as exc:
+            get_agent(agent_type="nope")
+        assert "one of ," not in str(exc.value)
+
+    def test_custom_without_a_command_raises(self) -> None:
+        # Previously fell through to the codex adapter.
+        with pytest.raises(UnknownAgentTypeError, match="no agent command"):
+            get_agent(agent_type="custom")
+
+    def test_custom_with_a_command_works(self) -> None:
+        assert isinstance(get_agent("echo hi", agent_type="custom"), CustomAgent)
+
+    def test_an_explicit_command_wins_regardless_of_type(self) -> None:
+        # agent_cmd short-circuits before any type validation, which is
+        # the pre-existing contract.
+        assert isinstance(get_agent("echo hi", agent_type="nonsense"), CustomAgent)
+
+
+class TestOneVocabulary:
+    def test_cli_uses_the_shared_table(self) -> None:
+        from kstrl.cli import _AGENT_TYPE_ALIASES
+
+        assert _AGENT_TYPE_ALIASES is AGENT_TYPE_ALIASES
+
+    @pytest.mark.parametrize("spelling", sorted(AGENT_TYPE_ALIASES))
+    def test_every_alias_resolves_or_raises_deliberately(
+        self, spelling: str,
+    ) -> None:
+        """No alias may reach the fallthrough by accident.
+
+        "custom" raises without a command; everything else constructs.
+        """
+        canonical = canonical_agent_type(spelling)
+        assert canonical is not None
+        if canonical == "custom":
+            with pytest.raises(UnknownAgentTypeError):
+                get_agent(agent_type=spelling)
+        else:
+            assert get_agent(agent_type=spelling) is not None
+
+    def test_canonical_agent_type_rejects_unknown(self) -> None:
+        assert canonical_agent_type("typo") is None
+        assert canonical_agent_type(None) is None

--- a/tests/test_agent_type_validation.py
+++ b/tests/test_agent_type_validation.py
@@ -145,17 +145,30 @@ class TestFamilyResolverMatchesTheAdapter:
     def test_family_agrees_with_the_constructed_adapter(
         self, agent_type: str | None,
     ) -> None:
+        """Both sides must read the SAME environment.
+
+        `auto`/None auto-detect, so `get_agent` consults
+        `ClaudeCodeAgent.is_available()` for real. Passing a hardcoded
+        `claude_available=True` made this pass on a machine with the
+        claude CLI installed and fail in CI without it - an
+        environment-dependent test, which is its own defect. The flag is
+        taken from the same source the adapter uses.
+        """
         from kstrl.factory import _cli_family
 
-        assert _cli_family(None, agent_type, True) == self._expected_family(
-            agent_type
-        )
+        claude_available = ClaudeCodeAgent.is_available()
+        assert _cli_family(
+            None, agent_type, claude_available,
+        ) == self._expected_family(agent_type)
 
     def test_claude_alias_is_the_claude_family(self) -> None:
         # The regression in one line: this returned "codex".
         from kstrl.factory import _cli_family
 
+        # An explicit type never auto-detects, so the availability flag
+        # is irrelevant here - assert under both to prove it.
         assert _cli_family(None, "claude", True) == "claude-code"
+        assert _cli_family(None, "claude", False) == "claude-code"
 
     def test_unset_type_still_autodetects(self) -> None:
         """None means auto-detect, not unknown.
@@ -186,7 +199,7 @@ class TestFamilyResolverMatchesTheAdapter:
         reviewer when both CLIs are installed."""
         from kstrl.factory import _cli_family
 
-        engineer_family = _cli_family(None, "claude", True)
+        engineer_family = _cli_family(None, "claude", ClaudeCodeAgent.is_available())
         assert engineer_family == "claude-code"
         # The rotation's job is to choose the OTHER family; with the old
         # behavior engineer_family was "codex" and it chose claude-code -

--- a/tests/test_agent_type_validation.py
+++ b/tests/test_agent_type_validation.py
@@ -114,3 +114,81 @@ class TestOneVocabulary:
     def test_canonical_agent_type_rejects_unknown(self) -> None:
         assert canonical_agent_type("typo") is None
         assert canonical_agent_type(None) is None
+
+
+class TestFamilyResolverMatchesTheAdapter:
+    """`_cli_family` decides the ENGINEER's family and R7.1 then picks a
+    reviewer from the OTHER family. If it disagrees with `get_agent`, the
+    run gets SAME-family review while the audit trail claims otherwise -
+    the correlated-blind-spot failure R7.1 exists to prevent.
+
+    Review regression: `get_agent` learned the "claude" alias while this
+    mirror kept its own literal tuple, so a Claude engineer resolved as
+    codex and the "cross-family" reviewer came back claude-code. The two
+    had previously agreed by both being wrong, which is why fixing only
+    one side made the safety property fail rather than merely mislabel.
+    """
+
+    @staticmethod
+    def _expected_family(agent_type: str | None) -> str:
+        return (
+            "codex"
+            if isinstance(get_agent(agent_type=agent_type), CodexAgent)
+            else "claude-code"
+        )
+
+    @pytest.mark.parametrize(
+        "agent_type",
+        ["claude", "CLAUDE", " claude-code ", "claude-code", "claude-sdk",
+         "codex", "auto", None],
+    )
+    def test_family_agrees_with_the_constructed_adapter(
+        self, agent_type: str | None,
+    ) -> None:
+        from kstrl.factory import _cli_family
+
+        assert _cli_family(None, agent_type, True) == self._expected_family(
+            agent_type
+        )
+
+    def test_claude_alias_is_the_claude_family(self) -> None:
+        # The regression in one line: this returned "codex".
+        from kstrl.factory import _cli_family
+
+        assert _cli_family(None, "claude", True) == "claude-code"
+
+    def test_unset_type_still_autodetects(self) -> None:
+        """None means auto-detect, not unknown.
+
+        `canonical_agent_type` returns None for BOTH "unset" and
+        "unrecognized", so splitting them is load-bearing: without it the
+        ordinary no-type-configured case raises.
+        """
+        from kstrl.factory import _cli_family
+
+        assert _cli_family(None, None, True) == "claude-code"
+        assert _cli_family(None, None, False) == "codex"
+
+    def test_unknown_type_raises_like_get_agent(self) -> None:
+        from kstrl.factory import _cli_family
+
+        with pytest.raises(UnknownAgentTypeError):
+            _cli_family(None, "typo-here", True)
+
+    def test_custom_command_is_an_unknown_family(self) -> None:
+        # Pre-existing contract: a custom command's family cannot be known.
+        from kstrl.factory import _cli_family
+
+        assert _cli_family("echo hi", "claude", True) is None
+
+    def test_rotation_picks_a_genuinely_different_family(self) -> None:
+        """End of the chain: a "claude" engineer must not get a Claude
+        reviewer when both CLIs are installed."""
+        from kstrl.factory import _cli_family
+
+        engineer_family = _cli_family(None, "claude", True)
+        assert engineer_family == "claude-code"
+        # The rotation's job is to choose the OTHER family; with the old
+        # behavior engineer_family was "codex" and it chose claude-code -
+        # the same family the engineer actually used.
+        assert engineer_family != "codex"


### PR DESCRIPTION
Two layers disagreed about what `[agent] type` means, and the disagreement silently changed which model wrote your code.

`kstrl/cli.py` kept a private `_AGENT_TYPE_ALIASES` table canonicalizing `"claude"` to `"claude-code"`. `get_agent` had no such table, and its final unguarded `return CodexAgent(...)` swallowed anything unrecognized:

```
get_agent(agent_type="claude")     -> CodexAgent
get_agent(agent_type="typo-here")  -> CodexAgent
get_agent(agent_type="custom")     -> CodexAgent   (no command set)
```

Any caller not routed through the CLI preflight - a test, an embedder, a future entry point - got a different model than the documented spelling names, with nothing said. Reproduced before fixing.

**A correction I owe the record:** earlier in this cycle I described `type = "claude"` as "not a valid type" and treated it as a broken config. It is a **supported alias**. The defect was never the spelling; it was that only one of two layers honored it. I repeated that mischaracterization several times without checking it against the alias table.

## The fix

- `AGENT_TYPE_ALIASES` and `canonical_agent_type` now live beside the adapters they select, and the CLI imports the same object. A test pins `_AGENT_TYPE_ALIASES is AGENT_TYPE_ALIASES`, so the two tables cannot drift apart again.
- `get_agent` canonicalizes, then **raises** `UnknownAgentTypeError` on a genuine typo rather than falling back. A fallback that silently swaps the model is worse than a loud failure - you cannot debug a wrong answer you were never told about.
- `type = "custom"` with no command raises instead of resolving to codex. The CLI already said this; the library did not.
- Case and surrounding whitespace are tolerated.
- `VALID_AGENT_TYPES` excludes the internal `""` alias, so messages do not read "expected one of , auto, ...".

An explicit `agent_cmd` still short-circuits before type validation - pre-existing contract, still covered.

## Why now

This came out of preparing a real factory run. The previous attempt died on environment issues before it could exercise anything, and the surviving question was what else in the startup path fails quietly. This is one answer.

## Tests

27 tests: every documented spelling resolves to its adapter, the `"claude"` regression in one line, case and whitespace handling, unknown types raising with the valid list in the message, custom with and without a command, and a parametrized sweep asserting no alias can reach the fallthrough by accident.

Full suite **2359 passed / 28 skipped / 0 failed**, `mypy --strict` and `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
