### PR TITLE
fix: write the engineer's progress log inside the component's scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ interactive = false  # human-in-the-loop mode for the legacy loop
 [paths]
 prompt = "scripts/kstrl/prompt.md"              # engineer prompt file
 prd = "scripts/kstrl/prd.json"                  # PRD file
-progress = "scripts/kstrl/progress.txt"         # progress log the agent appends to
+progress = "scripts/kstrl/progress.txt"         # progress log the agent appends to; set = forced on every factory component, unset = each writes beside its own PRD
 codebase_map = "scripts/kstrl/codebase_map.md"  # brownfield codebase notes
 allowed = []                                    # diff-scope allowlist, e.g. ["src/", "tests/"]; empty = unrestricted
 
@@ -319,20 +319,20 @@ allow_network = false  # re-open outbound network inside the sandbox (off = deny
 
 # Phase 1 mechanical verification
 [verify]
-test_command = ""                                  # empty = smart default (uv run pytest)
-typecheck_command = ""                             # empty = smart default (uv run mypy)
-lint_command = ""                                  # empty = smart default (uv run ruff check)
-check_diff_scope = true                            # fail on changes outside allowed paths
-check_bad_patterns = true                          # scan the diff for secret-like patterns
-dead_code_cleanup = false                          # optional dead-code check
-dead_code_command = ""                             # empty = smart default when dead_code_cleanup is on
-mutation_testing = false                           # optional mutation testing
-mutation_threshold = 50.0                          # minimum mutation kill rate (percent)
-mutation_timeout = 600.0                           # seconds for the mutation run
-subprocess_timeout = 300.0                         # seconds per verification subprocess
-require_self_critique = false                      # fail Phase 1 if the ## Self-Critique block is missing/sparse
-self_critique_min_bullets = 3                      # minimum substantive bullets in the block
-progress_file_path = "scripts/kstrl/progress.txt"  # progress file the self-critique check reads
+test_command = ""              # empty = smart default (uv run pytest)
+typecheck_command = ""         # empty = smart default (uv run mypy)
+lint_command = ""              # empty = smart default (uv run ruff check)
+check_diff_scope = true        # fail on changes outside allowed paths
+check_bad_patterns = true      # scan the diff for secret-like patterns
+dead_code_cleanup = false      # optional dead-code check
+dead_code_command = ""         # empty = smart default when dead_code_cleanup is on
+mutation_testing = false       # optional mutation testing
+mutation_threshold = 50.0      # minimum mutation kill rate (percent)
+mutation_timeout = 600.0       # seconds for the mutation run
+subprocess_timeout = 300.0     # seconds per verification subprocess
+require_self_critique = false  # fail Phase 1 if the ## Self-Critique block is missing/sparse
+self_critique_min_bullets = 3  # minimum substantive bullets in the block
+progress_file_path = ""        # progress file the self-critique check reads; empty = the log beside the component's PRD
 
 # Phase 1 approved-fixtures oracle (R7.2; default off)
 [fixtures]

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ interactive = false  # human-in-the-loop mode for the legacy loop
 [paths]
 prompt = "scripts/kstrl/prompt.md"              # engineer prompt file
 prd = "scripts/kstrl/prd.json"                  # PRD file
-progress = "scripts/kstrl/progress.txt"         # progress log the agent appends to; set = forced on every factory component, unset = each writes beside its own PRD
+progress = ""                                   # progress log the agent appends to; empty = each factory component writes beside its own PRD (inside its allowedPaths), set = that one path is forced on every component
 codebase_map = "scripts/kstrl/codebase_map.md"  # brownfield codebase notes
 allowed = []                                    # diff-scope allowlist, e.g. ["src/", "tests/"]; empty = unrestricted
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -16,7 +16,7 @@ Precedence: **CLI flag > env var > `kstrl.toml` > dataclass default**.
 | `MAX_ITERATIONS` | int | 10 | Per-component max agent iterations |
 | `PROMPT_FILE` | path | `scripts/kstrl/prompt.md` | |
 | `PRD_FILE` | path | `scripts/kstrl/prd.json` | |
-| `PROGRESS_FILE` | path | `scripts/kstrl/progress.txt` | |
+| `PROGRESS_FILE` | path | `scripts/kstrl/progress.txt` | Setting it forces that path on every factory component; unset, each component's engineer writes `progress.txt` beside its own PRD, inside the component's `allowedPaths` |
 | `CODEBASE_MAP_FILE` | path | `scripts/kstrl/codebase_map.md` | |
 | `SLEEP_SECONDS` | float | 2.0 | Inter-iteration sleep |
 | `INTERACTIVE` | bool | false | Pause between iterations for human input |
@@ -221,7 +221,7 @@ agent's worktree by construction on both CLIs.
 | `KSTRL_TIMEOUT_VERIFY` | float | 300 |
 | `KSTRL_VERIFY_REQUIRE_SELF_CRITIQUE` | bool (`1`) | false |
 | `KSTRL_VERIFY_SELF_CRITIQUE_MIN_BULLETS` | int | 3 |
-| `KSTRL_VERIFY_PROGRESS_FILE` | path | `scripts/kstrl/progress.txt` |
+| `KSTRL_VERIFY_PROGRESS_FILE` | path | unset = the progress log beside the component's PRD |
 
 ## FixturesConfig (`[fixtures]`)
 

--- a/kstrl.toml.example
+++ b/kstrl.toml.example
@@ -17,7 +17,13 @@ interactive = false
 [paths]
 prompt = "scripts/kstrl/prompt.md"
 prd = "scripts/kstrl/prd.json"
-progress = "scripts/kstrl/progress.txt"
+# Left unset on purpose. Unset, each factory component's engineer writes
+# progress.txt beside its own PRD (scripts/kstrl/feature/<id>/), which is
+# inside the component's allowedPaths; `ks run` still uses
+# scripts/kstrl/progress.txt. Setting this key FORCES one path on every
+# component, and a path outside the component subtree fails Phase 1
+# diff_scope.
+# progress = "scripts/kstrl/progress.txt"
 codebase_map = "scripts/kstrl/codebase_map.md"
 allowed = []                       # e.g., ["scripts/kstrl/", "src/"]
 
@@ -157,7 +163,7 @@ mutation_timeout = 600.0
 subprocess_timeout = 300.0
 require_self_critique = false      # opt-in: fail Phase 1 if engineer's ## Self-Critique block missing/sparse
 self_critique_min_bullets = 3
-progress_file_path = "scripts/kstrl/progress.txt"
+progress_file_path = ""            # empty = the progress log beside the component's PRD
 
 # Phase 1 policy envelope (R8.1): declarative merge guardrails enforced on
 # ARTIFACTS (git diff, uv.lock), never on agent self-report. Opt-in: when

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -31,7 +31,12 @@ from kstrl.agents.base import Agent
 from kstrl.agents.logging import LoggingAgent
 from kstrl.breaker import BreakerConfig
 from kstrl.commandrun import CommandRun, open_command_run
-from kstrl.config import KstrlConfig, _parse_paths, resolve_config_file
+from kstrl.config import (
+    KstrlConfig,
+    _parse_paths,
+    reconcile_progress_paths,
+    resolve_config_file,
+)
 from kstrl.config_report import build_config_report
 from kstrl.config_report import normalize_ui_mode as _normalize_ui_mode
 from kstrl.decompose import SpecBlockerError, decompose_spec
