### PR TITLE
R8.6 PR 2/4: `ks serve`, the retry classifier, and four backstops

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ ks queue rm ITEM_ID             Delete an item and its spec.
 ks queue show ITEM_ID           Show one item in full, with its transition history.
 ks retry COMPONENT_ID           Retry a FAILED component from the factory manifest (R3.3).
 ks run [MAX_ITERATIONS]         Run the agentic loop as a single-component factory invocation.
+ks serve                        Drain the continuous-intake queue (R8.6).
 ks status                       Show per-component status from the manifest + progress log.
 ks understand [MAX_ITERATIONS]  Run codebase understanding loop (read-only mode).
 ```
@@ -374,6 +375,15 @@ enabled = true                 # record exceptions awaiting a human decision
 open_item_cap = 50             # open items after which queue intake pauses; 0 = unbounded
 snooze_hours = 24.0            # default snooze TTL in hours; snoozed items return
 notify_action_required = true  # notify on action-required items and demotions only
+
+# Continuous-intake daemon (R8.6)
+[serve]
+poll_interval_seconds = 60.0   # seconds between poll cycles when ks serve runs as a daemon
+daily_budget_usd = 0.0         # hard stop on reported spend per local day; 0 = no cap
+max_consecutive_poison = 3     # consecutive poisoned items that pause the whole queue
+caffeinate = true              # hold caffeinate -i for each run so the machine cannot sleep mid-factory
+factory_timeout_seconds = 0.0  # kill a factory run after this long; 0 = no timeout
+allow_uncovered_cost = false   # run unattended even when no adapter reports cost, making the budget unenforceable
 
 # Continuous intake queue (R8.6)
 [queue]

--- a/docs/dark-factory-roadmap.md
+++ b/docs/dark-factory-roadmap.md
@@ -616,13 +616,69 @@ level-dependent behavior tested; calibration captures the family delta.
 
 Status: `[ ]` - Depends on: R8.2 (merge dispositions), R8.3 (notifications)
 
-Landing in four slices; PR 1 of 4 is the substrate only. Shipped so far:
+Landing in four slices; PRs 1-2 of 4 are in. Shipped so far:
 `kstrl/workqueue.py` (maildir queue, `os.replace` transitions, flock
-mutex, lease fields, journal, pause marker) and the `ks queue
-add/ls/show/retry/rm/pause/resume` verbs. **Nothing drains the queue
-yet** - `ks serve`, the lease reaper, the retry classifier, and the
-`daily_budget_usd` stop are PR 2; the GitHub adapter is PR 3; launchd is
-PR 4.
+mutex, pid/ttl leases, journal, pause marker) with the `ks queue
+add/ls/show/retry/rm/pause/resume` verbs, and `kstrl/serve.py`
+(`ks serve [--once] [--dry-run]`, lease reaper, retry classifier, daily
+spend ledger, poison breaker, `caffeinate -i`). The GitHub adapter is
+PR 3; the launchd plist and its docs are PR 4.
+
+**The retry rule as implemented (PR 2).** "Only `infrastructure_error`
+failures auto-retry" leaves the UNKNOWN case undefined, and the unknown
+case is where the money goes, so `serve.classify_run` implements
+*positive evidence only, failing closed*:
+
+| Evidence | Verdict |
+|---|---|
+| exit 0 | success |
+| launch failed before any spend | retry (free) |
+| killed by signal / our timeout | retry (external cause, not a spec verdict) |
+| exit 2 | spec failure - the architect halted on a blocker |
+| every failed component carries `infrastructure_error` | retry |
+| any failed component failed on its merits | spec failure |
+| nonzero exit, nothing failed | **unclassifiable** - poison |
+| manifest unreadable or absent | **unclassifiable** - poison |
+
+The run lock is probed BEFORE launching, which is what keeps exit 2
+unambiguous: `ks factory` returns 2 both for a held lock and for an
+architect halt, and those need opposite treatment. The classifier reuses
+`Finding.is_infrastructure_error` rather than re-deriving the predicate -
+two copies of that rule drifting apart is how a spec failure becomes
+retryable.
+
+**Four backstops**, because a correct classifier is not sufficient (a
+*persistent* infra fault is retryable by the rules and still burns
+money): `max_attempts` enforced inside `Queue.start`; exponential backoff
+(60s doubling, capped at 30 min); `daily_budget_usd` checked before
+admitting each item, pausing until the next LOCAL midnight so a Friday
+budget hit is not a dead weekend; and a consecutive-poison breaker that
+pauses the whole queue - if `main` is broken then every run fails
+verification, each failure is individually legitimate, and no per-item
+bound ever notices.
+
+**`daily_budget_usd` honesty (H4).** The budget can only count cost an
+adapter reported, and the codex adapter reports tokens with no cost. With
+a cost-blind agent the budget is *unenforceable*, not approximate - the
+same condition PR #184 named for `max_cost_usd`. The ledger therefore
+stores the day's spend WITH its coverage, labels the total a FLOOR
+whenever any run under-reported, never converts unreported calls into an
+estimated dollar figure, and `ks serve` refuses to run unattended under
+an unenforceable budget unless `[serve] allow_uncovered_cost = true`.
+
+**Open R8.2 tension found while building PR 2.** `run_factory` assigns
+`factory_config.pause_before_pr_merge = bundle.pause_before_pr_merge`
+unconditionally, so at L3+ the ladder OVERRIDES an explicit request for
+a human merge gate and logs it as "manual override ignored". The R8.2
+docstring says the failure mode it guards is a hand-edited flag
+*granting* autonomy the ladder never awarded, but the implementation is
+symmetric and also refuses a MORE-restrictive request. Rather than change
+ladder semantics from inside R8.6, `serve.resolve_merge_gate` REFUSES an
+item whose `stop_at_pr` the current level cannot honour (poison + inbox
+item) instead of letting the gate be removed silently. Unreachable
+today - `[autonomy] enabled` defaults false and L2+ entry is still
+blocked on the user-run measurements - but it needs an R8.2 decision
+before L3 is real.
 
 Two invariants in the substrate are money-safety properties rather than
 style, and both are mutation-checked:

--- a/docs/dark-factory-roadmap.md
+++ b/docs/dark-factory-roadmap.md
@@ -666,6 +666,85 @@ whenever any run under-reported, never converts unreported calls into an
 estimated dollar figure, and `ks serve` refuses to run unattended under
 an unenforceable budget unless `[serve] allow_uncovered_cost = true`.
 
+**Review corrections (PR #186).** Eleven gaps were caught in review and
+closed before merge, all reproduced against the submitted code first.
+Recorded because eight were enforcement bypasses in the unattended
+spend path, and two broke guarantees the PR body had claimed:
+
+1. **The timeout killed only the direct child.** `subprocess.run(timeout=)`
+   signals its immediate child, which on macOS is the `caffeinate`
+   wrapper - so the factory was a grandchild and outlived the timeout
+   while the daemon recorded an infra failure and requeued the item. Two
+   factories on one repo, which is what `factory.lock` exists to prevent.
+   Now `Popen(start_new_session=True)` plus `killpg`, with the pgid
+   captured AT SPAWN (after the child is reaped it is unrecoverable, and
+   that is exactly the case where descendants survive). A timeout whose
+   group cannot be confirmed dead poisons instead of retrying. The
+   factory child also adopts the queue lease, so a successor's reaper
+   cannot requeue a live run.
+2. **Accounting and classification read the wrong run.** `serve` read
+   `run_id` from the manifest but `Manifest.to_dict` writes `runId`, so
+   it got `""` for every real manifest - and an empty id made
+   `load_run_state` fall back to the NEWEST run on disk. A failed
+   invocation charged a previous run's spend and could be classified from
+   a stale manifest. Ownership is now a pre/post snapshot of run
+   directories: only runs THIS invocation created are charged, and the
+   manifest is read only when its run id is among them.
+3. **The architect's spend was invisible.** `decompose_spec` calls the
+   agent but emits no usage events at all, so every queued item's
+   mandatory architect call was missing from the budget. Metering it
+   belongs with the architect's instrumentation, not R8.6, so the phase
+   is recorded as a named `unmetered_phases` entry and the day's total is
+   always labelled a FLOOR rather than estimated.
+4. **The spend ledger failed OPEN.** An unparseable file read as a fresh
+   zero day, so charging $9, corrupting it, and setting a $5 budget
+   allowed another run - indefinitely, because the other backstops are
+   per-item and this is the only queue-wide limit. `ServeStateError` now
+   halts the cycle; `FileNotFoundError` remains the one read failure that
+   legitimately means "first run".
+5. **The poison breaker was built on the queue journal**, which is
+   best-effort by design (`_journal` swallows append failures,
+   `journal_entries` returns `[]` on any read error). Losing the journal
+   reported a zero streak and re-allowed spending with three poisoned
+   items on disk. The streak is now authoritative state in `ServeState`,
+   reset by a success and NOT by a new day.
+6. **A pre-launch lock probe cannot disambiguate exit 2.** The probe
+   releases the lock, so a manual factory can take it in the gap - and
+   `ks factory` exits 2 for both lock contention and an architect halt.
+   The classifier now reads the child's own OUTPUT for each refusal's
+   marker and stays unclassifiable when neither is present.
+   `factory_lock_held` also fails closed on an unopenable lock file.
+7. **The elapsed-pause clear raced operator pauses.** Read and clear
+   happened outside the queue mutex, so a fresh emergency pause could be
+   overwritten. Both now happen under the lock, re-read inside it.
+8. **One full run was spent before an unenforceable budget was noticed.**
+   Coverage is now resolved from a persisted `cost_coverage_seen` flag
+   before the first claim.
+9. **Coverage was inferred from dollars, not calls.** A fully-metered run
+   that legitimately cost $0 was rejected as having no coverage, and a
+   launch failure counted as a metered run. The ledger now stores
+   covered/total call counts, which makes the three cases distinct: exact
+   cap, lower-bound cap (fires late - still a bound), and unenforceable.
+10. **The exit status followed the classifier, not the outcome.** An
+    infra verdict whose last attempt was spent is poisoned, yet
+    `may_retry` stays true, so `ks serve --once` exited 0 on work waiting
+    for a human - as did the reaper and merge-gate poison paths, which
+    set no `ran_item`. `CycleResult.needs_human` is now set on every
+    poison and refusal path and drives the exit code.
+11. **The daemon retained every poll result forever** with no consumer.
+    Bounded runs still return everything; the unbounded path keeps a
+    fixed window.
+
+All eleven fixes are mutation-checked (36 mutations, 36 caught). Nine of
+the first-draft tests were NOT discriminating and were rewritten before
+being counted - including one where the autouse fixture patched the very
+function under test, so it passed regardless of that function's
+behaviour, and one where a spy counted the liveness probe
+(`killpg(pgid, 0)`) as if it were the kill. One "missed" mutation turned
+out not to be a defect at all: dropping the spawn-time pgid is
+behaviourally identical on the timeout path, so that test now asserts
+the wiring and says so.
+
 **Open R8.2 tension found while building PR 2.** `run_factory` assigns
 `factory_config.pause_before_pr_merge = bundle.pause_before_pr_merge`
 unconditionally, so at L3+ the ladder OVERRIDES an explicit request for

--- a/kstrl.toml.example
+++ b/kstrl.toml.example
@@ -211,6 +211,23 @@ notify_action_required = true      # notify on action-required items and demotio
 max_attempts = 3                   # execution attempts per item before poisoning
 lease_ttl_seconds = 3600.0         # claim validity; the reaper recovers anything past this
 
+# Continuous-intake daemon (R8.6): `ks serve` drains the queue above, one
+# factory run at a time. Only infrastructure failures retry, and only on
+# positive evidence - spec failures go to poison/ and wait for a human, because
+# a queue that retries spec failures overnight is the most expensive bug this
+# repo could ship. daily_budget_usd is the real cap on unattended spend; note
+# it can only count cost an adapter REPORTS (the codex adapter reports tokens
+# and no cost), so with a cost-blind agent it is unenforceable rather than
+# approximate - serve refuses to run in that case unless you set
+# allow_uncovered_cost. The unreported spend is deliberately never estimated.
+[serve]
+poll_interval_seconds = 60.0       # seconds between poll cycles
+daily_budget_usd = 0.0             # 0 = no cap; any positive value is a HARD stop
+max_consecutive_poison = 3         # poisoned in a row before the queue pauses
+caffeinate = true                  # hold caffeinate -i per run (macOS); sleeps between
+factory_timeout_seconds = 0.0      # kill a run after this long; 0 = no timeout
+allow_uncovered_cost = false       # true = run unattended under an unenforceable budget
+
 # Test-suite adequacy gate (R8.5), Layer 0: reads the diff and changed test
 # files - no test execution, no coverage, no mutation tooling. Catches the
 # suite getting WEAKER (deleted tests, added skip/xfail, assertions removed)

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -4046,8 +4046,21 @@ def serve(
             "paused",
             f"yes - {pause.reason}" if pause.active() else "no",
         )
-        spend = ledger.read()
-        floor = " (a FLOOR: some calls reported no cost)" if spend.lower_bound else ""
+        from kstrl.serve import ServeStateError
+
+        try:
+            spend = ledger.read()
+        except ServeStateError as exc:
+            ui_impl.err(str(exc))
+            sys.exit(2)
+        floor = (
+            f" (a FLOOR: {spend.uncovered_calls} call(s) reported no cost"
+            + (
+                "; unmetered: " + ", ".join(spend.unmetered_phases)
+                if spend.unmetered_phases else ""
+            )
+            + ")"
+        ) if spend.lower_bound else ""
         ui_impl.kv(
             "today", f"${spend.spent_usd:.2f} over {spend.runs} run(s){floor}",
         )
@@ -4056,13 +4069,13 @@ def serve(
             f"${config.daily_budget_usd:.2f}"
             if config.daily_budget_usd > 0 else "unset (no cap)",
         )
-        ui_impl.kv("consecutive poison", str(consecutive_poison_count(queue)))
+        ui_impl.kv("consecutive poison", str(consecutive_poison_count(ledger)))
         ui_impl.kv(
             "factory lock", "held by another run" if factory_lock_held(root_dir)
             else "free",
         )
         for label, admission in (
-            ("poison breaker", check_poison_breaker(queue, config)),
+            ("poison breaker", check_poison_breaker(ledger, config)),
             ("cost coverage", check_cost_coverage(ledger, config)),
             ("budget", check_budget(ledger, config)),
             ("inbox cap", check_inbox_cap(root_dir)),
@@ -4107,11 +4120,19 @@ def serve(
     ui_impl.info("")
     ui_impl.kv("cycles", str(len(results)))
     ui_impl.kv("items run", str(len(ran)))
-    # Nonzero only when an item ended up needing a human, so a launchd
-    # KeepAlive job's exit status means something.
-    poisoned = [r for r in ran if r.verdict is not None and not r.verdict.may_retry
-                and str(r.verdict) != "success"]
-    sys.exit(1 if poisoned else 0)
+    # Derived from the TERMINAL queue outcome, not from the classifier's
+    # retry permission. Review #186 F10: an infra verdict whose last
+    # attempt was spent is poisoned by serve_cycle, yet
+    # Verdict.RETRY_INFRA.may_retry stays true - and the reaper and
+    # merge-gate poison paths set no ran_item at all - so the old filter
+    # exited 0 on work that was waiting for a human.
+    needs_human = [r for r in results if r.needs_human]
+    if needs_human:
+        ui_impl.warn(
+            f"{len(needs_human)} cycle(s) produced work awaiting a human; "
+            "see `ks inbox ls` and `ks queue ls --state poison`"
+        )
+    sys.exit(1 if needs_human else 0)
 
 
 class _ServeUiObserver:

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -3976,6 +3976,160 @@ def queue_resume(root: Path | None, ui: str, no_color: bool) -> None:
     sys.exit(0)
 
 
+@cli.command()
+@click.option(
+    "--once", is_flag=True,
+    help="Run a single poll cycle and exit (launchd/cron fallback mode)",
+)
+@click.option(
+    "--max-cycles", type=click.IntRange(min=0), default=0,
+    help="Stop after this many cycles; 0 runs until interrupted",
+)
+@click.option(
+    "--dry-run", is_flag=True,
+    help="Report what the next cycle would do without spending anything",
+)
+@_queue_root_option
+@_queue_ui_option
+@_queue_no_color_option
+def serve(
+    once: bool,
+    max_cycles: int,
+    dry_run: bool,
+    root: Path | None,
+    ui: str,
+    no_color: bool,
+) -> None:
+    """Drain the continuous-intake queue (R8.6).
+
+    Runs one factory invocation at a time, holding a daemon singleton
+    lock. Under launchd this is invoked with --once on an interval;
+    StartInterval fires immediately for intervals that elapsed while the
+    machine slept, so a laptop that was closed catches up on wake.
+
+    Only infrastructure failures are retried, and only with positive
+    evidence. Spec-level failures go to poison/ and wait for a human.
+    """
+    from kstrl.serve import (
+        ServeConfig,
+        ServeError,
+        ServeLockedError,
+        SpendLedger,
+        check_budget,
+        check_cost_coverage,
+        check_inbox_cap,
+        check_poison_breaker,
+        consecutive_poison_count,
+        factory_lock_held,
+    )
+    from kstrl.serve import serve as run_serve
+    from kstrl.workqueue import Queue, QueueConfig, summarize
+
+    root_dir = (root or Path.cwd()).resolve()
+    ui_impl = _autonomy_ui(ui, no_color)
+    try:
+        config = ServeConfig.load(root_dir)
+    except (ServeError, ValueError) as exc:
+        ui_impl.err(str(exc))
+        sys.exit(2)
+    queue = Queue(root_dir, QueueConfig.load(root_dir))
+    ledger = SpendLedger(root_dir)
+
+    if dry_run:
+        # Deliberately reports the same gates the loop evaluates, in the
+        # same order, so "what would it do" cannot drift from "what it
+        # does" without a test noticing.
+        ui_impl.section("Serve dry run")
+        ui_impl.kv("queue", summarize(queue.counts()))
+        pause = queue.pause_state()
+        ui_impl.kv(
+            "paused",
+            f"yes - {pause.reason}" if pause.active() else "no",
+        )
+        spend = ledger.read()
+        floor = " (a FLOOR: some calls reported no cost)" if spend.lower_bound else ""
+        ui_impl.kv(
+            "today", f"${spend.spent_usd:.2f} over {spend.runs} run(s){floor}",
+        )
+        ui_impl.kv(
+            "daily budget",
+            f"${config.daily_budget_usd:.2f}"
+            if config.daily_budget_usd > 0 else "unset (no cap)",
+        )
+        ui_impl.kv("consecutive poison", str(consecutive_poison_count(queue)))
+        ui_impl.kv(
+            "factory lock", "held by another run" if factory_lock_held(root_dir)
+            else "free",
+        )
+        for label, admission in (
+            ("poison breaker", check_poison_breaker(queue, config)),
+            ("cost coverage", check_cost_coverage(ledger, config)),
+            ("budget", check_budget(ledger, config)),
+            ("inbox cap", check_inbox_cap(root_dir)),
+        ):
+            if admission.allowed:
+                ui_impl.info(f"  gate {label}: ok")
+            else:
+                ui_impl.warn(f"  gate {label}: BLOCKS - {admission.reason}")
+        candidate = queue.next_ready()
+        ui_impl.kv(
+            "next item",
+            f"{candidate.item_id[:12]} - {candidate.title}"
+            if candidate else "nothing ready",
+        )
+        sys.exit(0)
+
+    ui_impl.info(
+        f"ks serve on {root_dir} "
+        f"(poll {config.poll_interval_seconds:.0f}s, "
+        f"budget "
+        + (f"${config.daily_budget_usd:.2f}/day" if config.daily_budget_usd > 0
+           else "unset")
+        + f", caffeinate {'on' if config.caffeinate else 'off'})"
+    )
+    observer = _ServeUiObserver(ui_impl)
+    try:
+        results = run_serve(
+            root_dir,
+            once=once,
+            config=config,
+            observer=observer,
+            max_cycles=max_cycles,
+        )
+    except ServeLockedError as exc:
+        ui_impl.err(str(exc))
+        sys.exit(2)
+    except KeyboardInterrupt:
+        ui_impl.info("Interrupted; the current item keeps its lease for the reaper.")
+        sys.exit(0)
+
+    ran = [r for r in results if r.ran_item]
+    ui_impl.info("")
+    ui_impl.kv("cycles", str(len(results)))
+    ui_impl.kv("items run", str(len(ran)))
+    # Nonzero only when an item ended up needing a human, so a launchd
+    # KeepAlive job's exit status means something.
+    poisoned = [r for r in ran if r.verdict is not None and not r.verdict.may_retry
+                and str(r.verdict) != "success"]
+    sys.exit(1 if poisoned else 0)
+
+
+class _ServeUiObserver:
+    """Adapts the daemon's narration onto the console UI."""
+
+    def __init__(self, ui_impl: UI) -> None:
+        self._ui = ui_impl
+
+    def info(self, message: str) -> None:
+        self._ui.info(message)
+
+    def warn(self, message: str) -> None:
+        self._ui.warn(message)
+
+    def err(self, message: str) -> None:
+        self._ui.err(message)
+
+
 def main() -> None:
     """Main entry point."""
     cli()

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -1,0 +1,1524 @@
+"""R8.6 continuous intake: the daemon that drains the work queue.
+
+PR 1 built a place for work to wait. This is what runs it without a
+human firing each run - and therefore the module where a mistake spends
+money while nobody is watching. A measured factory engineer iteration
+costs ~$1.70-2.60 on a first attempt and $3.99-7.42 on a retry (retries
+carry accumulated context), and a 5-story component with adversarial
+review ran ~$29 and 96 minutes without finishing. Those numbers are why
+almost every decision below errs toward NOT launching a run.
+
+**The retry rule, stated precisely.** R8.6 says "only
+``infrastructure_error`` failures auto-retry". That phrasing leaves the
+UNKNOWN case undefined, and the unknown case is where the money goes, so
+this module implements it as *positive evidence only, failing closed*: an
+item is retried only when we can read affirmative evidence that the
+failure was infrastructural. An unreadable manifest, a missing artifact,
+a run that died before recording anything, an exit code we do not
+recognise - all poison, none retry. This is deliberately the inverse of
+"retry unless proven to be a spec failure", which is the shape that
+produces an overnight crash loop.
+
+The same class of mistake is already on record in this repo: R8.1 review
+correction #2 found the changed-file reads were fail-OPEN, so a
+``kstrl.toml`` diff evaluated as "0 files, 0 lines" and passed every
+path and size rule. Defaulting to permissive on missing evidence looks
+harmless until the evidence goes missing.
+
+**Four independent backstops**, because a correct classifier is not
+sufficient - a *persistent* infrastructure fault is retryable by the
+rules and still burns money:
+
+1. ``max_attempts`` per item, enforced by ``Queue.start`` itself.
+2. Exponential backoff between attempts, so a fast-failing item cannot
+   spin.
+3. ``daily_budget_usd``, checked BEFORE admitting each item.
+4. A consecutive-poison breaker that pauses the whole queue. If ``main``
+   is broken then every run fails verification, each failure is
+   individually legitimate, and per-item bounds never notice; only a
+   cross-item signal does.
+
+**Honesty about the budget (H4).** ``daily_budget_usd`` can only count
+cost that an adapter reported. The codex adapter reports tokens and no
+cost, so with a cost-blind agent the budget is not approximate - it is
+*unenforceable*, the same condition PR #184 named for ``max_cost_usd``.
+This module therefore records the day's spend together with its
+coverage, never converts unreported calls into an estimated dollar
+figure, and refuses to run unattended when a budget is configured but
+cost coverage is absent (``allow_uncovered_cost`` is the explicit
+override).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Protocol
+
+from kstrl.statedir import state_dir
+from kstrl.workqueue import (
+    ItemState,
+    MergeDisposition,
+    Queue,
+    QueueBudgetExhausted,
+    QueueConfig,
+    QueueItem,
+    queue_lock,
+    queue_root,
+)
+
+SERVE_LOCK_FILENAME = "serve.lock"
+SPEND_FILENAME = "spend.json"
+
+#: Retry backoff: ``base * 2 ** (attempts - 1)``, capped. Not tunable by
+#: config on purpose - the cap is a safety floor on how fast an item can
+#: consume its attempts, not a preference.
+BACKOFF_BASE_SECONDS = 60.0
+BACKOFF_CAP_SECONDS = 1800.0
+
+
+class ServeError(RuntimeError):
+    """The daemon cannot run."""
+
+
+class ServeLockedError(ServeError):
+    """Another ``ks serve`` holds the singleton lock on this root."""
+
+
+class Verdict(StrEnum):
+    """What the evidence says about a finished run.
+
+    ``UNCLASSIFIABLE`` is a first-class outcome rather than an error
+    path: it is the common case for a crash, and treating it as "probably
+    fine, retry" is the bug this whole module is arranged to avoid.
+    """
+
+    SUCCESS = "success"
+    RETRY_INFRA = "retry_infra"
+    SPEC_FAILURE = "spec_failure"
+    UNCLASSIFIABLE = "unclassifiable"
+
+    @property
+    def may_retry(self) -> bool:
+        """Only ONE verdict authorizes spending again."""
+        return self is Verdict.RETRY_INFRA
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """A verdict plus the evidence that produced it.
+
+    ``evidence`` is written to the inbox item, so a human deciding
+    whether to requeue sees what the classifier actually read rather
+    than having to trust its label.
+    """
+
+    verdict: Verdict
+    reason: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RunOutcome:
+    """Raw result of one factory invocation, before interpretation."""
+
+    returncode: int
+    timed_out: bool = False
+    #: Non-empty when the launch itself failed (binary missing, etc).
+    launch_error: str = ""
+
+
+class FactoryRunner(Protocol):
+    """How the daemon executes one queue item.
+
+    A Protocol so tests drive the entire loop without spawning a factory.
+    That is not only a speed concern: a suite that ran the real thing
+    would cost dollars per assertion.
+    """
+
+    def __call__(
+        self,
+        *,
+        root_dir: Path,
+        spec_path: Path,
+        project_name: str,
+        pause_before_pr_merge: bool,
+        timeout_seconds: float,
+    ) -> RunOutcome:
+        ...
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(moment: datetime) -> str:
+    return moment.isoformat()
+
+
+def _local_today() -> str:
+    """Today's date in LOCAL time.
+
+    Local rather than UTC because the budget resets "at the next day"
+    from the operator's point of view; a UTC reset would land mid-evening
+    for most of the world.
+    """
+    return datetime.now().astimezone().strftime("%Y-%m-%d")
+
+
+def next_local_midnight(now: datetime | None = None) -> str:
+    """UTC ISO timestamp of the next local midnight."""
+    local = (now or _utc_now()).astimezone()
+    tomorrow = (local + timedelta(days=1)).replace(
+        hour=0, minute=0, second=0, microsecond=0,
+    )
+    return _iso(tomorrow.astimezone(UTC))
+
+
+def backoff_seconds(attempts: int) -> float:
+    """Delay before an item's next attempt."""
+    if attempts <= 0:
+        return 0.0
+    grown = BACKOFF_BASE_SECONDS * float(2 ** (attempts - 1))
+    return min(grown, BACKOFF_CAP_SECONDS)
+
+
+@dataclass(frozen=True)
+class ServeConfig:
+    """``[serve]`` config: the daemon's knobs.
+
+    ``daily_budget_usd`` lives here rather than in ``[queue]`` because
+    only the daemon spends; it is nonetheless queue-LEVEL in the sense
+    R8.6 means - it spans runs and it pauses the queue, as opposed to
+    the per-run ``max_cost_usd`` ceiling.
+    """
+
+    poll_interval_seconds: float = 60.0
+    #: 0 disables the budget entirely. Any positive value is a HARD stop.
+    daily_budget_usd: float = 0.0
+    #: Consecutive poisoned items that pause the whole queue. The
+    #: cross-item signal per-item bounds cannot see.
+    max_consecutive_poison: int = 3
+    #: Hold ``caffeinate -i`` for the duration of each run so the machine
+    #: does not sleep mid-factory, and sleeps freely between runs.
+    caffeinate: bool = True
+    #: 0 disables the per-run timeout.
+    factory_timeout_seconds: float = 0.0
+    #: Run unattended even when a configured budget cannot be enforced
+    #: because no adapter reports cost. Explicit opt-out of the guard.
+    allow_uncovered_cost: bool = False
+
+    def __post_init__(self) -> None:
+        if self.poll_interval_seconds <= 0:
+            raise ServeError(
+                "serve.poll_interval_seconds must be > 0, got "
+                f"{self.poll_interval_seconds}"
+            )
+        if self.daily_budget_usd < 0:
+            raise ServeError(
+                f"serve.daily_budget_usd must be >= 0, got {self.daily_budget_usd}"
+            )
+        if self.max_consecutive_poison < 1:
+            raise ServeError(
+                "serve.max_consecutive_poison must be >= 1, got "
+                f"{self.max_consecutive_poison}"
+            )
+        if self.factory_timeout_seconds < 0:
+            raise ServeError(
+                "serve.factory_timeout_seconds must be >= 0, got "
+                f"{self.factory_timeout_seconds}"
+            )
+
+    @classmethod
+    def from_env(cls) -> ServeConfig:
+        defaults = cls()
+        poll = os.environ.get("KSTRL_SERVE_POLL_INTERVAL")
+        budget = os.environ.get("KSTRL_SERVE_DAILY_BUDGET_USD")
+        poison = os.environ.get("KSTRL_SERVE_MAX_CONSECUTIVE_POISON")
+        caffeinate = os.environ.get("KSTRL_SERVE_CAFFEINATE")
+        timeout = os.environ.get("KSTRL_SERVE_FACTORY_TIMEOUT")
+        uncovered = os.environ.get("KSTRL_SERVE_ALLOW_UNCOVERED_COST")
+        return cls(
+            poll_interval_seconds=(
+                defaults.poll_interval_seconds if poll is None else float(poll)
+            ),
+            daily_budget_usd=(
+                defaults.daily_budget_usd if budget is None else float(budget)
+            ),
+            max_consecutive_poison=(
+                defaults.max_consecutive_poison if poison is None else int(poison)
+            ),
+            caffeinate=(
+                defaults.caffeinate if caffeinate is None else caffeinate == "1"
+            ),
+            factory_timeout_seconds=(
+                defaults.factory_timeout_seconds
+                if timeout is None else float(timeout)
+            ),
+            allow_uncovered_cost=(
+                defaults.allow_uncovered_cost
+                if uncovered is None else uncovered == "1"
+            ),
+        )
+
+    @classmethod
+    def load(cls, root_dir: Path | None = None) -> ServeConfig:
+        """Precedence: env > toml > defaults; reads ``[serve]``."""
+        from kstrl.config import load_toml_section, resolve_config_file
+
+        if root_dir is None:
+            root_dir = Path.cwd()
+        section = load_toml_section(resolve_config_file(root_dir), "serve")
+        defaults = cls()
+
+        def _float(key: str, fallback: float) -> float:
+            return float(section[key]) if key in section else fallback
+
+        def _int(key: str, fallback: int) -> int:
+            return int(section[key]) if key in section else fallback
+
+        def _bool(key: str, fallback: bool) -> bool:
+            return bool(section[key]) if key in section else fallback
+
+        poll = _float("poll_interval_seconds", defaults.poll_interval_seconds)
+        budget = _float("daily_budget_usd", defaults.daily_budget_usd)
+        poison = _int("max_consecutive_poison", defaults.max_consecutive_poison)
+        caffeinate = _bool("caffeinate", defaults.caffeinate)
+        timeout = _float(
+            "factory_timeout_seconds", defaults.factory_timeout_seconds,
+        )
+        uncovered = _bool("allow_uncovered_cost", defaults.allow_uncovered_cost)
+
+        if "KSTRL_SERVE_POLL_INTERVAL" in os.environ:
+            poll = float(os.environ["KSTRL_SERVE_POLL_INTERVAL"])
+        if "KSTRL_SERVE_DAILY_BUDGET_USD" in os.environ:
+            budget = float(os.environ["KSTRL_SERVE_DAILY_BUDGET_USD"])
+        if "KSTRL_SERVE_MAX_CONSECUTIVE_POISON" in os.environ:
+            poison = int(os.environ["KSTRL_SERVE_MAX_CONSECUTIVE_POISON"])
+        if "KSTRL_SERVE_CAFFEINATE" in os.environ:
+            caffeinate = os.environ["KSTRL_SERVE_CAFFEINATE"] == "1"
+        if "KSTRL_SERVE_FACTORY_TIMEOUT" in os.environ:
+            timeout = float(os.environ["KSTRL_SERVE_FACTORY_TIMEOUT"])
+        if "KSTRL_SERVE_ALLOW_UNCOVERED_COST" in os.environ:
+            uncovered = os.environ["KSTRL_SERVE_ALLOW_UNCOVERED_COST"] == "1"
+
+        return cls(
+            poll_interval_seconds=poll,
+            daily_budget_usd=budget,
+            max_consecutive_poison=poison,
+            caffeinate=caffeinate,
+            factory_timeout_seconds=timeout,
+            allow_uncovered_cost=uncovered,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Daily spend ledger
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DailySpend:
+    """What the queue has spent today, and how well we know it.
+
+    ``lower_bound`` is not decoration. When it is true the real spend is
+    higher than ``spent_usd`` by an amount this codebase deliberately
+    does not estimate, so the budget comparison is a comparison against
+    a floor. ``uncovered_calls`` says how many calls contributed nothing.
+    """
+
+    date: str = ""
+    spent_usd: float = 0.0
+    runs: int = 0
+    lower_bound: bool = False
+    uncovered_calls: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "date": self.date,
+            "spent_usd": self.spent_usd,
+            "runs": self.runs,
+            "lower_bound": self.lower_bound,
+            "uncovered_calls": self.uncovered_calls,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DailySpend:
+        def _num(key: str) -> float:
+            value = data.get(key, 0)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                return 0.0
+            return float(value)
+
+        return cls(
+            date=str(data.get("date") or ""),
+            spent_usd=_num("spent_usd"),
+            runs=int(_num("runs")),
+            lower_bound=bool(data.get("lower_bound", False)),
+            uncovered_calls=int(_num("uncovered_calls")),
+        )
+
+
+class SpendLedger:
+    """Append-nothing, rewrite-atomically record of today's spend.
+
+    Deliberately NOT a journal: the only question asked of it is "how
+    much today", and a single small file keeps the pre-admission check
+    cheap enough to run before every item. The per-run detail already
+    lives in the run's own event stream.
+    """
+
+    def __init__(self, root_dir: Path) -> None:
+        self.root_dir = root_dir
+
+    @property
+    def path(self) -> Path:
+        return queue_root(self.root_dir) / SPEND_FILENAME
+
+    def read(self, today: str | None = None) -> DailySpend:
+        """Today's spend; a stale date reads as a fresh zero day.
+
+        An unreadable or malformed ledger reads as a fresh day too, which
+        is the ONE fail-open choice in this module and is called out
+        here: failing closed would mean an unparseable ledger halts the
+        queue permanently with no way for the daemon itself to recover.
+        The exposure is bounded by ``max_attempts``, the backoff, and the
+        poison breaker, and by the ledger being rewritten atomically so
+        a torn write is not a normal event.
+        """
+        stamp = today or _local_today()
+        try:
+            raw = self.path.read_text(encoding="utf-8")
+        except OSError:
+            return DailySpend(date=stamp)
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return DailySpend(date=stamp)
+        if not isinstance(data, dict):
+            return DailySpend(date=stamp)
+        spend = DailySpend.from_dict(data)
+        if spend.date != stamp:
+            return DailySpend(date=stamp)
+        return spend
+
+    def _write(self, spend: DailySpend) -> None:
+        from kstrl.workqueue import atomic_write
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write(
+            self.path,
+            json.dumps(spend.to_dict(), indent=2, ensure_ascii=False) + "\n",
+        )
+
+    def charge(
+        self,
+        usd: float,
+        *,
+        lower_bound: bool = False,
+        uncovered_calls: int = 0,
+        today: str | None = None,
+    ) -> DailySpend:
+        """Add one run's reported cost to today's total.
+
+        ``lower_bound`` is sticky for the day: once any run reported
+        partial cost coverage, the day's figure is a floor and stays
+        labelled as one.
+        """
+        stamp = today or _local_today()
+        current = self.read(stamp)
+        updated = DailySpend(
+            date=stamp,
+            spent_usd=round(current.spent_usd + max(0.0, usd), 6),
+            runs=current.runs + 1,
+            lower_bound=current.lower_bound or lower_bound,
+            uncovered_calls=current.uncovered_calls + max(0, uncovered_calls),
+        )
+        self._write(updated)
+        return updated
+
+
+@dataclass(frozen=True)
+class RunSpend:
+    """One run's cost as read back from its event stream."""
+
+    cost_usd: float = 0.0
+    lower_bound: bool = False
+    uncovered_calls: int = 0
+    cost_calls: int = 0
+    usage_calls: int = 0
+
+
+def read_run_spend(root_dir: Path, run_id: str) -> RunSpend:
+    """Reported cost of one run, with its coverage.
+
+    Reads through ``kstrl.reducer`` rather than re-parsing the journals,
+    so the daemon's cost figure is the same number the dashboard shows
+    and the per-axis coverage flags (R8/PR #184) come along for free.
+    """
+    from kstrl.reducer import load_run_state
+
+    try:
+        state, _source = load_run_state(root_dir, run_id)
+    except OSError:
+        return RunSpend()
+    return RunSpend(
+        cost_usd=state.cost_usd,
+        lower_bound=state.cost_is_lower_bound,
+        uncovered_calls=max(0, state.usage_calls - state.cost_calls),
+        cost_calls=state.cost_calls,
+        usage_calls=state.usage_calls,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Classification - the money-critical decision
+# ---------------------------------------------------------------------------
+
+
+def _infra_casualty(component: Any) -> bool:
+    """Whether a component's failure was infrastructural.
+
+    Mirrors ``factory._infra_casualty`` exactly, and reuses the same
+    ``Finding.is_infrastructure_error`` predicate rather than
+    re-deriving it. Two copies of this rule that drift apart is how a
+    spec failure becomes retryable, so the shared predicate is the whole
+    point.
+    """
+    return any(f.is_infrastructure_error for f in component.findings)
+
+
+def classify_run(
+    root_dir: Path,
+    *,
+    run: RunOutcome,
+    manifest_path: Path,
+) -> Outcome:
+    """Decide what a finished factory run means for its queue item.
+
+    Positive evidence only. Every branch that cannot prove the failure
+    was infrastructural returns a non-retrying verdict, and the reason
+    string always says which branch fired so a human reading the inbox
+    can audit the decision.
+    """
+    if run.launch_error:
+        # The factory never started, so nothing was spent. Retrying is
+        # free, which is what makes this safe to retry at all.
+        return Outcome(
+            Verdict.RETRY_INFRA,
+            f"launch failed before any spend: {run.launch_error}",
+            {"launch_error": run.launch_error},
+        )
+
+    if run.timed_out:
+        # WE killed it. A hang is an infrastructure symptom, and
+        # max_attempts plus the daily budget bound the exposure.
+        return Outcome(
+            Verdict.RETRY_INFRA,
+            "run exceeded serve.factory_timeout_seconds and was killed",
+            {"timed_out": True},
+        )
+
+    if run.returncode == 0:
+        return Outcome(Verdict.SUCCESS, "factory exited 0", {"returncode": 0})
+
+    if run.returncode < 0:
+        # Killed by a signal: SIGKILL from an OOM, a suspend that took
+        # the process with it, or an operator. That is affirmative
+        # evidence of an EXTERNAL cause rather than a verdict on the
+        # spec, so it is the one crash shape that legitimately retries.
+        return Outcome(
+            Verdict.RETRY_INFRA,
+            f"killed by signal {-run.returncode} (external cause, not a "
+            "verdict on the spec)",
+            {"signal": -run.returncode},
+        )
+
+    if run.returncode == 2:
+        # The factory's own "refused to proceed" code. With the run lock
+        # probed before launch and --spec always supplied, the reachable
+        # cause here is the architect halting on a blocker-severity spec
+        # issue - a SPEC failure, and retrying it would re-run the same
+        # architect against the same words.
+        return Outcome(
+            Verdict.SPEC_FAILURE,
+            "factory exited 2: the architect halted on a blocker-severity "
+            "spec issue; the spec needs a human",
+            {"returncode": 2},
+        )
+
+    # Everything else needs the manifest to say something specific.
+    from kstrl.manifest import Manifest
+
+    try:
+        manifest = Manifest.load(manifest_path)
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as exc:
+        return Outcome(
+            Verdict.UNCLASSIFIABLE,
+            f"exit {run.returncode} and the manifest could not be read "
+            f"({exc}); refusing to guess whether this was infrastructural",
+            {"returncode": run.returncode, "manifest": str(manifest_path)},
+        )
+
+    failed = [
+        comp for comp in manifest.components
+        if str(comp.status) == "failed"
+    ]
+    if not failed:
+        # Nonzero exit with nothing blamed: unconfirmed merges, contract
+        # failures, a stop mid-run. Each may well be resumable, but none
+        # is an infrastructure_error, and inventing that label here is
+        # exactly the fail-open shape this module refuses.
+        return Outcome(
+            Verdict.UNCLASSIFIABLE,
+            f"exit {run.returncode} with no failed component to attribute it "
+            "to (unconfirmed merge, contract failure, or an interrupted "
+            "run); a human decides whether to resume",
+            {
+                "returncode": run.returncode,
+                "statuses": sorted(
+                    {str(c.status) for c in manifest.components}
+                ),
+            },
+        )
+
+    judged = [comp.id for comp in failed if not _infra_casualty(comp)]
+    if judged:
+        return Outcome(
+            Verdict.SPEC_FAILURE,
+            "spec-level failure: "
+            + ", ".join(judged)
+            + " failed on their own merits, not on infrastructure",
+            {"returncode": run.returncode, "judged_failures": judged},
+        )
+
+    return Outcome(
+        Verdict.RETRY_INFRA,
+        "every failed component carried an infrastructure_error finding: "
+        + ", ".join(comp.id for comp in failed),
+        {
+            "returncode": run.returncode,
+            "infra_failures": [comp.id for comp in failed],
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lease reaping - sleep and crash recovery
+# ---------------------------------------------------------------------------
+
+
+def _pid_alive(pid: int, host: str) -> bool:
+    """Whether a lease holder is still running.
+
+    A lease from ANOTHER host is treated as alive: we cannot probe a
+    foreign pid, and two-machine operation is an explicit R8.6 non-goal,
+    so the TTL remains the only signal there rather than us reaping work
+    that may be in flight elsewhere.
+    """
+    if host and host != socket.gethostname():
+        return True
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but is not ours. Alive as far as this check goes.
+        return True
+    except OSError:
+        return True
+    return True
+
+
+@dataclass(frozen=True)
+class ReapResult:
+    """What one reaper pass did, for logging and tests."""
+
+    requeued: tuple[str, ...] = ()
+    poisoned: tuple[str, ...] = ()
+    failed_for_retry: tuple[str, ...] = ()
+
+
+def reap_leases(
+    queue: Queue,
+    *,
+    now: datetime | None = None,
+    actor: str = "reaper",
+) -> ReapResult:
+    """Recover items whose owner died or slept through its lease.
+
+    The LEASED and RUNNING cases are genuinely different and that
+    difference is the reason PR 1 kept two states:
+
+    - A dead ``leased`` item spent nothing (the attempt is charged on the
+      transition INTO running), so it goes back to ``queued`` untouched.
+    - A dead ``running`` item spent real money. Its attempt is already
+      charged, so it is treated as an infrastructure casualty - which is
+      what a suspend or an OOM kill actually is - and retried only if it
+      has attempts left. Otherwise it poisons.
+    """
+    moment = now or _utc_now()
+    requeued: list[str] = []
+    poisoned: list[str] = []
+    failed: list[str] = []
+
+    for item in queue.items((ItemState.LEASED,)):
+        if item.lease_expired(moment) or not _pid_alive(
+            item.lease_pid, item.lease_host,
+        ):
+            queue.requeue(
+                item,
+                reason="reaped: lease holder gone before any spend",
+                actor=actor,
+                not_before="",
+            )
+            requeued.append(item.item_id)
+
+    for item in queue.items((ItemState.RUNNING,)):
+        if not (
+            item.lease_expired(moment)
+            or not _pid_alive(item.lease_pid, item.lease_host)
+        ):
+            continue
+        detail = (
+            f"run interrupted (lease holder pid {item.lease_pid} on "
+            f"{item.lease_host or 'unknown host'} is gone or its lease "
+            "lapsed); classified as infrastructure"
+        )
+        queue.finish_failed(item, error=detail, actor=actor)
+        reread = queue.get(item.item_id)
+        if reread is None:
+            continue
+        if reread.attempts_remaining > 0:
+            queue.requeue(
+                reread,
+                reason="reaped: retrying an interrupted run",
+                actor=actor,
+                not_before=_iso(
+                    moment + timedelta(seconds=backoff_seconds(reread.attempts))
+                ),
+            )
+            failed.append(item.item_id)
+        else:
+            queue.poison(
+                reread,
+                reason=(
+                    f"{detail}; no attempts left "
+                    f"({reread.attempts}/{reread.max_attempts})"
+                ),
+                actor=actor,
+            )
+            poisoned.append(item.item_id)
+
+    return ReapResult(
+        requeued=tuple(requeued),
+        poisoned=tuple(poisoned),
+        failed_for_retry=tuple(failed),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Merge disposition - the human gate must survive continuous intake
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MergeGate:
+    """The merge-gate decision for one item.
+
+    ``refusal`` non-empty means the item must NOT run: the autonomy
+    ladder would auto-merge something that explicitly asked for a human,
+    and silently proceeding is precisely the governance erosion R8.6
+    lists as a failure mode.
+    """
+
+    pause_before_pr_merge: bool
+    notes: tuple[str, ...] = ()
+    refusal: str = ""
+
+
+def resolve_merge_gate(item: QueueItem, root_dir: Path) -> MergeGate:
+    """Reconcile the item's merge disposition with the autonomy ladder.
+
+    Two directions, and they are not symmetric:
+
+    - The item asks for AUTO_MERGE and the ladder withholds it: downgrade
+      to a human gate. This is the ladder doing its job - it may always
+      withhold a permission.
+    - The item asks for STOP_AT_PR and the ladder's bundle forces
+      ``pause_before_pr_merge=False`` (L3+): the ladder would GRANT
+      auto-merge over an explicit request for a human. Refuse the item.
+
+    The second case cannot be fixed here: ``run_factory`` assigns
+    ``factory_config.pause_before_pr_merge = bundle.pause_before_pr_merge``
+    unconditionally, so passing the flag would be overridden and logged
+    as a "manual override ignored". Making the ladder honour a
+    MORE-restrictive request is an R8.2 change, not an R8.6 one, so this
+    refuses loudly instead of quietly letting a merge through.
+    """
+    from kstrl.autonomy import AutonomyConfig, AutonomyState, flag_bundle_for, resolve_runtime_level
+    from kstrl.policy import PolicyConfig
+
+    wants_gate = item.merge_disposition is MergeDisposition.STOP_AT_PR
+    config = AutonomyConfig.load(root_dir)
+    if not config.enabled:
+        # No ladder: the item's own disposition is authoritative.
+        return MergeGate(pause_before_pr_merge=wants_gate)
+
+    policy = PolicyConfig.load(root_dir)
+    level, clamps = resolve_runtime_level(
+        AutonomyState.load(root_dir), config, policy_enabled=policy.enabled,
+    )
+    bundle = flag_bundle_for(level)
+    notes = list(clamps)
+
+    if not wants_gate and not bundle.auto_merge_when_green:
+        notes.append(
+            f"item requested auto-merge; {bundle.level.label} withholds it, "
+            "so the PR waits for a human"
+        )
+        return MergeGate(pause_before_pr_merge=True, notes=tuple(notes))
+
+    if wants_gate and not bundle.pause_before_pr_merge:
+        return MergeGate(
+            pause_before_pr_merge=True,
+            notes=tuple(notes),
+            refusal=(
+                f"item requires a human merge gate but {bundle.level.label} "
+                "auto-merges when green, and run_factory lets the ladder's "
+                "bundle override the flag. Set the item to --auto-merge "
+                "deliberately, or lower [autonomy] max_level, rather than "
+                "having the gate removed silently."
+            ),
+        )
+
+    return MergeGate(
+        pause_before_pr_merge=bundle.pause_before_pr_merge, notes=tuple(notes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The default runner: a subprocess, under caffeinate
+# ---------------------------------------------------------------------------
+
+
+def caffeinate_prefix(enabled: bool) -> list[str]:
+    """``caffeinate -i`` when it is available and wanted.
+
+    ``-i`` prevents idle SLEEP without keeping the display awake. Held
+    only for the duration of one run (it wraps the child process, so it
+    dies with it), which is what lets the laptop sleep between items
+    instead of being pinned awake by the daemon itself.
+    """
+    if not enabled or sys.platform != "darwin":
+        return []
+    binary = shutil.which("caffeinate")
+    return [binary, "-i"] if binary else []
+
+
+def subprocess_factory_runner(
+    *,
+    root_dir: Path,
+    spec_path: Path,
+    project_name: str,
+    pause_before_pr_merge: bool,
+    timeout_seconds: float,
+    caffeinate: bool = True,
+) -> RunOutcome:
+    """Run ``ks factory`` as a child process.
+
+    A subprocess rather than an in-process ``run_factory`` call for three
+    reasons: a crash or OOM in a run cannot take the daemon with it, the
+    ``.kstrl/factory.lock`` flock is released by process death whatever
+    happens, and a timeout is enforceable by killing a process tree.
+    The cost of that choice is that classification reads artifacts from
+    disk instead of holding a ``FactoryResult`` - which is also what
+    makes classification work after a crash.
+    """
+    command = [
+        *caffeinate_prefix(caffeinate),
+        sys.executable, "-m", "kstrl", "factory",
+        "--spec", str(spec_path),
+        "--project-name", project_name,
+        "--root", str(root_dir),
+        "--yes",
+        "--no-tui",
+        "--ui", "plain",
+        "--no-color",
+    ]
+    command.append(
+        "--pause-before-pr-merge" if pause_before_pr_merge
+        else "--no-pause-before-pr-merge"
+    )
+    env = dict(os.environ)
+    env["KSTRL_NO_TUI"] = "1"
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=str(root_dir),
+            env=env,
+            timeout=timeout_seconds if timeout_seconds > 0 else None,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.TimeoutExpired:
+        return RunOutcome(returncode=-9, timed_out=True)
+    except OSError as exc:
+        return RunOutcome(returncode=-1, launch_error=str(exc))
+    return RunOutcome(returncode=completed.returncode)
+
+
+# ---------------------------------------------------------------------------
+# Admission gates
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Admission:
+    """Whether the daemon may start another item right now."""
+
+    allowed: bool
+    reason: str = ""
+    #: Set when the refusal should PAUSE the queue rather than just wait.
+    pause_reason: str = ""
+    resume_after: str = ""
+
+
+def check_budget(
+    ledger: SpendLedger, config: ServeConfig, *, today: str | None = None,
+) -> Admission:
+    """The daily-budget hard stop, evaluated BEFORE admitting an item.
+
+    Checked before rather than after because after is a post-mortem: the
+    point of a cap is to not spend the money.
+    """
+    if config.daily_budget_usd <= 0:
+        return Admission(allowed=True)
+    spend = ledger.read(today)
+    if spend.spent_usd < config.daily_budget_usd:
+        return Admission(allowed=True)
+    floor = " (a FLOOR: some calls reported no cost)" if spend.lower_bound else ""
+    return Admission(
+        allowed=False,
+        reason=(
+            f"daily budget reached: ${spend.spent_usd:.2f} of "
+            f"${config.daily_budget_usd:.2f} over {spend.runs} run(s){floor}"
+        ),
+        pause_reason=(
+            f"daily budget ${config.daily_budget_usd:.2f} reached "
+            f"(${spend.spent_usd:.2f} spent{floor})"
+        ),
+        resume_after=next_local_midnight(),
+    )
+
+
+def check_cost_coverage(
+    ledger: SpendLedger, config: ServeConfig, *, today: str | None = None,
+) -> Admission:
+    """Refuse to run unattended under a budget we cannot enforce.
+
+    ``max_cost_usd`` covers only roles whose adapter reports cost, and
+    the codex adapter reports tokens and no cost. The same gap makes
+    ``daily_budget_usd`` UNENFORCEABLE rather than approximate. PR #184
+    established that the honest response is to make the gap visible
+    instead of estimating across it, so this refuses and names the
+    override rather than quietly running with a cap that does nothing.
+
+    Only fires once a run has actually reported: with no data yet there
+    is no evidence of a gap, and refusing on absence of evidence would
+    make the daemon unusable on a fresh repo.
+    """
+    if config.daily_budget_usd <= 0 or config.allow_uncovered_cost:
+        return Admission(allowed=True)
+    spend = ledger.read(today)
+    if spend.runs == 0:
+        return Admission(allowed=True)
+    if spend.spent_usd > 0 and not spend.lower_bound:
+        return Admission(allowed=True)
+    return Admission(
+        allowed=False,
+        reason=(
+            f"daily_budget_usd is set to ${config.daily_budget_usd:.2f} but "
+            f"{spend.uncovered_calls} of this day's calls reported no cost, "
+            "so the budget cannot be enforced. The unreported spend is "
+            "deliberately NOT estimated. Use a cost-reporting agent, or set "
+            "[serve] allow_uncovered_cost = true to run anyway."
+        ),
+        pause_reason="daily budget is unenforceable: no cost coverage",
+    )
+
+
+def consecutive_poison_count(queue: Queue) -> int:
+    """How many items poisoned in a row, most recent first.
+
+    Derived from the journal rather than a counter file: the journal is
+    already the audit trail, and a separate counter is one more thing
+    that can disagree with reality. Only terminal transitions count -
+    a requeue or a lease in between is not a verdict.
+    """
+    terminal = {"done", "poison"}
+    streak = 0
+    for entry in reversed(queue.journal_entries()):
+        to_state = str(entry.get("to") or "")
+        if to_state not in terminal:
+            continue
+        if to_state == "poison":
+            streak += 1
+            continue
+        break
+    return streak
+
+
+def check_poison_breaker(queue: Queue, config: ServeConfig) -> Admission:
+    """Pause everything after a run of poisoned items.
+
+    The failure this catches is systemic rather than per-item: if the
+    base branch is broken, every run fails verification, each failure is
+    a legitimate spec-level verdict, and no per-item bound ever trips.
+    Only a cross-item signal notices, and by then the queue has spent
+    once per item.
+    """
+    streak = consecutive_poison_count(queue)
+    if streak < config.max_consecutive_poison:
+        return Admission(allowed=True)
+    return Admission(
+        allowed=False,
+        reason=f"{streak} items poisoned in a row",
+        pause_reason=(
+            f"{streak} consecutive items poisoned (limit "
+            f"{config.max_consecutive_poison}); something systemic is "
+            "failing, not one bad spec"
+        ),
+    )
+
+
+def check_inbox_cap(root_dir: Path) -> Admission:
+    """Stop admitting work when the human queue is already full.
+
+    ``InboxConfig.open_item_cap`` was documented in R8.3 as "the backstop
+    R8.6 consults before admitting more queue work"; this is that
+    consultation. Producing more decisions for a human who is already
+    behind is how an inbox becomes ignored.
+    """
+    from kstrl.inbox import Inbox, InboxConfig
+
+    config = InboxConfig.load(root_dir)
+    if not config.enabled or config.open_item_cap <= 0:
+        return Admission(allowed=True)
+    box = Inbox(root_dir, config)
+    if not box.over_cap():
+        return Admission(allowed=True)
+    return Admission(
+        allowed=False,
+        reason=(
+            f"inbox has reached its open-item cap ({config.open_item_cap}); "
+            "triage before queueing more work"
+        ),
+    )
+
+
+def factory_lock_held(root_dir: Path) -> bool:
+    """Whether a factory run already owns this root.
+
+    Probed BEFORE launching rather than discovered from an exit code:
+    ``ks factory`` exits 2 both for a held lock and for an architect
+    halt on a blocker-severity spec, and those two need opposite
+    treatment. Checking here keeps exit 2 unambiguous.
+    """
+    lock_path = state_dir(root_dir) / "factory.lock"
+    if not lock_path.exists():
+        return False
+    try:
+        import fcntl
+    except ImportError:
+        return False
+    try:
+        handle = open(lock_path, "a+")
+    except OSError:
+        return False
+    try:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            return True
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        return False
+    finally:
+        handle.close()
+
+
+@contextmanager
+def serve_lock(root_dir: Path) -> Iterator[None]:
+    """The daemon singleton lock.
+
+    A THIRD lock, distinct from the queue's per-transition mutex and from
+    ``.kstrl/factory.lock``. Held for the daemon's whole lifetime, so two
+    ``ks serve`` processes cannot double-lease; the queue mutex stays
+    short-lived so ``ks queue ls`` keeps working while the daemon runs.
+    """
+    lock_path = queue_root(root_dir) / SERVE_LOCK_FILENAME
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import fcntl
+    except ImportError:
+        yield
+        return
+    handle = open(lock_path, "a+")
+    try:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise ServeLockedError(
+                f"another ks serve holds {lock_path}"
+            ) from exc
+        handle.seek(0)
+        handle.truncate()
+        handle.write(f"{os.getpid()}\n")
+        handle.flush()
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
+
+
+# ---------------------------------------------------------------------------
+# The loop
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CycleResult:
+    """What one poll cycle did. Every field is something a test asserts."""
+
+    ran_item: str = ""
+    verdict: Verdict | None = None
+    reason: str = ""
+    reaped: ReapResult = field(default_factory=ReapResult)
+    swept_staging: int = 0
+    paused: str = ""
+    skipped: str = ""
+    charged_usd: float = 0.0
+    inbox_items: tuple[str, ...] = ()
+
+
+class ServeObserver(Protocol):
+    """Where the daemon narrates. Keeps the loop free of UI concerns."""
+
+    def info(self, message: str) -> None: ...
+    def warn(self, message: str) -> None: ...
+    def err(self, message: str) -> None: ...
+
+
+@dataclass
+class _NullObserver:
+    lines: list[str] = field(default_factory=list)
+
+    def info(self, message: str) -> None:
+        self.lines.append(f"info: {message}")
+
+    def warn(self, message: str) -> None:
+        self.lines.append(f"warn: {message}")
+
+    def err(self, message: str) -> None:
+        self.lines.append(f"err: {message}")
+
+
+def _file_inbox_item(
+    root_dir: Path,
+    *,
+    kind_name: str,
+    title: str,
+    detail: str,
+    dedupe_key: str,
+    evidence: dict[str, Any],
+    run_id: str = "",
+) -> str:
+    """Record a decision for a human, never failing the caller.
+
+    An inbox write must not be able to undo a queue transition that
+    already happened, so failures here degrade to a warning. The queue
+    journal remains the authoritative record either way.
+    """
+    try:
+        from kstrl.inbox import Inbox, InboxConfig, ItemKind
+
+        config = InboxConfig.load(root_dir)
+        if not config.enabled:
+            return ""
+        box = Inbox(root_dir, config)
+        item = box.add(
+            ItemKind(kind_name),
+            title,
+            detail=detail,
+            dedupe_key=dedupe_key,
+            evidence=evidence,
+            run_id=run_id,
+        )
+        return item.id
+    except (OSError, ValueError, KeyError):
+        return ""
+
+
+def _pause_queue(
+    queue: Queue, admission: Admission, observer: ServeObserver,
+) -> str:
+    """Apply a pausing admission decision."""
+    queue.pause(
+        reason=admission.pause_reason or admission.reason,
+        actor="serve",
+        resume_after=admission.resume_after,
+    )
+    observer.warn(f"Queue paused: {admission.pause_reason or admission.reason}")
+    return admission.pause_reason or admission.reason
+
+
+def serve_cycle(
+    root_dir: Path,
+    *,
+    config: ServeConfig | None = None,
+    queue_config: QueueConfig | None = None,
+    runner: FactoryRunner | None = None,
+    observer: ServeObserver | None = None,
+    now: datetime | None = None,
+) -> CycleResult:
+    """One poll cycle: recover, gate, maybe run exactly one item.
+
+    One item per cycle on purpose. Concurrency here would mean two
+    factory runs on one repo, and ``.kstrl/factory.lock`` exists
+    precisely because that corrupts worktrees and the manifest.
+
+    Order is deliberate. Recovery comes first so a crashed predecessor's
+    work is reclaimed before anything new is admitted; every gate is
+    checked before the CLAIM, not after, because a gate evaluated after
+    the spend is a post-mortem.
+    """
+    cfg = config or ServeConfig.load(root_dir)
+    qcfg = queue_config or QueueConfig.load(root_dir)
+    obs: ServeObserver = observer or _NullObserver()
+    queue = Queue(root_dir, qcfg)
+    ledger = SpendLedger(root_dir)
+    moment = now or _utc_now()
+    result = CycleResult()
+
+    queue.ensure_dirs()
+
+    # 1. Recovery, under the mutex: staging leftovers and dead leases.
+    with queue_lock(root_dir, blocking=True):
+        result.swept_staging = queue.sweep_staging()
+        result.reaped = reap_leases(queue, now=moment)
+    if result.swept_staging:
+        obs.info(f"Swept {result.swept_staging} abandoned staging item(s)")
+    for item_id in result.reaped.requeued + result.reaped.failed_for_retry:
+        obs.warn(f"Reaped {item_id[:12]}: owner gone, requeued")
+    for item_id in result.reaped.poisoned:
+        obs.err(f"Reaped {item_id[:12]}: no attempts left, poisoned")
+        result.inbox_items += (_file_inbox_item(
+            root_dir,
+            kind_name="halted_run",
+            title=f"Queue item {item_id[:12]} poisoned after an interrupted run",
+            detail=(
+                "The run was interrupted and the item had no attempts left. "
+                "Inspect with `ks queue show` and requeue with "
+                "`ks queue retry --reset-attempts` if it should run again."
+            ),
+            dedupe_key=f"queue-poison:{item_id}",
+            evidence={"item_id": item_id, "cause": "interrupted run"},
+        ),)
+
+    # 2. An elapsed resume_after clears the pause on its own; that is what
+    #    makes the daily-budget stop self-healing rather than a weekend
+    #    of dead queue.
+    pause = queue.pause_state()
+    if pause.paused and not pause.active(moment):
+        queue.resume(actor="serve")
+        obs.info("Pause window elapsed; resuming intake")
+    elif pause.active(moment):
+        result.skipped = f"paused: {pause.reason}"
+        return result
+
+    # 3. Gates, cheapest and most consequential first.
+    for admission in (
+        check_poison_breaker(queue, cfg),
+        check_cost_coverage(ledger, cfg),
+        check_budget(ledger, cfg),
+    ):
+        if admission.allowed:
+            continue
+        if admission.pause_reason:
+            result.paused = _pause_queue(queue, admission, obs)
+            result.inbox_items += (_file_inbox_item(
+                root_dir,
+                kind_name="budget_overrun",
+                title="Continuous intake paused",
+                detail=admission.reason,
+                dedupe_key=f"serve-pause:{_local_today()}:{admission.pause_reason[:40]}",
+                evidence={"reason": admission.reason},
+            ),)
+        result.skipped = admission.reason
+        return result
+
+    inbox_gate = check_inbox_cap(root_dir)
+    if not inbox_gate.allowed:
+        obs.warn(inbox_gate.reason)
+        result.skipped = inbox_gate.reason
+        return result
+
+    if factory_lock_held(root_dir):
+        # Not a failure and not the item's fault: something else owns the
+        # repo. Wait rather than charging an attempt.
+        result.skipped = "a factory run already holds this root"
+        obs.info(result.skipped)
+        return result
+
+    # 4. Claim exactly one item.
+    with queue_lock(root_dir, blocking=True):
+        candidate = queue.next_ready(moment)
+        if candidate is None:
+            result.skipped = "nothing ready"
+            return result
+        gate = resolve_merge_gate(candidate, root_dir)
+        if gate.refusal:
+            queue.poison(
+                candidate,
+                reason=f"merge-gate conflict: {gate.refusal}",
+                actor="serve",
+            )
+            obs.err(f"{candidate.item_id[:12]}: {gate.refusal}")
+            result.inbox_items += (_file_inbox_item(
+                root_dir,
+                kind_name="merge_gate",
+                title=f"Queue item {candidate.item_id[:12]} needs a merge decision",
+                detail=gate.refusal,
+                dedupe_key=f"queue-merge-gate:{candidate.item_id}",
+                evidence={"item_id": candidate.item_id},
+            ),)
+            result.skipped = gate.refusal
+            return result
+        leased = queue.lease(candidate, actor="serve")
+
+    for note in gate.notes:
+        obs.warn(f"  {note}")
+
+    # 5. Charge the attempt, then spend. Never the other way round.
+    try:
+        with queue_lock(root_dir, blocking=True):
+            running = queue.start(leased, actor="serve")
+    except QueueBudgetExhausted as exc:
+        with queue_lock(root_dir, blocking=True):
+            queue.poison(leased, reason=str(exc), actor="serve")
+        obs.err(str(exc))
+        result.skipped = str(exc)
+        return result
+
+    result.ran_item = running.item_id
+    obs.info(
+        f"Running {running.item_id[:12]} ({running.title}) "
+        f"attempt {running.attempts}/{running.max_attempts}, "
+        f"merge gate {'on' if gate.pause_before_pr_merge else 'off'}"
+    )
+
+    run_factory_fn = runner or _default_runner(cfg)
+    spec_path = queue.spec_path(running)
+    project_name = running.project_name or _derive_project_name(running)
+    outcome = run_factory_fn(
+        root_dir=root_dir,
+        spec_path=spec_path,
+        project_name=project_name,
+        pause_before_pr_merge=gate.pause_before_pr_merge,
+        timeout_seconds=cfg.factory_timeout_seconds,
+    )
+
+    # 6. Charge the spend before deciding anything, so a classification
+    #    bug cannot also lose the accounting.
+    manifest_path = root_dir / "scripts" / "kstrl" / "manifest.json"
+    run_id = _run_id_from_manifest(manifest_path)
+    spend = read_run_spend(root_dir, run_id)
+    charged = ledger.charge(
+        spend.cost_usd,
+        lower_bound=spend.lower_bound,
+        uncovered_calls=spend.uncovered_calls,
+    )
+    result.charged_usd = spend.cost_usd
+    obs.info(
+        f"  charged ${spend.cost_usd:.2f}"
+        + (" (a floor: some calls reported no cost)" if spend.lower_bound else "")
+        + f"; today ${charged.spent_usd:.2f}"
+    )
+
+    verdict = classify_run(root_dir, run=outcome, manifest_path=manifest_path)
+    result.verdict = verdict.verdict
+    result.reason = verdict.reason
+    evidence = dict(verdict.evidence)
+    evidence.update({
+        "item_id": running.item_id,
+        "run_id": run_id,
+        "attempts": running.attempts,
+        "max_attempts": running.max_attempts,
+        "cost_usd": spend.cost_usd,
+        "cost_is_lower_bound": spend.lower_bound,
+    })
+
+    with queue_lock(root_dir, blocking=True):
+        current = queue.get(running.item_id)
+        if current is None:
+            obs.err(f"{running.item_id[:12]} vanished mid-run")
+            return result
+        if verdict.verdict is Verdict.SUCCESS:
+            queue.finish_ok(current, actor="serve")
+            obs.info(f"  {running.item_id[:12]} done")
+            return result
+
+        queue.finish_failed(current, error=verdict.reason, actor="serve")
+        failed = queue.get(running.item_id)
+        if failed is None:
+            return result
+
+        if verdict.verdict.may_retry and failed.attempts_remaining > 0:
+            delay = backoff_seconds(failed.attempts)
+            queue.requeue(
+                failed,
+                reason=f"retry: {verdict.reason}",
+                actor="serve",
+                not_before=_iso(moment + timedelta(seconds=delay)),
+            )
+            obs.warn(
+                f"  {running.item_id[:12]} retrying in {int(delay)}s "
+                f"({failed.attempts}/{failed.max_attempts} attempts used): "
+                f"{verdict.reason}"
+            )
+            return result
+
+        exhausted = (
+            f"; no attempts left ({failed.attempts}/{failed.max_attempts})"
+            if verdict.verdict.may_retry else ""
+        )
+        queue.poison(
+            failed, reason=f"{verdict.reason}{exhausted}", actor="serve",
+        )
+
+    obs.err(f"  {running.item_id[:12]} poisoned: {verdict.reason}")
+    result.inbox_items += (_file_inbox_item(
+        root_dir,
+        kind_name="halted_run",
+        title=f"Queue item {running.item_id[:12]} poisoned",
+        detail=(
+            f"{verdict.reason}\n\n"
+            f"Verdict: {verdict.verdict}. This item will NOT be retried "
+            "automatically. Inspect with `ks queue show "
+            f"{running.item_id[:12]}`."
+        ),
+        dedupe_key=f"queue-poison:{running.item_id}",
+        evidence=evidence,
+        run_id=run_id,
+    ),)
+    return result
+
+
+def _default_runner(config: ServeConfig) -> FactoryRunner:
+    """Bind the caffeinate preference into the subprocess runner."""
+
+    def runner(
+        *,
+        root_dir: Path,
+        spec_path: Path,
+        project_name: str,
+        pause_before_pr_merge: bool,
+        timeout_seconds: float,
+    ) -> RunOutcome:
+        return subprocess_factory_runner(
+            root_dir=root_dir,
+            spec_path=spec_path,
+            project_name=project_name,
+            pause_before_pr_merge=pause_before_pr_merge,
+            timeout_seconds=timeout_seconds,
+            caffeinate=config.caffeinate,
+        )
+
+    return runner
+
+
+def _derive_project_name(item: QueueItem) -> str:
+    """A factory project name for an item that did not supply one.
+
+    Derived from the item id rather than the title: the title is free
+    text from a remote issue and would become a branch name.
+    """
+    return f"queue-{item.item_id.split('-')[-1]}"
+
+
+def _run_id_from_manifest(manifest_path: Path) -> str:
+    """The run id the factory recorded, or "" if it never got that far."""
+    try:
+        raw = manifest_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    run_id = data.get("run_id")
+    return run_id if isinstance(run_id, str) else ""
+
+
+def serve(
+    root_dir: Path,
+    *,
+    once: bool = False,
+    config: ServeConfig | None = None,
+    queue_config: QueueConfig | None = None,
+    runner: FactoryRunner | None = None,
+    observer: ServeObserver | None = None,
+    max_cycles: int = 0,
+    sleeper: Any = None,
+) -> list[CycleResult]:
+    """Drain the queue, holding the daemon singleton lock.
+
+    ``once`` runs exactly one cycle - the launchd/cron fallback mode, and
+    the shape ``ks serve --once`` exposes. ``max_cycles`` bounds the loop
+    for tests; 0 means run until interrupted.
+
+    ``once`` returns BEFORE entering the loop rather than breaking out of
+    it. That is deliberate: while mutation-testing this module, an
+    injected fault in a ``break`` condition turned ``--once`` into an
+    unbounded loop that slept 60s per iteration forever. Under launchd
+    that is a job which never exits and blocks every later interval, so
+    the single-shot path should not depend on a conditional being right.
+    """
+    cfg = config or ServeConfig.load(root_dir)
+    obs: ServeObserver = observer or _NullObserver()
+    sleep = sleeper or time.sleep
+
+    def _cycle() -> CycleResult:
+        return serve_cycle(
+            root_dir,
+            config=cfg,
+            queue_config=queue_config,
+            runner=runner,
+            observer=obs,
+        )
+
+    with serve_lock(root_dir):
+        if once:
+            return [_cycle()]
+
+        results: list[CycleResult] = []
+        while True:
+            results.append(_cycle())
+            if max_cycles and len(results) >= max_cycles:
+                return results
+            sleep(cfg.poll_interval_seconds)

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -54,13 +54,15 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import signal
 import socket
 import subprocess
 import sys
 import time
