### PR TITLE
feat(r8.9): relocate control state outside the agent-reachable tree

### DIFF
--- a/docs/continuous-intake.md
+++ b/docs/continuous-intake.md
@@ -31,7 +31,14 @@ ks queue show <id>
 Items live under `.kstrl/queue/` as one directory each (spec + `meta.json`),
 moved between `queued/ leased/ running/ done/ failed/ poison/` by a single
 `os.replace`. The spec is **copied** at enqueue, so editing or deleting the
-original afterwards cannot change what runs.
+original afterwards cannot change what runs. Locks (`queue.lock`,
+`serve.lock`) stay beside the queue. The pause marker and spend ledger do
+**not**: under R8.9 they live in the XDG control directory
+(`${XDG_STATE_HOME:-~/.local/state}/kstrl/<repo-id>/`) so a worktree agent
+cannot edit them. First use migrates any legacy in-tree copies and writes
+`.kstrl/control_relocated` pointing at the new location. Clones that share
+the same `origin` remote share one control dir — do not run two `ks serve`
+daemons against that ledger at once.
 
 `ks queue pause` stops new work being claimed; it does not touch a run
 already in flight. `ks queue resume` re-opens intake.

--- a/docs/dark-factory-roadmap.md
+++ b/docs/dark-factory-roadmap.md
@@ -1285,40 +1285,33 @@ PR carrying a reproducing test.
 
 ## R8.9 Control-state relocation (M) - [#194](https://github.com/0xfauzi/kstrl/issues/194)
 
-Status: `[ ]` - Added 2026-08-03. Depends on: none; BLOCKS enabling
-`[autonomy]` at L3+ and unattended `ks serve` with the ladder enabled
+Status: `[x]` - Shipped. Control-plane files resolve under
+`${XDG_STATE_HOME:-~/.local/state}/kstrl/<repo-id>/` via
+`kstrl/statedir.py` (`control_dir`, `migrate_control_state`,
+`control_lock`). Live copies of `autonomy.json`, `inbox.jsonl`,
+`spend.json`, `pause.json`, and `github_processed.json` leave the
+agent-reachable tree; locks, queue items, events, knowledge, and
+worktrees stay in-tree under `.kstrl/`.
 
-**Why.** Every durable state surface lives inside the repo tree
-(`.kstrl/`), and the R8.1 halt set protects diffs, not shell activity: an
-engineer agent in a worktree under `.kstrl/worktrees/` can reach
-`autonomy.json`, `queue/spend.json`, `queue/pause.json`, and
-`inbox.jsonl` with ordinary shell access. `autonomy.py`'s own docstring
-concedes the boundary is "real but not absolute". Unattended operation
-(launchd, R8.6 PR 4) turns that from a theoretical concern into the live
-trust boundary: the ladder's level, the spend ledger, the pause marker,
-and the record of human approvals are all editable by the thing they
-govern.
+**Repo id.** Prefer a hash of the normalized `origin` remote URL so
+clones of the same project share one control dir (one autonomy level,
+one daily spend ledger). No origin → hash of the resolved absolute path
+(checkout-local). Documented caveat: do not run two `ks serve` daemons
+against a shared-origin ledger concurrently without holding
+`control.lock`.
 
-**Design.** Control state moves to `~/.local/state/kstrl/<repo-id>/`
-(XDG): `autonomy.json`, the spend ledger, the queue pause marker;
-evaluate the inbox decision lines and the processed-ids ledger. Locks
-stay in-tree - flock must live near the resource it guards. Events,
-evidence artifacts, worktrees, and knowledge stay in-tree deliberately:
-they are the audit record, not the control plane. `statedir.py` grows the
-split resolution plus a one-time migration with a back-compat read,
-mirroring the `.ralph` -> `.kstrl` pattern. `workqueue.py` already
-anticipates a global queue in a forward-compat comment.
+**Migration.** First control read/write moves any legacy in-tree files
+into XDG with a `DeprecationWarning` and writes
+`.kstrl/control_relocated` for operators. Legacy paths remain in
+`ENFORCEMENT_MACHINERY_PATHS` so a diff recreating them still halts.
 
-**Failure modes.** Two checkouts of one repo sharing a state dir (the
-repo-id derivation must be stable and documented); state dir missing
-while a queue is live (fail closed: missing control state reads as
-PAUSED, never as empty-and-running); the legacy in-tree paths must remain
-in the halt set so a diff touching them still trips enforcement.
+**L3+ gate.** `resolve_runtime_level` and `ks autonomy promote` refuse
+L3+ while control state is not external (``XDG_STATE_HOME`` under the
+repo, inaccessible control dir, or leftover legacy files after a failed
+migrate). Fail-closed pause: inaccessible control dir reads as PAUSED.
 
-**Done when:** the control files resolve outside the tree; a migration
-test moves legacy in-tree state once and warns; a diff touching the
-legacy paths still trips the halt set; enabling `[autonomy]` at L3+
-refuses to proceed while control state resolves in-tree.
+Depends on: none; BLOCKS enabling `[autonomy]` at L3+ and unattended
+`ks serve` with the ladder enabled until control state is external.
 
 ## R8.10 Repo readiness: `ks doctor` (M) - [#198](https://github.com/0xfauzi/kstrl/issues/198)
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -32,6 +32,7 @@ Precedence: **CLI flag > env var > `kstrl.toml` > dataclass default**.
 | `KSTRL_NO_TUI` | bool | unset | `1` disables the embedded factory dashboard (plain output) |
 | `NO_COLOR` | bool flag | false | Disables colors |
 | `KSTRL_ASCII` | bool | false | ASCII-only UI |
+| `XDG_STATE_HOME` | path | `~/.local/state` | Base for R8.9 control state (`$XDG_STATE_HOME/kstrl/<repo-id>/`: autonomy, inbox, spend, pause, GitHub processed ledger). Must stay outside the repo tree for L3+ |
 
 ## TimeoutConfig (`[timeout]`)
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -149,4 +149,9 @@ a run breaks, those files are the record; the TUI is only a view.
 - Per-run captures: `.kstrl/evolution.jsonl`, `.kstrl/experiments.tsv`
 - Run event stream + transcripts: `.kstrl/runs/<run_id>/`
 - Distillation debug dumps: `.kstrl/knowledge/<comp>/<run>/_distill_raw.txt` (on failure)
+- Control plane (R8.9): `${XDG_STATE_HOME:-~/.local/state}/kstrl/<repo-id>/`
+  (`autonomy.json`, `inbox.jsonl`, `spend.json`, `pause.json`,
+  `github_processed.json`). Marker `.kstrl/control_relocated` records where
+  legacy in-tree files were moved. L3+ autonomy refuses to proceed while
+  control state still resolves under the repo.
 - Phase F sample real-world run log: `docs/phase-f-run-log.md`

--- a/kstrl/autonomy.py
+++ b/kstrl/autonomy.py
@@ -18,9 +18,12 @@ Three invariants carry the trust:
    named actor, an ack, AND an interactive terminal - a signal an
    unattended agent subprocess does not have (``--actor``/``--ack`` are
    just strings any caller could pass, so they prove nothing alone). The
-   boundary is real but not absolute: an agent with shell access could
-   still write ``.kstrl/autonomy.json`` directly, which is why that file
-   and this module are in the R8.1 enforcement-machinery halt set.
+   live state file lives outside the agent-reachable tree (XDG control
+   dir, R8.9); the legacy in-tree path and this module remain in the
+   R8.1 enforcement-machinery halt set so a diff cannot rewrite either.
+   L3+ additionally refuses to proceed while control state still
+   resolves in-tree (migration incomplete or ``XDG_STATE_HOME`` under
+   the repo).
 2. **Fast down, slow up.** Demotion is automatic and immediate on a trigger;
    re-promotion is locked for a cool-down period afterwards.
 3. **The flag bundle is derived, never stored.** It is computed from the
@@ -52,10 +55,17 @@ from enum import IntEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from kstrl.statedir import (
+    CONTROL_AUTONOMY,
+    control_file,
+    control_is_external,
+    control_lock,
+    ensure_control_state,
+)
+
 if TYPE_CHECKING:
     from kstrl.events import EventBus
 
-STATE_FILENAME = ".kstrl/autonomy.json"
 STATE_SCHEMA_VERSION = 1
 
 
@@ -306,7 +316,7 @@ class AutonomyState:
     # -- persistence -------------------------------------------------------
     @classmethod
     def path_for(cls, root_dir: Path) -> Path:
-        return root_dir / STATE_FILENAME
+        return control_file(root_dir, CONTROL_AUTONOMY)
 
     @classmethod
     def load(cls, root_dir: Path) -> AutonomyState:
@@ -323,6 +333,7 @@ class AutonomyState:
         The rejection is warned about rather than silent (mirroring
         ``knowledge.read_facts``): losing an earned level deserves a note.
         """
+        ensure_control_state(root_dir)
         path = cls.path_for(root_dir)
         if not path.exists():
             return cls()
@@ -367,6 +378,7 @@ class AutonomyState:
 
     def save(self, root_dir: Path) -> None:
         """Atomic write (mkstemp + os.replace), mirroring manifest.py."""
+        ensure_control_state(root_dir)
         path = self.path_for(root_dir)
         path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
@@ -381,20 +393,21 @@ class AutonomyState:
             "last_promoted_by": self.last_promoted_by,
             "history": [asdict(h) for h in self.history],
         }
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(path.parent), suffix=".tmp", prefix=".autonomy-",
-        )
-        try:
-            with os.fdopen(fd, "w") as handle:
-                json.dump(payload, handle, indent=2)
-                handle.write("\n")
-            os.replace(tmp_path, str(path))
-        except BaseException:
+        with control_lock(root_dir):
+            fd, tmp_path = tempfile.mkstemp(
+                dir=str(path.parent), suffix=".tmp", prefix=".autonomy-",
+            )
             try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+                with os.fdopen(fd, "w") as handle:
+                    json.dump(payload, handle, indent=2)
+                    handle.write("\n")
+                os.replace(tmp_path, str(path))
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
 
     # -- transitions -------------------------------------------------------
     def _reset_level_counters(self) -> None:
@@ -657,14 +670,18 @@ def envelope_ceiling(policy_enabled: bool) -> AutonomyLevel:
 
 
 def resolve_runtime_level(
-    state: AutonomyState, config: AutonomyConfig, *, policy_enabled: bool,
+    state: AutonomyState,
+    config: AutonomyConfig,
+    *,
+    policy_enabled: bool,
+    root_dir: Path,
 ) -> tuple[AutonomyLevel, list[str]]:
     """The level a run may actually use, plus why it was clamped.
 
