### PR TITLE
R10.4: name safe mode, one predicate over the four existing degraded states

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -290,6 +290,24 @@ Everything lives under `.kstrl/` at the project root (gitignored):
 | `.kstrl/snapshots/` | Approved-fixture output snapshots |
 | `.kstrl/factory.lock` | Run-level flock: a second invocation on the same root refuses to start |
 
+## Safe mode
+
+kstrl degrades safely in four places: an untrusted control directory
+stops the daemon spending, a damaged `autonomy.json` falls back to L1,
+the queue pauses, and an adversarial phase can be skipped. Each acts on
+its own, and each did so without a shared name.
+
+`kstrl/safemode.py` gives them one. `safe_mode_reasons(root_dir)` reads
+all four and returns a list of `SafeModeReason` (source, detail,
+recovery anchor); empty means nominal. `ks status` and `ks serve
+--dry-run` print it.
+
+The predicate changes no behaviour. It adds no gate, no pause and no
+halt, and it never refuses anything, because every signal it reads
+already refuses where refusing is right. It is a question with an
+answer, not a new control. Details and recovery steps are in
+[docs/runbook.md](docs/runbook.md#safe-mode).
+
 ## The fixtures sandbox
 
 Approved fixtures (README: "Approved fixtures") are the independent

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -299,8 +299,10 @@ its own, and each did so without a shared name.
 
 `kstrl/safemode.py` gives them one. `safe_mode_reasons(root_dir)` reads
 all four and returns a list of `SafeModeReason` (source, detail,
-recovery anchor); empty means nominal. `ks status` and `ks serve
---dry-run` print it.
+recovery anchor); empty means nominal. The plain `ks status` report and
+`ks serve --dry-run` print it. The dashboard does not show it yet: on a
+terminal `ks status` opens the dashboard when a run exists, so asking
+the question interactively means `ks status --no-tui`.
 
 The predicate changes no behaviour. It adds no gate, no pause and no
 halt, and it never refuses anything, because every signal it reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ stage, runtime feedback, and an earned-autonomy ladder). See
   and a callout inside a pull request body. `safe_mode_reasons(root_dir)`
   reads all four and returns a source, a detail sentence taken verbatim
   from the existing signal, and the runbook anchor that recovers it;
-  `ks status` and `ks serve --dry-run` print `safe mode: nominal` or one
-  line per reason. It never raises: a signal that cannot be read is
+  the plain `ks status` report and `ks serve --dry-run` print
+  `safe mode: nominal` or one line per reason. The dashboard does not
+  show it yet, so on a terminal the question is asked with
+  `ks status --no-tui`. It never raises: a signal that cannot be read is
   itself a reason, because a reader that failed is not evidence that the
   signal is clear. No behaviour changed and no gate was added, since
   every signal it reads already refuses where refusing is right

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ stage, runtime feedback, and an earned-autonomy ladder). See
 
 ### Added
 