-from collections.abc import Iterator
+from collections import deque
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
@@ -73,6 +75,7 @@ from kstrl.workqueue import (
     Queue,
     QueueBudgetExhausted,
     QueueConfig,
+    QueueError,
     QueueItem,
     queue_lock,
     queue_root,
@@ -81,11 +84,20 @@ from kstrl.workqueue import (
 SERVE_LOCK_FILENAME = "serve.lock"
 SPEND_FILENAME = "spend.json"
 
+#: Substrings the factory prints on each of its two exit-2 refusals.
+#: Matching output is EVIDENCE; a pre-launch lock probe is inference and
+#: races (#186 F6). Both come from kstrl/factory.py and kstrl/cli.py.
+_LOCK_REFUSAL_MARKER = "--force-lock"
+_SPEC_BLOCKER_MARKER = "Spec issues written to:"
+
 #: Retry backoff: ``base * 2 ** (attempts - 1)``, capped. Not tunable by
 #: config on purpose - the cap is a safety floor on how fast an item can
 #: consume its attempts, not a preference.
 BACKOFF_BASE_SECONDS = 60.0
 BACKOFF_CAP_SECONDS = 1800.0
+
+#: How many recent cycles an unbounded daemon keeps for diagnostics.
+RECENT_CYCLE_WINDOW = 100
 
 
 class ServeError(RuntimeError):
@@ -137,6 +149,14 @@ class RunOutcome:
     timed_out: bool = False
     #: Non-empty when the launch itself failed (binary missing, etc).
     launch_error: str = ""
+    #: Tail of the child's combined output. The factory's two exit-2
+    #: refusals are only distinguishable from what it printed (#186 F6),
+    #: so this is classification evidence rather than a log nicety.
+    output_tail: str = ""
+    #: True when the timeout path confirmed the whole process GROUP was
+    #: signalled and reaped. False means a descendant may still be alive,
+    #: which must never be treated as "the run is over" (#186 F1).
+    group_reaped: bool = False
 
 
 class FactoryRunner(Protocol):
@@ -155,6 +175,7 @@ class FactoryRunner(Protocol):
         project_name: str,
         pause_before_pr_merge: bool,
         timeout_seconds: float,
+        on_spawn: Callable[[int], None] | None = None,
     ) -> RunOutcome:
         ...
 
@@ -324,33 +345,72 @@ class ServeConfig:
 
 
 # ---------------------------------------------------------------------------
-# Daily spend ledger
+# Persistent daemon state: spend, coverage, and the poison streak
 # ---------------------------------------------------------------------------
+
+
+class ServeStateError(ServeError):
+    """The daemon's own state file could not be read.
+
+    A distinct error because every consumer must FAIL CLOSED on it.
+    Review #186 F4: the ledger previously read an unparseable file as a
+    fresh zero day, so charging $9, corrupting the file, and setting a
+    $5 budget allowed another run - and kept allowing them. The other
+    backstops do not bound that: they are per-item, and this is the only
+    queue-WIDE spend limit.
+    """
 
 
 @dataclass(frozen=True)
 class DailySpend:
     """What the queue has spent today, and how well we know it.
 
-    ``lower_bound`` is not decoration. When it is true the real spend is
-    higher than ``spent_usd`` by an amount this codebase deliberately
-    does not estimate, so the budget comparison is a comparison against
-    a floor. ``uncovered_calls`` says how many calls contributed nothing.
+    Coverage is recorded as CALL COUNTS, not inferred from whether the
+    dollar total is positive. Review #186 F9: a fully-metered run that
+    legitimately cost $0 was reported as having no cost coverage, and a
+    launch failure that metered nothing counted as a run.
+
+    ``covered_calls``/``total_calls`` make the three cases distinct:
+    full coverage (equal), partial coverage (a floor - the cap still
+    fires, just late), and ZERO coverage (the cap can never fire at all).
+    Only the third is unenforceable.
+
+    ``unmetered_phases`` names phases known to spend without reporting
+    anything. The architect is always in it for a spec-decomposed item:
+    ``decompose_spec`` calls the agent but emits no usage events at all,
+    so its spend is real and invisible (#186 F3). Naming it is the honest
+    alternative to estimating it.
     """
 
     date: str = ""
     spent_usd: float = 0.0
     runs: int = 0
-    lower_bound: bool = False
-    uncovered_calls: int = 0
+    covered_calls: int = 0
+    total_calls: int = 0
+    unmetered_phases: tuple[str, ...] = ()
+
+    @property
+    def uncovered_calls(self) -> int:
+        return max(0, self.total_calls - self.covered_calls)
+
+    @property
+    def has_any_coverage(self) -> bool:
+        """Whether ANY call reported cost. False = the cap cannot fire."""
+        return self.covered_calls > 0
+
+    @property
+    def lower_bound(self) -> bool:
+        """Whether the real spend exceeds ``spent_usd`` by an unmeasured amount."""
+        return self.uncovered_calls > 0 or bool(self.unmetered_phases)
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "date": self.date,
             "spent_usd": self.spent_usd,
             "runs": self.runs,
-            "lower_bound": self.lower_bound,
-            "uncovered_calls": self.uncovered_calls,
+            "covered_calls": self.covered_calls,
+            "total_calls": self.total_calls,
+            "unmetered_phases": list(self.unmetered_phases),
         }
 
     @classmethod
