### PR TITLE
Add the standard pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,281 @@
+# ONE config, copied verbatim into every Python repo here.
+#
+# It is a copy on purpose. pre-commit has no `extends`: config inheritance was
+# requested in issues 1308, 2337 and 3422 and declined, so a shared config is not
+# a thing that exists. A custom sharing mechanism was built and rejected: it works,
+# but it means every future reader has to learn a scheme that is not pre-commit.
+# Plain duplication uses nothing but stock pre-commit, and `diff` is how you check
+# two repos agree - a standard tool instead of a bespoke hook.
+#
+# The custom checks live in scripts/precommit/ as ordinary `repo: local` hooks.
+# That directory and this file are the unit you copy. Everything else a repo needs
+# to differ about (ruff rules, vulture paths, codespell vocabulary) belongs in that
+# repo's pyproject.toml, which is where those tools read their settings anyway.
+#
+# A few excludes below name paths that only exist in one repo (deckgen's captured
+# model output and reference corpora). They stay in every copy so the file is
+# BYTE-IDENTICAL everywhere; a path that does not exist costs nothing to exclude.
+
+repos:
+  # --- file hygiene ---------------------------------------------------------
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        # Captured model output is evidence: reformatting it destroys the
+        # provenance a spike's findings rest on. Linted as evidence, never source.
+        exclude: &evidence ^experiments/(taste-spike|walking-skeleton)/out/|^fixtures/sources/
+      - id: end-of-file-fixer
+        exclude: *evidence
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-added-large-files
+        # uv.lock is a required commit artifact over 500 KB; uv-lock owns its
+        # integrity. The rest are irreplaceable measurement inputs: reference decks,
+        # source filings, and round-trip evidence that cost manual work to produce.
+        exclude: '^(uv\.lock$|experiments/walking-skeleton/out/(screenshots/|inserted-saved\.pptx$)|fixtures/corpus/|fixtures/sources/|experiments/E16/out/(probe\.pdf|probe-bold-powerpoint\.pdf|E17-results\.json)$)'
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: mixed-line-ending
+        exclude: *evidence
+      - id: debug-statements
+      - id: detect-private-key
+        # A test that asserts a redactor strips private keys must contain one.
+        # The fixture IS the test; deleting the key deletes the subject.
+        exclude: '^tests/test_review_regressions\.py$'
+
+  # --- python ---------------------------------------------------------------
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.4
+    hooks:
+      # Lint before format: --fix rewrites code, and formatting the result is the
+      # only order that converges in one pass.
+      # scripts/precommit/ is excluded because those files must stay BYTE-IDENTICAL
+      # across every repo, and each repo's ruff settings differ. Measured: running
+      # this hook under systemap's config reformatted two of them, which would make
+      # the copies diverge on first commit and defeat the whole point of copying.
+      # They are checked against ruff and both complexity gates before being copied.
+      - id: ruff-check
+        args: [--fix]
+        exclude: &vendored ^scripts/precommit/|^experiments/(taste-spike|walking-skeleton)/out/|^fixtures/sources/
+      - id: ruff-format
+        exclude: *vendored
+
+  # --- complexity: two gates answering two different questions --------------
+  #
+  # complexipy measures COGNITIVE complexity: how hard the code is to read,
+  # weighted by nesting. --staged diffs the git index against HEAD, so it fails
+  # only on a function this commit adds above 15 or worsens past it. A flat gate at
+  # 15 would block 38% of deckgen's source files, 71% of systemap's and 42% of
+  # ralph's on day one, which is a hook that gets --no-verify'd within a week.
+  #
+  # cyclomatic-ratchet (below, local) measures CYCLOMATIC complexity: independent
+  # paths through a function, roughly the tests branch coverage needs.
+  #
+  # Both are kept because they disagree where it matters. A flat 14-branch dispatch
+  # table measures cognitive 14 and cyclomatic 15: the first forgives it, the second
+  # does not, and each is right about its own question.
+  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+    rev: v7.0.1
+    hooks:
+      - id: complexipy
+        # --suggest-refactors is what makes a failure actionable rather than a bare
+        # exit 1: it names the function, the lines, the estimated reduction and the
+        # rule. Measured at 5 ms. An agent shown "exit code 1" silences the hook.
+        args: [--staged, --max-complexity-allowed, "15", --suggest-refactors, --color, "no"]
+        exclude: *evidence
+
+  # --- rot ------------------------------------------------------------------
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.3
+    hooks:
+      # Vocabulary and skip lists live in [tool.codespell] in pyproject.toml.
+      # Every finding across three repos here was a false positive on first run:
+      # deliberate misspellings in tests asserting closest-match suggestions,
+      # fragments of regexes like propert(y|ies), and project names.
+      #
+      # The excludes are all evidence: captured model output quotes error strings
+      # containing model-authored typos, render-probe results quote raw tesseract
+      # OCR misreads (the misread IS the measurement), and E40's manual results
+      # quote source documents verbatim, truncated mid-word to fit a table.
+      - id: codespell
+        exclude: '^scripts/precommit/|^experiments/(taste-spike|walking-skeleton)/out/|^fixtures/sources/|^experiments/(E[0-9]+|render-probes)/results.*\.json$|^experiments/E40/manual-results\.md$'
+
+  - repo: https://github.com/jendrikseipp/vulture
+    rev: v2.16
+    hooks:
+      # Needs [tool.vulture] with `paths` in pyproject.toml. Without it vulture
+      # exits 2, which reads as a broken hook rather than a finding.
+      - id: vulture
+
+  # --- secrets --------------------------------------------------------------
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      # Scans the STAGED diff, so it stops a secret before it is committed.
+      # Deliberately not a history scan.
+      - id: gitleaks
+      # The same binary, the same rev, one shared hook environment, pointed at the
+      # tree instead of the staged diff, because the staged scan CANNOT work on a
+      # server: CI has a clean checkout with nothing staged. The one hook whose whole
+      # purpose is to run where --no-verify cannot reach was the one hook CI did not
+      # enforce.
+      #
+      # stages: [manual], so it never runs on a local commit: measured at 6.2s over
+      # 60 MB against the staged hook's milliseconds, and a developer already has the
+      # staged hook. The copy that counts is
+      # `pre-commit run --hook-stage manual gitleaks-tree --all-files` in CI.
+      - id: gitleaks
+        alias: gitleaks-tree
+        name: secrets anywhere in the checked-out tree
+        entry: gitleaks dir . --redact
+        pass_filenames: false
+        always_run: true
+        stages: [manual]
+        # Print the scan line even on a pass. Without this pre-commit reports
+        # "Passed" and nothing else, indistinguishable in a CI log from a silent
+        # "0 commits scanned" - the exact failure this hook was added to end.
+        verbose: true
+
+  # --- packaging ------------------------------------------------------------
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.11.29
+    hooks:
+      # Skips cleanly in a repo with no uv.lock.
+      - id: uv-lock
+
+  # --- shell ----------------------------------------------------------------
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      # shellcheck-py rather than koalaman/shellcheck-precommit: the latter is
+      # language: docker_image, which does not skip without docker, it FAILS.
+      - id: shellcheck
+
+  # --- CI workflows ---------------------------------------------------------
+  # All four skip cleanly in a repo with no .github/workflows.
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      # A typo in a job key or a step id is not a YAML error, it is a workflow that
+      # silently does less. check-yaml catches none of it.
+      - id: actionlint
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.29.0
+    hooks:
+      # actionlint checks the workflow is correct; zizmor checks it is safe. No
+      # overlap. --offline is not the default: zizmor goes online whenever GH_TOKEN
+      # happens to be exported, which would make the hook behave differently for two
+      # people on the same commit.
+      - id: zizmor
+        args: [--no-progress, --offline]
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.38.0
+    hooks:
+      # actionlint knows expression types and shell; the schema knows which keys are
+      # allowed to exist at all. They disagree about what they catch.
+      - id: check-github-workflows
+      - id: check-dependabot
+      # A job with no timeout-minutes inherits GitHub's 6-hour default, so one hang
+      # bills six hours of a private repo's minutes.
+      - id: check-github-workflows-require-timeout
+
+  # --- our own checks -------------------------------------------------------
+  # Ordinary local hooks. The scripts sit in scripts/precommit/ and are copied
+  # alongside this file.
+  - repo: local
+    hooks:
+      # Cyclomatic complexity, ratcheted against HEAD. Limit 10, and the limit is
+      # the whole argument for this hook existing alongside complexipy: measured
+      # over 1814 paired functions against a cognitive gate of 15, a cyclomatic gate
+      # at 20 catches ZERO functions cognitive misses, at 15 it catches 4, at 10 it
+      # catches 64. Those 64 are wide flat branching, which cognitive deliberately
+      # forgives. 10 is also McCabe's own 1976 number.
+      #
+      # A script rather than ruff's C901 because ruff cannot compare a function
+      # against its own previous value. A flat C901 at 10 reports 264 existing
+      # functions across these repos, and `# noqa: C901` silences each one
+      # permanently, including when it later goes from 20 to 40.
+      #
+      # `diff-quality --violations=ruff.check` is the off-the-shelf version and does
+      # not work: it matches violations to changed LINES, and a C901 violation sits
+      # on the `def` line, so a function taken from 9 to 15 by editing its body was
+      # reported as "100% quality". Measured on a probe repo, not assumed.
+      #
+      # Needs uv on PATH; calls a pinned uvx ruff so the number is reproducible.
+      # Cost: 85 ms for a 3-file commit, 157 ms for 12.
+      - id: cyclomatic-ratchet
+        name: cyclomatic complexity does not grow
+        language: system
+        entry: python3 scripts/precommit/cyclomatic_ratchet.py
+        types: [python]
+        exclude: *evidence
+
+      # Stops a file GROWING TO more than 800 lines. Two cases fail: a file this
+      # commit adds already over the limit, and a file that was at or under it and
+      # is now over. Those are the moments a file becomes a problem.
+      #
+      # A file ALREADY over the limit is reported when it grows, not failed. That
+      # differs from the complexity gates on purpose: complexity is a property of
+      # one function, so freezing a bad one costs nothing because you can edit its
+      # neighbour. Length is a property of the whole file, so failing on growth
+      # would block every edit until somebody does a large refactor they did not
+      # come here to do. Measured across these repos: 135 Python files are already
+      # over 800 lines, 77 of them source. Freezing 135 files is how a hook gets
+      # --no-verify'd. FREEZE_OVERSIZE in the script flips this if you want it.
+      #
+      # Lines, not bytes: check-added-large-files caps bytes and only looks at
+      # files being ADDED, so a file growing past a megabyte one commit at a time
+      # is invisible to it. Neither hook covers what this one does.
+      #
+      # Python only. A generic length rule fires on lock files, JSON fixtures and
+      # generated output, where length is not a defect.
+      - id: file-length-ratchet
+        name: no file grows past 800 lines
+        language: system
+        entry: python3 scripts/precommit/file_length_ratchet.py
+        types: [python]
+        exclude: *vendored
+
+      - id: no-em-dash
+        name: forbid em dashes
+        language: pygrep
+        # U+2014's UTF-8 bytes. pygrep compiles a BYTES pattern and Python's re
+        # rejects \u escapes there ("bad escape \u"). Still escaped, so the hook does
+        # not match its own config.
+        entry: '\xe2\x80\x94'
+        types: [text]
+        # House style is ours to keep in our own prose. A source document's em dashes
+        # are part of the text a measurement is graded against.
+        exclude: '^(uv\.lock|experiments/(taste-spike|walking-skeleton)/out/|fixtures/sources/)'
+
+      # Parses with ast rather than grepping. The regex version of this rule claimed
+      # that requiring the CALL or the IMPORT meant prose could not trip it; measured
+      # across two repos that is false. After excluding tests it still reported six
+      # hits, and every one was a docstring or comment EXPLAINING mock behaviour, such
+      # as "coerces to 1 via MagicMock.__index__". ast never sees a comment, and a
+      # docstring is a string expression rather than a Name or an Import.
+      - id: no-mocks-in-production
+        name: mocks and stubs stay in tests
+        language: system
+        entry: python3 scripts/precommit/check_no_mocks.py
+        types: [python]
+        # Tests are supposed to mock. Without this it reported 493 hits in one repo
+        # and 344 in another, all of them tests doing their job.
+        exclude: '(^|/)tests?/|(^|/)test_[^/]*\.py$|_test\.py$|(^|/)conftest\.py$'
+
+      # Two files describing the same project to two different agents drift
+      # invisibly: both still read fine alone, but one agent ends up told about a
+      # section the other has never heard of. Compares heading structure.
+      # A CLAUDE.md containing only `@AGENTS.md` is an import, so there is one source
+      # of truth and it passes. Deliberate renames go in .agent-docs-aliases.json.
+      # A repo with no AGENTS.md passes silently.
+      - id: agent-docs-sync
+        name: AGENTS.md and CLAUDE.md have not drifted
+        language: system
+        entry: python3 scripts/precommit/check_agent_docs_sync.py
+        pass_filenames: false
+        files: (AGENTS|CLAUDE)\.md$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,3 +143,18 @@ strict = true
 # factory's verify phase in lockstep -- no command-line override needed.
 # kstrl is the only Python package.
 files = ["kstrl"]
