### PR TITLE
R8.6 PR 1/4: maildir work-queue substrate and `ks queue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,13 @@ ks inbox retry ITEM_ID          Requeue the item's component and close the item.
 ks inbox show ITEM_ID           Show one item in full, including its evidence.
 ks inbox snooze ITEM_ID         Defer an item; it returns when the TTL lapses.
 ks init [DIRECTORY]             Initialize kstrl in a project directory.
+ks queue add SPEC               Enqueue a spec file.
+ks queue ls                     List queue items in run order.
+ks queue pause                  Stop admitting queued work.
+ks queue resume                 Start admitting queued work again.
+ks queue retry ITEM_ID          Send a failed or poisoned item back to queued.
+ks queue rm ITEM_ID             Delete an item and its spec.
+ks queue show ITEM_ID           Show one item in full, with its transition history.
 ks retry COMPONENT_ID           Retry a FAILED component from the factory manifest (R3.3).
 ks run [MAX_ITERATIONS]         Run the agentic loop as a single-component factory invocation.
 ks status                       Show per-component status from the manifest + progress log.
@@ -367,6 +374,11 @@ enabled = true                 # record exceptions awaiting a human decision
 open_item_cap = 50             # open items after which queue intake pauses; 0 = unbounded
 snooze_hours = 24.0            # default snooze TTL in hours; snoozed items return
 notify_action_required = true  # notify on action-required items and demotions only
+
+# Continuous intake queue (R8.6)
+[queue]
+max_attempts = 3            # execution attempts per queue item before it is poisoned
+lease_ttl_seconds = 3600.0  # claim validity in seconds; the reaper recovers anything past this
 
 # Test-suite adequacy gate (R8.5; opt-in, advisory first)
 [adequacy]

--- a/docs/dark-factory-roadmap.md
+++ b/docs/dark-factory-roadmap.md
@@ -616,6 +616,32 @@ level-dependent behavior tested; calibration captures the family delta.
 
 Status: `[ ]` - Depends on: R8.2 (merge dispositions), R8.3 (notifications)
 
+Landing in four slices; PR 1 of 4 is the substrate only. Shipped so far:
+`kstrl/workqueue.py` (maildir queue, `os.replace` transitions, flock
+mutex, lease fields, journal, pause marker) and the `ks queue
+add/ls/show/retry/rm/pause/resume` verbs. **Nothing drains the queue
+yet** - `ks serve`, the lease reaper, the retry classifier, and the
+`daily_budget_usd` stop are PR 2; the GitHub adapter is PR 3; launchd is
+PR 4.
+
+Two invariants in the substrate are money-safety properties rather than
+style, and both are mutation-checked:
+
+1. **The attempt is charged before the rename into `running/`.** Every
+   transition writes `meta.json` first and renames second, so a crash in
+   the commit window over-counts an attempt (one fewer retry - safe)
+   instead of under-counting one (a retry nobody recorded - an unbounded
+   loop at $1.70-2.60 per first attempt and $3.99-7.42 per retry).
+2. **The item directory is authoritative; the sidecar's `state` is a
+   mirror.** Readers derive state from the parent directory, so the same
+   crash window cannot leave an item whose location and metadata
+   disagree about what it is.
+
+Corrupt metadata resolves toward the GATED value in both directions an
+attacker or a bad disk could push it: an unreadable `merge_disposition`
+decodes to `stop_at_pr`, never `auto_merge`, and an unreadable pause
+marker reads as PAUSED, never as running.
+
 **Why.** Intake is one-shot; the factory has no queue. The first US software
 factory (SDC, 1972-78) died because work was not required to flow through
 it - intake is a survival capability, not plumbing.

--- a/docs/dark-factory-roadmap.md
+++ b/docs/dark-factory-roadmap.md
@@ -642,6 +642,59 @@ attacker or a bad disk could push it: an unreadable `merge_disposition`
 decodes to `stop_at_pr`, never `auto_merge`, and an unreadable pause
 marker reads as PAUSED, never as running.
 
+**Review corrections (PR #185).** Seven gaps were caught in review and
+closed before merge, all reproduced against the submitted code first.
+Recorded here because five were enforcement bypasses rather than style
+notes, and two of them broke guarantees the PR body had claimed:
+
+1. **`meta.json` was trusted for item IDENTITY**, not just for the
+   fields the directory does not carry. A sidecar edited to
+   `"item_id": "../../../outside-dir"` loaded normally and then made
+   `remove()` delete an unrelated directory while leaving the real item
+   in place. The directory entry is now authoritative for identity
+   exactly as it already was for state, symlinked items are rejected,
+   and every path component passes `is_safe_component`.
+2. **`spec_filename` was joined to a queue path unvalidated.** The
+   text form of `Queue.add` is the API PR 3's remote adapters will call,
+   and `spec_filename="../../../../escaped.md"` wrote outside the queue
+   while still publishing a normal-looking item. Validated on enqueue
+   AND on decode, with a containment re-check in `spec_path`.
+3. **Staging directories were scanned.** A process killed after
+   `meta.json` was written but before the publishing rename left a
+   `.staging-*` entry inside `queued/` that `items()` returned as a real
+   item whose directory did not exist - defeating the stated invariant
+   that scans never see partially published work. Staging moved OUT of
+   the state directories into `.kstrl/queue/.staging/`, scans skip
+   dotted entries as defence in depth, and `sweep_staging()` is the
+   explicit recovery policy (run under the queue lock, where an
+   abandoned staging dir is stale by definition - no age heuristic).
+4. **`max_attempts` was advertised but not enforced.** `start -> fail
+   -> requeue -> lease -> start` produced a running item with
+   `attempts == 2` against `max_attempts == 1`. The bound now holds at
+   the SPENDING boundary (`Queue.start` raises `QueueBudgetExhausted`),
+   not only in the CLI's retry path - the callers here are an
+   unattended daemon and a reaper, so a bound that requires every caller
+   to remember it is not a bound. The pre-existing test skipped the
+   second `start()` when no attempts remained, so it asserted the
+   caller's good manners rather than the substrate's guarantee.
+5. **The per-item `max_attempts` override bypassed `QueueConfig`'s
+   validation**, admitting an item with a zero execution budget.
+   Rejected in `Queue.add` and by a `click.IntRange(min=1)` option.
+6. **`remove()` used `ignore_errors=True` and then journaled success**,
+   so a permission failure produced a false operator result AND a false
+   audit trail. Failures now propagate and the record is written only
+   after the directory is confirmed gone.
+7. **The pause marker failed OPEN.** A broad `except OSError` meant a
+   `PermissionError` on `pause.json` read as RUNNING, which would have
+   resumed unattended spend on an unreadable stop signal.
+   `FileNotFoundError` is now the only read failure that means unpaused.
+
+All seven fixes are mutation-checked (14 mutations, 14 caught). Three
+of the first-draft regression tests were NOT discriminating - they
+passed with the fix reverted, because a second, redundant guard caught
+the same case - and were rewritten to assert the specific mechanism
+before being counted.
+
 **Why.** Intake is one-shot; the factory has no queue. The first US software
 factory (SDC, 1972-78) died because work was not required to flow through
 it - intake is a survival capability, not plumbing.

--- a/kstrl.toml.example
+++ b/kstrl.toml.example
@@ -200,6 +200,17 @@ open_item_cap = 50                 # open items after which queue intake pauses 
 snooze_hours = 24.0                # default snooze TTL; a snoozed item RETURNS
 notify_action_required = true      # notify on action-required items and demotions only
 
+# Continuous intake (R8.6): the local work queue under .kstrl/queue/. Work
+# waits here instead of a human firing each run; `ks queue add` enqueues and
+# (from PR 2) `ks serve` drains. max_attempts is the retry BOUND - it holds
+# even when the failure classifier is wrong, which is the point: a measured
+# engineer iteration costs ~$1.70-2.60 first-attempt and $3.99-7.42 on a
+# retry, so an unbounded loop is real money. Only infrastructure_error
+# failures are ever retried automatically; spec-level failures go to poison/.
+[queue]
+max_attempts = 3                   # execution attempts per item before poisoning
+lease_ttl_seconds = 3600.0         # claim validity; the reaper recovers anything past this
+
 # Test-suite adequacy gate (R8.5), Layer 0: reads the diff and changed test
 # files - no test execution, no coverage, no mutation tooling. Catches the
 # suite getting WEAKER (deleted tests, added skip/xfail, assertions removed)

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -3696,7 +3696,7 @@ def _resolve_queue_item(queue: Any, item_id: str, ui_impl: UI) -> Any:
     ),
 )
 @click.option(
-    "--max-attempts", type=int, default=None,
+    "--max-attempts", type=click.IntRange(min=1), default=None,
     help="Execution attempts before poisoning (default: [queue] max_attempts)",
 )
 @_queue_root_option
@@ -3727,6 +3727,10 @@ def queue_add(
     )
     try:
         with queue_lock(root_dir):
+            # Under the lock, any staging directory is abandoned by
+            # definition (R8.6 #185 F3), so this is the natural recovery
+            # point for an enqueue killed mid-publish.
+            queue.sweep_staging()
             item = queue.add(
                 spec,
                 title=title,
@@ -3921,8 +3925,10 @@ def queue_rm(
     try:
         with queue_lock(root_dir):
             queue.remove(item, actor=_actor())
-    except QueueError as exc:
-        ui_impl.err(str(exc))
+    except (QueueError, OSError) as exc:
+        # A deletion that failed must not print success: the operator
+        # would believe the item is gone when it is still queued (#185 F6).
+        ui_impl.err(f"Could not remove {item.item_id[:12]}: {exc}")
         sys.exit(1)
     ui_impl.ok(f"Removed {item.item_id[:12]}")
     sys.exit(0)

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -3636,6 +3636,340 @@ def inbox_retry(
     sys.exit(0)
 
 
+@cli.group(name="queue")
+def queue_group() -> None:
+    """Manage the continuous-intake work queue (R8.6).
+
+    Work waits here instead of requiring a human to fire each run.
+    `ks serve` drains it. Nothing in this group starts a factory run or
+    spends anything: these verbs only move items between states.
+    """
+
+
+_queue_root_option = click.option(
+    "--root", type=click.Path(path_type=Path),
+    help="Project root path (defaults to current directory)",
+)
+_queue_ui_option = click.option(
+    "--ui", type=click.Choice(["auto", "rich", "plain", "gum"]),
+    default="auto", help="UI mode",
+)
+_queue_no_color_option = click.option(
+    "--no-color", is_flag=True, help="Disable colors",
+)
+
+
+def _queue_for(root: Path | None) -> tuple[Path, Any]:
+    from kstrl.workqueue import Queue, QueueConfig
+
+    root_dir = (root or Path.cwd()).resolve()
+    return root_dir, Queue(root_dir, QueueConfig.load(root_dir))
+
+
+def _resolve_queue_item(queue: Any, item_id: str, ui_impl: UI) -> Any:
+    """Look up one item or exit; an ambiguous prefix is an error."""
+    from kstrl.workqueue import QueueError
+
+    try:
+        item = queue.get(item_id)
+    except QueueError as exc:
+        ui_impl.err(str(exc))
+        sys.exit(1)
+    if item is None:
+        ui_impl.err(f"No queue item matching {item_id!r}")
+        sys.exit(1)
+    return item
+
+
+@queue_group.command(name="add")
+@click.argument("spec", type=click.Path(exists=True, path_type=Path))
+@click.option("--priority", type=int, default=0, help="Higher runs first")
+@click.option("--title", default="", help="Human label (default: spec filename)")
+@click.option("--project-name", default="", help="Factory project name")
+@click.option(
+    "--auto-merge/--stop-at-pr",
+    "auto_merge",
+    default=False,
+    help=(
+        "Request auto-merge when green (still gated by the autonomy "
+        "ladder), or stop at the PR for a human (default)"
+    ),
+)
+@click.option(
+    "--max-attempts", type=int, default=None,
+    help="Execution attempts before poisoning (default: [queue] max_attempts)",
+)
+@_queue_root_option
+@_queue_ui_option
+@_queue_no_color_option
+def queue_add(
+    spec: Path,
+    priority: int,
+    title: str,
+    project_name: str,
+    auto_merge: bool,
+    max_attempts: int | None,
+    root: Path | None,
+    ui: str,
+    no_color: bool,
+) -> None:
+    """Enqueue a spec file.
+
+    The spec is COPIED into the item, so editing or deleting the
+    original afterwards cannot change what eventually runs.
+    """
+    from kstrl.workqueue import MergeDisposition, QueueError, queue_lock
+
+    root_dir, queue = _queue_for(root)
+    ui_impl = _autonomy_ui(ui, no_color)
+    disposition = (
+        MergeDisposition.AUTO_MERGE if auto_merge else MergeDisposition.STOP_AT_PR
+    )
+    try:
+        with queue_lock(root_dir):
+            item = queue.add(
+                spec,
+                title=title,
+                priority=priority,
+                project_name=project_name,
+                merge_disposition=disposition,
+                max_attempts=max_attempts,
+                actor=_actor(),
+            )
+    except QueueError as exc:
+        ui_impl.err(str(exc))
+        sys.exit(1)
+    ui_impl.ok(f"Queued {item.item_id} - {item.title}")
+    ui_impl.kv("merge", str(item.merge_disposition))
+    ui_impl.kv("attempts allowed", str(item.max_attempts))
+    if queue.is_paused():
+        ui_impl.warn("Queue is paused; this item waits until `ks queue resume`.")
+    sys.exit(0)
+
+
+@queue_group.command(name="ls")
+@click.option(
+    "--state", "states", multiple=True,
+    help="Filter by state (repeatable): queued/leased/running/done/failed/poison",
+)
+@_queue_root_option
+@_queue_ui_option
+@_queue_no_color_option
+def queue_ls(
+    states: tuple[str, ...], root: Path | None, ui: str, no_color: bool,
+) -> None:
+    """List queue items in run order."""
+    from kstrl.workqueue import ItemState, summarize
+
+    _root_dir, queue = _queue_for(root)
+    ui_impl = _autonomy_ui(ui, no_color)
+    selected: tuple[ItemState, ...] | None = None
+    if states:
+        try:
+            selected = tuple(ItemState(value) for value in states)
+        except ValueError as exc:
+            ui_impl.err(str(exc))
+            sys.exit(1)
+    items = queue.items(selected)
+    pause = queue.pause_state()
+    if pause.active():
+        detail = f" ({pause.reason})" if pause.reason else ""
+        ui_impl.warn(f"Queue is PAUSED{detail}")
+    if not items:
+        ui_impl.ok("Queue is empty.")
+        sys.exit(0)
+    ui_impl.section("Queue")
+    for item in items:
+        attempts = f"{item.attempts}/{item.max_attempts}"
+        ui_impl.info(
+            f"  {item.item_id[:12]}  {str(item.state):<8} "
+            f"p{item.priority:<3} {attempts:<6} {item.title}"
+        )
+    ui_impl.info("")
+    ui_impl.kv("summary", summarize(queue.counts()))
+    sys.exit(0)
+
+
+@queue_group.command(name="show")
+@click.argument("item_id")
+@_queue_root_option
+@_queue_ui_option
+@_queue_no_color_option
+def queue_show(
+    item_id: str, root: Path | None, ui: str, no_color: bool,
+) -> None:
+    """Show one item in full, with its transition history."""
+    _root_dir, queue = _queue_for(root)
+    ui_impl = _autonomy_ui(ui, no_color)
+    item = _resolve_queue_item(queue, item_id, ui_impl)
+
+    ui_impl.section(item.title)
+    ui_impl.kv("id", item.item_id)
+    ui_impl.kv("state", str(item.state))
+    ui_impl.kv("priority", str(item.priority))
+    ui_impl.kv("attempts", f"{item.attempts} of {item.max_attempts}")
+    ui_impl.kv("merge", str(item.merge_disposition))
+    ui_impl.kv("source", str(item.source) + (f" ({item.source_ref})" if item.source_ref else ""))
+    ui_impl.kv("created", item.created_at)
+    ui_impl.kv("updated", item.updated_at)
+    if item.project_name:
+        ui_impl.kv("project", item.project_name)
+    if item.last_run_id:
+        ui_impl.kv("last run", item.last_run_id)
+    if item.lease_pid:
+        ui_impl.kv(
+            "lease",
+            f"pid {item.lease_pid} on {item.lease_host} "
+            f"until {item.lease_expires_at}"
+            + (" (EXPIRED)" if item.lease_expired() else ""),
+        )
+    if item.last_error:
+        ui_impl.kv("last error", item.last_error)
+    if item.poison_reason:
+        ui_impl.kv("poisoned", item.poison_reason)
+    ui_impl.kv("spec", str(queue.spec_path(item)))
+
+    history = queue.journal_entries(item.item_id)
+    if history:
+        ui_impl.subsection("History")
+        for entry in history:
+            origin = entry.get("from") or "-"
+            reason = entry.get("reason") or ""
+            ui_impl.info(
+                f"  {entry.get('ts', '')}  {origin} -> {entry.get('to', '')}"
+                + (f"  ({reason})" if reason else "")
+            )
+    sys.exit(0)
+
+
+@queue_group.command(name="retry")
+@click.argument("item_id")
+@click.option(
+    "--reset-attempts", is_flag=True,
+    help="Zero the attempt counter (explicit human decision to spend again)",
+)
+@_queue_root_option
+@_queue_ui_option
+@_queue_no_color_option
+def queue_retry(
+    item_id: str,
+    reset_attempts: bool,
+    root: Path | None,
+    ui: str,
+    no_color: bool,
+) -> None:
+    """Send a failed or poisoned item back to queued.
+
+    A poisoned item that has already spent its attempts needs
+    `--reset-attempts` to run again: re-queuing it otherwise would have
+    it poisoned straight back without spending anything, which looks
+    like the command silently failed.
+    """
+    from kstrl.workqueue import ItemState, QueueError, queue_lock
+
+    root_dir, queue = _queue_for(root)
+    ui_impl = _autonomy_ui(ui, no_color)
+    item = _resolve_queue_item(queue, item_id, ui_impl)
+    if item.state not in (ItemState.FAILED, ItemState.POISON):
+        ui_impl.err(
+            f"{item.item_id[:12]} is {item.state}; only failed or poisoned "
+            "items can be retried"
+        )
+        sys.exit(1)
+    if not reset_attempts and item.attempts_remaining == 0:
+        ui_impl.err(
+            f"{item.item_id[:12]} has used all {item.max_attempts} attempts; "
+            "pass --reset-attempts to authorize spending again"
+        )
+        sys.exit(1)
+    try:
+        with queue_lock(root_dir):
+            queue.requeue(
+                item, reason="retry (manual)", actor=_actor(),
+                reset_attempts=reset_attempts,
+            )
+    except (QueueError, OSError) as exc:
+        ui_impl.err(str(exc))
+        sys.exit(1)
+    ui_impl.ok(
+        f"Requeued {item.item_id[:12]} "
+        f"({item.attempts}/{item.max_attempts} attempts used)"
+    )
+    sys.exit(0)
+
+
+@queue_group.command(name="rm")
+@click.argument("item_id")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt")
+@_queue_root_option
+@_queue_ui_option
+@_queue_no_color_option
+def queue_rm(
+    item_id: str, yes: bool, root: Path | None, ui: str, no_color: bool,
+) -> None:
+    """Delete an item and its spec."""
+    from kstrl.workqueue import QueueError, queue_lock
+
+    root_dir, queue = _queue_for(root)
+    ui_impl = _autonomy_ui(ui, no_color)
+    item = _resolve_queue_item(queue, item_id, ui_impl)
+    if not yes and not click.confirm(
+        f"Delete {item.item_id[:12]} ({item.title})?", default=False,
+    ):
+        ui_impl.info("Left alone.")
+        sys.exit(0)
+    try:
+        with queue_lock(root_dir):
+            queue.remove(item, actor=_actor())
+    except QueueError as exc:
+        ui_impl.err(str(exc))
+        sys.exit(1)
+    ui_impl.ok(f"Removed {item.item_id[:12]}")
+    sys.exit(0)
+
+
+@queue_group.command(name="pause")
+@click.option("--reason", default="", help="Why intake is paused")
+@_queue_root_option
+@_queue_ui_option
+@_queue_no_color_option
+def queue_pause(
+    reason: str, root: Path | None, ui: str, no_color: bool,
+) -> None:
+    """Stop admitting queued work.
+
+    Does not touch anything already running - a pause is an admission
+    gate, not a kill switch.
+    """
+    from kstrl.workqueue import queue_lock
+
+    root_dir, queue = _queue_for(root)
+    ui_impl = _autonomy_ui(ui, no_color)
+    with queue_lock(root_dir):
+        queue.pause(reason=reason, actor=_actor())
+    ui_impl.ok("Queue paused; nothing new will be claimed.")
+    if reason:
+        ui_impl.kv("reason", reason)
+    sys.exit(0)
+
+
+@queue_group.command(name="resume")
+@_queue_root_option
+@_queue_ui_option
+@_queue_no_color_option
+def queue_resume(root: Path | None, ui: str, no_color: bool) -> None:
+    """Start admitting queued work again."""
+    from kstrl.workqueue import ItemState, queue_lock
+
+    root_dir, queue = _queue_for(root)
+    ui_impl = _autonomy_ui(ui, no_color)
+    with queue_lock(root_dir):
+        queue.resume(actor=_actor())
+    waiting = len(queue.items((ItemState.QUEUED,)))
+    ui_impl.ok(f"Queue resumed; {waiting} item(s) waiting.")
+    sys.exit(0)
+
+
 def main() -> None:
     """Main entry point."""
     cli()

--- a/kstrl/workqueue.py
+++ b/kstrl/workqueue.py
@@ -1,0 +1,1073 @@
+"""R8.6 continuous intake: the local work queue substrate.
+
+Intake before this module is one-shot - a human fires ``ks factory
+--spec`` and the run ends. The queue is what lets work arrive without a
+human firing each run, so it is the survival capability R8.6 exists to
+add, not plumbing around one.
+
+**Why a directory queue and not a library.** Queue libraries were
+evaluated and rejected in the R8.6 verdict (litequeue is near-dormant and
+conflicts with our Python floor; persist-queue buys nothing at a
+concurrency of one; huey inverts control - it would own the process the
+factory needs to own). A maildir-style directory tree gives durability,
+crash recovery, and human inspectability with no dependency and no
+schema migration story.
+
+**Layout.** Each state is a directory under ``.kstrl/queue/``; each item
+is a DIRECTORY holding its spec file plus ``meta.json``::
+
+    .kstrl/queue/
+      queued/<item_id>/{<spec>, meta.json}
+      leased/   claimed by a worker, nothing spent yet
+      running/  executing; money is being spent
+      done/     finished green
+      failed/   finished red and eligible to retry
+      poison/   finished red and NOT eligible to retry
+      journal.jsonl
+      pause.json    (absent = running)
+      queue.lock    (short-lived per-transition mutex)
+
+The item is a directory rather than two sibling files so that one
+``os.replace`` moves the spec and its sidecar together. Two sibling files
+would need two renames and could be interrupted between them, leaving an
+item whose spec and metadata disagree about what state it is in.
+
+**The directory is the source of truth.** ``meta.json`` also carries a
+``state`` field, but it is a convenience mirror: readers derive state
+from the parent directory name and overwrite the mirror. That makes the
+crash window between "write meta" and "rename dir" harmless in both
+directions - whichever step got interrupted, the directory still says
+what is true and the mirror self-heals on the next write.
+
+**Ordering is a money-safety property, not a style choice.** Every
+transition writes ``meta.json`` FIRST and renames SECOND, because the
+rename is the commit point. ``attempts`` is therefore incremented before
+the rename that starts execution: a crash in the window over-counts an
+attempt (the item gets one fewer retry - safe) instead of under-counting
+one (the item retries without the attempt being recorded - an unbounded
+retry loop). A measured factory engineer iteration costs ~$1.70-2.60 on
+a first attempt and $3.99-7.42 on a retry, so an uncounted attempt is
+not a bookkeeping slip.
+
+The retry POLICY - which failures may be retried at all - deliberately
+does not live here. This module records attempts and moves items; R8.6
+PR 2 (``ks serve``) decides, on positive evidence only, whether a
+failure was an infrastructure error. See ``docs/dark-factory-roadmap.md``
+R8.6.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import shutil
+import tempfile
+import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+from typing import IO, Any
+
+from kstrl.statedir import state_dir
+
+QUEUE_DIR_NAME = "queue"
+META_FILENAME = "meta.json"
+JOURNAL_FILENAME = "journal.jsonl"
+PAUSE_FILENAME = "pause.json"
+LOCK_FILENAME = "queue.lock"
+QUEUE_SCHEMA_VERSION = 1
+
+
+class QueueError(RuntimeError):
+    """A queue operation could not be completed."""
+
+
+class QueueLockedError(QueueError):
+    """Another process holds the queue mutex."""
+
+
+class ItemState(StrEnum):
+    """Where an item is. Also the on-disk directory name.
+
+    ``LEASED`` and ``RUNNING`` are deliberately distinct even though a
+    worker passes through both in quick succession: the reaper (PR 2)
+    treats them differently. A leased item whose owner died spent
+    nothing, so it returns to ``QUEUED`` for free. A running item whose
+    owner died spent real money and needs its failure classified before
+    anything decides to spend more.
+    """
+
+    QUEUED = "queued"
+    LEASED = "leased"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    POISON = "poison"
+
+
+#: Every state directory, created eagerly so a scan never has to
+#: distinguish "no such directory" from "no items in it".
+ALL_STATES: tuple[ItemState, ...] = tuple(ItemState)
+
+#: Legal moves. Anything absent raises rather than being silently
+#: allowed: an illegal transition means a caller's state machine is
+#: wrong, and in this module a wrong state machine spends money.
+_LEGAL_TRANSITIONS: dict[ItemState, frozenset[ItemState]] = {
+    ItemState.QUEUED: frozenset({ItemState.LEASED, ItemState.POISON}),
+    # A lease can be dropped back to queued by the reaper (owner died
+    # before spending) or fail outright if the worker could not start.
+    ItemState.LEASED: frozenset({
+        ItemState.QUEUED, ItemState.RUNNING, ItemState.FAILED,
+        ItemState.POISON,
+    }),
+    ItemState.RUNNING: frozenset({
+        ItemState.DONE, ItemState.FAILED, ItemState.POISON,
+    }),
+    # Terminal-ish: a human (or the retry policy) can requeue, and a
+    # failed item that exhausts its attempts is poisoned.
+    ItemState.FAILED: frozenset({ItemState.QUEUED, ItemState.POISON}),
+    ItemState.POISON: frozenset({ItemState.QUEUED}),
+    ItemState.DONE: frozenset(),
+}
+
+
+class MergeDisposition(StrEnum):
+    """Whether a finished item's PR merges without a human.
+
+    ``STOP_AT_PR`` is the default for everything, and R8.6 requires it be
+    the default for remote-sourced items specifically: continuous intake
+    must not silently delete the human merge gate. ``AUTO_MERGE`` is
+    per-item opt-in AND ladder-gated - the R8.2 flag bundle
+    (``auto_merge_when_green``) can withhold it, and this field can only
+    ever request it, never grant it.
+    """
+
+    STOP_AT_PR = "stop_at_pr"
+    AUTO_MERGE = "auto_merge"
+
+
+class ItemSource(StrEnum):
+    """Where the item came from. ``source_ref`` names the specific one."""
+
+    LOCAL = "local"
+    GITHUB = "github"
+    LINEAR = "linear"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(moment: datetime) -> str:
+    return moment.isoformat()
+
+
+def _parse_iso(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def mint_item_id() -> str:
+    """``q-YYYYMMDD-HHMMSS.ffffff-<nonce>``.
+
+    Shaped like :func:`kstrl.runid.mint_run_id` and for the same reason:
+    the microsecond stamp makes same-second ids order deterministically
+    by creation time, which is what gives the queue FIFO ordering within
+    a priority band, and the nonce guards same-microsecond collisions.
+    """
+    stamp = _utc_now().strftime("%Y%m%d-%H%M%S.%f")
+    return f"q-{stamp}-{secrets.token_hex(3)}"
+
+
+def _warn_rejected(path: Path, reason: str) -> None:
+    """Announce a skipped item rather than swallowing it.
+
+    A silently dropped queue item is work that vanished. Mirrors
+    ``autonomy._warn_rejected_state``.
+    """
+    warnings.warn(
+        f"queue: rejected item {path} ({reason}); skipping",
+        RuntimeWarning,
+        stacklevel=3,
+    )
+
+
+def _as_int(data: dict[str, Any], key: str, default: int) -> int:
+    value = data.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return default
+    return value
+
+
+def _as_str(data: dict[str, Any], key: str, default: str = "") -> str:
+    value = data.get(key, default)
+    return value if isinstance(value, str) else default
+
+
+@dataclass
+class QueueItem:
+    """One unit of intake: a spec plus everything decided about it.
+
+    Not frozen: an item's ``state``, ``attempts``, and lease fields are
+    exactly what a transition mutates. The frozen container in this
+    module is :class:`QueueConfig`, which genuinely never changes after
+    load.
+    """
+
+    item_id: str
+    title: str
+    spec_filename: str
+    state: ItemState = ItemState.QUEUED
+    #: Higher runs first; ties break by ``item_id`` (creation order).
+    priority: int = 0
+    created_at: str = ""
+    updated_at: str = ""
+    #: Execution attempts CHARGED so far - incremented before the rename
+    #: into ``running/``, never after. See the module docstring.
+    attempts: int = 0
+    max_attempts: int = 3
+    merge_disposition: MergeDisposition = MergeDisposition.STOP_AT_PR
+    source: ItemSource = ItemSource.LOCAL
+    #: Identifies the specific origin, e.g. ``0xfauzi/kstrl#153``. The
+    #: processed-ids ledger (PR 3) dedupes on this.
+    source_ref: str = ""
+    #: Forward-compatibility for a global ``~/.kstrl/queue`` (roadmap
+    #: open question 3). Empty means "the repo this queue lives in".
+    #: Carried from day one so moving to a global queue is a config
+    #: change rather than a migration of on-disk items.
+    target_repo: str = ""
+    project_name: str = ""
+    lease_pid: int = 0
+    lease_host: str = ""
+    lease_expires_at: str = ""
+    last_error: str = ""
+    last_run_id: str = ""
+    #: Why this item may never be retried automatically. Set only on the
+    #: transition into ``poison/``.
+    poison_reason: str = ""
+    schema_version: int = QUEUE_SCHEMA_VERSION
+
+    @property
+    def attempts_remaining(self) -> int:
+        return max(0, self.max_attempts - self.attempts)
+
+    @property
+    def sort_key(self) -> tuple[int, str]:
+        """Highest priority first, then oldest first."""
+        return (-self.priority, self.item_id)
+
+    def lease_expired(self, now: datetime | None = None) -> bool:
+        """Whether this item's lease has lapsed.
+
+        A missing or unparseable expiry counts as EXPIRED. An item
+        holding a lease nobody can read is exactly the sleep/crash case
+        the reaper exists for; treating it as live would wedge the
+        queue forever.
+        """
+        expires = _parse_iso(self.lease_expires_at)
+        if expires is None:
+            return True
+        return (now or _utc_now()) >= expires
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "item_id": self.item_id,
+            "title": self.title,
+            "spec_filename": self.spec_filename,
+            "state": str(self.state),
+            "priority": self.priority,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "attempts": self.attempts,
+            "max_attempts": self.max_attempts,
+            "merge_disposition": str(self.merge_disposition),
+            "source": str(self.source),
+            "source_ref": self.source_ref,
+            "target_repo": self.target_repo,
+            "project_name": self.project_name,
+            "lease_pid": self.lease_pid,
+            "lease_host": self.lease_host,
+            "lease_expires_at": self.lease_expires_at,
+            "last_error": self.last_error,
+            "last_run_id": self.last_run_id,
+            "poison_reason": self.poison_reason,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> QueueItem | None:
+        """Decode a sidecar, tolerating fields written by older versions.
+
+        Returns None only when the item has no identity or no spec -
+        without those there is nothing to run. Every other malformed
+        field falls back to its default, because dropping a whole unit
+        of work over an unreadable priority would lose real work.
+        """
+        item_id = _as_str(data, "item_id")
+        spec_filename = _as_str(data, "spec_filename")
+        if not item_id or not spec_filename:
+            return None
+
+        raw_state = _as_str(data, "state", str(ItemState.QUEUED))
+        try:
+            state = ItemState(raw_state)
+        except ValueError:
+            state = ItemState.QUEUED
+
+        raw_disposition = _as_str(
+            data, "merge_disposition", str(MergeDisposition.STOP_AT_PR),
+        )
+        try:
+            disposition = MergeDisposition(raw_disposition)
+        except ValueError:
+            # An unreadable disposition falls back to the gated value,
+            # never to auto-merge: a corrupt field must not be able to
+            # grant a permission nobody asked for.
+            disposition = MergeDisposition.STOP_AT_PR
+
+        raw_source = _as_str(data, "source", str(ItemSource.LOCAL))
+        try:
+            source = ItemSource(raw_source)
+        except ValueError:
+            source = ItemSource.LOCAL
+
+        return cls(
+            item_id=item_id,
+            title=_as_str(data, "title") or item_id,
+            spec_filename=spec_filename,
+            state=state,
+            priority=_as_int(data, "priority", 0),
+            created_at=_as_str(data, "created_at"),
+            updated_at=_as_str(data, "updated_at"),
+            attempts=_as_int(data, "attempts", 0),
+            max_attempts=_as_int(data, "max_attempts", 3),
+            merge_disposition=disposition,
+            source=source,
+            source_ref=_as_str(data, "source_ref"),
+            target_repo=_as_str(data, "target_repo"),
+            project_name=_as_str(data, "project_name"),
+            lease_pid=_as_int(data, "lease_pid", 0),
+            lease_host=_as_str(data, "lease_host"),
+            lease_expires_at=_as_str(data, "lease_expires_at"),
+            last_error=_as_str(data, "last_error"),
+            last_run_id=_as_str(data, "last_run_id"),
+            poison_reason=_as_str(data, "poison_reason"),
+            schema_version=_as_int(
+                data, "schema_version", QUEUE_SCHEMA_VERSION,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class QueueConfig:
+    """``[queue]`` config.
+
+    Only the fields the substrate itself needs. The daemon's knobs
+    (poll interval, ``daily_budget_usd``, the poison breaker) land with
+    ``ks serve`` in PR 2 rather than being declared here unused.
+    """
+
+    #: Execution attempts per item before it is poisoned. Bounds the
+    #: retry loop even when the classifier is wrong.
+    max_attempts: int = 3
+    #: How long a claim stays valid without a heartbeat. The reaper
+    #: recovers anything past this; it is the sleep/crash recovery knob.
+    lease_ttl_seconds: float = 3600.0
+
+    def __post_init__(self) -> None:
+        if self.max_attempts < 1:
+            raise QueueError(
+                f"queue.max_attempts must be >= 1, got {self.max_attempts}"
+            )
+        if self.lease_ttl_seconds <= 0:
+            raise QueueError(
+                "queue.lease_ttl_seconds must be > 0, got "
+                f"{self.lease_ttl_seconds}"
+            )
+
+    @classmethod
+    def from_env(cls) -> QueueConfig:
+        defaults = cls()
+        attempts = os.environ.get("KSTRL_QUEUE_MAX_ATTEMPTS")
+        ttl = os.environ.get("KSTRL_QUEUE_LEASE_TTL")
+        return cls(
+            max_attempts=(
+                defaults.max_attempts if attempts is None else int(attempts)
+            ),
+            lease_ttl_seconds=(
+                defaults.lease_ttl_seconds if ttl is None else float(ttl)
+            ),
+        )
+
+    @classmethod
+    def load(cls, root_dir: Path | None = None) -> QueueConfig:
+        """Precedence: env > toml > defaults; reads ``[queue]``."""
+        from kstrl.config import load_toml_section, resolve_config_file
+
+        if root_dir is None:
+            root_dir = Path.cwd()
+        section = load_toml_section(resolve_config_file(root_dir), "queue")
+        defaults = cls()
+        max_attempts = (
+            int(section["max_attempts"])
+            if "max_attempts" in section
+            else defaults.max_attempts
+        )
+        lease_ttl_seconds = (
+            float(section["lease_ttl_seconds"])
+            if "lease_ttl_seconds" in section
+            else defaults.lease_ttl_seconds
+        )
+        if "KSTRL_QUEUE_MAX_ATTEMPTS" in os.environ:
+            max_attempts = int(os.environ["KSTRL_QUEUE_MAX_ATTEMPTS"])
+        if "KSTRL_QUEUE_LEASE_TTL" in os.environ:
+            lease_ttl_seconds = float(os.environ["KSTRL_QUEUE_LEASE_TTL"])
+        return cls(
+            max_attempts=max_attempts, lease_ttl_seconds=lease_ttl_seconds,
+        )
+
+
+@dataclass(frozen=True)
+class PauseState:
+    """Whether intake is paused, and until when.
+
+    ``resume_after`` is what makes the R8.6 daily-budget stop
+    self-clearing: the budget pause sets tomorrow's local midnight and
+    the queue admits work again on its own, so a Friday-night budget hit
+    does not mean a dead queue all weekend.
+    """
+
+    paused: bool = False
+    reason: str = ""
+    since: str = ""
+    resume_after: str = ""
+
+    def active(self, now: datetime | None = None) -> bool:
+        """Paused right now, accounting for a lapsed ``resume_after``."""
+        if not self.paused:
+            return False
+        deadline = _parse_iso(self.resume_after)
+        if deadline is None:
+            return True
+        return (now or _utc_now()) < deadline
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "paused": self.paused,
+            "reason": self.reason,
+            "since": self.since,
+            "resume_after": self.resume_after,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PauseState:
+        return cls(
+            paused=bool(data.get("paused", False)),
+            reason=_as_str(data, "reason"),
+            since=_as_str(data, "since"),
+            resume_after=_as_str(data, "resume_after"),
+        )
+
+
+@dataclass
+class JournalEntry:
+    """One recorded transition. The queue's audit trail."""
+
+    ts: str
+    item_id: str
+    from_state: str
+    to_state: str
+    reason: str = ""
+    actor: str = ""
+    attempts: int = 0
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ts": self.ts,
+            "item_id": self.item_id,
+            "from": self.from_state,
+            "to": self.to_state,
+            "reason": self.reason,
+            "actor": self.actor,
+            "attempts": self.attempts,
+            "detail": self.detail,
+        }
+
+
+def _atomic_write(target: Path, content: str) -> None:
+    """Write ``content`` to ``target`` atomically.
+
+    ``tempfile.mkstemp`` in the destination directory plus ``os.replace``
+    - the pattern established at ``manifest.py:189`` and mirrored in
+    ``knowledge.write_facts``. Same-directory temp keeps the replace on
+    one filesystem, which is what makes it atomic.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(target.parent), prefix=f".{target.name}-", suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        os.replace(tmp_path, str(target))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+@contextmanager
+def queue_lock(root_dir: Path, *, blocking: bool = False) -> Iterator[None]:
+    """Hold the per-transition queue mutex.
+
+    Short-lived by design: taken around one transition and released, so
+    ``ks queue ls`` stays responsive while a run is in flight. The
+    daemon's singleton lock is a SEPARATE file (``serve.lock``, PR 2) -
+    conflating them would make listing the queue block on a running
+    factory.
+
+    POSIX only, like the A4 per-component lock and the run-level factory
+    lock. Without ``fcntl`` we degrade to no exclusion rather than
+    refusing to work; the sequencing that protects ``attempts`` does not
+    depend on the lock.
+    """
+    lock_path = queue_root(root_dir) / LOCK_FILENAME
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import fcntl
+    except ImportError:
+        yield
+        return
+
+    handle: IO[str] = open(lock_path, "a+")
+    try:
+        flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
+        try:
+            fcntl.flock(handle.fileno(), flags)
+        except OSError as exc:
+            raise QueueLockedError(
+                f"queue is locked by another process ({lock_path})"
+            ) from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
+
+
+def queue_root(root_dir: Path) -> Path:
+    """The queue directory for ``root_dir``."""
+    return state_dir(root_dir) / QUEUE_DIR_NAME
+
+
+class Queue:
+    """Maildir-style work queue over ``.kstrl/queue/``.
+
+    Reads scan the state directories; writes rename an item directory
+    between them. No method rewrites history - the journal is
+    append-only and the item directories carry current state.
+    """
+
+    def __init__(self, root_dir: Path, config: QueueConfig | None = None) -> None:
+        self.root_dir = root_dir
+        self.config = config or QueueConfig()
+
+    @property
+    def path(self) -> Path:
+        return queue_root(self.root_dir)
+
+    @property
+    def journal_path(self) -> Path:
+        return self.path / JOURNAL_FILENAME
+
+    def state_path(self, state: ItemState) -> Path:
+        return self.path / str(state)
+
+    def item_dir(self, item: QueueItem) -> Path:
+        return self.state_path(item.state) / item.item_id
+
+    def ensure_dirs(self) -> None:
+        for state in ALL_STATES:
+            self.state_path(state).mkdir(parents=True, exist_ok=True)
+
+    # ---------------------------------------------------------------- read
+
+    def _load_item_dir(self, item_path: Path, state: ItemState) -> QueueItem | None:
+        meta_path = item_path / META_FILENAME
+        try:
+            raw = meta_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            _warn_rejected(item_path, f"unreadable {META_FILENAME}: {exc}")
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            _warn_rejected(item_path, f"malformed {META_FILENAME}: {exc}")
+            return None
+        if not isinstance(data, dict):
+            _warn_rejected(item_path, f"{META_FILENAME} is not an object")
+            return None
+        item = QueueItem.from_dict(data)
+        if item is None:
+            _warn_rejected(item_path, "missing item_id or spec_filename")
+            return None
+        # The DIRECTORY is authoritative; the sidecar's copy is a mirror
+        # that may be one crash behind. See the module docstring.
+        item.state = state
+        return item
+
+    def items(self, states: tuple[ItemState, ...] | None = None) -> list[QueueItem]:
+        """Every item in the given states, in run order."""
+        found: list[QueueItem] = []
+        for state in states or ALL_STATES:
+            directory = self.state_path(state)
+            if not directory.is_dir():
+                continue
+            for entry in sorted(directory.iterdir()):
+                if not entry.is_dir():
+                    continue
+                item = self._load_item_dir(entry, state)
+                if item is not None:
+                    found.append(item)
+        found.sort(key=lambda candidate: candidate.sort_key)
+        return found
+
+    def get(self, item_id: str) -> QueueItem | None:
+        """Find one item by full id or unique prefix.
+
+        A prefix matching more than one item raises rather than picking
+        one: silently operating on the wrong unit of work is worse than
+        making the operator type more characters.
+        """
+        exact: QueueItem | None = None
+        prefixed: list[QueueItem] = []
+        for item in self.items():
+            if item.item_id == item_id:
+                exact = item
+                break
+            if item.item_id.startswith(item_id):
+                prefixed.append(item)
+        if exact is not None:
+            return exact
+        if not prefixed:
+            return None
+        if len(prefixed) > 1:
+            matches = ", ".join(candidate.item_id for candidate in prefixed)
+            raise QueueError(f"{item_id!r} matches multiple items: {matches}")
+        return prefixed[0]
+
+    def find_by_source_ref(self, source_ref: str) -> QueueItem | None:
+        """First item from a given origin, in any state.
+
+        The in-queue half of PR 3's idempotency: a re-seen GitHub issue
+        must not enqueue a second copy of the same work.
+        """
+        if not source_ref:
+            return None
+        for item in self.items():
+            if item.source_ref == source_ref:
+                return item
+        return None
+
+    def spec_path(self, item: QueueItem) -> Path:
+        return self.item_dir(item) / item.spec_filename
+
+    def read_spec(self, item: QueueItem) -> str:
+        return self.spec_path(item).read_text(encoding="utf-8")
+
+    # ------------------------------------------------------------- journal
+
+    def _journal(self, entry: JournalEntry) -> None:
+        """Append one transition. Never raises into a caller's path.
+
+        A failed journal write must not undo a transition that already
+        happened on disk - the directory is the truth and the journal is
+        the narration. Losing a line is visible (journal replay vs a
+        directory scan disagree); rolling back a committed rename would
+        be silent.
+        """
+        self.path.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(entry.to_dict(), ensure_ascii=False)
+        try:
+            with open(self.journal_path, "a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+        except OSError as exc:
+            warnings.warn(
+                f"queue: journal append failed ({exc}); the transition "
+                "itself succeeded",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+
+    def journal_entries(self, item_id: str = "") -> list[dict[str, Any]]:
+        """Read the journal, optionally filtered to one item."""
+        try:
+            raw = self.journal_path.read_text(encoding="utf-8")
+        except OSError:
+            return []
+        entries: list[dict[str, Any]] = []
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(data, dict):
+                continue
+            if item_id and data.get("item_id") != item_id:
+                continue
+            entries.append(data)
+        return entries
+
+    # --------------------------------------------------------------- write
+
+    def _write_meta(self, item: QueueItem, directory: Path) -> None:
+        _atomic_write(
+            directory / META_FILENAME,
+            json.dumps(item.to_dict(), indent=2, ensure_ascii=False) + "\n",
+        )
+
+    def add(
+        self,
+        spec_source: Path | str,
+        *,
+        title: str = "",
+        priority: int = 0,
+        merge_disposition: MergeDisposition = MergeDisposition.STOP_AT_PR,
+        source: ItemSource = ItemSource.LOCAL,
+        source_ref: str = "",
+        target_repo: str = "",
+        project_name: str = "",
+        max_attempts: int | None = None,
+        spec_filename: str = "spec.md",
+        actor: str = "",
+    ) -> QueueItem:
+        """Enqueue a spec.
+
+        ``spec_source`` is either a path to copy or literal spec text.
+        The spec is COPIED into the item directory rather than
+        referenced: an item whose spec file was edited or deleted after
+        enqueue would run something other than what was reviewed.
+        """
+        if isinstance(spec_source, Path):
+            content = spec_source.read_text(encoding="utf-8")
+            spec_filename = spec_source.name
+            resolved_title = title or spec_source.stem
+        else:
+            content = spec_source
+            resolved_title = title or "untitled"
+        if not content.strip():
+            raise QueueError("refusing to enqueue an empty spec")
+
+        now = _iso(_utc_now())
+        item = QueueItem(
+            item_id=mint_item_id(),
+            title=resolved_title,
+            spec_filename=spec_filename,
+            state=ItemState.QUEUED,
+            priority=priority,
+            created_at=now,
+            updated_at=now,
+            max_attempts=(
+                self.config.max_attempts if max_attempts is None else max_attempts
+            ),
+            merge_disposition=merge_disposition,
+            source=source,
+            source_ref=source_ref,
+            target_repo=target_repo,
+            project_name=project_name,
+        )
+
+        self.ensure_dirs()
+        directory = self.state_path(ItemState.QUEUED) / item.item_id
+        if directory.exists():
+            raise QueueError(f"queue item {item.item_id} already exists")
+        # Build in a hidden staging directory and rename into place, so a
+        # scan never sees an item whose spec has not landed yet.
+        staging = self.state_path(ItemState.QUEUED) / f".staging-{item.item_id}"
+        staging.mkdir(parents=True, exist_ok=False)
+        try:
+            _atomic_write(staging / spec_filename, content)
+            self._write_meta(item, staging)
+            os.replace(str(staging), str(directory))
+        except BaseException:
+            shutil.rmtree(staging, ignore_errors=True)
+            raise
+
+        self._journal(JournalEntry(
+            ts=now, item_id=item.item_id, from_state="", to_state=str(ItemState.QUEUED),
+            reason="added", actor=actor, attempts=item.attempts,
+            detail={"source": str(source), "source_ref": source_ref},
+        ))
+        return item
+
+    def transition(
+        self,
+        item: QueueItem,
+        to_state: ItemState,
+        *,
+        reason: str = "",
+        actor: str = "",
+        charge_attempt: bool = False,
+        **updates: Any,
+    ) -> QueueItem:
+        """Move ``item`` to ``to_state``, recording why.
+
+        Writes ``meta.json`` first and renames second - the rename is the
+        commit point (see the module docstring). ``charge_attempt``
+        increments ``attempts`` in the pre-rename write, so an interrupted
+        transition over-counts rather than under-counts.
+        """
+        from_state = item.state
+        legal = _LEGAL_TRANSITIONS.get(from_state, frozenset())
+        if to_state not in legal:
+            allowed = ", ".join(sorted(str(s) for s in legal)) or "nothing"
+            raise QueueError(
+                f"illegal queue transition {from_state} -> {to_state} "
+                f"for {item.item_id} (legal: {allowed})"
+            )
+
+        source_dir = self.item_dir(item)
+        if not source_dir.is_dir():
+            raise QueueError(
+                f"queue item {item.item_id} is not in {from_state} "
+                f"(expected {source_dir})"
+            )
+        target_dir = self.state_path(to_state) / item.item_id
+        target_dir.parent.mkdir(parents=True, exist_ok=True)
+        if target_dir.exists():
+            raise QueueError(
+                f"queue item {item.item_id} already exists in {to_state}"
+            )
+
+        for key, value in updates.items():
+            if not hasattr(item, key):
+                raise QueueError(f"unknown QueueItem field {key!r}")
+            setattr(item, key, value)
+        if charge_attempt:
+            item.attempts += 1
+        item.state = to_state
+        item.updated_at = _iso(_utc_now())
+
+        # Order is load-bearing: meta first (so a charged attempt is
+        # durable before any spend), rename second (the commit).
+        self._write_meta(item, source_dir)
+        try:
+            os.replace(str(source_dir), str(target_dir))
+        except OSError:
+            # The move did not commit, so the in-memory object must stop
+            # claiming it did - a caller that kept using this item would
+            # otherwise address the wrong directory. ``attempts`` is
+            # deliberately NOT rolled back: it is already durable on disk
+            # and an over-count is the safe direction.
+            item.state = from_state
+            raise
+
+        self._journal(JournalEntry(
+            ts=item.updated_at, item_id=item.item_id,
+            from_state=str(from_state), to_state=str(to_state),
+            reason=reason, actor=actor, attempts=item.attempts,
+        ))
+        return item
+
+    def lease(
+        self, item: QueueItem, *, pid: int = 0, host: str = "", actor: str = "",
+    ) -> QueueItem:
+        """Claim a queued item for this worker. Spends nothing."""
+        import socket
+
+        expires = _utc_now() + timedelta(seconds=self.config.lease_ttl_seconds)
+        return self.transition(
+            item, ItemState.LEASED, reason="leased", actor=actor,
+            lease_pid=pid or os.getpid(),
+            lease_host=host or socket.gethostname(),
+            lease_expires_at=_iso(expires),
+        )
+
+    def start(self, item: QueueItem, *, run_id: str = "", actor: str = "") -> QueueItem:
+        """Begin execution. THIS is where the attempt is charged.
+
+        Charged here rather than on completion because completion is the
+        step a crash, a sleep, or a killed process can skip. An attempt
+        that ran but was never counted is an unbounded retry loop.
+        """
+        return self.transition(
+            item, ItemState.RUNNING, reason="started", actor=actor,
+            charge_attempt=True, last_run_id=run_id,
+        )
+
+    def finish_ok(self, item: QueueItem, *, actor: str = "") -> QueueItem:
+        return self.transition(
+            item, ItemState.DONE, reason="completed", actor=actor, last_error="",
+        )
+
+    def finish_failed(
+        self, item: QueueItem, *, error: str = "", actor: str = "",
+    ) -> QueueItem:
+        """Record a red finish that MAY be retried.
+
+        Whether it actually is retried is the daemon's decision (PR 2),
+        made on positive evidence of an infrastructure error. Landing in
+        ``failed/`` is not permission to retry.
+        """
+        return self.transition(
+            item, ItemState.FAILED, reason="failed", actor=actor, last_error=error,
+        )
+
+    def poison(
+        self, item: QueueItem, *, reason: str, actor: str = "",
+    ) -> QueueItem:
+        """Park an item that must never be retried automatically.
+
+        The terminal state for spec-level failures and for anything whose
+        failure could not be positively classified. Requires a reason:
+        an item a human has to look at should say what it is waiting for.
+        """
+        if not reason.strip():
+            raise QueueError("poison requires a reason")
+        return self.transition(
+            item, ItemState.POISON, reason="poisoned", actor=actor,
+            poison_reason=reason,
+        )
+
+    def requeue(
+        self,
+        item: QueueItem,
+        *,
+        reason: str = "requeued",
+        actor: str = "",
+        reset_attempts: bool = False,
+    ) -> QueueItem:
+        """Send an item back to ``queued/``.
+
+        ``reset_attempts`` is for an explicit human retry only. The
+        automatic paths never reset the counter - a retry policy that
+        can zero its own bound is not a bound.
+        """
+        updates: dict[str, Any] = {
+            "lease_pid": 0, "lease_host": "", "lease_expires_at": "",
+        }
+        if reset_attempts:
+            updates["attempts"] = 0
+            updates["poison_reason"] = ""
+        return self.transition(
+            item, ItemState.QUEUED, reason=reason, actor=actor, **updates,
+        )
+
+    def remove(self, item: QueueItem, *, actor: str = "") -> None:
+        """Delete an item outright.
+
+        Refuses while the item is running: removing the directory out
+        from under a live worker loses the audit trail for money already
+        spent.
+        """
+        if item.state is ItemState.RUNNING:
+            raise QueueError(
+                f"{item.item_id} is running; stop the run before removing it"
+            )
+        directory = self.item_dir(item)
+        shutil.rmtree(directory, ignore_errors=True)
+        self._journal(JournalEntry(
+            ts=_iso(_utc_now()), item_id=item.item_id,
+            from_state=str(item.state), to_state="removed",
+            reason="removed", actor=actor, attempts=item.attempts,
+        ))
+
+    # ---------------------------------------------------------------- pause
+
+    @property
+    def pause_path(self) -> Path:
+        return self.path / PAUSE_FILENAME
+
+    def pause_state(self) -> PauseState:
+        try:
+            raw = self.pause_path.read_text(encoding="utf-8")
+        except OSError:
+            return PauseState()
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            # An unreadable pause marker means PAUSED. Failing open here
+            # would resume unattended spending on the strength of a
+            # corrupt file.
+            return PauseState(paused=True, reason="unreadable pause marker")
+        if not isinstance(data, dict):
+            return PauseState(paused=True, reason="malformed pause marker")
+        return PauseState.from_dict(data)
+
+    def is_paused(self, now: datetime | None = None) -> bool:
+        return self.pause_state().active(now)
+
+    def pause(
+        self, *, reason: str = "", actor: str = "", resume_after: str = "",
+    ) -> PauseState:
+        state = PauseState(
+            paused=True, reason=reason, since=_iso(_utc_now()),
+            resume_after=resume_after,
+        )
+        self.path.mkdir(parents=True, exist_ok=True)
+        _atomic_write(
+            self.pause_path,
+            json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
+        )
+        self._journal(JournalEntry(
+            ts=state.since, item_id="", from_state="", to_state="paused",
+            reason=reason, actor=actor,
+            detail={"resume_after": resume_after},
+        ))
+        return state
+
+    def resume(self, *, actor: str = "") -> PauseState:
+        state = PauseState()
+        self.path.mkdir(parents=True, exist_ok=True)
+        _atomic_write(
+            self.pause_path,
+            json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
+        )
+        self._journal(JournalEntry(
+            ts=_iso(_utc_now()), item_id="", from_state="paused",
+            to_state="running", reason="resumed", actor=actor,
+        ))
+        return state
+
+    # --------------------------------------------------------------- report
+
+    def counts(self) -> dict[ItemState, int]:
+        tally = dict.fromkeys(ALL_STATES, 0)
+        for item in self.items():
+            tally[item.state] += 1
+        return tally
+
+    def next_ready(self, now: datetime | None = None) -> QueueItem | None:
+        """The item a worker should claim next, or None.
+
+        Returns None while paused: the pause is an admission gate, and
+        checking it anywhere other than the point of claiming would let
+        a racing worker slip one more run past a budget stop.
+        """
+        if self.is_paused(now):
+            return None
+        ready = self.items((ItemState.QUEUED,))
+        return ready[0] if ready else None
+
+
+def summarize(counts: dict[ItemState, int]) -> str:
+    """One-line queue summary, omitting empty states."""
+    parts = [
+        f"{count} {state}" for state, count in counts.items() if count
+    ]
+    return ", ".join(parts) if parts else "empty"

--- a/kstrl/workqueue.py
+++ b/kstrl/workqueue.py
@@ -23,6 +23,7 @@ is a DIRECTORY holding its spec file plus ``meta.json``::
       done/     finished green
       failed/   finished red and eligible to retry
       poison/   finished red and NOT eligible to retry
+      .staging/ items being assembled; NEVER scanned
       journal.jsonl
       pause.json    (absent = running)
       queue.lock    (short-lived per-transition mutex)
@@ -88,6 +89,47 @@ class QueueError(RuntimeError):
 
 class QueueLockedError(QueueError):
     """Another process holds the queue mutex."""
+
+
+class QueueBudgetExhausted(QueueError):
+    """An item was asked to run with no attempts left.
+
+    Raised by :meth:`Queue.start` - the substrate's own enforcement of
+    ``max_attempts``, independent of whatever the caller believes. The
+    daemon catches this and poisons the item; a caller that ignores it
+    leaves the item leased for the reaper, never running.
+    """
+
+
+#: Names a queue path component may never take. ``.`` and ``..`` are the
+#: traversal primitives; the empty string collapses a join silently.
+_UNSAFE_NAMES = frozenset({"", ".", ".."})
+
+#: Prefix for the hidden staging directory used while publishing an item.
+#: It lives OUTSIDE the state directories so a scan cannot reach it even
+#: if the name filter were removed (review #185 F3).
+STAGING_DIR_NAME = ".staging"
+
+
+def is_safe_component(name: str) -> bool:
+    """Whether ``name`` is a single path component safe to join.
+
+    Rejects separators, traversal, empty names, NUL, and leading dots.
+    Every string that becomes part of a queue path passes through here,
+    because two of them (``item_id`` and ``spec_filename``) are read back
+    from a sidecar an operator or a remote adapter can write. Review
+    #185 F1/F2 demonstrated both: an ``item_id`` of ``../../../outside``
+    made ``remove()`` delete an unrelated directory, and a
+    ``spec_filename`` of ``../../../../escaped.md`` wrote outside the
+    queue while still publishing a normal-looking item.
+    """
+    if name in _UNSAFE_NAMES:
+        return False
+    if name.startswith("."):
+        return False
+    if "/" in name or "\\" in name or "\x00" in name:
+        return False
+    return Path(name).name == name
 
 
 class ItemState(StrEnum):
@@ -315,6 +357,11 @@ class QueueItem:
         item_id = _as_str(data, "item_id")
         spec_filename = _as_str(data, "spec_filename")
         if not item_id or not spec_filename:
+            return None
+        # Both become path components. A sidecar is operator-writable and
+        # (from PR 3) remote-adapter-writable, so it is untrusted input:
+        # reject traversal here rather than at each join site (#185 F2).
+        if not is_safe_component(spec_filename):
             return None
 
         raw_state = _as_str(data, "state", str(ItemState.QUEUED))
@@ -596,16 +643,66 @@ class Queue:
     def state_path(self, state: ItemState) -> Path:
         return self.path / str(state)
 
+    @property
+    def staging_path(self) -> Path:
+        """Where items are assembled before being published.
+
+        Deliberately a sibling of the state directories rather than a
+        hidden entry inside ``queued/``: a scan cannot reach it even if
+        the name filter were removed. Same filesystem, so the publishing
+        ``os.replace`` is still atomic (#185 F3).
+        """
+        return self.path / STAGING_DIR_NAME
+
     def item_dir(self, item: QueueItem) -> Path:
+        if not is_safe_component(item.item_id):
+            raise QueueError(f"unsafe queue item id {item.item_id!r}")
         return self.state_path(item.state) / item.item_id
 
     def ensure_dirs(self) -> None:
         for state in ALL_STATES:
             self.state_path(state).mkdir(parents=True, exist_ok=True)
+        self.staging_path.mkdir(parents=True, exist_ok=True)
+
+    def sweep_staging(self) -> int:
+        """Delete every half-published item, returning how many went.
+
+        A staging directory only exists while ``add`` is mid-publish, and
+        ``add`` runs under the queue mutex, so anything found here while
+        holding that mutex is by definition abandoned - no age heuristic
+        is needed. Call it under ``queue_lock``; calling it without the
+        lock can race a concurrent enqueue. This is the recovery half of
+        the staging policy the scan filter enforces (#185 F3).
+        """
+        if not self.staging_path.is_dir():
+            return 0
+        swept = 0
+        for entry in sorted(self.staging_path.iterdir()):
+            if entry.is_dir() and not entry.is_symlink():
+                shutil.rmtree(entry, ignore_errors=True)
+                swept += 1
+        if swept:
+            self._journal(JournalEntry(
+                ts=_iso(_utc_now()), item_id="", from_state="staging",
+                to_state="swept", reason="abandoned mid-publish",
+                detail={"count": swept},
+            ))
+        return swept
 
     # ---------------------------------------------------------------- read
 
     def _load_item_dir(self, item_path: Path, state: ItemState) -> QueueItem | None:
+        # The DIRECTORY ENTRY is the item's identity, exactly as it is the
+        # item's state. A sidecar that disagrees is corrupt or tampered
+        # with, and trusting its ``item_id`` let a crafted value redirect
+        # rmtree outside the queue (#185 F1).
+        if item_path.is_symlink():
+            _warn_rejected(item_path, "queue items may not be symlinks")
+            return None
+        if not is_safe_component(item_path.name):
+            _warn_rejected(item_path, "unsafe item directory name")
+            return None
+
         meta_path = item_path / META_FILENAME
         try:
             raw = meta_path.read_text(encoding="utf-8")
@@ -622,10 +719,21 @@ class Queue:
             return None
         item = QueueItem.from_dict(data)
         if item is None:
-            _warn_rejected(item_path, "missing item_id or spec_filename")
+            _warn_rejected(
+                item_path, "missing/unsafe item_id or spec_filename",
+            )
             return None
-        # The DIRECTORY is authoritative; the sidecar's copy is a mirror
-        # that may be one crash behind. See the module docstring.
+        # The DIRECTORY is authoritative for both identity and state; the
+        # sidecar's copies are mirrors that may be one crash behind. See
+        # the module docstring.
+        if item.item_id != item_path.name:
+            warnings.warn(
+                f"queue: sidecar item_id {item.item_id!r} disagrees with "
+                f"directory {item_path.name!r}; using the directory",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+            item.item_id = item_path.name
         item.state = state
         return item
 
@@ -638,6 +746,12 @@ class Queue:
                 continue
             for entry in sorted(directory.iterdir()):
                 if not entry.is_dir():
+                    continue
+                # Dotted entries are never published items: staging lives
+                # under its own directory now, but the filter stays as
+                # defence in depth so a leftover from any source is inert
+                # rather than surfacing as a phantom item (#185 F3).
+                if entry.name.startswith("."):
                     continue
                 item = self._load_item_dir(entry, state)
                 if item is not None:
@@ -683,7 +797,23 @@ class Queue:
         return None
 
     def spec_path(self, item: QueueItem) -> Path:
-        return self.item_dir(item) / item.spec_filename
+        """The item's spec file, guaranteed to be inside the item.
+
+        Belt and braces over the decode-time filter: an item constructed
+        in memory rather than loaded from disk never passed through
+        ``from_dict``, so the containment check is re-done here (#185 F2).
+        """
+        directory = self.item_dir(item)
+        if not is_safe_component(item.spec_filename):
+            raise QueueError(
+                f"unsafe spec filename {item.spec_filename!r} on {item.item_id}"
+            )
+        candidate = directory / item.spec_filename
+        if directory.resolve() not in candidate.resolve().parents:
+            raise QueueError(
+                f"spec path for {item.item_id} escapes its item directory"
+            )
+        return candidate
 
     def read_spec(self, item: QueueItem) -> str:
         return self.spec_path(item).read_text(encoding="utf-8")
@@ -772,6 +902,23 @@ class Queue:
             resolved_title = title or "untitled"
         if not content.strip():
             raise QueueError("refusing to enqueue an empty spec")
+        # The text form of this API is what PR 3's remote adapters call,
+        # so the filename is untrusted: a caller-supplied
+        # "../../../escaped.md" wrote outside the queue while still
+        # publishing a normal-looking item (#185 F2).
+        if not is_safe_component(spec_filename):
+            raise QueueError(
+                f"spec filename must be a plain basename, got {spec_filename!r}"
+            )
+        resolved_attempts = (
+            self.config.max_attempts if max_attempts is None else max_attempts
+        )
+        # QueueConfig rejects this, but a per-item override bypassed it and
+        # admitted an item with no execution budget at all (#185 F4).
+        if resolved_attempts < 1:
+            raise QueueError(
+                f"max_attempts must be >= 1, got {resolved_attempts}"
+            )
 
         now = _iso(_utc_now())
         item = QueueItem(
@@ -782,9 +929,7 @@ class Queue:
             priority=priority,
             created_at=now,
             updated_at=now,
-            max_attempts=(
-                self.config.max_attempts if max_attempts is None else max_attempts
-            ),
+            max_attempts=resolved_attempts,
             merge_disposition=merge_disposition,
             source=source,
             source_ref=source_ref,
@@ -796,9 +941,10 @@ class Queue:
         directory = self.state_path(ItemState.QUEUED) / item.item_id
         if directory.exists():
             raise QueueError(f"queue item {item.item_id} already exists")
-        # Build in a hidden staging directory and rename into place, so a
-        # scan never sees an item whose spec has not landed yet.
-        staging = self.state_path(ItemState.QUEUED) / f".staging-{item.item_id}"
+        # Build under the staging directory and rename into place, so a
+        # scan never sees an item whose spec has not landed yet. Staging
+        # sits outside the state directories entirely (#185 F3).
+        staging = self.staging_path / item.item_id
         staging.mkdir(parents=True, exist_ok=False)
         try:
             _atomic_write(staging / spec_filename, content)
@@ -904,7 +1050,20 @@ class Queue:
         Charged here rather than on completion because completion is the
         step a crash, a sleep, or a killed process can skip. An attempt
         that ran but was never counted is an unbounded retry loop.
+
+        ``max_attempts`` is enforced HERE, at the spending boundary, not
+        only in the CLI's retry policy. Review #185 F5 showed the bound
+        was advertised but not enforced: start -> fail -> requeue ->
+        lease -> start produced a running item with ``attempts == 2``
+        against ``max_attempts == 1``. A bound that only holds when every
+        caller remembers to check it is not a bound, and the callers here
+        will be an unattended daemon and a reaper.
         """
+        if item.attempts_remaining <= 0:
+            raise QueueBudgetExhausted(
+                f"{item.item_id} has used all {item.max_attempts} attempts; "
+                "refusing to start (poison it or reset attempts explicitly)"
+            )
         return self.transition(
             item, ItemState.RUNNING, reason="started", actor=actor,
             charge_attempt=True, last_run_id=run_id,
@@ -980,7 +1139,15 @@ class Queue:
                 f"{item.item_id} is running; stop the run before removing it"
             )
         directory = self.item_dir(item)
-        shutil.rmtree(directory, ignore_errors=True)
+        # NOT ignore_errors: that swallowed permission and filesystem
+        # failures, after which this journaled a "removed" record and the
+        # CLI printed success for an item still on disk - a false operator
+        # result AND a false audit trail (#185 F6).
+        shutil.rmtree(directory)
+        if directory.exists():
+            raise QueueError(
+                f"failed to remove {item.item_id}: {directory} still exists"
+            )
         self._journal(JournalEntry(
             ts=_iso(_utc_now()), item_id=item.item_id,
             from_state=str(item.state), to_state="removed",
@@ -996,8 +1163,16 @@ class Queue:
     def pause_state(self) -> PauseState:
         try:
             raw = self.pause_path.read_text(encoding="utf-8")
-        except OSError:
+        except FileNotFoundError:
+            # The ONLY read failure that means "not paused". Everything
+            # else is a marker we could not read, and a broad `except
+            # OSError` here made a PermissionError read as RUNNING -
+            # exactly the fail-open this module claims not to do (#185 F7).
             return PauseState()