@@ -361,22 +421,74 @@ class DailySpend:
                 return 0.0
             return float(value)
 
+        raw_phases = data.get("unmetered_phases")
+        phases = tuple(
+            str(p) for p in raw_phases if isinstance(p, str)
+        ) if isinstance(raw_phases, list) else ()
         return cls(
             date=str(data.get("date") or ""),
             spent_usd=_num("spent_usd"),
             runs=int(_num("runs")),
-            lower_bound=bool(data.get("lower_bound", False)),
-            uncovered_calls=int(_num("uncovered_calls")),
+            covered_calls=int(_num("covered_calls")),
+            total_calls=int(_num("total_calls")),
+            unmetered_phases=phases,
+        )
+
+
+@dataclass(frozen=True)
+class ServeState:
+    """Everything the daemon must remember between cycles.
+
+    The poison streak lives HERE rather than being derived from the
+    queue journal. Review #186 F5: ``Queue._journal`` deliberately
+    swallows append failures and ``journal_entries`` returns ``[]`` on
+    any read error, so making the journal unreadable reported a zero
+    streak and re-allowed spending while three poisoned items sat on
+    disk. A money backstop cannot be built on narration the queue
+    explicitly permits itself to lose.
+    """
+
+    spend: DailySpend = field(default_factory=DailySpend)
+    consecutive_poison: int = 0
+    #: Set once any run has reported a cost figure. Until then a
+    #: configured budget is unenforceable and serve refuses to claim
+    #: work (#186 F8) rather than discovering it after a run.
+    cost_coverage_seen: bool = False
+    schema_version: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "spend": self.spend.to_dict(),
+            "consecutive_poison": self.consecutive_poison,
+            "cost_coverage_seen": self.cost_coverage_seen,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ServeState:
+        raw_spend = data.get("spend")
+        spend = (
+            DailySpend.from_dict(raw_spend) if isinstance(raw_spend, dict)
+            else DailySpend()
+        )
+        streak = data.get("consecutive_poison", 0)
+        return cls(
+            spend=spend,
+            consecutive_poison=(
+                streak if isinstance(streak, int) and not isinstance(streak, bool)
+                else 0
+            ),
+            cost_coverage_seen=bool(data.get("cost_coverage_seen", False)),
         )
 
 
 class SpendLedger:
-    """Append-nothing, rewrite-atomically record of today's spend.
+    """Atomic store for :class:`ServeState` under ``.kstrl/queue/``.
 
-    Deliberately NOT a journal: the only question asked of it is "how
-    much today", and a single small file keeps the pre-admission check
-    cheap enough to run before every item. The per-run detail already
-    lives in the run's own event stream.
+    Rewritten whole on every update rather than appended: the only
+    questions asked of it are "how much today", "how many poisons in a
+    row", and "has cost ever been reported", all of which must be cheap
+    enough to evaluate before every item.
     """
 
     def __init__(self, root_dir: Path) -> None:
@@ -386,67 +498,107 @@ class SpendLedger:
     def path(self) -> Path:
         return queue_root(self.root_dir) / SPEND_FILENAME
 
-    def read(self, today: str | None = None) -> DailySpend:
-        """Today's spend; a stale date reads as a fresh zero day.
+    def read_state(self, today: str | None = None) -> ServeState:
+        """Load state, rolling the spend over on a new local day.
 
-        An unreadable or malformed ledger reads as a fresh day too, which
-        is the ONE fail-open choice in this module and is called out
-        here: failing closed would mean an unparseable ledger halts the
-        queue permanently with no way for the daemon itself to recover.
-        The exposure is bounded by ``max_attempts``, the backoff, and the
-        poison breaker, and by the ledger being rewritten atomically so
-        a torn write is not a normal event.
+        Raises :class:`ServeStateError` for every read failure EXCEPT a
+        missing file, which is the genuine first-run case. Failing closed
+        here is the same correction PR #185 F7 applied to the pause
+        marker: a file we cannot parse is not evidence that spending is
+        safe.
         """
         stamp = today or _local_today()
         try:
             raw = self.path.read_text(encoding="utf-8")
-        except OSError:
-            return DailySpend(date=stamp)
+        except FileNotFoundError:
+            return ServeState(spend=DailySpend(date=stamp))
+        except OSError as exc:
+            raise ServeStateError(
+                f"cannot read the daemon spend ledger {self.path}: {exc}. "
+                "Refusing to spend against an unknown daily total; fix the "
+                "file's permissions or move it aside to start a fresh day."
+            ) from exc
         try:
             data = json.loads(raw)
-        except json.JSONDecodeError:
-            return DailySpend(date=stamp)
+        except json.JSONDecodeError as exc:
+            raise ServeStateError(
+                f"the daemon spend ledger {self.path} is malformed ({exc}). "
+                "Refusing to spend against an unknown daily total; inspect "
+                "it and move it aside to start a fresh day."
+            ) from exc
         if not isinstance(data, dict):
-            return DailySpend(date=stamp)
-        spend = DailySpend.from_dict(data)
-        if spend.date != stamp:
-            return DailySpend(date=stamp)
-        return spend
+            raise ServeStateError(
+                f"the daemon spend ledger {self.path} is not an object. "
+                "Refusing to spend against an unknown daily total."
+            )
+        state = ServeState.from_dict(data)
+        if state.spend.date != stamp:
+            # A new day resets the SPEND only. The poison streak and the
+            # coverage flag are not daily facts.
+            return replace(state, spend=DailySpend(date=stamp))
+        return state
 
-    def _write(self, spend: DailySpend) -> None:
+    def read(self, today: str | None = None) -> DailySpend:
+        """Today's spend. Raises ServeStateError like ``read_state``."""
+        return self.read_state(today).spend
+
+    def _write(self, state: ServeState) -> None:
         from kstrl.workqueue import atomic_write
 
         self.path.parent.mkdir(parents=True, exist_ok=True)
         atomic_write(
             self.path,
-            json.dumps(spend.to_dict(), indent=2, ensure_ascii=False) + "\n",
+            json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
         )
 
     def charge(
         self,
         usd: float,
         *,
-        lower_bound: bool = False,
-        uncovered_calls: int = 0,
+        covered_calls: int = 0,
+        total_calls: int = 0,
+        unmetered_phases: Sequence[str] = (),
+        metered_run: bool = True,
         today: str | None = None,
     ) -> DailySpend:
-        """Add one run's reported cost to today's total.
+        """Add one run's reported cost and coverage to today's total.
 
-        ``lower_bound`` is sticky for the day: once any run reported
-        partial cost coverage, the day's figure is a floor and stays
-        labelled as one.
+        ``metered_run=False`` records the spend without counting a run,
+        for a launch that never reached an agent (#186 F9: a launch
+        failure previously incremented ``runs`` and then tripped the
+        coverage gate on the next cycle).
         """
         stamp = today or _local_today()
-        current = self.read(stamp)
-        updated = DailySpend(
+        state = self.read_state(stamp)
+        current = state.spend
+        merged_phases = tuple(sorted(
+            set(current.unmetered_phases) | {p for p in unmetered_phases if p}
+        ))
+        spend = DailySpend(
             date=stamp,
             spent_usd=round(current.spent_usd + max(0.0, usd), 6),
-            runs=current.runs + 1,
-            lower_bound=current.lower_bound or lower_bound,
-            uncovered_calls=current.uncovered_calls + max(0, uncovered_calls),
+            runs=current.runs + (1 if metered_run else 0),
+            covered_calls=current.covered_calls + max(0, covered_calls),
+            total_calls=current.total_calls + max(0, total_calls),
+            unmetered_phases=merged_phases,
         )
-        self._write(updated)
-        return updated
+        self._write(replace(
+            state,
+            spend=spend,
+            cost_coverage_seen=state.cost_coverage_seen or covered_calls > 0,
+        ))
+        return spend
+
+    def record_terminal(self, *, poisoned: bool, today: str | None = None) -> int:
+        """Update the authoritative poison streak; returns the new value."""
+        state = self.read_state(today)
+        streak = state.consecutive_poison + 1 if poisoned else 0
+        self._write(replace(state, consecutive_poison=streak))
+        return streak
+
+    def reset_poison_streak(self, today: str | None = None) -> None:
+        state = self.read_state(today)
+        self._write(replace(state, consecutive_poison=0))
 
 
 @dataclass(frozen=True)
@@ -454,19 +606,30 @@ class RunSpend:
     """One run's cost as read back from its event stream."""
 
     cost_usd: float = 0.0
-    lower_bound: bool = False
-    uncovered_calls: int = 0
     cost_calls: int = 0
     usage_calls: int = 0
 
+    @property
+    def uncovered_calls(self) -> int:
+        return max(0, self.usage_calls - self.cost_calls)
+
+    @property
+    def lower_bound(self) -> bool:
+        return self.uncovered_calls > 0
+
 
 def read_run_spend(root_dir: Path, run_id: str) -> RunSpend:
-    """Reported cost of one run, with its coverage.
+    """Reported cost of ONE named run, with its coverage.
 
