### PR TITLE
docs(pages): landing page so https://0xfauzi.github.io/kstrl/ resolves

### DIFF
--- a/docs/control-loop-design.md
+++ b/docs/control-loop-design.md
@@ -1002,7 +1002,7 @@ Cycle: R10, milestone [R10: Control Loop](https://github.com/0xfauzi/kstrl/miles
 
 | Order | Item | Issue | Status |
 |---|---|---|---|
-| 1 | 5.1 `ks sense` standalone sensor command | [#222](https://github.com/0xfauzi/kstrl/issues/222) | `[~]` PR #237 open |
+| 1 | 5.1 `ks sense` standalone sensor command | [#222](https://github.com/0xfauzi/kstrl/issues/222) | `[x]` merged in #237 |
 | 2 | 5.3 level-triggered retry context | [#223](https://github.com/0xfauzi/kstrl/issues/223) | `[ ]` |
 | 3 | 5.2 set-point agreement | [#224](https://github.com/0xfauzi/kstrl/issues/224) | `[ ]` |
 | 4 | 5.9 name safe mode | [#225](https://github.com/0xfauzi/kstrl/issues/225) | `[ ]` |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>kstrl</title>
+<style>
+:root{color-scheme:dark;--bg:#161310;--surface:#1E1A15;--raised:#27221A;--line:#2E2820;
+--line-2:#4A4237;--ink:#ECE5D8;--ink-2:#C4B9A4;--ink-3:#A2967F;--accent:#E5A84F;
+--fs:ui-sans-serif,system-ui,-apple-system,"SF Pro Text","Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+--fm:ui-monospace,"SF Mono",SFMono-Regular,"JetBrains Mono",Menlo,Consolas,monospace}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--fs);font-size:15px;
+line-height:1.5;-webkit-font-smoothing:antialiased}
+main{max-width:44rem;margin:0 auto;padding:4rem 1.4rem 5rem}
+h1{font-family:var(--fm);font-size:22px;font-weight:600;margin:0 0 .3rem;letter-spacing:-.01em}
+h1 span{color:var(--accent);font-weight:400}
+.lede{margin:0 0 2.2rem;color:var(--ink-3);font-size:14px;max-width:34rem}
+.card{display:block;text-decoration:none;color:inherit;background:var(--surface);
+border:1px solid var(--line);border-radius:8px;padding:1rem 1.1rem;margin:0 0 .8rem}
+.card:hover{border-color:var(--accent)}
+.card:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.card b{display:block;font-family:var(--fm);font-size:14px;color:var(--accent);
+font-weight:600;margin-bottom:.2rem}
+.card span{color:var(--ink-2);font-size:14px}
+.foot{margin-top:2.4rem;font-size:12px;color:var(--ink-3)}
+.foot code{font-family:var(--fm)}
+.foot a{color:var(--ink-2)}
+</style></head><body>
+<main>
+<h1>kstrl <span>docs</span></h1>
+<p class="lede">An adversarial coding-agent harness: a factory that turns a spec into merged
+pull requests and never lets the agent grade its own work.</p>
+<a class="card" href="atlas/">
+  <b>System atlas</b>
+  <span>One map of every component and flow, read in seven layers; click a part to see
+  what it is to its neighbours.</span>
+</a>
+<a class="card" href="lessons/">
+  <b>Lessons</b>
+  <span>What individual changes taught, each with the same map marking where the change
+  landed.</span>
+</a>
+<p class="foot">The atlas is regenerated from the code by <code>scripts/atlas</code> and
+committed under <code>docs/atlas</code>. Source:
+<a href="https://github.com/0xfauzi/kstrl">github.com/0xfauzi/kstrl</a>.</p>
+</main>
+</body></html>


### PR DESCRIPTION
## Summary

GitHub Pages is enabled from `main:/docs`. `/atlas/` already serves (200); the root returned 404 because `docs/` had no index. This adds `docs/index.html` (links the atlas and the lessons, in the kstrl identity) and `docs/.nojekyll` so the folder is served as-is and generated pages are never rewritten by Jekyll.

Note: `.nojekyll` also stops the markdown under `docs/` being rendered as HTML pages (for example `/runbook.html` currently renders via Jekyll); those files were never linked from anywhere as pages, and the repository renders them on GitHub itself.

## What was tested vs assumed (H4)

Docs only. The landing page is the one produced by the atlas version 2 work (not yet pushed); it fetches nothing. Not opened in a browser here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)