+- Safe mode: one name, and one question, for the four degraded states
+  kstrl already entered separately. An untrusted control directory stops
+  the daemon spending, a damaged `autonomy.json` falls back to L1
+  Supervised (or a ceiling clamps the run below the level it earned),
+  the queue pauses, and an adversarial phase can be skipped for a
+  component. Each was correct on its own and each spoke on a different
+  surface: a warning line at run start, `ks queue`, `ks serve` output,
+  and a callout inside a pull request body. `safe_mode_reasons(root_dir)`
+  reads all four and returns a source, a detail sentence taken verbatim
+  from the existing signal, and the runbook anchor that recovers it;
+  `ks status` and `ks serve --dry-run` print `safe mode: nominal` or one
+  line per reason. It never raises: a signal that cannot be read is
+  itself a reason, because a reader that failed is not evidence that the
+  signal is clear. No behaviour changed and no gate was added, since
+  every signal it reads already refuses where refusing is right
+  (R10.4, #225).
+
 - Set-point agreement: a story counts as done only when the reviewer's
   per-story verdicts confirm the engineer's `passes: true`. The engineer
   agent was the only writer of that flag, so the thing doing the work

--- a/docs/control-loop-design.md
+++ b/docs/control-loop-design.md
@@ -1016,4 +1016,6 @@ Cycle: R10, milestone [R10: Control Loop](https://github.com/0xfauzi/kstrl/miles
 | 12 | 5.10 iterate faster (blocked on entry criterion) | [#233](https://github.com/0xfauzi/kstrl/issues/233) | `[ ]` |
 | 13 | section 4, reframe ARCHITECTURE.md | [#234](https://github.com/0xfauzi/kstrl/issues/234) | `[ ]` |
 
+Follow-up from R10.4, noted here because the issue put it out of scope: safe mode has no dashboard surface. On a terminal `ks status` opens the dashboard whenever a run directory exists, so the plain report that prints the safe-mode block is reached only with `--no-tui`, from a pipe, from CI, or with `--watch`. A masthead chip on the dashboard closes that gap; the predicate it needs now exists.
+
 Graduation follow-ups are listed on #235 and are filed only after the advisory item they depend on has produced output on real runs. The lesson that teaches this document is `docs/lessons/pr-221.html`.

--- a/docs/control-loop-design.md
+++ b/docs/control-loop-design.md
@@ -1005,7 +1005,7 @@ Cycle: R10, milestone [R10: Control Loop](https://github.com/0xfauzi/kstrl/miles
 | 1 | 5.1 `ks sense` standalone sensor command | [#222](https://github.com/0xfauzi/kstrl/issues/222) | `[x]` merged in #237 |
 | 2 | 5.3 level-triggered retry context | [#223](https://github.com/0xfauzi/kstrl/issues/223) | `[x]` |
 | 3 | 5.2 set-point agreement | [#224](https://github.com/0xfauzi/kstrl/issues/224) | `[x]` |
-| 4 | 5.9 name safe mode | [#225](https://github.com/0xfauzi/kstrl/issues/225) | `[ ]` |
+| 4 | 5.9 name safe mode | [#225](https://github.com/0xfauzi/kstrl/issues/225) | `[x]` |
 | 5 | 5.9 adversarial budget: hard mode halts | [#226](https://github.com/0xfauzi/kstrl/issues/226) | `[ ]` |
 | 6 | 5.5 dampener | [#227](https://github.com/0xfauzi/kstrl/issues/227) | `[ ]` |
 | 7 | 5.6 flow control | [#228](https://github.com/0xfauzi/kstrl/issues/228) | `[ ]` |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -266,9 +266,20 @@ choices; the third is worth acting on, because it means components
 merged on mechanical checks alone. See also
 [Adversarial budget exhausted mid-run](#adversarial-budget-exhausted-mid-run).
 
-This reason clears when the next run completes without skipping a phase.
-It reports the newest run only, so it is a statement about what just
-happened rather than a running tally.
+This reason clears when the next factory run **completes** without
+skipping a phase. A run that is still in flight does not clear it: a run
+writes its first event long before it reaches review, so treating "no
+skip recorded yet" as "no skip" would clear the verdict the moment the
+next run started. Runs of other kinds (`decompose`, `feature`,
+`understand`) never clear it either, because they have no phase chain
+and so finish clean by construction without ever asking the question.
+
+A separate detail line beginning `could not read run` means the question
+could not be answered rather than answered clean: the newest factory run
+left no event stream (`[factory] progress_log_enabled = false` writes
+accounting files and no events), or its `events.jsonl` could not be
+opened. When that happens the last finished run's verdict is still
+reported beside it.
 
 ## Where to find things
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -171,6 +171,105 @@ transcripts), `components/<id>/{review,security,distill}.log` (phase
 transcripts), and `orchestrator.log` (embedded-mode narration). When
 a run breaks, those files are the record; the TUI is only a view.
 
+## Safe mode
+
+kstrl is in **safe mode** whenever any of the four signals below is
+degraded. It is one name for four states that already existed
+separately, and asking about it costs nothing: `ks status` prints
+`safe mode: nominal` or `safe mode: <n> reason(s)` followed by one line
+per reason, and `ks serve --dry-run` prints the same block above its
+admission gates.
+
+Safe mode itself refuses nothing. Each signal below already refuses
+where refusing is right, and the predicate only reads them, so leaving
+safe mode always means fixing the underlying signal rather than
+clearing a flag.
+
+A reason line looks like this:
+
+```
+  safe mode:      1 reason(s)
+  - [queue] daily budget exhausted (see docs/runbook.md#queue-paused)
+```
+
+The label in brackets is the source; the anchor at the end is the
+subsection to read here.
+
+### Control directory untrusted
+
+Live control state (`autonomy.json`, `pause.json`, `spend.json`,
+`inbox.jsonl`, `github_processed.json`) must sit outside the tree the
+agent can write to. When it does not, kstrl refuses to spend and treats
+the queue as paused, because a factory that can edit its own budget
+ledger is not bounded by it.
+
+The detail line is the reason verbatim: `XDG_STATE_HOME` resolving under
+the repository, legacy in-tree control files left behind by a partial
+migration, a control file that is a symlink or resolves outside the
+control directory, or a control directory that cannot be created or
+listed at all.
+
+To recover, point `XDG_STATE_HOME` outside the repository and finish the
+migration. See "Control plane (R8.9)" under
+[Where to find things](#where-to-find-things) for the exact layout, and
+note that L3+ autonomy refuses to run at all while this is unresolved.
+
+### Autonomy fell back or was clamped
+
+Two distinct things land here.
+
+**Fell back.** `AutonomyState.load` validates every field, not just the
+level. Any malformed field, history entry, or out-of-range level
+discards the whole record and returns a fresh L1 Supervised state,
+because the safe direction for unknown autonomy is the least autonomy.
+The earned level is lost. Restore `autonomy.json` from a backup if you
+have one, or re-earn the level; `ks autonomy status` shows what the next
+promotion needs.
+
+**Clamped.** The run is executing below the level the ladder awarded.
+Three independent ceilings can do this and the lowest wins: `[autonomy]
+max_level` in `kstrl.toml`, `[policy] enabled = false` (L3 is
+auto-merge inside the policy envelope, so with no envelope there is
+nothing to merge inside and L2 is the ceiling), and control state that
+still resolves under the repository (R8.9). The detail line names the
+ceiling that fired. Clamping does not consume the earned level: raise
+the ceiling and the level returns.
+
+This source is silent while `[autonomy] enabled` is false, which is the
+default. A ladder nobody switched on is not a ladder that fell down.
+
+### Queue paused
+
+`ks serve` admits no new work while the queue is paused. A pause is
+either deliberate (`ks queue pause`) or self-inflicted by the daemon:
+the daily budget stop sets tomorrow's local midnight as `resume_after`
+and clears itself, and the poison breaker pauses after consecutive
+poisoned items. Run `ks queue` to see the marker, and `ks queue resume`
+to lift a pause that no longer applies.
+
+An unreadable pause marker also reads as paused, and the detail line
+says so. That is deliberate: resuming unattended spending on the
+strength of a corrupt file is the one failure this marker exists to
+prevent. Repair or delete `pause.json` in the control directory.
+
+### An adversarial phase did not run
+
+Review or security did not execute for at least one component of the
+newest run. The count and the run id are in the detail line, and the
+per-component reason is in the pull request body and in that run's event
+stream (`.kstrl/runs/<run_id>/events.jsonl`, `phase_skipped` events).
+
+The usual causes are `mode = skip` in `[security]` or the review config,
+a security reviewer that was never configured, and the adversarial LLM
+budget (`max_adversarial_calls`) running out mid-run. The first two are
+choices; the third is worth acting on, because it means components
+merged on mechanical checks alone. See also
+[Adversarial budget exhausted mid-run](#adversarial-budget-exhausted-mid-run).
+
+This reason clears when the next run completes without skipping a phase.
+It reports the newest run only, so it is a statement about what just
+happened rather than a running tally.
+
 ## Where to find things
 
 - Tracker for the hardening roadmap: `docs/adversarial-roadmap.md`

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -175,10 +175,18 @@ a run breaks, those files are the record; the TUI is only a view.
 
 kstrl is in **safe mode** whenever any of the four signals below is
 degraded. It is one name for four states that already existed
-separately, and asking about it costs nothing: `ks status` prints
-`safe mode: nominal` or `safe mode: <n> reason(s)` followed by one line
-per reason, and `ks serve --dry-run` prints the same block above its
-admission gates.
+separately, and asking about it costs nothing.
+
+Two surfaces print it. `ks status` prints `safe mode: nominal` or
+`safe mode: <n> reason(s)` followed by one line per reason, and
+`ks serve --dry-run` prints the same block above its admission gates.
+
+One caveat worth knowing before you rely on it: on a terminal, `ks
+status` opens the dashboard instead of the plain report whenever a run
+directory exists, and **the dashboard does not show safe mode yet**. Ask
+with `ks status --no-tui` (or from a pipe, from CI, or with `--watch`),
+or with `ks serve --dry-run`. A masthead chip on the dashboard is the
+tracked follow-up.
 
 Safe mode itself refuses nothing. Each signal below already refuses
 where refusing is right, and the predicate only reads them, so leaving

--- a/kstrl/autonomy.py
+++ b/kstrl/autonomy.py
@@ -143,13 +143,20 @@ def _utc_now_iso() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat()
 
 
-def _warn_rejected_state(path: Path, reason: str) -> None:
-    warnings.warn(
+def _warn_rejected_state(path: Path, reason: str) -> str:
+    """Warn that a ladder state was rejected; return the same sentence.
+
+    Returned as well as warned so ``AutonomyState.load`` can put the
+    identical text on the transient ``degraded_reason`` field. One
+    string, two consumers: a second copy of the wording could drift from
+    the warning an operator actually sees.
+    """
+    message = (
         f"autonomy: rejected ladder state {path} ({reason}); "
-        "failing closed to L1 Supervised",
-        RuntimeWarning,
-        stacklevel=3,
+        "failing closed to L1 Supervised"
     )
+    warnings.warn(message, RuntimeWarning, stacklevel=3)
+    return message
 
 
 def _require_int(data: dict[str, Any], key: str, default: int) -> int:
@@ -305,6 +312,14 @@ class AutonomyState:
     cooldown_runs_remaining: int = 0
     last_promoted_by: str = ""
     history: list[Transition] = field(default_factory=list)
+    #: Why ``load`` discarded the stored record and fell back to a fresh
+    #: L1 state, or None when nothing was discarded. TRANSIENT: set by
+    #: ``load`` on its fail-closed paths, never parsed from disk, and
+    #: never written by ``save`` (whose payload is built key by key, not
+    #: from ``asdict``). It exists so ``safemode.safe_mode_reasons`` can
+    #: report the fallback without re-implementing the parser that
+    #: detected it.
+    degraded_reason: str | None = None
 
     @property
     def autonomy_level(self) -> AutonomyLevel:
@@ -332,6 +347,13 @@ class AutonomyState:
 
         The rejection is warned about rather than silent (mirroring
         ``knowledge.read_facts``): losing an earned level deserves a note.
+        It is also recorded on the returned state's transient
+        ``degraded_reason``, because a warning is only seen by whoever
+        was watching the terminal at the time, and ``ks status`` needs to
+        answer the question afterwards.
+
+        A missing file is NOT a fallback: that is first run, and
+        ``degraded_reason`` stays None.
         """
         ensure_control_state(root_dir)
         path = cls.path_for(root_dir)
@@ -340,11 +362,17 @@ class AutonomyState:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
-            _warn_rejected_state(path, f"unreadable: {exc}")
-            return cls()
+            return cls(
+                degraded_reason=_warn_rejected_state(
+                    path, f"unreadable: {exc}",
+                ),
+            )
         if not isinstance(data, dict):
-            _warn_rejected_state(path, "top-level value is not an object")
-            return cls()
+            return cls(
+                degraded_reason=_warn_rejected_state(
+                    path, "top-level value is not an object",
+                ),
+            )
         try:
             level = int(AutonomyLevel(_require_int(data, "level", 1)))
             history = _parse_history(data.get("history", []))
@@ -372,8 +400,7 @@ class AutonomyState:
                 history=history,
             )
         except (ValueError, TypeError) as exc:
-            _warn_rejected_state(path, str(exc))
-            return cls()
+            return cls(degraded_reason=_warn_rejected_state(path, str(exc)))
         return state
 
     def save(self, root_dir: Path) -> None:

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -2894,6 +2894,10 @@ def status(
             manifest = Manifest.load(manifest_file)
         except (OSError, ValueError) as exc:
             ui_impl.err(f"Failed to load manifest {manifest_file}: {exc}")
+            # Same reason as the missing-manifest path above: the
+            # predicate does not read the manifest, so a broken one must
+            # not hide a paused queue.
+            _render_safe_mode(ui_impl, root_dir)
             return 1
 
         state, source_path = _load_state(manifest)

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -2482,6 +2482,31 @@ def _age_label_epoch(ts: float) -> str:
     return f"{format_age(age)} ago"
 
 
+def _render_safe_mode(ui_impl: UI, root_dir: Path) -> None:
+    """Print the safe-mode block: nominal, or one line per reason.
+
+    Shared by `ks status` and `ks serve --dry-run` so the two surfaces
+    cannot word the same state differently. A REPORT, never a gate:
+    safe mode refuses nothing by itself, because every signal it reads
+    already refuses where refusing is right.
+
+    ``info`` rather than ``warn`` for the reason lines: PlainUI prefixes
+    warnings with "WARN: ", which would break the line format the
+    runbook documents.
+    """
+    from kstrl.safemode import safe_mode_reasons
+
+    reasons = safe_mode_reasons(root_dir)
+    if not reasons:
+        ui_impl.kv("safe mode", "nominal")
+        return
+    ui_impl.kv("safe mode", f"{len(reasons)} reason(s)")
+    for reason in reasons:
+        ui_impl.info(
+            f"  - [{reason.source}] {reason.detail} (see {reason.recovery})"
+        )
+
+
 def _render_status(
     manifest: Manifest,
     manifest_file: Path,
@@ -2537,6 +2562,9 @@ def _render_status(
                 # The ceiling's own words, uncovered magnitude in TOKENS.
                 if gap.detail:
                     ui_impl.kv("  coverage", gap.detail)
+
+    if root_dir is not None:
+        _render_safe_mode(ui_impl, root_dir)
 
     counts: dict[str, int] = {}
     for comp in manifest.components:
@@ -2854,6 +2882,12 @@ def status(
             ui_impl.info(
                 "Run `ks factory` or `ks run` first, or pass --manifest."
             )
+            # Safe mode does not depend on a manifest, and "nothing has
+            # run here" is exactly when an operator wants to know whether
+            # the factory is holding back. Withholding the answer on this
+            # path would make the question unaskable on a repo that has
+            # never completed a run - including this one (R10.4).
+            _render_safe_mode(ui_impl, root_dir)
             return 1
 
         try:
@@ -4506,6 +4540,7 @@ def serve(
         # same order, so "what would it do" cannot drift from "what it
         # does" without a test noticing.
         ui_impl.section("Serve dry run")
+        _render_safe_mode(ui_impl, root_dir)
         ui_impl.kv("queue", summarize(queue.counts()))
         pause = queue.pause_state()
         ui_impl.kv(

--- a/kstrl/reducer.py
+++ b/kstrl/reducer.py
@@ -564,12 +564,16 @@ def _v2_run_dirs(root_dir: Path) -> list[Path]:
     must distinguish "no runs" from "could not look" wants
     :func:`run_dirs_newest_first` instead.
     """
+    from kstrl.runid import run_sort_key
+
     try:
-        newest_first = run_dirs_newest_first(root_dir)
-        return [
-            d for d in reversed(newest_first)
-            if (d / "events.jsonl").exists()
-        ]
+        return sorted(
+            (
+                d for d in _run_dirs_unsorted(root_dir)
+                if (d / "events.jsonl").exists()
+            ),
+            key=lambda d: run_sort_key(d.name),
+        )
     except OSError:
         return []
 
@@ -587,6 +591,21 @@ def read_run_dir(run_dir: Path) -> list[ev.Event]:
             events.extend(ev.read_events(comp_dir / "engineer.jsonl"))
     events.sort(key=_sort_key)
     return events
+
+
+def _run_dirs_unsorted(root_dir: Path) -> list[Path]:
+    """Run directories in filesystem order, unsorted.
+
+    Shared so the two orderings below cannot disagree about which
+    directories exist. Raises on an unreadable ``runs/``; a missing one
+    is not an error, it is "no runs".
+    """
+    from kstrl.statedir import state_dir
+
+    runs_root = state_dir(root_dir) / "runs"
+    if not runs_root.exists():
+        return []
+    return [d for d in runs_root.iterdir() if d.is_dir()]
 
 
 def run_dirs_newest_first(root_dir: Path) -> list[Path]:
@@ -610,13 +629,9 @@ def run_dirs_newest_first(root_dir: Path) -> list[Path]:
     component.
     """
     from kstrl.runid import run_sort_key
-    from kstrl.statedir import state_dir
 
-    runs_root = state_dir(root_dir) / "runs"
-    if not runs_root.exists():
-        return []
     return sorted(
-        (d for d in runs_root.iterdir() if d.is_dir()),
+        _run_dirs_unsorted(root_dir),
         key=lambda d: run_sort_key(d.name),
         reverse=True,
     )

--- a/kstrl/reducer.py
+++ b/kstrl/reducer.py
@@ -589,6 +589,20 @@ def read_run_dir(run_dir: Path) -> list[ev.Event]:
     return events
 
 
+def latest_run_dir(root_dir: Path) -> Path | None:
+    """The newest run directory under ``.kstrl/runs/``, or None.
+
+    The same resolution :func:`load_run_state` uses, exposed on its own
+    for callers that want to scan a run's raw event stream rather than
+    fold it. ``safemode`` is one: it asks whether an adversarial phase
+    was skipped, and the folded ``ComponentState.recent_findings`` is
+    capped at :data:`MAX_RECENT_FINDINGS`, so a component that recorded
+    more findings afterwards would lose the record.
+    """
+    run_dirs = _v2_run_dirs(root_dir)
+    return run_dirs[-1] if run_dirs else None
+
+
 def load_run_state(
     root_dir: Path, run_id: str = "",
 ) -> tuple[RunState, Path | None]:

--- a/kstrl/reducer.py
+++ b/kstrl/reducer.py
@@ -557,21 +557,21 @@ def _sort_key(event: ev.Event) -> tuple[float, str, int]:
 
 
 def _v2_run_dirs(root_dir: Path) -> list[Path]:
-    from kstrl.statedir import state_dir
+    """Run dirs that carry an event stream, oldest first (newest last).
 
-    runs_root = state_dir(root_dir) / "runs"
+    Tolerant by contract: ``load_run_state`` answers an unreadable
+    ``runs/`` with "no runs" and falls back to the v1 log. A caller that
+    must distinguish "no runs" from "could not look" wants
+    :func:`run_dirs_newest_first` instead.
+    """
     try:
-        candidates = [
-            d for d in runs_root.iterdir()
+        newest_first = run_dirs_newest_first(root_dir)
+        return [
+            d for d in reversed(newest_first)
             if (d / "events.jsonl").exists()
         ]
     except OSError:
         return []
-    # Sort by the stamp after the kind prefix (kstrl.runid) so
-    # decompose-*/factory-* interleave chronologically; newest last.
-    from kstrl.runid import run_sort_key
-
-    return sorted(candidates, key=lambda d: run_sort_key(d.name))
 
 
 def read_run_dir(run_dir: Path) -> list[ev.Event]:
@@ -589,18 +589,37 @@ def read_run_dir(run_dir: Path) -> list[ev.Event]:
     return events
 
 
-def latest_run_dir(root_dir: Path) -> Path | None:
-    """The newest run directory under ``.kstrl/runs/``, or None.
+def run_dirs_newest_first(root_dir: Path) -> list[Path]:
+    """Every run directory under ``.kstrl/runs/``, newest first.
 
-    The same resolution :func:`load_run_state` uses, exposed on its own
-    for callers that want to scan a run's raw event stream rather than
-    fold it. ``safemode`` is one: it asks whether an adversarial phase
-    was skipped, and the folded ``ComponentState.recent_findings`` is
-    capped at :data:`MAX_RECENT_FINDINGS`, so a component that recorded
-    more findings afterwards would lose the record.
+    Differs from :func:`_v2_run_dirs` in the two ways a caller asking
+    "did a gate run" needs:
+
+    - it includes a run that left no ``events.jsonl``. A run with
+      ``[factory] progress_log_enabled = false`` writes its accounting
+      files and no events at all (``factory.py``, the ``usage_paths``
+      comment), so filtering on the stream would hide the newest run
+      behind an older one.
+    - it does not swallow a filesystem error. ``_v2_run_dirs`` answers
+      an unreadable ``runs/`` with an empty list, which reads as "no
+      runs" and therefore as "nothing was skipped".
+
+    ``safemode`` is that caller. It also cannot use the folded
+    ``ComponentState.recent_findings``, which is capped at
+    :data:`MAX_RECENT_FINDINGS` and would lose a skip behind a noisy
+    component.
     """
-    run_dirs = _v2_run_dirs(root_dir)
-    return run_dirs[-1] if run_dirs else None
+    from kstrl.runid import run_sort_key
+    from kstrl.statedir import state_dir
+
+    runs_root = state_dir(root_dir) / "runs"
+    if not runs_root.exists():
+        return []
+    return sorted(
+        (d for d in runs_root.iterdir() if d.is_dir()),
+        key=lambda d: run_sort_key(d.name),
+        reverse=True,
+    )
 
 
 def load_run_state(

--- a/kstrl/safemode.py
+++ b/kstrl/safemode.py
@@ -184,9 +184,10 @@ def _report_for_run(run_dir: Path) -> tuple[list[SafeModeReason], bool]:
 
     events_path = run_dir / "events.jsonl"
     try:
-        # A strict open. read_events swallows OSError into [].
-        with events_path.open("rb"):
-            pass
+        # ONE strict snapshot. Opening to probe and then calling
+        # ``read_events`` would open twice: a stream deleted between the
+        # two opens comes back as [], which reads as "nothing skipped".
+        raw = events_path.read_bytes()
     except FileNotFoundError:
         return [_reason(
             "adversarial_skipped",
@@ -201,7 +202,19 @@ def _report_for_run(run_dir: Path) -> tuple[list[SafeModeReason], bool]:
 
     skipped: dict[str, set[str]] = {phase: set() for phase in GATED_PHASES}
     finished = False
-    for event in ev.read_events(events_path):
+    torn = 0
+    lines = raw.decode("utf-8", errors="replace").splitlines()
+    for index, line in enumerate(lines):
+        event = ev.parse_event_line(line)
+        if event is None:
+            # ``read_events`` drops these silently, so a corrupt
+            # phase_skipped line followed by a valid factory_completed
+            # reads as a clean finished run. A torn LAST line is normal
+            # for a run being appended to right now; anything earlier is
+            # damage, and damage is not a clean sensor.
+            if line.strip() and index < len(lines) - 1:
+                torn += 1
+            continue
         if isinstance(event, ev.RunCompleted):
             finished = True
         elif isinstance(event, ev.PhaseSkipped) and event.phase in skipped:
@@ -215,6 +228,15 @@ def _report_for_run(run_dir: Path) -> tuple[list[SafeModeReason], bool]:
         )
         for phase in GATED_PHASES if skipped[phase]
     ]
+    if torn:
+        reasons.append(_reason(
+            "adversarial_skipped",
+            f"could not read run {run_dir.name}: {torn} unparseable "
+            "line(s) in the event stream, so a skipped phase could be "
+            "hidden in the damage",
+        ))
+        # Damaged, so it has not answered: the caller keeps looking back.
+        finished = False
     return reasons, finished
 
 
@@ -226,27 +248,39 @@ def _adversarial_reasons(root_dir: Path) -> list[SafeModeReason]:
     # can skip an adversarial gate. Without this filter a `ks decompose`
     # started afterwards becomes "the newest run", finishes clean because
     # it has no phases at all, and clears a factory run's skip.
-    runs = [
+    factory_runs = [
         d for d in run_dirs_newest_first(root_dir)
         if run_kind(d.name) == _SKIPPING_RUN_KIND
-    ][:_LOOKBACK_RUNS]
+    ]
+    runs = factory_runs[:_LOOKBACK_RUNS]
     if not runs:
         return []
 
-    reasons, finished = _report_for_run(runs[0])
-    if finished:
-        return reasons
-
-    # The newest run has not finished, and "no skip recorded yet" is not
+    # Walk back until a run has FINISHED. "No skip recorded yet" is not
     # "no skip": run B writes its first event long before it reaches
-    # review, so reporting only B would clear run A's skip the moment B
-    # starts. The last run that DID finish holds the answer until a run
-    # finishes without skipping.
-    for older in runs[1:]:
-        older_reasons, older_finished = _report_for_run(older)
-        if older_finished:
-            reasons.extend(older_reasons)
+    # review, so stopping at B would clear run A's skip the moment B
+    # started. Every run passed on the way contributes its own skips -
+    # a crashed run that did record one still recorded it, and dropping
+    # that was this loop's own bug in the previous round.
+    reasons: list[SafeModeReason] = []
+    settled = False
+    for run_dir in runs:
+        run_reasons, finished = _report_for_run(run_dir)
+        reasons.extend(run_reasons)
+        if finished:
+            settled = True
             break
+
+    if not settled and len(factory_runs) > len(runs):
+        # The walk hit the backstop with no finished run behind it, and
+        # there are older runs it did not open. Silence here would be a
+        # verdict the search never reached.
+        reasons.append(_reason(
+            "adversarial_skipped",
+            f"could not determine whether the adversarial gates ran: no "
+            f"finished factory run among the {_LOOKBACK_RUNS} most "
+            f"recent of {len(factory_runs)}",
+        ))
     return reasons
 
 
@@ -270,8 +304,22 @@ def safe_mode_reasons(root_dir: Path) -> list[SafeModeReason]:
     See the module docstring for what "read-only" means here and for why
     an exactly duplicated ``detail`` is dropped.
     """
+    try:
+        # Migrate FIRST, so every reader below sees the same control
+        # state. Without this the control reader reports leftover legacy
+        # files as untrusted and the queue reader then migrates them
+        # through its own ensure_control_state, leaving a reason whose
+        # recovery target no longer exists by the time it is printed.
+        from kstrl.statedir import ensure_control_state
+
+        ensure_control_state(root_dir)
+    except OSError:
+        # Not fatal: the control reader below reports an unusable
+        # control directory in its own words.
+        pass
+
     reasons: list[SafeModeReason] = []
-    seen: set[str] = set()
+    control_details: set[str] = set()
     for source, read in _READERS:
         try:
             found = read(root_dir)
@@ -279,9 +327,15 @@ def safe_mode_reasons(root_dir: Path) -> list[SafeModeReason]:
             found = [_reason(
                 source, f"could not read the {source} signal: {exc}",
             )]
+        if source == "control_dir":
+            control_details = {reason.detail for reason in found}
         for reason in found:
-            if reason.detail in seen:
+            # The ONE known aliasing, and only it: Queue.pause_state
+            # consults control_untrusted_reason itself and hands back
+            # that exact string. Dropping every repeated detail instead
+            # would let an operator's pause reason silently delete an
+            # unrelated source and its recovery anchor.
+            if source == "queue" and reason.detail in control_details:
                 continue
-            seen.add(reason.detail)
             reasons.append(reason)
     return reasons

--- a/kstrl/safemode.py
+++ b/kstrl/safemode.py
@@ -1,0 +1,225 @@
+"""Safe mode: one name for the degraded states kstrl already enters.
+
+kstrl refuses to do the risky thing in four separate places, and each
+refusal is correct on its own:
+
+- the control directory is untrusted, so the daemon will not spend
+  (``statedir.control_untrusted_reason``)
+- the autonomy ladder fell back to L1 on a damaged state file, or a
+  ceiling clamped the run below the level it earned (``autonomy``)
+- the queue is paused, including the fail-closed case where the pause
+  marker itself could not be read (``workqueue.Queue.pause_state``)
+- an adversarial phase did not run for some component of the newest run
+  (``pipeline.Pipeline._record_phase_skip``)
+
+What was missing was a single question. An operator who wanted to know
+whether the factory was holding back had to check a warning line at run
+start, ``ks queue``, ``ks serve`` output, and a callout inside a pull
+request body, and there was no word that covered all four. A spacecraft
+carries one named safe mode with one recovery procedure, and the value is
+precisely that it is one state with one question: are we in it, and why.
+
+This module answers that question and nothing else. It adds no gate, no
+pause and no halt, and it changes no decision: every signal it reads
+already acts on its own.
+
+Two things worth being exact about.
+
+**"Read-only" here means with respect to factory decisions, not with
+respect to the filesystem.** ``Queue.pause_state`` and
+``AutonomyState.load`` both call ``statedir.ensure_control_state``, which
+creates the XDG control directory and migrates any legacy in-tree control
+files. Every control-plane read in kstrl does that; this one is not
+special, and claiming it writes nothing would be false.
+
+**Two readers can return the same sentence.** ``Queue.pause_state``
+consults ``control_untrusted_reason`` itself and, when it is non-None,
+reports the queue as paused with that exact string. Printing it twice
+under two labels would tell an operator there are two problems when there
+is one, so a reason whose ``detail`` exactly matches one already recorded
+is dropped. The rule is exact string equality and nothing cleverer: two
+readers that genuinely disagree still both speak.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+#: Adversarial phases whose absence puts the factory in safe mode.
+#: ``verify`` is deliberately not here: a skipped mechanical verification
+#: is reported by ``ks status`` per component already, and unlike review
+#: and security it cannot be skipped by budget exhaustion.
+GATED_PHASES: tuple[str, ...] = ("review", "security")
+
+_RUNBOOK = "docs/runbook.md"
+
+#: Where an operator reads what to do about each source. The anchors are
+#: the headings under "## Safe mode" in the runbook, and
+#: ``tests/test_safemode.py`` asserts every one of them resolves, so the
+#: code and the document cannot drift apart quietly.
+RECOVERY: dict[str, str] = {
+    "control_dir": f"{_RUNBOOK}#control-directory-untrusted",
+    "autonomy": f"{_RUNBOOK}#autonomy-fell-back-or-was-clamped",
+    "queue": f"{_RUNBOOK}#queue-paused",
+    "adversarial_skipped": f"{_RUNBOOK}#an-adversarial-phase-did-not-run",
+}
+
+
+@dataclass(frozen=True)
+class SafeModeReason:
+    """One degraded state the factory is currently in."""
+
+    #: Which reader produced this. One of the keys of :data:`RECOVERY`.
+    source: str
+    #: A human sentence, taken verbatim from the existing signal wherever
+    #: that signal already has words of its own.
+    detail: str
+    #: The runbook anchor to read, e.g. ``docs/runbook.md#queue-paused``.
+    recovery: str
+
+
+def _reason(source: str, detail: str) -> SafeModeReason:
+    return SafeModeReason(
+        source=source, detail=detail, recovery=RECOVERY[source],
+    )
+
+
+def _control_dir_reasons(root_dir: Path) -> list[SafeModeReason]:
+    from kstrl.statedir import control_untrusted_reason
+
+    untrusted = control_untrusted_reason(root_dir)
+    return [_reason("control_dir", untrusted)] if untrusted else []
+
+
+def _autonomy_reasons(root_dir: Path) -> list[SafeModeReason]:
+    from kstrl.autonomy import (
+        AutonomyConfig,
+        AutonomyState,
+        resolve_runtime_level,
+    )
+    from kstrl.policy import PolicyConfig
+
+    config = AutonomyConfig.load(root_dir)
+    if not config.enabled:
+        # A ladder that is switched off is not a ladder that fell down.
+        # ``[autonomy] enabled`` is False by default, so reporting a
+        # damaged autonomy.json here would put every repo that never
+        # opted in into safe mode over a file nothing reads.
+        return []
+
+    state = AutonomyState.load(root_dir)
+    reasons: list[SafeModeReason] = []
+    if state.degraded_reason:
+        reasons.append(_reason("autonomy", state.degraded_reason))
+
+    level, clamps = resolve_runtime_level(
+        state,
+        config,
+        policy_enabled=PolicyConfig.load(root_dir).enabled,
+        root_dir=root_dir,
+    )
+    if int(level) < state.level:
+        # ``clamps`` carries the ceiling's own words. The fallback keeps
+        # the predicate speaking if a future ceiling ever clamps without
+        # writing a note, rather than going quiet.
+        notes = clamps or [f"clamped to L{int(level)}"]
+        reasons.extend(
+            _reason(
+                "autonomy",
+                f"running at L{int(level)}, earned level is "
+                f"L{state.level}: {note}",
+            )
+            for note in notes
+        )
+    return reasons
+
+
+def _queue_reasons(root_dir: Path) -> list[SafeModeReason]:
+    from kstrl.workqueue import Queue, QueueConfig
+
+    pause = Queue(root_dir, QueueConfig.load(root_dir)).pause_state()
+    # ``active`` rather than ``paused``: a lapsed ``resume_after`` means
+    # the queue is admitting work again, which is what the daemon's own
+    # ``is_paused`` asks.
+    if not pause.active():
+        return []
+    return [_reason("queue", pause.reason or "paused, no reason recorded")]
+
+
+def _adversarial_reasons(root_dir: Path) -> list[SafeModeReason]:
+    from kstrl import events as ev
+    from kstrl.reducer import latest_run_dir
+
+    runs_root = root_dir / ".kstrl" / "runs"
+    if runs_root.exists() and not runs_root.is_dir():
+        # ``_v2_run_dirs`` swallows this into "no runs", which reads as
+        # "nothing was skipped" - a fail-open on a question about
+        # whether a gate ran.
+        return [_reason(
+            "adversarial_skipped",
+            f"could not read {runs_root}: not a directory",
+        )]
+
+    run_dir = latest_run_dir(root_dir)
+    if run_dir is None:
+        return []
+
+    # Scanned from the raw stream rather than folded: ``PhaseSkipped`` has
+    # exactly one emitter and is never capped, while the reducer's
+    # ``recent_findings`` keeps only the last MAX_RECENT_FINDINGS per
+    # component and would lose the record behind a noisy component.
+    skipped: dict[str, set[str]] = {phase: set() for phase in GATED_PHASES}
+    for event in ev.read_events(run_dir / "events.jsonl"):
+        if isinstance(event, ev.PhaseSkipped) and event.phase in skipped:
+            skipped[event.phase].add(event.component)
+
+    reasons: list[SafeModeReason] = []
+    for phase in GATED_PHASES:
+        components = skipped[phase]
+        if not components:
+            continue
+        reasons.append(_reason(
+            "adversarial_skipped",
+            f"{phase} did not run for {len(components)} component(s) "
+            f"in run {run_dir.name}",
+        ))
+    return reasons
+
+
+#: Readers in evaluation order. The order is the order reasons appear.
+_READERS: tuple[tuple[str, Callable[[Path], list[SafeModeReason]]], ...] = (
+    ("control_dir", _control_dir_reasons),
+    ("autonomy", _autonomy_reasons),
+    ("queue", _queue_reasons),
+    ("adversarial_skipped", _adversarial_reasons),
+)
+
+
+def safe_mode_reasons(root_dir: Path) -> list[SafeModeReason]:
+    """Every degraded state the factory is currently in. Empty is nominal.
+
+    Never raises. Each reader is wrapped on its own, so one that fails
+    cannot hide the answers of the other three, and its failure becomes a
+    reason of its own source: a signal that could not be read is not
+    evidence that the signal is clear.
+
+    See the module docstring for what "read-only" means here and for why
+    an exactly duplicated ``detail`` is dropped.
+    """
+    reasons: list[SafeModeReason] = []
+    seen: set[str] = set()
+    for source, read in _READERS:
+        try:
+            found = read(root_dir)
+        except Exception as exc:  # noqa: BLE001 - a failed read IS a reason
+            found = [_reason(
+                source, f"could not read the {source} signal: {exc}",
+            )]
+        for reason in found:
+            if reason.detail in seen:
+                continue
+            seen.add(reason.detail)
+            reasons.append(reason)
+    return reasons

--- a/kstrl/safemode.py
+++ b/kstrl/safemode.py
@@ -32,6 +32,16 @@ creates the XDG control directory and migrates any legacy in-tree control
 files. Every control-plane read in kstrl does that; this one is not
 special, and claiming it writes nothing would be false.
 
+**Absence of evidence is not evidence of absence.** Every reader here
+had to be written so that "I could not look" is distinguishable from
+"nothing is wrong". ``ev.read_events`` answers an unreadable file with an
+empty list; ``reducer._v2_run_dirs`` answers an unreadable ``runs/`` with
+an empty list; a run in flight has recorded no skip yet; a ``decompose``
+run has no phase chain and so finishes clean without ever asking. Each of
+those reads as nominal unless the reader is explicit about it, and each
+would be a fail-open on exactly the question this module exists to
+answer.
+
 **Two readers can return the same sentence.** ``Queue.pause_state``
 consults ``control_untrusted_reason`` itself and, when it is non-None,
 reports the queue as paused with that exact string. Printing it twice
@@ -46,6 +56,15 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+
+#: Run kind whose stream can carry a skipped adversarial gate. Only a
+#: factory run drives the phase chain that emits ``PhaseSkipped``.
+_SKIPPING_RUN_KIND = "factory"
+
+#: How far back to look for a finished run while a newer one is in
+#: flight. A backstop, not a policy: the factory lock means at most one
+#: run is live, so the second entry almost always settles it.
+_LOOKBACK_RUNS = 20
 
 #: Adversarial phases whose absence puts the factory in safe mode.
 #: ``verify`` is deliberately not here: a skipped mechanical verification
@@ -148,43 +167,86 @@ def _queue_reasons(root_dir: Path) -> list[SafeModeReason]:
     return [_reason("queue", pause.reason or "paused, no reason recorded")]
 
 
-def _adversarial_reasons(root_dir: Path) -> list[SafeModeReason]:
-    from kstrl import events as ev
-    from kstrl.reducer import latest_run_dir
+def _report_for_run(run_dir: Path) -> tuple[list[SafeModeReason], bool]:
+    """One run's skipped gates, and whether that run finished.
 
-    runs_root = root_dir / ".kstrl" / "runs"
-    if runs_root.exists() and not runs_root.is_dir():
-        # ``_v2_run_dirs`` swallows this into "no runs", which reads as
-        # "nothing was skipped" - a fail-open on a question about
-        # whether a gate ran.
+    Read from the raw stream rather than the reducer's fold, because
+    ``ComponentState.recent_findings`` is capped at 50 per component and
+    would lose a skip behind a noisy component.
+
+    A stream that cannot be read returns a reason and ``False``, never an
+    empty list: ``ev.read_events`` answers OSError with ``[]``, and an
+    empty list here would mean "nothing was skipped". ``False`` is also
+    right for the caller's look-back, since a run we could not read has
+    not answered the question either.
+    """
+    from kstrl import events as ev
+
+    events_path = run_dir / "events.jsonl"
+    try:
+        # A strict open. read_events swallows OSError into [].
+        with events_path.open("rb"):
+            pass
+    except FileNotFoundError:
         return [_reason(
             "adversarial_skipped",
-            f"could not read {runs_root}: not a directory",
-        )]
+            f"could not read run {run_dir.name}: no event stream "
+            "(is [factory] progress_log_enabled false?)",
+        )], False
+    except OSError as exc:
+        return [_reason(
+            "adversarial_skipped",
+            f"could not read run {run_dir.name}: {exc}",
+        )], False
 
-    run_dir = latest_run_dir(root_dir)
-    if run_dir is None:
-        return []
-
-    # Scanned from the raw stream rather than folded: ``PhaseSkipped`` has
-    # exactly one emitter and is never capped, while the reducer's
-    # ``recent_findings`` keeps only the last MAX_RECENT_FINDINGS per
-    # component and would lose the record behind a noisy component.
     skipped: dict[str, set[str]] = {phase: set() for phase in GATED_PHASES}
-    for event in ev.read_events(run_dir / "events.jsonl"):
-        if isinstance(event, ev.PhaseSkipped) and event.phase in skipped:
+    finished = False
+    for event in ev.read_events(events_path):
+        if isinstance(event, ev.RunCompleted):
+            finished = True
+        elif isinstance(event, ev.PhaseSkipped) and event.phase in skipped:
             skipped[event.phase].add(event.component)
 
-    reasons: list[SafeModeReason] = []
-    for phase in GATED_PHASES:
-        components = skipped[phase]
-        if not components:
-            continue
-        reasons.append(_reason(
+    reasons = [
+        _reason(
             "adversarial_skipped",
-            f"{phase} did not run for {len(components)} component(s) "
+            f"{phase} did not run for {len(skipped[phase])} component(s) "
             f"in run {run_dir.name}",
-        ))
+        )
+        for phase in GATED_PHASES if skipped[phase]
+    ]
+    return reasons, finished
+
+
+def _adversarial_reasons(root_dir: Path) -> list[SafeModeReason]:
+    from kstrl.reducer import run_dirs_newest_first
+    from kstrl.runid import run_kind
+
+    # Only a factory run drives the phase chain, so only a factory run
+    # can skip an adversarial gate. Without this filter a `ks decompose`
+    # started afterwards becomes "the newest run", finishes clean because
+    # it has no phases at all, and clears a factory run's skip.
+    runs = [
+        d for d in run_dirs_newest_first(root_dir)
+        if run_kind(d.name) == _SKIPPING_RUN_KIND
+    ][:_LOOKBACK_RUNS]
+    if not runs:
+        return []
+
+    reasons, finished = _report_for_run(runs[0])
+    if finished:
+        return reasons
+
+    # The newest run has not finished, and "no skip recorded yet" is not
+    # "no skip": run B writes its first event long before it reaches
+    # review, so reporting only B would clear run A's skip the moment B
+    # starts. The last run that DID finish holds the answer until a run
+    # finishes without skipping.
+    for older in runs[1:]:
+        older_reasons, older_finished = _report_for_run(older)
+        if older_finished:
+            reasons.extend(older_reasons)
+            break
     return reasons
 
 

--- a/tests/test_reducer.py
+++ b/tests/test_reducer.py
@@ -403,6 +403,37 @@ class TestLoadRunState:
         assert source is None
         assert state.components == {}
 
+    def test_latest_run_dir_agrees_with_load_run_state(
+        self, tmp_path: Path,
+    ) -> None:
+        """R10.4 exposed this resolution on its own so a caller can scan
+        a run's raw stream instead of folding it. The two must not be
+        able to disagree about WHICH run is newest."""
+        self._write_v2(tmp_path, "factory-20260720-000001.000000-x", "older")
+        self._write_v2(tmp_path, "factory-20260720-000009.000000-x", "newer")
+
+        run_dir = reducer.latest_run_dir(tmp_path)
+        _, source = reducer.load_run_state(tmp_path)
+
+        assert run_dir is not None and source is not None
+        assert run_dir == source.parent
+        assert run_dir.name == "factory-20260720-000009.000000-x"
+
+    def test_latest_run_dir_is_none_without_runs(self, tmp_path: Path) -> None:
+        assert reducer.latest_run_dir(tmp_path) is None
+
+    def test_latest_run_dir_ignores_a_dir_without_events(
+        self, tmp_path: Path,
+    ) -> None:
+        self._write_v2(tmp_path, "factory-20260720-000001.000000-x", "real")
+        (tmp_path / ".kstrl" / "runs" / "factory-20260720-000009.000000-x"
+         ).mkdir(parents=True)
+
+        run_dir = reducer.latest_run_dir(tmp_path)
+
+        assert run_dir is not None
+        assert run_dir.name == "factory-20260720-000001.000000-x"
+
     def test_torn_tail_in_run_dir(self, tmp_path: Path) -> None:
         run_id = "factory-20260720-000003.000000-x"
         self._write_v2(tmp_path, run_id, "proj")

--- a/tests/test_reducer.py
+++ b/tests/test_reducer.py
@@ -450,6 +450,24 @@ class TestLoadRunState:
             tmp_path / ".kstrl" / "runs" / "factory-20260720-000001.000000-x",
         ]
 
+    def test_a_tie_resolves_the_same_way_it_did_before(
+        self, tmp_path: Path,
+    ) -> None:
+        """Two kinds can share a run_sort_key (same stamp, same nonce).
+        sorted(reverse=True) keeps ties in their original order, so
+        reversing that list FLIPS them - and load_run_state takes the
+        last element, so it would pick the other run. Pin the old order
+        rather than change working behaviour inside a refactor."""
+        self._write_v2(tmp_path, "factory-20260720-000001.000000-x", "fac")
+        self._write_v2(tmp_path, "decompose-20260720-000001.000000-x", "dec")
+
+        ordered = reducer._v2_run_dirs(tmp_path)
+        listed = [
+            d for d in (tmp_path / ".kstrl" / "runs").iterdir() if d.is_dir()
+        ]
+
+        assert [d.name for d in ordered] == [d.name for d in listed]
+
     def test_run_dirs_newest_first_does_not_swallow_a_read_error(
         self, tmp_path: Path,
     ) -> None:

--- a/tests/test_reducer.py
+++ b/tests/test_reducer.py
@@ -8,6 +8,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from kstrl import events as ev
 from kstrl import reducer
 from kstrl.observability import ProgressLog, read_progress_events, summarize_events
@@ -403,36 +405,63 @@ class TestLoadRunState:
         assert source is None
         assert state.components == {}
 
-    def test_latest_run_dir_agrees_with_load_run_state(
+    def test_run_dirs_newest_first_orders_and_agrees_with_the_fold(
         self, tmp_path: Path,
     ) -> None:
-        """R10.4 exposed this resolution on its own so a caller can scan
-        a run's raw stream instead of folding it. The two must not be
-        able to disagree about WHICH run is newest."""
+        """R10.4 exposed this listing so a caller can scan a run's raw
+        stream instead of folding it. The two must not be able to
+        disagree about WHICH run is newest."""
         self._write_v2(tmp_path, "factory-20260720-000001.000000-x", "older")
         self._write_v2(tmp_path, "factory-20260720-000009.000000-x", "newer")
 
-        run_dir = reducer.latest_run_dir(tmp_path)
+        dirs = reducer.run_dirs_newest_first(tmp_path)
         _, source = reducer.load_run_state(tmp_path)
 
-        assert run_dir is not None and source is not None
-        assert run_dir == source.parent
-        assert run_dir.name == "factory-20260720-000009.000000-x"
+        assert [d.name for d in dirs] == [
+            "factory-20260720-000009.000000-x",
+            "factory-20260720-000001.000000-x",
+        ]
+        assert source is not None and dirs[0] == source.parent
 
-    def test_latest_run_dir_is_none_without_runs(self, tmp_path: Path) -> None:
-        assert reducer.latest_run_dir(tmp_path) is None
-
-    def test_latest_run_dir_ignores_a_dir_without_events(
+    def test_run_dirs_newest_first_is_empty_without_runs(
         self, tmp_path: Path,
     ) -> None:
+        assert reducer.run_dirs_newest_first(tmp_path) == []
+
+    def test_run_dirs_newest_first_includes_a_run_with_no_events(
+        self, tmp_path: Path,
+    ) -> None:
+        """A run with [factory] progress_log_enabled = false writes its
+        accounting files and no events. Filtering it out would hide the
+        newest run behind an older one, and safe mode would report a
+        stale verdict as though it were current."""
         self._write_v2(tmp_path, "factory-20260720-000001.000000-x", "real")
         (tmp_path / ".kstrl" / "runs" / "factory-20260720-000009.000000-x"
          ).mkdir(parents=True)
 
-        run_dir = reducer.latest_run_dir(tmp_path)
+        dirs = reducer.run_dirs_newest_first(tmp_path)
 
-        assert run_dir is not None
-        assert run_dir.name == "factory-20260720-000001.000000-x"
+        assert [d.name for d in dirs] == [
+            "factory-20260720-000009.000000-x",
+            "factory-20260720-000001.000000-x",
+        ]
+        # The fold still sees only the run that has a stream.
+        assert reducer._v2_run_dirs(tmp_path) == [
+            tmp_path / ".kstrl" / "runs" / "factory-20260720-000001.000000-x",
+        ]
+
+    def test_run_dirs_newest_first_does_not_swallow_a_read_error(
+        self, tmp_path: Path,
+    ) -> None:
+        """_v2_run_dirs answers an unreadable runs/ with "no runs", which
+        reads as "nothing was skipped". This listing must not."""
+        runs = tmp_path / ".kstrl" / "runs"
+        runs.parent.mkdir(parents=True, exist_ok=True)
+        runs.write_text("i am a file", encoding="utf-8")
+
+        with pytest.raises(OSError):
+            reducer.run_dirs_newest_first(tmp_path)
+        assert reducer._v2_run_dirs(tmp_path) == []   # unchanged contract
 
     def test_torn_tail_in_run_dir(self, tmp_path: Path) -> None:
         run_id = "factory-20260720-000003.000000-x"

--- a/tests/test_safemode.py
+++ b/tests/test_safemode.py
@@ -456,6 +456,129 @@ def root_events(root: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
+class TestRoundTwoFindings:
+    """Round 2 review. Two of these are defects that round 1's own fixes
+    introduced, which is why a single review round is not a review."""
+
+    def test_a_crashed_run_keeps_its_recorded_skip(
+        self, tmp_path: Path,
+    ) -> None:
+        """Completed-clean A, crashed B that DID skip review, clean
+        in-flight C. Walking back to A and reporting only A threw away
+        the one thing B actually recorded."""
+        write_run(tmp_path, "factory-20260827-100000-aaaa", finished=True)
+        write_run(tmp_path, "factory-20260827-110000-bbbb",
+                  skips=("review",), finished=False)
+        write_run(tmp_path, "factory-20260827-120000-cccc", finished=False)
+
+        details = [r.detail for r in safe_mode_reasons(tmp_path)]
+
+        assert len(details) == 1
+        assert details[0] == (
+            "review did not run for 1 component(s) in run "
+            "factory-20260827-110000-bbbb"
+        )
+
+    def test_a_torn_line_is_damage_not_a_clean_run(
+        self, tmp_path: Path,
+    ) -> None:
+        """ev.read_events drops unparseable lines silently, so a corrupt
+        phase_skipped followed by a valid factory_completed read as a
+        finished run with nothing skipped."""
+        write_run(tmp_path, "factory-20260827-110000-bbbb", finished=True)
+        events = (tmp_path / ".kstrl" / "runs"
+                  / "factory-20260827-110000-bbbb" / "events.jsonl")
+        lines = events.read_text(encoding="utf-8").splitlines()
+        lines.insert(1, '{"event": "phase_skipped", "phase": "rev')
+        events.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["adversarial_skipped"]
+        assert "unparseable" in reasons[0].detail
+
+    def test_a_torn_final_line_is_normal(self, tmp_path: Path) -> None:
+        """A run being appended to right now has a half-written last
+        line. That is ordinary, not damage."""
+        write_run(tmp_path, "factory-20260827-110000-bbbb",
+                  skips=("review",), finished=False)
+        events = (tmp_path / ".kstrl" / "runs"
+                  / "factory-20260827-110000-bbbb" / "events.jsonl")
+        with events.open("a", encoding="utf-8") as handle:
+            handle.write('{"event": "iteration_star')
+
+        details = [r.detail for r in safe_mode_reasons(tmp_path)]
+
+        assert len(details) == 1
+        assert details[0].startswith("review did not run")
+
+    def test_an_exhausted_lookback_says_so(self, tmp_path: Path) -> None:
+        """A backstop that runs out must report that the search never
+        reached a verdict, not report nominal."""
+        write_run(tmp_path, "factory-20260827-000000-oldest",
+                  skips=("review",), finished=True)
+        for index in range(25):
+            write_run(
+                tmp_path, f"factory-20260827-1{index:05d}-crash",
+                finished=False,
+            )
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["adversarial_skipped"]
+        assert reasons[0].detail.startswith("could not determine")
+
+    def test_a_short_history_of_unfinished_runs_is_not_indeterminate(
+        self, tmp_path: Path,
+    ) -> None:
+        """The other side of it: a first run still in flight has simply
+        produced no verdict yet, and that is nominal, not degraded."""
+        write_run(tmp_path, "factory-20260827-110000-bbbb", finished=False)
+
+        assert safe_mode_reasons(tmp_path) == []
+
+    def test_dedup_does_not_swallow_an_unrelated_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The rule exists for ONE aliasing: Queue.pause_state handing
+        back the control-dir verdict. Dropping every repeated detail
+        would let a pause reason delete an unrelated source."""
+        skip_detail = (
+            "review did not run for 1 component(s) in run "
+            "factory-20260827-110000-bbbb"
+        )
+        write_run(tmp_path, "factory-20260827-110000-bbbb",
+                  skips=("review",), finished=True)
+        Queue(tmp_path, QueueConfig()).pause(reason=skip_detail, actor="test")
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["queue", "adversarial_skipped"]
+        assert reasons[1].recovery == RECOVERY["adversarial_skipped"]
+
+    def test_legacy_control_files_are_migrated_before_any_reader(
+        self, tmp_path: Path,
+    ) -> None:
+        """The control reader reported leftover legacy files as
+        untrusted, then the queue reader migrated them away through its
+        own ensure_control_state - leaving a reason whose recovery target
+        no longer existed by the time it was printed."""
+        from kstrl.statedir import CONTROL_PAUSE, legacy_control_paths
+
+        legacy = legacy_control_paths(tmp_path)[CONTROL_PAUSE]
+        legacy.parent.mkdir(parents=True, exist_ok=True)
+        legacy.write_text(
+            json.dumps({"paused": True, "reason": "legacy pause"}) + "\n",
+            encoding="utf-8",
+        )
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert not legacy.exists()          # migrated before any reader ran
+        assert [r.source for r in reasons] == ["queue"]
+        assert reasons[0].detail == "legacy pause"
+
+
 class TestComposition:
     def test_multiple_reasons_are_reported_in_evaluation_order(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_safemode.py
+++ b/tests/test_safemode.py
@@ -1,0 +1,457 @@
+"""R10.4: safe mode, one predicate over four existing degraded states.
+
+Every condition here is built with the real writer that creates it in
+production - ``Queue.pause``, ``AutonomyState.save``, ``JsonlSink``, a
+real ``kstrl.toml``, a real ``XDG_STATE_HOME``. Nothing the predicate
+reads is mocked, because a predicate whose inputs are faked proves only
+that the fake was shaped correctly.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from kstrl import events as ev
+from kstrl.autonomy import AutonomyLevel, AutonomyState
+from kstrl.safemode import RECOVERY, safe_mode_reasons
+from kstrl.workqueue import Queue, QueueConfig
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUN_ID = "factory-20260827-120000-abcd"
+
+
+# ---------------------------------------------------------------------------
+# Condition builders - one per degrade path, shared by the specific tests
+# below and by the coverage test that proves all four are reachable.
+# ---------------------------------------------------------------------------
+
+
+def make_control_dir_untrusted(
+    root: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Point XDG_STATE_HOME inside the repo, the documented untrusted case."""
+    from kstrl.statedir import clear_xdg_state_home_cache
+
+    nested = root / "nested-xdg"
+    nested.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("XDG_STATE_HOME", str(nested))
+    clear_xdg_state_home_cache()
+
+
+def make_autonomy_degraded(
+    root: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Enable the ladder over an autonomy.json that will not parse."""
+    (root / "kstrl.toml").write_text(
+        "[autonomy]\nenabled = true\n", encoding="utf-8",
+    )
+    path = AutonomyState.path_for(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+
+
+def make_queue_paused(root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    Queue(root, QueueConfig()).pause(
+        reason="daily budget exhausted", actor="test",
+    )
+
+
+def make_review_skipped(root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write a real event stream in which review never ran."""
+    sink = ev.JsonlSink(root / ".kstrl" / "runs" / RUN_ID / "events.jsonl")
+    try:
+        for component in ("comp-a", "comp-b"):
+            sink.emit(ev.PhaseSkipped(
+                component=component,
+                phase="review",
+                reason="adversarial LLM budget exhausted",
+            ))
+    finally:
+        sink.close()
+
+
+SCENARIOS = {
+    "control_dir": make_control_dir_untrusted,
+    "autonomy": make_autonomy_degraded,
+    "queue": make_queue_paused,
+    "adversarial_skipped": make_review_skipped,
+}
+
+
+def sources(root: Path) -> list[str]:
+    return [reason.source for reason in safe_mode_reasons(root)]
+
+
+# ---------------------------------------------------------------------------
+# Acceptance: all four paths reachable, and the four are the documented four
+# ---------------------------------------------------------------------------
+
+
+class TestEveryDegradePathIsReachable:
+    @pytest.mark.parametrize("source", sorted(SCENARIOS))
+    def test_source_is_reported(
+        self, source: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        SCENARIOS[source](tmp_path, monkeypatch)
+        with pytest.warns(RuntimeWarning) if source == "autonomy" else _noop():
+            assert source in sources(tmp_path)
+
+    def test_the_scenarios_cover_exactly_the_documented_sources(self) -> None:
+        """The acceptance criterion as a mechanism rather than a promise.
+
+        Adding a fifth source to RECOVERY without a scenario that
+        produces it fails here, which is the only thing stopping the
+        count from drifting away from four silently.
+        """
+        assert set(SCENARIOS) == set(RECOVERY)
+        assert len(SCENARIOS) == 4
+
+
+class _noop:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Nominal
+# ---------------------------------------------------------------------------
+
+
+class TestNominal:
+    def test_nominal_when_nothing_is_wrong(self, tmp_path: Path) -> None:
+        assert safe_mode_reasons(tmp_path) == []
+
+    def test_a_disabled_ladder_is_not_a_degraded_ladder(
+        self, tmp_path: Path,
+    ) -> None:
+        """[autonomy] is off by default, and a file nothing reads is not
+        a degraded state. Reporting one would put every repo that never
+        opted in into safe mode."""
+        path = AutonomyState.path_for(tmp_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not json", encoding="utf-8")
+
+        assert safe_mode_reasons(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Per-source detail
+# ---------------------------------------------------------------------------
+
+
+class TestControlDir:
+    def test_untrusted_control_dir_is_one_reason(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        make_control_dir_untrusted(tmp_path, monkeypatch)
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert len(reasons) == 1
+        assert reasons[0].source == "control_dir"
+        assert "XDG_STATE_HOME" in reasons[0].detail
+
+
+class TestAutonomy:
+    def test_fallback_is_reported(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        make_autonomy_degraded(tmp_path, monkeypatch)
+
+        with pytest.warns(RuntimeWarning, match="failing closed to L1"):
+            reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["autonomy"]
+        assert "failing closed to L1" in reasons[0].detail
+
+    def test_degraded_reason_is_never_written_to_disk(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The field is transient by construction: ``save`` builds its
+        payload key by key, not from ``asdict``. This pins that."""
+        make_autonomy_degraded(tmp_path, monkeypatch)
+
+        with pytest.warns(RuntimeWarning):
+            state = AutonomyState.load(tmp_path)
+        assert state.degraded_reason is not None
+        state.save(tmp_path)
+
+        written = json.loads(
+            AutonomyState.path_for(tmp_path).read_text(encoding="utf-8"),
+        )
+        assert "degraded_reason" not in written
+        # And a reload of what we just wrote is clean, not degraded.
+        assert AutonomyState.load(tmp_path).degraded_reason is None
+
+    def test_first_run_is_not_a_fallback(self, tmp_path: Path) -> None:
+        """No autonomy.json at all is first run, not a damaged record."""
+        assert AutonomyState.load(tmp_path).degraded_reason is None
+
+    def test_clamp_names_both_levels(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """L3 is auto-merge INSIDE the policy envelope. With [policy]
+        enabled=false there is no envelope, so L2 is the ceiling."""
+        (tmp_path / "kstrl.toml").write_text(
+            "[autonomy]\nenabled = true\n\n[policy]\nenabled = false\n",
+            encoding="utf-8",
+        )
+        AutonomyState(
+            level=int(AutonomyLevel.L3_ENVELOPED_AUTO),
+        ).save(tmp_path)
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["autonomy"]
+        assert "L3" in reasons[0].detail
+        assert "L2" in reasons[0].detail
+
+    def test_level_at_its_ceiling_is_not_a_clamp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An enabled ladder sitting at a level nothing lowers is nominal."""
+        (tmp_path / "kstrl.toml").write_text(
+            "[autonomy]\nenabled = true\n", encoding="utf-8",
+        )
+        AutonomyState(level=int(AutonomyLevel.L2_GATED_MERGE)).save(tmp_path)
+
+        assert safe_mode_reasons(tmp_path) == []
+
+
+class TestQueue:
+    def test_paused_queue_carries_the_pause_reason(
+        self, tmp_path: Path,
+    ) -> None:
+        Queue(tmp_path, QueueConfig()).pause(
+            reason="poison breaker tripped", actor="test",
+        )
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["queue"]
+        assert reasons[0].detail == "poison breaker tripped"
+
+    def test_unreadable_pause_marker_is_a_reason(
+        self, tmp_path: Path,
+    ) -> None:
+        """Fail-closed: a corrupt marker means paused, never running."""
+        from kstrl.statedir import CONTROL_PAUSE, control_file
+
+        path = control_file(tmp_path, CONTROL_PAUSE)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{ not json", encoding="utf-8")
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["queue"]
+        assert "unreadable" in reasons[0].detail
+
+    def test_a_lapsed_pause_is_not_a_reason(self, tmp_path: Path) -> None:
+        """resume_after in the past means the queue admits work again,
+        which is what the daemon's own is_paused asks."""
+        Queue(tmp_path, QueueConfig()).pause(
+            reason="daily budget", actor="test",
+            resume_after="2020-01-01T00:00:00+00:00",
+        )
+
+        assert safe_mode_reasons(tmp_path) == []
+
+
+class TestAdversarialSkipped:
+    def test_skipped_review_counts_components_and_names_the_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        make_review_skipped(tmp_path, monkeypatch)
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["adversarial_skipped"]
+        assert reasons[0].detail == (
+            f"review did not run for 2 component(s) in run {RUN_ID}"
+        )
+
+    def test_review_and_security_are_separate_reasons(
+        self, tmp_path: Path,
+    ) -> None:
+        sink = ev.JsonlSink(root_events(tmp_path))
+        try:
+            sink.emit(ev.PhaseSkipped(
+                component="comp-a", phase="review", reason="mode=skip",
+            ))
+            sink.emit(ev.PhaseSkipped(
+                component="comp-a", phase="security", reason="mode=skip",
+            ))
+        finally:
+            sink.close()
+
+        details = [r.detail for r in safe_mode_reasons(tmp_path)]
+
+        assert len(details) == 2
+        assert details[0].startswith("review did not run")
+        assert details[1].startswith("security did not run")
+
+    def test_a_skipped_verify_is_not_a_safe_mode_reason(
+        self, tmp_path: Path,
+    ) -> None:
+        """Mechanical verification is reported per component by `ks
+        status` already, and unlike review it cannot be dropped by budget
+        exhaustion. Only the adversarial gates land here."""
+        sink = ev.JsonlSink(root_events(tmp_path))
+        try:
+            sink.emit(ev.PhaseSkipped(
+                component="comp-a", phase="verify", reason="--no-verify",
+            ))
+        finally:
+            sink.close()
+
+        assert safe_mode_reasons(tmp_path) == []
+
+    def test_no_runs_is_no_reason(self, tmp_path: Path) -> None:
+        assert safe_mode_reasons(tmp_path) == []
+
+
+def root_events(root: Path) -> Path:
+    return root / ".kstrl" / "runs" / RUN_ID / "events.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Composition: several reasons, and the duplicate rule
+# ---------------------------------------------------------------------------
+
+
+class TestComposition:
+    def test_multiple_reasons_are_reported_in_evaluation_order(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Two independent readers, both unhappy. The pair is autonomy
+        plus queue rather than control_dir plus queue, because
+        Queue.pause_state consults control_untrusted_reason itself and
+        the second pair collapses to one reason by design."""
+        make_autonomy_degraded(tmp_path, monkeypatch)
+        make_queue_paused(tmp_path, monkeypatch)
+
+        with pytest.warns(RuntimeWarning):
+            reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["autonomy", "queue"]
+
+    def test_the_control_dir_verdict_is_not_repeated_by_the_queue(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Queue.pause_state returns the untrusted reason verbatim, so a
+        naive predicate would print the same sentence under two labels
+        and tell the operator there are two problems when there is one."""
+        make_queue_paused(tmp_path, monkeypatch)
+        make_control_dir_untrusted(tmp_path, monkeypatch)
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["control_dir"]
+
+    def test_every_reason_carries_its_own_recovery_anchor(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        make_autonomy_degraded(tmp_path, monkeypatch)
+        make_queue_paused(tmp_path, monkeypatch)
+        make_review_skipped(tmp_path, monkeypatch)
+
+        with pytest.warns(RuntimeWarning):
+            reasons = safe_mode_reasons(tmp_path)
+
+        assert len(reasons) >= 3
+        for reason in reasons:
+            assert reason.recovery == RECOVERY[reason.source]
+
+
+# ---------------------------------------------------------------------------
+# The never-raises contract
+# ---------------------------------------------------------------------------
+
+
+class TestNeverRaises:
+    def test_a_runs_path_that_is_a_file_becomes_a_reason(
+        self, tmp_path: Path,
+    ) -> None:
+        """_v2_run_dirs swallows this into "no runs", which would read as
+        "nothing was skipped" - a fail-open on a question about whether a
+        gate ran."""
+        runs = tmp_path / ".kstrl" / "runs"
+        runs.parent.mkdir(parents=True, exist_ok=True)
+        runs.write_text("i am a file", encoding="utf-8")
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["adversarial_skipped"]
+        assert reasons[0].detail.startswith("could not read")
+
+    def test_a_reader_that_raises_becomes_a_reason(
+        self, tmp_path: Path,
+    ) -> None:
+        """max_level = 99 makes AutonomyConfig.__post_init__ raise. The
+        predicate must report that it could not read the signal rather
+        than propagate, and must still answer for the other three."""
+        (tmp_path / "kstrl.toml").write_text(
+            "[autonomy]\nenabled = true\nmax_level = 99\n", encoding="utf-8",
+        )
+        Queue(tmp_path, QueueConfig()).pause(reason="paused", actor="test")
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["autonomy", "queue"]
+        assert reasons[0].detail.startswith("could not read")
+        # One reader failing did not hide the next one's answer.
+        assert reasons[1].detail == "paused"
+
+    def test_a_malformed_kstrl_toml_does_not_propagate(
+        self, tmp_path: Path,
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text("[[[not toml", encoding="utf-8")
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert all(r.detail.startswith("could not read") for r in reasons)
+
+
+# ---------------------------------------------------------------------------
+# The code and the runbook cannot drift apart
+# ---------------------------------------------------------------------------
+
+
+def _github_anchor(heading: str) -> str:
+    slug = heading.strip().lower()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    return re.sub(r"\s+", "-", slug)
+
+
+class TestRecoveryAnchors:
+    def test_every_anchor_resolves_to_a_runbook_heading(self) -> None:
+        """Without this, ``recovery`` is a convention: a renamed heading
+        would send an operator in safe mode to a section that no longer
+        exists, and nothing would notice."""
+        runbook = REPO_ROOT / "docs" / "runbook.md"
+        anchors = {
+            _github_anchor(line.lstrip("#").strip())
+            for line in runbook.read_text(encoding="utf-8").splitlines()
+            if line.startswith("#")
+        }
+
+        for source, recovery in sorted(RECOVERY.items()):
+            path, _, anchor = recovery.partition("#")
+            assert path == "docs/runbook.md", source
+            assert anchor in anchors, (
+                f"{source} points at #{anchor}, which is not a heading in "
+                f"docs/runbook.md"
+            )
+
+    def test_the_runbook_has_the_safe_mode_section(self) -> None:
+        runbook = (REPO_ROOT / "docs" / "runbook.md").read_text(
+            encoding="utf-8",
+        )
+        assert "\n## Safe mode\n" in runbook

--- a/tests/test_safemode.py
+++ b/tests/test_safemode.py
@@ -317,6 +317,136 @@ class TestAdversarialSkipped:
         assert safe_mode_reasons(tmp_path) == []
 
 
+def write_run(
+    root: Path, run_id: str, *, skips: tuple[str, ...] = (),
+    finished: bool = True, component: str = "comp-a",
+) -> None:
+    """A run stream with the given skipped phases, terminal or in flight."""
+    sink = ev.JsonlSink(root / ".kstrl" / "runs" / run_id / "events.jsonl")
+    try:
+        # Every real run opens with this, so an in-flight run always has
+        # a stream. Without it the sink never creates the file and the
+        # run would look like the progress-logging-disabled case.
+        sink.emit(ev.RunStarted(project="demo", components=1))
+        for phase in skips:
+            sink.emit(ev.PhaseSkipped(
+                component=component, phase=phase, reason="mode=skip",
+            ))
+        if finished:
+            sink.emit(ev.RunCompleted(completed=1, failed=0, skipped=0))
+    finally:
+        sink.close()
+
+
+class TestTheSkipVerdictIsNotClearedTooEarly:
+    """Round 1 review, three of four findings. "No skip recorded yet" is
+    not "no skip", and a signal that could not be read is not a clear
+    signal. Each test below fails on the pre-review implementation."""
+
+    def test_a_run_in_flight_does_not_clear_an_earlier_skip(
+        self, tmp_path: Path,
+    ) -> None:
+        """Run B writes its first event long before it reaches review, so
+        selecting B and finding no skip would clear A the moment B
+        starts - on the very question safe mode exists to answer."""
+        write_run(tmp_path, "factory-20260827-100000-aaaa",
+                  skips=("review",), finished=True)
+        write_run(tmp_path, "factory-20260827-110000-bbbb", finished=False)
+
+        details = [r.detail for r in safe_mode_reasons(tmp_path)]
+
+        assert len(details) == 1
+        assert "factory-20260827-100000-aaaa" in details[0]
+
+    def test_a_finished_clean_run_does_clear_it(
+        self, tmp_path: Path,
+    ) -> None:
+        """The other half of the rule, and the runbook's wording."""
+        write_run(tmp_path, "factory-20260827-100000-aaaa",
+                  skips=("review",), finished=True)
+        write_run(tmp_path, "factory-20260827-110000-bbbb", finished=True)
+
+        assert safe_mode_reasons(tmp_path) == []
+
+    def test_a_decompose_run_does_not_clear_a_factory_skip(
+        self, tmp_path: Path,
+    ) -> None:
+        """Only a factory run drives the phase chain. A decompose run has
+        no phases at all, so it finishes clean by construction and would
+        clear the verdict without ever having asked the question."""
+        write_run(tmp_path, "factory-20260827-100000-aaaa",
+                  skips=("review",), finished=True)
+        write_run(tmp_path, "decompose-20260827-110000-bbbb", finished=True)
+
+        details = [r.detail for r in safe_mode_reasons(tmp_path)]
+
+        assert len(details) == 1
+        assert "factory-20260827-100000-aaaa" in details[0]
+
+    def test_an_in_flight_run_still_reports_its_own_skip(
+        self, tmp_path: Path,
+    ) -> None:
+        """A skip already recorded is a fact, finished or not."""
+        write_run(tmp_path, "factory-20260827-110000-bbbb",
+                  skips=("security",), finished=False)
+
+        details = [r.detail for r in safe_mode_reasons(tmp_path)]
+
+        assert len(details) == 1
+        assert details[0].startswith("security did not run")
+
+    def test_a_run_with_no_event_stream_is_a_reason(
+        self, tmp_path: Path,
+    ) -> None:
+        """[factory] progress_log_enabled = false creates the run dir and
+        writes no events. Falling back to the previous run would report a
+        stale verdict as current; reporting nominal would answer a
+        question we cannot see."""
+        write_run(tmp_path, "factory-20260827-100000-aaaa", finished=True)
+        (tmp_path / ".kstrl" / "runs" / "factory-20260827-110000-bbbb"
+         ).mkdir(parents=True)
+
+        reasons = safe_mode_reasons(tmp_path)
+
+        assert [r.source for r in reasons] == ["adversarial_skipped"]
+        assert reasons[0].detail.startswith("could not read run")
+        assert "progress_log_enabled" in reasons[0].detail
+
+    def test_an_unreadable_event_stream_is_a_reason(
+        self, tmp_path: Path,
+    ) -> None:
+        """ev.read_events answers OSError with [], which reads as "no
+        skips". The predicate promises the opposite."""
+        write_run(tmp_path, "factory-20260827-110000-bbbb",
+                  skips=("review",), finished=True)
+        events = (tmp_path / ".kstrl" / "runs"
+                  / "factory-20260827-110000-bbbb" / "events.jsonl")
+        events.chmod(0o000)
+        try:
+            reasons = safe_mode_reasons(tmp_path)
+        finally:
+            events.chmod(0o644)
+
+        assert [r.source for r in reasons] == ["adversarial_skipped"]
+        assert reasons[0].detail.startswith("could not read run")
+
+    def test_an_unreadable_newest_run_still_reports_the_last_verdict(
+        self, tmp_path: Path,
+    ) -> None:
+        """A run we could not read has not answered either, so the last
+        finished run's verdict still stands beside the read failure."""
+        write_run(tmp_path, "factory-20260827-100000-aaaa",
+                  skips=("review",), finished=True)
+        (tmp_path / ".kstrl" / "runs" / "factory-20260827-110000-bbbb"
+         ).mkdir(parents=True)
+
+        details = [r.detail for r in safe_mode_reasons(tmp_path)]
+
+        assert len(details) == 2
+        assert details[0].startswith("could not read run")
+        assert "factory-20260827-100000-aaaa" in details[1]
+
+
 def root_events(root: Path) -> Path:
     return root / ".kstrl" / "runs" / RUN_ID / "events.jsonl"
 

--- a/tests/test_serve_cli.py
+++ b/tests/test_serve_cli.py
@@ -89,6 +89,41 @@ class TestDryRun:
         for gate in ("poison breaker", "cost coverage", "budget", "inbox cap"):
             assert gate in result.output
 
+    def test_dry_run_reports_safe_mode_above_the_gates(
+        self, tmp_path: Path,
+    ) -> None:
+        """R10.4. Above the gates because it frames them: an operator
+        reading "budget: ok" while the queue is paused for an unreadable
+        control file has been told the truth and still misled."""
+        result = _invoke(["serve", "--dry-run"], tmp_path)
+
+        lines = result.output.splitlines()
+        safe = next(i for i, line in enumerate(lines) if "safe mode:" in line)
+        gate = next(i for i, line in enumerate(lines) if "gate budget" in line)
+        assert safe < gate
+        assert "nominal" in lines[safe]
+
+    def test_dry_run_names_a_safe_mode_reason(self, tmp_path: Path) -> None:
+        _queue(tmp_path).pause(reason="poison breaker tripped", actor="test")
+
+        result = _invoke(["serve", "--dry-run"], tmp_path)
+
+        assert "safe mode:" in result.output
+        assert "1 reason(s)" in result.output
+        assert "[queue] poison breaker tripped" in result.output
+
+    def test_safe_mode_blocks_nothing_by_itself(self, tmp_path: Path) -> None:
+        """It is a report, not a gate. Every signal it reads already
+        refuses where refusing is right, so the predicate adding a second
+        refusal would be a behaviour change this issue does not make."""
+        _queue(tmp_path).pause(reason="paused", actor="test")
+
+        result = _invoke(["serve", "--dry-run"], tmp_path)
+
+        assert result.exit_code == 0
+        for gate in ("poison breaker", "cost coverage", "budget", "inbox cap"):
+            assert f"gate {gate}: ok" in result.output
+
     def test_dry_run_reports_a_blocking_budget(self, tmp_path: Path) -> None:
         (tmp_path / "kstrl.toml").write_text(
             "[serve]\ndaily_budget_usd = 5.0\nallow_uncovered_cost = true\n"

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -421,3 +421,77 @@ class TestStatusPerAxisCoverage:
         assert "1000+ tokens" not in output
         assert "$5.0000+" in output         # cost axis is not
         assert "cost coverage is PARTIAL" in output
+
+
+class TestSafeModeLine:
+    """R10.4: `ks status` answers "is the factory holding back, and why".
+
+    The plain report is the contract for pipes and CI, so this is where
+    the safe-mode block has to be legible without colour codes.
+    """
+
+    def test_nominal_root_says_nominal(self, tmp_path: Path) -> None:
+        _synthetic_manifest().save(
+            tmp_path / "scripts" / "kstrl" / "manifest.json",
+        )
+
+        exit_code, output = _invoke_status("--root", str(tmp_path))
+
+        assert exit_code == 0
+        assert "safe mode:" in output
+        assert "nominal" in output
+
+    def test_paused_queue_is_named_and_counted(self, tmp_path: Path) -> None:
+        from kstrl.workqueue import Queue, QueueConfig
+
+        _synthetic_manifest().save(
+            tmp_path / "scripts" / "kstrl" / "manifest.json",
+        )
+        Queue(tmp_path, QueueConfig()).pause(
+            reason="daily budget exhausted", actor="test",
+        )
+
+        exit_code, output = _invoke_status("--root", str(tmp_path))
+
+        assert exit_code == 0
+        assert "safe mode:" in output
+        assert "1 reason(s)" in output
+        assert "[queue] daily budget exhausted" in output
+        assert "docs/runbook.md#queue-paused" in output
+        assert "nominal" not in output
+
+    def test_it_is_answerable_without_a_manifest(
+        self, tmp_path: Path,
+    ) -> None:
+        """A repo that has never completed a run still has a control
+        directory, a ladder and a queue. Withholding the answer until a
+        manifest exists would make the question unaskable exactly when an
+        operator is asking why nothing has run."""
+        from kstrl.workqueue import Queue, QueueConfig
+
+        Queue(tmp_path, QueueConfig()).pause(
+            reason="poison breaker tripped", actor="test",
+        )
+
+        exit_code, output = _invoke_status("--root", str(tmp_path))
+
+        assert exit_code == 1          # the manifest really is missing
+        assert "No manifest found" in output
+        assert "[queue] poison breaker tripped" in output
+
+    def test_the_line_carries_no_colour_codes(self, tmp_path: Path) -> None:
+        from kstrl.workqueue import Queue, QueueConfig
+
+        _synthetic_manifest().save(
+            tmp_path / "scripts" / "kstrl" / "manifest.json",
+        )
+        Queue(tmp_path, QueueConfig()).pause(reason="paused", actor="test")
+
+        _, output = _invoke_status("--root", str(tmp_path))
+
+        safe_lines = [
+            line for line in output.splitlines()
+            if "safe mode:" in line or "[queue]" in line
+        ]
+        assert len(safe_lines) == 2
+        assert not any("\x1b[" in line for line in safe_lines)

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -479,6 +479,24 @@ class TestSafeModeLine:
         assert "No manifest found" in output
         assert "[queue] poison breaker tripped" in output
 
+    def test_it_is_answerable_with_a_broken_manifest(
+        self, tmp_path: Path,
+    ) -> None:
+        """The predicate does not read the manifest, so a corrupt one
+        must not hide a paused queue either."""
+        from kstrl.workqueue import Queue, QueueConfig
+
+        manifest = tmp_path / "scripts" / "kstrl" / "manifest.json"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text("{ not json", encoding="utf-8")
+        Queue(tmp_path, QueueConfig()).pause(reason="paused", actor="test")
+
+        exit_code, output = _invoke_status("--root", str(tmp_path))
+
+        assert exit_code == 1
+        assert "Failed to load manifest" in output
+        assert "[queue] paused" in output
+
     def test_the_line_carries_no_colour_codes(self, tmp_path: Path) -> None:
         from kstrl.workqueue import Queue, QueueConfig
 


### PR DESCRIPTION
## Summary

kstrl already refuses to do the risky thing in four places. Each refusal was correct and each spoke on a different surface: a warning line at run start, `ks queue`, `ks serve` output, and a callout inside a pull request body. There was no word that covered all four, so "is the factory holding back right now, and why" had no single answer.

`kstrl/safemode.py` gives it one. `safe_mode_reasons(root_dir)` reads all four signals and returns a `source`, a `detail` sentence taken verbatim from the existing signal, and the runbook anchor that recovers it. Empty means nominal. `ks status` and `ks serve --dry-run` print it.

No behaviour changed. No gate, pause, halt, event, phase, or status enum was added. Every signal it reads already refuses where refusing is right, so the predicate refuses nothing itself.

Closes #225

## Three places the issue's recipe collided with the code

All three were checked against the source and decided with the issue author before implementing.

**1. The control-dir verdict arrives twice.** `Queue.pause_state` calls `control_untrusted_reason` itself and, when it is non-None, returns `PauseState(paused=True, reason=<that same string>)` (`kstrl/workqueue.py:1245-1248`). A literal implementation prints the same sentence under two labels and tells the operator there are two problems when there is one, and the issue's test 2 (one reason expected) fails. A reason whose `detail` exactly matches one already recorded is now dropped. Exact string equality, nothing cleverer. `tests/test_safemode.py::TestComposition::test_the_control_dir_verdict_is_not_repeated_by_the_queue` pins it.

Consequence: the issue's test 8 paired control_dir with queue, and under this rule that pair collapses to one reason by design. The multi-reason test pairs a malformed `autonomy.json` with a paused queue instead, which are genuinely independent readers.

**2. The reducer is lossy for the skip question.** `ComponentState.recent_findings` is capped at `MAX_RECENT_FINDINGS = 50` (`kstrl/reducer.py:35`), so a component that records more than 50 findings after a skip loses the record. `ev.PhaseSkipped` has exactly one emitter (`Pipeline._record_phase_skip`) and is never capped. The skip signal is scanned from the run's raw `events.jsonl`, one pass and no fold. `reducer.latest_run_dir` is a four-line public wrapper over the existing private `_v2_run_dirs` so a caller can do that without reaching into the TUI package.

**3. `ks status` exited before printing anything when no manifest existed.** This repository has no `scripts/kstrl/manifest.json`, so the acceptance criterion "`ks status` on this repository prints a `safe mode:` line" was unreachable as planned. Safe mode does not depend on a manifest, and "nothing has run here" is exactly when an operator asks the question, so the block prints on that path too. See the side effect below.

## Side effect worth naming

`ks status` did not previously touch the control plane at all. It now does, because `Queue.pause_state` and `AutonomyState.load` both call `statedir.ensure_control_state`, which creates the XDG control directory and migrates any legacy in-tree control files. Every other control-plane read in kstrl already does this and the migration is idempotent, but it is new on this path and should not be discovered rather than stated. The module docstring says "read-only with respect to factory decisions", not "writes nothing", for the same reason.

## Review record: two rounds of `codex review`, both at xhigh effort

Round 1 was the built-in reviewer (`codex review --base main`). Round 2 was a custom prompt, because `--base` and a prompt are mutually exclusive and a two-round cap needs the second round aimed rather than repeated. It was told that round 1's fixes were unreviewed code and given ten specific attacks.

That framing earned its keep: **two of round 2's five P2 findings were defects that round 1's own fixes introduced.** One review round would have shipped both.

### Round 1: three P2, all one root cause

All three were absence of evidence read as evidence of absence. Verifying them turned up a fourth of the same family that the review missed.

| Defect | Effect |
|---|---|
| A run in flight cleared an earlier skip | Run B writes its first event long before it reaches review, so safe mode read `nominal` the moment B started while run A's components had merged with no reviewer |
| A `decompose` run cleared a factory skip (found by me while verifying) | Only factory runs drive the phase chain, so a decompose run finishes clean without ever asking the question |
| A `progress_log_enabled = false` run was invisible | It creates the run directory and writes no events, so `_v2_run_dirs` filtered it out and an older verdict was reported as current |
| An unreadable `events.jsonl` read as "no skips" | `ev.read_events` answers `OSError` with `[]` |

Fixed in `c784393`: the last **finished** factory run holds the verdict until a run finishes clean; the reader filters on run kind; `reducer.latest_run_dir` became `run_dirs_newest_first`, which lists every run directory and does not swallow a filesystem error.

### Round 2: five P2, three P3

Introduced by round 1's fixes:

- **The look-back discarded the skips of every unfinished run it walked past.** Completed-clean A, crashed B that did skip review, clean in-flight C reported nothing at all. Every run on the walk now contributes its own skips.
- **The 20-run backstop could cut off the last finished run**, and silence then looked like a verdict. An exhausted walk now says the search never reached one, but only when runs were actually left unopened, so a first run still in flight stays nominal.

Present since the first commit:

- **The stream was opened twice**, to probe and then to read. Beyond the delete-between-opens window, the real problem was that `read_events` drops unparseable lines silently, so a corrupt `phase_skipped` followed by a valid `factory_completed` read as a clean finished run. Now one strict snapshot, parsed here, with a torn line reported as damage. A torn **last** line stays normal, because that is what a run being appended to looks like.
- **The duplicate rule dropped any repeated detail.** It exists for exactly one aliasing and is now restricted to it: an operator's pause reason could otherwise delete an unrelated source and its recovery anchor.
- **Control state is now migrated once up front.** The control reader reported leftover legacy files as untrusted and the queue reader then migrated them away, leaving a reason whose recovery target no longer existed.
- **`ks status` hid safe mode when the manifest failed to parse**, having been fixed only for a manifest that was missing.
- **`_v2_run_dirs` sorted descending and reversed, which flips ties.** Two runs sharing a `run_sort_key` resolved to the other one, changing behaviour the TUI and `ks status` already depended on. A gratuitous change inside a refactor, now reverted to the original ordering and pinned by a test.

### One P2 not fixed, and stated rather than implied

**Safe mode has no dashboard surface.** On a terminal `ks status` opens the dashboard whenever a run directory exists, so the plain report is reached only with `--no-tui`, from a pipe, from CI, or with `--watch`. The reviewer is right that this guts the default interactive path.

The issue puts the TUI explicitly out of scope and asks for the gap to be recorded, not built, so it is recorded: in the `docs/control-loop-design.md` tracker, and in `docs/runbook.md`, `ARCHITECTURE.md` and `CHANGELOG.md`, which previously claimed `ks status` shows it without qualification. That overclaim was the actual defect here and it is fixed.

### What round 2 confirmed clean

Independently checked, at my request, because I had already got one of these wrong: **no pre-existing test was removed or weakened** anywhere in the diff (`git diff origin/main -- tests/`, word-diff). It also compared the runbook anchor test against `github-slugger`'s real slug algorithm and found no runbook heading that collides or that the test would wrongly accept. Static checks all passed under its own run.


## What was tested vs assumed (H4)

**Ran, output read:**

- `uv run pytest tests/` on the final tree: **3378 passed, 28 skipped** in 262.92s. The issue's recorded baseline (3200/28 at `94fdbbd`, 2026-08-24) is stale by three merged pull requests; this is the number the run actually printed.
- `uv run mypy kstrl/ --strict`: Success, no issues in 112 source files.
- `uv run ruff check kstrl/ tests/`: All checks passed.
- `uv run python scripts/gen_docs.py --check`: README generated sections are current. Expected, since no click command and no config key changed.
- 53 new tests across `tests/test_safemode.py` (42), `tests/test_status_cmd.py` (5), `tests/test_serve_cli.py` (3), `tests/test_reducer.py` (3 net, 5 added). Every round 1 and round 2 finding has a test that fails without its fix.
- The reviewer's own check, run first: every `pause(`, `halt`, `refuse`, `sys.exit` and `raise ` in the added `kstrl/` lines sits inside a docstring saying the predicate refuses nothing. No gate, pause, or halt code path moved.

**`ks status` on this repository**, which is the acceptance evidence:

```
ERROR: No manifest found (looked for: .../scripts/kstrl/manifest.json, .../scripts/kstrl/run-manifest.json)
Run `ks factory` or `ks run` first, or pass --manifest.
  safe mode:    nominal
```

Exit code 1, because the manifest genuinely is missing. The safe-mode line prints regardless, which is the point.

**`ks serve --dry-run` on this repository**, showing the report line above the gates it frames:

```
== Serve dry run ==
  safe mode:    nominal
  queue:        empty
  paused:       no
  ...
  gate poison breaker: ok
  gate cost coverage: ok
  gate budget: ok
  gate inbox cap: ok
```

**Non-nominal, three independent readers unhappy at once** (sandbox root, real writers throughout, no mocks):

```
  safe mode:    3 reason(s)
  - [autonomy] running at L2, earned level is L3: clamped to L2 Gated-merge: L3+ requires the R8.1 policy envelope, but [policy] enabled=false - there is no envelope to auto-merge inside (see docs/runbook.md#autonomy-fell-back-or-was-clamped)
  - [queue] daily budget exhausted (see docs/runbook.md#queue-paused)
  - [adversarial_skipped] review did not run for 2 component(s) in run factory-20260827-120000-a1b2 (see docs/runbook.md#an-adversarial-phase-did-not-run)
```

**Assumed, not measured:** the per-invocation cost `ks status` now pays (four readers plus one pass over the newest run's `events.jsonl`) has not been timed. The event scan is the only part that grows with run size. If it turns out to matter it needs a measurement, not a guess.

## Acceptance

- [x] All four degrade paths reachable. `TestEveryDegradePathIsReachable` parametrizes over a scenario per source, and `test_the_scenarios_cover_exactly_the_documented_sources` asserts the scenario set equals `RECOVERY`'s keys and has four entries. Adding a fifth source without a scenario fails there, so the count cannot drift silently.
- [x] The predicate never raises. Three tests: a `.kstrl/runs` path that is a file (which `_v2_run_dirs` otherwise swallows into "no runs", a fail-open on a question about whether a gate ran), an `[autonomy] max_level = 99` that makes `__post_init__` raise, and a malformed `kstrl.toml`. The second also asserts the failing reader did not hide the next one's answer.
- [x] `degraded_reason` is never written to disk, and a reload of what was just written is clean.
- [x] `ks status` on this repository prints a `safe mode:` line. Pasted above.
- [x] No behaviour change. Full suite passes with no existing test modified; the grep is above.
- [x] `docs/runbook.md` has a `## Safe mode` section, and `test_every_anchor_resolves_to_a_runbook_heading` asserts every `recovery` string resolves to a real heading, so a renamed section fails the suite rather than sending an operator in safe mode to a heading that no longer exists.

## Two small deviations from the issue text, both deliberate

- The `adversarial_skipped` detail says "`<phase>` did not run for N component(s) in run `<id>`" rather than "merged without `<phase>`". A `PhaseSkipped` event does not say the component merged, and the wording should not claim more than the evidence.
- `verify` is deliberately not in `GATED_PHASES`. `ks status` already reports a skipped verify per component, and unlike review and security it cannot be dropped by budget exhaustion. `test_a_skipped_verify_is_not_a_safe_mode_reason` pins the choice.

## Checklist

- [x] `uv run pytest tests/` passes
- [x] `uv run mypy kstrl/ --strict` passes
- [x] `uv run ruff check kstrl/ tests/` passes
- [x] `uv run python scripts/gen_docs.py --check` passes
- [x] Tracker row 4 in `docs/control-loop-design.md` ticked in this PR

## Provenance

- [x] This change was written or substantially assisted by an AI agent
- [x] It has been reviewed by a human (AI self-review does not count - H1)

## Prompt changes

None. No adversarial prompt body was touched, so H2 and H3 do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