+
+[tool.vulture]
+# vulture exits 2 with no paths, which reads as a broken hook rather than a
+# finding, so this section is what makes the pre-commit hook usable at all.
+# min_confidence 80 keeps it to findings worth reading; a reviewed whitelist.py
+# goes in paths once one exists.
+min_confidence = 80
+paths = ['kstrl']
+
+[tool.codespell]
+# All verified false positives, not typos. critcial is a deliberately invalid
+# env value in a test asserting ValueError. Excetra is a project name.
+# unparseable and pre-empt are accepted spellings codespell dislikes.
+ignore-words-list = "crasher,critcial,excetra,missable,nd,pre-empt,unparseable"
+skip = "uv.lock,*/package-lock.json,.git"

--- a/scripts/precommit/check_agent_docs_sync.py
+++ b/scripts/precommit/check_agent_docs_sync.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Fail when AGENTS.md and its CLAUDE.md sibling have drifted structurally.
+
+Two files describing the same project to two different agents will diverge, and
+the divergence is invisible: both files still read fine on their own. What goes
+wrong is that one agent is told about a section the other has never heard of.
+Comparing HEADING STRUCTURE catches that while ignoring the wording differences
+that are deliberate.
+
+Adapted from the version in smartdecks. Two things were changed to make it
+shareable: the repo root is the working directory (pre-commit's contract) rather
+than the script's parent, and the alias table is loaded from the consuming repo
+instead of being hardcoded.
+
+Aliases: put a JSON object in .agent-docs-aliases.json mapping the AGENTS.md
+spelling to the CLAUDE.md spelling, for sections deliberately renamed:
+
+    {"Project - AGENTS Runbook": "Project - Claude Code Runbook"}
+
+No AGENTS.md anywhere means nothing to check, and the hook passes silently. That
+is what makes it safe to put in the shared set for every repo.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ALIAS_FILE = ".agent-docs-aliases.json"
+HEADING = re.compile(r"^(#{1,6})\s+(.*)")
+
+
+def emit(text: str = "") -> None:
+    sys.stdout.write(text + "\n")
+
+
+def load_aliases(root: Path) -> dict[str, str]:
+    path = root / ALIAS_FILE
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        emit(f"{ALIAS_FILE} is not readable JSON; ignoring it.")
+        return {}
+    return {str(k): str(v) for k, v in data.items()} if isinstance(data, dict) else {}
+
+
+def headings(path: Path, aliases: dict[str, str]) -> list[str]:
+    out: list[str] = []
+    for line in path.read_text(errors="replace").splitlines():
+        m = HEADING.match(line)
+        if m is None:
+            continue
+        title = m.group(2).strip()
+        for agents_form, claude_form in aliases.items():
+            title = title.replace(agents_form, claude_form)
+        out.append(f"{'#' * len(m.group(1))} {title}")
+    return out
+
+
+IMPORT_LINE = re.compile(r"^@(\S+)\s*$")
+
+
+def imports_the_other(claude: Path, agents: Path) -> bool:
+    """True when CLAUDE.md is just an import of AGENTS.md.
+
+    Claude Code treats a line of `@path` in CLAUDE.md as an import: the target's
+    text is pulled in wholesale. A CLAUDE.md whose only content is `@AGENTS.md`
+    therefore has ONE source of truth and cannot drift, which is the best possible
+    answer to the problem this hook exists for. Comparing headings would report
+    every section as missing, so the pointer is recognised instead of punished.
+    """
+    lines = [ln.strip() for ln in claude.read_text(errors="replace").splitlines()]
+    body = [ln for ln in lines if ln and not ln.startswith("<!--")]
+    if not body:
+        return False
+    targets = []
+    for ln in body:
+        m = IMPORT_LINE.match(ln)
+        if m is None:
+            return False
+        targets.append(m.group(1))
+    return any((claude.parent / t).resolve() == agents.resolve() for t in targets)
+
+
+def check_pair(
+    agents: Path, claude: Path, root: Path, aliases: dict[str, str]
+) -> list[str]:
+    where = agents.parent.relative_to(root)
+    if not claude.exists():
+        return [f"{where}: CLAUDE.md is missing, but AGENTS.md is there"]
+    if imports_the_other(claude, agents):
+        return []
+    if claude.is_symlink():
+        return [
+            (
+                f"{where}: CLAUDE.md is a symlink. The two files are meant to say"
+                f" different things to different agents, so make it a real adapted"
+                f" copy."
+            )
+        ]
+    a = headings(agents, aliases)
+    c = headings(claude, aliases)
+    if a == c:
+        return []
+    only_a = set(a) - set(c)
+    only_c = set(c) - set(a)
+    if not only_a and not only_c:
+        return [f"{where}: same sections, different order"]
+    return [
+        f"{where}: section {h!r} is in AGENTS.md but not CLAUDE.md"
+        for h in sorted(only_a)
+    ] + [
+        f"{where}: section {h!r} is in CLAUDE.md but not AGENTS.md"
+        for h in sorted(only_c)
+    ]
+
+
+def tracked_agents_files(root: Path) -> list[Path]:
+    """Every AGENTS.md this repo actually owns.
+
+    `rglob` is the obvious way and it is wrong: it descends into .venv and into
+    scratch checkouts, and reports drift in a vendored package's own AGENTS.md.
+    Measured on two repos here, it produced findings under
+    .venv/.../litellm/proxy/_experimental/mcp_server and inside a benchmark
+    scratch checkout, neither of which the repo can act on.
+
+    git ls-files is the exact answer to "files this repo owns", and it already
+    honours .gitignore. No git, no pairs: this hook must never invent work.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "ls-files", "-z", "--", "*AGENTS.md", "AGENTS.md"],
+            cwd=root,
+            capture_output=True,
+            check=True,
+        ).stdout.decode()
+    except (subprocess.CalledProcessError, FileNotFoundError, UnicodeDecodeError):
+        return []
+    return sorted({root / name for name in out.split("\0") if name})
+
+
+def main() -> int:
+    root = Path.cwd()
+    pairs = [(p, p.parent / "CLAUDE.md") for p in tracked_agents_files(root)]
+    if not pairs:
+        return 0
+    aliases = load_aliases(root)
+    problems: list[str] = []
+    for agents, claude in pairs:
+        problems.extend(check_pair(agents, claude, root, aliases))
+    if not problems:
+        return 0
+    emit("AGENTS.md and CLAUDE.md have drifted apart:")
+    for p in problems:
+        emit(f"  {p}")
+    emit("")
+    emit(f"If a section was renamed on purpose, record it in {ALIAS_FILE}.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/precommit/check_no_mocks.py
+++ b/scripts/precommit/check_no_mocks.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Fail when production code imports or uses a mocking primitive.
+
+A fake in a production path answers where the real component would refuse. That
+is the rule. The interesting part is how it is checked.
+
+WHY THIS IS NOT A pygrep HOOK
+-----------------------------
+The obvious spelling is a line regex over
+`unittest\\.mock|MagicMock|AsyncMock|mock\\.patch|@patch\\b|monkeypatch\\.`, and
+that is how this rule started life in another repo, whose config asserts that
+requiring the CALL or the IMPORT means "prose does not trip it". Measured across
+two other repos, that assertion does not hold: after excluding tests it still
+reported six hits, and all six were docstrings and comments EXPLAINING mock
+behaviour, e.g. a comment reading "coerces to 1 via MagicMock.__index__". A line
+regex cannot tell code from prose, because by the time it runs, both are text.
+
+So this parses instead. `ast` never sees a comment, and a docstring is a plain
+string expression rather than a Name or an Import, so prose is invisible here by
+construction rather than by a pattern that hopes to miss it.
+
+Flags: importing unittest.mock in any spelling; referring to MagicMock,
+AsyncMock, NonCallableMock, Mock or PropertyMock; calling mock.patch or
+patch.object; the @patch decorator; and touching pytest's monkeypatch fixture.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+MOCK_NAMES = frozenset(
+    {
+        "MagicMock",
+        "AsyncMock",
+        "NonCallableMock",
+        "NonCallableMagicMock",
+        "PropertyMock",
+        "create_autospec",
+        "mock_open",
+        "seal",
+    }
+)
+MOCK_MODULES = frozenset({"unittest.mock", "mock"})
+
+
+def emit(text: str = "") -> None:
+    sys.stdout.write(text + "\n")
+
+
+class Finder(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.hits: list[tuple[int, str]] = []
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            if alias.name in MOCK_MODULES:
+                self.hits.append((node.lineno, f"imports {alias.name}"))
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        module = node.module or ""
+        if module in MOCK_MODULES:
+            names = ", ".join(a.name for a in node.names)
+            self.hits.append((node.lineno, f"imports {names} from {module}"))
+        elif module == "unittest" and any(a.name == "mock" for a in node.names):
+            self.hits.append((node.lineno, "imports mock from unittest"))
+        self.generic_visit(node)
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if node.id in MOCK_NAMES:
+            self.hits.append((node.lineno, f"uses {node.id}"))
+        elif node.id == "monkeypatch":
+            self.hits.append((node.lineno, "uses pytest's monkeypatch fixture"))
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if node.attr in MOCK_NAMES:
+            self.hits.append((node.lineno, f"uses {node.attr}"))
+        elif (
+            isinstance(node.value, ast.Name)
+            and node.value.id in {"mock", "patch"}
+            and node.attr in {"patch", "object", "dict", "multiple"}
+        ):
+            self.hits.append((node.lineno, f"calls {node.value.id}.{node.attr}"))
+        self.generic_visit(node)
+
+
+def check(path: Path) -> list[str]:
+    try:
+        tree = ast.parse(path.read_text(errors="replace"), filename=str(path))
+    except SyntaxError:
+        # Not this hook's job to report; ruff and the compiler both will.
+        return []
+    finder = Finder()
+    finder.visit(tree)
+    seen: set[tuple[int, str]] = set()
+    out: list[str] = []
+    for lineno, what in finder.hits:
+        if (lineno, what) in seen:
+            continue
+        seen.add((lineno, what))
+        out.append(f"  {path}:{lineno}: {what}")
+    return out
+
+
+def main(argv: list[str]) -> int:
+    problems: list[str] = []
+    for name in argv:
+        path = Path(name)
+        if path.suffix == ".py" and path.is_file():
+            problems.extend(check(path))
+    if not problems:
+        return 0
+    emit("Mocking primitives in production code:")
+    emit("")
+    for p in sorted(problems):
+        emit(p)
+    emit("")
+    emit("A fake here answers where the real component would refuse. Move it into")
+    emit("the tests, or inject the real seam so the test can supply its own double.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/precommit/cyclomatic_ratchet.py
+++ b/scripts/precommit/cyclomatic_ratchet.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Ratchet cyclomatic complexity: fail only on what this commit makes worse.
+
+WHY THIS EXISTS AND WHY IT IS NOT JUST A RUFF SETTING
+-----------------------------------------------------
+Ruff already computes cyclomatic complexity (rule C901). What it cannot do is
+compare a function against its own previous value, and a flat C901 threshold at
+the level where the metric carries information (10) reports 264 existing
+functions across these repos. A gate that fails 264 times on day one gets
+switched off. The alternative, baselining each one with `# noqa: C901`,
+suppresses that function forever: it stays quiet when the same function later
+goes from 20 to 40, which is the case most worth catching.
+
+So this does for cyclomatic complexity what `complexipy --staged` does for
+cognitive complexity. It reads each function's C901 value in the git INDEX and
+in HEAD, matches them by name, and fails only when this commit adds a function
+above the gate or pushes an existing one past it. Existing debt is grandfathered
+by construction: no baseline file, no suppression comments.
+
+WHY NOT diff-quality
+--------------------
+`diff-quality --violations=ruff.check` is the obvious off-the-shelf answer and
+it is wrong for this rule. It reports violations whose LINE falls inside the
+diff, and a C901 violation is anchored to the `def` line. Measured on a probe
+repo: a function taken from cyclomatic 9 to 15 by adding branches to its body,
+never touching the `def` line, was reported by diff-quality as
+"Violations: 0 lines, % Quality: 100%". It silently passes function-level
+metrics. This script catches that case.
+
+WHY 10 AND NOT 15
+-----------------
+Cyclomatic and cognitive complexity mostly agree, so a high cyclomatic gate is
+redundant with the cognitive one already running alongside it. Measured over
+1814 paired deckgen functions, against a cognitive gate of 15: a cyclomatic gate
+at 20 catches ZERO functions the cognitive gate misses, at 15 it catches 4, at
+10 it catches 64. Those 64 are the shape cognitive complexity deliberately
+forgives, many branches with little nesting, e.g. cyclomatic 20 / cognitive 13.
+That is a long if/elif chain or a flat dispatch table. It reads easily and still
+needs 20 tests for branch coverage, which is what cyclomatic complexity is
+actually good for. 10 is also McCabe's own 1976 recommendation.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Pinned so the number this gate produces is reproducible. Ruff's mccabe is not
+# interchangeable with other tools': measured on this tree, ruff and lizard agree
+# on only 47.9% of the same functions, because lizard counts `and`/`or` as
+# decision points and ruff does not. A cyclomatic threshold means nothing without
+# naming the tool that produced it.
+RUFF = ["uvx", "ruff@0.16.4"]
+
+# Sentinel for "the file as it sits on disk", as opposed to a git ref or the index.
+# The commit gate compares the INDEX against HEAD, because the index is what the
+# commit will contain. The edit-time advisory compares the WORKING TREE against
+# HEAD, because an agent's edit is not staged yet and would otherwise read as no
+# change at all.
+WORKTREE = "\x00worktree"
+MAX_COMPLEXITY = 10
+
+# max-complexity = 0 makes ruff report EVERY function with its value, which turns
+# a pass/fail rule into the full census this needs.
+CENSUS = [
+    "--isolated",
+    "--select",
+    "C901",
+    "--config",
+    "lint.mccabe.max-complexity = 0",
+    "--output-format",
+    "concise",
+    "--no-cache",
+]
+
+REPORT = re.compile(
+    r"^(?P<path>.*?):\d+:\d+: C901 `(?P<name>.+?)` "
+    r"is too complex \((?P<value>\d+) > 0\)$"
+)
+
+
+def emit(text: str = "") -> None:
+    """Write one line to stdout.
+
+    Not `print`. Ruff's T201 (flake8-print) is selected in several of the repos
+    this is dropped into, and deckgen alone carries about 40 per-file-ignore
+    entries to work around it. Going through sys.stdout means this file lints
+    clean anywhere without a config entry having to travel with it.
+    """
+    sys.stdout.write(text + "\n")
+
+
+def census(root: Path) -> dict[tuple[str, str], int]:
+    """Map (relative path, function name) -> cyclomatic complexity for a tree."""
+    proc = subprocess.run(
+        [*RUFF, "check", ".", *CENSUS],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    found: dict[tuple[str, str], list[int]] = {}
+    for raw in proc.stdout.splitlines():
+        match = REPORT.match(raw.strip())
+        if match is None:
+            continue
+        key = (match.group("path").lstrip("./"), match.group("name"))
+        found.setdefault(key, []).append(int(match.group("value")))
+    # One file can define two functions with the same name: a method on two
+    # classes, or a redefinition under `if TYPE_CHECKING`. Taking the worst value
+    # per name is the conservative read - it never lets a regression hide behind
+    # a namesake.
+    return {key: max(values) for key, values in found.items()}
+
+
+def materialise(paths: list[str], repo: Path, ref: str, dest: Path) -> None:
+    """Write each path's content at `ref` into dest, preserving layout.
+
+    `ref` of "" means the git index; WORKTREE means the file as it sits on disk.
+    A path absent at `ref` is one this commit adds; it is simply not written, so
+    every function in it reads as new, which is correct.
+    """
+    for rel in paths:
+        out = dest / rel
+        if ref == WORKTREE:
+            source = repo / rel
+            if not source.is_file():
+                continue
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(source.read_bytes())
+            continue
+        spec = f"{ref}:{rel}" if ref else f":{rel}"
+        proc = subprocess.run(
+            ["git", "-C", str(repo), "show", spec],
+            capture_output=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            continue
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(proc.stdout)
+
+
+def find_repo() -> Path | None:
+    """The repo whose index we compare against, or None if there is nothing to do."""
+    try:
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "-C", top, "rev-parse", "--verify", "HEAD"],
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        # No repo, or no commits yet. There is nothing to compare against, so
+        # there is no regression to report. Passing is the honest answer.
+        return None
+    return Path(top)
+
+
+def classify(
+    before: dict[tuple[str, str], int],
+    after: dict[tuple[str, str], int],
+) -> tuple[list[str], list[str]]:
+    """Split each changed function into blocking failures and informational notes."""
+    failures: list[str] = []
+    notes: list[str] = []
+    limit = MAX_COMPLEXITY
+    for (path, name), now in sorted(after.items()):
+        was = before.get((path, name))
+        where = f"{path}::{name}"
+        if was is None:
+            if now > limit:
+                failures.append(
+                    f"  NEW        {where}  cyclomatic {now}  (limit {limit})"
+                )
+        elif now > was:
+            if now > limit:
+                failures.append(
+                    f"  REGRESSED  {where}  cyclomatic {was} -> {now}  (limit {limit})"
+                )
+            else:
+                notes.append(
+                    f"  rose       {where}  cyclomatic {was} -> {now} (under limit)"
+                )
+        elif now < was:
+            notes.append(f"  IMPROVED   {where}  cyclomatic {was} -> {now}")
+    return failures, notes
+
+
+def main(argv: list[str]) -> int:
+    compare_from = WORKTREE if "--worktree" in argv else ""
+    paths = [p for p in argv if p.endswith(".py")]
+    if not paths:
+        return 0
+
+    repo = find_repo()
+    if repo is None:
+        return 0
+
+    try:
+        rel = [str(Path(p).resolve().relative_to(repo)) for p in paths]
+    except ValueError:
+        # A path outside this repo. Nothing to compare it against here.
+        return 0
+
+    with tempfile.TemporaryDirectory() as tmp:
+        head = Path(tmp) / "head"
+        index = Path(tmp) / "index"
+        head.mkdir()
+        index.mkdir()
+        materialise(rel, repo, "HEAD", head)
+        materialise(rel, repo, compare_from, index)
+        failures, notes = classify(census(head), census(index))
+
+    if not failures:
+        for note in notes:
+            emit(note)
+        return 0
+
+    emit("Cyclomatic complexity ratchet: this commit adds or worsens branching")
+    emit("past the limit.")
+    emit()
+    for failure in failures:
+        emit(failure)
+    emit()
+    emit("Cyclomatic complexity counts independent paths through a function, so")
+    emit("the number above is roughly how many tests it needs for branch")
+    emit(f"coverage. Functions already over {MAX_COMPLEXITY} are grandfathered; this")
+    emit("only refuses to let the number grow.")
+    emit()
+    emit("Split the function, or replace a long if/elif chain with a lookup")
+    emit("table. If it is genuinely irreducible, `# noqa: C901` on the `def` line")
+    emit("is the escape hatch, and it shows up in review as the deliberate")
+    emit("choice it is.")
+    for note in notes:
+        emit(note)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/precommit/file_length_ratchet.py
+++ b/scripts/precommit/file_length_ratchet.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Stop a file GROWING TO more than 800 lines.
+
+WHAT IT FAILS ON, AND WHY NOT MORE
+----------------------------------
+Two cases fail: a file this commit adds that is already over the limit, and a
+file that was at or under the limit and is now over it. Those are the moments a
+file becomes a problem.
+
+A file that is ALREADY over the limit and grows is reported, not failed. That is
+a deliberate difference from the complexity gates, and the reason is that length
+is a property of the whole file while complexity is a property of one function.
+You can leave a monstrous function alone and edit its neighbour, so freezing it
+costs nothing. You cannot add a line to a 5994-line file without touching the
+file, so failing on growth would block every edit to it until somebody does a
+large refactor they did not come here to do. Measured on these repos: 135 Python
+files are already over 800 lines, 77 of them source. Freezing all 135 is how a
+hook gets --no-verify'd.
+
+If you want the stricter rule, set FREEZE_OVERSIZE = True below. Nothing else
+changes.
+
+WHY 800 AND WHY IT COUNTS LINES
+-------------------------------
+800 is the number the owner asked for; it is not derived from measurement here.
+Lines, not bytes: `check-added-large-files` already caps bytes, and it only looks
+at files being ADDED, so a file that grows past a megabyte one commit at a time
+is invisible to it. Neither hook covers what this one does.
+
+Python only, via `types: [python]` in the hook config. A generic length rule
+fires on lock files, JSON fixtures and generated output, where length is not a
+defect. Widen it there if you want more.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+MAX_LINES = 800
+FREEZE_OVERSIZE = False
+
+
+def emit(text: str = "") -> None:
+    sys.stdout.write(text + "\n")
+
+
+def find_repo() -> Path | None:
+    """The repo whose index we compare against, or None if there is nothing to do."""
+    try:
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "-C", top, "rev-parse", "--verify", "HEAD"],
+            capture_output=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        # No repo, or no commits yet: nothing to compare against, so nothing to
+        # report. Passing is the honest answer.
+        return None
+    return Path(top)
+
+
+def line_count_at(repo: Path, ref: str, rel: str) -> int | None:
+    """Lines in `rel` at a git ref, or None when the file is not there."""
+    spec = f"{ref}:{rel}" if ref else f":{rel}"
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "show", spec], capture_output=True, check=False
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.count(b"\n")
+
+
+def classify(repo: Path, rel: str) -> tuple[str | None, str | None]:
+    """Return (blocking failure, informational note) for one file."""
+    now = line_count_at(repo, "", rel)
+    if now is None or now <= MAX_LINES:
+        return None, None
+    was = line_count_at(repo, "HEAD", rel)
+    if was is None:
+        return f"  ADDED    {rel}  {now} lines  (limit {MAX_LINES})", None
+    if was <= MAX_LINES:
+        return f"  CROSSED  {rel}  {was} -> {now} lines  (limit {MAX_LINES})", None
+    if now > was:
+        line = f"  {rel}  {was} -> {now} lines, already over the limit"
+        return (f"  GREW    {line}", None) if FREEZE_OVERSIZE else (None, line)
+    return None, None
+
+
+def survey(repo: Path, paths: list[str]) -> tuple[list[str], list[str]]:
+    """Split every path into blocking failures and informational notes."""
+    failures: list[str] = []
+    notes: list[str] = []
+    for name in paths:
+        try:
+            rel = str(Path(name).resolve().relative_to(repo))
+        except ValueError:
+            # A path outside this repo. Nothing here to compare it against.
+            continue
+        failure, note = classify(repo, rel)
+        if failure:
+            failures.append(failure)
+        if note:
+            notes.append(note)
+    return failures, notes
+
+
+def main(argv: list[str]) -> int:
+    paths = [p for p in argv if p.endswith(".py")]
+    if not paths:
+        return 0
+
+    repo = find_repo()
+    if repo is None:
+        return 0
+
+    failures, notes = survey(repo, paths)
+
+    if not failures:
+        for note in notes:
+            emit(note)
+        return 0
+
+    emit(f"File length: this commit takes a file past {MAX_LINES} lines.")
+    emit("")
+    for failure in failures:
+        emit(failure)
+    emit("")
+    emit("Split it. A file this long has more than one job in it, and the split")
+    emit("is cheapest now, while you still remember what the new part does.")
+    emit("")
+    emit("Files already over the limit are grandfathered and are not failed for")
+    emit("growing; set FREEZE_OVERSIZE = True in this script to change that.")
+    for note in notes:
+        emit(note)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Adds `.pre-commit-config.yaml` plus `scripts/precommit/`, byte-identical with deckgen, systemap, praxis and explain-pr.

## What lands

**30 hooks in six groups**

- **Tidiness (11)** whitespace, end-of-file, YAML/TOML/JSON parse, large files, merge markers, case conflicts, line endings, leftover `breakpoint()`, private keys
- **Python (2)** `ruff-check --fix` then `ruff-format`
- **Complexity and size (3)** cognitive complexity (15), cyclomatic complexity (10), file length (800 lines)
- **Rot (2)** `codespell`, `vulture`
- **Secrets and CI (7)** `gitleaks` staged and tree-wide, `uv-lock`, `shellcheck`, `actionlint`, `zizmor`, GitHub workflow schema checks
- **Ours (5)** the three ratchets plus `no-em-dash`, `no-mocks-in-production`, `agent-docs-sync`

## Everything size-related is a ratchet

Each gate compares a function or file against its own value in `HEAD`. Existing code is grandfathered; only growth fails. A flat cognitive gate at 15 would block **44 of this repo's 106 source files** on day one, and that hook gets `--no-verify`d within a week.

## It is a copy on purpose

pre-commit has no `extends` (issues 1308, 2337, 3422, all declined). A shared hooks repo was built and rejected: it worked, but it is a mechanism every future reader has to learn. `diff` against a sibling repo is the standard way to check two copies agree.

## pyproject.toml

Gains `[tool.vulture]` and `[tool.codespell]`. `vulture` exits 2 without a `paths` entry, which reads as a broken hook rather than a finding.

The codespell ignore list holds seven entries, **every one verified as a false positive**: `critcial` is a deliberately invalid env value in a test asserting `ValueError`, `Excetra` is a project name, `nd` is a variable, and `unparseable`, `pre-empt`, `crasher` and `missable` are accepted spellings codespell dislikes.

## This will not pass on day one

Measured against a clean clone. All of it is pre-existing and none of it was touched by this PR:

| Hook | Findings |
|---|---|
| `ruff-check` | 14 |
| `no-em-dash` | 18 lines, mostly under `docs/` |
| `zizmor` | 22 workflow security findings |
| `vulture` | 1: unused `cancel_futures` at `kstrl/factory.py:1693` |
| `trailing-whitespace`, `end-of-file-fixer`, `ruff-format` | auto-fix on first run |

Everything else passes, including both complexity gates and the new file length gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)