+        except OSError as exc:
+            return PauseState(
+                paused=True, reason=f"unreadable pause marker: {exc}",
+            )
         try:
             data = json.loads(raw)
         except json.JSONDecodeError:

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -135,6 +135,7 @@ def _section_specs() -> list[SectionSpec]:
     from kstrl.security import SecurityConfig
     from kstrl.timeout import TimeoutConfig
     from kstrl.verify import VerifyConfig
+    from kstrl.workqueue import QueueConfig
 
     def kstrl_loader(root: Path) -> Any:
         return KstrlConfig.load(root_dir=root)
@@ -267,6 +268,14 @@ def _section_specs() -> list[SectionSpec]:
             ]),
             lambda root: InboxConfig.load(root_dir=root),
             InboxConfig(), probe_undocumented_fields=True,
+        ),
+        SectionSpec(
+            "queue", "Continuous intake queue (R8.6)",
+            identity_keys(QueueConfig, [
+                f.name for f in dataclasses.fields(QueueConfig)
+            ]),
+            lambda root: QueueConfig.load(root_dir=root),
+            QueueConfig(), probe_undocumented_fields=True,
         ),
         SectionSpec(
             "adequacy", "Test-suite adequacy gate (R8.5; opt-in, advisory first)",
@@ -446,6 +455,10 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("inbox", "open_item_cap"): "open items after which queue intake pauses; 0 = unbounded",
     ("inbox", "snooze_hours"): "default snooze TTL in hours; snoozed items return",
     ("inbox", "notify_action_required"): "notify on action-required items and demotions only",
+    ("queue", "max_attempts"):
+        "execution attempts per queue item before it is poisoned",
+    ("queue", "lease_ttl_seconds"):
+        "claim validity in seconds; the reaper recovers anything past this",
     ("adequacy", "enabled"): "run the Layer 0 test-adequacy checks (opt-in)",
     ("adequacy", "layer0"): "advisory | block; the ladder can raise it, never lower",
     ("adequacy", "require_strong_oracle"): "each new test file needs one falsifiable assertion",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ KSTRL_ENV_PREFIXES: tuple[str, ...] = (
     "KSTRL_DEAD_CODE_",
     "KSTRL_LINEAR_",
     "KSTRL_NOTIFY_",
+    "KSTRL_QUEUE_",
 )
 
 # Legacy single-loop env vars (exact names, no shared prefix).

--- a/tests/test_queue_cli.py
+++ b/tests/test_queue_cli.py
@@ -1,0 +1,332 @@
+"""R8.6 PR 1: `ks queue` CLI tests.
+
+The CLI is the human's half of the safety story, so the behaviors pinned
+here are the ones that stop an operator spending money by accident: a
+poisoned item that has used its attempts refuses to requeue without an
+explicit authorization flag, `rm` will not delete a live run, and the
+auto-merge opt-in has to be typed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner, Result
+
+from kstrl.cli import cli
+from kstrl.workqueue import (
+    ItemState,
+    MergeDisposition,
+    Queue,
+    QueueConfig,
+)
+
+
+@pytest.fixture
+def spec_file(tmp_path: Path) -> Path:
+    path = tmp_path / "feature.md"
+    path.write_text("# Feature\n\nDo the thing.\n")
+    return path
+
+
+def _queue(root: Path) -> Queue:
+    return Queue(root, QueueConfig())
+
+
+def _invoke(args: list[str], root: Path) -> Result:
+    return CliRunner().invoke(cli, [*args, "--root", str(root), "--no-color"])
+
+
+class TestQueueHelp:
+    def test_group_is_registered(self) -> None:
+        result = CliRunner().invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "queue" in result.output
+
+    def test_group_help_lists_the_verbs(self) -> None:
+        result = CliRunner().invoke(cli, ["queue", "--help"])
+        assert result.exit_code == 0
+        for verb in ("add", "ls", "show", "retry", "rm", "pause", "resume"):
+            assert verb in result.output
+
+
+class TestAdd:
+    def test_add_enqueues(self, tmp_path: Path, spec_file: Path) -> None:
+        result = _invoke(["queue", "add", str(spec_file)], tmp_path)
+        assert result.exit_code == 0
+        items = _queue(tmp_path).items()
+        assert len(items) == 1
+        assert items[0].title == "feature"
+        assert items[0].state is ItemState.QUEUED
+
+    def test_add_defaults_to_stop_at_pr(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        item = _queue(tmp_path).items()[0]
+        assert item.merge_disposition is MergeDisposition.STOP_AT_PR
+        assert "stop_at_pr" in _invoke(
+            ["queue", "show", item.item_id], tmp_path,
+        ).output
+
+    def test_auto_merge_must_be_typed(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file), "--auto-merge"], tmp_path)
+        item = _queue(tmp_path).items()[0]
+        assert item.merge_disposition is MergeDisposition.AUTO_MERGE
+
+    def test_priority_and_max_attempts_are_carried(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(
+            ["queue", "add", str(spec_file), "--priority", "4",
+             "--max-attempts", "1"],
+            tmp_path,
+        )
+        item = _queue(tmp_path).items()[0]
+        assert item.priority == 4
+        assert item.max_attempts == 1
+
+    def test_add_warns_while_paused(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "pause", "--reason", "budget"], tmp_path)
+        result = _invoke(["queue", "add", str(spec_file)], tmp_path)
+        assert result.exit_code == 0
+        assert "paused" in result.output.lower()
+
+    def test_missing_spec_is_rejected(self, tmp_path: Path) -> None:
+        result = _invoke(["queue", "add", str(tmp_path / "nope.md")], tmp_path)
+        assert result.exit_code != 0
+
+    def test_empty_spec_is_rejected(self, tmp_path: Path) -> None:
+        blank = tmp_path / "blank.md"
+        blank.write_text("\n\n")
+        result = _invoke(["queue", "add", str(blank)], tmp_path)
+        assert result.exit_code == 1
+        assert "empty spec" in result.output
+
+
+class TestLs:
+    def test_empty_queue(self, tmp_path: Path) -> None:
+        result = _invoke(["queue", "ls"], tmp_path)
+        assert result.exit_code == 0
+        assert "empty" in result.output.lower()
+
+    def test_lists_items_in_run_order(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file), "--title", "low"], tmp_path)
+        _invoke(
+            ["queue", "add", str(spec_file), "--title", "high", "--priority", "9"],
+            tmp_path,
+        )
+        result = _invoke(["queue", "ls"], tmp_path)
+        assert result.output.index("high") < result.output.index("low")
+
+    def test_state_filter(self, tmp_path: Path, spec_file: Path) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        queue = _queue(tmp_path)
+        queue.finish_ok(queue.start(queue.lease(queue.items()[0])))
+        assert "empty" in _invoke(
+            ["queue", "ls", "--state", "queued"], tmp_path,
+        ).output.lower()
+        assert "done" in _invoke(
+            ["queue", "ls", "--state", "done"], tmp_path,
+        ).output
+
+    def test_unknown_state_filter_is_an_error(self, tmp_path: Path) -> None:
+        result = _invoke(["queue", "ls", "--state", "wat"], tmp_path)
+        assert result.exit_code == 1
+
+    def test_paused_queue_is_announced(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        _invoke(["queue", "pause", "--reason", "daily budget"], tmp_path)
+        result = _invoke(["queue", "ls"], tmp_path)
+        assert "PAUSED" in result.output
+        assert "daily budget" in result.output
+
+
+class TestShow:
+    def test_show_reports_the_item(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        item = _queue(tmp_path).items()[0]
+        result = _invoke(["queue", "show", item.item_id], tmp_path)
+        assert result.exit_code == 0
+        assert item.item_id in result.output
+        assert "feature" in result.output
+
+    def test_show_includes_transition_history(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        queue = _queue(tmp_path)
+        queue.start(queue.lease(queue.items()[0]))
+        item = queue.items()[0]
+        result = _invoke(["queue", "show", item.item_id], tmp_path)
+        assert "queued -> leased" in result.output
+        assert "leased -> running" in result.output
+
+    def test_show_flags_an_expired_lease(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        queue = _queue(tmp_path)
+        item = queue.lease(queue.items()[0])
+        meta = queue.item_dir(item) / "meta.json"
+        data = json.loads(meta.read_text())
+        data["lease_expires_at"] = "2000-01-01T00:00:00+00:00"
+        meta.write_text(json.dumps(data))
+        result = _invoke(["queue", "show", item.item_id], tmp_path)
+        assert "EXPIRED" in result.output
+
+    def test_unknown_id(self, tmp_path: Path) -> None:
+        result = _invoke(["queue", "show", "q-nope"], tmp_path)
+        assert result.exit_code == 1
+        assert "No queue item" in result.output
+
+    def test_ambiguous_prefix_is_an_error(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        result = _invoke(["queue", "show", "q-"], tmp_path)
+        assert result.exit_code == 1
+        assert "matches multiple items" in result.output
+
+
+class TestRetry:
+    def test_retry_requeues_a_failed_item(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        queue = _queue(tmp_path)
+        queue.finish_failed(queue.start(queue.lease(queue.items()[0])), error="infra")
+        item = queue.items()[0]
+
+        result = _invoke(["queue", "retry", item.item_id], tmp_path)
+        assert result.exit_code == 0
+        assert _queue(tmp_path).items()[0].state is ItemState.QUEUED
+
+    def test_retry_does_not_reset_attempts(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        queue = _queue(tmp_path)
+        queue.finish_failed(queue.start(queue.lease(queue.items()[0])))
+        _invoke(["queue", "retry", queue.items()[0].item_id], tmp_path)
+        assert _queue(tmp_path).items()[0].attempts == 1
+
+    def test_exhausted_item_refuses_without_explicit_authorization(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        """Spending again after the budget is used up must be deliberate."""
+        _invoke(
+            ["queue", "add", str(spec_file), "--max-attempts", "1"], tmp_path,
+        )
+        queue = _queue(tmp_path)
+        queue.finish_failed(queue.start(queue.lease(queue.items()[0])))
+        item = queue.items()[0]
+
+        result = _invoke(["queue", "retry", item.item_id], tmp_path)
+        assert result.exit_code == 1
+        assert "--reset-attempts" in result.output
+        assert _queue(tmp_path).items()[0].state is ItemState.FAILED
+
+    def test_reset_attempts_authorizes_it(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(
+            ["queue", "add", str(spec_file), "--max-attempts", "1"], tmp_path,
+        )
+        queue = _queue(tmp_path)
+        queue.finish_failed(queue.start(queue.lease(queue.items()[0])))
+        item = queue.items()[0]
+
+        result = _invoke(
+            ["queue", "retry", item.item_id, "--reset-attempts"], tmp_path,
+        )
+        assert result.exit_code == 0
+        reread = _queue(tmp_path).items()[0]
+        assert reread.state is ItemState.QUEUED
+        assert reread.attempts == 0
+
+    def test_retry_refuses_a_queued_item(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        item = _queue(tmp_path).items()[0]
+        result = _invoke(["queue", "retry", item.item_id], tmp_path)
+        assert result.exit_code == 1
+        assert "only failed or poisoned" in result.output
+
+    def test_retry_of_a_poisoned_item(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        queue = _queue(tmp_path)
+        queue.poison(queue.items()[0], reason="spec ambiguous")
+        item = queue.items()[0]
+        result = _invoke(
+            ["queue", "retry", item.item_id, "--reset-attempts"], tmp_path,
+        )
+        assert result.exit_code == 0
+        assert _queue(tmp_path).items()[0].poison_reason == ""
+
+
+class TestRm:
+    def test_rm_with_yes_deletes(self, tmp_path: Path, spec_file: Path) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        item = _queue(tmp_path).items()[0]
+        result = _invoke(["queue", "rm", item.item_id, "--yes"], tmp_path)
+        assert result.exit_code == 0
+        assert _queue(tmp_path).items() == []
+
+    def test_rm_declined_leaves_the_item(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        item = _queue(tmp_path).items()[0]
+        result = CliRunner().invoke(
+            cli,
+            ["queue", "rm", item.item_id, "--root", str(tmp_path), "--no-color"],
+            input="n\n",
+        )
+        assert result.exit_code == 0
+        assert len(_queue(tmp_path).items()) == 1
+
+    def test_rm_refuses_a_running_item(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        queue = _queue(tmp_path)
+        queue.start(queue.lease(queue.items()[0]))
+        item = queue.items()[0]
+        result = _invoke(["queue", "rm", item.item_id, "--yes"], tmp_path)
+        assert result.exit_code == 1
+        assert "is running" in result.output
+        assert len(_queue(tmp_path).items()) == 1
+
+
+class TestPauseResume:
+    def test_pause_then_resume(self, tmp_path: Path, spec_file: Path) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        assert _invoke(["queue", "pause"], tmp_path).exit_code == 0
+        assert _queue(tmp_path).is_paused()
+        assert _queue(tmp_path).next_ready() is None
+
+        result = _invoke(["queue", "resume"], tmp_path)
+        assert result.exit_code == 0
+        assert "1 item" in result.output
+        assert not _queue(tmp_path).is_paused()
+
+    def test_pause_records_the_reason(self, tmp_path: Path) -> None:
+        _invoke(["queue", "pause", "--reason", "daily budget"], tmp_path)
+        assert _queue(tmp_path).pause_state().reason == "daily budget"

--- a/tests/test_queue_cli.py
+++ b/tests/test_queue_cli.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner, Result
@@ -108,6 +109,36 @@ class TestAdd:
         result = _invoke(["queue", "add", str(blank)], tmp_path)
         assert result.exit_code == 1
         assert "empty spec" in result.output
+
+    def test_zero_max_attempts_is_rejected_by_the_option(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        """#185 F4: this used to exit 0 and admit an unrunnable item.
+
+        Asserts the OPTION rejects it (exit 2, a click usage error) rather
+        than merely that something did. `Queue.add` refuses the same value
+        as defence in depth, so a weaker assertion would pass with the
+        option constraint removed and prove only the library guard.
+        """
+        result = _invoke(
+            ["queue", "add", str(spec_file), "--max-attempts", "0"], tmp_path,
+        )
+        assert result.exit_code == 2, "click usage error, not a runtime error"
+        assert "is not in the range" in result.output
+        assert _queue(tmp_path).items() == []
+
+    def test_add_sweeps_an_abandoned_staging_dir(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        """#185 F3: enqueue under the lock is the staging recovery point."""
+        queue = _queue(tmp_path)
+        queue.ensure_dirs()
+        (queue.staging_path / "q-ghost").mkdir(parents=True)
+
+        result = _invoke(["queue", "add", str(spec_file)], tmp_path)
+        assert result.exit_code == 0
+        assert list(_queue(tmp_path).staging_path.iterdir()) == []
+        assert len(_queue(tmp_path).items()) == 1
 
 
 class TestLs:
@@ -300,6 +331,21 @@ class TestRm:
             input="n\n",
         )
         assert result.exit_code == 0