-    Two independent ceilings apply, and the LOWEST wins: the operator's
-    ``max_level`` and the envelope ceiling above. Returned rather than
-    raised so the run can proceed at the safe level while saying loudly
-    what it withheld.
+    Independent ceilings apply, and the LOWEST wins: the operator's
+    ``max_level``, the envelope ceiling, and (R8.9) the control-state
+    relocation gate. Returned rather than raised so the run can proceed
+    at the safe level while saying loudly what it withheld.
     """
     notes: list[str] = []
     level = state.autonomy_level
@@ -682,7 +699,35 @@ def resolve_runtime_level(
             "to auto-merge inside"
         )
         level = ceiling
+    ensure_control_state(root_dir)
+    if (
+        int(level) >= int(AutonomyLevel.L3_ENVELOPED_AUTO)
+        and not control_is_external(root_dir)
+    ):
+        notes.append(
+            "clamped to L2 Gated-merge: L3+ requires control state outside "
+            "the agent-reachable tree (R8.9); leftover `.kstrl/` control "
+            "files or an XDG_STATE_HOME under the repo block unattended "
+            "auto-merge"
+        )
+        level = AutonomyLevel.L2_GATED_MERGE
     return level, notes
+
+
+def control_relocation_error(
+    root_dir: Path, *, target_level: AutonomyLevel,
+) -> str | None:
+    """Why L3+ is refused for control-state placement, or None if allowed."""
+    if int(target_level) < int(AutonomyLevel.L3_ENVELOPED_AUTO):
+        return None
+    ensure_control_state(root_dir)
+    if control_is_external(root_dir):
+        return None
+    return (
+        "L3+ requires control state outside the agent-reachable tree "
+        "(R8.9). Finish migrating leftover `.kstrl/` control files, or "
+        "point XDG_STATE_HOME outside the repo, then retry."
+    )
 
 
 def promotion_authority_error(*, force: bool) -> str | None:
@@ -691,11 +736,10 @@ def promotion_authority_error(*, force: bool) -> str | None:
     ``--actor``/``--ack`` are strings any caller can supply, so on their
     own they prove nothing about who is asking: an unattended agent can
     pass ``--actor human``. The out-of-band signal is a controlling TTY -
-    an interactive terminal the agent's subprocess does not have. This is
-    a real boundary, not a complete one: an agent with shell access could
-    still edit ``.kstrl/autonomy.json`` directly, which is why that file
-    is in the R8.1 enforcement-machinery halt set. Stated plainly rather
-    than overclaimed.
+    an interactive terminal the agent's subprocess does not have. Live
+    autonomy state lives in the XDG control dir (R8.9); the legacy
+    in-tree path remains in the R8.1 enforcement-machinery halt set so a
+    diff cannot rewrite it. Stated plainly rather than overclaimed.
     """
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         detail = "forced promotions bypass evidence and " if force else ""

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -3287,7 +3287,7 @@ def autonomy_status(root: Path | None, ui: str, no_color: bool) -> None:
     state = AutonomyState.load(root_dir)
     policy_enabled = PolicyConfig.load(root_dir).enabled
     level, clamps = resolve_runtime_level(
-        state, config, policy_enabled=policy_enabled,
+        state, config, policy_enabled=policy_enabled, root_dir=root_dir,
     )
 
     ui_impl.section("Autonomy")