@@ -1271,6 +1276,8 @@ def feature(
     # R2.4 preflight: accept whichever agent the resolved config selects.
     _check_agent_preflight(base_config, ui_impl)
 
+
+
     sandbox_cfg = SandboxConfig.load(root_dir)
     if sandbox_cfg.enabled and base_config.agent_cmd:
         ui_impl.warn(
@@ -2225,6 +2232,36 @@ def factory(
     # through to the codex default - and _cli_family misreads the
     # engineer family, inverting the R7.1 reviewer rotation.
     _check_agent_preflight(base_config, ui_impl)
+
+    # --no-verify leaves no reader, so there is nothing to reconcile.
+    if v_config is not None:
+        # R8 review: the progress log's writer ([paths] progress) and its
+        # reader ([verify] progress_file_path) default to the same
+        # derivation, so they agree until exactly ONE is set - and then the
+        # self-critique check inspects a file the engineer never wrote and
+        # fails for a reason the operator cannot see from either setting.
+        writer_path, reader_path = reconcile_progress_paths(
+            base_config.progress_file if base_config.progress_file_explicit else None,
+            v_config.progress_file_path,
+        )
+        if (
+            writer_path is not None
+            and reader_path is not None
+            and writer_path != reader_path
+        ):
+            # Both named, and named differently. Not overridden - an operator
+            # who set two paths meant two paths - but said out loud, because
+            # the failure it produces is otherwise unattributable.
+            ui_impl.warn(
+                f"progress log writer ([paths] progress = {writer_path}) and "
+                f"reader ([verify] progress_file_path = {reader_path}) point "
+                "at different files; the self-critique check will inspect a "
+                "file the engineer does not write"
+            )
+        v_config.progress_file_path = reader_path
+        if writer_path is not None:
+            base_config.progress_file = Path(writer_path)
+            base_config.progress_file_explicit = True
 
     # Ensure prompt file exists
     if not base_config.prompt_file.exists():

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -34,7 +34,7 @@ from kstrl.commandrun import CommandRun, open_command_run
 from kstrl.config import (
     KstrlConfig,
     _parse_paths,
-    reconcile_progress_paths,
+    reconcile_progress_config,
     resolve_config_file,
 )
 from kstrl.config_report import build_config_report
@@ -2240,28 +2240,12 @@ def factory(
         # derivation, so they agree until exactly ONE is set - and then the
         # self-critique check inspects a file the engineer never wrote and
         # fails for a reason the operator cannot see from either setting.
-        writer_path, reader_path = reconcile_progress_paths(
-            base_config.progress_file if base_config.progress_file_explicit else None,
-            v_config.progress_file_path,
-        )
-        if (
-            writer_path is not None
-            and reader_path is not None
-            and writer_path != reader_path
-        ):
-            # Both named, and named differently. Not overridden - an operator
-            # who set two paths meant two paths - but said out loud, because
-            # the failure it produces is otherwise unattributable.
-            ui_impl.warn(
-                f"progress log writer ([paths] progress = {writer_path}) and "
-                f"reader ([verify] progress_file_path = {reader_path}) point "
-                "at different files; the self-critique check will inspect a "
-                "file the engineer does not write"
-            )
-        v_config.progress_file_path = reader_path
-        if writer_path is not None:
-            base_config.progress_file = Path(writer_path)
-            base_config.progress_file_explicit = True
+        # The reconciliation lives in config.py (and is applied in ONE path
+        # domain, review finding 3) so a test can exercise the same wiring
+        # this command runs.
+        mismatch = reconcile_progress_config(base_config, v_config, root_dir)
+        if mismatch is not None:
+            ui_impl.warn(mismatch)
 
     # Ensure prompt file exists
     if not base_config.prompt_file.exists():

--- a/kstrl/config.py
+++ b/kstrl/config.py
@@ -61,6 +61,34 @@ def relative_to_root(path: Path, root_dir: Path) -> str:
 COMPONENT_PROGRESS_FILENAME = "progress.txt"
 
 
+def reconcile_progress_paths(
+    writer_explicit: str | Path | None,
+    reader_explicit: str | Path | None,
+) -> tuple[str | None, str | None]:
+    """Keep the progress log's WRITER and READER pointing at one file.
+
+    ``[paths] progress`` (or ``PROGRESS_FILE``) configures where the
+    engineer WRITES its progress log; ``[verify] progress_file_path``
+    (or ``KSTRL_VERIFY_PROGRESS_FILE``) configures where the
+    self-critique check READS it. Both default to the same derivation,
+    so they agree until exactly one of them is set - and then the
+    reader silently inspects a file the engineer never wrote, which
+    fails the self-critique gate for a reason the operator cannot see.
+
+    Setting one propagates it to the other. Setting BOTH is left alone,
+    including when they differ: an operator who named two paths meant
+    two paths, and the caller warns rather than overriding. Returns
+    ``(writer, reader)`` as strings, or None where nothing is set.
+    """
+    writer = str(writer_explicit) if writer_explicit is not None else None
+    reader = str(reader_explicit) if reader_explicit is not None else None
+    if writer is not None and reader is None:
+        return writer, writer
+    if reader is not None and writer is None:
+        return reader, reader
+    return writer, reader
+
+
 def component_progress_path(
     prd_path: str | Path,
     configured: str | Path | None = None,

--- a/kstrl/config.py
+++ b/kstrl/config.py
@@ -7,7 +7,7 @@ import re
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 
 def _parse_bool(value: str | None) -> bool:
@@ -60,6 +60,15 @@ def relative_to_root(path: Path, root_dir: Path) -> str:
 # retry on a real paid run: $12.93.
 COMPONENT_PROGRESS_FILENAME = "progress.txt"
 
+# Where the STANDALONE loop (`ks understand`, `ks feature`) writes its
+# progress log when nothing is configured. There is no component PRD to
+# derive a sibling from there, and the prompt template needs a concrete
+# path, so this historical default is materialized by
+# KstrlConfig.resolved_progress_file - never stored in the field itself,
+# which stays None so "unset" remains distinguishable from "set to the
+# default" (R8 review finding 2).
+DEFAULT_PROGRESS_FILE = "scripts/kstrl/progress.txt"
+
 
 def reconcile_progress_paths(
     writer_explicit: str | Path | None,
@@ -89,6 +98,67 @@ def reconcile_progress_paths(
     return writer, reader
 
 
+class ProgressReaderConfig(Protocol):
+    """The one field ``reconcile_progress_config`` needs from a
+    ``VerifyConfig``. Declared structurally so this module does not
+    import kstrl.verify, which imports this one."""
+
+    progress_file_path: str | None
+
+
+def reconcile_progress_config(
+    base_config: KstrlConfig,
+    verify_config: ProgressReaderConfig,
+    root_dir: Path,
+) -> str | None:
+    """Reconcile the progress log's writer and reader IN ONE PATH DOMAIN.
+
+    Returns a warning message when both were set to different files, or
+    None. Mutates both configs.
+
+    The domain is ROOT-RELATIVE for anything inside ``root_dir``, which
+    is the domain both consumers actually resolve in: the engineer's
+    worker joins the writer path onto its WORKTREE
+    (``factory._run_component``), and the self-critique check joins the
+    reader path onto the same worktree (``verify.run_mechanical_
+    verification``). Reconciling the raw values instead (R8 review
+    finding 3) compared an ABSOLUTE writer - ``KstrlConfig.load``
+    resolves ``[paths] progress`` against the main checkout - against a
+    verbatim-relative reader. The two STRINGS came out equal while the
+    runtime paths did not: the worker wrote ``<worktree>/docs/p.md`` and
+    the check read ``<root>/docs/p.md``, so self-critique still failed,
+    or passed against a stale file in the main checkout.
+
+    A path OUTSIDE ``root_dir`` stays absolute (``relative_to_root``
+    cannot relativize it), which is also self-consistent: joining an
+    absolute path onto a worktree is a no-op, so writer and reader both
+    land on that one file, in the main checkout, for every component.
+    """
+    writer_domain = (
+        relative_to_root(base_config.progress_file, root_dir)
+        if base_config.progress_file is not None else None
+    )
+    reader_domain = (
+        relative_to_root(Path(verify_config.progress_file_path), root_dir)
+        if verify_config.progress_file_path else None
+    )
+    writer, reader = reconcile_progress_paths(writer_domain, reader_domain)
+    verify_config.progress_file_path = reader
+    if writer is not None:
+        base_config.progress_file = Path(writer)
+    if writer is not None and reader is not None and writer != reader:
+        # Both named, and named differently. Not overridden - an operator
+        # who set two paths meant two paths - but said out loud, because
+        # the failure it produces is otherwise unattributable.
+        return (
+            f"progress log writer ([paths] progress = {writer}) and "
+            f"reader ([verify] progress_file_path = {reader}) point at "
+            "different files; the self-critique check will inspect a "
+            "file the engineer does not write"
+        )
+    return None
+
+
 def component_progress_path(
     prd_path: str | Path,
     configured: str | Path | None = None,
@@ -115,14 +185,27 @@ class KstrlConfig:
     max_iterations: int = 10
     prompt_file: Path = field(default_factory=lambda: Path("scripts/kstrl/prompt.md"))
     prd_file: Path = field(default_factory=lambda: Path("scripts/kstrl/prd.json"))
-    progress_file: Path = field(default_factory=lambda: Path("scripts/kstrl/progress.txt"))
-    # Was the progress path explicitly configured ([paths] progress or
-    # PROGRESS_FILE)? Only an explicit setting is forced on every factory
-    # component; otherwise each component derives its own next to its PRD
-    # (see component_progress_path). Mirrors kstrl_branch_explicit rather
-    # than comparing the value against the default - an explicit setting
-    # that happens to equal the default is still explicit.
-    progress_file_explicit: bool = False
+    # None = UNSET, and unset is the safe default: every factory
+    # component then derives its own log next to its own PRD, inside its
+    # allowedPaths (see component_progress_path). Any non-None value -
+    # from [paths] progress, PROGRESS_FILE, a constructor argument, or a
+    # plain attribute assignment - is an explicit setting and is forced
+    # on every component verbatim.
+    #
+    # The sentinel replaced a separate progress_file_explicit flag (R8
+    # review finding 2): the flag was set only by the toml/env loaders,
+    # so a programmatic caller doing
+    # KstrlConfig(progress_file=Path("docs/p.md")) had its value silently
+    # ignored - a regression for tests, embedders and the SDK, which
+    # could previously pass a base config to run_factory and be obeyed.
+    # It is NOT a compare-against-default heuristic (R2.1 deliberately
+    # removed that pattern from VerifyConfig.load): pinning the
+    # historical path explicitly still counts as explicit, because the
+    # field holds a Path only when someone put one there.
+    #
+    # Standalone callers that need a concrete path (the prompt template's
+    # $progress_path) call resolved_progress_file(root_dir).
+    progress_file: Path | None = None
     codebase_map_file: Path = field(
         default_factory=lambda: Path("scripts/kstrl/codebase_map.md")
     )
@@ -164,7 +247,6 @@ class KstrlConfig:
         # immediately usable regardless of cwd at the call site.
         config.prompt_file = root_dir / "scripts/kstrl/prompt.md"
         config.prd_file = root_dir / "scripts/kstrl/prd.json"
-        config.progress_file = root_dir / "scripts/kstrl/progress.txt"
         config.codebase_map_file = root_dir / "scripts/kstrl/codebase_map.md"
         _apply_env_overrides(config, root_dir)
         return config
@@ -177,7 +259,6 @@ class KstrlConfig:
         config = cls()
         config.prompt_file = root_dir / "scripts/kstrl/prompt.md"
         config.prd_file = root_dir / "scripts/kstrl/prd.json"
-        config.progress_file = root_dir / "scripts/kstrl/progress.txt"
         config.codebase_map_file = root_dir / "scripts/kstrl/codebase_map.md"
         if toml_path.exists():
             _apply_toml_overrides(config, toml_path, root_dir)
@@ -203,7 +284,6 @@ class KstrlConfig:
         config = cls()
         config.prompt_file = root_dir / "scripts/kstrl/prompt.md"
         config.prd_file = root_dir / "scripts/kstrl/prd.json"
-        config.progress_file = root_dir / "scripts/kstrl/progress.txt"
         config.codebase_map_file = root_dir / "scripts/kstrl/codebase_map.md"
 
         if toml_path.exists():
@@ -224,9 +304,29 @@ class KstrlConfig:
         """
         configured = (
             relative_to_root(self.progress_file, root_dir)
-            if self.progress_file_explicit else None
+            if self.progress_file is not None else None
         )
         return component_progress_path(prd_path, configured).as_posix()
+
+    def resolved_progress_file(self, root_dir: Path) -> Path:
+        """Concrete progress path for the STANDALONE loop.
+
+        ``progress_file`` is None until someone sets it, but the loop
+        substitutes ``$progress_path`` into the engineer prompt and needs
+        a real path there. Standalone runs have no component PRD to
+        derive a sibling from, so they get the historical repo-root
+        default; a relative explicit setting is anchored to ``root_dir``
+        the same way the loaders anchor one.
+
+        The factory does NOT come through here: its workers are handed an
+        already-concrete per-component path (factory._run_component), and
+        this method returns it untouched.
+        """
+        if self.progress_file is None:
+            return root_dir / DEFAULT_PROGRESS_FILE
+        if self.progress_file.is_absolute():
+            return self.progress_file
+        return root_dir / self.progress_file
 
     def validate(self) -> list[str]:
         """Validate configuration, returning list of errors."""
@@ -329,7 +429,6 @@ def _apply_toml_overrides(
             config.prd_file = _resolve_path(paths["prd"], root_dir)
         if isinstance(paths.get("progress"), str) and paths["progress"]:
             config.progress_file = _resolve_path(paths["progress"], root_dir)
-            config.progress_file_explicit = True
         if isinstance(paths.get("codebase_map"), str) and paths["codebase_map"]:
             config.codebase_map_file = _resolve_path(paths["codebase_map"], root_dir)
         allowed = paths.get("allowed")
@@ -371,7 +470,6 @@ def _apply_env_overrides(config: KstrlConfig, root_dir: Path) -> None:
         config.prd_file = _resolve_path(os.environ["PRD_FILE"], root_dir)
     if "PROGRESS_FILE" in os.environ:
         config.progress_file = _resolve_path(os.environ["PROGRESS_FILE"], root_dir)
-        config.progress_file_explicit = True
     if "CODEBASE_MAP_FILE" in os.environ:
         config.codebase_map_file = _resolve_path(
             os.environ["CODEBASE_MAP_FILE"], root_dir

--- a/kstrl/config.py
+++ b/kstrl/config.py
@@ -32,6 +32,54 @@ def _resolve_path(value: str, root_dir: Path) -> Path:
     return root_dir / p
 
 
+def relative_to_root(path: Path, root_dir: Path) -> str:
+    """Render ``path`` relative to ``root_dir`` for use inside a
+    per-component worktree. Falls back to the absolute path string when
+    relativization fails (e.g. a path on a different mount)."""
+    if not path.is_absolute():
+        return str(path)
+    try:
+        return path.relative_to(root_dir).as_posix()
+    except ValueError:
+        try:
+            return path.resolve().relative_to(root_dir.resolve()).as_posix()
+        except ValueError:
+            return str(path)
+
+
+# A FACTORY component's progress log lives NEXT TO that component's PRD.
+# DECOMPOSE_PROMPT rule 12 tells the architect that a component's
+# allowedPaths include exactly `scripts/kstrl/feature/<component-id>/`
+# "(the agent updates progress.txt and PRD passes there)", so a progress
+# path derived from prdPath is inside the component's write scope BY
+# CONSTRUCTION. Pointing the engineer at the repo-root
+# scripts/kstrl/progress.txt instead put it one level ABOVE that
+# subtree: the engineer wrote the file the harness told it to write,
+# Phase 1 `diff_scope` reported "files outside allowed scope", and the
+# component was failed and retried from base. Measured cost of one such
+# retry on a real paid run: $12.93.
+COMPONENT_PROGRESS_FILENAME = "progress.txt"
+
+
+def component_progress_path(
+    prd_path: str | Path,
+    configured: str | Path | None = None,
+) -> Path:
+    """Progress-log path for the component whose PRD is at ``prd_path``.
+
+    ``configured`` is an explicitly set progress path ([paths] progress
+    or PROGRESS_FILE) and wins verbatim for every component - explicit
+    configuration is never silently rewritten. With nothing configured
+    the log is a SIBLING of the PRD, which reproduces the historical
+    ``scripts/kstrl/progress.txt`` for the single-component layout (PRD
+    at ``scripts/kstrl/prd.json``) and lands inside the component's own
+    feature subtree for a decomposed one.
+    """
+    if configured is not None:
+        return Path(configured)
+    return Path(prd_path).parent / COMPONENT_PROGRESS_FILENAME
+
+
 @dataclass
 class KstrlConfig:
     """Configuration for the kstrl agentic loop."""
@@ -40,6 +88,13 @@ class KstrlConfig:
     prompt_file: Path = field(default_factory=lambda: Path("scripts/kstrl/prompt.md"))
     prd_file: Path = field(default_factory=lambda: Path("scripts/kstrl/prd.json"))
     progress_file: Path = field(default_factory=lambda: Path("scripts/kstrl/progress.txt"))
+    # Was the progress path explicitly configured ([paths] progress or
+    # PROGRESS_FILE)? Only an explicit setting is forced on every factory
+    # component; otherwise each component derives its own next to its PRD
+    # (see component_progress_path). Mirrors kstrl_branch_explicit rather
+    # than comparing the value against the default - an explicit setting
+    # that happens to equal the default is still explicit.
+    progress_file_explicit: bool = False
     codebase_map_file: Path = field(
         default_factory=lambda: Path("scripts/kstrl/codebase_map.md")
     )
@@ -127,6 +182,23 @@ class KstrlConfig:
             _apply_toml_overrides(config, toml_path, root_dir)
         _apply_env_overrides(config, root_dir)
         return config
+
+    def component_progress_file(
+        self, prd_path: str | Path, root_dir: Path,
+    ) -> str:
+        """Worktree-relative progress path for one factory component.
+
+        The single place the factory decides where a component's
+        engineer writes its progress log: an explicit configuration wins
+        for every component, otherwise the path is derived from the
+        component's own PRD so it sits inside the component's
+        allowedPaths (see ``component_progress_path``).
+        """
+        configured = (
+            relative_to_root(self.progress_file, root_dir)
+            if self.progress_file_explicit else None
+        )
+        return component_progress_path(prd_path, configured).as_posix()
 
     def validate(self) -> list[str]:
         """Validate configuration, returning list of errors."""
@@ -229,6 +301,7 @@ def _apply_toml_overrides(
             config.prd_file = _resolve_path(paths["prd"], root_dir)
         if isinstance(paths.get("progress"), str) and paths["progress"]:
             config.progress_file = _resolve_path(paths["progress"], root_dir)
+            config.progress_file_explicit = True
         if isinstance(paths.get("codebase_map"), str) and paths["codebase_map"]:
             config.codebase_map_file = _resolve_path(paths["codebase_map"], root_dir)
         allowed = paths.get("allowed")
@@ -270,6 +343,7 @@ def _apply_env_overrides(config: KstrlConfig, root_dir: Path) -> None:
         config.prd_file = _resolve_path(os.environ["PRD_FILE"], root_dir)
     if "PROGRESS_FILE" in os.environ:
         config.progress_file = _resolve_path(os.environ["PROGRESS_FILE"], root_dir)
+        config.progress_file_explicit = True
     if "CODEBASE_MAP_FILE" in os.environ:
         config.codebase_map_file = _resolve_path(
             os.environ["CODEBASE_MAP_FILE"], root_dir

--- a/kstrl/config_report.py
+++ b/kstrl/config_report.py
@@ -102,10 +102,29 @@ def scrubbed_environ() -> Iterator[None]:
         os.environ.update(saved)
 
 
+# Rows whose None means something more specific than "no value", and
+# where printing bare None (or, worse, a materialized default) would
+# misreport what a run will do. R8 review finding 1: `ks config show`
+# printed <root>/scripts/kstrl/progress.txt as the effective progress
+# path, which is exactly the out-of-scope location the factory no longer
+# uses - an operator copying it into kstrl.toml would recreate the
+# defect the sentinel removed.
+UNSET_RENDERINGS: dict[tuple[str, str], str] = {
+    ("paths", "progress"): "<unset: each component writes beside its own PRD>",
+}
+
+
 def format_config_value(value: Any) -> str:
     if isinstance(value, Path):
         return str(value)
     return repr(value)
+
+
+def format_row_value(section: str, key: str, value: Any) -> str:
+    """``format_config_value`` plus the per-row unset renderings."""
+    if value is None and (section, key) in UNSET_RENDERINGS:
+        return UNSET_RENDERINGS[(section, key)]
+    return format_config_value(value)
 
 
 def kstrl_config_defaults(root_dir: Path) -> KstrlConfig:
@@ -113,7 +132,6 @@ def kstrl_config_defaults(root_dir: Path) -> KstrlConfig:
     config = KstrlConfig()
     config.prompt_file = root_dir / "scripts/kstrl/prompt.md"
     config.prd_file = root_dir / "scripts/kstrl/prd.json"
-    config.progress_file = root_dir / "scripts/kstrl/progress.txt"
     config.codebase_map_file = root_dir / "scripts/kstrl/codebase_map.md"
     return config
 
@@ -232,7 +250,9 @@ def build_config_report(
             rows.append(ConfigRow(
                 section=section,
                 key=toml_key,
-                value=format_config_value(getattr(resolved_base, field_name)),
+                value=format_row_value(
+                    section, toml_key, getattr(resolved_base, field_name),
+                ),
                 source=base_sources[field_name],
             ))
     for section, _, knob_fields in phase_sections:

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -32,7 +32,7 @@ from kstrl.autonomy import (
 )
 from kstrl.breaker import BreakerConfig
 from kstrl.commandrun import start_heartbeat as _start_heartbeat
-from kstrl.config import KstrlConfig
+from kstrl.config import KstrlConfig, component_progress_path, relative_to_root
 from kstrl.context import IterationContext
 from kstrl.contract import (
     ContractCleanupError,
@@ -1198,7 +1198,7 @@ def _run_component(
     scaffold_cmd: str | None = None,
     component_deps: list[str] | None = None,
     knowledge_prefix: str = "",
-    progress_file_str: str = "scripts/kstrl/progress.txt",
+    progress_file_str: str | None = None,
     codebase_map_file_str: str = "scripts/kstrl/codebase_map.md",
     agent_iteration_timeout: float = 1800.0,
     component_timeout: float = 7200.0,
@@ -1246,6 +1246,11 @@ def _run_component(
     the spend recorded before this worker launched, so the engineer loop
     can halt itself BETWEEN iterations instead of waiting for the
     parent's next phase boundary. None disables the in-loop check.
+
+    ``progress_file_str`` is None unless the operator explicitly
+    configured a progress path; None means "derive it next to this
+    component's PRD", which is what keeps the file inside the
+    component's allowedPaths (see config.component_progress_path).
     """
     from kstrl.agents import (
     get_agent,
@@ -1380,7 +1385,9 @@ def _run_component(
         max_iterations=max_iterations,
         prompt_file=worktree_prompt,
         prd_file=worktree_prd,
-        progress_file=worktree_path / progress_file_str,
+        progress_file=worktree_path / component_progress_path(
+            prd_path_str, progress_file_str,
+        ),
         codebase_map_file=worktree_path / codebase_map_file_str,
         sleep_seconds=sleep_seconds,
         interactive=interactive,
@@ -2432,18 +2439,13 @@ def _run_factory_locked(
         """Render `path` relative to root_dir for use inside per-component
         worktrees. Falls back to the absolute path string when relativization
         fails (e.g. a path on a different mount)."""
-        if not path.is_absolute():
-            return str(path)
-        try:
-            return path.relative_to(root_dir).as_posix()
-        except ValueError:
-            try:
-                return path.resolve().relative_to(root_dir.resolve()).as_posix()
-            except ValueError:
-                return str(path)
+        return relative_to_root(path, root_dir)
 
     prompt_file_rel = _path_relative_to_root(base_config.prompt_file)
-    progress_file_rel = _path_relative_to_root(base_config.progress_file)
+    # The progress path is deliberately NOT hoisted out of the per-component
+    # loop: unless it was explicitly configured, each component derives its
+    # own next to its PRD so the engineer writes inside its allowedPaths
+    # (base_config.component_progress_file, called from _submit_args).
     codebase_map_file_rel = _path_relative_to_root(base_config.codebase_map_file)
 
     def _launch_component(comp: Component) -> Path | None:
@@ -2502,7 +2504,9 @@ def _run_factory_locked(
             comp.scaffold or None,
             comp.dependencies or None,
             knowledge_prefix,
-            progress_file_rel,
+            # Per-component, not run-wide: KstrlConfig.component_progress_file
+            # keeps the engineer's progress log inside allowedPaths.
+            base_config.component_progress_file(comp.prd_path, root_dir),
             codebase_map_file_rel,
             timeout_cfg.agent_iteration,
             timeout_cfg.component_total,

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -642,6 +642,11 @@ class ComponentResult:
     budget_exceeded: bool = False
     budget_halt_condition: str = ""
     budget_halt_ceilings: tuple[str, ...] = ()
+    # Files the in-loop scope guard rejected. Carried so the pipeline can
+    # file the halt under the retry context's verification-failures
+    # section, where R0.4 established the retry agent looks for scope
+    # guidance - catching the violation earlier must not relocate it.
+    guard_violations: tuple[str, ...] = ()
 
 
 @dataclass
@@ -1027,7 +1032,14 @@ def _component_scope(
     """
     try:
         prd = PRD.load(root_dir / comp.prd_path)
-    except (FileNotFoundError, ValueError):
+    except (OSError, ValueError):
+        # OSError, not FileNotFoundError (R8 review finding 5): a PRD
+        # path that is a DIRECTORY raises IsADirectoryError, and an
+        # unreadable one PermissionError - both OSError subclasses that
+        # escaped the narrower catch and aborted SCHEDULING, before
+        # Phase 1 ever ran. This runs per component while the run is
+        # being planned, so an escape here takes the whole run down for
+        # one bad file. ValueError covers the parse/schema failures.
         return base_config.allowed_paths or None
     return prd.allowed_paths or base_config.allowed_paths or None
 
@@ -1244,6 +1256,7 @@ def _run_component(
     redirect_output: bool = True,
     live_line: Callable[[str], None] | None = None,
     stop_check: Callable[[], bool] | None = None,
+    base_branch: str = "main",
 ) -> ComponentResult:
     """Run a single component's implementation loop.
 
@@ -1488,6 +1501,7 @@ def _run_component(
             stop_check=stop_check,
             budget=token_budget,
             on_iteration_usage=on_iteration_usage,
+            guard_base_ref=base_branch,
         )
         # Report which limit fired so the retry/fail path can act on it
         # (timeout errors trigger the recreate-from-base retry hygiene).
@@ -1507,14 +1521,28 @@ def _run_component(
             # redo the same edit. Mirrors check_diff_scope's wording so
             # the two scope failures read identically wherever they are
             # caught.
+            #
+            # R0.4 is why the base branch and the COMPLETE allowed-paths
+            # list are repeated verbatim rather than paraphrased: the
+            # recorded e2e run guessed `main` as the base and reverted
+            # base-branch content with `git checkout main -- ...`,
+            # failing again. Those two lines used to arrive from Phase 1;
+            # now that the in-loop guard fires FIRST, this message is
+            # what reaches attempt 2, so it must carry them itself.
             shown = list(result.guard_violations[:15])
             more = len(result.guard_violations) - len(shown)
             listed = ", ".join(shown) + (f" ... and {more} more" if more else "")
             error = (
                 f"{len(result.guard_violations)} file(s) outside the "
                 f"component's allowed scope, caught in-loop after "
-                f"iteration {result.iterations}: {listed}. Revert only "
-                "your own out-of-scope edits; do not widen allowedPaths."
+                f"iteration {result.iterations}: {listed}. "
+                f"Base branch: {base_branch} "
+                f"(scope is judged on `git diff {base_branch}...HEAD`; "
+                f"do NOT `git checkout {base_branch} -- <path>`, revert "
+                "only your own out-of-scope commits/edits). "
+                f"Allowed paths (complete list): "
+                f"{', '.join(allowed_paths or [])}. "
+                "Do not widen allowedPaths."
             )
         elif result.no_progress:
             error = (
@@ -1546,6 +1574,7 @@ def _run_component(
             budget_exceeded=bool(result.budget_halt_reason),
             budget_halt_condition=result.budget_halt_condition,
             budget_halt_ceilings=result.budget_halt_ceilings,
+            guard_violations=result.guard_violations,
         )
     except Exception as exc:
         return ComponentResult(
@@ -2746,6 +2775,11 @@ def _run_factory_locked(
                         # ends at token_budget by construction.
                         task = functools.partial(
                             _run_component, *args,
+                            # Keyword, NOT appended to args: the tuple
+                            # ends at token_budget by construction (see
+                            # above) and a positional extra silently
+                            # lands on redirect_output.
+                            base_branch=manifest.base_branch,
                             redirect_output=False,  # type: ignore[misc]
                             live_line=functools.partial(
                                 ui.stream_line, "AI",
@@ -2756,7 +2790,20 @@ def _run_factory_locked(
                         )
                         future = executor.submit(task)
                     else:
-                        future = executor.submit(_run_component, *args)
+                        # Bound through partial rather than passed as a
+                        # submit() kwarg: Executor.submit types its own
+                        # **kwargs, so a keyword meant for the worker
+                        # reads as a duplicate of submit's. Picklable -
+                        # _run_component is module-level and the base
+                        # branch is a plain str.
+                        future = executor.submit(
+                            functools.partial(
+                                _run_component, *args,
+                                # Same unprovable-*args limitation the
+                                # inline branch annotates above.
+                                base_branch=manifest.base_branch,  # type: ignore[misc]
+                            ),
+                        )
                     running_futures[future] = comp.id
                     if backstop_seconds > 0:
                         future_deadlines[future] = (

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -84,6 +84,7 @@ from kstrl.observability import (
 from kstrl.pipeline import ComponentPipeline, PipelineHooks, _iso_now
 from kstrl.policy import PolicyConfig
 from kstrl.pr import create_prs_in_order, create_single_pr
+from kstrl.prd import PRD
 from kstrl.review import (
     ReviewMode,
     run_chunked_review,
@@ -1006,6 +1007,31 @@ def _prune_stale_worktrees(
         )
 
 
+def _component_scope(
+    comp: Component, root_dir: Path, base_config: KstrlConfig,
+) -> list[str] | None:
+    """The scope the in-loop guard enforces for one component.
+
+    The component's architect-emitted ``allowedPaths``, falling back to
+    the run-wide ``--allowed-paths`` flag when the PRD carries none
+    (legacy PRDs predate the field).
+
+    Fails OPEN, unlike Phase 1's ``check_diff_scope``, and the asymmetry
+    is deliberate. This guard is an early, cheap tripwire; Phase 1 is the
+    gate. A PRD that cannot be read here returns None, the loop runs
+    unguarded, and Phase 1 still fails CLOSED on the same unreadable PRD
+    (R1.5) - so nothing merges unverified. Failing closed here instead
+    would convert an unreadable PRD into an immediate component failure
+    before the engineer has done anything, which is a worse trade for a
+    tripwire whose only job is to save iterations.
+    """
+    try:
+        prd = PRD.load(root_dir / comp.prd_path)
+    except (FileNotFoundError, ValueError):
+        return base_config.allowed_paths or None
+    return prd.allowed_paths or base_config.allowed_paths or None
+
+
 def _preflight_component_branches(
     manifest: Manifest, root_dir: Path, ui: UI,
 ) -> list[str]:
@@ -1473,6 +1499,23 @@ def _run_component(
             # pipeline needs when its own totals do not yet show a
             # breach (unreported-usage case).
             error = result.budget_halt_reason
+        elif result.guard_violations:
+            # R8 review: name the files. The guard used to fail the
+            # iteration and fall through to "Did not complete", so the
+            # retry agent was told only that something went wrong - and
+            # the cheapest strategy for an agent with no diagnosis is to
+            # redo the same edit. Mirrors check_diff_scope's wording so
+            # the two scope failures read identically wherever they are
+            # caught.
+            shown = list(result.guard_violations[:15])
+            more = len(result.guard_violations) - len(shown)
+            listed = ", ".join(shown) + (f" ... and {more} more" if more else "")
+            error = (
+                f"{len(result.guard_violations)} file(s) outside the "
+                f"component's allowed scope, caught in-loop after "
+                f"iteration {result.iterations}: {listed}. Revert only "
+                "your own out-of-scope edits; do not widen allowedPaths."
+            )
         elif result.no_progress:
             error = (
                 "no-progress circuit breaker tripped: "
@@ -2515,7 +2558,23 @@ def _run_factory_locked(
             # hardcoded 30 non-interactive iterations with no path guard.
             base_config.max_iterations,
             base_config.interactive,
-            base_config.allowed_paths or None,
+            # R8 review: the COMPONENT's allowedPaths, not the run-wide
+            # --allowed-paths flag. That flag is empty in every ordinary
+            # factory run, so `if config.allowed_paths` in the loop was
+            # False and guards.enforce_allowed_paths never ran: the
+            # in-loop guard existed and was inert. A scope violation was
+            # therefore only caught at Phase 1, AFTER the whole engineer
+            # loop had been paid for - measured at $12.93 for one such
+            # component, versus ~$2.50 for the single iteration it takes
+            # to catch it here.
+            #
+            # Read from root_dir, NOT the worktree: Phase 1 deliberately
+            # re-reads the PRD from the worktree (fail-closed on load
+            # error), but an in-loop guard sourced from a file the agent
+            # may edit would let the agent widen its own scope mid-run.
+            # The pre-run PRD is the honest input for enforcement; the
+            # worktree copy remains the input for verification.
+            _component_scope(comp, root_dir, base_config),
             # R7.5: no-progress circuit breaker limits.
             breaker_cfg.no_progress_iterations,
             breaker_cfg.test_command,

--- a/kstrl/git.py
+++ b/kstrl/git.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re as _re
 import subprocess
 from collections.abc import Iterable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -212,7 +213,20 @@ def get_changed_files(
                 line.strip() for line in result.stdout.splitlines() if line.strip()
             )
 
-        # Untracked files
+    except subprocess.TimeoutExpired:
+        pass
+
+    files.update(get_untracked_files(cwd, timeout))
+    return files
+
+
+def get_untracked_files(
+    cwd: Path | None = None, timeout: float = DEFAULT_TIMEOUT,
+) -> set[str]:
+    """Untracked, non-ignored files. Separate from ``get_changed_files``
+    because a baseline comparison needs them WITHOUT the index/HEAD
+    deltas that function also folds in (see get_changed_files_since)."""
+    try:
         result = subprocess.run(
             ["git", "ls-files", "--others", "--exclude-standard"],
             cwd=cwd,
@@ -220,14 +234,223 @@ def get_changed_files(
             text=True,
             timeout=timeout,
         )
-        if result.returncode == 0:
-            files.update(
-                line.strip() for line in result.stdout.splitlines() if line.strip()
-            )
     except subprocess.TimeoutExpired:
-        pass
+        return set()
+    if result.returncode != 0:
+        return set()
+    return {
+        line.strip() for line in result.stdout.splitlines() if line.strip()
+    }
 
-    return files
+
+@dataclass(frozen=True)
+class WorkspaceBaseline:
+    """The workspace as it stood BEFORE an agent was let loose on it.
+
+    ``head`` is the commit HEAD pointed at (None in a repo with no
+    commits yet, or when rev-parse failed); ``dirty`` is the set of files
+    that were already staged, modified or untracked at that moment.
+
+    Both halves exist because ``get_changed_files`` alone answers the
+    wrong question for scope enforcement (R8 review finding 4). It sees
+    only the index and the working tree, and the engineer prompt tells
+    the agent to COMMIT after every story - so an out-of-scope file that
+    was committed is invisible to it, i.e. the tripwire was blind exactly
+    when the agent had done the most work. The converse also bit: in a
+    --no-worktrees run, an operator's own uncommitted file was reported
+    as the AGENT's violation and could be destroyed by "Revert and
+    continue".
+    """
+
+    head: str | None
+    dirty: frozenset[str]
+
+
+def get_head_sha(
+    cwd: Path | None = None, timeout: float = DEFAULT_TIMEOUT,
+) -> str | None:
+    """The commit HEAD points at, or None (unborn HEAD, not a repo,
+    timeout)."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", "HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def capture_workspace_baseline(
+    cwd: Path | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    base_ref: str | None = None,
+) -> WorkspaceBaseline:
+    """Snapshot the comparison commit and the pre-existing dirty set.
+
+    ``base_ref`` should be the component's BASE BRANCH, so this guard
+    judges scope from the same point ``check_diff_scope`` does. Anchoring
+    on the worker's starting HEAD instead looked more natural and was
+    wrong: a retry resumes the component branch carrying the previous
+    attempt's out-of-scope commit, so DELETING that file - the exact fix
+    the retry prompt asks for - registers as a fresh out-of-scope change
+    and the guard rejects its own remedy. Against the base branch the
+    add-and-delete nets to nothing, which is why Phase 1 never had this
+    problem.
+
+    Falls back to HEAD when no ref is given or it cannot be resolved
+    (``ks run`` outside a factory has no base branch), which is the
+    pre-existing behavior. Cheap: two plumbing calls, taken once per
+    loop rather than once per iteration.
+    """
+    head = resolve_ref(base_ref, cwd, timeout) if base_ref else None
+    return WorkspaceBaseline(
+        head=head or get_head_sha(cwd, timeout),
+        dirty=frozenset(get_changed_files(cwd, timeout)),
+    )
+
+
+def resolve_ref(
+    ref: str, cwd: Path | None = None, timeout: float = DEFAULT_TIMEOUT,
+) -> str | None:
+    """The sha ``ref`` names, or None when it does not resolve.
+
+    Tries the local ref first, then ``origin/<ref>``: a fresh worktree
+    may carry the remote-tracking ref only.
+    """
+    for candidate in (ref, f"origin/{ref}"):
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}"],
+                cwd=cwd, capture_output=True, text=True, timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return None
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    return None
+
+
+def get_changed_files_since(
+    baseline: WorkspaceBaseline,
+    cwd: Path | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> set[str]:
+    """The COMPLETE delta an agent produced since ``baseline``.
+
+    Every tracked file that differs between the baseline COMMIT and the
+    working tree - which spans the agent's commits, its index and its
+    unstaged edits in one comparison - plus everything untracked, MINUS
+    the files that were already dirty when the baseline was taken.
+
+    Measured against the BASELINE, never against HEAD: HEAD moves as the
+    agent commits, so a file reverted to its baseline content still
+    differs from HEAD and would be reported as an outstanding change
+    forever. The question here is only "does this differ from how the
+    agent found it".
+
+    The subtraction is what keeps an operator's own uncommitted work out
+    of the agent's violation list in a --no-worktrees run. Its cost is a
+    known false NEGATIVE: a file the operator had already modified and
+    the agent then modified again is attributed to the operator and not
+    reported. Chosen over refusing to run in a dirty checkout because it
+    is the less disruptive half of that trade, and because the missed
+    case is bounded by files a human touched deliberately - whereas the
+    committed-file blind spot it replaces covered EVERY file the agent
+    touched after its first commit.
+
+    Fails OPEN like the rest of this module: an unborn HEAD (nothing to
+    diff against) or a diff that cannot be produced falls back to the
+    working-tree view, which is today's behavior, rather than raising.
+    """
+    if baseline.head is None:
+        changed = get_changed_files(cwd, timeout)
+    else:
+        changed = set(_committed_since(baseline.head, cwd, timeout))
+        changed.update(get_untracked_files(cwd, timeout))
+    return changed - set(baseline.dirty)
+
+
+def _committed_since(
+    ref: str, cwd: Path | None = None, timeout: float = DEFAULT_TIMEOUT,
+) -> list[str]:
+    """Paths differing between ``ref`` and the working tree.
+
+    ``git diff <ref>`` spans commits AND the index AND the working tree,
+    so one call covers "committed since the baseline" without a separate
+    rev-list. Rename/copy records contribute both paths, exactly as
+    ``get_diff_names`` does, because for scope purposes content left the
+    source too.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-status", "-z", ref, "--"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return []
+    if result.returncode != 0:
+        return []
+    return _unique_paths(path for _, path in _parse_name_status_records(result.stdout))
+
+
+def restore_file_from(
+    file: str,
+    ref: str,
+    cwd: Path | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> bool:
+    """Restore ``file`` to its content at ``ref`` (index AND working tree).
+
+    Returns False when the file did not exist at ``ref`` - the caller's
+    cue that reverting means deleting it, not restoring it. Needed
+    because a baseline-aware guard can be reverting a COMMITTED change,
+    which ``restore_file`` (index/HEAD as the source) would treat as
+    already-correct and leave in place.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "git", "restore", f"--source={ref}", "--staged", "--worktree",
+                "--", file,
+            ],
+            cwd=cwd,
+            capture_output=True,
+            timeout=timeout,
+        )
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
+
+
+def remove_from_index(
+    file: str, cwd: Path | None = None, timeout: float = DEFAULT_TIMEOUT,
+) -> bool:
+    """Drop ``file`` from the index, leaving the working tree alone.
+
+    Paired with ``delete_untracked`` to revert a file the agent both
+    created and committed: after both, the path is absent from the index
+    and from disk, so it no longer appears in the delta against the
+    baseline.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rm", "--cached", "--ignore-unmatch", "-q", "--", file],
+            cwd=cwd,
+            capture_output=True,
+            timeout=timeout,
+        )
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
 
 
 def restore_file(

--- a/kstrl/guards.py
+++ b/kstrl/guards.py
@@ -61,12 +61,45 @@ def check_violations(
     return violations
 
 
+def _revert_violation(
+    file: str,
+    ui: UI,
+    cwd: Path | None,
+    baseline: git.WorkspaceBaseline | None,
+) -> None:
+    """Undo one out-of-scope change.
+
+    With a baseline the revert source is the BASELINE COMMIT, not the
+    index: the violation may already be committed, and restoring from
+    the index would be a no-op that reports success while leaving the
+    file exactly as the agent left it - the guard would then clear the
+    violation and the next iteration would re-detect it forever. A file
+    that did not exist at the baseline is dropped from the index and
+    deleted, so it disappears from the delta the way a revert should.
+    """
+    if baseline is not None and baseline.head is not None:
+        if git.restore_file_from(file, baseline.head, cwd):
+            ui.info(f"  Restored: {file}")
+        else:
+            git.remove_from_index(file, cwd)
+            git.delete_untracked(file, cwd)
+            ui.info(f"  Deleted: {file}")
+        return
+    if git.is_file_tracked(file, cwd):
+        git.restore_file(file, cwd)
+        ui.info(f"  Restored: {file}")
+    else:
+        git.delete_untracked(file, cwd)
+        ui.info(f"  Deleted: {file}")
+
+
 def enforce_allowed_paths(
     config: KstrlConfig,
     ui: UI,
     cwd: Path | None = None,
     interaction: InteractionChannel | None = None,
     ignored_paths: list[str] | None = None,
+    baseline: git.WorkspaceBaseline | None = None,
 ) -> tuple[bool, list[str]]:
     """Enforce ALLOWED_PATHS after an iteration.
 
@@ -76,6 +109,14 @@ def enforce_allowed_paths(
 
     ``ignored_paths`` is the caller's exact set of harness-owned outputs
     for the active run.
+
+    ``baseline`` is the workspace as it stood before the agent started
+    (``git.capture_workspace_baseline``). With one, the guard judges the
+    agent's COMPLETE delta since that point, commits included, and
+    subtracts files that were already dirty. Without one it keeps the
+    historical index+worktree-only view, which is blind to anything the
+    agent committed (R8 review finding 4) - a default preserved so
+    direct callers that never captured a baseline behave as before.
 
     In non-interactive mode, returns (False, violations) if any violations.
     In interactive mode, prompts user for action.
@@ -89,7 +130,10 @@ def enforce_allowed_paths(
         return True, []
 
     # Get changed files
-    changed = git.get_changed_files(cwd)
+    changed = (
+        git.get_changed_files_since(baseline, cwd)
+        if baseline is not None else git.get_changed_files(cwd)
+    )
     violations = check_violations(
         changed, config.allowed_paths, ignored_paths,
     )
@@ -137,12 +181,7 @@ def enforce_allowed_paths(
         # Revert
         ui.info("Reverting disallowed changes...")
         for f in violations:
-            if git.is_file_tracked(f, cwd):
-                git.restore_file(f, cwd)
-                ui.info(f"  Restored: {f}")
-            else:
-                git.delete_untracked(f, cwd)
-                ui.info(f"  Deleted: {f}")
+            _revert_violation(f, ui, cwd, baseline)
         return True, []
     else:
         # Continue anyway

--- a/kstrl/init_cmd.py
+++ b/kstrl/init_cmd.py
@@ -388,6 +388,9 @@ DEFAULT_KSTRL_TOML = """\
 [paths]
 # prompt = "scripts/kstrl/prompt.md"
 # prd = "scripts/kstrl/prd.json"
+# Setting `progress` forces ONE path on every factory component; left
+# unset, each component's engineer writes beside its own PRD, which is
+# inside that component's allowedPaths.
 # progress = "scripts/kstrl/progress.txt"
 # codebase_map = "scripts/kstrl/codebase_map.md"
 # allowed = []                     # e.g. ["scripts/kstrl/", "src/"]
@@ -427,7 +430,7 @@ DEFAULT_KSTRL_TOML = """\
 # subprocess_timeout = 300.0
 # require_self_critique = false    # fail Phase 1 if the ## Self-Critique block is missing/sparse
 # self_critique_min_bullets = 3
-# progress_file_path = "scripts/kstrl/progress.txt"
+# progress_file_path = ""          # empty = the log beside the component's PRD
 
 # Phase 1 policy envelope (R8.1): declarative merge guardrails enforced on
 # ARTIFACTS (git diff, uv.lock), never agent self-report. Opt-in; when

--- a/kstrl/loop.py
+++ b/kstrl/loop.py
@@ -419,6 +419,10 @@ def run_loop(
     interaction: InteractionChannel | None = None,
     stop_check: Callable[[], bool] | None = None,
     guard_ignored_paths: list[str] | None = None,
+    # The component's base branch. The in-loop scope guard measures from
+    # here so it asks the same question check_diff_scope does; None (the
+    # standalone `ks run` case) falls back to the starting HEAD.
+    guard_base_ref: str | None = None,
     budget: LoopBudget | None = None,
     on_iteration_usage: Callable[[UsageTotals], None] | None = None,
 ) -> LoopResult:
@@ -509,9 +513,14 @@ def run_loop(
             "to scaffold a customizable copy)."
         )
         raw_prompt = DEFAULT_PROMPT
+    # $progress_path must be CONCRETE: the agent is told to append to it.
+    # config.progress_file is None until someone configures one (R8
+    # review finding 2), so the standalone loop materializes the
+    # historical repo-root default here. A factory worker arrives with an
+    # already-resolved per-component path and gets it back untouched.
     prompt = Template(raw_prompt).safe_substitute(
         prd_path=str(config.prd_file),
-        progress_path=str(config.progress_file),
+        progress_path=str(config.resolved_progress_file(cwd)),
         codebase_map_path=str(config.codebase_map_file),
     )
 
@@ -554,8 +563,25 @@ def run_loop(
 
     # Guardrails info
     ui.subsection("Guardrails")
+    guard_baseline: git.WorkspaceBaseline | None = None
     if config.allowed_paths and is_repo:
         ui.info(f"Enforcing ALLOWED_PATHS={','.join(config.allowed_paths)}")
+        # R8 review finding 4: the guard's question is "what did THIS
+        # agent change", and only a before-picture can answer it. Taken
+        # once, here, BEFORE the first iteration and after the harness
+        # has finished staging its own files into the worktree: what is
+        # already dirty now belongs to the operator or the harness, and
+        # everything the agent does from here - committed or not - is
+        # attributable to the agent.
+        guard_baseline = git.capture_workspace_baseline(
+            cwd, base_ref=guard_base_ref,
+        )
+        if guard_baseline.dirty:
+            ui.info(
+                f"Guard baseline: HEAD {guard_baseline.head or '<unborn>'}, "
+                f"{len(guard_baseline.dirty)} pre-existing uncommitted "
+                "file(s) excluded from enforcement"
+            )
     else:
         ui.info("ALLOWED_PATHS is empty; enforcement disabled")
 
@@ -668,6 +694,7 @@ def run_loop(
             ok, violations = guards.enforce_allowed_paths(
                 config, ui, cwd, interaction=channel,
                 ignored_paths=ignored_paths,
+                baseline=guard_baseline,
             )
             if not ok:
                 return LoopResult(

--- a/kstrl/loop.py
+++ b/kstrl/loop.py
@@ -398,6 +398,12 @@ class LoopResult:
     # breach and a dead ceiling coexisted - or from the prose above.
     budget_halt_condition: str = ""
     budget_halt_ceilings: tuple[str, ...] = ()
+    # R8 review: files the in-loop ALLOWED_PATHS guard rejected. Carried
+    # because the guard used to discard them (``ok, _ =``) and the
+    # factory then reported the halt as "Did not complete" - the retry
+    # agent was told nothing about what it had touched, so its cheapest
+    # strategy was to repeat the edit.
+    guard_violations: tuple[str, ...] = ()
 
 
 def run_loop(
@@ -659,7 +665,7 @@ def run_loop(
             ignored_paths = list(guard_ignored_paths or ())
             if bus is not None and bus.run_id:
                 ignored_paths.append(f".kstrl/runs/{bus.run_id}/")
-            ok, _ = guards.enforce_allowed_paths(
+            ok, violations = guards.enforce_allowed_paths(
                 config, ui, cwd, interaction=channel,
                 ignored_paths=ignored_paths,
             )
@@ -672,6 +678,7 @@ def run_loop(
                     iteration_durations=iteration_durations,
                     timed_out_iterations=timed_out_iterations,
                     usage=collect_usage(agent),
+                    guard_violations=tuple(violations),
                 )
 
         # Check for completion

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -2639,8 +2639,16 @@ class ComponentPipeline:
             )
             if prefix:
                 progress_text = ""
+                # Resolved exactly the way the engineer's worker
+                # resolved it, so the metric reads the file this
+                # component actually wrote. The hardcoded
+                # scripts/kstrl/progress.txt this replaced was a second
+                # copy of the out-of-scope default and read nothing for
+                # every decomposed component.
                 progress_path = (
-                    wt_path / "scripts" / "kstrl" / "progress.txt"
+                    wt_path / self.base_config.component_progress_file(
+                        comp.prd_path, self.root_dir,
+                    )
                 )
                 try:
                     progress_text = progress_path.read_text(encoding="utf-8")

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -1521,6 +1521,36 @@ class ComponentPipeline:
                 success=False,
                 error=comp_result.error,
             ))
+            if comp_result.guard_violations:
+                # The in-loop guard runs the SAME check as Phase 1's
+                # diff_scope, only earlier, so it must produce the same
+                # audit record - otherwise moving the catch forward
+                # silently changes the shape of the journal, and a
+                # scope failure caught in-loop would leave no
+                # verification_result behind at all.
+                #
+                # Exactly one check is reported. Listing the others
+                # would claim tests and typecheck ran when the loop
+                # halted before they could.
+                detail = comp_result.error or "files outside allowed scope"
+                self.bus.emit(ev.VerificationResultEvent(
+                    component=comp.id, passed=False,
+                    checks=("diff_scope",), failures=(detail,),
+                    duration_seconds=0.0,
+                ))
+                # Same "<check>: FAIL" token as
+                # VerificationResult.as_context(), and the same retry
+                # reason Phase 1 uses: consumers keying on either keep
+                # working no matter which layer caught the violation. A
+                # second wording for one failure is how a mislabel
+                # becomes a divergence (R7.1 / #179).
+                ctx.add_verification_failure(f"diff_scope: FAIL - {detail}")
+                return PipelineOutcome(
+                    transition=self.retry_or_fail(
+                        comp, "Mechanical verification failed", ctx.to_json(),
+                        phase="verify", check="diff_scope",
+                    ),
+                )
             return PipelineOutcome(
                 transition=self.retry_or_fail(
                     comp, comp_result.error or "Unknown error", ctx.to_json(),
@@ -1762,6 +1792,16 @@ class ComponentPipeline:
         # agent that corrupts or deletes its own PRD would unbind its
         # write scope. Load failure now flows into check_diff_scope as
         # allowed_paths_error, which fails the check closed.
+        #
+        # R8 review finding 5: the family is OSError, not just
+        # FileNotFoundError. A prd.json that is a DIRECTORY raises
+        # IsADirectoryError and an unreadable one PermissionError; both
+        # escaped this block and became a factory EXCEPTION instead of a
+        # failed verification. Fail-closed only works if the failure is
+        # caught: an unreadable PRD must produce a verification RESULT
+        # (check_diff_scope failing on allowed_paths_error), which is
+        # recorded, retried and reported, rather than an exception the
+        # component's error path never sees.
         component_allowed_paths: list[str] | None = None
         allowed_paths_error: str | None = None
         try:
@@ -1769,6 +1809,8 @@ class ComponentPipeline:
             component_allowed_paths = prd_for_scope.allowed_paths
         except FileNotFoundError as exc:
             allowed_paths_error = f"PRD not found: {exc}"
+        except OSError as exc:
+            allowed_paths_error = f"PRD could not be read: {exc}"
         except ValueError as exc:
             allowed_paths_error = f"PRD failed to parse: {exc}"
         # R7.2: fixtures config resolves from toml/env when the

--- a/kstrl/verify.py
+++ b/kstrl/verify.py
@@ -22,6 +22,7 @@ from kstrl.adequacy import (
     is_test_path,
     layer0_blocks,
 )
+from kstrl.config import component_progress_path
 from kstrl.findings import Finding
 from kstrl.guards import path_is_allowed
 from kstrl.parsers import (
@@ -228,7 +229,15 @@ class VerifyConfig:
     # iteration's progress.txt entry omits the block.
     require_self_critique: bool = False
     self_critique_min_bullets: int = 3
-    progress_file_path: str = "scripts/kstrl/progress.txt"
+    # Where check_self_critique looks for the engineer's progress log.
+    # None (the default) derives it from the component's PRD
+    # (config.component_progress_path), which is where the engineer was
+    # actually told to write and the only location inside the
+    # component's allowedPaths. An explicit value wins for every
+    # component. It is None-defaulted rather than carrying a separate
+    # "was it set?" flag because every scalar field of this dataclass is
+    # a documented kstrl.toml key (scripts/gen_docs.py probes for that).
+    progress_file_path: str | None = None
 
     @classmethod
     def from_env(cls) -> VerifyConfig:
@@ -253,9 +262,7 @@ class VerifyConfig:
             self_critique_min_bullets=int(
                 os.environ.get("KSTRL_VERIFY_SELF_CRITIQUE_MIN_BULLETS", "3"),
             ),
-            progress_file_path=os.environ.get(
-                "KSTRL_VERIFY_PROGRESS_FILE", "scripts/kstrl/progress.txt",
-            ),
+            progress_file_path=os.environ.get("KSTRL_VERIFY_PROGRESS_FILE"),
         )
 
     @classmethod
@@ -295,7 +302,7 @@ class VerifyConfig:
                 section["self_critique_min_bullets"]
             )
         if "progress_file_path" in section:
-            config.progress_file_path = str(section["progress_file_path"])
+            config.progress_file_path = str(section["progress_file_path"]) or None
         # Env overrides. Each var is applied only when it is explicitly
         # set in the environment: the previous compare-against-default
         # heuristic silently dropped an env value that happened to equal
@@ -1439,7 +1446,17 @@ def run_mechanical_verification(
         ))
 
     if config.require_self_critique:
-        progress_path = worktree_path / config.progress_file_path
+        # Read the log the engineer was actually pointed at: a factory
+        # component writes NEXT TO its PRD (the only location inside its
+        # allowedPaths), so resolving a repo-root default here would
+        # check a file that was never written and fail the component for
+        # the harness's own path confusion. An explicit config wins.
+        # prd_path is worktree-absolute at the factory call site, so the
+        # derived sibling is too; the join is a no-op for an absolute
+        # path and still anchors a relative one.
+        progress_path = worktree_path / component_progress_path(
+            prd_path, config.progress_file_path,
+        )
         checks.append(check_self_critique(
             progress_path, config.self_critique_min_bullets,
         ))

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -346,7 +346,9 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("run", "interactive"): "human-in-the-loop mode for the legacy loop",
     ("paths", "prompt"): "engineer prompt file",
     ("paths", "prd"): "PRD file",
-    ("paths", "progress"): "progress log the agent appends to",
+    ("paths", "progress"):
+        "progress log the agent appends to; set = forced on every "
+        "factory component, unset = each writes beside its own PRD",
     ("paths", "codebase_map"): "brownfield codebase notes",
     ("paths", "allowed"): 'diff-scope allowlist, e.g. ["src/", "tests/"]; empty = unrestricted',
     ("git", "branch"): "branch override; empty = use PRD branchName",
@@ -409,7 +411,9 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("verify", "require_self_critique"):
         "fail Phase 1 if the ## Self-Critique block is missing/sparse",
     ("verify", "self_critique_min_bullets"): "minimum substantive bullets in the block",
-    ("verify", "progress_file_path"): "progress file the self-critique check reads",
+    ("verify", "progress_file_path"):
+        "progress file the self-critique check reads; "
+        "empty = the log beside the component's PRD",
     ("fixtures", "enabled"):
         "run PRD-defined fixtures during Phase 1 (sandboxed; opt-in)",
     ("fixtures", "snapshot_on_success"):

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -346,9 +346,15 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("run", "interactive"): "human-in-the-loop mode for the legacy loop",
     ("paths", "prompt"): "engineer prompt file",
     ("paths", "prd"): "PRD file",
+    # Rendered as `progress = ""` because the dataclass default is None
+    # (unset). Copying the generated line is therefore INERT - the empty
+    # string is ignored by the loader. The previous rendering emitted the
+    # live repo-root path, and copying THAT recreated the out-of-scope
+    # defect this key's default was changed to avoid (review finding 1).
     ("paths", "progress"):
-        "progress log the agent appends to; set = forced on every "
-        "factory component, unset = each writes beside its own PRD",
+        'progress log the agent appends to; empty = each factory '
+        "component writes beside its own PRD (inside its allowedPaths), "
+        "set = that one path is forced on every component",
     ("paths", "codebase_map"): "brownfield codebase notes",
     ("paths", "allowed"): 'diff-scope allowlist, e.g. ["src/", "tests/"]; empty = unrestricted',
     ("git", "branch"): "branch override; empty = use PRD branchName",

--- a/tests/test_progress_scope.py
+++ b/tests/test_progress_scope.py
@@ -20,12 +20,16 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 
+from kstrl import git
 from kstrl.config import KstrlConfig, component_progress_path
 from kstrl.decompose import _generate_component_prd
 from kstrl.events import EventBus, V1CompatSink
@@ -34,10 +38,13 @@ from kstrl.factory import (
     ComponentResult,
     FactoryConfig,
     FactoryResult,
+    _component_scope,
     run_factory,
 )
-from kstrl.guards import path_is_allowed
+from kstrl.guards import enforce_allowed_paths, path_is_allowed
+from kstrl.interaction import PromptRequest, PromptResponse
 from kstrl.knowledge import KnowledgeConfig
+from kstrl.loop import run_loop
 from kstrl.manifest import Component, Manifest
 from kstrl.observability import NotifyConfig, NotifyHooks, ProgressLog
 from kstrl.pipeline import ComponentPipeline, PipelineHooks
@@ -102,16 +109,90 @@ def _manifest(components: list[Component]) -> Manifest:
 
 
 def _base_config(root: Path) -> KstrlConfig:
+    """A factory base config with NOTHING configured for the progress
+    log. ``progress_file`` is deliberately left at its None default:
+    passing a value here is now an explicit setting that is forced on
+    every component (review finding 2)."""
     return KstrlConfig(
         prompt_file=root / "scripts" / "kstrl" / "prompt.md",
         prd_file=root / "scripts" / "kstrl" / "prd.json",
-        progress_file=root / "scripts" / "kstrl" / "progress.txt",
         sleep_seconds=0,
         agent_cmd="echo test",
         kstrl_branch="",
         kstrl_branch_explicit=True,
         ui_mode="plain",
         no_color=True,
+    )
+
+
+def _pipeline(
+    root: Path,
+    comp: Component,
+    wt_path: Path,
+    *,
+    measure_fact_utilization: Any = None,
+    run_mechanical_verification: Any = None,
+) -> ComponentPipeline:
+    """A ComponentPipeline wired to stub hooks so a single phase can be
+    driven directly. Only the hooks a test cares about are injected."""
+    ui = PlainUI(no_color=True, file=io.StringIO())
+    return ComponentPipeline(
+        manifest=_manifest([comp]),
+        manifest_path=root / "manifest.json",
+        factory_config=FactoryConfig(
+            use_worktrees=False, create_prs=False, max_parallel=1,
+            max_retries=0, retry_delay=0, review_mode="skip",
+        ),
+        base_config=_base_config(root),
+        ui=ui,
+        root_dir=root,
+        run_id="run-test",
+        bus=EventBus(
+            V1CompatSink(ProgressLog(
+                root / "progress.jsonl", run_id="run-test",
+            )),
+            run_id="run-test",
+        ),
+        journal_path=None,
+        notify=NotifyHooks(
+            NotifyConfig(), run_id="run-test", project="t", warn=ui.warn,
+        ),
+        review_selection=AdversarialAgentSelection(
+            phase="review", agent_cmd=None, agent_type=None, model=None,
+            reasoning=None, source="explicit", identity="test-review",
+        ),
+        security_selection=None,
+        knowledge_config=KnowledgeConfig(enabled=True),
+        factory_result=FactoryResult(),
+        hooks=PipelineHooks(
+            run_mechanical_verification=(
+                run_mechanical_verification
+                or (lambda *a, **k: VerificationResult(passed=True, checks=[]))
+            ),
+            run_review=lambda *a, **k: ReviewResult(
+                passed=True, mode="advisory",
+            ),
+            run_chunked_review=lambda *a, **k: ReviewResult(
+                passed=True, mode="hard",
+            ),
+            run_security_review=lambda *a, **k: SecurityResult(
+                passed=True, mode="advisory",
+            ),
+            run_chunked_security_review=lambda *a, **k: SecurityResult(
+                passed=True, mode="hard",
+            ),
+            distill_facts=lambda *a, **k: (1, "1 fact written"),
+            build_knowledge_context=lambda *a, **k: "FACT: fact-alpha",
+            measure_fact_utilization=(
+                measure_fact_utilization
+                or (lambda *a, **k: {"injected": 0, "referenced": 0})
+            ),
+            cleanup_worktree=lambda *a, **k: None,
+        ),
+        worktree_paths={comp.id: wt_path},
+        component_contexts={},
+        fresh_base_retry_ids=set(),
+        component_failure_signatures={},
     )
 
 
@@ -179,13 +260,16 @@ class TestProgressPathInsideAllowedPaths:
         ) == f"{FEATURE_DIR}/progress.txt"
 
     def test_single_component_layout_is_unchanged(self, tmp_path: Path) -> None:
-        """``ks run`` has no feature subtree: a PRD at
+        """The standalone loop has no feature subtree: a PRD at
         scripts/kstrl/prd.json still yields scripts/kstrl/progress.txt,
-        so the standalone loop keeps its historical path."""
+        and an unconfigured config still resolves to the historical
+        repo-root path when a concrete one is demanded."""
         assert component_progress_path(
             "scripts/kstrl/prd.json",
         ) == Path("scripts/kstrl/progress.txt")
-        assert KstrlConfig().progress_file == Path("scripts/kstrl/progress.txt")
+        assert KstrlConfig().resolved_progress_file(tmp_path) == (
+            tmp_path / "scripts/kstrl/progress.txt"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +285,7 @@ class TestExplicitConfigurationWins:
             '[paths]\nprogress = "docs/agent-progress.md"\n'
         )
         config = KstrlConfig.load(tmp_path)
-        assert config.progress_file_explicit
+        assert config.progress_file is not None
         assert config.component_progress_file(
             f"{FEATURE_DIR}/prd.json", tmp_path,
         ) == "docs/agent-progress.md"
@@ -211,7 +295,7 @@ class TestExplicitConfigurationWins:
     ) -> None:
         monkeypatch.setenv("PROGRESS_FILE", "docs/env-progress.md")
         config = KstrlConfig.load(tmp_path)
-        assert config.progress_file_explicit
+        assert config.progress_file is not None
         assert config.component_progress_file(
             f"{FEATURE_DIR}/prd.json", tmp_path,
         ) == "docs/env-progress.md"
@@ -219,19 +303,103 @@ class TestExplicitConfigurationWins:
     def test_explicit_value_equal_to_the_default_is_still_explicit(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Explicitness is tracked, not inferred by comparing against
-        the default - an operator who pins the historical path gets it.
+        """Explicitness is carried by the sentinel, not inferred by
+        comparing against the default (R2.1 removed that pattern) - an
+        operator who pins the historical path gets it.
         """
         monkeypatch.setenv("PROGRESS_FILE", "scripts/kstrl/progress.txt")
         config = KstrlConfig.load(tmp_path)
-        assert config.progress_file_explicit
+        assert config.progress_file is not None
         assert config.component_progress_file(
             f"{FEATURE_DIR}/prd.json", tmp_path,
         ) == "scripts/kstrl/progress.txt"
 
-    def test_unset_config_is_not_explicit(self, tmp_path: Path) -> None:
-        assert not KstrlConfig.load(tmp_path).progress_file_explicit
-        assert not KstrlConfig.from_env(tmp_path).progress_file_explicit
+    def test_unset_config_is_the_none_sentinel(self, tmp_path: Path) -> None:
+        assert KstrlConfig.load(tmp_path).progress_file is None
+        assert KstrlConfig.from_env(tmp_path).progress_file is None
+        assert KstrlConfig.from_toml(tmp_path / "kstrl.toml").progress_file is None
+
+
+class TestProgrammaticallySetProgressFileIsHonored:
+    """Review finding 2: a caller that CONSTRUCTS a config must be obeyed.
+
+    ``progress_file_explicit`` was set only by the toml and env loaders,
+    so ``KstrlConfig(progress_file=...)`` - the shape used by tests,
+    embedders and the SDK, and honored by ``run_factory(..., base_config)``
+    before this PR - was silently ignored and the derived per-component
+    path used instead. The None sentinel makes construction and attribute
+    assignment unambiguously explicit with no second field to coordinate.
+    """
+
+    def test_constructor_value_is_honored(self, tmp_path: Path) -> None:
+        config = KstrlConfig(progress_file=Path("docs/custom-progress.md"))
+        assert config.component_progress_file(
+            f"{FEATURE_DIR}/prd.json", tmp_path,
+        ) == "docs/custom-progress.md"
+
+    def test_attribute_assignment_is_honored(self, tmp_path: Path) -> None:
+        config = _base_config(tmp_path)
+        assert config.component_progress_file(
+            f"{FEATURE_DIR}/prd.json", tmp_path,
+        ) == f"{FEATURE_DIR}/progress.txt"
+        config.progress_file = tmp_path / "docs" / "custom-progress.md"
+        assert config.component_progress_file(
+            f"{FEATURE_DIR}/prd.json", tmp_path,
+        ) == "docs/custom-progress.md"
+
+    def test_run_factory_honors_a_directly_constructed_config(
+        self, tmp_path: Path,
+    ) -> None:
+        """The end-to-end shape of the regression: no toml, no env, one
+        constructor argument, and the worker must be told THAT path."""
+        _setup_project(tmp_path, [COMPONENT_ID])
+        captured: list[tuple[Any, ...]] = []
+
+        def fake_component(*args: Any, **kwargs: Any) -> ComponentResult:
+            captured.append(args)
+            return ComponentResult(
+                COMPONENT_ID, success=True, iterations=1,
+                duration_seconds=1.0,
+            )
+
+        base = _base_config(tmp_path)
+        base.progress_file = Path("docs/custom-progress.md")
+
+        with patch(
+            "kstrl.factory._run_component", side_effect=fake_component,
+        ), patch("kstrl.git.get_diff_content", return_value=""):
+            run_factory(
+                _manifest([_component()]),
+                FactoryConfig(
+                    use_worktrees=False, create_prs=False, max_parallel=1,
+                    max_retries=0, retry_delay=0, review_mode="skip",
+                    verify_config=None,
+                    progress_log_path=tmp_path / "progress.jsonl",
+                ),
+                base,
+                PlainUI(no_color=True, file=io.StringIO()),
+                tmp_path,
+            )
+
+        assert captured, "worker was never invoked"
+        assert "docs/custom-progress.md" in captured[0]
+
+    def test_the_standalone_loop_still_gets_a_concrete_path(
+        self, tmp_path: Path,
+    ) -> None:
+        """The sentinel must not leak "None" into the engineer prompt:
+        the loop resolves it against the run root."""
+        assert KstrlConfig().resolved_progress_file(tmp_path) == (
+            tmp_path / "scripts/kstrl/progress.txt"
+        )
+        # An absolute explicit setting is returned untouched (the factory
+        # worker's case); a relative one is anchored to the root.
+        assert KstrlConfig(
+            progress_file=tmp_path / "wt" / "p.txt",
+        ).resolved_progress_file(tmp_path) == tmp_path / "wt" / "p.txt"
+        assert KstrlConfig(
+            progress_file=Path("docs/p.md"),
+        ).resolved_progress_file(tmp_path) == tmp_path / "docs" / "p.md"
 
 
 # ---------------------------------------------------------------------------
@@ -426,60 +594,9 @@ class TestFactUtilizationReadsTheComponentLog:
             seen.append(progress)
             return {"injected": 1, "referenced": 1}
 
-        ui = PlainUI(no_color=True, file=io.StringIO())
-        pipeline = ComponentPipeline(
-            manifest=_manifest([comp]),
-            manifest_path=tmp_path / "manifest.json",
-            factory_config=FactoryConfig(
-                use_worktrees=False, create_prs=False, max_parallel=1,
-                max_retries=0, retry_delay=0, review_mode="skip",
-            ),
-            base_config=_base_config(tmp_path),
-            ui=ui,
-            root_dir=tmp_path,
-            run_id="run-test",
-            bus=EventBus(
-                V1CompatSink(ProgressLog(
-                    tmp_path / "progress.jsonl", run_id="run-test",
-                )),
-                run_id="run-test",
-            ),
-            journal_path=None,
-            notify=NotifyHooks(
-                NotifyConfig(), run_id="run-test", project="t", warn=ui.warn,
-            ),
-            review_selection=AdversarialAgentSelection(
-                phase="review", agent_cmd=None, agent_type=None, model=None,
-                reasoning=None, source="explicit", identity="test-review",
-            ),
-            security_selection=None,
-            knowledge_config=KnowledgeConfig(enabled=True),
-            factory_result=FactoryResult(),
-            hooks=PipelineHooks(
-                run_mechanical_verification=(
-                    lambda *a, **k: VerificationResult(passed=True, checks=[])
-                ),
-                run_review=lambda *a, **k: ReviewResult(
-                    passed=True, mode="advisory",
-                ),
-                run_chunked_review=lambda *a, **k: ReviewResult(
-                    passed=True, mode="hard",
-                ),
-                run_security_review=lambda *a, **k: SecurityResult(
-                    passed=True, mode="advisory",
-                ),
-                run_chunked_security_review=lambda *a, **k: SecurityResult(
-                    passed=True, mode="hard",
-                ),
-                distill_facts=lambda *a, **k: (1, "1 fact written"),
-                build_knowledge_context=lambda *a, **k: "FACT: fact-alpha",
-                measure_fact_utilization=fake_measure,
-                cleanup_worktree=lambda *a, **k: None,
-            ),
-            worktree_paths={comp.id: wt_path},
-            component_contexts={},
-            fresh_base_retry_ids=set(),
-            component_failure_signatures={},
+        pipeline = _pipeline(
+            tmp_path, comp, wt_path,
+            measure_fact_utilization=fake_measure,
         )
 
         pipeline._phase_distill(
@@ -638,3 +755,633 @@ class TestProgressWriterAndReaderAgree:
         assert reconcile_progress_paths("a/p.txt", "b/p.txt") == (
             "a/p.txt", "b/p.txt",
         )
+
+
+# ---------------------------------------------------------------------------
+# Review finding 3: the writer and the reader must be reconciled in ONE
+# path domain, and the proof is the RUNTIME paths, not the strings.
+# ---------------------------------------------------------------------------
+
+
+_CUSTOM_PROGRESS = "docs/custom-progress.md"
+
+
+def _worker_write_path(
+    base_config: KstrlConfig, root: Path, wt_path: Path, prd_rel: str,
+) -> Path:
+    """The file the engineer's worker actually writes.
+
+    Both steps are the production ones: ``component_progress_file`` is
+    what ``factory._submit_args`` passes down, and ``_run_component``
+    turns that into the ``KstrlConfig.progress_file`` the loop hands to
+    the agent as ``$progress_path``.
+    """
+    from kstrl.factory import _run_component
+    from kstrl.loop import LoopResult
+
+    seen: list[KstrlConfig] = []
+
+    def fake_run_loop(
+        config: KstrlConfig, *args: Any, **kwargs: Any,
+    ) -> LoopResult:
+        seen.append(config)
+        return LoopResult(
+            completed=True, iterations=1, exit_code=0, duration_seconds=0.0,
+        )
+
+    with patch("kstrl.loop.run_loop", side_effect=fake_run_loop):
+        _run_component(
+            component_id=COMPONENT_ID,
+            prd_path_str=prd_rel,
+            worktree_path_str=str(wt_path),
+            root_dir_str=str(root),
+            prompt_file_str="scripts/kstrl/prompt.md",
+            agent_cmd="echo test",
+            model=None, reasoning=None, agent_type=None,
+            sleep_seconds=0.0,
+            progress_file_str=base_config.component_progress_file(
+                prd_rel, root,
+            ),
+            redirect_output=False,
+        )
+
+    assert seen, "run_loop was never called"
+    assert seen[0].progress_file is not None
+    return seen[0].progress_file
+
+
+class TestWriterAndReaderResolveToTheSameFILE:
+    """Review finding 3: reconciling the raw values compared an ABSOLUTE
+    writer (``KstrlConfig.load`` resolves ``[paths] progress`` against the
+    main checkout) with a verbatim-relative reader. The reconciled
+    STRINGS came out equal while the runtime paths did not - the worker
+    wrote ``<worktree>/docs/custom-progress.md`` and the self-critique
+    check read ``<root>/docs/custom-progress.md``.
+
+    These tests compare the paths, never the strings: the writer path is
+    the one ``_run_component`` hands the loop, and the reader is the real
+    ``run_mechanical_verification``.
+    """
+
+    def _project(self, tmp_path: Path, toml: str) -> tuple[Path, Path, str]:
+        root = tmp_path / "root"
+        root.mkdir()
+        _setup_project(root, [COMPONENT_ID])
+        (root / "kstrl.toml").write_text(toml)
+        wt_path = tmp_path / "wt"
+        prd_rel = f"{FEATURE_DIR}/prd.json"
+        (wt_path / FEATURE_DIR).mkdir(parents=True)
+        (wt_path / prd_rel).write_text(json.dumps({
+            "branchName": "test", "userStories": [],
+        }))
+        return root, wt_path, prd_rel
+
+    def _reconciled(self, root: Path) -> tuple[KstrlConfig, VerifyConfig]:
+        """The factory command's wiring, verbatim."""
+        from kstrl.config import reconcile_progress_config
+
+        base_config = KstrlConfig.load(root)
+        v_config = VerifyConfig.load(root)
+        v_config.require_self_critique = True
+        v_config.test_command = "true"
+        v_config.typecheck_command = "true"
+        v_config.lint_command = "true"
+        v_config.check_diff_scope = False
+        v_config.check_bad_patterns = False
+        v_config.subprocess_timeout = 10.0
+        assert reconcile_progress_config(base_config, v_config, root) is None
+        return base_config, v_config
+
+    def test_writer_path_is_what_the_verification_reads(
+        self, tmp_path: Path,
+    ) -> None:
+        """[paths] progress set alone: the file the worker writes is the
+        file Phase 1 reads, and it is inside the WORKTREE."""
+        root, wt_path, prd_rel = self._project(
+            tmp_path, f'[paths]\nprogress = "{_CUSTOM_PROGRESS}"\n',
+        )
+        base_config, v_config = self._reconciled(root)
+
+        write_path = _worker_write_path(base_config, root, wt_path, prd_rel)
+        assert write_path == wt_path / _CUSTOM_PROGRESS, (
+            "the worker writes inside its worktree; a reader anchored "
+            "anywhere else inspects a file that does not exist"
+        )
+
+        # The engineer writes its entry EXACTLY where it was told to.
+        write_path.parent.mkdir(parents=True, exist_ok=True)
+        write_path.write_text(_SELF_CRITIQUE_ENTRY)
+        # A stale copy in the main checkout must not rescue the check.
+        (root / "docs").mkdir(parents=True, exist_ok=True)
+        (root / _CUSTOM_PROGRESS).write_text("stale root copy, no critique\n")
+
+        result = run_mechanical_verification(
+            wt_path, wt_path / prd_rel, "main", None, v_config,
+        )
+        check = _self_critique_check(result)
+        assert check.passed, check.message
+
+    def test_reader_only_configuration_agrees_too(
+        self, tmp_path: Path,
+    ) -> None:
+        """The symmetric case: [verify] progress_file_path set alone
+        propagates to the writer in the same domain."""
+        root, wt_path, prd_rel = self._project(
+            tmp_path,
+            f'[verify]\nprogress_file_path = "{_CUSTOM_PROGRESS}"\n',
+        )
+        base_config, v_config = self._reconciled(root)
+
+        write_path = _worker_write_path(base_config, root, wt_path, prd_rel)
+        assert write_path == wt_path / _CUSTOM_PROGRESS
+
+        write_path.parent.mkdir(parents=True, exist_ok=True)
+        write_path.write_text(_SELF_CRITIQUE_ENTRY)
+        result = run_mechanical_verification(
+            wt_path, wt_path / prd_rel, "main", None, v_config,
+        )
+        assert _self_critique_check(result).passed
+
+    def test_both_set_differently_warns_and_overrides_neither(
+        self, tmp_path: Path,
+    ) -> None:
+        root, _wt_path, _prd_rel = self._project(
+            tmp_path,
+            '[paths]\nprogress = "docs/writer.md"\n'
+            '[verify]\nprogress_file_path = "docs/reader.md"\n',
+        )
+        from kstrl.config import reconcile_progress_config
+
+        base_config = KstrlConfig.load(root)
+        v_config = VerifyConfig.load(root)
+        warning = reconcile_progress_config(base_config, v_config, root)
+        assert warning is not None
+        assert "docs/writer.md" in warning
+        assert "docs/reader.md" in warning
+        assert base_config.progress_file == Path("docs/writer.md")
+        assert v_config.progress_file_path == "docs/reader.md"
+
+
+# ---------------------------------------------------------------------------
+# Review finding 1: the GENERATED docs must not ship the defective key
+# ---------------------------------------------------------------------------
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _generated_config_reference() -> str:
+    """The toml block README.md ships between the config-reference
+    markers - the text an operator copies into their kstrl.toml."""
+    text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    body = text.split("<!-- BEGIN GENERATED: config-reference -->", 1)[1]
+    body = body.split("<!-- END GENERATED: config-reference -->", 1)[0]
+    return body.split("```toml", 1)[1].split("```", 1)[0]
+
+
+class TestShippedConfigsKeepTheProgressLogInScope:
+    """Review finding 1: ``README.md`` (GENERATED by scripts/gen_docs.py)
+    emitted a LIVE ``progress = "scripts/kstrl/progress.txt"`` line.
+    Copying it recreated the exact defect this PR fixes - the resolved
+    progress path leaves the component's allowedPaths and Phase 1
+    diff_scope fails the component. Commenting the key out of
+    kstrl.toml.example alone was insufficient: the generator regenerates
+    the active block.
+    """
+
+    @pytest.mark.parametrize(
+        "source", ["readme", "example"],
+    )
+    def test_a_copied_config_keeps_the_log_inside_component_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, source: str,
+    ) -> None:
+        monkeypatch.delenv("PROGRESS_FILE", raising=False)
+        toml_text = (
+            _generated_config_reference() if source == "readme"
+            else (REPO_ROOT / "kstrl.toml.example").read_text(encoding="utf-8")
+        )
+        (tmp_path / "kstrl.toml").write_text(toml_text, encoding="utf-8")
+
+        config = KstrlConfig.load(tmp_path)
+        prd_rel = f"{FEATURE_DIR}/prd.json"
+        progress_rel = config.component_progress_file(prd_rel, tmp_path)
+
+        assert path_is_allowed(progress_rel, ARCHITECT_ALLOWED_PATHS), (
+            f"a config copied from {source} resolves the progress log to "
+            f"{progress_rel}, outside the component's allowedPaths "
+            f"{ARCHITECT_ALLOWED_PATHS}; Phase 1 diff_scope would fail "
+            "the component"
+        )
+        assert progress_rel == f"{FEATURE_DIR}/progress.txt"
+
+    def test_the_generated_line_is_inert(self) -> None:
+        """The rendering is `progress = ""`, i.e. unset. The value is
+        ignored by the loader, so the documented line cannot reintroduce
+        a forced repo-root path."""
+        block = _generated_config_reference()
+        assert 'progress = ""' in block
+        assert 'progress = "scripts/kstrl/progress.txt"' not in block
+
+    def test_config_show_reports_the_setting_as_unset(
+        self, tmp_path: Path,
+    ) -> None:
+        """`ks config show` reported <root>/scripts/kstrl/progress.txt as
+        the effective default - the obsolete path, presented as fact."""
+        from kstrl.config_report import build_config_report
+
+        report = build_config_report(tmp_path)
+        rows = [
+            r for r in report.rows
+            if r.section == "paths" and r.key == "progress"
+        ]
+        assert len(rows) == 1
+        assert rows[0].source == "default"
+        assert "scripts/kstrl/progress.txt" not in rows[0].value
+        assert "unset" in rows[0].value
+
+    def test_config_show_still_reports_a_configured_path(
+        self, tmp_path: Path,
+    ) -> None:
+        """The unset rendering must not swallow a real setting."""
+        from kstrl.config_report import build_config_report
+
+        (tmp_path / "kstrl.toml").write_text(
+            f'[paths]\nprogress = "{_CUSTOM_PROGRESS}"\n'
+        )
+        report = build_config_report(tmp_path)
+        row = next(
+            r for r in report.rows
+            if r.section == "paths" and r.key == "progress"
+        )
+        assert row.source == "toml"
+        assert row.value.endswith(_CUSTOM_PROGRESS)
+
+
+# ---------------------------------------------------------------------------
+# Review finding 4: the in-loop guard needs a per-worker change baseline
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True,
+    )
+
+
+def _git_repo(root: Path) -> None:
+    """A repo whose scaffolding is already COMMITTED, so the only later
+    changes are the ones a test makes."""
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(root)],
+        check=True, capture_output=True,
+    )
+    _git("config", "user.email", "t@t", cwd=root)
+    _git("config", "user.name", "t", cwd=root)
+    kstrl_dir = root / "scripts" / "kstrl"
+    kstrl_dir.mkdir(parents=True, exist_ok=True)
+    (kstrl_dir / "prompt.md").write_text("test prompt")
+    (kstrl_dir / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    (root / "src").mkdir(exist_ok=True)
+    (root / "src" / "existing.py").write_text("x = 1\n")
+    _git("add", "-A", cwd=root)
+    _git("commit", "-q", "-m", "init", cwd=root)
+
+
+def _guard_config(root: Path, *, interactive: bool = False) -> KstrlConfig:
+    return KstrlConfig(
+        max_iterations=1,
+        prompt_file=root / "scripts" / "kstrl" / "prompt.md",
+        prd_file=root / "scripts" / "kstrl" / "prd.json",
+        sleep_seconds=0,
+        interactive=interactive,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
+        allowed_paths=["src/"],
+    )
+
+
+class _ScriptedChannel:
+    """An InteractionChannel that always answers with one fixed choice."""
+
+    def __init__(self, choice: int) -> None:
+        self.choice = choice
+
+    def can_prompt(self) -> bool:
+        return True
+
+    def request(self, req: PromptRequest) -> PromptResponse:
+        return PromptResponse(
+            request_id=req.request_id, choice=self.choice, answered=True,
+        )
+
+
+class _CommittingRogueAgent:
+    """The engineer as the prompt actually instructs it: do the work,
+    then COMMIT. Here the work is out of scope."""
+
+    def __init__(self, repo: Path, rel_path: str) -> None:
+        self._repo = repo
+        self._rel_path = rel_path
+        self._final_message: str | None = None
+
+    @property
+    def name(self) -> str:
+        return "committing-rogue"
+
+    def run(
+        self, prompt: str, cwd: Path | None = None, timeout: float | None = None,
+    ) -> Iterator[str]:
+        target = self._repo / self._rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("out of scope\n")
+        _git("add", "-A", cwd=self._repo)
+        _git("commit", "-q", "-m", "story 1", cwd=self._repo)
+        yield "committed story 1"
+
+    @property
+    def final_message(self) -> str | None:
+        return self._final_message
+
+
+class TestGuardSeesCommittedChanges:
+    """Review finding 4, reproduced verbatim: the engineer COMMITS after
+    every story, and ``git.get_changed_files`` reports only staged,
+    unstaged and untracked files. The tripwire was therefore bypassed
+    exactly when it mattered - after the agent had done (and paid for)
+    the most work.
+    """
+
+    def test_the_blind_spot_is_real(self, tmp_path: Path) -> None:
+        """The premise, asserted rather than assumed: once committed, an
+        out-of-scope file is invisible to the old change source."""
+        _git_repo(tmp_path)
+        (tmp_path / "OUTSIDE.md").write_text("agent wrote this\n")
+        _git("add", "-A", cwd=tmp_path)
+        _git("commit", "-q", "-m", "story 1", cwd=tmp_path)
+
+        assert git.get_changed_files(tmp_path) == set()
+
+    def test_a_committed_out_of_scope_edit_is_caught(
+        self, tmp_path: Path,
+    ) -> None:
+        _git_repo(tmp_path)
+        baseline = git.capture_workspace_baseline(tmp_path)
+
+        (tmp_path / "OUTSIDE.md").write_text("agent wrote this\n")
+        _git("add", "-A", cwd=tmp_path)
+        _git("commit", "-q", "-m", "story 1", cwd=tmp_path)
+
+        ok, violations = enforce_allowed_paths(
+            _guard_config(tmp_path),
+            PlainUI(no_color=True, file=io.StringIO()),
+            tmp_path,
+            baseline=baseline,
+        )
+        assert not ok
+        assert violations == ["OUTSIDE.md"]
+
+    def test_a_committed_in_scope_edit_is_not_a_violation(
+        self, tmp_path: Path,
+    ) -> None:
+        """The guard must not simply flag everything committed."""
+        _git_repo(tmp_path)
+        baseline = git.capture_workspace_baseline(tmp_path)
+
+        (tmp_path / "src" / "new.py").write_text("y = 2\n")
+        _git("add", "-A", cwd=tmp_path)
+        _git("commit", "-q", "-m", "story 1", cwd=tmp_path)
+
+        ok, violations = enforce_allowed_paths(
+            _guard_config(tmp_path),
+            PlainUI(no_color=True, file=io.StringIO()),
+            tmp_path,
+            baseline=baseline,
+        )
+        assert ok
+        assert violations == []
+
+    def test_no_baseline_keeps_the_historical_semantics(
+        self, tmp_path: Path,
+    ) -> None:
+        """Backwards compatibility, stated explicitly: a caller that
+        supplies no baseline gets the index+worktree view it always got,
+        blind spot included. Every in-harness caller now supplies one."""
+        _git_repo(tmp_path)
+        (tmp_path / "OUTSIDE.md").write_text("agent wrote this\n")
+        _git("add", "-A", cwd=tmp_path)
+        _git("commit", "-q", "-m", "story 1", cwd=tmp_path)
+
+        ok, violations = enforce_allowed_paths(
+            _guard_config(tmp_path),
+            PlainUI(no_color=True, file=io.StringIO()),
+            tmp_path,
+        )
+        assert ok
+        assert violations == []
+
+    def test_the_loop_catches_a_committing_agent(
+        self, tmp_path: Path,
+    ) -> None:
+        """End to end through run_loop, which is where the baseline is
+        captured: an agent that commits out of scope halts the loop and
+        the violated file reaches the caller."""
+        _git_repo(tmp_path)
+        result = run_loop(
+            _guard_config(tmp_path),
+            PlainUI(no_color=True, file=io.StringIO()),
+            _CommittingRogueAgent(tmp_path, "OUTSIDE.md"),
+            tmp_path,
+        )
+        assert result.completed is False
+        assert result.exit_code == 1
+        assert result.guard_violations == ("OUTSIDE.md",)
+
+
+class TestGuardIgnoresPreExistingDirt:
+    """The converse failure: in a --no-worktrees run the operator's own
+    uncommitted file was reported as the AGENT's violation, and
+    "Revert and continue" would have destroyed it."""
+
+    def _dirty_operator_file(self, tmp_path: Path) -> None:
+        _git_repo(tmp_path)
+        (tmp_path / "operator-notes.txt").write_text("my notes\n")
+
+    def test_pre_existing_dirt_is_not_attributed_to_the_agent(
+        self, tmp_path: Path,
+    ) -> None:
+        self._dirty_operator_file(tmp_path)
+        baseline = git.capture_workspace_baseline(tmp_path)
+        assert "operator-notes.txt" in baseline.dirty
+
+        # The agent then works strictly in scope.
+        (tmp_path / "src" / "new.py").write_text("y = 2\n")
+
+        ok, violations = enforce_allowed_paths(
+            _guard_config(tmp_path),
+            PlainUI(no_color=True, file=io.StringIO()),
+            tmp_path,
+            baseline=baseline,
+        )
+        assert ok
+        assert violations == []
+
+    def test_without_a_baseline_the_operator_is_blamed(
+        self, tmp_path: Path,
+    ) -> None:
+        """The false positive being fixed, pinned so the contrast is not
+        a claim."""
+        self._dirty_operator_file(tmp_path)
+
+        ok, violations = enforce_allowed_paths(
+            _guard_config(tmp_path),
+            PlainUI(no_color=True, file=io.StringIO()),
+            tmp_path,
+        )
+        assert not ok
+        assert violations == ["operator-notes.txt"]
+
+    def test_the_loop_leaves_operator_work_alone(
+        self, tmp_path: Path,
+    ) -> None:
+        """Interactive "Revert and continue" must not reach a file the
+        agent never touched - it is not in the violation list at all."""
+        self._dirty_operator_file(tmp_path)
+        result = run_loop(
+            _guard_config(tmp_path, interactive=True),
+            PlainUI(no_color=True, file=io.StringIO()),
+            _CommittingRogueAgent(tmp_path, "src/in_scope.py"),
+            tmp_path,
+            interaction=_ScriptedChannel(1),
+        )
+        assert result.guard_violations == ()
+        assert (tmp_path / "operator-notes.txt").read_text() == "my notes\n"
+
+
+class TestRevertUndoesCommittedViolations:
+    """A baseline-aware guard can be reverting a COMMITTED change, which
+    ``git restore`` from the INDEX would report as reverted while leaving
+    the file exactly as the agent left it."""
+
+    def test_a_committed_new_file_is_removed(self, tmp_path: Path) -> None:
+        _git_repo(tmp_path)
+        baseline = git.capture_workspace_baseline(tmp_path)
+        (tmp_path / "OUTSIDE.md").write_text("agent wrote this\n")
+        _git("add", "-A", cwd=tmp_path)
+        _git("commit", "-q", "-m", "story 1", cwd=tmp_path)
+
+        ok, violations = enforce_allowed_paths(
+            _guard_config(tmp_path, interactive=True),
+            PlainUI(no_color=True, file=io.StringIO()),
+            tmp_path,
+            interaction=_ScriptedChannel(1),
+            baseline=baseline,
+        )
+        assert ok
+        assert violations == []
+        assert not (tmp_path / "OUTSIDE.md").exists()
+        # And the delta against the baseline no longer carries it, so the
+        # next iteration does not re-detect the same violation.
+        assert "OUTSIDE.md" not in git.get_changed_files_since(
+            baseline, tmp_path,
+        )
+
+    def test_a_committed_edit_to_a_tracked_file_is_rolled_back(
+        self, tmp_path: Path,
+    ) -> None:
+        _git_repo(tmp_path)
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "notes.md").write_text("original\n")
+        _git("add", "-A", cwd=tmp_path)
+        _git("commit", "-q", "-m", "docs", cwd=tmp_path)
+        baseline = git.capture_workspace_baseline(tmp_path)
+
+        (tmp_path / "docs" / "notes.md").write_text("agent rewrote this\n")
+        _git("add", "-A", cwd=tmp_path)
+        _git("commit", "-q", "-m", "story 1", cwd=tmp_path)
+
+        ok, violations = enforce_allowed_paths(
+            _guard_config(tmp_path, interactive=True),
+            PlainUI(no_color=True, file=io.StringIO()),
+            tmp_path,
+            interaction=_ScriptedChannel(1),
+            baseline=baseline,
+        )
+        assert ok
+        assert violations == []
+        assert (tmp_path / "docs" / "notes.md").read_text() == "original\n"
+        assert "docs/notes.md" not in git.get_changed_files_since(
+            baseline, tmp_path,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Review finding 5: an unreadable PRD must not abort scheduling or Phase 1
+# ---------------------------------------------------------------------------
+
+
+class TestUnreadablePrdIsCaught:
+    """``_component_scope`` caught only (FileNotFoundError, ValueError).
+    A prd.json that is a DIRECTORY raises IsADirectoryError and an
+    unreadable one PermissionError - both OSError subclasses that escaped
+    and aborted SCHEDULING, before Phase 1 ever ran."""
+
+    PRD_REL = "scripts/kstrl/feature/comp-a/prd.json"
+
+    def _component(self) -> Component:
+        return Component("comp-a", "A", "D", [], self.PRD_REL, "kstrl/comp-a")
+
+    def test_a_prd_that_is_a_directory_falls_back(
+        self, tmp_path: Path,
+    ) -> None:
+        (tmp_path / self.PRD_REL).mkdir(parents=True)
+        base = KstrlConfig(allowed_paths=["fallback/"])
+        assert _component_scope(
+            self._component(), tmp_path, base,
+        ) == ["fallback/"]
+
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root bypasses file permissions",
+    )
+    def test_an_unreadable_prd_falls_back(self, tmp_path: Path) -> None:
+        prd = tmp_path / self.PRD_REL
+        prd.parent.mkdir(parents=True)
+        prd.write_text('{"branchName": "b", "userStories": []}')
+        prd.chmod(0o000)
+        try:
+            base = KstrlConfig(allowed_paths=["fallback/"])
+            assert _component_scope(
+                self._component(), tmp_path, base,
+            ) == ["fallback/"]
+        finally:
+            prd.chmod(0o644)
+
+    def test_phase_1_turns_a_directory_prd_into_a_verification_result(
+        self, tmp_path: Path,
+    ) -> None:
+        """Fail-closed only works if the failure is CAUGHT: Phase 1 must
+        hand check_diff_scope an allowed_paths_error, not raise."""
+        comp = self._component()
+        wt_path = tmp_path / "wt"
+        (wt_path / self.PRD_REL).mkdir(parents=True)
+        seen: list[str | None] = []
+
+        def fake_verify(*args: Any, **kwargs: Any) -> VerificationResult:
+            seen.append(kwargs.get("allowed_paths_error"))
+            return VerificationResult(passed=False, checks=[])
+
+        pipeline = _pipeline(
+            tmp_path, comp, wt_path, run_mechanical_verification=fake_verify,
+        )
+        result = pipeline._phase_verify(
+            comp,
+            ComponentResult(
+                comp.id, success=True, iterations=1, duration_seconds=1.0,
+            ),
+            wt_path,
+        )
+        assert result.ran
+        assert seen and seen[0] is not None
+        assert "PRD could not be read" in seen[0]

--- a/tests/test_progress_scope.py
+++ b/tests/test_progress_scope.py
@@ -492,3 +492,149 @@ class TestFactUtilizationReadsTheComponentLog:
         )
 
         assert seen == ["component log: fact-alpha referenced\n"]
+
+
+class TestInLoopGuardSeesTheComponentScope:
+    """The in-loop ALLOWED_PATHS guard must enforce the COMPONENT's scope.
+
+    Production finding: `_run_component` was handed
+    `base_config.allowed_paths` - the run-wide `--allowed-paths` flag,
+    empty in every ordinary factory run. `if config.allowed_paths` in
+    run_loop was therefore False and `guards.enforce_allowed_paths`
+    never executed. The guard existed and was inert, so a scope
+    violation surfaced only at Phase 1, after the whole engineer loop
+    had been paid for: measured at $12.93 for one component, against
+    ~$2.50 for the single iteration it takes to catch it in-loop.
+    """
+
+    @staticmethod
+    def _component(prd_rel: str) -> Any:
+        from kstrl.manifest import Component
+
+        return Component(
+            "comp-a", "A", "D", [], prd_rel, "kstrl/comp-a",
+        )
+
+    def test_the_prd_scope_is_what_reaches_the_worker(
+        self, tmp_path: Path,
+    ) -> None:
+        from kstrl.config import KstrlConfig
+        from kstrl.factory import _component_scope
+
+        prd_rel = "scripts/kstrl/feature/comp-a/prd.json"
+        prd = tmp_path / prd_rel
+        prd.parent.mkdir(parents=True)
+        prd.write_text(json.dumps({
+            "branchName": "kstrl/comp-a",
+            "allowedPaths": ["src/", "tests/"],
+            "userStories": [],
+        }))
+        scope = _component_scope(
+            self._component(prd_rel), tmp_path, KstrlConfig(),
+        )
+        assert scope == ["src/", "tests/"]
+
+    def test_an_empty_run_wide_flag_no_longer_disables_the_guard(
+        self, tmp_path: Path,
+    ) -> None:
+        """The exact production condition: no --allowed-paths flag."""
+        from kstrl.config import KstrlConfig
+        from kstrl.factory import _component_scope
+
+        prd_rel = "scripts/kstrl/feature/comp-a/prd.json"
+        prd = tmp_path / prd_rel
+        prd.parent.mkdir(parents=True)
+        prd.write_text(json.dumps({
+            "branchName": "kstrl/comp-a",
+            "allowedPaths": ["hmac_signer/", "tests/"],
+            "userStories": [],
+        }))
+        base = KstrlConfig()
+        assert not base.allowed_paths, "precondition: run-wide flag unset"
+        scope = _component_scope(self._component(prd_rel), tmp_path, base)
+        assert scope, "guard would be inert with a falsy scope"
+
+    def test_a_legacy_prd_falls_back_to_the_run_wide_flag(
+        self, tmp_path: Path,
+    ) -> None:
+        from kstrl.config import KstrlConfig
+        from kstrl.factory import _component_scope
+
+        prd_rel = "scripts/kstrl/feature/comp-a/prd.json"
+        prd = tmp_path / prd_rel
+        prd.parent.mkdir(parents=True)
+        prd.write_text(json.dumps({
+            "branchName": "kstrl/comp-a", "userStories": [],
+        }))
+        base = KstrlConfig(allowed_paths=["fallback/"])
+        scope = _component_scope(self._component(prd_rel), tmp_path, base)
+        assert scope == ["fallback/"]
+
+    def test_an_unreadable_prd_fails_open_here_and_closed_at_phase_1(
+        self, tmp_path: Path,
+    ) -> None:
+        """Asymmetry by design: the tripwire yields, the gate does not.
+
+        Failing closed in-loop would fail a component before the
+        engineer had done anything. Phase 1 still fails CLOSED on the
+        same unreadable PRD (R1.5), so nothing merges unverified.
+        """
+        from kstrl.config import KstrlConfig
+        from kstrl.factory import _component_scope
+        from kstrl.verify import check_diff_scope
+
+        comp = self._component("scripts/kstrl/feature/comp-a/prd.json")
+        assert _component_scope(comp, tmp_path, KstrlConfig()) is None
+
+        gate = check_diff_scope(
+            tmp_path, "main", None,
+            allowed_paths_error="PRD not found: missing",
+        )
+        assert not gate.passed
+
+    def test_the_guard_reports_which_files_it_rejected(self) -> None:
+        """A halt the retry agent cannot diagnose is one it will repeat.
+
+        The guard discarded its violations (`ok, _ =`) and the factory
+        rendered the halt as "Did not complete".
+        """
+        from kstrl.loop import LoopResult
+
+        result = LoopResult(
+            completed=False, iterations=1, exit_code=1,
+            guard_violations=("uv.lock", "scripts/kstrl/progress.txt"),
+        )
+        assert result.guard_violations == (
+            "uv.lock", "scripts/kstrl/progress.txt",
+        )
+
+
+class TestProgressWriterAndReaderAgree:
+    """Setting only one of the two progress settings must not point the
+    writer and the reader at different files."""
+
+    @pytest.mark.parametrize(
+        ("writer", "reader", "expected"),
+        [
+            ("a/p.txt", None, ("a/p.txt", "a/p.txt")),
+            (None, "b/p.txt", ("b/p.txt", "b/p.txt")),
+            ("a/p.txt", "a/p.txt", ("a/p.txt", "a/p.txt")),
+            (None, None, (None, None)),
+        ],
+    )
+    def test_one_setting_propagates_to_the_other(
+        self, writer: str | None, reader: str | None,
+        expected: tuple[str | None, str | None],
+    ) -> None:
+        from kstrl.config import reconcile_progress_paths
+
+        assert reconcile_progress_paths(writer, reader) == expected
+
+    def test_two_explicit_paths_are_left_alone(self) -> None:
+        """An operator who named two paths meant two paths; the caller
+        warns rather than silently overriding one."""
+        from kstrl.config import reconcile_progress_paths
+
+        assert reconcile_progress_paths("a/p.txt", "b/p.txt") == (
+            "a/p.txt", "b/p.txt",
+        )

--- a/tests/test_progress_scope.py
+++ b/tests/test_progress_scope.py
@@ -1,0 +1,494 @@
+"""The engineer's progress file must live inside the component's scope.
+
+Regression net for a defect found by a real paid factory run: the
+harness told the engineer to write ``scripts/kstrl/progress.txt`` while
+DECOMPOSE_PROMPT told the architect that a component may only write
+under ``scripts/kstrl/feature/<component-id>/``. The engineer obeyed,
+Phase 1 ``diff_scope`` reported "files outside allowed scope", and the
+component was failed and retried from base. Measured cost of one such
+retry: $12.93.
+
+The property under test is a containment invariant, not a string:
+the DEFAULT progress path for a factory component is inside that
+component's own ``allowedPaths``, judged by the same
+``guards.path_is_allowed`` the diff-scope check uses. Explicit
+configuration still wins, and the single-component layout used by
+``ks run`` is unchanged.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from kstrl.config import KstrlConfig, component_progress_path
+from kstrl.decompose import _generate_component_prd
+from kstrl.events import EventBus, V1CompatSink
+from kstrl.factory import (
+    AdversarialAgentSelection,
+    ComponentResult,
+    FactoryConfig,
+    FactoryResult,
+    run_factory,
+)
+from kstrl.guards import path_is_allowed
+from kstrl.knowledge import KnowledgeConfig
+from kstrl.manifest import Component, Manifest
+from kstrl.observability import NotifyConfig, NotifyHooks, ProgressLog
+from kstrl.pipeline import ComponentPipeline, PipelineHooks
+from kstrl.prd import PRD
+from kstrl.review import ReviewResult
+from kstrl.security import SecurityResult
+from kstrl.ui.plain import PlainUI
+from kstrl.verify import VerificationResult, VerifyConfig, run_mechanical_verification
+
+COMPONENT_ID = "hmac-sign-verify"
+FEATURE_DIR = f"scripts/kstrl/feature/{COMPONENT_ID}"
+
+# Verbatim shape of the architect output that triggered the failure:
+# a source root, a test root, and the component's own feature subtree.
+ARCHITECT_ALLOWED_PATHS = [
+    "hmac_signer/",
+    "tests/",
+    f"{FEATURE_DIR}/",
+]
+
+
+def _architect_component(comp_id: str = COMPONENT_ID) -> dict[str, Any]:
+    """One component exactly as DECOMPOSE_PROMPT tells the architect to
+    emit it (rule 12: allowedPaths carries the feature subtree)."""
+    return {
+        "id": comp_id,
+        "title": "HMAC sign/verify",
+        "description": "Sign and verify payloads",
+        "dependencies": [],
+        "allowedPaths": [
+            "hmac_signer/", "tests/", f"scripts/kstrl/feature/{comp_id}/",
+        ],
+        "userStories": [
+            {
+                "id": "US-001",
+                "title": "Sign a payload",
+                "acceptanceCriteria": [
+                    "WHEN a payload is signed THE SYSTEM SHALL return a digest",
+                    "WHEN the key is empty THE SYSTEM SHALL raise ValueError",
+                ],
+                "priority": 1,
+                "passes": False,
+                "notes": "",
+            },
+        ],
+    }
+
+
+def _component(comp_id: str = COMPONENT_ID) -> Component:
+    return Component(
+        comp_id, comp_id.title(), "Desc", [],
+        f"scripts/kstrl/feature/{comp_id}/prd.json",
+        f"kstrl/factory/{comp_id}",
+    )
+
+
+def _manifest(components: list[Component]) -> Manifest:
+    return Manifest(
+        version="1", spec_file="spec.md", project_name="test",
+        base_branch="main", single_pr=False, components=components,
+    )
+
+
+def _base_config(root: Path) -> KstrlConfig:
+    return KstrlConfig(
+        prompt_file=root / "scripts" / "kstrl" / "prompt.md",
+        prd_file=root / "scripts" / "kstrl" / "prd.json",
+        progress_file=root / "scripts" / "kstrl" / "progress.txt",
+        sleep_seconds=0,
+        agent_cmd="echo test",
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
+        ui_mode="plain",
+        no_color=True,
+    )
+
+
+def _setup_project(root: Path, comp_ids: list[str]) -> None:
+    kstrl_dir = root / "scripts" / "kstrl"
+    kstrl_dir.mkdir(parents=True, exist_ok=True)
+    (kstrl_dir / "prompt.md").write_text("test prompt")
+    (kstrl_dir / "prd.json").write_text(
+        '{"branchName": "test", "userStories": []}'
+    )
+    (root / "kstrl.toml").write_text("[knowledge]\nenabled = false\n")
+    for comp_id in comp_ids:
+        feature_dir = kstrl_dir / "feature" / comp_id
+        feature_dir.mkdir(parents=True, exist_ok=True)
+        (feature_dir / "prd.json").write_text(json.dumps({
+            "branchName": "test",
+            "userStories": [{
+                "id": "US-001", "title": "Test",
+                "acceptanceCriteria": ["AC1"],
+                "priority": 1, "passes": True, "notes": "",
+            }],
+        }))
+
+
+# ---------------------------------------------------------------------------
+# The invariant that was violated
+# ---------------------------------------------------------------------------
+
+
+class TestProgressPathInsideAllowedPaths:
+    def test_default_progress_path_is_inside_component_allowed_paths(
+        self, tmp_path: Path,
+    ) -> None:
+        """THE regression: the default progress path for a factory
+        component passes the same guard the diff-scope check applies.
+
+        Both sides come from production code - the PRD is written by
+        decompose's real writer and re-read by PRD.load (so allowedPaths
+        is what the factory would actually enforce), and the progress
+        path is resolved by the factory's own resolver.
+        """
+        prd_path = _generate_component_prd(
+            _architect_component(), tmp_path, "kstrl/factory/hmac",
+        )
+        rel_prd = prd_path.relative_to(tmp_path).as_posix()
+        allowed = PRD.load(prd_path).allowed_paths
+        assert allowed == ARCHITECT_ALLOWED_PATHS
+
+        progress_rel = _base_config(tmp_path).component_progress_file(
+            rel_prd, tmp_path,
+        )
+
+        assert path_is_allowed(progress_rel, allowed), (
+            f"{progress_rel} is outside the component's allowedPaths "
+            f"{allowed}; Phase 1 diff_scope would fail the component"
+        )
+
+    def test_progress_path_is_a_sibling_of_the_component_prd(
+        self, tmp_path: Path,
+    ) -> None:
+        """Derived from prdPath, the same source of truth the architect
+        was told about - not a second string-built convention."""
+        assert _base_config(tmp_path).component_progress_file(
+            f"{FEATURE_DIR}/prd.json", tmp_path,
+        ) == f"{FEATURE_DIR}/progress.txt"
+
+    def test_single_component_layout_is_unchanged(self, tmp_path: Path) -> None:
+        """``ks run`` has no feature subtree: a PRD at
+        scripts/kstrl/prd.json still yields scripts/kstrl/progress.txt,
+        so the standalone loop keeps its historical path."""
+        assert component_progress_path(
+            "scripts/kstrl/prd.json",
+        ) == Path("scripts/kstrl/progress.txt")
+        assert KstrlConfig().progress_file == Path("scripts/kstrl/progress.txt")
+
+
+# ---------------------------------------------------------------------------
+# Explicit configuration still wins
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitConfigurationWins:
+    def test_toml_progress_path_wins_for_every_component(
+        self, tmp_path: Path,
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text(
+            '[paths]\nprogress = "docs/agent-progress.md"\n'
+        )
+        config = KstrlConfig.load(tmp_path)
+        assert config.progress_file_explicit
+        assert config.component_progress_file(
+            f"{FEATURE_DIR}/prd.json", tmp_path,
+        ) == "docs/agent-progress.md"
+
+    def test_env_progress_path_wins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("PROGRESS_FILE", "docs/env-progress.md")
+        config = KstrlConfig.load(tmp_path)
+        assert config.progress_file_explicit
+        assert config.component_progress_file(
+            f"{FEATURE_DIR}/prd.json", tmp_path,
+        ) == "docs/env-progress.md"
+
+    def test_explicit_value_equal_to_the_default_is_still_explicit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Explicitness is tracked, not inferred by comparing against
+        the default - an operator who pins the historical path gets it.
+        """
+        monkeypatch.setenv("PROGRESS_FILE", "scripts/kstrl/progress.txt")
+        config = KstrlConfig.load(tmp_path)
+        assert config.progress_file_explicit
+        assert config.component_progress_file(
+            f"{FEATURE_DIR}/prd.json", tmp_path,
+        ) == "scripts/kstrl/progress.txt"
+
+    def test_unset_config_is_not_explicit(self, tmp_path: Path) -> None:
+        assert not KstrlConfig.load(tmp_path).progress_file_explicit
+        assert not KstrlConfig.from_env(tmp_path).progress_file_explicit
+
+
+# ---------------------------------------------------------------------------
+# The factory actually points the engineer there
+# ---------------------------------------------------------------------------
+
+
+class TestFactoryWiring:
+    def test_worker_gets_the_feature_subtree_path(self, tmp_path: Path) -> None:
+        """run_factory's worker args carry the per-component progress
+        path, not the run-wide repo-root one."""
+        _setup_project(tmp_path, [COMPONENT_ID])
+        captured: list[tuple[Any, ...]] = []
+
+        def fake_component(*args: Any, **kwargs: Any) -> ComponentResult:
+            captured.append(args)
+            return ComponentResult(
+                COMPONENT_ID, success=True, iterations=1,
+                duration_seconds=1.0,
+            )
+
+        with patch(
+            "kstrl.factory._run_component", side_effect=fake_component,
+        ), patch("kstrl.git.get_diff_content", return_value=""):
+            run_factory(
+                _manifest([_component()]),
+                FactoryConfig(
+                    use_worktrees=False, create_prs=False, max_parallel=1,
+                    max_retries=0, retry_delay=0, review_mode="skip",
+                    verify_config=None,
+                    progress_log_path=tmp_path / "progress.jsonl",
+                ),
+                _base_config(tmp_path),
+                PlainUI(no_color=True, file=io.StringIO()),
+                tmp_path,
+            )
+
+        assert captured, "worker was never invoked"
+        args = captured[0]
+        assert f"{FEATURE_DIR}/progress.txt" in args
+        assert "scripts/kstrl/progress.txt" not in args
+
+    def test_run_component_default_derives_from_the_prd(
+        self, tmp_path: Path,
+    ) -> None:
+        """A direct caller that omits progress_file_str gets the
+        in-scope path too: the safe path is the default, not an opt-in.
+        """
+        from kstrl.factory import _run_component
+        from kstrl.loop import LoopResult
+
+        _setup_project(tmp_path, [COMPONENT_ID])
+        seen: list[KstrlConfig] = []
+
+        def fake_run_loop(
+            config: KstrlConfig, *args: Any, **kwargs: Any,
+        ) -> LoopResult:
+            seen.append(config)
+            return LoopResult(
+                completed=True, iterations=1, exit_code=0,
+                duration_seconds=0.0,
+            )
+
+        with patch("kstrl.loop.run_loop", side_effect=fake_run_loop):
+            _run_component(
+                component_id=COMPONENT_ID,
+                prd_path_str=f"{FEATURE_DIR}/prd.json",
+                worktree_path_str=str(tmp_path),
+                root_dir_str=str(tmp_path),
+                prompt_file_str="scripts/kstrl/prompt.md",
+                agent_cmd="echo test",
+                model=None, reasoning=None, agent_type=None,
+                sleep_seconds=0.0,
+                redirect_output=False,
+            )
+
+        assert seen, "run_loop was never called"
+        assert seen[0].progress_file == tmp_path / FEATURE_DIR / "progress.txt"
+
+
+# ---------------------------------------------------------------------------
+# The mechanical self-critique check reads the same file
+# ---------------------------------------------------------------------------
+
+
+_SELF_CRITIQUE_ENTRY = """## [2026-07-27] - US-001
+- Implemented signing
+
+## Self-Critique
+- If the key is empty, sign() raises, which is wrong because callers expect None.
+- If the payload is huge, memory spikes, which is wrong because we buffer it.
+- If the clock skews, verification fails, which is wrong because we compare ts.
+"""
+
+
+def _verify_config(**overrides: Any) -> VerifyConfig:
+    defaults: dict[str, Any] = dict(
+        test_command="true", typecheck_command="true", lint_command="true",
+        check_diff_scope=False, check_bad_patterns=False,
+        subprocess_timeout=10.0, require_self_critique=True,
+    )
+    defaults.update(overrides)
+    return VerifyConfig(**defaults)
+
+
+def _self_critique_check(result: VerificationResult) -> Any:
+    matches = [c for c in result.checks if c.name == "self_critique"]
+    assert matches, "self_critique check did not run"
+    return matches[0]
+
+
+class TestSelfCritiqueReadsTheComponentLog:
+    def _worktree(self, tmp_path: Path) -> Path:
+        feature_dir = tmp_path / FEATURE_DIR
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "prd.json").write_text(json.dumps({
+            "branchName": "b", "userStories": [],
+        }))
+        return feature_dir
+
+    def test_reads_the_log_next_to_the_component_prd(
+        self, tmp_path: Path,
+    ) -> None:
+        feature_dir = self._worktree(tmp_path)
+        (feature_dir / "progress.txt").write_text(_SELF_CRITIQUE_ENTRY)
+
+        result = run_mechanical_verification(
+            tmp_path, feature_dir / "prd.json", "main", None, _verify_config(),
+        )
+        check = _self_critique_check(result)
+        assert check.passed, check.message
+
+    def test_explicit_progress_file_path_still_wins(
+        self, tmp_path: Path,
+    ) -> None:
+        feature_dir = self._worktree(tmp_path)
+        (feature_dir / "progress.txt").write_text("no critique here\n")
+        custom = tmp_path / "docs"
+        custom.mkdir()
+        (custom / "progress.md").write_text(_SELF_CRITIQUE_ENTRY)
+
+        result = run_mechanical_verification(
+            tmp_path, feature_dir / "prd.json", "main", None,
+            _verify_config(progress_file_path="docs/progress.md"),
+        )
+        check = _self_critique_check(result)
+        assert check.passed, check.message
+
+    def test_verify_progress_path_is_unset_until_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Unset means "derive from the component PRD"; toml and env
+        both still pin an explicit file."""
+        assert VerifyConfig.load(tmp_path).progress_file_path is None
+        (tmp_path / "kstrl.toml").write_text(
+            '[verify]\nprogress_file_path = "docs/progress.md"\n'
+        )
+        assert VerifyConfig.load(tmp_path).progress_file_path == "docs/progress.md"
+
+        monkeypatch.setenv("KSTRL_VERIFY_PROGRESS_FILE", "docs/other.md")
+        assert VerifyConfig.load(tmp_path).progress_file_path == "docs/other.md"
+        assert VerifyConfig.from_env().progress_file_path == "docs/other.md"
+
+
+# ---------------------------------------------------------------------------
+# The knowledge fact-utilization metric reads the same file
+# ---------------------------------------------------------------------------
+
+
+class TestFactUtilizationReadsTheComponentLog:
+    def test_metric_reads_the_component_progress_log(
+        self, tmp_path: Path,
+    ) -> None:
+        """The metric's progress path was a second hardcoded copy of the
+        out-of-scope default, so it silently read nothing (or a stale
+        sibling) for every decomposed component."""
+        comp = _component()
+        wt_path = tmp_path / "wt"
+        (wt_path / FEATURE_DIR).mkdir(parents=True)
+        (wt_path / FEATURE_DIR / "progress.txt").write_text(
+            "component log: fact-alpha referenced\n"
+        )
+        (wt_path / "scripts" / "kstrl" / "progress.txt").write_text(
+            "decoy root log\n"
+        )
+
+        seen: list[str] = []
+
+        def fake_measure(
+            prefix: str, diff: str, progress: str,
+        ) -> dict[str, int]:
+            seen.append(progress)
+            return {"injected": 1, "referenced": 1}
+
+        ui = PlainUI(no_color=True, file=io.StringIO())
+        pipeline = ComponentPipeline(
+            manifest=_manifest([comp]),
+            manifest_path=tmp_path / "manifest.json",
+            factory_config=FactoryConfig(
+                use_worktrees=False, create_prs=False, max_parallel=1,
+                max_retries=0, retry_delay=0, review_mode="skip",
+            ),
+            base_config=_base_config(tmp_path),
+            ui=ui,
+            root_dir=tmp_path,
+            run_id="run-test",
+            bus=EventBus(
+                V1CompatSink(ProgressLog(
+                    tmp_path / "progress.jsonl", run_id="run-test",
+                )),
+                run_id="run-test",
+            ),
+            journal_path=None,
+            notify=NotifyHooks(
+                NotifyConfig(), run_id="run-test", project="t", warn=ui.warn,
+            ),
+            review_selection=AdversarialAgentSelection(
+                phase="review", agent_cmd=None, agent_type=None, model=None,
+                reasoning=None, source="explicit", identity="test-review",
+            ),
+            security_selection=None,
+            knowledge_config=KnowledgeConfig(enabled=True),
+            factory_result=FactoryResult(),
+            hooks=PipelineHooks(
+                run_mechanical_verification=(
+                    lambda *a, **k: VerificationResult(passed=True, checks=[])
+                ),
+                run_review=lambda *a, **k: ReviewResult(
+                    passed=True, mode="advisory",
+                ),
+                run_chunked_review=lambda *a, **k: ReviewResult(
+                    passed=True, mode="hard",
+                ),
+                run_security_review=lambda *a, **k: SecurityResult(
+                    passed=True, mode="advisory",
+                ),
+                run_chunked_security_review=lambda *a, **k: SecurityResult(
+                    passed=True, mode="hard",
+                ),
+                distill_facts=lambda *a, **k: (1, "1 fact written"),
+                build_knowledge_context=lambda *a, **k: "FACT: fact-alpha",
+                measure_fact_utilization=fake_measure,
+                cleanup_worktree=lambda *a, **k: None,
+            ),
+            worktree_paths={comp.id: wt_path},
+            component_contexts={},
+            fresh_base_retry_ids=set(),
+            component_failure_signatures={},
+        )
+
+        pipeline._phase_distill(
+            comp,
+            ComponentResult(
+                comp.id, success=True, iterations=1, duration_seconds=1.0,
+            ),
+            wt_path,
+            "diff",
+        )
+
+        assert seen == ["component log: fact-alpha referenced\n"]


### PR DESCRIPTION
## The defect

The harness told the engineer to write a file that the harness's own diff-scope check then rejected.

`DECOMPOSE_PROMPT` rule 12 (`kstrl/decompose.py:200-203`) tells the architect that a component's `allowedPaths` include exactly `scripts/kstrl/feature/<component-id>/` -- "(the agent updates progress.txt and PRD passes there)". The architect duly emits e.g. `["hmac_signer/", "tests/", "scripts/kstrl/feature/hmac-sign-verify/"]`.

The code disagreed:

- `config.KstrlConfig.progress_file` defaulted to `scripts/kstrl/progress.txt`, one level **above** the feature subtree.
- `factory._run_factory_locked` relativized that single path once and handed the same run-wide value to every component worker (`_submit_args` -> `_run_component(progress_file_str=...)`).

So the engineer wrote `scripts/kstrl/progress.txt`, Phase 1 `diff_scope` reported "files outside allowed scope", and the component was FAILED and retried from base.

**Measured cost of one such retry on a real paid run: $12.93.** In that run the engineer eventually diagnosed the harness's own bug itself and committed `chore: restore PRD diff scope - untrack uv.lock and progress.txt`, relocating progress into `scripts/kstrl/feature/hmac-sign-verify/progress.md` -- but only after the failure had already been paid for.

## The fix

The prompt was already right, so the **code moves to match the prompt** -- no `*_PROMPT` body changed, so no `*_PROMPT_VERSION` bump or snapshot update is required (H3).

The progress path is now derived from the same source of truth as `prdPath`: it is the PRD's **sibling**. That makes it inside `allowedPaths` by construction rather than by coincidence.

- `config.component_progress_path(prd_path, configured)` -- the single derivation.
- `KstrlConfig.component_progress_file(prd_path, root_dir)` -- the single place the factory resolves it per component; called from `_submit_args`, so the path is per-component instead of run-wide.
- `factory._run_component(progress_file_str=None)` -- None now means "derive it next to this component's PRD", so a direct caller gets the in-scope path too. The safe path is the default, not an opt-in.

### Explicit configuration still wins

`[paths] progress` / `PROGRESS_FILE` is forced on every component exactly as before. Explicitness is **tracked** (`KstrlConfig.progress_file_explicit`, mirroring the existing `kstrl_branch_explicit`) rather than inferred by comparing the value against the default -- the compare-against-default heuristic is the one R2.1 already removed from `VerifyConfig.load`, and it silently drops a setting that happens to equal the default.

### The standalone loop is untouched

`ks run` has no feature subtree, and the derivation reproduces its historical path for free: a PRD at `scripts/kstrl/prd.json` yields `scripts/kstrl/progress.txt`. Covered by a test.

### Two secondary readers of the same path

Both would have gone stale the moment the engineer moved, so they now use the same resolver:

- `verify.run_mechanical_verification` -- the opt-in `require_self_critique` check read `<worktree>/scripts/kstrl/progress.txt`, i.e. a file the engineer was never told to write. It would have failed components for the harness's own path confusion. `VerifyConfig.progress_file_path` is now `None`-defaulted meaning "derive it", matching how `test_command` / `dead_code_command` already express "unset". (A separate explicit-flag field was tried first and rejected: `scripts/gen_docs.py` treats **every** scalar field of `VerifyConfig` as a documented kstrl.toml key, so an internal flag leaks into the generated config reference.)
- `pipeline._phase_distill` -- the knowledge fact-utilization metric had a **second hardcoded copy** of `scripts/kstrl/progress.txt`. It sat inside a bare `try/except`, so it silently read nothing for every decomposed component and under-reported utilization.

### Config surface

`kstrl.toml.example` no longer ships a live `[paths] progress` -- copied verbatim it would have re-pinned the out-of-scope path for every component, reintroducing the bug through configuration. The scaffolded `kstrl.toml` (`ks init`) already had every key commented out; only the comments changed. README's config reference is regenerated from `scripts/gen_docs.py`.

## Verification

| | Before | After |
|---|---|---|
| `uv run pytest tests/` | 2459 passed, 28 skipped | **2472 passed, 28 skipped** |
| collected | 2487 | 2500 (+13 new) |
| `uv run mypy kstrl/ --strict` | clean | clean (108 files) |
| `uv run ruff check kstrl/ tests/` | clean | clean |

### Mutation check (the fix was reverted and the tests watched to fail)

The four call sites were reverted to their pre-fix behavior with the new API left in place, so each failure is attributable:

```
6 failed, 7 passed
FAILED TestProgressPathInsideAllowedPaths::test_default_progress_path_is_inside_component_allowed_paths
FAILED TestProgressPathInsideAllowedPaths::test_progress_path_is_a_sibling_of_the_component_prd
FAILED TestFactoryWiring::test_worker_gets_the_feature_subtree_path
FAILED TestFactoryWiring::test_run_component_default_derives_from_the_prd
FAILED TestSelfCritiqueReadsTheComponentLog::test_reads_the_log_next_to_the_component_prd
FAILED TestFactUtilizationReadsTheComponentLog::test_metric_reads_the_component_progress_log
```

The invariant test reproduces the production failure verbatim:

```
E  AssertionError: scripts/kstrl/progress.txt is outside the component's allowedPaths
   ['hmac_signer/', 'tests/', 'scripts/kstrl/feature/hmac-sign-verify/'];
   Phase 1 diff_scope would fail the component
E  +  where False = path_is_allowed('scripts/kstrl/progress.txt', [...])
```

Restored -> 13 passed. The 7 that pass under mutation are the guard tests (explicit-config precedence, single-component layout unchanged), which are supposed to hold either way.

### The invariant test

`tests/test_progress_scope.py::test_default_progress_path_is_inside_component_allowed_paths` asserts the property that was actually violated, with **both sides produced by production code**: the PRD is written by `decompose._generate_component_prd` and re-read by `PRD.load` (so `allowedPaths` is what the factory would really enforce), the progress path comes from `KstrlConfig.component_progress_file`, and containment is judged by `guards.path_is_allowed` -- the same function `check_diff_scope` calls.

## Not fixed (deliberately)

- **`uv.lock` untracked.** The same run also tripped on `uv.lock`. Out of scope per the brief, and I agree it was the experiment's repo setup rather than a harness defect. There is a defensible generalisation -- a lockfile the agent is *required* to regenerate but is not allowed to commit is a scope trap of the same shape -- but the honest fix is for the architect to include lockfiles in `allowedPaths` when the stack has them, not for `check_diff_scope` to grow a hardcoded artifact denylist. A denylist would silently widen every component's write scope, which is exactly what R1.5 hardened against.
- **The in-loop guard never sees the component's `allowedPaths`.** `_run_component` builds `KstrlConfig(allowed_paths=base_config.allowed_paths)` -- the run-wide flag, not `prd.allowed_paths`. So `guards.enforce_allowed_paths` is a no-op in normal factory runs and a scope violation is only discovered after the whole engineer loop has been paid for, at Phase 1. Forwarding the component's own `allowedPaths` (plus `guard_ignored_paths` for harness-owned files) would turn a whole wasted component into a single wasted iteration. Real money, but a behavior change to the engineer loop that deserves its own PR and its own calibration thought.
- **Divergence between `[paths] progress` and `[verify] progress_file_path`.** Setting one but not the other still points writer and reader at different files. Pre-existing, unchanged by this PR, and arguably correct as an explicit-means-explicit contract.

## Assumed vs verified

- **Verified:** the invariant, all four call sites, the mutation results, the explicit-config precedence for toml and env (including an explicit value that equals the default), the single-component layout, the full suite / mypy / ruff, and that no `*_PROMPT` body changed.
- **Assumed, not verified:** that this alone makes the real hmac-sign-verify run pass. That needs a live factory run to confirm; this PR fixes the specific harness-caused `diff_scope` failure the run exhibited, and I did not re-run the $13 experiment.
- **Note:** the progress log is now committed alongside the component PRD (the repo's `.gitignore` only ignores the exact path `scripts/kstrl/progress.txt`). That is the same treatment the per-component `prd.json` already gets and is what the architect's `allowedPaths` anticipates, so it is intended, not incidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