+        assert len(_queue(tmp_path).items()) == 1
+
+    def test_rm_reports_a_failed_deletion_as_failure(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        """#185 F6: the operator must not be told an item is gone."""
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        item = _queue(tmp_path).items()[0]
+        with patch(
+            "kstrl.workqueue.shutil.rmtree",
+            side_effect=PermissionError("read-only"),
+        ):
+            result = _invoke(["queue", "rm", item.item_id, "--yes"], tmp_path)
+        assert result.exit_code == 1
+        assert "Could not remove" in result.output
         assert len(_queue(tmp_path).items()) == 1
 
     def test_rm_refuses_a_running_item(

--- a/tests/test_workqueue.py
+++ b/tests/test_workqueue.py
@@ -1,0 +1,684 @@
+"""R8.6 PR 1: work-queue substrate regression tests.
+
+The tests that matter most here are not the CRUD ones. They are the
+money-safety invariants, because this substrate is what an unattended
+`ks serve` will drive:
+
+- an attempt is charged BEFORE the rename into ``running/``, so an
+  interrupted transition over-counts rather than under-counts (an
+  uncounted attempt is an unbounded retry loop, at a measured
+  $1.70-2.60 per first attempt and $3.99-7.42 per retry);
+- the item DIRECTORY is authoritative, so a crash between the sidecar
+  write and the rename cannot make state ambiguous;
+- corrupt metadata falls back to the GATED value, never to auto-merge;
+- an unreadable pause marker reads as PAUSED, never as running.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kstrl.workqueue import (
+    ItemSource,
+    ItemState,
+    MergeDisposition,
+    PauseState,
+    Queue,
+    QueueConfig,
+    QueueError,
+    QueueItem,
+    QueueLockedError,
+    mint_item_id,
+    queue_lock,
+    summarize,
+)
+
+
+def _queue(root: Path, **config: object) -> Queue:
+    return Queue(root, QueueConfig(**config))  # type: ignore[arg-type]
+
+
+def _add(queue: Queue, text: str = "# Spec\n\nBuild a thing.\n", **kwargs: object) -> QueueItem:
+    return queue.add(text, **kwargs)  # type: ignore[arg-type]
+
+
+class TestAdd:
+    def test_add_text_lands_in_queued_with_spec_and_meta(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue, title="build a thing")
+
+        item_dir = tmp_path / ".kstrl" / "queue" / "queued" / item.item_id
+        assert item_dir.is_dir()
+        assert (item_dir / "spec.md").read_text() == "# Spec\n\nBuild a thing.\n"
+        meta = json.loads((item_dir / "meta.json").read_text())
+        assert meta["item_id"] == item.item_id
+        assert meta["state"] == "queued"
+        assert meta["title"] == "build a thing"
+
+    def test_add_from_path_copies_the_spec(self, tmp_path: Path) -> None:
+        """A spec edited after enqueue must not change what runs."""
+        source = tmp_path / "feature-x.md"
+        source.write_text("original\n")
+        queue = _queue(tmp_path)
+        item = _add(queue, source)  # type: ignore[arg-type]
+
+        source.write_text("TAMPERED\n")
+        assert queue.read_spec(queue.items()[0]) == "original\n"
+        assert item.spec_filename == "feature-x.md"
+        assert item.title == "feature-x"
+
+    def test_add_refuses_an_empty_spec(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        with pytest.raises(QueueError, match="empty spec"):
+            _add(queue, "   \n\n")
+
+    def test_add_defaults_to_stop_at_pr(self, tmp_path: Path) -> None:
+        """Continuous intake must not silently delete the merge gate."""
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        assert item.merge_disposition is MergeDisposition.STOP_AT_PR
+
+    def test_add_inherits_max_attempts_from_config(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path, max_attempts=7)
+        assert _add(queue).max_attempts == 7
+
+    def test_add_leaves_no_staging_dir_when_the_write_fails(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        with patch(
+            "kstrl.workqueue._atomic_write", side_effect=OSError("disk full"),
+        ):
+            with pytest.raises(OSError):
+                _add(queue)
+        queued = tmp_path / ".kstrl" / "queue" / "queued"
+        assert list(queued.iterdir()) == []
+
+    def test_item_ids_sort_chronologically(self) -> None:
+        ids = [mint_item_id() for _ in range(5)]
+        assert ids == sorted(ids)
+
+
+class TestOrdering:
+    def test_fifo_within_a_priority_band(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        first = _add(queue, title="first")
+        second = _add(queue, title="second")
+        assert [i.item_id for i in queue.items()] == [first.item_id, second.item_id]
+
+    def test_higher_priority_runs_first(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue, title="normal")
+        urgent = _add(queue, title="urgent", priority=5)
+        assert queue.items()[0].item_id == urgent.item_id
+        assert queue.next_ready() is not None
+        ready = queue.next_ready()
+        assert ready is not None and ready.item_id == urgent.item_id
+
+
+class TestLookup:
+    def test_get_by_prefix(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        found = queue.get(item.item_id[:10])
+        assert found is not None and found.item_id == item.item_id
+
+    def test_ambiguous_prefix_raises_instead_of_guessing(
+        self, tmp_path: Path,
+    ) -> None:
+        """Operating on the wrong unit of work is worse than a retype."""
+        queue = _queue(tmp_path)
+        _add(queue)
+        _add(queue)
+        with pytest.raises(QueueError, match="matches multiple items"):
+            queue.get("q-")
+
+    def test_get_missing_returns_none(self, tmp_path: Path) -> None:
+        assert _queue(tmp_path).get("nope") is None
+
+    def test_find_by_source_ref(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue, source=ItemSource.GITHUB, source_ref="0xfauzi/kstrl#153")
+        assert queue.find_by_source_ref("0xfauzi/kstrl#153") is not None
+        assert queue.find_by_source_ref("0xfauzi/kstrl#999") is None
+        assert queue.find_by_source_ref("") is None
+
+
+class TestTransitions:
+    def test_full_happy_path(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        item = queue.lease(item)
+        assert item.state is ItemState.LEASED
+        item = queue.start(item, run_id="factory-1")
+        assert item.state is ItemState.RUNNING
+        item = queue.finish_ok(item)
+        assert item.state is ItemState.DONE
+        assert (tmp_path / ".kstrl" / "queue" / "done" / item.item_id).is_dir()
+        assert not (tmp_path / ".kstrl" / "queue" / "queued" / item.item_id).exists()
+
+    def test_illegal_transition_raises(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        with pytest.raises(QueueError, match="illegal queue transition"):
+            queue.transition(item, ItemState.DONE)
+
+    def test_done_is_terminal(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = queue.finish_ok(queue.start(queue.lease(_add(queue))))
+        with pytest.raises(QueueError, match="illegal queue transition"):
+            queue.requeue(item)
+
+    def test_transition_rejects_unknown_fields(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        with pytest.raises(QueueError, match="unknown QueueItem field"):
+            queue.transition(item, ItemState.LEASED, nonsense=1)
+
+    def test_transition_refuses_when_the_source_dir_is_gone(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        for child in queue.item_dir(item).iterdir():
+            child.unlink()
+        queue.item_dir(item).rmdir()
+        with pytest.raises(QueueError, match="is not in queued"):
+            queue.lease(item)
+
+    def test_spec_travels_with_the_item(self, tmp_path: Path) -> None:
+        """One rename moves spec and sidecar together."""
+        queue = _queue(tmp_path)
+        item = queue.start(queue.lease(_add(queue, "# payload\n")))
+        assert queue.read_spec(item) == "# payload\n"
+
+
+class TestAttemptCharging:
+    """The single most expensive thing to get wrong (R8.6 safety)."""
+
+    def test_start_charges_the_attempt(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        assert item.attempts == 0
+        item = queue.lease(item)
+        assert item.attempts == 0, "leasing spends nothing"
+        item = queue.start(item)
+        assert item.attempts == 1
+
+    def test_attempt_is_durable_before_the_rename_commits(
+        self, tmp_path: Path,
+    ) -> None:
+        """A crash in the commit window must not lose the charge.
+
+        Simulates the process dying between the sidecar write and the
+        rename. The item stays in ``leased/`` (the directory is
+        authoritative) but the attempt is already recorded on disk, so a
+        reaper cannot hand out an uncounted retry.
+        """
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        item = queue.lease(item)
+
+        real_replace = os.replace
+
+        def die_on_directory_move(src: object, dst: object) -> None:
+            # Only the item-directory rename fails. The sidecar's own
+            # atomic commit must still succeed, or the test would prove
+            # nothing about the window BETWEEN the two.
+            if Path(str(src)).is_dir():
+                raise OSError("crash mid-transition")
+            real_replace(src, dst)  # type: ignore[arg-type]
+
+        with patch("kstrl.workqueue.os.replace", side_effect=die_on_directory_move):
+            with pytest.raises(OSError):
+                queue.start(item)
+
+        on_disk = json.loads(
+            (
+                tmp_path / ".kstrl" / "queue" / "leased" / item.item_id / "meta.json"
+            ).read_text()
+        )
+        assert on_disk["attempts"] == 1, "the attempt must survive the crash"
+
+        reread = queue.items()[0]
+        assert reread.state is ItemState.LEASED, "the directory is the truth"
+        assert reread.attempts == 1
+
+    def test_a_failed_move_leaves_the_item_object_honest(
+        self, tmp_path: Path,
+    ) -> None:
+        """An uncommitted move must not leave the object claiming success."""
+        queue = _queue(tmp_path)
+        item = queue.lease(_add(queue))
+        real_replace = os.replace
+
+        def die_on_directory_move(src: object, dst: object) -> None:
+            if Path(str(src)).is_dir():
+                raise OSError("crash mid-transition")
+            real_replace(src, dst)  # type: ignore[arg-type]
+
+        with patch("kstrl.workqueue.os.replace", side_effect=die_on_directory_move):
+            with pytest.raises(OSError):
+                queue.start(item)
+
+        assert item.state is ItemState.LEASED
+        assert item.attempts == 1, "the charge stays; over-counting is safe"
+
+    def test_retries_are_bounded_by_max_attempts(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path, max_attempts=2)
+        item = _add(queue)
+        for _ in range(2):
+            item = queue.start(queue.lease(item))
+            item = queue.finish_failed(item, error="infra")
+            if item.attempts_remaining:
+                item = queue.requeue(item)
+        assert item.attempts == 2
+        assert item.attempts_remaining == 0
+
+    def test_requeue_does_not_reset_attempts_by_default(
+        self, tmp_path: Path,
+    ) -> None:
+        """A retry policy that can zero its own bound is not a bound."""
+        queue = _queue(tmp_path)
+        item = queue.finish_failed(queue.start(queue.lease(_add(queue))))
+        item = queue.requeue(item)
+        assert item.attempts == 1
+
+    def test_reset_attempts_is_explicit_and_clears_poison(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        item = queue.start(queue.lease(_add(queue)))
+        item = queue.poison(item, reason="spec is ambiguous")
+        item = queue.requeue(item, reset_attempts=True)
+        assert item.attempts == 0
+        assert item.poison_reason == ""
+
+
+class TestDirectoryIsAuthoritative:
+    def test_state_comes_from_the_directory_not_the_sidecar(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        meta_path = tmp_path / ".kstrl" / "queue" / "queued" / item.item_id / "meta.json"
+        data = json.loads(meta_path.read_text())
+        data["state"] = "done"
+        meta_path.write_text(json.dumps(data))
+
+        assert queue.items()[0].state is ItemState.QUEUED
+
+    def test_stale_mirror_self_heals_on_the_next_write(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        meta_path = queue.item_dir(item) / "meta.json"
+        data = json.loads(meta_path.read_text())
+        data["state"] = "poison"
+        meta_path.write_text(json.dumps(data))
+
+        moved = queue.lease(queue.items()[0])
+        landed = json.loads((queue.item_dir(moved) / "meta.json").read_text())
+        assert landed["state"] == "leased"
+
+
+class TestCorruptionHandling:
+    def test_malformed_meta_is_skipped_with_a_warning(
+        self, tmp_path: Path,
+    ) -> None:
+        """A dropped item is lost work; say so rather than swallowing it."""
+        queue = _queue(tmp_path)
+        good = _add(queue, title="good")
+        broken_dir = tmp_path / ".kstrl" / "queue" / "queued" / "q-broken"
+        broken_dir.mkdir(parents=True)
+        (broken_dir / "meta.json").write_text("{not json")
+
+        with pytest.warns(RuntimeWarning, match="rejected item"):
+            items = queue.items()
+        assert [i.item_id for i in items] == [good.item_id]
+
+    def test_missing_meta_is_skipped(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        orphan = tmp_path / ".kstrl" / "queue" / "queued" / "q-orphan"
+        orphan.mkdir(parents=True)
+        with pytest.warns(RuntimeWarning, match="unreadable meta.json"):
+            assert queue.items() == []
+
+    def test_meta_without_identity_is_rejected(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        bad = tmp_path / ".kstrl" / "queue" / "queued" / "q-nameless"
+        bad.mkdir(parents=True)
+        (bad / "meta.json").write_text(json.dumps({"title": "x"}))
+        with pytest.warns(RuntimeWarning, match="missing item_id"):
+            assert queue.items() == []
+
+    def test_corrupt_merge_disposition_falls_back_to_gated(self) -> None:
+        """A corrupt field must never GRANT a permission."""
+        item = QueueItem.from_dict({
+            "item_id": "q-1", "spec_filename": "spec.md",
+            "merge_disposition": "yolo-merge-everything",
+        })
+        assert item is not None
+        assert item.merge_disposition is MergeDisposition.STOP_AT_PR
+
+    def test_unknown_state_decodes_to_queued(self) -> None:
+        item = QueueItem.from_dict({
+            "item_id": "q-1", "spec_filename": "spec.md", "state": "wat",
+        })
+        assert item is not None and item.state is ItemState.QUEUED
+
+    def test_non_integer_priority_falls_back(self) -> None:
+        item = QueueItem.from_dict({
+            "item_id": "q-1", "spec_filename": "spec.md", "priority": "high",
+        })
+        assert item is not None and item.priority == 0
+
+    def test_legacy_payload_without_new_fields_decodes(self) -> None:
+        """Sidecars written before a field existed must still load."""
+        item = QueueItem.from_dict({
+            "item_id": "q-1", "spec_filename": "spec.md", "title": "old",
+        })
+        assert item is not None
+        assert item.target_repo == ""
+        assert item.max_attempts == 3
+        assert item.source is ItemSource.LOCAL
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        original = _add(
+            queue, title="round trip", priority=3,
+            source=ItemSource.GITHUB, source_ref="o/r#1",
+            target_repo="o/r", project_name="proj",
+        )
+        decoded = QueueItem.from_dict(original.to_dict())
+        assert decoded is not None
+        assert decoded.to_dict() == original.to_dict()
+
+
+class TestLeases:
+    def test_lease_records_pid_host_and_expiry(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path, lease_ttl_seconds=60)
+        item = queue.lease(_add(queue))
+        assert item.lease_pid == os.getpid()
+        assert item.lease_host
+        assert not item.lease_expired()
+
+    def test_expired_lease_is_detected(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path, lease_ttl_seconds=60)
+        item = queue.lease(_add(queue))
+        future = datetime.now(UTC) + timedelta(seconds=120)
+        assert item.lease_expired(future)
+
+    def test_missing_expiry_counts_as_expired(self) -> None:
+        """A lease nobody can read must not wedge the queue forever."""
+        item = QueueItem(item_id="q-1", title="t", spec_filename="s.md")
+        assert item.lease_expired()
+
+    def test_unparseable_expiry_counts_as_expired(self) -> None:
+        item = QueueItem(
+            item_id="q-1", title="t", spec_filename="s.md",
+            lease_expires_at="not-a-date",
+        )
+        assert item.lease_expired()
+
+    def test_requeue_clears_the_lease(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = queue.requeue(queue.lease(_add(queue)))
+        assert item.lease_pid == 0
+        assert item.lease_host == ""
+        assert item.lease_expires_at == ""
+
+
+class TestPoison:
+    def test_poison_requires_a_reason(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = queue.start(queue.lease(_add(queue)))
+        with pytest.raises(QueueError, match="poison requires a reason"):
+            queue.poison(item, reason="  ")
+
+    def test_poison_records_why(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = queue.start(queue.lease(_add(queue)))
+        item = queue.poison(item, reason="spec-level failure: tests failed")
+        assert item.state is ItemState.POISON
+        assert item.poison_reason == "spec-level failure: tests failed"
+        assert (tmp_path / ".kstrl" / "queue" / "poison" / item.item_id).is_dir()
+
+    def test_a_queued_item_can_be_poisoned_without_running(
+        self, tmp_path: Path,
+    ) -> None:
+        """Admission-time rejection never spends anything."""
+        queue = _queue(tmp_path)
+        item = queue.poison(_add(queue), reason="rejected at admission")
+        assert item.attempts == 0
+
+
+class TestRemoval:
+    def test_remove_deletes_the_item(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        queue.remove(item)
+        assert queue.items() == []
+        assert not (tmp_path / ".kstrl" / "queue" / "queued" / item.item_id).exists()
+
+    def test_remove_refuses_while_running(self, tmp_path: Path) -> None:
+        """Deleting a live item loses the trail for money already spent."""
+        queue = _queue(tmp_path)
+        item = queue.start(queue.lease(_add(queue)))
+        with pytest.raises(QueueError, match="is running"):
+            queue.remove(item)
+
+
+class TestPause:
+    def test_default_is_running(self, tmp_path: Path) -> None:
+        assert not _queue(tmp_path).is_paused()
+
+    def test_pause_and_resume(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        queue.pause(reason="daily budget")
+        assert queue.is_paused()
+        assert queue.pause_state().reason == "daily budget"
+        queue.resume()
+        assert not queue.is_paused()
+
+    def test_next_ready_is_none_while_paused(self, tmp_path: Path) -> None:
+        """The pause is an admission gate checked at the claim point."""
+        queue = _queue(tmp_path)
+        _add(queue)
+        queue.pause(reason="stop")
+        assert queue.next_ready() is None
+        queue.resume()
+        assert queue.next_ready() is not None
+
+    def test_resume_after_expires_the_pause(self, tmp_path: Path) -> None:
+        """The daily-budget stop clears itself at the next local day."""
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        state = PauseState(paused=True, reason="budget", resume_after=past)
+        assert not state.active()
+
+    def test_resume_after_in_the_future_still_pauses(self) -> None:
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        state = PauseState(paused=True, reason="budget", resume_after=future)
+        assert state.active()
+
+    def test_unreadable_pause_marker_reads_as_paused(
+        self, tmp_path: Path,
+    ) -> None:
+        """Fail closed: never resume unattended spend on a corrupt file."""
+        queue = _queue(tmp_path)
+        queue.ensure_dirs()
+        queue.pause_path.write_text("{not json")
+        assert queue.is_paused()
+        assert "unreadable" in queue.pause_state().reason
+
+    def test_non_object_pause_marker_reads_as_paused(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        queue.ensure_dirs()
+        queue.pause_path.write_text("[]")
+        assert queue.is_paused()
+
+
+class TestJournal:
+    def test_every_transition_is_recorded(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = queue.finish_ok(queue.start(queue.lease(_add(queue))))
+        entries = queue.journal_entries(item.item_id)
+        assert [(e["from"], e["to"]) for e in entries] == [
+            ("", "queued"), ("queued", "leased"),
+            ("leased", "running"), ("running", "done"),
+        ]
+
+    def test_journal_records_the_attempt_count(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = queue.start(queue.lease(_add(queue)))
+        started = [
+            e for e in queue.journal_entries(item.item_id) if e["to"] == "running"
+        ]
+        assert started[0]["attempts"] == 1
+
+    def test_removal_is_journaled(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        queue.remove(item, actor="tester")
+        entries = queue.journal_entries(item.item_id)
+        assert entries[-1]["to"] == "removed"
+        assert entries[-1]["actor"] == "tester"
+
+    def test_pause_is_journaled(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        queue.pause(reason="budget", actor="serve")
+        assert any(
+            e["to"] == "paused" and e["reason"] == "budget"
+            for e in queue.journal_entries()
+        )
+
+    def test_a_failed_journal_write_does_not_undo_the_transition(
+        self, tmp_path: Path,
+    ) -> None:
+        """The directory is the truth; the journal is the narration."""
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        with patch("kstrl.workqueue.open", side_effect=OSError("read-only")):
+            with pytest.warns(RuntimeWarning, match="journal append failed"):
+                moved = queue.lease(item)
+        assert moved.state is ItemState.LEASED
+        assert queue.items()[0].state is ItemState.LEASED
+
+    def test_corrupt_journal_lines_are_skipped(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        with open(queue.journal_path, "a", encoding="utf-8") as handle:
+            handle.write("{not json\n\n")
+        assert len(queue.journal_entries(item.item_id)) == 1
+
+
+class TestLock:
+    def test_a_second_holder_is_refused(self, tmp_path: Path) -> None:
+        pytest.importorskip("fcntl")
+        with queue_lock(tmp_path):
+            with pytest.raises(QueueLockedError):
+                with queue_lock(tmp_path):
+                    pass
+
+    def test_the_lock_is_released_on_exit(self, tmp_path: Path) -> None:
+        pytest.importorskip("fcntl")
+        with queue_lock(tmp_path):
+            pass
+        with queue_lock(tmp_path):
+            pass
+
+    def test_the_lock_is_released_when_the_body_raises(
+        self, tmp_path: Path,
+    ) -> None:
+        pytest.importorskip("fcntl")
+        with pytest.raises(ValueError):
+            with queue_lock(tmp_path):
+                raise ValueError("boom")
+        with queue_lock(tmp_path):
+            pass
+
+    def test_the_queue_lock_is_separate_from_the_factory_lock(
+        self, tmp_path: Path,
+    ) -> None:
+        """Listing the queue must not block on a running factory."""
+        from kstrl.workqueue import LOCK_FILENAME, queue_root
+
+        with queue_lock(tmp_path):
+            pass
+        assert (queue_root(tmp_path) / LOCK_FILENAME).exists()
+        assert not (tmp_path / ".kstrl" / "factory.lock").exists()
+
+
+class TestConfig:
+    def test_defaults(self) -> None:
+        config = QueueConfig()
+        assert config.max_attempts == 3
+        assert config.lease_ttl_seconds == 3600.0
+
+    def test_rejects_a_zero_attempt_budget(self) -> None:
+        with pytest.raises(QueueError, match="max_attempts must be >= 1"):
+            QueueConfig(max_attempts=0)
+
+    def test_rejects_a_nonpositive_ttl(self) -> None:
+        with pytest.raises(QueueError, match="lease_ttl_seconds must be > 0"):
+            QueueConfig(lease_ttl_seconds=0)
+
+    def test_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KSTRL_QUEUE_MAX_ATTEMPTS", "5")
+        monkeypatch.setenv("KSTRL_QUEUE_LEASE_TTL", "120")
+        config = QueueConfig.from_env()
+        assert config.max_attempts == 5
+        assert config.lease_ttl_seconds == 120.0
+
+    def test_load_reads_the_toml_section(self, tmp_path: Path) -> None:
+        (tmp_path / "kstrl.toml").write_text(
+            "[queue]\nmax_attempts = 9\nlease_ttl_seconds = 30\n"
+        )
+        config = QueueConfig.load(tmp_path)
+        assert config.max_attempts == 9
+        assert config.lease_ttl_seconds == 30.0
+
+    def test_env_beats_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text("[queue]\nmax_attempts = 9\n")
+        monkeypatch.setenv("KSTRL_QUEUE_MAX_ATTEMPTS", "2")
+        assert QueueConfig.load(tmp_path).max_attempts == 2
+
+    def test_load_without_a_config_file_uses_defaults(
+        self, tmp_path: Path,
+    ) -> None:
+        assert QueueConfig.load(tmp_path).max_attempts == 3
+
+
+class TestReporting:
+    def test_counts(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        queue.finish_ok(queue.start(queue.lease(_add(queue))))
+        counts = queue.counts()
+        assert counts[ItemState.QUEUED] == 1
+        assert counts[ItemState.DONE] == 1
+        assert counts[ItemState.POISON] == 0
+
+    def test_summarize_omits_empty_states(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        assert summarize(queue.counts()) == "1 queued"
+
+    def test_summarize_of_an_empty_queue(self, tmp_path: Path) -> None:
+        assert summarize(_queue(tmp_path).counts()) == "empty"
+
+    def test_next_ready_ignores_non_queued_items(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        queue.start(queue.lease(_add(queue)))
+        assert queue.next_ready() is None

--- a/tests/test_workqueue.py
+++ b/tests/test_workqueue.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+import warnings
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
@@ -30,10 +31,12 @@ from kstrl.workqueue import (
     MergeDisposition,
     PauseState,
     Queue,
+    QueueBudgetExhausted,
     QueueConfig,
     QueueError,
     QueueItem,
     QueueLockedError,
+    is_safe_component,
     mint_item_id,
     queue_lock,
     summarize,
@@ -87,6 +90,24 @@ class TestAdd:
     def test_add_inherits_max_attempts_from_config(self, tmp_path: Path) -> None:
         queue = _queue(tmp_path, max_attempts=7)
         assert _add(queue).max_attempts == 7
+
+    def test_add_refuses_a_zero_attempt_budget(self, tmp_path: Path) -> None:
+        """#185 F4: the per-item override bypassed QueueConfig's check.
+
+        An admitted item with max_attempts=0 has no execution budget at
+        all, so it can never legitimately run.
+        """
+        queue = _queue(tmp_path)
+        with pytest.raises(QueueError, match="max_attempts must be >= 1"):
+            queue.add("# spec\n", max_attempts=0)
+        assert queue.items() == []
+
+    def test_add_refuses_a_negative_attempt_budget(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        with pytest.raises(QueueError, match="max_attempts must be >= 1"):
+            queue.add("# spec\n", max_attempts=-1)
 
     def test_add_leaves_no_staging_dir_when_the_write_fails(
         self, tmp_path: Path,
@@ -270,6 +291,30 @@ class TestAttemptCharging:
         assert item.state is ItemState.LEASED
         assert item.attempts == 1, "the charge stays; over-counting is safe"
 
+    def test_the_substrate_refuses_to_start_past_the_bound(
+        self, tmp_path: Path,
+    ) -> None:
+        """#185 F5: the bound is enforced at the SPENDING boundary.
+
+        The previous version of this test skipped the second `start()`
+        when no attempts remained, so it asserted the caller's good
+        manners rather than the substrate's guarantee. It passed while
+        start -> fail -> requeue -> lease -> start happily produced a
+        running item with attempts=2 against max_attempts=1.
+        """
+        queue = _queue(tmp_path, max_attempts=1)
+        item = queue.finish_failed(queue.start(queue.lease(_add(queue))))
+        item = queue.requeue(item)
+        item = queue.lease(item)
+
+        with pytest.raises(QueueBudgetExhausted, match="used all 1 attempts"):
+            queue.start(item)
+
+        assert queue.items()[0].state is ItemState.LEASED, (
+            "a refused start must not leave the item running"
+        )
+        assert queue.items()[0].attempts == 1
+
     def test_retries_are_bounded_by_max_attempts(self, tmp_path: Path) -> None:
         queue = _queue(tmp_path, max_attempts=2)
         item = _add(queue)
@@ -280,6 +325,213 @@ class TestAttemptCharging:
                 item = queue.requeue(item)
         assert item.attempts == 2
         assert item.attempts_remaining == 0
+
+    def test_a_reset_item_can_start_again(self, tmp_path: Path) -> None:
+        """The bound is a bound, not a one-way door."""
+        queue = _queue(tmp_path, max_attempts=1)
+        item = queue.finish_failed(queue.start(queue.lease(_add(queue))))
+        item = queue.requeue(item, reset_attempts=True)
+        started = queue.start(queue.lease(item))
+        assert started.state is ItemState.RUNNING
+        assert started.attempts == 1
+
+
+class TestPathSafety:
+    """#185 F1/F2: sidecars are untrusted input.
+
+    A queue item's metadata is writable by an operator today and by a
+    remote adapter from PR 3, and two of its fields become path
+    components. Both were demonstrated escaping the queue.
+    """
+
+    def test_a_crafted_item_id_cannot_redirect_removal(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue, title="safe")
+        outside = tmp_path / "outside-dir"
+        outside.mkdir()
+        (outside / "precious.txt").write_text("do not delete")
+
+        meta = queue.item_dir(item) / "meta.json"
+        data = json.loads(meta.read_text())
+        data["item_id"] = "../../../outside-dir"
+        meta.write_text(json.dumps(data))
+
+        with pytest.warns(RuntimeWarning, match="disagrees with directory"):
+            loaded = queue.items()
+        assert loaded[0].item_id == item.item_id, "the directory names the item"
+
+        queue.remove(loaded[0])
+        assert outside.is_dir(), "an unrelated directory must survive"
+        assert (outside / "precious.txt").exists()
+
+    def test_item_dir_refuses_an_unsafe_id(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        rogue = QueueItem(
+            item_id="../escape", title="t", spec_filename="spec.md",
+        )
+        with pytest.raises(QueueError, match="unsafe queue item id"):
+            queue.item_dir(rogue)
+
+    def test_a_symlinked_item_is_rejected(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        (elsewhere / "meta.json").write_text(
+            json.dumps({"item_id": "q-link", "spec_filename": "spec.md"})
+        )
+        (queue.state_path(ItemState.QUEUED) / "q-link").symlink_to(elsewhere)
+
+        with pytest.warns(RuntimeWarning, match="may not be symlinks"):
+            loaded = queue.items()
+        assert [i.item_id for i in loaded] == [item.item_id]
+
+    def test_add_refuses_a_traversing_spec_filename(
+        self, tmp_path: Path,
+    ) -> None:
+        """The text form of add() is what PR 3's adapters will call."""
+        queue = _queue(tmp_path)
+        with pytest.raises(QueueError, match="plain basename"):
+            queue.add("remote body\n", spec_filename="../../../../escaped.md")
+        assert not (tmp_path.parent / "escaped.md").exists()
+        assert not (tmp_path / "escaped.md").exists()
+
+    @pytest.mark.parametrize(
+        "name", ["../x.md", "a/b.md", "..", ".", "", ".hidden", "a\\b.md"],
+    )
+    def test_unsafe_names_are_rejected(self, name: str) -> None:
+        assert not is_safe_component(name)
+
+    @pytest.mark.parametrize("name", ["spec.md", "q-1", "a b.md", "SPEC.MD"])
+    def test_safe_names_are_accepted(self, name: str) -> None:
+        assert is_safe_component(name)
+
+    def test_a_crafted_spec_filename_is_rejected_on_decode(self) -> None:
+        assert QueueItem.from_dict({
+            "item_id": "q-1", "spec_filename": "../../../etc/passwd",
+        }) is None
+
+    def test_spec_path_refuses_to_escape_the_item(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        item.spec_filename = "../../../../etc/passwd"
+        with pytest.raises(QueueError, match="unsafe spec filename"):
+            queue.spec_path(item)
+
+
+class TestStagingIsNeverScanned:
+    """#185 F3: a death mid-publish must leave nothing a scan can see."""
+
+    def test_staging_lives_outside_the_state_directories(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        queue.ensure_dirs()
+        assert queue.staging_path.name == ".staging"
+        assert queue.staging_path.parent == queue.path
+        for state in ItemState:
+            assert queue.staging_path.parent != queue.state_path(state)
+
+    def test_a_leftover_staging_item_is_not_a_phantom_item(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        real = _add(queue, title="real")
+        ghost = queue.staging_path / "q-ghost"
+        ghost.mkdir(parents=True)
+        (ghost / "spec.md").write_text("# ghost\n")
+        (ghost / "meta.json").write_text(json.dumps({
+            "item_id": "q-ghost", "spec_filename": "spec.md", "title": "ghost",
+        }))
+
+        assert [i.item_id for i in queue.items()] == [real.item_id]
+
+    def test_a_pre_fix_staging_dir_inside_queued_is_ignored_SILENTLY(
+        self, tmp_path: Path,
+    ) -> None:
+        """A queue written by the previous build must not wedge scans.
+
+        Silence is the assertion that matters. The name-safety check
+        would reject a `.staging-*` entry anyway, but it does so with a
+        warning - and a permanent rejected-item warning on every scan is
+        itself the defect #185 F3 reported. The dot filter is what makes
+        the leftover inert rather than noisy.
+        """
+        queue = _queue(tmp_path)
+        real = _add(queue, title="real")
+        legacy = queue.state_path(ItemState.QUEUED) / ".staging-q-ghost"
+        legacy.mkdir(parents=True)
+        (legacy / "meta.json").write_text(json.dumps({
+            "item_id": "q-ghost", "spec_filename": "spec.md", "title": "ghost",
+        }))
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            found = queue.items()
+        assert [i.item_id for i in found] == [real.item_id]
+        assert caught == [], (
+            f"a scan must not warn about a staging leftover: "
+            f"{[str(w.message) for w in caught]}"
+        )
+
+    def test_a_hard_kill_mid_publish_leaves_no_phantom_item(
+        self, tmp_path: Path,
+    ) -> None:
+        """The reason staging lives outside the state directories.
+
+        Models SIGKILL rather than an exception: the publishing rename
+        fails AND `add`'s cleanup never runs, so a half-written item is
+        left on disk exactly as a killed process would leave it. With
+        staging inside `queued/`, that leftover carries a valid
+        `meta.json` and a non-dotted name, so a scan returns it as a
+        real queued item whose directory does not exist.
+        """
+        queue = _queue(tmp_path)
+        _add(queue, title="real")
+        real_replace = os.replace
+
+        def die_on_publish(src: object, dst: object) -> None:
+            if Path(str(src)).is_dir():
+                raise OSError("SIGKILL mid-publish")
+            real_replace(src, dst)  # type: ignore[arg-type]
+
+        with patch("kstrl.workqueue.os.replace", side_effect=die_on_publish):
+            with patch("kstrl.workqueue.shutil.rmtree"):  # no cleanup on kill
+                with pytest.raises(OSError):
+                    _add(queue, title="ghost")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            found = queue.items()
+        assert [i.title for i in found] == ["real"], (
+            "a killed publish must leave nothing a scan can see"
+        )
+        assert caught == []
+
+    def test_sweep_removes_abandoned_staging(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        queue.ensure_dirs()
+        (queue.staging_path / "q-ghost").mkdir(parents=True)
+        (queue.staging_path / "q-ghost2").mkdir(parents=True)
+
+        assert queue.sweep_staging() == 2
+        assert list(queue.staging_path.iterdir()) == []
+        assert any(e["to"] == "swept" for e in queue.journal_entries())
+
+    def test_sweep_on_an_empty_queue_is_a_noop(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        assert queue.sweep_staging() == 0
+
+    def test_a_successful_add_leaves_staging_empty(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        assert list(queue.staging_path.iterdir()) == []
 
     def test_requeue_does_not_reset_attempts_by_default(
         self, tmp_path: Path,
@@ -356,7 +608,7 @@ class TestCorruptionHandling:
         bad = tmp_path / ".kstrl" / "queue" / "queued" / "q-nameless"
         bad.mkdir(parents=True)
         (bad / "meta.json").write_text(json.dumps({"title": "x"}))
-        with pytest.warns(RuntimeWarning, match="missing item_id"):
+        with pytest.warns(RuntimeWarning, match="missing/unsafe item_id"):
             assert queue.items() == []
 
     def test_corrupt_merge_disposition_falls_back_to_gated(self) -> None:
@@ -475,6 +727,37 @@ class TestRemoval:
         with pytest.raises(QueueError, match="is running"):
             queue.remove(item)
 
+    def test_a_failed_deletion_is_not_reported_as_success(
+        self, tmp_path: Path,
+    ) -> None:
+        """#185 F6: ignore_errors made both the result and the trail false."""
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        with patch(
+            "kstrl.workqueue.shutil.rmtree",
+            side_effect=PermissionError("read-only"),
+        ):
+            with pytest.raises(OSError):
+                queue.remove(item)
+
+        assert len(queue.items()) == 1, "the item is still there"
+        assert not any(
+            e["to"] == "removed" for e in queue.journal_entries(item.item_id)
+        ), "the audit trail must not claim a removal that did not happen"
+
+    def test_a_silently_failed_deletion_is_caught(
+        self, tmp_path: Path,
+    ) -> None:
+        """Even a no-op rmtree must not produce a `removed` record."""
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        with patch("kstrl.workqueue.shutil.rmtree", return_value=None):
+            with pytest.raises(QueueError, match="still exists"):
+                queue.remove(item)
+        assert not any(
+            e["to"] == "removed" for e in queue.journal_entries(item.item_id)
+        )
+
 
 class TestPause:
     def test_default_is_running(self, tmp_path: Path) -> None:
@@ -525,6 +808,42 @@ class TestPause:
         queue.ensure_dirs()
         queue.pause_path.write_text("[]")
         assert queue.is_paused()
+
+    def test_an_unreadable_marker_file_reads_as_paused(
+        self, tmp_path: Path,
+    ) -> None:
+        """#185 F7: a broad `except OSError` made PermissionError = RUNNING.
+
+        Only FileNotFoundError means "not paused". Any other read failure
+        is a marker we could not read, and resuming unattended spend on
+        that basis is the exact fail-open this module claims not to do.
+        """
+        queue = _queue(tmp_path)
+        queue.ensure_dirs()
+        queue.pause(reason="daily budget")
+
+        with patch.object(
+            Path, "read_text", side_effect=PermissionError("denied"),
+        ):
+            assert queue.is_paused()
+            assert "unreadable" in queue.pause_state().reason
+
+    def test_an_absent_marker_reads_as_running(self, tmp_path: Path) -> None:
+        """FileNotFoundError is the ONE read failure that means unpaused."""
+        queue = _queue(tmp_path)
+        queue.ensure_dirs()
+        assert not queue.pause_path.exists()
+        assert not queue.is_paused()
+
+    def test_next_ready_is_none_when_the_marker_is_unreadable(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        with patch.object(
+            Path, "read_text", side_effect=PermissionError("denied"),
+        ):
+            assert queue.next_ready() is None
 
 
 class TestJournal:


### PR DESCRIPTION
First of four slices for [#153](https://github.com/0xfauzi/kstrl/issues/153) (R8.6 continuous intake). This is the **substrate only** - it adds a place for work to wait and the verbs to manage it. **Nothing drains the queue yet.**

Slicing agreed before writing code:

| PR | Contents | Status |
|---|---|---|
| **1** | **queue substrate + `ks queue` CLI** | **this PR** |
| 2 | `ks serve`, lease reaper, retry classifier, `daily_budget_usd`, caffeinate | next |
| 3 | GitHub Issues adapter, processed-ids ledger, `ks queue sync` | |
| 4 | launchd plist + docs | |

## What landed

`kstrl/workqueue.py` (~600 lines, no new dependency - queue libraries were evaluated and rejected in the R8.6 verdict):

- maildir layout `.kstrl/queue/{queued,leased,running,done,failed,poison}/`
- item = **directory** holding a spec file + `meta.json`, transitioned with one `os.replace`
- flock mutex, pid/ttl lease fields, append-only `journal.jsonl`, `pause.json` marker
- `QueueConfig` with the house `from_env()` + `load(root_dir)` pair, `[queue]` section

`ks queue add|ls|show|retry|rm|pause|resume`.

## The two invariants worth reviewing closely

Both are money-safety properties rather than style, because an unattended `ks serve` will drive this substrate in PR 2. Both are mutation-checked.

**1. The attempt is charged before the rename into `running/`.** Every transition writes `meta.json` first and renames second - the rename is the commit point. So a crash in that window over-counts an attempt (the item gets one fewer retry, which is safe) instead of under-counting one (a retry nobody recorded, which is an unbounded loop). At a measured \$1.70-2.60 per first attempt and \$3.99-7.42 per retry, an uncounted attempt is not a bookkeeping slip.

**2. The item directory is authoritative; the sidecar's `state` field is a mirror.** Readers derive state from the parent directory name and overwrite the mirror, so the same crash window cannot leave an item whose location and metadata disagree. The mirror self-heals on the next write.

An item is a directory rather than two sibling files specifically so one rename moves the spec and its sidecar together - two files would need two renames with an interruptible gap between them.

## Fail-closed choices

Corrupt or unreadable state resolves toward the *gated* value in every direction:

- an unreadable `merge_disposition` decodes to `stop_at_pr`, never `auto_merge` - a corrupt field must not be able to **grant** a permission
- an unreadable pause marker reads as **PAUSED** - never resume unattended spend on the strength of a file you cannot parse
- a missing or unparseable lease expiry counts as **expired** - a lease nobody can read must not wedge the queue forever
- `ks queue retry` refuses an item that has spent its attempts unless `--reset-attempts` is passed, and the automatic paths can never reset the counter: a retry policy that can zero its own bound is not a bound

The spec is **copied** into the item at enqueue, so editing or deleting the original afterwards cannot change what eventually runs.

## Tested vs assumed (H4)

**Tested.** 103 new tests (73 substrate, 30 CLI). Every invariant test was mutation-checked: the invariant was broken, the test was **watched failing**, then restored. 14/14 mutations caught -

attempt-charge ordering; in-memory rollback on an uncommitted move; `merge_disposition` fallback; pause fail-closed; lease-expiry default; attempt reset on requeue; directory-over-sidecar authority; removal of a running item; ambiguous-prefix guard; transition legality table; poison reason requirement; journal-failure isolation; staging-dir cleanup; pause admission gate.

One of these caught a defect in my own first draft: the initial crash-window test patched `os.replace` globally, which also broke `_atomic_write`'s own commit and so proved nothing about the window between the two renames. Fixed to fail only the directory rename.

**Assumed, not tested.** POSIX-only behavior of `flock` and directory `os.replace` (consistent with the existing A4 worktree lock and run-level factory lock; the codebase is POSIX-first). No live factory run was performed - this PR executes nothing.

## Verification

```
uv run pytest tests/ -v     2585 -> 2688 passed, 28 skipped   (baseline measured on 7e3269f before starting)
uv run mypy kstrl/ --strict Success: no issues found in 109 source files
uv run ruff check kstrl/ tests/ scripts/   All checks passed!
```

No prompt bodies changed, so H2/H3 do not apply. `scripts/gen_docs.py` gained the `[queue]` section and README was regenerated by the generator, not by hand. `KSTRL_QUEUE_` was added to the conftest env-scrub prefixes so ambient env cannot alter the `from_env`/`load` tests.

## Notes for review

- Module is `workqueue.py`, not `queue.py`: `kstrl/agents/proc.py` imports the stdlib `queue`. Absolute imports make `kstrl/queue.py` technically safe, but it is a trap not worth leaving.
- The queue mutex (`queue.lock`) is deliberately separate from `.kstrl/factory.lock` and short-lived, so `ks queue ls` stays responsive while a run is in flight. PR 2's serve singleton will be a third, long-held lock.
- `meta.json` carries `target_repo` from day one. It is unused here - it exists so that moving to a global `~/.kstrl/queue` (roadmap open question 3) is a config change rather than a migration of on-disk items.
- Per H1 I have not run `/code-review` on this. You are the gating reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)