### PR TITLE
fix(serve): inbox open-item cap fails closed on unparseable lines

### DIFF
--- a/docs/dark-factory-roadmap.md
+++ b/docs/dark-factory-roadmap.md
@@ -686,10 +686,13 @@ ledger, label/comment writeback). The launchd plist and its docs are PR 4.
 consults the inbox open-item cap before admitting queue work IS fulfilled
 in code - `check_inbox_cap` is one of serve's admission gates - it was
 just never stated in this section. One defect found in that wiring: the
-cap currently fails OPEN, because the inbox fold skips unparseable lines
-by design, so a torn emission line undercounts open items and admits work
-past the cap. Fail-closed fix tracked in
-[#190](https://github.com/0xfauzi/kstrl/issues/190).
+cap originally failed OPEN, because the inbox fold skips unparseable lines
+by design, so a torn emission line undercounted open items and admitted
+work past the cap. Fixed fail-closed for
+[#190](https://github.com/0xfauzi/kstrl/issues/190): `check_inbox_cap`
+adds `Inbox.unparseable_line_count()` to the open total, so every line
+that MIGHT be an open item counts as one; the tolerant fold is unchanged
+for the `ks inbox` display path.
 
 **GitHub intake (PR 3).** The trigger is the LABEL, not the issue, and
 that is the entire access-control story: applying a label needs write

--- a/docs/dark-factory-roadmap.md
+++ b/docs/dark-factory-roadmap.md
@@ -690,9 +690,12 @@ cap originally failed OPEN, because the inbox fold skips unparseable lines
 by design, so a torn emission line undercounted open items and admitted
 work past the cap. Fixed fail-closed for
 [#190](https://github.com/0xfauzi/kstrl/issues/190): `check_inbox_cap`
-adds `Inbox.unparseable_line_count()` to the open total, so every line
-that MIGHT be an open item counts as one; the tolerant fold is unchanged
-for the `ks inbox` display path.
+takes one `Inbox.scan()` snapshot and adds `unparseable_count()` to the
+open total, so every line that MIGHT be an open item counts as one; a
+whole-file read/decode failure is its own `unreadable` state and refuses
+regardless of the configured cap (collapsing it to one skip would
+re-admit under any cap > 1). The tolerant fold is unchanged for the
+`ks inbox` display path.
 
 **GitHub intake (PR 3).** The trigger is the LABEL, not the issue, and
 that is the entire access-control story: applying a label needs write

--- a/kstrl/inbox.py
+++ b/kstrl/inbox.py
@@ -328,6 +328,40 @@ class InboxConfig:
         )
 
 
+@dataclass(frozen=True)
+class InboxScan:
+    """One pass over ``.kstrl/inbox.jsonl``.
+
+    ``unreadable`` means the gate has no positive evidence the backlog
+    is under its cap - admission must refuse regardless of
+    ``open_item_cap``. Display callers ignore the flag and treat the
+    (empty) records as a clear inbox, same as the pre-#190 fold.
+    """
+
+    records: tuple[dict[str, Any], ...] = ()
+    skipped_lines: int = 0
+    unreadable: bool = False
+
+    def folded_items(self) -> list[InboxItem]:
+        folded: dict[str, InboxItem] = {}
+        for record in self.records:
+            item = InboxItem.from_dict(record)
+            if item is None:
+                continue
+            folded[item.id] = item
+        return list(folded.values())
+
+    def open_count(self) -> int:
+        return sum(1 for item in self.folded_items() if item.is_open)
+
+    def unparseable_count(self) -> int:
+        """Lines the display fold would skip: torn JSON, non-dicts, and
+        dicts ``InboxItem.from_dict`` cannot rebuild."""
+        return self.skipped_lines + sum(
+            1 for record in self.records if InboxItem.from_dict(record) is None
+        )
+
+
 class Inbox:
     """Append-only store over ``.kstrl/inbox.jsonl``.
 
@@ -345,24 +379,35 @@ class Inbox:
         return self.root_dir / INBOX_FILENAME
 
     # -- reading -----------------------------------------------------------
-    def _scan(self) -> tuple[list[dict[str, Any]], int]:
-        """Parse the log: (readable records, skipped-line count).
+    def scan(self) -> InboxScan:
+        """One pass over the log: readable records + skip count + readability.
 
         Tolerant by design for the DISPLAY path: a torn tail must not
-        make the whole backlog unreadable. The skip count exists because
-        that tolerance must not leak into safety gates (#190) - see
-        ``unparseable_line_count``. An existing-but-unreadable file
-        counts as one skip for the same reason: the gate has no positive
-        evidence the backlog is clear.
+        make the whole backlog unreadable. Safety gates (#190) must not
+        sit on that tolerance - they consume this snapshot once and treat
+        ``unreadable`` or every skipped line as open capacity. An
+        existing-but-unreadable file (OSError on exists/read, or a
+        UnicodeDecodeError on a torn multibyte write) is its own state:
+        the gate has no positive evidence the backlog is under the cap,
+        so collapsing it to ``skipped=1`` would re-admit under any cap
+        greater than one.
         """
-        if not self.path.exists():
-            return [], 0
+        try:
+            exists = self.path.exists()
+        except OSError:
+            return InboxScan(unreadable=True)
+        if not exists:
+            return InboxScan()
+        try:
+            raw = self.path.read_bytes()
+        except OSError:
+            return InboxScan(unreadable=True)
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return InboxScan(unreadable=True)
         records: list[dict[str, Any]] = []
         skipped = 0
-        try:
-            text = self.path.read_text(encoding="utf-8")
-        except OSError:
-            return [], 1
         for line in text.splitlines():
             line = line.strip()
             if not line:
@@ -376,24 +421,19 @@ class Inbox:
                 records.append(record)
             else:
                 skipped += 1
-        return records, skipped
+        return InboxScan(records=tuple(records), skipped_lines=skipped)
 
     def _read_lines(self) -> list[dict[str, Any]]:
-        return self._scan()[0]
+        return list(self.scan().records)
 
     def unparseable_line_count(self) -> int:
         """Nonempty log lines the display fold would skip (#190).
 
-        A skipped EMISSION line undercounts open items, so a capacity
-        gate sitting on the tolerant fold fails open. Gate consumers add
-        this count to the open total, treating every line that MIGHT be
-        an open item as one (fail closed). Counts torn JSON, non-dict
-        lines, and dicts ``InboxItem.from_dict`` cannot rebuild.
+        Prefer ``scan()`` when open and unparseable counts must come from
+        the same snapshot (the serve admission gate). This helper remains
+        for callers that only need the skip side.
         """
-        records, skipped = self._scan()
-        return skipped + sum(
-            1 for record in records if InboxItem.from_dict(record) is None
-        )
+        return self.scan().unparseable_count()
 
     def _folded(self) -> list[InboxItem]:
         """Latest state per id, in the order the ids first appeared.

--- a/kstrl/inbox.py
+++ b/kstrl/inbox.py
@@ -345,14 +345,24 @@ class Inbox:
         return self.root_dir / INBOX_FILENAME
 
     # -- reading -----------------------------------------------------------
-    def _read_lines(self) -> list[dict[str, Any]]:
+    def _scan(self) -> tuple[list[dict[str, Any]], int]:
+        """Parse the log: (readable records, skipped-line count).
+
+        Tolerant by design for the DISPLAY path: a torn tail must not
+        make the whole backlog unreadable. The skip count exists because
+        that tolerance must not leak into safety gates (#190) - see
+        ``unparseable_line_count``. An existing-but-unreadable file
+        counts as one skip for the same reason: the gate has no positive
+        evidence the backlog is clear.
+        """
         if not self.path.exists():
-            return []
+            return [], 0
         records: list[dict[str, Any]] = []
+        skipped = 0
         try:
             text = self.path.read_text(encoding="utf-8")
         except OSError:
-            return []
+            return [], 1
         for line in text.splitlines():
             line = line.strip()
             if not line:
@@ -360,10 +370,30 @@ class Inbox:
             try:
                 record = json.loads(line)
             except json.JSONDecodeError:
-                continue          # tolerate a torn tail; skip, never raise
+                skipped += 1      # tolerate a torn tail; skip, never raise
+                continue
             if isinstance(record, dict):
                 records.append(record)
-        return records
+            else:
+                skipped += 1
+        return records, skipped
+
+    def _read_lines(self) -> list[dict[str, Any]]:
+        return self._scan()[0]
+
+    def unparseable_line_count(self) -> int:
+        """Nonempty log lines the display fold would skip (#190).
+
+        A skipped EMISSION line undercounts open items, so a capacity
+        gate sitting on the tolerant fold fails open. Gate consumers add
+        this count to the open total, treating every line that MIGHT be
+        an open item as one (fail closed). Counts torn JSON, non-dict
+        lines, and dicts ``InboxItem.from_dict`` cannot rebuild.
+        """
+        records, skipped = self._scan()
+        return skipped + sum(
+            1 for record in records if InboxItem.from_dict(record) is None
+        )
 
     def _folded(self) -> list[InboxItem]:
         """Latest state per id, in the order the ids first appeared.

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -1537,15 +1537,31 @@ def check_inbox_cap(root_dir: Path) -> Admission:
     sitting on that tolerant count admits work past N - a safety gate
     failing open. Only this gate pays the stricter price; the display
     path keeps the tolerant fold.
+
+    Open and unparseable counts come from ONE ``Inbox.scan()`` snapshot
+    so a concurrent torn append cannot split them into an admitting
+    world. A whole-file read/decode failure is its own state: refuse
+    regardless of the configured cap - collapsing it to one skipped
+    line would re-admit under any cap greater than one.
     """
     from kstrl.inbox import Inbox, InboxConfig
 
     config = InboxConfig.load(root_dir)
     if not config.enabled or config.open_item_cap <= 0:
         return Admission(allowed=True)
-    box = Inbox(root_dir, config)
-    garbled = box.unparseable_line_count()
-    if len(box.open_items()) + garbled < config.open_item_cap:
+    scan = Inbox(root_dir, config).scan()
+    if scan.unreadable:
+        return Admission(
+            allowed=False,
+            reason=(
+                "inbox is unreadable (.kstrl/inbox.jsonl could not be "
+                "read or decoded); refusing admission until the log is "
+                "inspectable - the open-item cap fails closed, #190"
+            ),
+        )
+    open_count = scan.open_count()
+    garbled = scan.unparseable_count()
+    if open_count + garbled < config.open_item_cap:
         return Admission(allowed=True)
     detail = (
         f" ({garbled} unparseable inbox line(s) counted as open - the cap "

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -1530,6 +1530,13 @@ def check_inbox_cap(root_dir: Path) -> Admission:
     R8.6 consults before admitting more queue work"; this is that
     consultation. Producing more decisions for a human who is already
     behind is how an inbox becomes ignored.
+
+    Unparseable inbox lines count as OPEN here (#190). The fold skips
+    them by design so one torn write cannot hide the backlog from `ks
+    inbox`, but a skipped emission line undercounts open items and a cap
+    sitting on that tolerant count admits work past N - a safety gate
+    failing open. Only this gate pays the stricter price; the display
+    path keeps the tolerant fold.
     """
     from kstrl.inbox import Inbox, InboxConfig
 
@@ -1537,13 +1544,20 @@ def check_inbox_cap(root_dir: Path) -> Admission:
     if not config.enabled or config.open_item_cap <= 0:
         return Admission(allowed=True)
     box = Inbox(root_dir, config)
-    if not box.over_cap():
+    garbled = box.unparseable_line_count()
+    if len(box.open_items()) + garbled < config.open_item_cap:
         return Admission(allowed=True)
+    detail = (
+        f" ({garbled} unparseable inbox line(s) counted as open - the cap "
+        "fails closed, #190; inspect .kstrl/inbox.jsonl to clear them)"
+        if garbled
+        else ""
+    )
     return Admission(
         allowed=False,
         reason=(
             f"inbox has reached its open-item cap ({config.open_item_cap}); "
-            "triage before queueing more work"
+            f"triage before queueing more work{detail}"
         ),
     )
 

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -241,6 +241,45 @@ class TestCapacityAndNotification:
         assert first.priority is Priority.HIGH
 
 
+class TestUnparseableLineCount:
+    """Issue #190: the fold tolerates garbled lines for DISPLAY; a safety
+    gate must not sit on that tolerance. ``unparseable_line_count`` is the
+    fail-closed signal the serve admission cap adds to the open total.
+    """
+
+    def test_missing_and_clean_logs_count_zero(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        assert box.unparseable_line_count() == 0    # no file yet
+        box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        assert box.unparseable_line_count() == 0    # every line parses
+
+    def test_torn_json_line_counts(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        with box.path.open("a", encoding="utf-8") as handle:
+            handle.write('{"id": "torn-tail", "kind": "halted_r\n')
+        assert box.unparseable_line_count() == 1
+        # the tolerant display fold is unchanged: still one readable item
+        assert len(box.items()) == 1
+
+    def test_non_dict_and_idless_lines_count(self, tmp_path: Path) -> None:
+        """json-decodable is not enough: a non-dict line and a dict the
+        fold cannot rebuild (no id) are equally invisible open items."""
+        box = _box(tmp_path)
+        box.path.parent.mkdir(parents=True, exist_ok=True)
+        box.path.write_text('[1, 2]\n{"title": "no id"}\n', encoding="utf-8")
+        assert box.unparseable_line_count() == 2
+        assert box.items() == []
+
+    def test_blank_lines_do_not_count(self, tmp_path: Path) -> None:
+        box = _box(tmp_path)
+        item = box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        with box.path.open("a", encoding="utf-8") as handle:
+            handle.write("\n\n")
+        assert box.unparseable_line_count() == 0
+        assert box.open_items() == [item]
+
+
 class TestConfig:
     def test_enabled_by_default(self) -> None:
         assert InboxConfig().enabled is True

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -279,6 +279,53 @@ class TestUnparseableLineCount:
         assert box.unparseable_line_count() == 0
         assert box.open_items() == [item]
 
+    def test_read_oserror_is_unreadable_not_one_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Whole-file read failure is not 'one garbled line' - the gate
+        has no positive evidence the backlog is under the cap (#190 P1)."""
+        box = _box(tmp_path)
+        box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        real_read_bytes = Path.read_bytes
+
+        def flaky_read(self: Path) -> bytes:
+            if self == box.path:
+                raise OSError("EIO")
+            return real_read_bytes(self)
+
+        monkeypatch.setattr(Path, "read_bytes", flaky_read)
+        scan = box.scan()
+        assert scan.unreadable is True
+        assert box.items() == []          # display stays tolerant
+
+    def test_exists_oserror_is_unreadable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        box = _box(tmp_path)
+        real_exists = Path.exists
+
+        def flaky_exists(self: Path) -> bool:
+            if self == box.path:
+                raise OSError("EACCES")
+            return real_exists(self)
+
+        monkeypatch.setattr(Path, "exists", flaky_exists)
+        assert box.scan().unreadable is True
+        assert box.items() == []
+
+    def test_invalid_utf8_is_unreadable_and_display_tolerant(
+        self, tmp_path: Path,
+    ) -> None:
+        """A write torn inside a multibyte character must not raise out of
+        the fold or the gate (#190 P1). Whole-file decode failure is the
+        same fail-closed state as OSError - replacement-decoding the
+        damaged line as one skip would still admit under a cap > 1."""
+        box = _box(tmp_path)
+        box.path.parent.mkdir(parents=True, exist_ok=True)
+        box.path.write_bytes(b"\xff\n")
+        assert box.scan().unreadable is True
+        assert box.items() == []          # no UnicodeDecodeError escape
+
 
 class TestConfig:
     def test_enabled_by_default(self) -> None:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -889,6 +889,99 @@ class TestInboxCapGate:
         assert not admission.allowed
         assert box.open_items() == []
 
+    def test_unreadable_inbox_refuses_regardless_of_cap(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Review P1: collapsing a whole-file read failure to one skipped
+        line admitted under the default cap of 50. Unreadable is its own
+        state - deny independently of open_item_cap."""
+        box = self._inbox(tmp_path, cap=50)
+        box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        real_read_bytes = Path.read_bytes
+
+        def flaky_read(self: Path) -> bytes:
+            if self == box.path:
+                raise OSError("EIO")
+            return real_read_bytes(self)
+
+        monkeypatch.setattr(Path, "read_bytes", flaky_read)
+        admission = check_inbox_cap(tmp_path)
+        assert not admission.allowed
+        assert "unreadable" in admission.reason
+
+    def test_invalid_utf8_refuses_admission(
+        self, tmp_path: Path,
+    ) -> None:
+        """Review P1: ``read_text`` raised UnicodeDecodeError on a torn
+        multibyte write, escaping the gate entirely."""
+        box = self._inbox(tmp_path, cap=50)
+        box.path.parent.mkdir(parents=True, exist_ok=True)
+        box.path.write_bytes(b"\xff\n")
+        admission = check_inbox_cap(tmp_path)
+        assert not admission.allowed
+        assert "unreadable" in admission.reason
+
+    def test_gate_uses_one_scan_snapshot(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Review P1: unparseable_line_count() and open_items() each
+        scanned the log. A torn append between those calls produced
+        garbled=0 then open=1, so at cap 2 the gate admitted. One
+        snapshot keeps the counts consistent; the gate must not re-scan.
+        """
+        box = self._inbox(tmp_path, cap=2)
+        box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        with box.path.open("a", encoding="utf-8") as handle:
+            handle.write('{"id": "torn-between-scans", "kind": "halted_r\n')
+
+        scans = 0
+        real_scan = Inbox.scan
+
+        def counted_scan(self: Inbox) -> object:
+            nonlocal scans
+            scans += 1
+            return real_scan(self)
+
+        monkeypatch.setattr(Inbox, "scan", counted_scan)
+        admission = check_inbox_cap(tmp_path)
+        assert not admission.allowed
+        assert scans == 1
+
+    def test_interleaved_append_cannot_split_gate_counts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Deterministic reproduction of the dual-scan race: after the
+        first scan returns, inject a torn line. A second scan would see
+        a different world; the gate must decide from the first snapshot
+        alone (and therefore must not call scan again).
+        """
+        box = self._inbox(tmp_path, cap=2)
+        box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        # File currently: 1 open. Cap 2. A torn line mid-gate would tip
+        # a dual-scan world into open=1 + garbled=0 (admit) if unparseable
+        # ran first on the clean file, then open_items ran after inject.
+
+        scans = 0
+        real_scan = Inbox.scan
+
+        def inject_after_first(self: Inbox) -> object:
+            nonlocal scans
+            scans += 1
+            snap = real_scan(self)
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write('{"id": "injected-after-scan", "kind": "h\n')
+            return snap
+
+        monkeypatch.setattr(Inbox, "scan", inject_after_first)
+        admission = check_inbox_cap(tmp_path)
+        # Snapshot was clean (1 open, 0 garbled) → under cap → admit.
+        # The inject is visible to the NEXT cycle, not this one.
+        assert admission.allowed
+        assert scans == 1
+        # And the next evaluation sees the torn line and refuses.
+        monkeypatch.setattr(Inbox, "scan", real_scan)
+        assert not check_inbox_cap(tmp_path).allowed
+
 
 # --------------------------------------------------------------------------
 # The lease reaper

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from kstrl.findings import Finding
+from kstrl.inbox import Inbox, InboxConfig, ItemKind
 from kstrl.manifest import Component, ComponentStatus, Manifest
 from kstrl.serve import (
     BACKOFF_CAP_SECONDS,
@@ -38,6 +39,7 @@ from kstrl.serve import (
     caffeinate_prefix,
     check_budget,
     check_cost_coverage,
+    check_inbox_cap,
     check_poison_breaker,
     classify_run,
     consecutive_poison_count,
@@ -828,6 +830,64 @@ class TestPoisonBreaker:
         ledger.path.write_text("{corrupt")
         with pytest.raises(ServeStateError):
             check_poison_breaker(ledger, ServeConfig())
+
+
+# --------------------------------------------------------------------------
+# The inbox open-item cap
+# --------------------------------------------------------------------------
+
+
+class TestInboxCapGate:
+    """Issue #190: the open-item cap must fail CLOSED on garbled lines.
+
+    The inbox fold skips unparseable lines by design (a torn tail must
+    not make the backlog invisible), but a skipped emission line
+    undercounts open items, so a cap sitting on the tolerant fold admits
+    work past N. The gate therefore counts every unparseable line as an
+    open item; the tolerant display path is untouched.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in ("KSTRL_INBOX_ENABLED", "KSTRL_INBOX_OPEN_CAP"):
+            monkeypatch.delenv(var, raising=False)
+
+    def _inbox(self, tmp_path: Path, cap: int) -> Inbox:
+        (tmp_path / "kstrl.toml").write_text(
+            f"[inbox]\nopen_item_cap = {cap}\n"
+        )
+        return Inbox(tmp_path, InboxConfig.load(tmp_path))
+
+    def test_open_items_below_the_cap_admit(self, tmp_path: Path) -> None:
+        box = self._inbox(tmp_path, cap=2)
+        box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        assert check_inbox_cap(tmp_path).allowed
+
+    def test_a_garbled_line_counts_toward_the_cap(
+        self, tmp_path: Path,
+    ) -> None:
+        """Same backlog as above plus one torn line: admission refused."""
+        box = self._inbox(tmp_path, cap=2)
+        box.add(ItemKind.HALTED_RUN, "a", dedupe_key="a")
+        with box.path.open("a", encoding="utf-8") as handle:
+            handle.write('{"id": "torn-emission", "kind": "halted_r\n')
+        admission = check_inbox_cap(tmp_path)
+        assert not admission.allowed
+        assert "unparseable" in admission.reason
+        # the display fold stays tolerant: the torn line is invisible there
+        assert len(box.open_items()) == 1
+
+    def test_garbled_lines_alone_can_fill_the_cap(
+        self, tmp_path: Path,
+    ) -> None:
+        """No readable open items at all - the fold reads an empty inbox -
+        yet the gate must refuse: every torn line MIGHT be an open item."""
+        box = self._inbox(tmp_path, cap=1)
+        box.path.parent.mkdir(parents=True, exist_ok=True)
+        box.path.write_text("{not json\n", encoding="utf-8")
+        admission = check_inbox_cap(tmp_path)
+        assert not admission.allowed
+        assert box.open_items() == []
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #190.

## Summary

- `check_inbox_cap` gated queue admission on the tolerant inbox fold, which skips garbled lines by design - so a torn emission line undercounted open items and the cap admitted work past N, a safety gate failing open (the defect class already corrected twice: R8.1 review correction 2, and the serve retry classifier's fail-closed doctrine).
- Fix is the issue's option 1: new `Inbox.unparseable_line_count()` reports every nonempty line the fold would skip (torn JSON, non-dict lines, dicts `from_dict` cannot rebuild, plus an existing-but-unreadable log counting as one), and `check_inbox_cap` adds it to the open total. Every line that MIGHT be an open item counts as one.
- Only the gate pays the stricter price: `_folded`, `over_cap`, and the `ks inbox` display path are behaviorally unchanged. When garbled lines contribute to a refusal, the reason names the count and points at `.kstrl/inbox.jsonl`.
- The R8.6 roadmap note that documented the defect now records the fix (issue acceptance criterion).

## Tested vs assumed (H4)

Tested (TDD - all 7 new tests were watched failing against the old code first; the gate tests failed with `allowed=True`, the exact fail-open defect):
- `tests/test_inbox.py::TestUnparseableLineCount`: torn JSON, non-dict lines, id-less dicts, blank lines, missing/clean logs - each also asserting the display fold stays tolerant.
- `tests/test_serve.py::TestInboxCapGate`: a garbled line tips the same backlog from admitted to refused; garbled lines alone can fill the cap even when the fold reads an empty inbox; refusal reason says "unparseable".
- Full suite: 3165 passed, 28 skipped. `uv run mypy kstrl/ --strict` clean. `uv run ruff check kstrl/ tests/` clean.

Assumed, not tested: the OSError branch (existing-but-unreadable log counts as one skip) has no dedicated test - portably forcing a read failure in-suite is awkward; it is one line following the same fail-closed rule.

No prompts touched, so no calibration run required (H2 does not apply).

Made with [Cursor](https://cursor.com)