### PR TITLE
fix: carry budget-halt condition and ceilings into the progress log

### DIFF
--- a/kstrl/events.py
+++ b/kstrl/events.py
@@ -781,7 +781,8 @@ class V1CompatSink:
             log.budget_exceeded(
                 comp, event.total_tokens, event.max_total_tokens,
                 cost_usd=event.cost_usd, max_cost_usd=event.max_cost_usd,
-                ceiling=event.ceiling,
+                ceiling=event.ceiling, condition=event.condition,
+                ceilings=event.ceilings,
             )
         elif isinstance(event, ContractResult):
             log.contract_result(

--- a/kstrl/observability.py
+++ b/kstrl/observability.py
@@ -6,7 +6,7 @@ import json
 import os
 import subprocess
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -233,18 +233,31 @@ class ProgressLog:
         cost_usd: float = 0.0,
         max_cost_usd: float = 0.0,
         ceiling: str = "",
+        condition: str = "",
+        ceilings: Sequence[str] = (),
     ) -> None:
         """R3.1/R8: a run-level ceiling tripped; the named component was
-        failed with a synthetic budget finding. ``ceiling`` names which
-        one (``max_total_tokens`` / ``max_cost_usd``); it is empty when
-        the halt came from the in-loop unenforceable branch, where no
-        ceiling was numerically breached."""
+        failed with a synthetic budget finding.
+
+        ``ceiling`` is the joined legacy string. ``condition``
+        (``"breached"`` / ``"unenforceable"``) and ``ceilings`` carry the
+        halt structurally, matching :class:`events.BudgetExceeded`.
+
+        This emitter had a hand-written field list, so when the
+        structural pair was added the progress log kept writing only
+        ``ceiling`` - the durable ``events.jsonl`` carried both fields
+        while ``progress.jsonl`` silently dropped them. Caught by a real
+        factory run, not by the suite, because nothing asserted the two
+        sinks agreed.
+        """
         self.emit("budget_exceeded", component_id=component_id, data={
             "total_tokens": total_tokens,
             "max_total_tokens": max_total_tokens,
             "cost_usd": cost_usd,
             "max_cost_usd": max_cost_usd,
             "ceiling": ceiling,
+            "condition": condition,
+            "ceilings": list(ceilings),
         })
 
     def contract_result(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -416,3 +416,95 @@ class TestJsonlSink:
         sink2.close()
         texts = [json.loads(line)["data"]["text"] for line in p.read_text().splitlines()]
         assert texts == ["one", "two"]
+
+
+class TestBothSinksCarryTheSameBudgetHalt:
+    """The durable sink and the progress log must record the same facts.
+
+    Found by a real factory run, not by this suite: `JsonlSink` writes
+    the event via `to_json_line`, so it picked up `condition`/`ceilings`
+    automatically, while `V1CompatSink` delegates to a `ProgressLog`
+    method with a HAND-WRITTEN field list that was never updated. The
+    durable events.jsonl carried both fields; progress.jsonl silently
+    dropped them.
+
+    Nothing asserted the two agreed, which is why a whole-field
+    divergence survived a green suite. These tests fix that, and are
+    written to fail for ANY future field added to one sink and not the
+    other - not just this pair.
+    """
+
+    @staticmethod
+    def _emit_both(
+        tmp_path: Path, event: ev.BudgetExceeded,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        from kstrl.observability import ProgressLog
+
+        durable_path = tmp_path / "events.jsonl"
+        progress_path = tmp_path / "progress.jsonl"
+        ev.JsonlSink(durable_path).emit(event)
+        ev.V1CompatSink(ProgressLog(progress_path)).emit(event)
+
+        def payload(path: Path) -> dict[str, Any]:
+            for line in path.read_text().splitlines():
+                if not line.strip():
+                    continue
+                row = json.loads(line)
+                if row.get("event") == "budget_exceeded":
+                    return dict(row["data"])
+            raise AssertionError(f"no budget_exceeded line in {path}")
+
+        return payload(durable_path), payload(progress_path)
+
+    def test_a_breach_reaches_both_sinks_identically(
+        self, tmp_path: Path,
+    ) -> None:
+        durable, progress = self._emit_both(tmp_path, ev.BudgetExceeded(
+            component="comp-a", total_tokens=4017316, max_total_tokens=0,
+            cost_usd=5.123713, max_cost_usd=5.0, ceiling="max_cost_usd",
+            condition="breached", ceilings=("max_cost_usd",),
+        ))
+        assert durable == progress
+
+    def test_an_unenforceable_halt_reaches_both_sinks_identically(
+        self, tmp_path: Path,
+    ) -> None:
+        """The multi-ceiling case is where a single-value field loses
+        the most, so it is the one most worth pinning."""
+        durable, progress = self._emit_both(tmp_path, ev.BudgetExceeded(
+            component="comp-a", total_tokens=0, max_total_tokens=500,
+            cost_usd=0.0, max_cost_usd=100.0,
+            ceiling="max_total_tokens, max_cost_usd",
+            condition="unenforceable",
+            ceilings=("max_total_tokens", "max_cost_usd"),
+        ))
+        assert durable == progress
+        assert progress["ceilings"] == ["max_total_tokens", "max_cost_usd"]
+        assert progress["condition"] == "unenforceable"
+
+    def test_every_event_field_survives_the_progress_log(
+        self, tmp_path: Path,
+    ) -> None:
+        """Generic guard: any field added to BudgetExceeded later must
+        appear in BOTH sinks. This is the assertion whose absence let a
+        two-field divergence ship."""
+        import dataclasses
+
+        event = ev.BudgetExceeded(
+            component="comp-a", total_tokens=1, max_total_tokens=2,
+            cost_usd=3.0, max_cost_usd=4.0, ceiling="max_cost_usd",
+            condition="breached", ceilings=("max_cost_usd",),
+        )
+        durable, progress = self._emit_both(tmp_path, event)
+
+        base = {f.name for f in dataclasses.fields(ev.Event)}
+        payload_fields = {
+            f.name for f in dataclasses.fields(event)
+        } - base - {"type"}
+        missing = payload_fields - progress.keys()
+        assert not missing, (
+            f"BudgetExceeded fields missing from progress.jsonl: {missing}. "
+            "Add them to ProgressLog.budget_exceeded and the V1CompatSink "
+            "bridge."
+        )
+        assert payload_fields <= durable.keys()


### PR DESCRIPTION
Found by the first real factory run under the #180 cost ceiling, not by the test suite.

## What happened

The run halted on `max_cost_usd`. The durable substrate recorded the halt correctly:

```json
// .kstrl/runs/<run-id>/events.jsonl
{"ceiling": "max_cost_usd", "condition": "breached", "ceilings": ["max_cost_usd"]}
```

The progress log, from the same halt, recorded only:

```json
// .kstrl/progress.jsonl
{"ceiling": "max_cost_usd"}
```

## Cause

`JsonlSink` serializes the event itself via `to_json_line`, so it picked up the `condition`/`ceilings` pair added in #180 automatically. `V1CompatSink` delegates to `ProgressLog.budget_exceeded`, which has a **hand-written field list** that was never updated. Anything reconstructing a halt from `progress.jsonl` lost both facts - and for a multi-ceiling unenforceable halt, that is the difference between naming both dead ceilings and naming none.

## Why the suite missed it

Nothing asserted the two sinks agreed. Both were tested in isolation, and both passed in isolation.

The new tests assert the two payloads are **equal**, not merely well-formed. The third is deliberately generic: it walks `BudgetExceeded`'s dataclass fields and fails for any field present in one sink and absent from the other, so the next field added cannot repeat this.

## Also

Corrects the emitter docstring, which still claimed `ceiling` is empty for unenforceable halts. Untrue since #180 - those halts now name every dead ceiling.

## Verification

- 2459 passed, 28 skipped
- `ruff` clean; `mypy --strict` clean across 108 files
- Mutation-checked: reverting the emitter to its pre-fix field list fails all 3 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)