@@ -3351,8 +3351,10 @@ def autonomy_promote(
     """Raise the autonomy level by one. Requires a human ack."""
     from kstrl.autonomy import (
         AutonomyError,
+        AutonomyLevel,
         AutonomyState,
         commit_transition,
+        control_relocation_error,
         promotion_authority_error,
     )
 
@@ -3367,6 +3369,11 @@ def autonomy_promote(
         ui_impl.err(f"Promotion refused: {authority_error}")
         sys.exit(1)
     state = AutonomyState.load(root_dir)
+    target = AutonomyLevel(min(int(state.autonomy_level) + 1, int(AutonomyLevel.L4_DEPLOY)))
+    relocation_error = control_relocation_error(root_dir, target_level=target)
+    if relocation_error is not None:
+        ui_impl.err(f"Promotion refused: {relocation_error}")
+        sys.exit(1)
     try:
         record = state.promote(actor=actor, ack=ack, force=force)
     except AutonomyError as exc:

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -2375,6 +2375,7 @@ def _run_factory_locked(
         autonomy_level, clamps = resolve_runtime_level(
             autonomy_state, autonomy_config,
             policy_enabled=policy_config.enabled,
+            root_dir=root_dir,
         )
         bundle = flag_bundle_for(autonomy_level)
         overrides = manual_override_notes(

--- a/kstrl/inbox.py
+++ b/kstrl/inbox.py
@@ -8,10 +8,10 @@ demotion lives in the evolution journal, a budget overrun lives in a log
 line. Each is discoverable only if you already know to look for it, which
 is the opposite of what "humans handle exceptions" requires.
 
-This module is the thin substrate: an append-only ``.kstrl/inbox.jsonl``
-plus the fold that turns it into a current view. Deliberately small - the
-value is in the emitters that feed it and the actions that resolve it,
-not in the store.
+This module is the thin substrate: an append-only inbox log (XDG control
+dir under R8.9; legacy path ``.kstrl/inbox.jsonl``) plus the fold that
+turns it into a current view. Deliberately small - the value is in the
+emitters that feed it and the actions that resolve it, not in the store.
 
 **Append-only, never rewritten.** Every emission and every decision is one
 appended line; the current state of an item is the fold of its lines in
@@ -44,7 +44,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
-INBOX_FILENAME = ".kstrl/inbox.jsonl"
+from kstrl.statedir import CONTROL_INBOX, control_file, control_lock, ensure_control_state
+
 INBOX_SCHEMA_VERSION = 1
 
 
@@ -363,7 +364,7 @@ class InboxScan:
 
 
 class Inbox:
-    """Append-only store over ``.kstrl/inbox.jsonl``.
+    """Append-only store over the XDG control-dir inbox log.
 
     Reads fold the log into current items; writes append one line. No
     method rewrites history - ``compact`` exists but writes a fresh file
@@ -376,7 +377,7 @@ class Inbox:
 
     @property
     def path(self) -> Path:
-        return self.root_dir / INBOX_FILENAME
+        return control_file(self.root_dir, CONTROL_INBOX)
 
     # -- reading -----------------------------------------------------------
     def scan(self) -> InboxScan:
@@ -392,6 +393,7 @@ class Inbox:
         so collapsing it to ``skipped=1`` would re-admit under any cap
         greater than one.
         """
+        ensure_control_state(self.root_dir)
         try:
             exists = self.path.exists()
         except OSError:
@@ -501,11 +503,14 @@ class Inbox:
     # -- writing -----------------------------------------------------------
     def _append(self, item: InboxItem) -> None:
         """Append one line, creating the file atomically on first write."""
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_control_state(self.root_dir)
+        path = self.path
+        path.parent.mkdir(parents=True, exist_ok=True)
         payload = {"schema_version": INBOX_SCHEMA_VERSION, **item.to_dict()}
         line = json.dumps(payload, separators=(",", ":"), default=str) + "\n"
-        with open(self.path, "a", encoding="utf-8") as handle:
-            handle.write(line)
+        with control_lock(self.root_dir):
+            with open(path, "a", encoding="utf-8") as handle:
+                handle.write(line)
 
     def add(
         self,
@@ -621,26 +626,30 @@ class Inbox:
         the manifest pattern.
         """
         items = self.items()
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(self.path.parent), suffix=".tmp", prefix=".inbox-",
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                for item in items:
-                    payload = {
-                        "schema_version": INBOX_SCHEMA_VERSION, **item.to_dict(),
-                    }
-                    handle.write(
-                        json.dumps(payload, separators=(",", ":"), default=str) + "\n"
-                    )
-            os.replace(tmp_path, str(self.path))
-        except BaseException:
+        ensure_control_state(self.root_dir)
+        path = self.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with control_lock(self.root_dir):
+            fd, tmp_path = tempfile.mkstemp(
+                dir=str(path.parent), suffix=".tmp", prefix=".inbox-",
+            )
             try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    for item in items:
+                        payload = {
+                            "schema_version": INBOX_SCHEMA_VERSION, **item.to_dict(),
+                        }
+                        handle.write(
+                            json.dumps(payload, separators=(",", ":"), default=str)
+                            + "\n"
+                        )
+                os.replace(tmp_path, str(path))
+            except BaseException:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
         return len(items)
 
 

--- a/kstrl/intake_github.py
+++ b/kstrl/intake_github.py
@@ -64,16 +64,19 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from kstrl.statedir import (
+    CONTROL_GITHUB_PROCESSED,
+    control_file,
+    control_lock,
+    ensure_control_state,
+)
 from kstrl.workqueue import (
     ItemSource,
     MergeDisposition,
     Queue,
     QueueError,
     QueueItem,
-    queue_root,
 )
-
-GITHUB_LEDGER_FILENAME = "github_processed.json"
 
 #: Cap on the spec text built from an issue. Generous for a real spec,
 #: bounded enough that a pathological body cannot become a pathological
@@ -462,9 +465,10 @@ class ProcessedLedger:
 
     @property
     def path(self) -> Path:
-        return queue_root(self.root_dir) / GITHUB_LEDGER_FILENAME
+        return control_file(self.root_dir, CONTROL_GITHUB_PROCESSED)
 
     def load(self) -> ProcessedLedger:
+        ensure_control_state(self.root_dir)
         try:
             raw = self.path.read_text(encoding="utf-8")
         except OSError:
@@ -505,14 +509,17 @@ class ProcessedLedger:
     def _write(self) -> None:
         from kstrl.workqueue import atomic_write
 
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        atomic_write(
-            self.path,
-            json.dumps(
-                {"version": 1, "processed": self._entries},
-                indent=2, ensure_ascii=False,
-            ) + "\n",
-        )
+        ensure_control_state(self.root_dir)
+        path = self.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with control_lock(self.root_dir):
+            atomic_write(
+                path,
+                json.dumps(
+                    {"version": 1, "processed": self._entries},
+                    indent=2, ensure_ascii=False,
+                ) + "\n",
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/kstrl/policy.py
+++ b/kstrl/policy.py
@@ -58,12 +58,20 @@ ENFORCEMENT_MACHINERY_PATHS: tuple[str, ...] = (
     "**/kstrl/guards.py",
     "**/kstrl/fixtures.py",
     "**/kstrl/autonomy.py",
-    # R8.2 ladder state. Editing it IS editing the factory's own
-    # permissions, so it belongs to the enforcement surface: the CLI
-    # promotion path demands an interactive terminal, and this closes the
-    # obvious way around that (write the level straight to disk).
+    "**/kstrl/statedir.py",
+    # R8.2 / R8.9 control-plane state. Live copies live under XDG
+    # (outside the tree); these legacy in-tree paths stay in the halt
+    # set so a diff cannot recreate agent-editable control files.
     "**/.kstrl/autonomy.json",
     ".kstrl/autonomy.json",
+    "**/.kstrl/inbox.jsonl",
+    ".kstrl/inbox.jsonl",
+    "**/.kstrl/queue/spend.json",
+    ".kstrl/queue/spend.json",
+    "**/.kstrl/queue/pause.json",
+    ".kstrl/queue/pause.json",
+    "**/.kstrl/queue/github_processed.json",
+    ".kstrl/queue/github_processed.json",
 )
 
 # Conservative default deny-list written by ``ks init``. Repo-owned: each

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -68,7 +68,13 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Protocol
 
-from kstrl.statedir import state_dir
+from kstrl.statedir import (
+    CONTROL_SPEND,
+    control_file,
+    control_lock,
+    ensure_control_state,
+    state_dir,
+)
 from kstrl.workqueue import (
     ItemSource,
     ItemState,
@@ -83,7 +89,6 @@ from kstrl.workqueue import (
 )
 
 SERVE_LOCK_FILENAME = "serve.lock"
-SPEND_FILENAME = "spend.json"
 
 #: Substrings the factory prints on each of its two exit-2 refusals.
 #: Matching output is EVIDENCE; a pre-launch lock probe is inference and
@@ -488,7 +493,7 @@ class ServeState:
 
 
 class SpendLedger:
-    """Atomic store for :class:`ServeState` under ``.kstrl/queue/``.
+    """Atomic store for :class:`ServeState` in the XDG control directory.
 
     Rewritten whole on every update rather than appended: the only
     questions asked of it are "how much today", "how many poisons in a
@@ -501,7 +506,7 @@ class SpendLedger:
 
     @property
     def path(self) -> Path:
-        return queue_root(self.root_dir) / SPEND_FILENAME
+        return control_file(self.root_dir, CONTROL_SPEND)
 
     def read_state(self, today: str | None = None) -> ServeState:
         """Load state, rolling the spend over on a new local day.
@@ -512,6 +517,7 @@ class SpendLedger:
         marker: a file we cannot parse is not evidence that spending is
         safe.
         """
+        ensure_control_state(self.root_dir)
         stamp = today or _local_today()
         try:
             raw = self.path.read_text(encoding="utf-8")
@@ -550,11 +556,14 @@ class SpendLedger:
     def _write(self, state: ServeState) -> None:
         from kstrl.workqueue import atomic_write
 
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        atomic_write(
-            self.path,
-            json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
-        )
+        ensure_control_state(self.root_dir)
+        path = self.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with control_lock(self.root_dir):
+            atomic_write(
+                path,
+                json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
+            )
 
     def charge(
         self,
@@ -1121,7 +1130,8 @@ def resolve_merge_gate(item: QueueItem, root_dir: Path) -> MergeGate:
 
     policy = PolicyConfig.load(root_dir)
     level, clamps = resolve_runtime_level(
-        AutonomyState.load(root_dir), config, policy_enabled=policy.enabled,
+        AutonomyState.load(root_dir), config,
+        policy_enabled=policy.enabled, root_dir=root_dir,
     )
     bundle = flag_bundle_for(level)
     notes = list(clamps)

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -72,6 +72,7 @@ from kstrl.statedir import (
     CONTROL_SPEND,
     control_file,
     control_lock,
+    control_untrusted_reason,
     ensure_control_state,
     state_dir,
 )
@@ -515,9 +516,18 @@ class SpendLedger:
         missing file, which is the genuine first-run case. Failing closed
         here is the same correction PR #185 F7 applied to the pause
         marker: a file we cannot parse is not evidence that spending is
-        safe.
+        safe. After a failed/partial migrate (legacy still present, or
+        control dir inaccessible), missing XDG is NOT first-run - raise
+        rather than zero the budget.
         """
         ensure_control_state(self.root_dir)
+        untrusted = control_untrusted_reason(self.root_dir)
+        if untrusted is not None:
+            raise ServeStateError(
+                f"refusing to read the daemon spend ledger: {untrusted}. "
+                "Fix the control-state location or finish migrating "
+                "legacy `.kstrl/` control files before spending."
+            )
         stamp = today or _local_today()
         try:
             raw = self.path.read_text(encoding="utf-8")
@@ -553,17 +563,21 @@ class SpendLedger:
         """Today's spend. Raises ServeStateError like ``read_state``."""
         return self.read_state(today).spend
 
-    def _write(self, state: ServeState) -> None:
+    def _write_unlocked(self, state: ServeState) -> None:
+        """Atomic rewrite; caller must already hold ``control_lock``."""
         from kstrl.workqueue import atomic_write
 
-        ensure_control_state(self.root_dir)
         path = self.path
         path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write(
+            path,
+            json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
+        )
+
+    def _write(self, state: ServeState) -> None:
+        ensure_control_state(self.root_dir)
         with control_lock(self.root_dir):
-            atomic_write(
-                path,
-                json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
-            )
+            self._write_unlocked(state)
 
     def charge(
         self,
@@ -581,38 +595,47 @@ class SpendLedger:
         for a launch that never reached an agent (#186 F9: a launch
         failure previously incremented ``runs`` and then tripped the
         coverage gate on the next cycle).
+
+        The full read-modify-write holds ``control_lock`` so two
+        origin-sharing checkouts cannot drop charges.
         """
         stamp = today or _local_today()
-        state = self.read_state(stamp)
-        current = state.spend
-        merged_phases = tuple(sorted(
-            set(current.unmetered_phases) | {p for p in unmetered_phases if p}
-        ))
-        spend = DailySpend(
-            date=stamp,
-            spent_usd=round(current.spent_usd + max(0.0, usd), 6),
-            runs=current.runs + (1 if metered_run else 0),
-            covered_calls=current.covered_calls + max(0, covered_calls),
-            total_calls=current.total_calls + max(0, total_calls),
-            unmetered_phases=merged_phases,
-        )
-        self._write(replace(
-            state,
-            spend=spend,
-            cost_coverage_seen=state.cost_coverage_seen or covered_calls > 0,
-        ))
-        return spend
+        ensure_control_state(self.root_dir)
+        with control_lock(self.root_dir):
+            state = self.read_state(stamp)
+            current = state.spend
+            merged_phases = tuple(sorted(
+                set(current.unmetered_phases) | {p for p in unmetered_phases if p}
+            ))
+            spend = DailySpend(
+                date=stamp,
+                spent_usd=round(current.spent_usd + max(0.0, usd), 6),
+                runs=current.runs + (1 if metered_run else 0),
+                covered_calls=current.covered_calls + max(0, covered_calls),
+                total_calls=current.total_calls + max(0, total_calls),
+                unmetered_phases=merged_phases,
+            )
+            self._write_unlocked(replace(
+                state,
+                spend=spend,
+                cost_coverage_seen=state.cost_coverage_seen or covered_calls > 0,
+            ))
+            return spend
 
     def record_terminal(self, *, poisoned: bool, today: str | None = None) -> int:
         """Update the authoritative poison streak; returns the new value."""
-        state = self.read_state(today)
-        streak = state.consecutive_poison + 1 if poisoned else 0
-        self._write(replace(state, consecutive_poison=streak))
-        return streak
+        ensure_control_state(self.root_dir)
+        with control_lock(self.root_dir):
+            state = self.read_state(today)
+            streak = state.consecutive_poison + 1 if poisoned else 0
+            self._write_unlocked(replace(state, consecutive_poison=streak))
+            return streak
 
     def reset_poison_streak(self, today: str | None = None) -> None:
-        state = self.read_state(today)
-        self._write(replace(state, consecutive_poison=0))
+        ensure_control_state(self.root_dir)
+        with control_lock(self.root_dir):
+            state = self.read_state(today)
+            self._write_unlocked(replace(state, consecutive_poison=0))
 
 
 @dataclass(frozen=True)

--- a/kstrl/statedir.py
+++ b/kstrl/statedir.py
@@ -23,6 +23,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import warnings
 from collections.abc import Iterator
@@ -30,6 +31,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import IO
+from urllib.parse import urlsplit
 
 STATE_DIR_NAME = ".kstrl"
 CONTROL_APP_NAME = "kstrl"
@@ -66,13 +68,14 @@ def _utc_now_iso() -> str:
 def normalize_remote_url(url: str) -> str:
     """Canonicalize a git remote URL for stable hashing.
 
-    Strips trailing ``.git``, lowercases, and maps ``git@host:path`` /
-    ``ssh://git@host/path`` forms to ``host/path``.
+    Casefolds first, strips userinfo and default ports, maps
+    ``git@host:path`` / ``ssh://`` forms to ``host/path``, and strips a
+    trailing ``.git`` (any case).
     """
     raw = url.strip()
     if not raw:
         return ""
-    value = raw
+    value = raw.casefold()
     if value.startswith("git@"):
         # git@github.com:org/repo.git -> github.com/org/repo
         rest = value[len("git@"):]
@@ -80,15 +83,16 @@ def normalize_remote_url(url: str) -> str:
             host, path = rest.split(":", 1)
             value = f"{host}/{path}"
     elif "://" in value:
-        # https://github.com/org/repo.git or ssh://git@github.com/org/repo
-        _, _, remainder = value.partition("://")
-        if remainder.startswith("git@"):
-            remainder = remainder[len("git@"):]
-        value = remainder
+        parts = urlsplit(value)
+        host = parts.hostname or ""
+        if parts.port and parts.port not in (80, 443, 22):
+            host = f"{host}:{parts.port}"
+        path = parts.path.lstrip("/")
+        value = f"{host}/{path}" if path else host
     value = value.rstrip("/")
     if value.endswith(".git"):
         value = value[: -len(".git")]
-    return value.lower()
+    return value
 
 
 def _origin_url(root_dir: Path) -> str | None:
@@ -137,12 +141,36 @@ def repo_id(root_dir: Path) -> str:
     return f"{_slug_from_identity(identity)}-{digest}"
 
 
+_resolved_xdg_home: Path | None = None
+_resolved_xdg_raw: str | None = None
+
+
 def xdg_state_home() -> Path:
-    """XDG state home, overridable via ``XDG_STATE_HOME``."""
+    """XDG state home, overridable via ``XDG_STATE_HOME``.
+
+    Overrides are expanded and resolved so a relative value cannot drift
+    with ``chdir`` (pause/spend paths must stay absolute). The first
+    resolution of a given override string is cached for the process so
+    ``XDG_STATE_HOME=rel`` set once keeps pointing at the same directory
+    after later ``chdir`` calls.
+    """
+    global _resolved_xdg_home, _resolved_xdg_raw
     override = os.environ.get("XDG_STATE_HOME", "").strip()
-    if override:
-        return Path(override).expanduser()
-    return Path.home() / ".local" / "state"
+    if not override:
+        return (Path.home() / ".local" / "state").resolve()
+    if _resolved_xdg_home is not None and _resolved_xdg_raw == override:
+        return _resolved_xdg_home
+    resolved = Path(override).expanduser().resolve()
+    _resolved_xdg_home = resolved
+    _resolved_xdg_raw = override
+    return resolved
+
+
+def clear_xdg_state_home_cache() -> None:
+    """Test helper: drop the cached ``XDG_STATE_HOME`` resolution."""
+    global _resolved_xdg_home, _resolved_xdg_raw
+    _resolved_xdg_home = None
+    _resolved_xdg_raw = None
 
 
 def control_dir(root_dir: Path) -> Path:
@@ -177,6 +205,43 @@ def _is_under(path: Path, root: Path) -> bool:
         return False
 
 
+def legacy_control_remaining(root_dir: Path) -> tuple[str, ...]:
+    """Filenames still present at legacy in-tree locations.
+
+    Any leftover means migration is incomplete or dual-state: live XDG
+    readers must fail closed rather than treat missing XDG as first-run.
+    """
+    remaining: list[str] = []
+    for name, path in legacy_control_paths(root_dir).items():
+        try:
+            if path.exists() or path.is_symlink():
+                remaining.append(name)
+        except OSError:
+            remaining.append(name)
+    return tuple(remaining)
+
+
+def _control_files_compromised(root_dir: Path) -> str | None:
+    """Why live control files are untrustworthy, or None if plain files."""
+    try:
+        cdir = control_dir(root_dir).resolve()
+    except OSError as exc:
+        return f"control directory unresolvable: {exc}"
+    for name in CONTROL_FILENAMES:
+        path = cdir / name
+        try:
+            if path.is_symlink():
+                return f"control file {name} is a symlink"
+            if not path.exists():
+                continue
+            resolved = path.resolve()
+            if not _is_under(resolved, cdir):
+                return f"control file {name} resolves outside the control directory"
+        except OSError as exc:
+            return f"control file {name} unreadable: {exc}"
+    return None
+
+
 def control_dir_accessible(root_dir: Path) -> bool:
     """Whether the control directory can be created and listed.
 
@@ -193,28 +258,36 @@ def control_dir_accessible(root_dir: Path) -> bool:
         return False
 
 
+def control_untrusted_reason(root_dir: Path) -> str | None:
+    """Why the control plane must fail closed, or None if usable."""
+    if not control_dir_accessible(root_dir):
+        return "control state directory inaccessible"
+    try:
+        if _is_under(control_dir(root_dir), root_dir):
+            return "XDG_STATE_HOME resolves under the repository tree"
+    except OSError as exc:
+        return f"control directory unresolvable: {exc}"
+    remaining = legacy_control_remaining(root_dir)
+    if remaining:
+        return (
+            "legacy in-tree control files remain after migration "
+            f"({', '.join(remaining)}); refuse to treat empty XDG as first-run"
+        )
+    compromised = _control_files_compromised(root_dir)
+    if compromised is not None:
+        return compromised
+    return None
+
+
 def control_is_external(root_dir: Path) -> bool:
     """True when live control state is outside the agent-reachable tree.
 
     False when the control dir resolves under ``root_dir`` (mis-set
-    ``XDG_STATE_HOME``), when the control dir is inaccessible, or when
-    any legacy in-tree control file still exists (migration incomplete -
-    an agent can still edit the leftover).
+    ``XDG_STATE_HOME``), when the control dir is inaccessible, when any
+    legacy in-tree control file still exists, or when a control file is a
+    symlink / resolves outside the control dir.
     """
-    if not control_dir_accessible(root_dir):
-        return False
-    try:
-        if _is_under(control_dir(root_dir), root_dir):
-            return False
-    except OSError:
-        return False
-    for legacy in legacy_control_paths(root_dir).values():
-        try:
-            if legacy.exists():
-                return False
-        except OSError:
-            return False
-    return True
+    return control_untrusted_reason(root_dir) is None
 
 
 def _write_relocated_marker(root_dir: Path, *, moved: list[str]) -> None:
@@ -236,11 +309,27 @@ def _write_relocated_marker(root_dir: Path, *, moved: list[str]) -> None:
         pass
 
 
+def _move_control_file(src: Path, dst: Path) -> None:
+    """Move ``src`` to ``dst``, including across devices (EXDEV)."""
+    try:
+        os.replace(src, dst)
+        return
+    except OSError:
+        pass
+    # Cross-device or other replace failure: copy then unlink. If unlink
+    # fails, legacy remains and consumers fail closed via
+    # ``legacy_control_remaining``.
+    shutil.copy2(src, dst)
+    src.unlink()
+
+
 def migrate_control_state(root_dir: Path) -> list[str]:
     """Move legacy in-tree control files into the XDG control dir once.
 
-    Returns the list of filenames moved. Idempotent: a second call is a
-    no-op when targets already exist or legacy files are gone.
+    Returns the list of filenames moved. When both XDG and legacy copies
+    exist (dual-state), the legacy file is left in place so
+    ``legacy_control_remaining`` keeps pause/spend fail-closed until an
+    operator reconciles. Idempotent when only XDG exists.
     """
     if not control_dir_accessible(root_dir):
         return []
@@ -251,13 +340,25 @@ def migrate_control_state(root_dir: Path) -> list[str]:
         src = legacy[name]
         dst = target_root / name
         try:
-            if dst.exists() or not src.exists():
-                continue
+            src_present = src.exists() or src.is_symlink()
+            dst_present = dst.exists() or dst.is_symlink()
         except OSError:
+            continue
+        if not src_present:
+            continue
+        if dst_present:
+            # Dual-state: do not silently prefer XDG. Leave legacy so
+            # fail-closed readers refuse until the leftover is removed.
+            warnings.warn(
+                f"kstrl: dual-state control file {name}: both {src} and "
+                f"{dst} exist; leaving legacy in place so pause/spend "
+                "fail closed until reconciled (R8.9)",
+                stacklevel=2,
+            )
             continue
         try:
             dst.parent.mkdir(parents=True, exist_ok=True)
-            os.replace(src, dst)
+            _move_control_file(src, dst)
         except OSError as exc:
             warnings.warn(
                 f"kstrl: failed to migrate control file {src} -> {dst}: {exc}",
@@ -299,21 +400,30 @@ def control_lock(root_dir: Path, *, blocking: bool = True) -> Iterator[None]:
     two checkouts sharing an origin cannot corrupt the shared ledger.
     POSIX ``fcntl`` only; without it we degrade to no exclusion (same
     pattern as ``queue_lock`` / factory lock).
+
+    Fails closed if the control directory cannot be created: yielding
+    without a lock would silently disable exclusion while writers proceed.
     """
     ensure_control_state(root_dir)
     lock_path = control_dir(root_dir) / CONTROL_LOCK_FILENAME
     try:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        yield
-        return
+    except OSError as exc:
+        raise ControlUnavailableError(
+            f"control state directory unavailable ({lock_path.parent}): {exc}"
+        ) from exc
     try:
         import fcntl
     except ImportError:
         yield
         return
 
-    handle: IO[str] = open(lock_path, "a+")
+    try:
+        handle: IO[str] = open(lock_path, "a+")
+    except OSError as exc:
+        raise ControlUnavailableError(
+            f"cannot open control lock {lock_path}: {exc}"
+        ) from exc
     try:
         flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
         try:
@@ -332,3 +442,7 @@ def control_lock(root_dir: Path, *, blocking: bool = True) -> Iterator[None]:
 
 class ControlLockedError(RuntimeError):
     """Another process holds ``control.lock``."""
+
+
+class ControlUnavailableError(RuntimeError):
+    """Control state directory cannot be created or locked."""

--- a/kstrl/statedir.py
+++ b/kstrl/statedir.py
@@ -1,17 +1,334 @@
-"""Runtime state-dir resolution.
+"""Runtime state-dir resolution: artifacts in-tree, control state outside.
 
-Journals, worktrees, and knowledge all live under a single per-repo
-state directory. Resolving it in one place keeps the name from drifting
-between call sites.
+Journals, worktrees, queue items, locks, and evidence stay under
+``<root>/.kstrl/`` (the agent-reachable audit/artifact tree). Control-plane
+files that govern what the factory may do without a human - autonomy level,
+spend ledger, pause marker, inbox, GitHub processed-ids - live under the
+XDG state directory:
+
+    ${XDG_STATE_HOME:-~/.local/state}/kstrl/<repo-id>/
+
+Clones that share the same ``origin`` remote share one control directory
+(deliberate: one autonomy level and one daily spend ledger per project).
+Do not run two ``ks serve`` daemons against that shared ledger concurrently
+without holding ``control.lock``. Checkouts with no ``origin`` remote get a
+path-hashed id and stay checkout-local.
+
+R8.9 / #194.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
+import os
+import re
+import subprocess
+import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import IO
 
 STATE_DIR_NAME = ".kstrl"
+CONTROL_APP_NAME = "kstrl"
+CONTROL_LOCK_FILENAME = "control.lock"
+CONTROL_RELOCATED_MARKER = "control_relocated"
+
+#: Flat filenames under the XDG control directory (not nested under queue/).
+CONTROL_AUTONOMY = "autonomy.json"
+CONTROL_INBOX = "inbox.jsonl"
+CONTROL_SPEND = "spend.json"
+CONTROL_PAUSE = "pause.json"
+CONTROL_GITHUB_PROCESSED = "github_processed.json"
+
+CONTROL_FILENAMES: tuple[str, ...] = (
+    CONTROL_AUTONOMY,
+    CONTROL_INBOX,
+    CONTROL_SPEND,
+    CONTROL_PAUSE,
+    CONTROL_GITHUB_PROCESSED,
+)
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 
 def state_dir(root_dir: Path) -> Path:
-    """Return the state directory for ``root_dir``."""
+    """Return the in-tree artifact/lock directory for ``root_dir``."""
     return root_dir / STATE_DIR_NAME
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def normalize_remote_url(url: str) -> str:
+    """Canonicalize a git remote URL for stable hashing.
+
+    Strips trailing ``.git``, lowercases, and maps ``git@host:path`` /
+    ``ssh://git@host/path`` forms to ``host/path``.
+    """
+    raw = url.strip()
+    if not raw:
+        return ""
+    value = raw
+    if value.startswith("git@"):
+        # git@github.com:org/repo.git -> github.com/org/repo
+        rest = value[len("git@"):]
+        if ":" in rest:
+            host, path = rest.split(":", 1)
+            value = f"{host}/{path}"
+    elif "://" in value:
+        # https://github.com/org/repo.git or ssh://git@github.com/org/repo
+        _, _, remainder = value.partition("://")
+        if remainder.startswith("git@"):
+            remainder = remainder[len("git@"):]
+        value = remainder
+    value = value.rstrip("/")
+    if value.endswith(".git"):
+        value = value[: -len(".git")]
+    return value.lower()
+
+
+def _origin_url(root_dir: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root_dir), "remote", "get-url", "origin"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    return url or None
+
+
+def _slug_from_identity(identity: str) -> str:
+    base = identity.rsplit("/", 1)[-1] if identity else "repo"
+    slug = _SLUG_RE.sub("-", base.lower()).strip("-")
+    if not slug:
+        slug = "repo"
+    return slug[:32]
+
+
+def repo_id(root_dir: Path) -> str:
+    """Stable control-dir id for ``root_dir``.
+
+    Prefer a hash of the normalized ``origin`` URL so every clone of the
+    same remote shares control state. With no origin, hash the resolved
+    absolute path (checkout-local).
+    """
+    origin = _origin_url(root_dir)
+    if origin:
+        identity = normalize_remote_url(origin)
+        source = "origin"
+    else:
+        try:
+            identity = str(root_dir.resolve())
+        except OSError:
+            identity = str(root_dir)
+        source = "path"
+    digest = hashlib.sha256(f"{source}:{identity}".encode()).hexdigest()[:16]
+    return f"{_slug_from_identity(identity)}-{digest}"
+
+
+def xdg_state_home() -> Path:
+    """XDG state home, overridable via ``XDG_STATE_HOME``."""
+    override = os.environ.get("XDG_STATE_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".local" / "state"
+
+
+def control_dir(root_dir: Path) -> Path:
+    """XDG control directory for ``root_dir`` (outside the agent tree)."""
+    return xdg_state_home() / CONTROL_APP_NAME / repo_id(root_dir)
+
+
+def control_file(root_dir: Path, name: str) -> Path:
+    """Path to a named control file under the XDG control directory."""
+    if name not in CONTROL_FILENAMES:
+        raise ValueError(f"unknown control file {name!r}; expected one of {CONTROL_FILENAMES}")
+    return control_dir(root_dir) / name
+
+
+def legacy_control_paths(root_dir: Path) -> dict[str, Path]:
+    """Former in-tree locations for each control file (migration + halt set)."""
+    queue = state_dir(root_dir) / "queue"
+    return {
+        CONTROL_AUTONOMY: state_dir(root_dir) / CONTROL_AUTONOMY,
+        CONTROL_INBOX: state_dir(root_dir) / CONTROL_INBOX,
+        CONTROL_SPEND: queue / CONTROL_SPEND,
+        CONTROL_PAUSE: queue / CONTROL_PAUSE,
+        CONTROL_GITHUB_PROCESSED: queue / CONTROL_GITHUB_PROCESSED,
+    }
+
+
+def _is_under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except (ValueError, OSError):
+        return False
+
+
+def control_dir_accessible(root_dir: Path) -> bool:
+    """Whether the control directory can be created and listed.
+
+    Used by fail-closed pause: an inaccessible control plane must not
+    look like "no pause marker → running".
+    """
+    try:
+        target = control_dir(root_dir)
+        target.mkdir(parents=True, exist_ok=True)
+        # Probe readability; ignore the listing itself.
+        list(target.iterdir())
+        return True
+    except OSError:
+        return False
+
+
+def control_is_external(root_dir: Path) -> bool:
+    """True when live control state is outside the agent-reachable tree.
+
+    False when the control dir resolves under ``root_dir`` (mis-set
+    ``XDG_STATE_HOME``), when the control dir is inaccessible, or when
+    any legacy in-tree control file still exists (migration incomplete -
+    an agent can still edit the leftover).
+    """
+    if not control_dir_accessible(root_dir):
+        return False
+    try:
+        if _is_under(control_dir(root_dir), root_dir):
+            return False
+    except OSError:
+        return False
+    for legacy in legacy_control_paths(root_dir).values():
+        try:
+            if legacy.exists():
+                return False
+        except OSError:
+            return False
+    return True
+
+
+def _write_relocated_marker(root_dir: Path, *, moved: list[str]) -> None:
+    marker = state_dir(root_dir) / CONTROL_RELOCATED_MARKER
+    try:
+        state_dir(root_dir).mkdir(parents=True, exist_ok=True)
+        payload = {
+            "repo_id": repo_id(root_dir),
+            "control_dir": str(control_dir(root_dir)),
+            "migrated_at": _utc_now_iso(),
+            "moved": moved,
+        }
+        marker.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    except OSError:
+        # Marker is operator convenience, not load-bearing.
+        pass
+
+
+def migrate_control_state(root_dir: Path) -> list[str]:
+    """Move legacy in-tree control files into the XDG control dir once.
+
+    Returns the list of filenames moved. Idempotent: a second call is a
+    no-op when targets already exist or legacy files are gone.
+    """
+    if not control_dir_accessible(root_dir):
+        return []
+    target_root = control_dir(root_dir)
+    moved: list[str] = []
+    legacy = legacy_control_paths(root_dir)
+    for name in CONTROL_FILENAMES:
+        src = legacy[name]
+        dst = target_root / name
+        try:
+            if dst.exists() or not src.exists():
+                continue
+        except OSError:
+            continue
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(src, dst)
+        except OSError as exc:
+            warnings.warn(
+                f"kstrl: failed to migrate control file {src} -> {dst}: {exc}",
+                stacklevel=2,
+            )
+            continue
+        moved.append(name)
+        warnings.warn(
+            f"kstrl: relocated control file {name} from {src} to {dst} "
+            "(R8.9; legacy in-tree path is no longer written)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    if moved:
+        _write_relocated_marker(root_dir, moved=moved)
+    return moved
+
+
+def ensure_control_state(root_dir: Path) -> Path:
+    """Ensure the XDG control dir exists and migrate any legacy files.
+
+    Call at the start of every control read/write path so CLI and daemon
+    both migrate before touching state.
+    """
+    migrate_control_state(root_dir)
+    target = control_dir(root_dir)
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    return target
+
+
+@contextmanager
+def control_lock(root_dir: Path, *, blocking: bool = True) -> Iterator[None]:
+    """Hold the cross-checkout mutex on the XDG control directory.
+
+    Serializes spend / pause / autonomy / inbox / GitHub-ledger writes so
+    two checkouts sharing an origin cannot corrupt the shared ledger.
+    POSIX ``fcntl`` only; without it we degrade to no exclusion (same
+    pattern as ``queue_lock`` / factory lock).
+    """
+    ensure_control_state(root_dir)
+    lock_path = control_dir(root_dir) / CONTROL_LOCK_FILENAME
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        yield
+        return
+    try:
+        import fcntl
+    except ImportError:
+        yield
+        return
+
+    handle: IO[str] = open(lock_path, "a+")
+    try:
+        flags = fcntl.LOCK_EX if blocking else fcntl.LOCK_EX | fcntl.LOCK_NB
+        try:
+            fcntl.flock(handle.fileno(), flags)
+        except OSError as exc:
+            raise ControlLockedError(
+                f"control state is locked by another process ({lock_path})"
+            ) from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
+
+
+class ControlLockedError(RuntimeError):
+    """Another process holds ``control.lock``."""

--- a/kstrl/workqueue.py
+++ b/kstrl/workqueue.py
@@ -77,9 +77,9 @@ from typing import IO, Any
 
 from kstrl.statedir import (
     CONTROL_PAUSE,
-    control_dir_accessible,
     control_file,
     control_lock,
+    control_untrusted_reason,
     ensure_control_state,
     state_dir,
 )
@@ -1242,11 +1242,9 @@ class Queue:
 
     def pause_state(self) -> PauseState:
         ensure_control_state(self.root_dir)
-        if not control_dir_accessible(self.root_dir):
-            return PauseState(
-                paused=True,
-                reason="control state directory inaccessible",
-            )
+        untrusted = control_untrusted_reason(self.root_dir)
+        if untrusted is not None:
+            return PauseState(paused=True, reason=untrusted)
         try:
             raw = self.pause_path.read_text(encoding="utf-8")
         except FileNotFoundError:

--- a/kstrl/workqueue.py
+++ b/kstrl/workqueue.py
@@ -25,8 +25,10 @@ is a DIRECTORY holding its spec file plus ``meta.json``::
       poison/   finished red and NOT eligible to retry
       .staging/ items being assembled; NEVER scanned
       journal.jsonl
-      pause.json    (absent = running)
       queue.lock    (short-lived per-transition mutex)
+
+Pause and spend ledgers live in the XDG control directory (R8.9), not
+under ``.kstrl/queue/``, so an agent in a worktree cannot edit them.
 
 The item is a directory rather than two sibling files so that one
 ``os.replace`` moves the spec and its sidecar together. Two sibling files
@@ -73,12 +75,18 @@ from enum import StrEnum
 from pathlib import Path
 from typing import IO, Any
 
-from kstrl.statedir import state_dir
+from kstrl.statedir import (
+    CONTROL_PAUSE,
+    control_dir_accessible,
+    control_file,
+    control_lock,
+    ensure_control_state,
+    state_dir,
+)
 
 QUEUE_DIR_NAME = "queue"
 META_FILENAME = "meta.json"
 JOURNAL_FILENAME = "journal.jsonl"
-PAUSE_FILENAME = "pause.json"
 LOCK_FILENAME = "queue.lock"
 QUEUE_SCHEMA_VERSION = 1
 
@@ -1230,9 +1238,15 @@ class Queue:
 
     @property
     def pause_path(self) -> Path:
-        return self.path / PAUSE_FILENAME
+        return control_file(self.root_dir, CONTROL_PAUSE)
 
     def pause_state(self) -> PauseState:
+        ensure_control_state(self.root_dir)
+        if not control_dir_accessible(self.root_dir):
+            return PauseState(
+                paused=True,
+                reason="control state directory inaccessible",
+            )
         try:
             raw = self.pause_path.read_text(encoding="utf-8")
         except FileNotFoundError:
@@ -1266,11 +1280,14 @@ class Queue:
             paused=True, reason=reason, since=_iso(_utc_now()),
             resume_after=resume_after,
         )
-        self.path.mkdir(parents=True, exist_ok=True)
-        atomic_write(
-            self.pause_path,
-            json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
-        )
+        ensure_control_state(self.root_dir)
+        path = self.pause_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with control_lock(self.root_dir):
+            atomic_write(
+                path,
+                json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
+            )
         self._journal(JournalEntry(
             ts=state.since, item_id="", from_state="", to_state="paused",
             reason=reason, actor=actor,
@@ -1280,11 +1297,14 @@ class Queue:
 
     def resume(self, *, actor: str = "") -> PauseState:
         state = PauseState()
-        self.path.mkdir(parents=True, exist_ok=True)
-        atomic_write(
-            self.pause_path,
-            json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
-        )
+        ensure_control_state(self.root_dir)
+        path = self.pause_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with control_lock(self.root_dir):
+            atomic_write(
+                path,
+                json.dumps(state.to_dict(), indent=2, ensure_ascii=False) + "\n",
+            )
         self._journal(JournalEntry(
             ts=_iso(_utc_now()), item_id="", from_state="paused",
             to_state="running", reason="resumed", actor=actor,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,11 +108,19 @@ def isolate_kstrl_state(
     Ambient env is cleared too, so a dev machine exporting FACTORY_* /
     KSTRL_* values cannot alter from_env/load tests.
 
+    R8.9: ``XDG_STATE_HOME`` is pointed at a *sibling* of ``tmp_path`` so
+    control-plane files land outside any repo root that uses ``tmp_path``
+    itself - otherwise ``control_is_external`` would falsely fail and L3
+    clamps would fire in unrelated tests.
+
     This redirect is convenience; ``guard_repo_kstrl_state`` is the
     enforcement.
     """
     monkeypatch.chdir(tmp_path)
     _clear_kstrl_env(monkeypatch)
+    xdg = tmp_path.parent / f"{tmp_path.name}.xdg-state"
+    xdg.mkdir(exist_ok=True)
+    monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
     return tmp_path
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,9 @@ def isolate_kstrl_state(
     xdg = tmp_path.parent / f"{tmp_path.name}.xdg-state"
     xdg.mkdir(exist_ok=True)
     monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+    from kstrl.statedir import clear_xdg_state_home_cache
+
+    clear_xdg_state_home_cache()
     return tmp_path
 
 

--- a/tests/test_autonomy_ladder.py
+++ b/tests/test_autonomy_ladder.py
@@ -573,42 +573,49 @@ class TestFactoryWiring:
 class TestEnvelopeCeiling:
     """L3 is *Enveloped* auto-merge: no envelope, no auto-merge."""
 
-    def test_l3_clamps_to_l2_without_policy_envelope(self) -> None:
+    def test_l3_clamps_to_l2_without_policy_envelope(
+        self, tmp_path: Path,
+    ) -> None:
         from kstrl.autonomy import resolve_runtime_level
 
         state = AutonomyState(level=int(AutonomyLevel.L3_ENVELOPED_AUTO))
         level, notes = resolve_runtime_level(
-            state, AutonomyConfig(enabled=True), policy_enabled=False,
+            state, AutonomyConfig(enabled=True),
+            policy_enabled=False, root_dir=tmp_path,
         )
         assert level is AutonomyLevel.L2_GATED_MERGE
         assert any("requires the R8.1 policy envelope" in n for n in notes)
 
-    def test_l4_clamps_to_l2_without_policy_envelope(self) -> None:
+    def test_l4_clamps_to_l2_without_policy_envelope(
+        self, tmp_path: Path,
+    ) -> None:
         from kstrl.autonomy import resolve_runtime_level
 
         state = AutonomyState(level=int(AutonomyLevel.L4_DEPLOY))
         level, _ = resolve_runtime_level(
-            state, AutonomyConfig(enabled=True), policy_enabled=False,
+            state, AutonomyConfig(enabled=True),
+            policy_enabled=False, root_dir=tmp_path,
         )
         assert level is AutonomyLevel.L2_GATED_MERGE
 
-    def test_l3_allowed_with_envelope(self) -> None:
+    def test_l3_allowed_with_envelope(self, tmp_path: Path) -> None:
         from kstrl.autonomy import resolve_runtime_level
 
         state = AutonomyState(level=int(AutonomyLevel.L3_ENVELOPED_AUTO))
         level, notes = resolve_runtime_level(
-            state, AutonomyConfig(enabled=True), policy_enabled=True,
+            state, AutonomyConfig(enabled=True),
+            policy_enabled=True, root_dir=tmp_path,
         )
         assert level is AutonomyLevel.L3_ENVELOPED_AUTO
         assert notes == []
 
-    def test_lowest_ceiling_wins(self) -> None:
+    def test_lowest_ceiling_wins(self, tmp_path: Path) -> None:
         from kstrl.autonomy import resolve_runtime_level
 
         state = AutonomyState(level=int(AutonomyLevel.L4_DEPLOY))
         level, notes = resolve_runtime_level(
             state, AutonomyConfig(enabled=True, max_level=3),
-            policy_enabled=False,
+            policy_enabled=False, root_dir=tmp_path,
         )
         assert level is AutonomyLevel.L2_GATED_MERGE   # envelope beats max_level
         assert len(notes) == 2
@@ -808,10 +815,19 @@ class TestPromotionAuthority:
 
     def test_ladder_state_is_enforcement_machinery(self) -> None:
         # The obvious way around the TTY gate is to write the level
-        # straight to disk; R8.1 must halt on that.
+        # straight to disk; R8.1 must halt on that. Legacy in-tree control
+        # paths stay halted after R8.9 relocated the live copies to XDG.
         from kstrl.policy import PolicyConfig, evaluate_policy
 
-        for path in (".kstrl/autonomy.json", "kstrl/autonomy.py"):
+        for path in (
+            ".kstrl/autonomy.json",
+            ".kstrl/inbox.jsonl",
+            ".kstrl/queue/spend.json",
+            ".kstrl/queue/pause.json",
+            ".kstrl/queue/github_processed.json",
+            "kstrl/autonomy.py",
+            "kstrl/statedir.py",
+        ):
             result = evaluate_policy(
                 [path], [(1, 0, path)], "", PolicyConfig(paths_deny=[]),
             )

--- a/tests/test_statedir.py
+++ b/tests/test_statedir.py
@@ -26,6 +26,15 @@ from kstrl.statedir import (
 from kstrl.workqueue import Queue
 
 
+@pytest.fixture(autouse=True)
+def _clear_xdg_cache() -> None:
+    from kstrl.statedir import clear_xdg_state_home_cache
+
+    clear_xdg_state_home_cache()
+    yield
+    clear_xdg_state_home_cache()
+
+
 @pytest.fixture
 def repo(tmp_path: Path) -> Path:
     root = tmp_path / "repo"
@@ -50,6 +59,30 @@ class TestNormalizeRemoteUrl:
         assert (
             normalize_remote_url("ssh://git@github.com/Org/Repo.git")
             == "github.com/org/repo"
+        )
+
+    def test_git_suffix_casefold(self) -> None:
+        assert (
+            normalize_remote_url("https://github.com/Org/Repo.GIT")
+            == "github.com/org/repo"
+        )
+
+    def test_strips_userinfo(self) -> None:
+        assert (
+            normalize_remote_url("https://user:token@github.com/Org/Repo.git")
+            == "github.com/org/repo"
+        )
+
+    def test_strips_default_https_port(self) -> None:
+        assert (
+            normalize_remote_url("https://github.com:443/Org/Repo.git")
+            == "github.com/org/repo"
+        )
+
+    def test_keeps_nondefault_port(self) -> None:
+        assert (
+            normalize_remote_url("https://git.example.com:8443/Org/Repo.git")
+            == "git.example.com:8443/org/repo"
         )
 
 
@@ -78,7 +111,7 @@ class TestRepoId:
 
 class TestControlDir:
     def test_honors_xdg_state_home(self, repo: Path) -> None:
-        xdg = Path(os.environ["XDG_STATE_HOME"])
+        xdg = Path(os.environ["XDG_STATE_HOME"]).resolve()
         with patch("kstrl.statedir._origin_url", return_value=None):
             target = control_dir(repo)
         assert target.is_relative_to(xdg)
@@ -159,8 +192,8 @@ class TestPauseFailClosed:
         with patch("kstrl.statedir._origin_url", return_value=None):
             ensure_control_state(repo)
             monkeypatch.setattr(
-                "kstrl.workqueue.control_dir_accessible",
-                lambda _root: False,
+                "kstrl.workqueue.control_untrusted_reason",
+                lambda _root: "control state directory inaccessible",
             )
             queue = Queue(repo)
             state = queue.pause_state()
@@ -256,3 +289,174 @@ class TestLegacyHaltPaths:
         }
         for path in expected:
             assert path in ENFORCEMENT_MACHINERY_PATHS
+
+
+class TestReviewFailClosed:
+    """Regressions for the adversarial review on PR #213."""
+
+    def test_failed_migrate_keeps_pause_and_spend_closed(
+        self, repo: Path,
+    ) -> None:
+        from kstrl.serve import ServeStateError, SpendLedger
+        from kstrl.statedir import CONTROL_PAUSE, CONTROL_SPEND
+
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            legacy = legacy_control_paths(repo)
+            legacy[CONTROL_PAUSE].parent.mkdir(parents=True, exist_ok=True)
+            legacy[CONTROL_PAUSE].write_text(
+                json.dumps({"paused": True, "reason": "budget", "since": ""}),
+                encoding="utf-8",
+            )
+            legacy[CONTROL_SPEND].write_text(
+                json.dumps({
+                    "spend": {
+                        "date": "2099-01-01",
+                        "spent_usd": 12.5,
+                        "runs": 1,
+                        "covered_calls": 1,
+                        "total_calls": 1,
+                        "unmetered_phases": [],
+                    },
+                    "consecutive_poison": 0,
+                    "cost_coverage_seen": True,
+                }),
+                encoding="utf-8",
+            )
+
+            with patch(
+                "kstrl.statedir._move_control_file",
+                side_effect=OSError(18, "Cross-device link"),
+            ):
+                ensure_control_state(repo)
+                assert legacy[CONTROL_PAUSE].exists()
+                assert legacy[CONTROL_SPEND].exists()
+                queue = Queue(repo)
+                assert queue.pause_state().paused is True
+                assert "legacy" in queue.pause_state().reason
+                with pytest.raises(ServeStateError, match="legacy"):
+                    SpendLedger(repo).read_state("2099-01-01")
+
+    def test_relative_xdg_survives_chdir(
+        self, repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kstrl.statedir import clear_xdg_state_home_cache
+
+        rel = Path("rel-xdg-state")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("XDG_STATE_HOME", str(rel))
+        clear_xdg_state_home_cache()
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            queue = Queue(repo)
+            queue.pause(reason="budget")
+            assert queue.is_paused()
+            work = tmp_path / "workdir"
+            work.mkdir()
+            monkeypatch.chdir(work)
+            assert queue.is_paused()
+
+    def test_dual_state_fail_closes_pause_and_spend(self, repo: Path) -> None:
+        from kstrl.serve import ServeStateError, SpendLedger
+        from kstrl.statedir import CONTROL_PAUSE, CONTROL_SPEND, control_file
+
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            ensure_control_state(repo)
+            control_file(repo, CONTROL_PAUSE).write_text(
+                json.dumps({"paused": False, "reason": "", "since": ""}),
+                encoding="utf-8",
+            )
+            control_file(repo, CONTROL_SPEND).write_text(
+                json.dumps({
+                    "spend": {
+                        "date": "2099-01-01",
+                        "spent_usd": 1.0,
+                        "runs": 1,
+                        "covered_calls": 1,
+                        "total_calls": 1,
+                        "unmetered_phases": [],
+                    },
+                    "consecutive_poison": 0,
+                    "cost_coverage_seen": True,
+                }),
+                encoding="utf-8",
+            )
+            legacy = legacy_control_paths(repo)
+            legacy[CONTROL_PAUSE].parent.mkdir(parents=True, exist_ok=True)
+            legacy[CONTROL_PAUSE].write_text(
+                json.dumps({"paused": True, "reason": "legacy", "since": ""}),
+                encoding="utf-8",
+            )
+            legacy[CONTROL_SPEND].write_text(
+                json.dumps({
+                    "spend": {
+                        "date": "2099-01-01",
+                        "spent_usd": 99.0,
+                        "runs": 1,
+                        "covered_calls": 1,
+                        "total_calls": 1,
+                        "unmetered_phases": [],
+                    },
+                    "consecutive_poison": 0,
+                    "cost_coverage_seen": True,
+                }),
+                encoding="utf-8",
+            )
+            with pytest.warns(UserWarning, match="dual-state"):
+                migrate_control_state(repo)
+            assert Queue(repo).pause_state().paused is True
+            with pytest.raises(ServeStateError, match="legacy"):
+                SpendLedger(repo).read_state("2099-01-01")
+
+    def test_symlink_control_file_not_external(self, repo: Path) -> None:
+        from kstrl.statedir import CONTROL_AUTONOMY, control_file
+
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            ensure_control_state(repo)
+            target = repo / "evil-autonomy.json"
+            target.write_text("{}\n", encoding="utf-8")
+            path = control_file(repo, CONTROL_AUTONOMY)
+            path.symlink_to(target)
+            assert control_is_external(repo) is False
+            assert Queue(repo).pause_state().paused is True
+
+    def test_control_lock_raises_when_mkdir_fails(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kstrl.statedir import ControlUnavailableError, control_lock
+
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            ensure_control_state(repo)
+
+            def boom(self: Path, *args: object, **kwargs: object) -> None:
+                raise OSError("permission denied")
+
+            monkeypatch.setattr(Path, "mkdir", boom)
+            with pytest.raises(ControlUnavailableError):
+                with control_lock(repo):
+                    pass
+
+    def test_exdev_migrate_succeeds_via_copy(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kstrl.statedir import CONTROL_PAUSE, control_file
+
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            legacy = legacy_control_paths(repo)
+            legacy[CONTROL_PAUSE].parent.mkdir(parents=True, exist_ok=True)
+            legacy[CONTROL_PAUSE].write_text(
+                json.dumps({"paused": True, "reason": "x", "since": ""}),
+                encoding="utf-8",
+            )
+
+            real_replace = os.replace
+
+            def replace_exdev(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+                raise OSError(18, "Cross-device link")
+
+            monkeypatch.setattr(os, "replace", replace_exdev)
+            with pytest.warns(DeprecationWarning, match="relocated"):
+                moved = migrate_control_state(repo)
+            assert CONTROL_PAUSE in moved
+            assert not legacy[CONTROL_PAUSE].exists()
+            assert control_file(repo, CONTROL_PAUSE).exists()
+            # restore for other tests in-process (monkeypatch undoes)
+            _ = real_replace

--- a/tests/test_statedir.py
+++ b/tests/test_statedir.py
@@ -1,0 +1,258 @@
+"""R8.9 control-state relocation: statedir, migration, L3 gate."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kstrl.statedir import (
+    CONTROL_AUTONOMY,
+    CONTROL_FILENAMES,
+    control_dir,
+    control_dir_accessible,
+    control_file,
+    control_is_external,
+    ensure_control_state,
+    legacy_control_paths,
+    migrate_control_state,
+    normalize_remote_url,
+    repo_id,
+    state_dir,
+)
+from kstrl.workqueue import Queue
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    return root
+
+
+class TestNormalizeRemoteUrl:
+    def test_https_strips_git_suffix(self) -> None:
+        assert (
+            normalize_remote_url("https://github.com/Org/Repo.git")
+            == "github.com/org/repo"
+        )
+
+    def test_ssh_scplike(self) -> None:
+        assert (
+            normalize_remote_url("git@github.com:Org/Repo.git")
+            == "github.com/org/repo"
+        )
+
+    def test_ssh_url(self) -> None:
+        assert (
+            normalize_remote_url("ssh://git@github.com/Org/Repo.git")
+            == "github.com/org/repo"
+        )
+
+
+class TestRepoId:
+    def test_same_origin_forms_share_id(self, repo: Path) -> None:
+        with patch(
+            "kstrl.statedir._origin_url",
+            return_value="https://github.com/acme/widget.git",
+        ):
+            a = repo_id(repo)
+        with patch(
+            "kstrl.statedir._origin_url",
+            return_value="git@github.com:acme/widget.git",
+        ):
+            b = repo_id(repo)
+        assert a == b
+        assert a.startswith("widget-")
+
+    def test_path_fallback_when_no_origin(self, repo: Path) -> None:
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            first = repo_id(repo)
+            second = repo_id(repo)
+        assert first == second
+        assert "-" in first
+
+
+class TestControlDir:
+    def test_honors_xdg_state_home(self, repo: Path) -> None:
+        xdg = Path(os.environ["XDG_STATE_HOME"])
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            target = control_dir(repo)
+        assert target.is_relative_to(xdg)
+        assert target.parent.name == "kstrl"
+
+    def test_control_file_rejects_unknown(self, repo: Path) -> None:
+        with pytest.raises(ValueError, match="unknown control file"):
+            control_file(repo, "nope.json")
+
+
+class TestMigration:
+    def test_moves_legacy_files_once(self, repo: Path) -> None:
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            legacy = legacy_control_paths(repo)
+            for name, path in legacy.items():
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(f"legacy-{name}\n", encoding="utf-8")
+
+            with pytest.warns(DeprecationWarning, match="relocated control file"):
+                moved = migrate_control_state(repo)
+            assert set(moved) == set(CONTROL_FILENAMES)
+
+            for name in CONTROL_FILENAMES:
+                assert not legacy[name].exists()
+                target = control_file(repo, name)
+                assert target.read_text(encoding="utf-8") == f"legacy-{name}\n"
+
+            marker = state_dir(repo) / "control_relocated"
+            assert marker.exists()
+            payload = json.loads(marker.read_text(encoding="utf-8"))
+            assert payload["control_dir"] == str(control_dir(repo))
+
+            # Second call is a no-op.
+            assert migrate_control_state(repo) == []
+
+    def test_ensure_then_consumers_use_xdg(self, repo: Path) -> None:
+        from kstrl.autonomy import AutonomyState
+        from kstrl.inbox import Inbox
+
+        xdg = Path(os.environ["XDG_STATE_HOME"])
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            ensure_control_state(repo)
+            AutonomyState(level=2).save(repo)
+            assert AutonomyState.path_for(repo).is_relative_to(xdg)
+            assert Inbox(repo).path.is_relative_to(xdg)
+            assert AutonomyState.path_for(repo).name == CONTROL_AUTONOMY
+
+
+class TestControlIsExternal:
+    def test_true_after_clean_ensure(self, repo: Path) -> None:
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            ensure_control_state(repo)
+            assert control_is_external(repo) is True
+
+    def test_false_while_legacy_remains(self, repo: Path) -> None:
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            ensure_control_state(repo)
+            leftover = legacy_control_paths(repo)[CONTROL_AUTONOMY]
+            leftover.parent.mkdir(parents=True, exist_ok=True)
+            leftover.write_text("{}\n", encoding="utf-8")
+            assert control_is_external(repo) is False
+
+    def test_false_when_xdg_under_repo(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        nested = repo / "nested-xdg"
+        nested.mkdir()
+        monkeypatch.setenv("XDG_STATE_HOME", str(nested))
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            ensure_control_state(repo)
+            assert control_is_external(repo) is False
+
+
+class TestPauseFailClosed:
+    def test_inaccessible_control_dir_is_paused(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            ensure_control_state(repo)
+            monkeypatch.setattr(
+                "kstrl.workqueue.control_dir_accessible",
+                lambda _root: False,
+            )
+            queue = Queue(repo)
+            state = queue.pause_state()
+            assert state.paused is True
+            assert "inaccessible" in state.reason
+
+    def test_missing_pause_marker_is_running(self, repo: Path) -> None:
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            ensure_control_state(repo)
+            assert control_dir_accessible(repo)
+            queue = Queue(repo)
+            assert queue.pause_state().paused is False
+
+
+class TestAutonomyL3Gate:
+    def test_resolve_clamps_l3_when_xdg_under_repo(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kstrl.autonomy import (
+            AutonomyConfig,
+            AutonomyLevel,
+            AutonomyState,
+            resolve_runtime_level,
+        )
+
+        nested = repo / "nested-xdg"
+        nested.mkdir()
+        monkeypatch.setenv("XDG_STATE_HOME", str(nested))
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            state = AutonomyState(level=int(AutonomyLevel.L3_ENVELOPED_AUTO))
+            level, notes = resolve_runtime_level(
+                state,
+                AutonomyConfig(enabled=True, max_level=4),
+                policy_enabled=True,
+                root_dir=repo,
+            )
+            assert level is AutonomyLevel.L2_GATED_MERGE
+            assert any("R8.9" in note for note in notes)
+
+    def test_control_relocation_error_for_l3(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kstrl.autonomy import AutonomyLevel, control_relocation_error
+
+        nested = repo / "nested-xdg"
+        nested.mkdir()
+        monkeypatch.setenv("XDG_STATE_HOME", str(nested))
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            err = control_relocation_error(
+                repo, target_level=AutonomyLevel.L3_ENVELOPED_AUTO,
+            )
+            assert err is not None
+            assert "R8.9" in err
+            assert (
+                control_relocation_error(
+                    repo, target_level=AutonomyLevel.L2_GATED_MERGE,
+                )
+                is None
+            )
+
+    def test_l3_allowed_when_external(self, repo: Path) -> None:
+        from kstrl.autonomy import (
+            AutonomyConfig,
+            AutonomyLevel,
+            AutonomyState,
+            resolve_runtime_level,
+        )
+
+        with patch("kstrl.statedir._origin_url", return_value=None):
+            ensure_control_state(repo)
+            state = AutonomyState(level=int(AutonomyLevel.L3_ENVELOPED_AUTO))
+            level, notes = resolve_runtime_level(
+                state,
+                AutonomyConfig(enabled=True, max_level=4),
+                policy_enabled=True,
+                root_dir=repo,
+            )
+            assert level is AutonomyLevel.L3_ENVELOPED_AUTO
+            assert notes == []
+
+
+class TestLegacyHaltPaths:
+    def test_all_legacy_control_paths_in_machinery(self) -> None:
+        from kstrl.policy import ENFORCEMENT_MACHINERY_PATHS
+
+        expected = {
+            ".kstrl/autonomy.json",
+            ".kstrl/inbox.jsonl",
+            ".kstrl/queue/spend.json",
+            ".kstrl/queue/pause.json",
+            ".kstrl/queue/github_processed.json",
+            "**/kstrl/statedir.py",
+        }
+        for path in expected:
+            assert path in ENFORCEMENT_MACHINERY_PATHS

--- a/tests/test_workqueue.py
+++ b/tests/test_workqueue.py
@@ -797,6 +797,7 @@ class TestPause:
         """Fail closed: never resume unattended spend on a corrupt file."""
         queue = _queue(tmp_path)
         queue.ensure_dirs()
+        queue.pause_path.parent.mkdir(parents=True, exist_ok=True)
         queue.pause_path.write_text("{not json")
         assert queue.is_paused()
         assert "unreadable" in queue.pause_state().reason
@@ -806,6 +807,7 @@ class TestPause:
     ) -> None:
         queue = _queue(tmp_path)
         queue.ensure_dirs()
+        queue.pause_path.parent.mkdir(parents=True, exist_ok=True)
         queue.pause_path.write_text("[]")
         assert queue.is_paused()
 


### PR DESCRIPTION
## Summary
- Move autonomy, inbox, spend, pause, and GitHub processed ledgers to `${XDG_STATE_HOME:-~/.local/state}/kstrl/<repo-id>/` so worktree agents cannot edit the trust boundary that governs unattended `ks serve` and L3+ autonomy (#194).
- Add one-time migration from legacy in-tree paths, `control.lock` for shared-origin checkouts, legacy halt-set coverage, and an L3+ refuse-until-external gate.
- Document the XDG layout, shared-origin caveat, and operator marker in the dark-factory roadmap, intake guide, runbook, and env-vars reference.

## Test plan
- [x] `uv run pytest tests/test_statedir.py tests/test_autonomy_ladder.py tests/test_inbox.py tests/test_serve.py tests/test_workqueue.py tests/test_intake_github.py tests/test_policy_envelope.py -v`
- [x] `uv run mypy kstrl/ --strict`
- [x] `uv run ruff check kstrl/ tests/`
- [ ] Confirm a checkout with legacy `.kstrl/autonomy.json` migrates on first `ks autonomy status` and writes `.kstrl/control_relocated`
- [ ] Confirm `ks autonomy promote` to L3 refuses when `XDG_STATE_HOME` is set under the repo

Closes #194


Made with [Cursor](https://cursor.com)