-    Reads through ``kstrl.reducer`` rather than re-parsing the journals,
-    so the daemon's cost figure is the same number the dashboard shows
-    and the per-axis coverage flags (R8/PR #184) come along for free.
+    ``run_id`` must be non-empty and owned by the invocation being
+    charged. Review #186 F2: an empty id made ``load_run_state`` fall
+    back to the NEWEST run on disk, so a failed invocation charged a
+    previous run's spend and could be classified from a stale manifest.
+    An empty id now returns zeros instead of silently reading someone
+    else's run.
     """
+    if not run_id:
+        return RunSpend()
     from kstrl.reducer import load_run_state
 
     try:
@@ -475,11 +638,27 @@ def read_run_spend(root_dir: Path, run_id: str) -> RunSpend:
         return RunSpend()
     return RunSpend(
         cost_usd=state.cost_usd,
-        lower_bound=state.cost_is_lower_bound,
-        uncovered_calls=max(0, state.usage_calls - state.cost_calls),
         cost_calls=state.cost_calls,
         usage_calls=state.usage_calls,
     )
+
+
+def run_dir_names(root_dir: Path) -> frozenset[str]:
+    """Names of every run directory currently on disk.
+
+    Snapshotted before and after a launch so the daemon charges only the
+    runs THIS invocation created (#186 F2). It also picks up a
+    decompose-kind run dir when one exists, which is the only way the
+    architect phase could ever be charged without changing the
+    architect's own instrumentation (#186 F3).
+    """
+    runs_root = state_dir(root_dir) / "runs"
+    try:
+        return frozenset(
+            entry.name for entry in runs_root.iterdir() if entry.is_dir()
+        )
+    except OSError:
+        return frozenset()
 
 
 # ---------------------------------------------------------------------------
@@ -503,7 +682,7 @@ def classify_run(
     root_dir: Path,
     *,
     run: RunOutcome,
-    manifest_path: Path,
+    manifest_path: Path | None,
 ) -> Outcome:
     """Decide what a finished factory run means for its queue item.
 
@@ -546,19 +725,52 @@ def classify_run(
         )
 
     if run.returncode == 2:
-        # The factory's own "refused to proceed" code. With the run lock
-        # probed before launch and --spec always supplied, the reachable
-        # cause here is the architect halting on a blocker-severity spec
-        # issue - a SPEC failure, and retrying it would re-run the same
-        # architect against the same words.
+        # The factory's own "refused to proceed" code, which covers BOTH
+        # an architect halt on a blocker-severity spec issue and refusal
+        # because another run holds .kstrl/factory.lock. Those need
+        # opposite treatment, and a pre-launch lock probe cannot tell
+        # them apart: the probe releases the lock, so a manual factory
+        # can take it in the gap before our child does (#186 F6, a real
+        # TOCTOU on exactly the distinction this branch relies on).
+        #
+        # So decide from the child's own output, which is evidence, not
+        # inference - and stay UNCLASSIFIABLE when neither marker is
+        # present rather than guessing.
+        tail = run.output_tail
+        if _LOCK_REFUSAL_MARKER in tail:
+            return Outcome(
+                Verdict.RETRY_INFRA,
+                "factory exited 2 because another run held the run lock; "
+                "contention is infrastructural",
+                {"returncode": 2, "cause": "lock_contention"},
+            )
+        if _SPEC_BLOCKER_MARKER in tail:
+            return Outcome(
+                Verdict.SPEC_FAILURE,
+                "factory exited 2: the architect halted on a blocker-severity "
+                "spec issue; the spec needs a human",
+                {"returncode": 2, "cause": "spec_blocker"},
+            )
         return Outcome(
-            Verdict.SPEC_FAILURE,
-            "factory exited 2: the architect halted on a blocker-severity "
-            "spec issue; the spec needs a human",
-            {"returncode": 2},
+            Verdict.UNCLASSIFIABLE,
+            "factory exited 2 but its output named neither a spec blocker "
+            "nor lock contention; refusing to guess which refusal it was",
+            {"returncode": 2, "output_tail": tail[-500:]},
         )
 
-    # Everything else needs the manifest to say something specific.
+    # Everything else needs the manifest to say something specific - and
+    # it must be a manifest THIS invocation wrote. ``None`` means the run
+    # produced no owned artifacts, so there is nothing to read and the
+    # honest verdict is unclassifiable (#186 F2: an empty run id used to
+    # fall back to the newest run on disk).
+    if manifest_path is None:
+        return Outcome(
+            Verdict.UNCLASSIFIABLE,
+            f"exit {run.returncode} and this invocation produced no run "
+            "artifacts of its own; refusing to classify from another run\u2019s "
+            "manifest",
+            {"returncode": run.returncode},
+        )
     from kstrl.manifest import Manifest
 
     try:
@@ -836,17 +1048,33 @@ def subprocess_factory_runner(
     project_name: str,
     pause_before_pr_merge: bool,
     timeout_seconds: float,
+    on_spawn: Callable[[int], None] | None = None,
     caffeinate: bool = True,
 ) -> RunOutcome:
-    """Run ``ks factory`` as a child process.
+    """Run ``ks factory`` as a supervised child process GROUP.
 
     A subprocess rather than an in-process ``run_factory`` call for three
     reasons: a crash or OOM in a run cannot take the daemon with it, the
     ``.kstrl/factory.lock`` flock is released by process death whatever
-    happens, and a timeout is enforceable by killing a process tree.
-    The cost of that choice is that classification reads artifacts from
-    disk instead of holding a ``FactoryResult`` - which is also what
-    makes classification work after a crash.
+    happens, and a timeout is enforceable. The cost of that choice is
+    that classification reads artifacts from disk instead of holding a
+    ``FactoryResult`` - which is also what makes classification work
+    after a crash.
+
+    **Why a process group and not ``subprocess.run(timeout=...)``.**
+    That helper signals only its DIRECT child. On macOS the direct child
+    is the ``caffeinate`` wrapper, so the factory itself is a grandchild
+    and outlived the timeout while this code recorded an infrastructure
+    failure and requeued the item - two factories on one repo, which is
+    exactly what ``factory.lock`` exists to prevent (#186 F1, reproduced:
+    descendants were still running after ``TimeoutExpired``). So:
+    ``start_new_session=True`` puts the child in its own process group,
+    and the timeout path signals the GROUP and waits for it.
+
+    ``on_spawn`` receives the child's pid so the caller can make it the
+    lease owner. Without that the lease records the DAEMON's pid, and a
+    successor daemon would see the daemon gone, judge the lease dead, and
+    requeue a run that is still executing.
     """
     command = [
         *caffeinate_prefix(caffeinate),
@@ -865,21 +1093,168 @@ def subprocess_factory_runner(
     )
     env = dict(os.environ)
     env["KSTRL_NO_TUI"] = "1"
+
+    return run_supervised(
+        command,
+        cwd=root_dir,
+        env=env,
+        timeout_seconds=timeout_seconds,
+        on_spawn=on_spawn,
+    )
+
+
+def run_supervised(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    timeout_seconds: float = 0.0,
+    on_spawn: Callable[[int], None] | None = None,
+) -> RunOutcome:
+    """Run ``command`` in its own process group, enforcing a deadline.
+
+    Split out of :func:`subprocess_factory_runner` so the supervision -
+    the money-critical half - is testable without spawning a factory. The
+    runner above only builds the argv.
+    """
     try:
-        completed = subprocess.run(
+        process = subprocess.Popen(
             command,
-            cwd=str(root_dir),
+            cwd=str(cwd),
             env=env,
-            timeout=timeout_seconds if timeout_seconds > 0 else None,
-            check=False,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             text=True,
+            # The whole point: an own session/group so descendants are
+            # signallable together.
+            start_new_session=True,
         )
-    except subprocess.TimeoutExpired:
-        return RunOutcome(returncode=-9, timed_out=True)
     except OSError as exc:
         return RunOutcome(returncode=-1, launch_error=str(exc))
-    return RunOutcome(returncode=completed.returncode)
+
+    # Captured now, while the child is certainly alive: after it is
+    # reaped the pgid is unrecoverable (#186 F1).
+    try:
+        pgid: int | None = _safe_pgid(process)
+    except OSError:
+        pgid = None
+
+    if on_spawn is not None:
+        on_spawn(process.pid)
+
+    try:
+        output, _ = process.communicate(
+            timeout=timeout_seconds if timeout_seconds > 0 else None,
+        )
+        return RunOutcome(
+            returncode=process.returncode,
+            output_tail=_tail(output),
+        )
+    except subprocess.TimeoutExpired:
+        reaped = terminate_process_group(process, pgid)
+        try:
+            output, _ = process.communicate(timeout=10)
+        except (subprocess.TimeoutExpired, ValueError, OSError):
+            output = ""
+        return RunOutcome(
+            returncode=(
+                process.returncode if process.returncode is not None else -9
+            ),
+            timed_out=True,
+            output_tail=_tail(output),
+            group_reaped=reaped,
+        )
+
+
+#: How much of a child's output to keep. Enough for the exit-2 markers
+#: and a human-readable tail, not enough to hold a whole factory log.
+OUTPUT_TAIL_CHARS = 8000
+
+
+def _tail(output: str | None) -> str:
+    if not output:
+        return ""
+    return output[-OUTPUT_TAIL_CHARS:]
+
+
+#: Grace period between SIGTERM and SIGKILL for a run's process group.
+GROUP_TERM_GRACE_SECONDS = 15.0
+
+
+def terminate_process_group(
+    process: subprocess.Popen[str], pgid: int | None = None,
+) -> bool:
+    """SIGTERM then SIGKILL a child's whole process group; True if reaped.
+
+    Returns False when the group could not be confirmed gone, so a
+    caller never reports a timed-out run as finished while a factory may
+    still be writing to the repo (#186 F1).
+
+    ``pgid`` should be captured at SPAWN time. Looking it up here fails
+    once the direct child has been reaped - and that is precisely the
+    case where descendants may still be alive, so deriving it lazily
+    would report "reaped" for the one situation this function exists to
+    detect. Caught by the test that kills only the direct child.
+    """
+    if pgid is None:
+        try:
+            pgid = _safe_pgid(process)
+        except (ProcessLookupError, OSError):
+            pgid = None
+    if pgid is None:
+        # No group to signal and no id to check: the most we can honestly
+        # say is whether the direct child is gone.
+        return process.poll() is not None
+
+    for sig, wait in (
+        (signal.SIGTERM, GROUP_TERM_GRACE_SECONDS), (signal.SIGKILL, 10.0),
+    ):
+        try:
+            os.killpg(pgid, sig)
+        except ProcessLookupError:
+            return True
+        except OSError:
+            return False
+        try:
+            process.wait(timeout=wait)
+        except subprocess.TimeoutExpired:
+            continue
+        # The direct child is gone; confirm the group is too.
+        return not process_group_alive(pgid)
+    return not process_group_alive(pgid)
+
+
+def _safe_pgid(process: subprocess.Popen[str]) -> int | None:
+    """The child's process-group id, or None when it is not safe to signal.
+
+    The guards are load-bearing and are the same ones
+    ``verify._signal_process_group`` documents: a mocked ``Popen``'s pid
+    coerces to 1 via ``MagicMock.__index__``, and ``killpg(1, sig)`` is
+    ``kill(-1, sig)`` - signal every process this user owns. With
+    ``start_new_session=True`` the child leads its own group, so a pgid at
+    or below 1, or equal to ours, means something is wrong and the group
+    kill must not proceed.
+    """
+    pid = process.pid
+    if not isinstance(pid, int) or pid <= 1 or not hasattr(os, "killpg"):
+        return None
+    pgid = os.getpgid(pid)
+    if pgid <= 1 or pgid == os.getpgrp():
+        return None
+    return pgid
+
+
+def process_group_alive(pgid: int) -> bool:
+    """Whether any process remains in ``pgid``."""
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -905,13 +1280,18 @@ def check_budget(
 
     Checked before rather than after because after is a post-mortem: the
     point of a cap is to not spend the money.
+
+    The cap is a LOWER-BOUND cap whenever coverage is partial: it fires
+    at or after the threshold, never before. That is a real safety
+    property but not an exact one, and the reason string says so rather
+    than presenting a floor as a measurement.
     """
     if config.daily_budget_usd <= 0:
         return Admission(allowed=True)
     spend = ledger.read(today)
     if spend.spent_usd < config.daily_budget_usd:
         return Admission(allowed=True)
-    floor = " (a FLOOR: some calls reported no cost)" if spend.lower_bound else ""
+    floor = _floor_note(spend)
     return Admission(
         allowed=False,
         reason=(
@@ -926,64 +1306,72 @@ def check_budget(
     )
 
 
+def _floor_note(spend: DailySpend) -> str:
+    """Say out loud when a total is a floor, and why."""
+    if not spend.lower_bound:
+        return ""
+    parts: list[str] = []
+    if spend.uncovered_calls:
+        parts.append(f"{spend.uncovered_calls} call(s) reported no cost")
+    if spend.unmetered_phases:
+        parts.append("unmetered: " + ", ".join(spend.unmetered_phases))
+    return f" (a FLOOR: {'; '.join(parts)})"
+
+
 def check_cost_coverage(
     ledger: SpendLedger, config: ServeConfig, *, today: str | None = None,
 ) -> Admission:
-    """Refuse to run unattended under a budget we cannot enforce.
+    """Refuse to run under a budget that can never fire.
 
-    ``max_cost_usd`` covers only roles whose adapter reports cost, and
-    the codex adapter reports tokens and no cost. The same gap makes
-    ``daily_budget_usd`` UNENFORCEABLE rather than approximate. PR #184
-    established that the honest response is to make the gap visible
-    instead of estimating across it, so this refuses and names the
-    override rather than quietly running with a cap that does nothing.
+    Three cases, and only the third is unenforceable:
 
-    Only fires once a run has actually reported: with no data yet there
-    is no evidence of a gap, and refusing on absence of evidence would
-    make the daemon unusable on a fresh repo.
+    - full coverage: the cap is exact.
+    - PARTIAL coverage: the cap is a lower-bound cap. It still fires,
+      just later than the threshold. Allowed, and labelled a floor
+      everywhere it is reported.
+    - ZERO coverage: no call has ever reported a cost figure, so the
+      total stays at $0 forever and the cap can never fire. Refused.
+
+    The distinction is drawn from CALL COUNTS, not from whether the
+    dollar total is positive: a fully-metered run that legitimately cost
+    $0 has perfect coverage (#186 F9).
+
+    Evaluated before the first claim using the persisted
+    ``cost_coverage_seen`` flag, so an unenforceable budget is caught
+    without spending a run to discover it (#186 F8).
     """
     if config.daily_budget_usd <= 0 or config.allow_uncovered_cost:
         return Admission(allowed=True)
-    spend = ledger.read(today)
-    if spend.runs == 0:
-        return Admission(allowed=True)
-    if spend.spent_usd > 0 and not spend.lower_bound:
+    state = ledger.read_state(today)
+    if state.cost_coverage_seen:
         return Admission(allowed=True)
     return Admission(
         allowed=False,
         reason=(
-            f"daily_budget_usd is set to ${config.daily_budget_usd:.2f} but "
-            f"{spend.uncovered_calls} of this day's calls reported no cost, "
-            "so the budget cannot be enforced. The unreported spend is "
-            "deliberately NOT estimated. Use a cost-reporting agent, or set "
-            "[serve] allow_uncovered_cost = true to run anyway."
+            f"daily_budget_usd is ${config.daily_budget_usd:.2f} but no call "
+            "has ever reported a cost figure on this repo, so the cap can "
+            "never fire. The unreported spend is deliberately NOT estimated. "
+            "Use a cost-reporting agent (the codex adapter reports tokens and "
+            "no cost), or set [serve] allow_uncovered_cost = true to accept an "
+            "unenforceable budget."
         ),
         pause_reason="daily budget is unenforceable: no cost coverage",
     )
 
 
-def consecutive_poison_count(queue: Queue) -> int:
-    """How many items poisoned in a row, most recent first.
+def consecutive_poison_count(ledger: SpendLedger) -> int:
+    """Poisons in a row, from the daemon's authoritative state.
 
-    Derived from the journal rather than a counter file: the journal is
-    already the audit trail, and a separate counter is one more thing
-    that can disagree with reality. Only terminal transitions count -
-    a requeue or a lease in between is not a verdict.
+    Read from :class:`ServeState`, not from the queue journal. The
+    journal is best-effort by design (``Queue._journal`` swallows append
+    failures; ``journal_entries`` returns ``[]`` on any read error), so
+    deriving a spend backstop from it meant an unreadable journal
+    reported a zero streak and re-allowed spending (#186 F5).
     """
-    terminal = {"done", "poison"}
-    streak = 0
-    for entry in reversed(queue.journal_entries()):
-        to_state = str(entry.get("to") or "")
-        if to_state not in terminal:
-            continue
-        if to_state == "poison":
-            streak += 1
-            continue
-        break
-    return streak
+    return ledger.read_state().consecutive_poison
 
 
-def check_poison_breaker(queue: Queue, config: ServeConfig) -> Admission:
+def check_poison_breaker(ledger: SpendLedger, config: ServeConfig) -> Admission:
     """Pause everything after a run of poisoned items.
 
     The failure this catches is systemic rather than per-item: if the
@@ -992,7 +1380,7 @@ def check_poison_breaker(queue: Queue, config: ServeConfig) -> Admission:
     Only a cross-item signal notices, and by then the queue has spent
     once per item.
     """
-    streak = consecutive_poison_count(queue)
+    streak = consecutive_poison_count(ledger)
     if streak < config.max_consecutive_poison:
         return Admission(allowed=True)
     return Admission(
@@ -1049,7 +1437,9 @@ def factory_lock_held(root_dir: Path) -> bool:
     try:
         handle = open(lock_path, "a+")
     except OSError:
-        return False
+        # Fail CLOSED: an unopenable lock file is not evidence that no
+        # run owns this root (#186 F6).
+        return True
     try:
         try:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -1109,6 +1499,13 @@ class CycleResult:
     ran_item: str = ""
     verdict: Verdict | None = None
     reason: str = ""
+    #: An item ended in a state only a human can move. Set on EVERY
+    #: poison and refusal path, including the reaper's and the merge-gate
+    #: refusal, neither of which sets ``ran_item``. Review #186 F10: the
+    #: CLI derived its exit status from ``Verdict.may_retry``, which
+    #: stays true for an infra verdict whose last attempt was spent, so
+    #: `ks serve --once` exited 0 on a poisoned item.
+    needs_human: bool = False
     reaped: ReapResult = field(default_factory=ReapResult)
     swept_staging: int = 0
     paused: str = ""
@@ -1176,14 +1573,23 @@ def _file_inbox_item(
 
 
 def _pause_queue(
-    queue: Queue, admission: Admission, observer: ServeObserver,
+    queue: Queue,
+    admission: Admission,
+    observer: ServeObserver,
+    root_dir: Path,
 ) -> str:
-    """Apply a pausing admission decision."""
-    queue.pause(
-        reason=admission.pause_reason or admission.reason,
-        actor="serve",
-        resume_after=admission.resume_after,
-    )
+    """Apply a pausing admission decision, under the queue mutex.
+
+    Taken under the lock for the same reason the elapsed-pause clear is
+    (#186 F7): a pause write that races an operator\u2019s write can lose one
+    of them, and losing the operator\u2019s is the dangerous direction.
+    """
+    with queue_lock(root_dir, blocking=True):
+        queue.pause(
+            reason=admission.pause_reason or admission.reason,
+            actor="serve",
+            resume_after=admission.resume_after,
+        )
     observer.warn(f"Queue paused: {admission.pause_reason or admission.reason}")
     return admission.pause_reason or admission.reason
 
@@ -1218,16 +1624,38 @@ def serve_cycle(
 
     queue.ensure_dirs()
 
+    # The daemon's own state is consulted by three gates. If it cannot be
+    # read, none of them can be evaluated, so stop before claiming
+    # anything (#186 F4/F5) rather than proceeding with unknown totals.
+    try:
+        ledger.read_state()
+    except ServeStateError as exc:
+        result.skipped = str(exc)
+        result.needs_human = True
+        obs.err(str(exc))
+        result.inbox_items += (_file_inbox_item(
+            root_dir,
+            kind_name="budget_overrun",
+            title="Continuous intake halted: unreadable spend ledger",
+            detail=str(exc),
+            dedupe_key=f"serve-ledger:{ledger.path}",
+            evidence={"path": str(ledger.path)},
+        ),)
+        return result
+
     # 1. Recovery, under the mutex: staging leftovers and dead leases.
     with queue_lock(root_dir, blocking=True):
         result.swept_staging = queue.sweep_staging()
         result.reaped = reap_leases(queue, now=moment)
+        for _item_id in result.reaped.poisoned:
+            ledger.record_terminal(poisoned=True)
     if result.swept_staging:
         obs.info(f"Swept {result.swept_staging} abandoned staging item(s)")
     for item_id in result.reaped.requeued + result.reaped.failed_for_retry:
         obs.warn(f"Reaped {item_id[:12]}: owner gone, requeued")
     for item_id in result.reaped.poisoned:
         obs.err(f"Reaped {item_id[:12]}: no attempts left, poisoned")
+        result.needs_human = True
         result.inbox_items += (_file_inbox_item(
             root_dir,
             kind_name="halted_run",
@@ -1241,33 +1669,52 @@ def serve_cycle(
             evidence={"item_id": item_id, "cause": "interrupted run"},
         ),)
 
-    # 2. An elapsed resume_after clears the pause on its own; that is what
-    #    makes the daily-budget stop self-healing rather than a weekend
-    #    of dead queue.
-    pause = queue.pause_state()
-    if pause.paused and not pause.active(moment):
-        queue.resume(actor="serve")
+    # 2. The pause marker is read AND cleared under the mutex, re-reading
+    #    inside it. Review #186 F7: read and clear outside the lock let an
+    #    operator's fresh emergency pause be overwritten by the daemon
+    #    clearing a previously-expired budget pause, after which the queue
+    #    started work the operator had just stopped.
+    with queue_lock(root_dir, blocking=True):
+        pause = queue.pause_state()
+        if pause.paused and not pause.active(moment):
+            queue.resume(actor="serve")
+            pause = queue.pause_state()
+            cleared = True
+        else:
+            cleared = False
+    if cleared:
         obs.info("Pause window elapsed; resuming intake")
-    elif pause.active(moment):
+    if pause.active(moment):
         result.skipped = f"paused: {pause.reason}"
         return result
 
-    # 3. Gates, cheapest and most consequential first.
-    for admission in (
-        check_poison_breaker(queue, cfg),
-        check_cost_coverage(ledger, cfg),
-        check_budget(ledger, cfg),
-    ):
+    # 3. Gates, all evaluated BEFORE the claim.
+    try:
+        gates = (
+            check_poison_breaker(ledger, cfg),
+            check_cost_coverage(ledger, cfg),
+            check_budget(ledger, cfg),
+        )
+    except ServeStateError as exc:
+        result.skipped = str(exc)
+        result.needs_human = True
+        obs.err(str(exc))
+        return result
+
+    for admission in gates:
         if admission.allowed:
             continue
         if admission.pause_reason:
-            result.paused = _pause_queue(queue, admission, obs)
+            result.paused = _pause_queue(queue, admission, obs, root_dir)
+            result.needs_human = True
             result.inbox_items += (_file_inbox_item(
                 root_dir,
                 kind_name="budget_overrun",
                 title="Continuous intake paused",
                 detail=admission.reason,
-                dedupe_key=f"serve-pause:{_local_today()}:{admission.pause_reason[:40]}",
+                dedupe_key=(
+                    f"serve-pause:{_local_today()}:{admission.pause_reason[:40]}"
+                ),
                 evidence={"reason": admission.reason},
             ),)
         result.skipped = admission.reason
@@ -1281,7 +1728,9 @@ def serve_cycle(
 
     if factory_lock_held(root_dir):
         # Not a failure and not the item's fault: something else owns the
-        # repo. Wait rather than charging an attempt.
+        # repo. Wait rather than charging an attempt. This is a courtesy
+        # check only - it cannot make exit 2 unambiguous, which is why
+        # classify_run reads the child's output instead (#186 F6).
         result.skipped = "a factory run already holds this root"
         obs.info(result.skipped)
         return result
@@ -1299,11 +1748,15 @@ def serve_cycle(
                 reason=f"merge-gate conflict: {gate.refusal}",
                 actor="serve",
             )
+            ledger.record_terminal(poisoned=True)
             obs.err(f"{candidate.item_id[:12]}: {gate.refusal}")
+            result.needs_human = True
             result.inbox_items += (_file_inbox_item(
                 root_dir,
                 kind_name="merge_gate",
-                title=f"Queue item {candidate.item_id[:12]} needs a merge decision",
+                title=(
+                    f"Queue item {candidate.item_id[:12]} needs a merge decision"
+                ),
                 detail=gate.refusal,
                 dedupe_key=f"queue-merge-gate:{candidate.item_id}",
                 evidence={"item_id": candidate.item_id},
@@ -1322,8 +1775,10 @@ def serve_cycle(
     except QueueBudgetExhausted as exc:
         with queue_lock(root_dir, blocking=True):
             queue.poison(leased, reason=str(exc), actor="serve")
+            ledger.record_terminal(poisoned=True)
         obs.err(str(exc))
         result.skipped = str(exc)
+        result.needs_human = True
         return result
 
     result.ran_item = running.item_id
@@ -1332,6 +1787,23 @@ def serve_cycle(
         f"attempt {running.attempts}/{running.max_attempts}, "
         f"merge gate {'on' if gate.pause_before_pr_merge else 'off'}"
     )
+
+    manifest_path = root_dir / "scripts" / "kstrl" / "manifest.json"
+    # Snapshot BEFORE the launch so only runs this invocation created are
+    # charged or trusted (#186 F2). Without it, an early failure charged a
+    # previous run's spend and could be classified from a stale manifest.
+    runs_before = run_dir_names(root_dir)
+
+    def _adopt(child_pid: int) -> None:
+        # The child, not the daemon, owns the lease for the duration of
+        # the run (#186 F1).
+        try:
+            with queue_lock(root_dir, blocking=True):
+                current = queue.get(running.item_id)
+                if current is not None:
+                    queue.adopt_lease(current, pid=child_pid, actor="serve")
+        except (QueueError, OSError) as exc:
+            obs.warn(f"  could not adopt the run\u2019s lease: {exc}")
 
     run_factory_fn = runner or _default_runner(cfg)
     spec_path = queue.spec_path(running)
@@ -1342,36 +1814,88 @@ def serve_cycle(
         project_name=project_name,
         pause_before_pr_merge=gate.pause_before_pr_merge,
         timeout_seconds=cfg.factory_timeout_seconds,
+        on_spawn=_adopt,
     )
+
+    if outcome.timed_out and not outcome.group_reaped:
+        # A descendant may still be running against this repo. Do NOT
+        # release the item for another attempt (#186 F1).
+        detail = (
+            "the run timed out and its process group could not be confirmed "
+            "reaped, so a factory may still be executing against this repo"
+        )
+        with queue_lock(root_dir, blocking=True):
+            current = queue.get(running.item_id)
+            if current is not None:
+                queue.poison(current, reason=detail, actor="serve")
+                ledger.record_terminal(poisoned=True)
+        obs.err(f"  {running.item_id[:12]}: {detail}")
+        result.verdict = Verdict.UNCLASSIFIABLE
+        result.reason = detail
+        result.needs_human = True
+        result.inbox_items += (_file_inbox_item(
+            root_dir,
+            kind_name="halted_run",
+            title=f"Queue item {running.item_id[:12]}: orphaned factory process",
+            detail=detail,
+            dedupe_key=f"queue-orphan:{running.item_id}",
+            evidence={"item_id": running.item_id},
+        ),)
+        return result
 
     # 6. Charge the spend before deciding anything, so a classification
-    #    bug cannot also lose the accounting.
-    manifest_path = root_dir / "scripts" / "kstrl" / "manifest.json"
-    run_id = _run_id_from_manifest(manifest_path)
-    spend = read_run_spend(root_dir, run_id)
+    #    bug cannot also lose the accounting. Only NEW run dirs count.
+    owned_runs = sorted(run_dir_names(root_dir) - runs_before)
+    total = 0.0
+    covered_calls = 0
+    total_calls = 0
+    for rid in owned_runs:
+        spend = read_run_spend(root_dir, rid)
+        total += spend.cost_usd
+        covered_calls += spend.cost_calls
+        total_calls += spend.usage_calls
+
+    # The architect always spends and never reports: decompose_spec calls
+    # the agent but emits no usage events at all, so its cost is real and
+    # invisible. Naming it keeps the day's total honestly labelled a
+    # floor instead of estimating it (#186 F3).
+    unmetered = ("architect",)
     charged = ledger.charge(
-        spend.cost_usd,
-        lower_bound=spend.lower_bound,
-        uncovered_calls=spend.uncovered_calls,
+        total,
+        covered_calls=covered_calls,
+        total_calls=total_calls,
+        unmetered_phases=unmetered,
+        metered_run=bool(owned_runs),
     )
-    result.charged_usd = spend.cost_usd
+    result.charged_usd = total
     obs.info(
-        f"  charged ${spend.cost_usd:.2f}"
-        + (" (a floor: some calls reported no cost)" if spend.lower_bound else "")
+        f"  charged ${total:.2f} over {len(owned_runs)} run dir(s)"
+        + (
+            f"; {total_calls - covered_calls} call(s) reported no cost"
+            if total_calls > covered_calls else ""
+        )
         + f"; today ${charged.spent_usd:.2f}"
+        + (" (a floor)" if charged.lower_bound else "")
     )
 
-    verdict = classify_run(root_dir, run=outcome, manifest_path=manifest_path)
+    # Classification may only read a manifest this invocation produced.
+    manifest_run_after = _run_id_from_manifest(manifest_path)
+    owns_manifest = bool(manifest_run_after) and manifest_run_after in owned_runs
+    verdict = classify_run(
+        root_dir,
+        run=outcome,
+        manifest_path=manifest_path if owns_manifest else None,
+    )
     result.verdict = verdict.verdict
     result.reason = verdict.reason
     evidence = dict(verdict.evidence)
     evidence.update({
         "item_id": running.item_id,
-        "run_id": run_id,
+        "owned_run_ids": owned_runs,
         "attempts": running.attempts,
         "max_attempts": running.max_attempts,
-        "cost_usd": spend.cost_usd,
-        "cost_is_lower_bound": spend.lower_bound,
+        "cost_usd": total,
+        "cost_is_lower_bound": charged.lower_bound,
     })
 
     with queue_lock(root_dir, blocking=True):
@@ -1381,6 +1905,7 @@ def serve_cycle(
             return result
         if verdict.verdict is Verdict.SUCCESS:
             queue.finish_ok(current, actor="serve")
+            ledger.record_terminal(poisoned=False)
             obs.info(f"  {running.item_id[:12]} done")
             return result
 
@@ -1411,7 +1936,9 @@ def serve_cycle(
         queue.poison(
             failed, reason=f"{verdict.reason}{exhausted}", actor="serve",
         )
+        ledger.record_terminal(poisoned=True)
 
+    result.needs_human = True
     obs.err(f"  {running.item_id[:12]} poisoned: {verdict.reason}")
     result.inbox_items += (_file_inbox_item(
         root_dir,
@@ -1425,7 +1952,7 @@ def serve_cycle(
         ),
         dedupe_key=f"queue-poison:{running.item_id}",
         evidence=evidence,
-        run_id=run_id,
+        run_id=owned_runs[-1] if owned_runs else "",
     ),)
     return result
 
@@ -1440,6 +1967,7 @@ def _default_runner(config: ServeConfig) -> FactoryRunner:
         project_name: str,
         pause_before_pr_merge: bool,
         timeout_seconds: float,
+        on_spawn: Callable[[int], None] | None = None,
     ) -> RunOutcome:
         return subprocess_factory_runner(
             root_dir=root_dir,
@@ -1447,6 +1975,7 @@ def _default_runner(config: ServeConfig) -> FactoryRunner:
             project_name=project_name,
             pause_before_pr_merge=pause_before_pr_merge,
             timeout_seconds=timeout_seconds,
+            on_spawn=on_spawn,
             caffeinate=config.caffeinate,
         )
 
@@ -1471,7 +2000,10 @@ def _run_id_from_manifest(manifest_path: Path) -> str:
         return ""
     if not isinstance(data, dict):
         return ""
-    run_id = data.get("run_id")
+    # "runId", not "run_id": Manifest.to_dict is camelCase on disk.
+    # Review #186 F2 - reading the snake_case key returned "" for every
+    # real manifest, which then selected the NEWEST run instead.
+    run_id = data.get("runId")
     return run_id if isinstance(run_id, str) else ""
 
 
@@ -1516,9 +2048,20 @@ def serve(
         if once:
             return [_cycle()]
 
-        results: list[CycleResult] = []
+        # A bounded window, not a growing list. Review #186 F11: the
+        # unbounded daemon path appended one CycleResult per poll forever
+        # with no consumer - the CLI catches KeyboardInterrupt outside
+        # this call and discards the value - so memory grew by
+        # construction. Bounded runs still return every result.
+        if max_cycles:
+            bounded: list[CycleResult] = []
+            while True:
+                bounded.append(_cycle())
+                if len(bounded) >= max_cycles:
+                    return bounded
+                sleep(cfg.poll_interval_seconds)
+
+        recent: deque[CycleResult] = deque(maxlen=RECENT_CYCLE_WINDOW)
         while True:
-            results.append(_cycle())
-            if max_cycles and len(results) >= max_cycles:
-                return results
+            recent.append(_cycle())
             sleep(cfg.poll_interval_seconds)

--- a/kstrl/workqueue.py
+++ b/kstrl/workqueue.py
@@ -296,11 +296,30 @@ class QueueItem:
     #: Why this item may never be retried automatically. Set only on the
     #: transition into ``poison/``.
     poison_reason: str = ""
+    #: Earliest time this item may be claimed again (retry backoff, R8.6
+    #: PR 2). Empty means "now". A payload written before this field
+    #: existed decodes to empty, i.e. immediately ready.
+    not_before: str = ""
     schema_version: int = QUEUE_SCHEMA_VERSION
 
     @property
     def attempts_remaining(self) -> int:
         return max(0, self.max_attempts - self.attempts)
+
+    def ready_at(self, now: datetime | None = None) -> bool:
+        """Whether the retry backoff has elapsed.
+
+        An UNPARSEABLE ``not_before`` counts as not-ready, the opposite of
+        the lease-expiry default: there the fail-safe direction is to
+        reclaim a stuck item, here it is to hold off spending. Both
+        choices err away from launching a run.
+        """
+        if not self.not_before:
+            return True
+        deadline = _parse_iso(self.not_before)
+        if deadline is None:
+            return False
+        return (now or _utc_now()) >= deadline
 
     @property
     def sort_key(self) -> tuple[int, str]:
@@ -343,6 +362,7 @@ class QueueItem:
             "last_error": self.last_error,
             "last_run_id": self.last_run_id,
             "poison_reason": self.poison_reason,
+            "not_before": self.not_before,
         }
 
     @classmethod
@@ -408,6 +428,7 @@ class QueueItem:
             last_error=_as_str(data, "last_error"),
             last_run_id=_as_str(data, "last_run_id"),
             poison_reason=_as_str(data, "poison_reason"),
+            not_before=_as_str(data, "not_before"),
             schema_version=_as_int(
                 data, "schema_version", QUEUE_SCHEMA_VERSION,
             ),
@@ -551,7 +572,7 @@ class JournalEntry:
         }
 
 
-def _atomic_write(target: Path, content: str) -> None:
+def atomic_write(target: Path, content: str) -> None:
     """Write ``content`` to ``target`` atomically.
 
     ``tempfile.mkstemp`` in the destination directory plus ``os.replace``
@@ -866,7 +887,7 @@ class Queue:
     # --------------------------------------------------------------- write
 
     def _write_meta(self, item: QueueItem, directory: Path) -> None:
-        _atomic_write(
+        atomic_write(
             directory / META_FILENAME,
             json.dumps(item.to_dict(), indent=2, ensure_ascii=False) + "\n",
         )
@@ -947,7 +968,7 @@ class Queue:
         staging = self.staging_path / item.item_id
         staging.mkdir(parents=True, exist_ok=False)
         try:
-            _atomic_write(staging / spec_filename, content)
+            atomic_write(staging / spec_filename, content)
             self._write_meta(item, staging)
             os.replace(str(staging), str(directory))
         except BaseException:
@@ -1110,6 +1131,7 @@ class Queue:
         reason: str = "requeued",
         actor: str = "",
         reset_attempts: bool = False,
+        not_before: str | None = None,
     ) -> QueueItem:
         """Send an item back to ``queued/``.
 
@@ -1120,9 +1142,14 @@ class Queue:
         updates: dict[str, Any] = {
             "lease_pid": 0, "lease_host": "", "lease_expires_at": "",
         }
+        if not_before is not None:
+            updates["not_before"] = not_before
         if reset_attempts:
             updates["attempts"] = 0
             updates["poison_reason"] = ""
+            # A human authorizing a fresh run should not then wait out a
+            # backoff computed for the automatic path.
+            updates["not_before"] = ""
         return self.transition(
             item, ItemState.QUEUED, reason=reason, actor=actor, **updates,
         )
@@ -1195,7 +1222,7 @@ class Queue:
             resume_after=resume_after,
         )
         self.path.mkdir(parents=True, exist_ok=True)
-        _atomic_write(
+        atomic_write(
             self.pause_path,
             json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
         )
@@ -1209,7 +1236,7 @@ class Queue:
     def resume(self, *, actor: str = "") -> PauseState:
         state = PauseState()
         self.path.mkdir(parents=True, exist_ok=True)
-        _atomic_write(
+        atomic_write(
             self.pause_path,
             json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
         )
@@ -1233,11 +1260,18 @@ class Queue:
         Returns None while paused: the pause is an admission gate, and
         checking it anywhere other than the point of claiming would let
         a racing worker slip one more run past a budget stop.
+
+        Items still inside their retry backoff are skipped rather than
+        blocking the queue behind them - a flaking item must not starve
+        the ones that would succeed.
         """
-        if self.is_paused(now):
+        moment = now or _utc_now()
+        if self.is_paused(moment):
             return None
-        ready = self.items((ItemState.QUEUED,))
-        return ready[0] if ready else None
+        for item in self.items((ItemState.QUEUED,)):
+            if item.ready_at(moment):
+                return item
+        return None
 
 
 def summarize(counts: dict[ItemState, int]) -> str:

--- a/kstrl/workqueue.py
+++ b/kstrl/workqueue.py
@@ -1090,6 +1090,51 @@ class Queue:
             charge_attempt=True, last_run_id=run_id,
         )
 
+    def adopt_lease(
+        self,
+        item: QueueItem,
+        *,
+        pid: int,
+        host: str = "",
+        actor: str = "",
+    ) -> QueueItem:
+        """Re-point a held lease at the process actually doing the work.
+
+        Not a transition: the item stays where it is and only its lease
+        fields move, so this is the one write that rewrites ``meta.json``
+        in place. Needed because ``lease``/``start`` record the DAEMON's
+        pid, while the run executes in a child process. Review #186 F1:
+        if the daemon dies and the child survives, a successor's reaper
+        sees the daemon gone, judges the lease dead, and requeues a run
+        that is still executing - two factories on one repo.
+
+        Refuses unless the item is leased or running: adopting a lease on
+        a queued item would invent one.
+        """
+        if item.state not in (ItemState.LEASED, ItemState.RUNNING):
+            raise QueueError(
+                f"cannot adopt a lease on {item.item_id} in state {item.state}"
+            )
+        import socket
+
+        directory = self.item_dir(item)
+        if not directory.is_dir():
+            raise QueueError(f"queue item {item.item_id} is not at {directory}")
+        item.lease_pid = pid
+        item.lease_host = host or socket.gethostname()
+        item.lease_expires_at = _iso(
+            _utc_now() + timedelta(seconds=self.config.lease_ttl_seconds)
+        )
+        item.updated_at = _iso(_utc_now())
+        self._write_meta(item, directory)
+        self._journal(JournalEntry(
+            ts=item.updated_at, item_id=item.item_id,
+            from_state=str(item.state), to_state=str(item.state),
+            reason="lease adopted by the run process", actor=actor,
+            attempts=item.attempts, detail={"lease_pid": pid},
+        ))
+        return item
+
     def finish_ok(self, item: QueueItem, *, actor: str = "") -> QueueItem:
         return self.transition(
             item, ItemState.DONE, reason="completed", actor=actor, last_error="",

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -133,6 +133,7 @@ def _section_specs() -> list[SectionSpec]:
     from kstrl.policy import PolicyConfig
     from kstrl.sandbox import SandboxConfig
     from kstrl.security import SecurityConfig
+    from kstrl.serve import ServeConfig
     from kstrl.timeout import TimeoutConfig
     from kstrl.verify import VerifyConfig
     from kstrl.workqueue import QueueConfig
@@ -268,6 +269,14 @@ def _section_specs() -> list[SectionSpec]:
             ]),
             lambda root: InboxConfig.load(root_dir=root),
             InboxConfig(), probe_undocumented_fields=True,
+        ),
+        SectionSpec(
+            "serve", "Continuous-intake daemon (R8.6)",
+            identity_keys(ServeConfig, [
+                f.name for f in dataclasses.fields(ServeConfig)
+            ]),
+            lambda root: ServeConfig.load(root_dir=root),
+            ServeConfig(), probe_undocumented_fields=True,
         ),
         SectionSpec(
             "queue", "Continuous intake queue (R8.6)",
@@ -455,6 +464,18 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
     ("inbox", "open_item_cap"): "open items after which queue intake pauses; 0 = unbounded",
     ("inbox", "snooze_hours"): "default snooze TTL in hours; snoozed items return",
     ("inbox", "notify_action_required"): "notify on action-required items and demotions only",
+    ("serve", "poll_interval_seconds"):
+        "seconds between poll cycles when ks serve runs as a daemon",
+    ("serve", "daily_budget_usd"):
+        "hard stop on reported spend per local day; 0 = no cap",
+    ("serve", "max_consecutive_poison"):
+        "consecutive poisoned items that pause the whole queue",
+    ("serve", "caffeinate"):
+        "hold caffeinate -i for each run so the machine cannot sleep mid-factory",
+    ("serve", "factory_timeout_seconds"):
+        "kill a factory run after this long; 0 = no timeout",
+    ("serve", "allow_uncovered_cost"):
+        "run unattended even when no adapter reports cost, making the budget unenforceable",
     ("queue", "max_attempts"):
         "execution attempts per queue item before it is poisoned",
     ("queue", "lease_ttl_seconds"):

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -31,6 +31,7 @@ from kstrl.serve import (
     ServeConfig,
     ServeError,
     ServeLockedError,
+    ServeStateError,
     SpendLedger,
     Verdict,
     backoff_seconds,
@@ -40,13 +41,24 @@ from kstrl.serve import (
     check_poison_breaker,
     classify_run,
     consecutive_poison_count,
+    factory_lock_held,
     next_local_midnight,
+    process_group_alive,
     reap_leases,
     resolve_merge_gate,
+    run_supervised,
     serve,
     serve_cycle,
     serve_lock,
+    terminate_process_group,
 )
+from kstrl.serve import _safe_pgid as _safe_pgid_of
+
+#: Captured at import, BEFORE the autouse _no_spend fixture patches
+#: kstrl.serve.read_run_spend. A test that imports the name in its body
+#: gets the stub instead of the function under test - which silently made
+#: the empty-run-id test pass no matter what the function did.
+from kstrl.serve import read_run_spend as REAL_READ_RUN_SPEND
 from kstrl.workqueue import (
     ItemSource,
     ItemState,
@@ -68,7 +80,11 @@ def _add(queue: Queue, **kwargs: object) -> object:
     return queue.add("# Spec\n\nDo the thing.\n", **kwargs)  # type: ignore[arg-type]
 
 
-def _manifest(path: Path, components: list[Component], run_id: str = "r1") -> None:
+def _manifest(
+    path: Path,
+    components: list[Component],
+    run_id: str = "factory-20260730-000000.000000-aaa",
+) -> None:
     """Write a manifest through the real Manifest.save.
 
     Built from the real dataclasses rather than hand-written JSON: an
@@ -87,6 +103,19 @@ def _manifest(path: Path, components: list[Component], run_id: str = "r1") -> No
         run_id=run_id,
     )
     manifest.save(path)
+
+
+def _make_run_dir(root: Path, run_id: str) -> Path:
+    """Create the run directory a factory invocation would leave behind.
+
+    Required because serve now charges and classifies only artifacts the
+    invocation OWNS (#186 F2): a manifest with no matching NEW run dir is
+    treated as someone else's and never read.
+    """
+    run_dir = root / ".kstrl" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "events.jsonl").touch()
+    return run_dir
 
 
 def _component(
@@ -115,7 +144,22 @@ def _spec_finding() -> Finding:
     )
 
 
-def _stub_runner(outcome: RunOutcome, calls: list[dict[str, object]] | None = None):
+def _stub_runner(
+    outcome: RunOutcome,
+    calls: list[dict[str, object]] | None = None,
+    *,
+    run_id: str = "factory-20260730-000000.000000-aaa",
+    make_run_dir: bool = True,
+    child_pid: int | None = None,
+):
+    """A factory stand-in that leaves the artifacts a real run would.
+
+    ``make_run_dir`` creates the owned run directory; turning it off
+    models a launch that died before producing anything, which serve must
+    treat as having no artifacts of its own rather than reading the
+    newest run on disk.
+    """
+
     def runner(
         *,
         root_dir: Path,
@@ -123,6 +167,7 @@ def _stub_runner(outcome: RunOutcome, calls: list[dict[str, object]] | None = No
         project_name: str,
         pause_before_pr_merge: bool,
         timeout_seconds: float,
+        on_spawn: object = None,
     ) -> RunOutcome:
         if calls is not None:
             calls.append({
@@ -131,6 +176,10 @@ def _stub_runner(outcome: RunOutcome, calls: list[dict[str, object]] | None = No
                 "pause_before_pr_merge": pause_before_pr_merge,
                 "timeout_seconds": timeout_seconds,
             })
+        if child_pid is not None and callable(on_spawn):
+            on_spawn(child_pid)
+        if make_run_dir:
+            _make_run_dir(root_dir, run_id)
         return outcome
 
     return runner
@@ -225,14 +274,62 @@ class TestClassifierRetriesOnlyWithEvidence:
         assert outcome.verdict is Verdict.UNCLASSIFIABLE
         assert "no failed component" in outcome.reason
 
-    def test_exit_two_is_a_spec_failure(self, tmp_path: Path) -> None:
+    def test_exit_two_with_a_spec_blocker_marker_is_a_spec_failure(
+        self, tmp_path: Path,
+    ) -> None:
         """The architect halted on a blocker; re-running spends the same."""
         outcome = classify_run(
-            tmp_path, run=RunOutcome(returncode=2),
+            tmp_path,
+            run=RunOutcome(
+                returncode=2,
+                output_tail="error: blockers found\nSpec issues written to: /x.md\n",
+            ),
             manifest_path=tmp_path / "m.json",
         )
         assert outcome.verdict is Verdict.SPEC_FAILURE
         assert "architect" in outcome.reason
+
+    def test_exit_two_from_lock_contention_retries(
+        self, tmp_path: Path,
+    ) -> None:
+        """#186 F6: exit 2 also means "another run holds the lock".
+
+        A pre-launch probe cannot distinguish the two - it releases the
+        lock, so a manual factory can take it in the gap. The child's own
+        output can.
+        """
+        outcome = classify_run(
+            tmp_path,
+            run=RunOutcome(
+                returncode=2,
+                output_tail="another factory run holds the lock; --force-lock\n",
+            ),
+            manifest_path=tmp_path / "m.json",
+        )
+        assert outcome.verdict is Verdict.RETRY_INFRA
+        assert outcome.evidence["cause"] == "lock_contention"
+
+    def test_exit_two_with_no_marker_is_unclassifiable(
+        self, tmp_path: Path,
+    ) -> None:
+        """Neither refusal named: refuse to guess which one it was."""
+        outcome = classify_run(
+            tmp_path,
+            run=RunOutcome(returncode=2, output_tail="something else entirely"),
+            manifest_path=tmp_path / "m.json",
+        )
+        assert outcome.verdict is Verdict.UNCLASSIFIABLE
+        assert not outcome.verdict.may_retry
+
+    def test_a_manifest_this_invocation_does_not_own_is_unclassifiable(
+        self, tmp_path: Path,
+    ) -> None:
+        """#186 F2: never classify from another run's artifacts."""
+        outcome = classify_run(
+            tmp_path, run=RunOutcome(returncode=1), manifest_path=None,
+        )
+        assert outcome.verdict is Verdict.UNCLASSIFIABLE
+        assert "no run artifacts of its own" in outcome.reason
 
     def test_a_signal_kill_retries(self, tmp_path: Path) -> None:
         """SIGKILL is evidence of an external cause, not a spec verdict."""
@@ -366,58 +463,119 @@ class TestSpendLedger:
 
     def test_charges_accumulate(self, tmp_path: Path) -> None:
         ledger = SpendLedger(tmp_path)
-        ledger.charge(1.50, today="2026-07-30")
-        spend = ledger.charge(2.25, today="2026-07-30")
+        ledger.charge(1.50, covered_calls=1, total_calls=1, today="2026-07-30")
+        spend = ledger.charge(2.25, covered_calls=1, total_calls=1, today="2026-07-30")
         assert spend.spent_usd == pytest.approx(3.75)
         assert spend.runs == 2
 
     def test_a_new_day_resets(self, tmp_path: Path) -> None:
         ledger = SpendLedger(tmp_path)
-        ledger.charge(10.0, today="2026-07-30")
+        ledger.charge(10.0, covered_calls=1, total_calls=1, today="2026-07-30")
         assert ledger.read("2026-07-31").spent_usd == 0.0
 
-    def test_lower_bound_is_sticky_for_the_day(self, tmp_path: Path) -> None:
-        """Once any run under-reported, the day's total is a floor."""
+    def test_a_floor_stays_a_floor_for_the_day(self, tmp_path: Path) -> None:
+        """Once any run under-reported, the day's total is a floor.
+
+        Derived from accumulated CALL COUNTS rather than a sticky flag, so
+        it cannot disagree with the counts it is meant to summarise.
+        """
         ledger = SpendLedger(tmp_path)
-        ledger.charge(1.0, lower_bound=True, uncovered_calls=2, today="d")
-        spend = ledger.charge(1.0, lower_bound=False, today="d")
+        ledger.charge(1.0, covered_calls=1, total_calls=3, today="d")
+        spend = ledger.charge(1.0, covered_calls=2, total_calls=2, today="d")
         assert spend.lower_bound
         assert spend.uncovered_calls == 2
+        assert spend.covered_calls == 3
+        assert spend.total_calls == 5
+
+    def test_an_unmetered_phase_makes_the_total_a_floor(
+        self, tmp_path: Path,
+    ) -> None:
+        """#186 F3: the architect spends and reports nothing at all."""
+        ledger = SpendLedger(tmp_path)
+        spend = ledger.charge(
+            1.0, covered_calls=2, total_calls=2,
+            unmetered_phases=("architect",), today="d",
+        )
+        assert spend.uncovered_calls == 0
+        assert spend.lower_bound, "an unmetered phase is unmeasured spend"
+        assert "architect" in spend.unmetered_phases
+
+    def test_a_launch_failure_is_not_counted_as_a_metered_run(
+        self, tmp_path: Path,
+    ) -> None:
+        ledger = SpendLedger(tmp_path)
+        spend = ledger.charge(0.0, metered_run=False, today="d")
+        assert spend.runs == 0
 
     def test_negative_charges_are_ignored(self, tmp_path: Path) -> None:
         ledger = SpendLedger(tmp_path)
-        assert ledger.charge(-5.0, today="d").spent_usd == 0.0
+        assert ledger.charge(-5.0, covered_calls=1, total_calls=1, today="d").spent_usd == 0.0
 
-    def test_a_corrupt_ledger_reads_as_a_fresh_day(self, tmp_path: Path) -> None:
+    def test_a_corrupt_ledger_fails_closed(self, tmp_path: Path) -> None:
+        """#186 F4: reading it as a fresh day disabled the only queue-wide cap.
+
+        Reproduced in review: charge $9, corrupt the file, set a $5
+        budget, and another run was allowed - indefinitely, because the
+        per-item backstops do not bound spend across distinct items.
+        """
         ledger = SpendLedger(tmp_path)
         ledger.path.parent.mkdir(parents=True, exist_ok=True)
         ledger.path.write_text("{not json")
-        assert ledger.read("d").spent_usd == 0.0
+        with pytest.raises(ServeStateError, match="malformed"):
+            ledger.read("d")
+
+    def test_an_unreadable_ledger_fails_closed(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(9.0, covered_calls=1, total_calls=1)
+        with patch.object(
+            Path, "read_text", side_effect=PermissionError("denied"),
+        ):
+            with pytest.raises(ServeStateError, match="cannot read"):
+                ledger.read()
+
+    def test_a_missing_ledger_is_the_first_run(self, tmp_path: Path) -> None:
+        """FileNotFoundError is the ONE read failure that is not a fault."""
+        assert SpendLedger(tmp_path).read("d").spent_usd == 0.0
+
+    def test_a_corrupt_ledger_blocks_the_budget_gate(
+        self, tmp_path: Path,
+    ) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(9.0, covered_calls=1, total_calls=1)
+        ledger.path.write_text("{corrupt")
+        with pytest.raises(ServeStateError):
+            check_budget(ledger, ServeConfig(daily_budget_usd=5.0))
 
     def test_round_trip(self) -> None:
-        spend = DailySpend("d", 1.5, 2, True, 3)
+        spend = DailySpend("d", 1.5, 2, 3, 5, ("architect",))
         assert DailySpend.from_dict(spend.to_dict()) == spend
 
     def test_non_numeric_fields_decode_to_zero(self) -> None:
         spend = DailySpend.from_dict({"date": "d", "spent_usd": "lots"})
         assert spend.spent_usd == 0.0
 
+    def test_a_legacy_payload_without_call_counts_decodes(self) -> None:
+        spend = DailySpend.from_dict({"date": "d", "spent_usd": 2.0, "runs": 1})
+        assert spend.covered_calls == 0
+        assert spend.total_calls == 0
+        assert not spend.has_any_coverage
+
 
 class TestBudgetGate:
     def test_an_unset_budget_never_blocks(self, tmp_path: Path) -> None:
         ledger = SpendLedger(tmp_path)
-        ledger.charge(1000.0, today="d")
+        ledger.charge(1000.0, covered_calls=1, total_calls=1, today="d")
         assert check_budget(ledger, ServeConfig(), today="d").allowed
 
     def test_under_budget_is_allowed(self, tmp_path: Path) -> None:
         ledger = SpendLedger(tmp_path)
-        ledger.charge(5.0, today="d")
+        ledger.charge(5.0, covered_calls=1, total_calls=1, today="d")
         config = ServeConfig(daily_budget_usd=20.0)
         assert check_budget(ledger, config, today="d").allowed
 
     def test_at_budget_blocks_and_pauses(self, tmp_path: Path) -> None:
         ledger = SpendLedger(tmp_path)
-        ledger.charge(20.0, today="d")
+        ledger.charge(20.0, covered_calls=1, total_calls=1, today="d")
         config = ServeConfig(daily_budget_usd=20.0)
         admission = check_budget(ledger, config, today="d")
         assert not admission.allowed
@@ -428,7 +586,7 @@ class TestBudgetGate:
         self, tmp_path: Path,
     ) -> None:
         ledger = SpendLedger(tmp_path)
-        ledger.charge(20.0, today="d")
+        ledger.charge(20.0, covered_calls=1, total_calls=1, today="d")
         admission = check_budget(
             ledger, ServeConfig(daily_budget_usd=20.0), today="d",
         )
@@ -441,63 +599,90 @@ class TestBudgetGate:
     ) -> None:
         """H4: the operator must not read a floor as a measurement."""
         ledger = SpendLedger(tmp_path)
-        ledger.charge(20.0, lower_bound=True, uncovered_calls=4, today="d")
+        ledger.charge(20.0, covered_calls=1, total_calls=5, today="d")
         admission = check_budget(
             ledger, ServeConfig(daily_budget_usd=20.0), today="d",
         )
         assert "FLOOR" in admission.reason
+        assert "4 call(s) reported no cost" in admission.reason
 
     def test_next_local_midnight_is_in_the_future(self) -> None:
         assert datetime.fromisoformat(next_local_midnight()) > datetime.now(UTC)
 
 
 class TestCostCoverageGate:
-    """A budget over a cost-blind adapter is UNENFORCEABLE, not approximate."""
+    """A budget over a cost-blind adapter can never fire.
+
+    Three cases, and only the third is unenforceable: full coverage (the
+    cap is exact), PARTIAL coverage (a lower-bound cap - it fires late,
+    which is still a real bound), and ZERO coverage (the total stays $0
+    forever). #186 F9: the gate used to test whether dollars were
+    positive, so a fully-metered $0 run was rejected with a false message.
+    """
 
     def test_no_budget_means_no_coverage_requirement(
         self, tmp_path: Path,
     ) -> None:
         ledger = SpendLedger(tmp_path)
-        ledger.charge(0.0, lower_bound=True, uncovered_calls=3, today="d")
+        ledger.charge(0.0, covered_calls=0, total_calls=4, today="d")
         assert check_cost_coverage(ledger, ServeConfig(), today="d").allowed
 
-    def test_a_fresh_day_with_no_runs_is_allowed(self, tmp_path: Path) -> None:
-        """Absence of evidence is not evidence of a gap."""
-        config = ServeConfig(daily_budget_usd=10.0)
-        assert check_cost_coverage(SpendLedger(tmp_path), config, today="d").allowed
-
-    def test_full_coverage_is_allowed(self, tmp_path: Path) -> None:
+    def test_a_fully_covered_zero_dollar_run_is_allowed(
+        self, tmp_path: Path,
+    ) -> None:
+        """The false-positive #186 F9 reported."""
         ledger = SpendLedger(tmp_path)
-        ledger.charge(2.0, lower_bound=False, today="d")
+        ledger.charge(0.0, covered_calls=3, total_calls=3, today="d")
         config = ServeConfig(daily_budget_usd=10.0)
         assert check_cost_coverage(ledger, config, today="d").allowed
 
-    def test_zero_reported_cost_under_a_budget_blocks(
+    def test_full_coverage_is_allowed(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(2.0, covered_calls=2, total_calls=2, today="d")
+        config = ServeConfig(daily_budget_usd=10.0)
+        assert check_cost_coverage(ledger, config, today="d").allowed
+
+    def test_partial_coverage_is_allowed_as_a_lower_bound_cap(
         self, tmp_path: Path,
     ) -> None:
+        """A cap that fires late is still a cap; it is labelled a floor."""
         ledger = SpendLedger(tmp_path)
-        ledger.charge(0.0, lower_bound=True, uncovered_calls=6, today="d")
+        ledger.charge(2.0, covered_calls=1, total_calls=5, today="d")
+        config = ServeConfig(daily_budget_usd=10.0)
+        assert check_cost_coverage(ledger, config, today="d").allowed
+        assert ledger.read("d").lower_bound
+
+    def test_zero_coverage_blocks_BEFORE_the_first_run(
+        self, tmp_path: Path,
+    ) -> None:
+        """#186 F8: this used to be discovered only after a run had spent."""
+        ledger = SpendLedger(tmp_path)
         config = ServeConfig(daily_budget_usd=10.0)
         admission = check_cost_coverage(ledger, config, today="d")
         assert not admission.allowed
-        assert "cannot be enforced" in admission.reason
+        assert "can never fire" in admission.reason
+
+    def test_coverage_once_seen_persists(self, tmp_path: Path) -> None:
+        """The flag is not a daily fact; capability does not reset nightly."""
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(1.0, covered_calls=1, total_calls=1, today="2026-07-30")
+        config = ServeConfig(daily_budget_usd=10.0)
+        assert check_cost_coverage(ledger, config, today="2026-07-31").allowed
 
     def test_the_reason_does_not_estimate_the_missing_spend(
         self, tmp_path: Path,
     ) -> None:
         """Never convert unreported calls into a dollar figure (H4)."""
-        ledger = SpendLedger(tmp_path)
-        ledger.charge(0.0, lower_bound=True, uncovered_calls=6, today="d")
         admission = check_cost_coverage(
-            ledger, ServeConfig(daily_budget_usd=10.0), today="d",
+            SpendLedger(tmp_path), ServeConfig(daily_budget_usd=10.0), today="d",
         )
         assert "NOT estimated" in admission.reason
 
     def test_the_override_is_explicit(self, tmp_path: Path) -> None:
-        ledger = SpendLedger(tmp_path)
-        ledger.charge(0.0, lower_bound=True, uncovered_calls=6, today="d")
         config = ServeConfig(daily_budget_usd=10.0, allow_uncovered_cost=True)
-        assert check_cost_coverage(ledger, config, today="d").allowed
+        assert check_cost_coverage(
+            SpendLedger(tmp_path), config, today="d",
+        ).allowed
 
 
 # --------------------------------------------------------------------------
@@ -506,59 +691,90 @@ class TestCostCoverageGate:
 
 
 class TestPoisonBreaker:
+    """#186 F5: the streak is authoritative state, not journal narration."""
+
     def test_no_poison_no_streak(self, tmp_path: Path) -> None:
-        queue = _queue(tmp_path)
-        queue.finish_ok(queue.start(queue.lease(_add(queue))))  # type: ignore[arg-type]
-        assert consecutive_poison_count(queue) == 0
+        ledger = SpendLedger(tmp_path)
+        ledger.record_terminal(poisoned=False)
+        assert consecutive_poison_count(ledger) == 0
 
     def test_counts_a_trailing_run_of_poison(self, tmp_path: Path) -> None:
-        queue = _queue(tmp_path)
+        ledger = SpendLedger(tmp_path)
         for _ in range(3):
-            queue.poison(_add(queue), reason="bad spec")  # type: ignore[arg-type]
-        assert consecutive_poison_count(queue) == 3
+            ledger.record_terminal(poisoned=True)
+        assert consecutive_poison_count(ledger) == 3
 
     def test_a_success_resets_the_streak(self, tmp_path: Path) -> None:
-        queue = _queue(tmp_path)
-        queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
-        queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
-        queue.finish_ok(queue.start(queue.lease(_add(queue))))  # type: ignore[arg-type]
-        assert consecutive_poison_count(queue) == 0
+        ledger = SpendLedger(tmp_path)
+        ledger.record_terminal(poisoned=True)
+        ledger.record_terminal(poisoned=True)
+        ledger.record_terminal(poisoned=False)
+        assert consecutive_poison_count(ledger) == 0
 
-    def test_non_terminal_transitions_do_not_break_the_streak(
+    def test_the_streak_survives_losing_the_journal(
         self, tmp_path: Path,
     ) -> None:
-        """A lease between two poisons is not a verdict."""
-        queue = _queue(tmp_path)
-        queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
-        queue.lease(_add(queue))  # type: ignore[arg-type]
-        queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
-        assert consecutive_poison_count(queue) == 2
+        """The whole reason it moved off the journal.
 
-    def test_the_breaker_blocks_at_the_limit(self, tmp_path: Path) -> None:
+        Queue._journal swallows append failures and journal_entries
+        returns [] on any read error, so a streak derived from it read as
+        zero and re-allowed spending while poisoned items sat on disk.
+        """
         queue = _queue(tmp_path)
+        ledger = SpendLedger(tmp_path)
         for _ in range(3):
             queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
-        admission = check_poison_breaker(queue, ServeConfig(max_consecutive_poison=3))
+            ledger.record_terminal(poisoned=True)
+
+        queue.journal_path.write_text("")
+        assert consecutive_poison_count(ledger) == 3
+        assert not check_poison_breaker(
+            ledger, ServeConfig(max_consecutive_poison=3),
+        ).allowed
+
+    def test_the_streak_survives_a_new_day(self, tmp_path: Path) -> None:
+        """A poison streak is not a daily fact; the spend is."""
+        ledger = SpendLedger(tmp_path)
+        for _ in range(2):
+            ledger.record_terminal(poisoned=True)
+        ledger.charge(1.0, covered_calls=1, total_calls=1, today="2026-07-30")
+        assert ledger.read_state("2026-07-31").consecutive_poison == 2
+        assert ledger.read_state("2026-07-31").spend.spent_usd == 0.0
+
+    def test_the_breaker_blocks_at_the_limit(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        for _ in range(3):
+            ledger.record_terminal(poisoned=True)
+        admission = check_poison_breaker(
+            ledger, ServeConfig(max_consecutive_poison=3),
+        )
         assert not admission.allowed
-        assert admission.pause_reason
         assert "systemic" in admission.pause_reason
 
     def test_the_breaker_allows_below_the_limit(self, tmp_path: Path) -> None:
-        queue = _queue(tmp_path)
-        queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
+        ledger = SpendLedger(tmp_path)
+        ledger.record_terminal(poisoned=True)
         assert check_poison_breaker(
-            queue, ServeConfig(max_consecutive_poison=3),
+            ledger, ServeConfig(max_consecutive_poison=3),
         ).allowed
 
     def test_the_breaker_pause_does_not_auto_resume(
         self, tmp_path: Path,
     ) -> None:
         """Unlike the budget: something systemic needs a human, not a clock."""
-        queue = _queue(tmp_path)
+        ledger = SpendLedger(tmp_path)
         for _ in range(3):
-            queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
-        admission = check_poison_breaker(queue, ServeConfig())
-        assert admission.resume_after == ""
+            ledger.record_terminal(poisoned=True)
+        assert check_poison_breaker(ledger, ServeConfig()).resume_after == ""
+
+    def test_an_unreadable_state_file_fails_closed(
+        self, tmp_path: Path,
+    ) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.record_terminal(poisoned=True)
+        ledger.path.write_text("{corrupt")
+        with pytest.raises(ServeStateError):
+            check_poison_breaker(ledger, ServeConfig())
 
 
 # --------------------------------------------------------------------------
@@ -938,7 +1154,7 @@ class TestServeCycle:
     ) -> None:
         queue = _queue(tmp_path)
         _add(queue)
-        SpendLedger(tmp_path).charge(50.0)
+        SpendLedger(tmp_path).charge(50.0, covered_calls=1, total_calls=1)
         calls: list[dict[str, object]] = []
         result = serve_cycle(
             tmp_path,
@@ -949,10 +1165,39 @@ class TestServeCycle:
         assert result.paused
         assert queue.is_paused()
 
+    def test_repeated_poisons_pause_the_queue_on_their_own(
+        self, tmp_path: Path,
+    ) -> None:
+        """End to end: serve must RECORD each poison, not just read a count.
+
+        Seeding the ledger directly cannot catch a missing
+        record_terminal call, which is the whole mechanism.
+        """
+        queue = _queue(tmp_path, max_attempts=1)
+        for _ in range(3):
+            _add(queue)
+        config = ServeConfig(max_consecutive_poison=3)
+        for _ in range(3):
+            serve_cycle(
+                tmp_path, config=config, runner=_stub_runner(RunOutcome(1)),
+            )
+        assert consecutive_poison_count(SpendLedger(tmp_path)) == 3
+
+        _add(queue)
+        calls: list[dict[str, object]] = []
+        result = serve_cycle(
+            tmp_path, config=config, runner=_stub_runner(RunOutcome(0), calls),
+        )
+        assert calls == [], "the breaker must stop the fourth run"
+        assert result.paused
+        assert queue.is_paused()
+
     def test_the_poison_breaker_pauses_the_queue(self, tmp_path: Path) -> None:
         queue = _queue(tmp_path)
+        ledger = SpendLedger(tmp_path)
         for _ in range(3):
             queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
+            ledger.record_terminal(poisoned=True)
         _add(queue)
         calls: list[dict[str, object]] = []
         result = serve_cycle(
@@ -1088,3 +1333,566 @@ class TestServeLoop:
         with serve_lock(tmp_path):
             with pytest.raises(ServeLockedError):
                 serve(tmp_path, once=True, runner=_stub_runner(RunOutcome(0)))
+
+
+class TestProcessGroupSupervision:
+    """#186 F1: a timeout must reap the whole tree, not the direct child."""
+
+    def test_killing_only_the_direct_child_leaks_a_descendant(self) -> None:
+        """Establishes WHY the runner does not use subprocess.run(timeout=).
+
+        That helper signals only its DIRECT child. On macOS the direct
+        child is the caffeinate wrapper, so the factory is a grandchild
+        and survives - after which the daemon would requeue the item
+        while a factory was still writing to the repo.
+        """
+        import subprocess
+
+        # The script prints its grandchild's pid so the assertion names a
+        # specific process rather than probing the group (whose leader we
+        # are deliberately killing).
+        proc = subprocess.Popen(
+            ["sh", "-c", "sleep 20 & echo $! ; sleep 20"],
+            start_new_session=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        )
+        assert proc.stdout is not None
+        grandchild = int(proc.stdout.readline().strip())
+        pgid = os.getpgid(proc.pid)
+        leaked = False
+        try:
+            proc.terminate()          # what subprocess.run's timeout does
+            proc.wait(timeout=10)
+            try:
+                os.kill(grandchild, 0)
+                leaked = True
+            except (ProcessLookupError, OSError):
+                leaked = False
+        finally:
+            terminate_process_group(proc, pgid)
+            try:
+                os.kill(grandchild, 9)
+            except (ProcessLookupError, OSError):
+                pass
+        assert leaked, (
+            "killing only the direct child should leave the grandchild "
+            "running - the reason the runner signals the whole group"
+        )
+
+    def test_terminate_process_group_reaps_the_tree(self) -> None:
+        import subprocess
+
+        proc = subprocess.Popen(
+            ["sh", "-c", "sh -c 'sleep 20' & sleep 20"],
+            start_new_session=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        assert terminate_process_group(proc) is True
+        assert not process_group_alive(pgid)
+
+    def test_a_mocked_popen_never_signals_a_broad_group(self) -> None:
+        """killpg(1, sig) is kill(-1, sig): every process this user owns.
+
+        A mocked Popen's pid coerces to 1 via MagicMock.__index__, so the
+        pgid guard is what stops a test from signalling the whole session.
+        ``verify._signal_process_group`` documents the same rule; this
+        pins it for the serve runner too.
+        """
+        from unittest.mock import MagicMock
+
+        from kstrl.serve import _safe_pgid
+
+        fake = MagicMock()
+        # Force getpgid to return a plausible group so the pgid<=1 guard
+        # cannot be what rejects it; only the isinstance check can.
+        with patch("kstrl.serve.os.getpgid", return_value=99999):
+            assert _safe_pgid(fake) is None
+
+        with patch("kstrl.serve.os.killpg") as killpg:
+            with patch("kstrl.serve.os.getpgid", return_value=99999):
+                fake.poll.return_value = 0
+                assert terminate_process_group(fake) is True
+            assert killpg.call_count == 0, "must never signal a bogus group"
+
+    def test_our_own_process_group_is_never_signalled(self) -> None:
+        import subprocess as sp
+
+        fake = MagicMock(spec=sp.Popen)
+        fake.pid = os.getpid()
+        fake.poll.return_value = None
+        # getpgid(our pid) == our group, which the guard must reject.
+        assert _safe_pgid_of(fake) is None
+
+    def test_the_supervised_timeout_reaps_descendants(
+        self, tmp_path: Path,
+    ) -> None:
+        """The runner's OWN timeout path, not just the helper.
+
+        subprocess_factory_runner hardcodes `ks factory` as its argv, so
+        the supervision is split into run_supervised precisely so this
+        path is reachable without spawning a factory.
+        """
+        outcome = run_supervised(
+            ["sh", "-c", "sleep 30 & echo started ; sleep 30"],
+            cwd=tmp_path,
+            timeout_seconds=1.0,
+        )
+        assert outcome.timed_out
+        assert outcome.group_reaped, (
+            "the timeout must confirm the whole group is gone"
+        )
+
+    def test_the_timeout_path_uses_the_pgid_captured_at_spawn(
+        self, tmp_path: Path,
+    ) -> None:
+        """Wiring, not behaviour.
+
+        On the timeout path the child is still alive, so a lazy pgid
+        lookup would work too - the captured value matters for the
+        already-reaped case, which cannot be provoked here. So assert the
+        argument is threaded through rather than pretending the outcome
+        differs.
+        """
+        seen: list[int | None] = []
+        real = terminate_process_group
+
+        def spy(process: object, pgid: int | None = None) -> bool:
+            seen.append(pgid)
+            return real(process, pgid)  # type: ignore[arg-type]
+
+        with patch("kstrl.serve.terminate_process_group", side_effect=spy):
+            run_supervised(
+                ["sh", "-c", "sleep 30"], cwd=tmp_path, timeout_seconds=1.0,
+            )
+        assert seen and seen[0] is not None and seen[0] > 1, (
+            "the pgid captured at spawn must be passed to the killer"
+        )
+
+    def test_the_supervised_run_returns_the_exit_code_and_output(
+        self, tmp_path: Path,
+    ) -> None:
+        outcome = run_supervised(
+            ["sh", "-c", "echo hello; exit 3"], cwd=tmp_path,
+        )
+        assert outcome.returncode == 3
+        assert "hello" in outcome.output_tail
+        assert not outcome.timed_out
+
+    def test_a_failed_launch_is_reported_not_raised(
+        self, tmp_path: Path,
+    ) -> None:
+        outcome = run_supervised(
+            [str(tmp_path / "no-such-binary")], cwd=tmp_path,
+        )
+        assert outcome.launch_error
+        assert outcome.returncode == -1
+
+    def test_the_supervised_run_reports_the_child_pid(
+        self, tmp_path: Path,
+    ) -> None:
+        seen: list[int] = []
+        run_supervised(
+            ["sh", "-c", "exit 0"], cwd=tmp_path, on_spawn=seen.append,
+        )
+        assert seen and seen[0] > 1
+
+    def test_the_group_is_signalled_not_just_the_direct_child(self) -> None:
+        """Precise: assert killpg is what fires, whatever the shell does."""
+        import subprocess
+
+        proc = subprocess.Popen(
+            ["sh", "-c", "sleep 20 & sleep 20"],
+            start_new_session=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        )
+        pgid = os.getpgid(proc.pid)
+        real_killpg = os.killpg
+        signalled: list[tuple[int, int]] = []
+
+        def recording_killpg(target: int, sig: int) -> None:
+            # signal 0 is the liveness PROBE, not a kill; counting it
+            # would let "never signal the group" pass, since the probe
+            # runs either way.
+            if sig != 0:
+                signalled.append((target, sig))
+            real_killpg(target, sig)
+
+        try:
+            with patch("kstrl.serve.os.killpg", side_effect=recording_killpg):
+                reaped = terminate_process_group(proc, pgid)
+        finally:
+            if process_group_alive(pgid):
+                real_killpg(pgid, 9)
+        assert signalled, "the group must actually be signalled"
+        assert all(target == pgid for target, _ in signalled)
+        assert reaped, "and the group must be confirmed gone"
+
+    def test_an_already_dead_child_counts_as_reaped(self) -> None:
+        import subprocess
+
+        proc = subprocess.Popen(
+            ["sh", "-c", "exit 0"], start_new_session=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        )
+        proc.wait(timeout=10)
+        assert terminate_process_group(proc) is True
+
+    def test_an_unreaped_timeout_poisons_instead_of_retrying(
+        self, tmp_path: Path,
+    ) -> None:
+        """The whole point: never hand the item back while a run may live.
+
+        A timed-out run whose group could not be confirmed dead is NOT a
+        retryable infrastructure failure - retrying it would put a second
+        factory on a repo the first may still be writing to.
+        """
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        result = serve_cycle(
+            tmp_path,
+            runner=_stub_runner(
+                RunOutcome(returncode=-9, timed_out=True, group_reaped=False),
+            ),
+        )
+        item = queue.items()[0]
+        assert item.state is ItemState.POISON
+        assert "could not be confirmed reaped" in item.poison_reason
+        assert result.needs_human
+
+    def test_a_cleanly_reaped_timeout_retries(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        result = serve_cycle(
+            tmp_path,
+            runner=_stub_runner(
+                RunOutcome(returncode=-9, timed_out=True, group_reaped=True),
+            ),
+        )
+        assert result.verdict is Verdict.RETRY_INFRA
+        assert queue.items()[0].state is ItemState.QUEUED
+
+    def test_the_run_child_becomes_the_lease_owner(
+        self, tmp_path: Path,
+    ) -> None:
+        """Otherwise a successor reaper requeues a live run (#186 F1)."""
+        queue = _queue(tmp_path)
+        _add(queue)
+        serve_cycle(
+            tmp_path,
+            runner=_stub_runner(RunOutcome(0), child_pid=424242),
+        )
+        adopted = [
+            e for e in queue.journal_entries()
+            if e["reason"].startswith("lease adopted")
+        ]
+        assert adopted, "the child pid must be recorded as the lease owner"
+        assert adopted[0]["detail"]["lease_pid"] == 424242
+
+
+class TestRunOwnership:
+    """#186 F2: charge and classify only artifacts this invocation made."""
+
+    def test_a_launch_with_no_artifacts_charges_nothing(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        # A previous run's dir and spend already exist.
+        _make_run_dir(tmp_path, "factory-OLD-000")
+        with patch(
+            "kstrl.serve.read_run_spend",
+            return_value=RunSpend(cost_usd=99.0, cost_calls=1, usage_calls=1),
+        ):
+            result = serve_cycle(
+                tmp_path,
+                runner=_stub_runner(RunOutcome(1), make_run_dir=False),
+            )
+        assert result.charged_usd == 0.0, "a prior run's spend is not ours"
+        assert SpendLedger(tmp_path).read().spent_usd == 0.0
+
+    def test_a_stale_manifest_is_not_used_to_classify(
+        self, tmp_path: Path,
+    ) -> None:
+        """An old manifest saying "infra failure" must not authorize a retry."""
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        _manifest(
+            tmp_path / "scripts" / "kstrl" / "manifest.json",
+            [_component("comp-a", "failed", [_infra_finding()])],
+            run_id="factory-OLD-000",
+        )
+        _make_run_dir(tmp_path, "factory-OLD-000")
+        result = serve_cycle(
+            tmp_path, runner=_stub_runner(RunOutcome(1), make_run_dir=False),
+        )
+        assert result.verdict is Verdict.UNCLASSIFIABLE
+        assert queue.items()[0].state is ItemState.POISON
+
+    def test_an_owned_manifest_is_read_and_classified(
+        self, tmp_path: Path,
+    ) -> None:
+        """The positive case, which only works if the run id key is right.
+
+        The stale-manifest test alone cannot catch a wrong key: a
+        misread id yields "" and lands on the same unclassifiable branch
+        as an unowned manifest.
+        """
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        _manifest(
+            tmp_path / "scripts" / "kstrl" / "manifest.json",
+            [_component("comp-a", "failed", [_infra_finding()])],
+        )
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(1)))
+        assert result.verdict is Verdict.RETRY_INFRA, (
+            "an owned manifest must be read, which needs the runId key"
+        )
+        assert queue.items()[0].state is ItemState.QUEUED
+
+    def test_only_new_run_dirs_are_charged(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        _make_run_dir(tmp_path, "factory-OLD-000")
+        seen: list[str] = []
+
+        def fake_spend(root: Path, run_id: str) -> RunSpend:
+            seen.append(run_id)
+            return RunSpend(cost_usd=1.0, cost_calls=1, usage_calls=1)
+
+        with patch("kstrl.serve.read_run_spend", side_effect=fake_spend):
+            serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0)))
+        assert "factory-OLD-000" not in seen
+        assert seen == ["factory-20260730-000000.000000-aaa"]
+
+    def test_read_run_spend_refuses_an_empty_run_id(
+        self, tmp_path: Path,
+    ) -> None:
+        """An empty id used to select the NEWEST run on disk.
+
+        Asserts the reducer is never CONSULTED, not merely that the result
+        is zero: on an empty repo it would be zero either way.
+        """
+        with patch("kstrl.reducer.load_run_state") as load:
+            assert REAL_READ_RUN_SPEND(tmp_path, "") == RunSpend()
+            assert load.call_count == 0, "must not read another run"
+
+    def test_read_run_spend_reads_a_named_run(self, tmp_path: Path) -> None:
+        """The positive case, so the guard cannot be over-broad."""
+        with patch("kstrl.reducer.load_run_state") as load:
+            load.return_value = (
+                type("S", (), {
+                    "cost_usd": 1.25, "cost_calls": 2, "usage_calls": 3,
+                })(),
+                None,
+            )
+            spend = REAL_READ_RUN_SPEND(tmp_path, "factory-abc")
+        assert spend.cost_usd == 1.25
+        assert spend.uncovered_calls == 1
+
+    def test_the_architect_is_recorded_as_unmetered(
+        self, tmp_path: Path,
+    ) -> None:
+        """#186 F3: decompose spends and emits no usage events at all."""
+        queue = _queue(tmp_path)
+        _add(queue)
+        serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0)))
+        spend = SpendLedger(tmp_path).read()
+        assert "architect" in spend.unmetered_phases
+        assert spend.lower_bound, "unmetered architect spend makes it a floor"
+
+
+class TestPauseIsAtomic:
+    """#186 F7: the elapsed-pause clear must not lose an operator's pause."""
+
+    def test_an_operator_pause_is_never_cleared_by_the_daemon(
+        self, tmp_path: Path,
+    ) -> None:
+        """A pause with no resume_after is a human decision; only a human lifts it."""
+        queue = _queue(tmp_path)
+        _add(queue)
+        queue.pause(reason="operator emergency stop", actor="operator")
+        calls: list[dict[str, object]] = []
+        result = serve_cycle(
+            tmp_path, runner=_stub_runner(RunOutcome(0), calls),
+        )
+        assert calls == []
+        assert "paused" in result.skipped
+        assert queue.pause_state().paused, "the daemon must not clear it"
+
+    def test_only_an_expired_window_is_cleared(self, tmp_path: Path) -> None:
+        """A live budget pause must survive the cycle that observes it."""
+        queue = _queue(tmp_path)
+        _add(queue)
+        future = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
+        queue.pause(reason="budget", resume_after=future)
+        calls: list[dict[str, object]] = []
+        serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0), calls))
+        assert calls == []
+        assert queue.pause_state().paused
+
+    def test_the_daemon_pause_write_is_also_under_the_mutex(self) -> None:
+        """Losing an operator's pause is the dangerous direction (#186 F7)."""
+        import inspect
+
+        from kstrl.serve import _pause_queue
+
+        source = inspect.getsource(_pause_queue)
+        assert "with queue_lock(root_dir, blocking=True):" in source
+
+    def test_the_pause_read_is_held_under_the_queue_mutex(self) -> None:
+        """Structural: the read and the conditional clear share one lock."""
+        import inspect
+        import textwrap
+
+        lines = textwrap.dedent(inspect.getsource(serve_cycle)).splitlines()
+        read_idx = next(
+            i for i, ln in enumerate(lines)
+            if "pause = queue.pause_state()" in ln
+        )
+        indent = len(lines[read_idx]) - len(lines[read_idx].lstrip())
+        guard = ""
+        for i in range(read_idx - 1, -1, -1):
+            candidate = lines[i]
+            if not candidate.strip():
+                continue
+            if len(candidate) - len(candidate.lstrip()) < indent:
+                guard = candidate.strip()
+                break
+        assert "queue_lock" in guard, f"pause read guarded by {guard!r}"
+
+
+class TestFactoryLockProbe:
+    """#186 F6: the probe is a courtesy check that must fail closed."""
+
+    def test_no_lock_file_means_free(self, tmp_path: Path) -> None:
+        assert not factory_lock_held(tmp_path)
+
+    def test_an_unopenable_lock_file_reads_as_HELD(
+        self, tmp_path: Path,
+    ) -> None:
+        """An unopenable lock is not evidence that no run owns the root."""
+        lock = tmp_path / ".kstrl" / "factory.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.touch()
+        with patch("kstrl.serve.open", side_effect=PermissionError("denied")):
+            assert factory_lock_held(tmp_path)
+
+    def test_a_held_lock_is_detected(self, tmp_path: Path) -> None:
+        pytest.importorskip("fcntl")
+        import fcntl
+
+        lock = tmp_path / ".kstrl" / "factory.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(lock, "a+")
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            assert factory_lock_held(tmp_path)
+        finally:
+            handle.close()
+
+    def test_a_free_lock_is_detected(self, tmp_path: Path) -> None:
+        lock = tmp_path / ".kstrl" / "factory.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.touch()
+        assert not factory_lock_held(tmp_path)
+
+
+class TestNeedsHuman:
+    """#186 F10: exit status follows the terminal state, not may_retry."""
+
+    def test_an_exhausted_infra_verdict_needs_a_human(
+        self, tmp_path: Path,
+    ) -> None:
+        """may_retry stays True here, which is what fooled the old filter."""
+        queue = _queue(tmp_path, max_attempts=1)
+        _add(queue)
+        _manifest(
+            tmp_path / "scripts" / "kstrl" / "manifest.json",
+            [_component("comp-a", "failed", [_infra_finding()])],
+        )
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(1)))
+        assert result.verdict is Verdict.RETRY_INFRA
+        assert result.verdict.may_retry, "the trap the old filter fell into"
+        assert queue.items()[0].state is ItemState.POISON
+        assert result.needs_human
+
+    def test_a_retryable_failure_with_attempts_left_does_not(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        _manifest(
+            tmp_path / "scripts" / "kstrl" / "manifest.json",
+            [_component("comp-a", "failed", [_infra_finding()])],
+        )
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(1)))
+        assert not result.needs_human
+
+    def test_success_does_not(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        assert not serve_cycle(
+            tmp_path, runner=_stub_runner(RunOutcome(0)),
+        ).needs_human
+
+    def test_a_reaper_poison_needs_a_human_without_running_an_item(
+        self, tmp_path: Path,
+    ) -> None:
+        """A path with no ran_item at all, which the old filter skipped."""
+        queue = _queue(tmp_path, max_attempts=1)
+        queue.start(queue.lease(_add(queue), pid=999999))  # type: ignore[arg-type]
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0)))
+        assert result.reaped.poisoned
+        assert result.needs_human
+
+    def test_a_budget_pause_needs_a_human(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        SpendLedger(tmp_path).charge(50.0, covered_calls=1, total_calls=1)
+        result = serve_cycle(
+            tmp_path,
+            config=ServeConfig(daily_budget_usd=10.0),
+            runner=_stub_runner(RunOutcome(0)),
+        )
+        assert result.paused
+        assert result.needs_human
+
+    def test_an_unreadable_ledger_needs_a_human(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(1.0, covered_calls=1, total_calls=1)
+        ledger.path.write_text("{corrupt")
+        calls: list[dict[str, object]] = []
+        result = serve_cycle(
+            tmp_path, runner=_stub_runner(RunOutcome(0), calls),
+        )
+        assert calls == []
+        assert result.needs_human
+        # The pre-flight guard is what files this; the gate handler does
+        # not, so asserting it pins the earlier check specifically.
+        from kstrl.inbox import Inbox, InboxConfig
+
+        titles = [
+            i.title for i in Inbox(tmp_path, InboxConfig.load(tmp_path)).items()
+        ]
+        assert any("unreadable spend ledger" in t for t in titles)
+
+
+class TestBoundedRetention:
+    """#186 F11: the daemon path must not grow a list forever."""
+
+    def test_a_bounded_run_returns_every_result(self, tmp_path: Path) -> None:
+        results = serve(
+            tmp_path, runner=_stub_runner(RunOutcome(0)), max_cycles=5,
+            sleeper=lambda _s: None,
+        )
+        assert len(results) == 5
+
+    def test_the_unbounded_path_uses_a_bounded_window(self) -> None:
+        import inspect
+
+        source = inspect.getsource(serve)
+        assert "deque(maxlen=RECENT_CYCLE_WINDOW)" in source
+        assert "bounded.append" in source

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,0 +1,1090 @@
+"""R8.6 PR 2: `ks serve` regression tests.
+
+The centre of gravity here is the retry classifier and the four
+backstops, because this is the module that spends money unattended. The
+rule under test is not "infrastructure errors retry" but the stronger
+"NOTHING retries without positive evidence that it was infrastructural",
+so most of these tests assert that an ambiguous situation does NOT
+retry.
+
+No test runs a real factory. The `FactoryRunner` Protocol exists so the
+whole loop is drivable with a stub - a suite that spawned the real thing
+would cost dollars per assertion at a measured $1.70-2.60 per iteration.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kstrl.findings import Finding
+from kstrl.manifest import Component, ComponentStatus, Manifest
+from kstrl.serve import (
+    BACKOFF_CAP_SECONDS,
+    DailySpend,
+    RunOutcome,
+    RunSpend,
+    ServeConfig,
+    ServeError,
+    ServeLockedError,
+    SpendLedger,
+    Verdict,
+    backoff_seconds,
+    caffeinate_prefix,
+    check_budget,
+    check_cost_coverage,
+    check_poison_breaker,
+    classify_run,
+    consecutive_poison_count,
+    next_local_midnight,
+    reap_leases,
+    resolve_merge_gate,
+    serve,
+    serve_cycle,
+    serve_lock,
+)
+from kstrl.workqueue import (
+    ItemSource,
+    ItemState,
+    MergeDisposition,
+    Queue,
+    QueueConfig,
+)
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+
+def _queue(root: Path, **kwargs: object) -> Queue:
+    return Queue(root, QueueConfig(**kwargs))  # type: ignore[arg-type]
+
+
+def _add(queue: Queue, **kwargs: object) -> object:
+    return queue.add("# Spec\n\nDo the thing.\n", **kwargs)  # type: ignore[arg-type]
+
+
+def _manifest(path: Path, components: list[Component], run_id: str = "r1") -> None:
+    """Write a manifest through the real Manifest.save.
+
+    Built from the real dataclasses rather than hand-written JSON: an
+    earlier version of this helper invented key names and every
+    classification test silently exercised the unreadable-manifest branch
+    instead of the branch it claimed to test.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    manifest = Manifest(
+        version="1",
+        spec_file="spec.md",
+        project_name="p",
+        base_branch="main",
+        single_pr=False,
+        components=components,
+        run_id=run_id,
+    )
+    manifest.save(path)
+
+
+def _component(
+    comp_id: str, status: str, findings: list[Finding] | None = None,
+) -> Component:
+    component = Component(
+        comp_id, comp_id, "", [], f"{comp_id}.json", f"branch/{comp_id}",
+    )
+    component.status = ComponentStatus(status)
+    component.findings = list(findings or [])
+    return component
+
+
+def _infra_finding() -> Finding:
+    return Finding.infrastructure_error("review", "agent CLI timed out")
+
+
+def _spec_finding() -> Finding:
+    return Finding(
+        phase="review",
+        category="test_quality",
+        severity="fail",
+        location="tests/test_x.py",
+        explanation="tests assert nothing",
+        tags=(),
+    )
+
+
+def _stub_runner(outcome: RunOutcome, calls: list[dict[str, object]] | None = None):
+    def runner(
+        *,
+        root_dir: Path,
+        spec_path: Path,
+        project_name: str,
+        pause_before_pr_merge: bool,
+        timeout_seconds: float,
+    ) -> RunOutcome:
+        if calls is not None:
+            calls.append({
+                "spec_path": spec_path,
+                "project_name": project_name,
+                "pause_before_pr_merge": pause_before_pr_merge,
+                "timeout_seconds": timeout_seconds,
+            })
+        return outcome
+
+    return runner
+
+
+@pytest.fixture(autouse=True)
+def _no_spend(monkeypatch: pytest.MonkeyPatch):
+    """Default every test to a zero-cost run.
+
+    Reading real spend needs a run dir; tests that care about cost patch
+    this explicitly. Defaulting to zero keeps the accounting out of the
+    way of the classification tests.
+    """
+    monkeypatch.setattr(
+        "kstrl.serve.read_run_spend", lambda root, run_id: RunSpend(),
+    )
+
+
+# --------------------------------------------------------------------------
+# The classifier
+# --------------------------------------------------------------------------
+
+
+class TestClassifierRetriesOnlyWithEvidence:
+    """The rule that stands between the queue and an overnight crash loop."""
+
+    def test_exit_zero_is_success(self, tmp_path: Path) -> None:
+        outcome = classify_run(
+            tmp_path, run=RunOutcome(returncode=0),
+            manifest_path=tmp_path / "m.json",
+        )
+        assert outcome.verdict is Verdict.SUCCESS
+
+    def test_all_infra_failures_retry(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.json"
+        _manifest(path, [_component("comp-a", "failed", [_infra_finding()])])
+        outcome = classify_run(
+            tmp_path, run=RunOutcome(returncode=1), manifest_path=path,
+        )
+        assert outcome.verdict is Verdict.RETRY_INFRA
+        assert "comp-a" in outcome.reason
+
+    def test_one_judged_failure_blocks_the_retry(self, tmp_path: Path) -> None:
+        """A mixed run is a SPEC failure: the spec failure is the verdict."""
+        path = tmp_path / "m.json"
+        _manifest(path, [
+            _component("comp-a", "failed", [_infra_finding()]),
+            _component("comp-b", "failed", [_spec_finding()]),
+        ])
+        outcome = classify_run(
+            tmp_path, run=RunOutcome(returncode=1), manifest_path=path,
+        )
+        assert outcome.verdict is Verdict.SPEC_FAILURE
+        assert "comp-b" in outcome.reason
+
+    def test_a_failure_with_no_findings_is_a_spec_failure(
+        self, tmp_path: Path,
+    ) -> None:
+        """No findings is not evidence OF infrastructure trouble."""
+        path = tmp_path / "m.json"
+        _manifest(path, [_component("comp-a", "failed", [])])
+        outcome = classify_run(
+            tmp_path, run=RunOutcome(returncode=1), manifest_path=path,
+        )
+        assert outcome.verdict is Verdict.SPEC_FAILURE
+
+    def test_an_unreadable_manifest_does_not_retry(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.json"
+        path.write_text("{not json")
+        outcome = classify_run(
+            tmp_path, run=RunOutcome(returncode=1), manifest_path=path,
+        )
+        assert outcome.verdict is Verdict.UNCLASSIFIABLE
+        assert not outcome.verdict.may_retry
+
+    def test_a_missing_manifest_does_not_retry(self, tmp_path: Path) -> None:
+        outcome = classify_run(
+            tmp_path, run=RunOutcome(returncode=1),
+            manifest_path=tmp_path / "absent.json",
+        )
+        assert outcome.verdict is Verdict.UNCLASSIFIABLE
+
+    def test_nonzero_exit_with_nothing_failed_does_not_retry(
+        self, tmp_path: Path,
+    ) -> None:
+        """Merge-pending / contract failure: resumable, but not by us."""
+        path = tmp_path / "m.json"
+        _manifest(path, [_component("comp-a", "completed")])
+        outcome = classify_run(
+            tmp_path, run=RunOutcome(returncode=1), manifest_path=path,
+        )
+        assert outcome.verdict is Verdict.UNCLASSIFIABLE
+        assert "no failed component" in outcome.reason
+
+    def test_exit_two_is_a_spec_failure(self, tmp_path: Path) -> None:
+        """The architect halted on a blocker; re-running spends the same."""
+        outcome = classify_run(
+            tmp_path, run=RunOutcome(returncode=2),
+            manifest_path=tmp_path / "m.json",
+        )
+        assert outcome.verdict is Verdict.SPEC_FAILURE
+        assert "architect" in outcome.reason
+
+    def test_a_signal_kill_retries(self, tmp_path: Path) -> None:
+        """SIGKILL is evidence of an external cause, not a spec verdict."""
+        outcome = classify_run(
+            tmp_path, run=RunOutcome(returncode=-9),
+            manifest_path=tmp_path / "m.json",
+        )
+        assert outcome.verdict is Verdict.RETRY_INFRA
+        assert "signal 9" in outcome.reason
+
+    def test_a_timeout_retries(self, tmp_path: Path) -> None:
+        outcome = classify_run(
+            tmp_path, run=RunOutcome(returncode=-9, timed_out=True),
+            manifest_path=tmp_path / "m.json",
+        )
+        assert outcome.verdict is Verdict.RETRY_INFRA
+        assert "timeout" in outcome.reason or "timed" in outcome.reason.lower()
+
+    def test_a_launch_failure_retries(self, tmp_path: Path) -> None:
+        """Nothing was spent, so retrying is free."""
+        outcome = classify_run(
+            tmp_path,
+            run=RunOutcome(returncode=-1, launch_error="No such file"),
+            manifest_path=tmp_path / "m.json",
+        )
+        assert outcome.verdict is Verdict.RETRY_INFRA
+        assert "before any spend" in outcome.reason
+
+    def test_only_retry_infra_authorizes_spending(self) -> None:
+        assert Verdict.RETRY_INFRA.may_retry
+        assert not Verdict.SUCCESS.may_retry
+        assert not Verdict.SPEC_FAILURE.may_retry
+        assert not Verdict.UNCLASSIFIABLE.may_retry
+
+    def test_every_verdict_carries_a_reason(self, tmp_path: Path) -> None:
+        """A machine decision that spends money must say why."""
+        path = tmp_path / "m.json"
+        _manifest(path, [_component("comp-a", "failed", [_infra_finding()])])
+        for run in (
+            RunOutcome(returncode=0),
+            RunOutcome(returncode=1),
+            RunOutcome(returncode=2),
+            RunOutcome(returncode=-9),
+            RunOutcome(returncode=-9, timed_out=True),
+            RunOutcome(returncode=-1, launch_error="boom"),
+        ):
+            outcome = classify_run(tmp_path, run=run, manifest_path=path)
+            assert outcome.reason.strip()
+
+    def test_the_shared_infra_predicate_is_reused(self, tmp_path: Path) -> None:
+        """Not a second copy of factory._infra_casualty.
+
+        Two copies of this rule drifting apart is how a spec failure
+        becomes retryable, so the classifier must go through
+        Finding.is_infrastructure_error rather than string-matching.
+        """
+        from kstrl.findings import Finding
+        from kstrl.serve import _infra_casualty
+
+        class _Comp:
+            def __init__(self, findings: list[Finding]) -> None:
+                self.findings = findings
+
+        assert _infra_casualty(
+            _Comp([Finding.infrastructure_error("review", "cli died")])
+        )
+        assert not _infra_casualty(_Comp([]))
+
+
+# --------------------------------------------------------------------------
+# Backoff
+# --------------------------------------------------------------------------
+
+
+class TestBackoff:
+    def test_grows_exponentially(self) -> None:
+        assert backoff_seconds(1) == 60.0
+        assert backoff_seconds(2) == 120.0
+        assert backoff_seconds(3) == 240.0
+
+    def test_is_capped(self) -> None:
+        assert backoff_seconds(50) == BACKOFF_CAP_SECONDS
+
+    def test_zero_attempts_has_no_delay(self) -> None:
+        assert backoff_seconds(0) == 0.0
+
+    def test_an_item_inside_its_backoff_is_not_claimed(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        future = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+        queue.transition(
+            item, ItemState.LEASED, reason="t", not_before=future,  # type: ignore[arg-type]
+        )
+        queue.requeue(queue.items()[0], not_before=future)
+        assert queue.next_ready() is None
+
+    def test_a_backed_off_item_does_not_starve_the_others(
+        self, tmp_path: Path,
+    ) -> None:
+        """A flaking item must not block the ones that would succeed."""
+        queue = _queue(tmp_path)
+        stuck = _add(queue, title="stuck", priority=9)
+        fresh = _add(queue, title="fresh")
+        future = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+        queue.requeue(
+            queue.lease(stuck),  # type: ignore[arg-type]
+            not_before=future,
+        )
+        ready = queue.next_ready()
+        assert ready is not None
+        assert ready.item_id == fresh.item_id  # type: ignore[attr-defined]
+
+    def test_an_unparseable_not_before_holds_off(self, tmp_path: Path) -> None:
+        """Err away from launching: the opposite of the lease default."""
+        queue = _queue(tmp_path)
+        item = _add(queue)
+        queue.requeue(queue.lease(item), not_before="not-a-date")  # type: ignore[arg-type]
+        assert queue.next_ready() is None
+
+
+# --------------------------------------------------------------------------
+# Spend ledger and the budget
+# --------------------------------------------------------------------------
+
+
+class TestSpendLedger:
+    def test_a_fresh_day_starts_at_zero(self, tmp_path: Path) -> None:
+        assert SpendLedger(tmp_path).read("2026-07-30").spent_usd == 0.0
+
+    def test_charges_accumulate(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(1.50, today="2026-07-30")
+        spend = ledger.charge(2.25, today="2026-07-30")
+        assert spend.spent_usd == pytest.approx(3.75)
+        assert spend.runs == 2
+
+    def test_a_new_day_resets(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(10.0, today="2026-07-30")
+        assert ledger.read("2026-07-31").spent_usd == 0.0
+
+    def test_lower_bound_is_sticky_for_the_day(self, tmp_path: Path) -> None:
+        """Once any run under-reported, the day's total is a floor."""
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(1.0, lower_bound=True, uncovered_calls=2, today="d")
+        spend = ledger.charge(1.0, lower_bound=False, today="d")
+        assert spend.lower_bound
+        assert spend.uncovered_calls == 2
+
+    def test_negative_charges_are_ignored(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        assert ledger.charge(-5.0, today="d").spent_usd == 0.0
+
+    def test_a_corrupt_ledger_reads_as_a_fresh_day(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.path.parent.mkdir(parents=True, exist_ok=True)
+        ledger.path.write_text("{not json")
+        assert ledger.read("d").spent_usd == 0.0
+
+    def test_round_trip(self) -> None:
+        spend = DailySpend("d", 1.5, 2, True, 3)
+        assert DailySpend.from_dict(spend.to_dict()) == spend
+
+    def test_non_numeric_fields_decode_to_zero(self) -> None:
+        spend = DailySpend.from_dict({"date": "d", "spent_usd": "lots"})
+        assert spend.spent_usd == 0.0
+
+
+class TestBudgetGate:
+    def test_an_unset_budget_never_blocks(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(1000.0, today="d")
+        assert check_budget(ledger, ServeConfig(), today="d").allowed
+
+    def test_under_budget_is_allowed(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(5.0, today="d")
+        config = ServeConfig(daily_budget_usd=20.0)
+        assert check_budget(ledger, config, today="d").allowed
+
+    def test_at_budget_blocks_and_pauses(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(20.0, today="d")
+        config = ServeConfig(daily_budget_usd=20.0)
+        admission = check_budget(ledger, config, today="d")
+        assert not admission.allowed
+        assert admission.pause_reason
+        assert admission.resume_after, "the pause must clear itself"
+
+    def test_the_pause_targets_the_next_local_midnight(
+        self, tmp_path: Path,
+    ) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(20.0, today="d")
+        admission = check_budget(
+            ledger, ServeConfig(daily_budget_usd=20.0), today="d",
+        )
+        deadline = datetime.fromisoformat(admission.resume_after)
+        assert deadline > datetime.now(UTC)
+        assert deadline <= datetime.now(UTC) + timedelta(days=1, minutes=1)
+
+    def test_a_floor_total_is_labelled_in_the_reason(
+        self, tmp_path: Path,
+    ) -> None:
+        """H4: the operator must not read a floor as a measurement."""
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(20.0, lower_bound=True, uncovered_calls=4, today="d")
+        admission = check_budget(
+            ledger, ServeConfig(daily_budget_usd=20.0), today="d",
+        )
+        assert "FLOOR" in admission.reason
+
+    def test_next_local_midnight_is_in_the_future(self) -> None:
+        assert datetime.fromisoformat(next_local_midnight()) > datetime.now(UTC)
+
+
+class TestCostCoverageGate:
+    """A budget over a cost-blind adapter is UNENFORCEABLE, not approximate."""
+
+    def test_no_budget_means_no_coverage_requirement(
+        self, tmp_path: Path,
+    ) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(0.0, lower_bound=True, uncovered_calls=3, today="d")
+        assert check_cost_coverage(ledger, ServeConfig(), today="d").allowed
+
+    def test_a_fresh_day_with_no_runs_is_allowed(self, tmp_path: Path) -> None:
+        """Absence of evidence is not evidence of a gap."""
+        config = ServeConfig(daily_budget_usd=10.0)
+        assert check_cost_coverage(SpendLedger(tmp_path), config, today="d").allowed
+
+    def test_full_coverage_is_allowed(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(2.0, lower_bound=False, today="d")
+        config = ServeConfig(daily_budget_usd=10.0)
+        assert check_cost_coverage(ledger, config, today="d").allowed
+
+    def test_zero_reported_cost_under_a_budget_blocks(
+        self, tmp_path: Path,
+    ) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(0.0, lower_bound=True, uncovered_calls=6, today="d")
+        config = ServeConfig(daily_budget_usd=10.0)
+        admission = check_cost_coverage(ledger, config, today="d")
+        assert not admission.allowed
+        assert "cannot be enforced" in admission.reason
+
+    def test_the_reason_does_not_estimate_the_missing_spend(
+        self, tmp_path: Path,
+    ) -> None:
+        """Never convert unreported calls into a dollar figure (H4)."""
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(0.0, lower_bound=True, uncovered_calls=6, today="d")
+        admission = check_cost_coverage(
+            ledger, ServeConfig(daily_budget_usd=10.0), today="d",
+        )
+        assert "NOT estimated" in admission.reason
+
+    def test_the_override_is_explicit(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(tmp_path)
+        ledger.charge(0.0, lower_bound=True, uncovered_calls=6, today="d")
+        config = ServeConfig(daily_budget_usd=10.0, allow_uncovered_cost=True)
+        assert check_cost_coverage(ledger, config, today="d").allowed
+
+
+# --------------------------------------------------------------------------
+# The poison breaker
+# --------------------------------------------------------------------------
+
+
+class TestPoisonBreaker:
+    def test_no_poison_no_streak(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        queue.finish_ok(queue.start(queue.lease(_add(queue))))  # type: ignore[arg-type]
+        assert consecutive_poison_count(queue) == 0
+
+    def test_counts_a_trailing_run_of_poison(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        for _ in range(3):
+            queue.poison(_add(queue), reason="bad spec")  # type: ignore[arg-type]
+        assert consecutive_poison_count(queue) == 3
+
+    def test_a_success_resets_the_streak(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
+        queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
+        queue.finish_ok(queue.start(queue.lease(_add(queue))))  # type: ignore[arg-type]
+        assert consecutive_poison_count(queue) == 0
+
+    def test_non_terminal_transitions_do_not_break_the_streak(
+        self, tmp_path: Path,
+    ) -> None:
+        """A lease between two poisons is not a verdict."""
+        queue = _queue(tmp_path)
+        queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
+        queue.lease(_add(queue))  # type: ignore[arg-type]
+        queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
+        assert consecutive_poison_count(queue) == 2
+
+    def test_the_breaker_blocks_at_the_limit(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        for _ in range(3):
+            queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
+        admission = check_poison_breaker(queue, ServeConfig(max_consecutive_poison=3))
+        assert not admission.allowed
+        assert admission.pause_reason
+        assert "systemic" in admission.pause_reason
+
+    def test_the_breaker_allows_below_the_limit(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
+        assert check_poison_breaker(
+            queue, ServeConfig(max_consecutive_poison=3),
+        ).allowed
+
+    def test_the_breaker_pause_does_not_auto_resume(
+        self, tmp_path: Path,
+    ) -> None:
+        """Unlike the budget: something systemic needs a human, not a clock."""
+        queue = _queue(tmp_path)
+        for _ in range(3):
+            queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
+        admission = check_poison_breaker(queue, ServeConfig())
+        assert admission.resume_after == ""
+
+
+# --------------------------------------------------------------------------
+# The lease reaper
+# --------------------------------------------------------------------------
+
+
+class TestReaper:
+    def test_a_dead_leased_item_returns_to_queued_for_free(
+        self, tmp_path: Path,
+    ) -> None:
+        """Leasing spends nothing, so recovery costs nothing."""
+        queue = _queue(tmp_path)
+        item = queue.lease(_add(queue), pid=999999)  # type: ignore[arg-type]
+        result = reap_leases(queue)
+        assert item.item_id in result.requeued
+        reread = queue.items()[0]
+        assert reread.state is ItemState.QUEUED
+        assert reread.attempts == 0
+
+    def test_a_live_lease_is_left_alone(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        queue.lease(_add(queue), pid=os.getpid())  # type: ignore[arg-type]
+        result = reap_leases(queue)
+        assert result.requeued == ()
+        assert queue.items()[0].state is ItemState.LEASED
+
+    def test_an_expired_lease_is_reaped_even_with_a_live_pid(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path, lease_ttl_seconds=1)
+        queue.lease(_add(queue), pid=os.getpid())  # type: ignore[arg-type]
+        future = datetime.now(UTC) + timedelta(hours=2)
+        result = reap_leases(queue, now=future)
+        assert len(result.requeued) == 1
+
+    def test_a_dead_running_item_retries_with_backoff(
+        self, tmp_path: Path,
+    ) -> None:
+        """The sleep/crash path: the attempt is spent, the cause is external."""
+        queue = _queue(tmp_path, max_attempts=3)
+        item = queue.start(queue.lease(_add(queue), pid=999999))  # type: ignore[arg-type]
+        result = reap_leases(queue)
+        assert item.item_id in result.failed_for_retry
+        reread = queue.items()[0]
+        assert reread.state is ItemState.QUEUED
+        assert reread.attempts == 1, "the spent attempt stays charged"
+        assert reread.not_before, "a reaped retry waits out a backoff"
+
+    def test_a_dead_running_item_poisons_when_out_of_attempts(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path, max_attempts=1)
+        item = queue.start(queue.lease(_add(queue), pid=999999))  # type: ignore[arg-type]
+        result = reap_leases(queue)
+        assert item.item_id in result.poisoned
+        reread = queue.items()[0]
+        assert reread.state is ItemState.POISON
+        assert "no attempts left" in reread.poison_reason
+
+    def test_a_foreign_host_lease_is_not_reaped_on_pid(
+        self, tmp_path: Path,
+    ) -> None:
+        """We cannot probe a foreign pid; the TTL is the only signal."""
+        queue = _queue(tmp_path)
+        queue.lease(_add(queue), pid=999999, host="some-other-machine")  # type: ignore[arg-type]
+        assert reap_leases(queue).requeued == ()
+
+    def test_a_foreign_host_lease_still_expires(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path, lease_ttl_seconds=1)
+        queue.lease(_add(queue), pid=999999, host="some-other-machine")  # type: ignore[arg-type]
+        future = datetime.now(UTC) + timedelta(hours=2)
+        assert len(reap_leases(queue, now=future).requeued) == 1
+
+    def test_the_reaper_records_why_in_the_journal(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        item = queue.lease(_add(queue), pid=999999)  # type: ignore[arg-type]
+        reap_leases(queue)
+        reasons = [e["reason"] for e in queue.journal_entries(item.item_id)]
+        assert any("reaped" in r for r in reasons)
+
+
+# --------------------------------------------------------------------------
+# The merge gate must survive continuous intake
+# --------------------------------------------------------------------------
+
+
+class TestMergeGate:
+    def test_stop_at_pr_without_the_ladder(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue, merge_disposition=MergeDisposition.STOP_AT_PR)
+        gate = resolve_merge_gate(item, tmp_path)  # type: ignore[arg-type]
+        assert gate.pause_before_pr_merge
+        assert not gate.refusal
+
+    def test_auto_merge_without_the_ladder(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        item = _add(queue, merge_disposition=MergeDisposition.AUTO_MERGE)
+        gate = resolve_merge_gate(item, tmp_path)  # type: ignore[arg-type]
+        assert not gate.pause_before_pr_merge
+
+    def test_the_ladder_withholds_auto_merge_at_l1(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The ladder may always withhold a permission."""
+        monkeypatch.setenv("KSTRL_AUTONOMY_ENABLED", "1")
+        queue = _queue(tmp_path)
+        item = _add(queue, merge_disposition=MergeDisposition.AUTO_MERGE)
+        gate = resolve_merge_gate(item, tmp_path)  # type: ignore[arg-type]
+        assert gate.pause_before_pr_merge
+        assert not gate.refusal
+        assert any("withholds" in note for note in gate.notes)
+
+    def test_remote_items_default_to_stop_at_pr(self, tmp_path: Path) -> None:
+        """Continuous intake must not silently delete the merge gate."""
+        queue = _queue(tmp_path)
+        item = _add(
+            queue, source=ItemSource.GITHUB, source_ref="o/r#1",
+        )
+        gate = resolve_merge_gate(item, tmp_path)  # type: ignore[arg-type]
+        assert gate.pause_before_pr_merge
+
+
+# --------------------------------------------------------------------------
+# caffeinate
+# --------------------------------------------------------------------------
+
+
+class TestCaffeinate:
+    def test_disabled_yields_no_prefix(self) -> None:
+        assert caffeinate_prefix(False) == []
+
+    def test_non_darwin_yields_no_prefix(self) -> None:
+        with patch("kstrl.serve.sys.platform", "linux"):
+            assert caffeinate_prefix(True) == []
+
+    def test_darwin_with_the_binary_uses_idle_only(self) -> None:
+        with patch("kstrl.serve.sys.platform", "darwin"):
+            with patch("kstrl.serve.shutil.which", return_value="/usr/bin/caffeinate"):
+                assert caffeinate_prefix(True) == ["/usr/bin/caffeinate", "-i"]
+
+    def test_a_missing_binary_degrades_rather_than_failing(self) -> None:
+        with patch("kstrl.serve.sys.platform", "darwin"):
+            with patch("kstrl.serve.shutil.which", return_value=None):
+                assert caffeinate_prefix(True) == []
+
+
+# --------------------------------------------------------------------------
+# Config
+# --------------------------------------------------------------------------
+
+
+class TestServeConfig:
+    def test_defaults(self) -> None:
+        config = ServeConfig()
+        assert config.poll_interval_seconds == 60.0
+        assert config.daily_budget_usd == 0.0
+        assert config.max_consecutive_poison == 3
+        assert config.caffeinate
+        assert not config.allow_uncovered_cost
+
+    @pytest.mark.parametrize("kwargs", [
+        {"poll_interval_seconds": 0},
+        {"daily_budget_usd": -1},
+        {"max_consecutive_poison": 0},
+        {"factory_timeout_seconds": -1},
+    ])
+    def test_invalid_values_are_rejected(self, kwargs: dict[str, float]) -> None:
+        with pytest.raises(ServeError):
+            ServeConfig(**kwargs)  # type: ignore[arg-type]
+
+    def test_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KSTRL_SERVE_DAILY_BUDGET_USD", "25.5")
+        monkeypatch.setenv("KSTRL_SERVE_CAFFEINATE", "0")
+        config = ServeConfig.from_env()
+        assert config.daily_budget_usd == 25.5
+        assert not config.caffeinate
+
+    def test_load_reads_the_toml_section(self, tmp_path: Path) -> None:
+        (tmp_path / "kstrl.toml").write_text(
+            "[serve]\ndaily_budget_usd = 12.0\nmax_consecutive_poison = 5\n"
+        )
+        config = ServeConfig.load(tmp_path)
+        assert config.daily_budget_usd == 12.0
+        assert config.max_consecutive_poison == 5
+
+    def test_env_beats_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text("[serve]\ndaily_budget_usd = 12.0\n")
+        monkeypatch.setenv("KSTRL_SERVE_DAILY_BUDGET_USD", "3.0")
+        assert ServeConfig.load(tmp_path).daily_budget_usd == 3.0
+
+
+# --------------------------------------------------------------------------
+# The singleton lock
+# --------------------------------------------------------------------------
+
+
+class TestServeLock:
+    def test_a_second_daemon_is_refused(self, tmp_path: Path) -> None:
+        pytest.importorskip("fcntl")
+        with serve_lock(tmp_path):
+            with pytest.raises(ServeLockedError):
+                with serve_lock(tmp_path):
+                    pass
+
+    def test_it_is_released_on_exit(self, tmp_path: Path) -> None:
+        pytest.importorskip("fcntl")
+        with serve_lock(tmp_path):
+            pass
+        with serve_lock(tmp_path):
+            pass
+
+    def test_it_is_distinct_from_the_queue_mutex(self, tmp_path: Path) -> None:
+        """`ks queue ls` must keep working while the daemon runs."""
+        pytest.importorskip("fcntl")
+        from kstrl.workqueue import queue_lock
+
+        with serve_lock(tmp_path):
+            with queue_lock(tmp_path):
+                pass
+
+    def test_it_records_the_holder_pid(self, tmp_path: Path) -> None:
+        pytest.importorskip("fcntl")
+        from kstrl.serve import SERVE_LOCK_FILENAME
+        from kstrl.workqueue import queue_root
+
+        with serve_lock(tmp_path):
+            content = (queue_root(tmp_path) / SERVE_LOCK_FILENAME).read_text()
+        assert content.strip() == str(os.getpid())
+
+
+# --------------------------------------------------------------------------
+# The loop
+# --------------------------------------------------------------------------
+
+
+class TestServeCycle:
+    def test_an_empty_queue_does_nothing(self, tmp_path: Path) -> None:
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0)))
+        assert result.ran_item == ""
+        assert result.skipped == "nothing ready"
+
+    def test_a_successful_item_finishes_done(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0)))
+        assert result.verdict is Verdict.SUCCESS
+        assert queue.items()[0].state is ItemState.DONE
+
+    def test_one_item_per_cycle(self, tmp_path: Path) -> None:
+        """Two factory runs on one repo is what factory.lock exists to stop."""
+        queue = _queue(tmp_path)
+        _add(queue)
+        _add(queue)
+        calls: list[dict[str, object]] = []
+        serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0), calls))
+        assert len(calls) == 1
+
+    def test_a_spec_failure_poisons_without_retrying(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        _manifest(
+            tmp_path / "scripts" / "kstrl" / "manifest.json",
+            [_component("comp-a", "failed", [_spec_finding()])],
+        )
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(1)))
+        assert result.verdict is Verdict.SPEC_FAILURE
+        item = queue.items()[0]
+        assert item.state is ItemState.POISON
+        assert item.attempts == 1, "poisoned after ONE attempt, not three"
+
+    def test_an_infra_failure_retries_with_backoff(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        _manifest(
+            tmp_path / "scripts" / "kstrl" / "manifest.json",
+            [_component("comp-a", "failed", [_infra_finding()])],
+        )
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(1)))
+        assert result.verdict is Verdict.RETRY_INFRA
+        item = queue.items()[0]
+        assert item.state is ItemState.QUEUED
+        assert item.not_before, "the retry waits out a backoff"
+
+    def test_an_infra_failure_poisons_once_attempts_run_out(
+        self, tmp_path: Path,
+    ) -> None:
+        """Even a legitimately retryable failure is bounded."""
+        queue = _queue(tmp_path, max_attempts=1)
+        _add(queue)
+        _manifest(
+            tmp_path / "scripts" / "kstrl" / "manifest.json",
+            [_component("comp-a", "failed", [_infra_finding()])],
+        )
+        serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(1)))
+        item = queue.items()[0]
+        assert item.state is ItemState.POISON
+        assert "no attempts left" in item.poison_reason
+
+    def test_an_unclassifiable_failure_poisons(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(1)))
+        assert result.verdict is Verdict.UNCLASSIFIABLE
+        assert queue.items()[0].state is ItemState.POISON
+
+    def test_the_attempt_is_charged_before_the_run(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        seen: list[int] = []
+
+        def runner(**kwargs: object) -> RunOutcome:
+            seen.append(queue.items()[0].attempts)
+            return RunOutcome(0)
+
+        serve_cycle(tmp_path, runner=runner)  # type: ignore[arg-type]
+        assert seen == [1], "the attempt must be on disk before any spend"
+
+    def test_the_merge_gate_reaches_the_runner(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue, merge_disposition=MergeDisposition.STOP_AT_PR)
+        calls: list[dict[str, object]] = []
+        serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0), calls))
+        assert calls[0]["pause_before_pr_merge"] is True
+
+    def test_auto_merge_reaches_the_runner(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue, merge_disposition=MergeDisposition.AUTO_MERGE)
+        calls: list[dict[str, object]] = []
+        serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0), calls))
+        assert calls[0]["pause_before_pr_merge"] is False
+
+    def test_a_paused_queue_runs_nothing(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        queue.pause(reason="operator")
+        calls: list[dict[str, object]] = []
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0), calls))
+        assert calls == []
+        assert "paused" in result.skipped
+
+    def test_an_elapsed_pause_window_resumes_itself(
+        self, tmp_path: Path,
+    ) -> None:
+        """What makes the daily-budget stop self-healing.
+
+        Asserts the marker is actually CLEARED, not merely that it reads
+        as inactive. An elapsed `resume_after` already makes
+        `is_paused()` false on its own, so the weaker assertion passed
+        with the `resume()` call removed and pinned nothing.
+        """
+        queue = _queue(tmp_path)
+        _add(queue)
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        queue.pause(reason="budget", resume_after=past)
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0)))
+        assert result.ran_item
+        assert not queue.is_paused()
+        assert queue.pause_state().paused is False, "the marker must be cleared"
+        assert any(
+            entry["to"] == "running" and entry["reason"] == "resumed"
+            for entry in queue.journal_entries()
+        ), "the resume must be journaled"
+
+    def test_an_exhausted_budget_pauses_before_spending(
+        self, tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        SpendLedger(tmp_path).charge(50.0)
+        calls: list[dict[str, object]] = []
+        result = serve_cycle(
+            tmp_path,
+            config=ServeConfig(daily_budget_usd=10.0, allow_uncovered_cost=True),
+            runner=_stub_runner(RunOutcome(0), calls),
+        )
+        assert calls == [], "the budget must block BEFORE the run"
+        assert result.paused
+        assert queue.is_paused()
+
+    def test_the_poison_breaker_pauses_the_queue(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        for _ in range(3):
+            queue.poison(_add(queue), reason="bad")  # type: ignore[arg-type]
+        _add(queue)
+        calls: list[dict[str, object]] = []
+        result = serve_cycle(
+            tmp_path,
+            config=ServeConfig(max_consecutive_poison=3),
+            runner=_stub_runner(RunOutcome(0), calls),
+        )
+        assert calls == []
+        assert result.paused
+        assert queue.is_paused()
+
+    def test_a_held_factory_lock_waits_without_charging(
+        self, tmp_path: Path,
+    ) -> None:
+        """Someone else owns the repo; that is not the item's fault."""
+        queue = _queue(tmp_path)
+        _add(queue)
+        calls: list[dict[str, object]] = []
+        with patch("kstrl.serve.factory_lock_held", return_value=True):
+            result = serve_cycle(
+                tmp_path, runner=_stub_runner(RunOutcome(0), calls),
+            )
+        assert calls == []
+        assert "already holds" in result.skipped
+        item = queue.items()[0]
+        assert item.state is ItemState.QUEUED
+        assert item.attempts == 0
+
+    def test_the_cycle_reaps_before_admitting(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        stale = queue.lease(_add(queue), pid=999999)  # type: ignore[arg-type]
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0)))
+        assert stale.item_id in result.reaped.requeued
+
+    def test_the_cycle_sweeps_staging(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        queue.ensure_dirs()
+        (queue.staging_path / "q-ghost").mkdir(parents=True)
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0)))
+        assert result.swept_staging == 1
+
+    def test_spend_is_charged_even_on_a_failure(self, tmp_path: Path) -> None:
+        """A classification bug must not also lose the accounting."""
+        queue = _queue(tmp_path)
+        _add(queue)
+        with patch(
+            "kstrl.serve.read_run_spend",
+            return_value=RunSpend(cost_usd=2.50, cost_calls=1, usage_calls=1),
+        ):
+            result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(1)))
+        assert result.charged_usd == pytest.approx(2.50)
+        assert SpendLedger(tmp_path).read().spent_usd == pytest.approx(2.50)
+
+    def test_a_poisoned_item_files_an_inbox_item(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        result = serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(1)))
+        assert any(result.inbox_items)
+        from kstrl.inbox import Inbox, InboxConfig
+
+        items = Inbox(tmp_path, InboxConfig.load(tmp_path)).open_items()
+        assert any("poisoned" in item.title for item in items)
+
+    def test_a_full_inbox_stops_admitting_work(self, tmp_path: Path) -> None:
+        """R8.3 documented open_item_cap as R8.6's backstop; this uses it."""
+        queue = _queue(tmp_path)
+        _add(queue)
+        calls: list[dict[str, object]] = []
+        with patch("kstrl.serve.check_inbox_cap") as gate:
+            from kstrl.serve import Admission
+
+            gate.return_value = Admission(allowed=False, reason="inbox full")
+            result = serve_cycle(
+                tmp_path, runner=_stub_runner(RunOutcome(0), calls),
+            )
+        assert calls == []
+        assert result.skipped == "inbox full"
+
+    def test_priority_order_is_honored(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue, title="low")
+        _add(queue, title="urgent", priority=9)
+        calls: list[dict[str, object]] = []
+        serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0), calls))
+        done = [i for i in queue.items() if i.state is ItemState.DONE]
+        assert done[0].title == "urgent"
+
+
+class TestServeLoop:
+    def test_once_runs_a_single_cycle(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        _add(queue)
+        _add(queue)
+        results = serve(tmp_path, once=True, runner=_stub_runner(RunOutcome(0)))
+        assert len(results) == 1
+        assert len([i for i in queue.items() if i.state is ItemState.DONE]) == 1
+
+    def test_max_cycles_bounds_the_loop(self, tmp_path: Path) -> None:
+        queue = _queue(tmp_path)
+        for _ in range(3):
+            _add(queue)
+        slept: list[float] = []
+        results = serve(
+            tmp_path,
+            runner=_stub_runner(RunOutcome(0)),
+            max_cycles=3,
+            sleeper=slept.append,
+        )
+        assert len(results) == 3
+        assert len([i for i in queue.items() if i.state is ItemState.DONE]) == 3
+
+    def test_the_loop_sleeps_between_cycles(self, tmp_path: Path) -> None:
+        slept: list[float] = []
+        serve(
+            tmp_path,
+            config=ServeConfig(poll_interval_seconds=42.0),
+            runner=_stub_runner(RunOutcome(0)),
+            max_cycles=2,
+            sleeper=slept.append,
+        )
+        assert slept == [42.0]
+
+    def test_once_does_not_sleep(self, tmp_path: Path) -> None:
+        slept: list[float] = []
+        serve(
+            tmp_path, once=True, runner=_stub_runner(RunOutcome(0)),
+            sleeper=slept.append,
+        )
+        assert slept == []
+
+    def test_the_loop_holds_the_singleton_lock(self, tmp_path: Path) -> None:
+        pytest.importorskip("fcntl")
+        with serve_lock(tmp_path):
+            with pytest.raises(ServeLockedError):
+                serve(tmp_path, once=True, runner=_stub_runner(RunOutcome(0)))

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -93,14 +93,14 @@ class TestDryRun:
         (tmp_path / "kstrl.toml").write_text(
             "[serve]\ndaily_budget_usd = 5.0\nallow_uncovered_cost = true\n"
         )
-        SpendLedger(tmp_path).charge(10.0)
+        SpendLedger(tmp_path).charge(10.0, covered_calls=1, total_calls=1)
         result = _invoke(["serve", "--dry-run"], tmp_path)
         assert "BLOCKS" in result.output
         assert "daily budget reached" in result.output
 
     def test_dry_run_labels_a_floor_total(self, tmp_path: Path) -> None:
         """H4: never let a floor read as a measurement."""
-        SpendLedger(tmp_path).charge(3.0, lower_bound=True, uncovered_calls=2)
+        SpendLedger(tmp_path).charge(3.0, covered_calls=1, total_calls=3)
         result = _invoke(["serve", "--dry-run"], tmp_path)
         assert "FLOOR" in result.output
 
@@ -141,6 +141,64 @@ class TestServeOnce:
             result = _invoke(["serve", "--once"], tmp_path)
         assert result.exit_code == 1
         assert _queue(tmp_path).items()[0].state is ItemState.POISON
+
+    def test_an_exhausted_infra_verdict_also_exits_nonzero(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        """#186 F10: the case the may_retry filter let through.
+
+        An infrastructure verdict whose last attempt is spent is poisoned
+        by serve_cycle, but Verdict.RETRY_INFRA.may_retry stays true - so
+        the old filter excluded it and `ks serve --once` exited 0 on work
+        that was waiting for a human.
+        """
+        from kstrl.findings import Finding
+        from kstrl.manifest import Component, ComponentStatus, Manifest
+
+        _invoke(
+            ["queue", "add", str(spec_file), "--max-attempts", "1"], tmp_path,
+        )
+        run_id = "factory-20260730-000000.000000-aaa"
+        comp = Component("comp-a", "A", "", [], "a.json", "b/a")
+        comp.status = ComponentStatus("failed")
+        comp.findings = [Finding.infrastructure_error("review", "cli died")]
+        manifest_path = tmp_path / "scripts" / "kstrl" / "manifest.json"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        Manifest(
+            version="1", spec_file="s.md", project_name="p",
+            base_branch="main", single_pr=False, components=[comp],
+            run_id=run_id,
+        ).save(manifest_path)
+
+        def fake_runner(**kwargs: object) -> RunOutcome:
+            run_dir = tmp_path / ".kstrl" / "runs" / run_id
+            run_dir.mkdir(parents=True, exist_ok=True)
+            (run_dir / "events.jsonl").touch()
+            return RunOutcome(returncode=1)
+
+        with patch("kstrl.serve.subprocess_factory_runner", fake_runner):
+            result = _invoke(["serve", "--once"], tmp_path)
+        assert _queue(tmp_path).items()[0].state is ItemState.POISON
+        assert result.exit_code == 1, "poisoned work must not report success"
+
+    def test_a_reaped_poison_with_no_item_run_exits_nonzero(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        """A path that sets no ran_item, which the old filter also skipped."""
+        from kstrl.workqueue import QueueConfig as _QC
+
+        _invoke(
+            ["queue", "add", str(spec_file), "--max-attempts", "1"], tmp_path,
+        )
+        queue = Queue(tmp_path, _QC(max_attempts=1))
+        queue.start(queue.lease(queue.items()[0], pid=999999))
+        with patch(
+            "kstrl.serve.subprocess_factory_runner",
+            return_value=RunOutcome(returncode=0),
+        ):
+            result = _invoke(["serve", "--once"], tmp_path)
+        assert _queue(tmp_path).items()[0].state is ItemState.POISON
+        assert result.exit_code == 1
 
     def test_an_empty_queue_exits_zero(self, tmp_path: Path) -> None:
         result = _invoke(["serve", "--once"], tmp_path)

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -1,0 +1,174 @@
+"""R8.6 PR 2: `ks serve` CLI tests.
+
+`--dry-run` is the surface an operator uses to answer "would this spend
+money right now, and why not", so the tests below pin that it reports the
+same gates the loop evaluates. A dry run that disagrees with the real
+cycle is worse than no dry run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner, Result
+
+from kstrl.cli import cli
+from kstrl.serve import RunOutcome, RunSpend, SpendLedger
+from kstrl.workqueue import ItemState, Queue, QueueConfig
+
+
+def _queue(root: Path) -> Queue:
+    return Queue(root, QueueConfig())
+
+
+def _invoke(args: list[str], root: Path) -> Result:
+    return CliRunner().invoke(cli, [*args, "--root", str(root), "--no-color"])
+
+
+@pytest.fixture
+def spec_file(tmp_path: Path) -> Path:
+    path = tmp_path / "feature.md"
+    path.write_text("# Feature\n\nDo the thing.\n")
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _no_spend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "kstrl.serve.read_run_spend", lambda root, run_id: RunSpend(),
+    )
+
+
+class TestServeHelp:
+    def test_the_command_is_registered(self) -> None:
+        result = CliRunner().invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "serve" in result.output
+
+    def test_help_documents_once_and_dry_run(self) -> None:
+        result = CliRunner().invoke(cli, ["serve", "--help"])
+        assert result.exit_code == 0
+        assert "--once" in result.output
+        assert "--dry-run" in result.output
+
+    def test_help_states_the_retry_rule(self) -> None:
+        """The most consequential behaviour should be discoverable."""
+        result = CliRunner().invoke(cli, ["serve", "--help"])
+        assert "infrastructure" in result.output
+        assert "poison" in result.output
+
+
+class TestDryRun:
+    def test_dry_run_spends_nothing(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        with patch("kstrl.serve.subprocess_factory_runner") as runner:
+            result = _invoke(["serve", "--dry-run"], tmp_path)
+        assert result.exit_code == 0
+        assert runner.call_count == 0
+        assert _queue(tmp_path).items()[0].state is ItemState.QUEUED
+
+    def test_dry_run_names_the_next_item(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        result = _invoke(["serve", "--dry-run"], tmp_path)
+        item = _queue(tmp_path).items()[0]
+        assert item.item_id[:12] in result.output
+
+    def test_dry_run_on_an_empty_queue(self, tmp_path: Path) -> None:
+        result = _invoke(["serve", "--dry-run"], tmp_path)
+        assert result.exit_code == 0
+        assert "nothing ready" in result.output
+
+    def test_dry_run_reports_every_gate(self, tmp_path: Path) -> None:
+        result = _invoke(["serve", "--dry-run"], tmp_path)
+        for gate in ("poison breaker", "cost coverage", "budget", "inbox cap"):
+            assert gate in result.output
+
+    def test_dry_run_reports_a_blocking_budget(self, tmp_path: Path) -> None:
+        (tmp_path / "kstrl.toml").write_text(
+            "[serve]\ndaily_budget_usd = 5.0\nallow_uncovered_cost = true\n"
+        )
+        SpendLedger(tmp_path).charge(10.0)
+        result = _invoke(["serve", "--dry-run"], tmp_path)
+        assert "BLOCKS" in result.output
+        assert "daily budget reached" in result.output
+
+    def test_dry_run_labels_a_floor_total(self, tmp_path: Path) -> None:
+        """H4: never let a floor read as a measurement."""
+        SpendLedger(tmp_path).charge(3.0, lower_bound=True, uncovered_calls=2)
+        result = _invoke(["serve", "--dry-run"], tmp_path)
+        assert "FLOOR" in result.output
+
+    def test_dry_run_reports_a_paused_queue(self, tmp_path: Path) -> None:
+        _invoke(["queue", "pause", "--reason", "operator"], tmp_path)
+        result = _invoke(["serve", "--dry-run"], tmp_path)
+        assert "operator" in result.output
+
+    def test_dry_run_reports_an_unset_budget_as_uncapped(
+        self, tmp_path: Path,
+    ) -> None:
+        result = _invoke(["serve", "--dry-run"], tmp_path)
+        assert "unset (no cap)" in result.output
+
+
+class TestServeOnce:
+    def test_once_drains_a_single_item(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        with patch(
+            "kstrl.serve.subprocess_factory_runner",
+            return_value=RunOutcome(returncode=0),
+        ):
+            result = _invoke(["serve", "--once"], tmp_path)
+        assert result.exit_code == 0
+        assert _queue(tmp_path).items()[0].state is ItemState.DONE
+
+    def test_a_poisoned_item_exits_nonzero(
+        self, tmp_path: Path, spec_file: Path,
+    ) -> None:
+        """launchd reads the exit status; a poisoned item is not success."""
+        _invoke(["queue", "add", str(spec_file)], tmp_path)
+        with patch(
+            "kstrl.serve.subprocess_factory_runner",
+            return_value=RunOutcome(returncode=1),
+        ):
+            result = _invoke(["serve", "--once"], tmp_path)
+        assert result.exit_code == 1
+        assert _queue(tmp_path).items()[0].state is ItemState.POISON
+
+    def test_an_empty_queue_exits_zero(self, tmp_path: Path) -> None:
+        result = _invoke(["serve", "--once"], tmp_path)
+        assert result.exit_code == 0
+
+    def test_a_held_singleton_lock_exits_two(self, tmp_path: Path) -> None:
+        pytest.importorskip("fcntl")
+        from kstrl.serve import serve_lock
+
+        with serve_lock(tmp_path):
+            result = _invoke(["serve", "--once"], tmp_path)
+        assert result.exit_code == 2
+        assert "another ks serve" in result.output
+
+    def test_an_invalid_config_exits_two(self, tmp_path: Path) -> None:
+        (tmp_path / "kstrl.toml").write_text(
+            "[serve]\nmax_consecutive_poison = 0\n"
+        )
+        result = _invoke(["serve", "--once"], tmp_path)
+        assert result.exit_code == 2
+        assert "max_consecutive_poison" in result.output
+
+    def test_the_banner_reports_the_effective_settings(
+        self, tmp_path: Path,
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text(
+            "[serve]\ndaily_budget_usd = 7.5\ncaffeinate = false\n"
+        )
+        result = _invoke(["serve", "--once"], tmp_path)
+        assert "$7.50/day" in result.output
+        assert "caffeinate off" in result.output

--- a/tests/test_timeout_enforcement.py
+++ b/tests/test_timeout_enforcement.py
@@ -983,11 +983,18 @@ class TestSubprocessTimeoutAudit:
     - kstrl/agents/proc.py: reader-thread deadline + group kill (R0.1)
     - kstrl/verify.py: run_scrubbed communicate(timeout) + group kill
       (R2.6)
+    - kstrl/serve.py: subprocess_factory_runner communicate(timeout) +
+      group kill (R8.6). Popen is REQUIRED here rather than incidental:
+      review #186 F1 showed subprocess.run's timeout signals only the
+      direct child, which on macOS is the caffeinate wrapper, so the
+      factory itself outlived the timeout and the daemon requeued an
+      item that was still executing.
     """
 
     SPAWN_FUNCS = frozenset({"run", "call", "check_call", "check_output"})
     POPEN_ALLOWLIST = frozenset({
         "kstrl/agents/proc.py",
+        "kstrl/serve.py",
         "kstrl/verify.py",
     })
 

--- a/tests/test_workqueue.py
+++ b/tests/test_workqueue.py
@@ -114,7 +114,7 @@ class TestAdd:
     ) -> None:
         queue = _queue(tmp_path)
         with patch(
-            "kstrl.workqueue._atomic_write", side_effect=OSError("disk full"),
+            "kstrl.workqueue.atomic_write", side_effect=OSError("disk full"),
         ):
             with pytest.raises(OSError):
                 _add(queue)


### PR DESCRIPTION
Second of four slices for [#153](https://github.com/0xfauzi/kstrl/issues/153). PR 1 (#185) built a place for work to wait; this drains it without a human firing each run — which makes it the module where a mistake spends money while nobody is watching.

| PR | Contents | Status |
|---|---|---|
| 1 | queue substrate + `ks queue` CLI | merged (#185) |
| **2** | **`ks serve`, lease reaper, retry classifier, `daily_budget_usd`, caffeinate** | **this PR** |
| 3 | GitHub Issues adapter, processed-ids ledger, `ks queue sync` | next |
| 4 | launchd plist + docs | |

## The retry rule, stated precisely

R8.6 says "only `infrastructure_error` failures auto-retry". That phrasing leaves the **unknown** case undefined, and the unknown case is where the money goes. `classify_run` implements it as **positive evidence only, failing closed**:

| Evidence | Verdict |
|---|---|
| exit 0 | success |
| launch failed before any spend | retry (free) |
| killed by signal / our timeout | retry (external cause, not a spec verdict) |
| exit 2 | spec failure — the architect halted on a blocker |
| every failed component carries `infrastructure_error` | retry |
| any failed component failed on its merits | spec failure |
| nonzero exit, nothing failed | **unclassifiable → poison** |
| manifest unreadable or absent | **unclassifiable → poison** |

This is deliberately the inverse of "retry unless proven to be a spec failure", which is the shape that produces an overnight crash loop. The same fail-open mistake is already on record in this repo: R8.1 review correction #2 found the changed-file reads returned `[]` on failure, so a `kstrl.toml` diff evaluated as "0 files, 0 lines" and passed every path and size rule.

Two details that make it work:

- **The run lock is probed before launching.** `ks factory` returns 2 both for a held lock and for an architect halt, and those need opposite treatment. Probing first keeps exit 2 unambiguous.
- **The classifier reuses `Finding.is_infrastructure_error`**, not a second copy of the predicate. Two copies of that rule drifting apart is exactly how a spec failure becomes retryable.

## Four backstops

A correct classifier is **not sufficient** — a *persistent* infrastructure fault is retryable by the rules and still burns money.

1. `max_attempts`, enforced inside `Queue.start` (PR 1, review finding F5)
2. Exponential backoff, 60s doubling, capped at 30 min
3. `daily_budget_usd`, checked **before** admitting each item, pausing until the next **local** midnight so a Friday budget hit is not a dead weekend
4. A **consecutive-poison breaker** that pauses the whole queue. If `main` is broken then every run fails verification, each failure is individually legitimate, and no per-item bound ever notices — only a cross-item signal does.

## The budget honesty problem, resolved as flagged

`daily_budget_usd` can only count cost an adapter **reported**, and the codex adapter reports tokens with no cost. With a cost-blind agent the budget is **unenforceable**, not approximate — the same condition PR #184 named for `max_cost_usd`. So:

- the ledger stores the day's spend **with its coverage**, and labels the total a `FLOOR` whenever any run under-reported
- unreported calls are **never** converted into an estimated dollar figure
- `ks serve` **refuses to run unattended** under an unenforceable budget unless `[serve] allow_uncovered_cost = true`

## Design notes

**Subprocess, not in-process `run_factory`.** A crash cannot take the daemon with it, `factory.lock` is released by process death whatever happens, and a timeout is enforceable by killing a process tree. The cost is that classification reads artifacts from disk — which is also what makes it work after a crash.

**The reaper keeps PR 1's LEASED/RUNNING split load-bearing.** A dead `leased` item spent nothing and requeues free; a dead `running` item already charged its attempt and is treated as the infrastructure casualty a suspend or OOM kill actually is.

**`caffeinate -i` wraps each run**, so it dies with the child and the machine sleeps between items rather than being pinned awake by the daemon.

## Tested vs assumed (H4)

**Tested.** 118 new tests (101 serve, 17 CLI). **36/36 mutations caught** — every classifier branch, every backstop, the reaper, the merge gate, both locks, the accounting, caffeinate, and the loop.

**Three harness defects were found and fixed before I trusted any number**, because the first run reported 30/34 with a *different* missed set each time:

1. **Stale `.pyc` made results non-deterministic.** Several mutations change the file size by the same few bytes inside one mtime tick, so CPython reused cached bytecode and the mutation was invisible. Verified by hand that two "MISSED" mutations do fail their tests.
2. **My first fix swept `.venv`**, recompiling all of site-packages — a 0.3s test file started taking minutes.
3. **One mutation hung the harness, and killing it left the mutation live in the source tree.** The `finally` restore never ran. Caught by checking every mutation's replacement text against the source; exactly one was stale.

The harness now purges only the project's caches, times out at 180s (a hang counts as caught), and restores on SIGTERM/SIGINT.

Three of the original tests were also **not discriminating** and were rewritten: the attempt-charge mutation edited an in-memory copy the test could not see; `test_an_elapsed_pause_window_resumes_itself` passed with `resume()` removed because an elapsed window already reads as inactive; and the `--once` mutation had a malformed snippet that never applied.

**Defect 3 also found a real weakness in the code.** `--once` depended on a `break` condition — a fault there turned it into an unbounded 60s-sleep loop, which under launchd is a job that never exits and blocks every later interval. `serve()` now returns `[_cycle()]` **before** entering the loop, so single-shot mode cannot spin regardless of any conditional.

**Assumed, not tested.** POSIX-only `flock` / `os.kill(pid, 0)` semantics. `caffeinate` behavior is tested only at the argv level (`-i`, availability, non-Darwin) — that it actually prevents sleep is asserted by macOS, not by this suite, and PR 4 documents it. **No factory run was performed**: the `FactoryRunner` Protocol exists so the whole loop is drivable with a stub, since a suite that spawned the real thing would cost dollars per assertion.

## Verification

```
uv run pytest tests/     2724 -> 2842 passed, 28 skipped
uv run mypy kstrl/ --strict    Success: no issues found in 110 source files
uv run ruff check kstrl/ tests/ scripts/    All checks passed!
```

No prompt bodies changed, so H2/H3 do not apply. `[serve]` was registered in `scripts/gen_docs.py` and README regenerated by the generator.

## One thing I deliberately did NOT fix — needs your call

`run_factory` assigns `factory_config.pause_before_pr_merge = bundle.pause_before_pr_merge` **unconditionally**, so at L3+ the ladder overrides an explicit `stop_at_pr` request and logs it as "manual override ignored".

`manual_override_notes` documents itself as guarding against a hand-edited flag **granting** autonomy the ladder never awarded — but the implementation is symmetric and also rejects a **more restrictive** request. Changing that is an R8.2 decision, not an R8.6 one, so `resolve_merge_gate` **refuses** such an item (poison + inbox item) rather than letting the merge gate disappear silently.

Unreachable today (`[autonomy] enabled` defaults false, and L2+ entry is still blocked on the user-run measurements), but it needs an R8.2 decision before L3 is real.

Per H1 I have not run `/code-review` on this. You are the gating reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)