### PR TITLE
fix(factory): a run that schedules nothing exits 1, not 0

### DIFF
--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -69,7 +69,7 @@ from kstrl.interaction import (
 )
 from kstrl.launch import assemble_factory_configs
 from kstrl.loop import run_loop
-from kstrl.manifest import Manifest
+from kstrl.manifest import COMPONENT_STATUS_VALUES, Manifest
 from kstrl.observability import (
     event_age_seconds,
     format_age,
@@ -87,6 +87,22 @@ from kstrl.sandbox import SandboxConfig
 from kstrl.shutdown import StopController, install_signal_handlers
 from kstrl.timeout import TimeoutConfig
 from kstrl.ui.base import UI
+
+
+def _format_component_status(status: str | None) -> str:
+    """Render a component status for the plan, flagging an off-enum one.
+
+    A status the enum does not know can never be scheduled, so echoing it
+    plain reads as confirmation that the manifest is correct - the plan
+    line for a component that will silently never run looks exactly like
+    the plan line for one that will (#263). ``None`` means the execution
+    order named an id the manifest has no component for.
+    """
+    if status is None:
+        return "?"
+    if status in COMPONENT_STATUS_VALUES:
+        return status
+    return f"{status} (not a valid status)"
 
 
 def _console_ui(
@@ -2369,7 +2385,7 @@ def factory(
     ui_impl.info("Execution order:")
     for i, comp_id in enumerate(topo, 1):
         comp = manifest.get_component(comp_id)
-        status = comp.status if comp else "?"
+        status = _format_component_status(comp.status if comp else None)
         dep_list = ", ".join(comp.dependencies) if comp and comp.dependencies else ""
         deps = f" (depends on: {dep_list})" if dep_list else ""
         ui_impl.info(f"  {i}. {comp_id} [{status}]{deps}")

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -89,6 +89,21 @@ from kstrl.timeout import TimeoutConfig
 from kstrl.ui.base import UI
 
 
+def _load_manifest_or_exit(path: Path, ui: UI) -> Manifest:
+    """Load a manifest, or print why not and exit 1.
+
+    A `Manifest.load` reachable from the CLI must never traceback at the
+    operator: the input is a file a human or another tool wrote, so a bad
+    one is an expected outcome. Shared so a new call site cannot forget
+    the guard, which is how `ks inbox retry` came to lack it (#263).
+    """
+    try:
+        return Manifest.load(path)
+    except (OSError, ValueError) as exc:
+        ui.err(f"Failed to load manifest {path}: {exc}")
+        sys.exit(1)
+
+
 def _format_component_status(status: str | None) -> str:
     """Render a component status for the plan, flagging an off-enum one.
 
@@ -3362,11 +3377,7 @@ def retry(
         ui_impl.err(f"No manifest found at {manifest_file}")
         ui_impl.info("Run `ks factory` first, or pass --manifest.")
         sys.exit(1)
-    try:
-        manifest = Manifest.load(manifest_file)
-    except (OSError, ValueError) as exc:
-        ui_impl.err(f"Failed to load manifest {manifest_file}: {exc}")
-        sys.exit(1)
+    manifest = _load_manifest_or_exit(manifest_file, ui_impl)
 
     try:
         prepare_retry(manifest, component_id, manifest_file, root_dir, ui_impl)
@@ -4136,8 +4147,6 @@ def inbox_retry(
     PENDING in the manifest (with its dependents un-skipped), so the next
     `ks factory` run picks it up.
     """
-    from kstrl.manifest import Manifest
-
     root_dir, box = _inbox_for(root)
     ui_impl = _autonomy_ui(ui, no_color)
     item = box.get(item_id)
@@ -4151,7 +4160,7 @@ def inbox_retry(
     if not manifest_path.exists():
         ui_impl.err(f"No manifest at {manifest_path}")
         sys.exit(1)
-    manifest = Manifest.load(manifest_path)
+    manifest = _load_manifest_or_exit(manifest_path, ui_impl)
     try:
         reset = manifest.reset_for_retry(item.component)
     except (ValueError, KeyError) as exc:

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -37,9 +37,8 @@ from kstrl.manifest import (
     Component,
     ComponentStatus,
     Manifest,
-    validate_branch_name,
-    validate_component_id,
 )
+from kstrl.names import validate_branch_name, validate_component_id
 from kstrl.prd import PRD
 
 if TYPE_CHECKING:

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -830,19 +830,44 @@ def resolve_exit_code(
         # so `ks factory && deploy` cannot deploy a run that built
         # nothing. An empty manifest and a fully COMPLETED one both leave
         # `unfinished` empty and stay at 0.
-        ui.err(
-            f"No component was scheduled from {len(manifest.components)} in the "
-            f"manifest, and {len(unfinished)} did not complete: "
-            f"{', '.join(unfinished)}"
-        )
-        ui.info(
-            "  Check each component's status against ComponentStatus "
-            f"({', '.join(COMPONENT_STATUS_VALUES)}). A component left in "
-            "'failed' or 'skipped' is not schedulable until `ks retry "
-            "<component-id>` resets it to 'pending'."
-        )
+        _report_nothing_scheduled(manifest, unfinished, ui)
         return 1
     return 0
+
+
+def _report_nothing_scheduled(
+    manifest: Manifest,
+    unfinished: list[str],
+    ui: UI,
+) -> None:
+    """Say what the run did not do, and name an action that will work.
+
+    The remedy has to be executable for the state it names, so the retry
+    targets come from ``Manifest.retryable_component_ids`` - the same
+    definition ``reset_for_retry`` enforces - rather than from a second
+    reading of the statuses here. A skipped component is never named:
+    it becomes runnable by retrying the failure that cascaded onto it,
+    and `ks retry <skipped-id>` exits 2.
+    """
+    ui.err(
+        f"No component was scheduled from {len(manifest.components)} in the "
+        f"manifest, and {len(unfinished)} did not complete: "
+        f"{', '.join(unfinished)}"
+    )
+    retryable = manifest.retryable_component_ids()
+    if retryable:
+        advice = (
+            f"  `ks retry <component-id>` resets a failed component to "
+            f"'{ComponentStatus.PENDING.value}', and with it every dependent "
+            f"it cascade-skipped. Failed here: {', '.join(retryable)}."
+        )
+    else:
+        advice = (
+            "  Check each component's status against ComponentStatus "
+            f"({', '.join(COMPONENT_STATUS_VALUES)}). `ks retry` accepts only "
+            f"a component in '{ComponentStatus.FAILED.value}', and none is."
+        )
+    ui.info(advice)
 
 
 class FactoryLockHeldError(RuntimeError):

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -74,7 +74,12 @@ from kstrl.knowledge import (
 )
 from kstrl.linear import LinearConfig, build_linear_sink
 from kstrl.loop import LoopBudget
-from kstrl.manifest import Component, ComponentStatus, Manifest
+from kstrl.manifest import (
+    COMPONENT_STATUS_VALUES,
+    Component,
+    ComponentStatus,
+    Manifest,
+)
 from kstrl.observability import (
     NotifyConfig,
     NotifyHooks,
@@ -779,7 +784,65 @@ class FactoryResult:
     # failed check). Non-empty forces a nonzero exit code even when no
     # single component could be blamed.
     contract_failures: list[str] = field(default_factory=list)
+    # Components this run actually handed to the executor, in launch
+    # order (a retried component appears once per attempt). The counters
+    # above cannot stand in for this: they are all empty both when the
+    # scheduler found nothing to do and when there was nothing left to
+    # do, and only the first of those is a failure (#263).
+    scheduled: list[str] = field(default_factory=list)
     exit_code: int = 0
+
+
+def resolve_exit_code(
+    factory_result: FactoryResult,
+    manifest: Manifest,
+    ui: UI,
+    *,
+    stopped: bool,
+) -> int:
+    """Map a finished run's state to its process exit code.
+
+    Emits the diagnostic for the nothing-was-scheduled case, which is the
+    only branch whose cause the summary counters do not already name.
+    """
+    if stopped:
+        return 130
+    if factory_result.failed or factory_result.contract_failures:
+        return 1
+    if factory_result.merge_pending:
+        # Incomplete, not failed: unconfirmed merges blocked their
+        # dependents. Nonzero so automation notices; a re-run re-polls.
+        return 1
+    if factory_result.skipped and not factory_result.completed:
+        return 1
+
+    # #263: components the manifest ends the run short of COMPLETED. Read
+    # from the manifest rather than the run counters, because the counters
+    # are equally empty whether the scheduler found nothing it COULD do or
+    # nothing it NEEDED to do, and only the first of those is a failure.
+    # Same reasoning the merge_pending list above is rebuilt from the
+    # manifest rather than accumulated during the run.
+    unfinished = [c.id for c in manifest.components if c.status != ComponentStatus.COMPLETED.value]
+    if not factory_result.scheduled and unfinished:
+        # The manifest held work and the scheduler launched none of it:
+        # an off-enum status, a component left FAILED or SKIPPED by an
+        # earlier run, or a future scheduling bug. Reported as a failure
+        # so `ks factory && deploy` cannot deploy a run that built
+        # nothing. An empty manifest and a fully COMPLETED one both leave
+        # `unfinished` empty and stay at 0.
+        ui.err(
+            f"No component was scheduled from {len(manifest.components)} in the "
+            f"manifest, and {len(unfinished)} did not complete: "
+            f"{', '.join(unfinished)}"
+        )
+        ui.info(
+            "  Check each component's status against ComponentStatus "
+            f"({', '.join(COMPONENT_STATUS_VALUES)}). A component left in "
+            "'failed' or 'skipped' is not schedulable until `ks retry "
+            "<component-id>` resets it to 'pending'."
+        )
+        return 1
+    return 0
 
 
 class FactoryLockHeldError(RuntimeError):
@@ -3073,6 +3136,7 @@ def _run_factory_locked(
                             ),
                         )
                     running_futures[future] = comp.id
+                    factory_result.scheduled.append(comp.id)
                     if backstop_seconds > 0:
                         future_deadlines[future] = time.monotonic() + backstop_seconds
 
@@ -3475,16 +3539,12 @@ def _run_factory_locked(
             "re-poll them: " + ", ".join(factory_result.merge_pending)
         )
 
-    if stop is not None and stop.is_set():
-        factory_result.exit_code = 130
-    elif factory_result.failed or factory_result.contract_failures:
-        factory_result.exit_code = 1
-    elif factory_result.merge_pending:
-        # Incomplete, not failed: unconfirmed merges blocked their
-        # dependents. Nonzero so automation notices; a re-run re-polls.
-        factory_result.exit_code = 1
-    elif factory_result.skipped and not factory_result.completed:
-        factory_result.exit_code = 1
+    factory_result.exit_code = resolve_exit_code(
+        factory_result,
+        manifest,
+        ui,
+        stopped=stop is not None and stop.is_set(),
+    )
 
     # R3.3: the run reached its terminal state; stamp the manifest so a
     # resume (and Linear, later) can tell a finished run from a crash.

--- a/kstrl/manifest.py
+++ b/kstrl/manifest.py
@@ -4,108 +4,22 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import tempfile
 import time
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 from kstrl.findings import Finding
+from kstrl.names import validate_branch_name, validate_component_id
 
 
 def _iso_now() -> str:
     """Current UTC time as ISO 8601, matching the factory's timestamps."""
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-
-
-# R0.6 input hygiene: component ids and branch names are LLM-emitted
-# (architect output) and flow into filesystem paths
-# (.kstrl/worktrees/<id>, scripts/kstrl/feature/<id>) and git argv
-# (git worktree add, git push -u origin <branch>). Both are validated
-# against conservative allowlists at every parse boundary. Rejection is
-# deliberate - silent sanitizing would hide architect drift.
-COMPONENT_ID_PATTERN = r"^[a-z0-9][a-z0-9._-]{0,63}$"
-_COMPONENT_ID_RE = re.compile(COMPONENT_ID_PATTERN)
-
-# ASCII allowlist for branch names. Anything outside it (whitespace,
-# ':', control characters, unicode dash confusables like U+2011) is
-# rejected wholesale rather than enumerated.
-_BRANCH_CHARSET_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
-MAX_BRANCH_NAME_LENGTH = 200
-
-
-def validate_component_id(comp_id: str) -> str | None:
-    """Validate a component id, returning an error message or None.
-
-    Component ids become path segments and branch segments, so the rules
-    are strict: lowercase alphanumeric start, then letters/digits/./_/-
-    only (max 64 chars total), no '..' sequence, no '.'/'.lock' suffix
-    ('<id>.lock' would collide with the worktree lock file for id
-    '<id>', and git refuses refs ending in '.' or '.lock').
-
-    Error messages state the rule so the decompose retry loop can feed
-    them back to the architect verbatim.
-    """
-    if not comp_id:
-        return "component id must be a non-empty string"
-    if not _COMPONENT_ID_RE.match(comp_id):
-        return (
-            f"component id {comp_id!r} is invalid: ids must match "
-            f"{COMPONENT_ID_PATTERN} - start with a lowercase letter or "
-            "digit, contain only lowercase letters, digits, '.', '_', "
-            "'-', and be at most 64 characters (no '/', no spaces, no "
-            "uppercase, ASCII only); e.g. 'auth-service'"
-        )
-    if ".." in comp_id:
-        return f"component id {comp_id!r} is invalid: '..' is not allowed"
-    if comp_id.endswith("."):
-        return f"component id {comp_id!r} is invalid: must not end with '.'"
-    if comp_id.endswith(".lock"):
-        return f"component id {comp_id!r} is invalid: must not end with '.lock'"
-    return None
-
-
-def validate_branch_name(branch: str) -> str | None:
-    """Validate a git branch name, returning an error message or None.
-
-    Branch names reach git argv in ref position (git push, git worktree
-    add, git merge). The rules reject option injection (leading '-'),
-    traversal ('..'), whitespace, ':', and unicode lookalikes via an
-    ASCII allowlist, while accepting the kstrl/factory/<id> pattern and
-    ordinary user branches.
-    """
-    if not branch:
-        return "branch name must be a non-empty string"
-    if len(branch) > MAX_BRANCH_NAME_LENGTH:
-        return f"branch name is too long ({len(branch)} chars, max {MAX_BRANCH_NAME_LENGTH})"
-    if not _BRANCH_CHARSET_RE.match(branch):
-        return (
-            f"branch name {branch!r} contains disallowed characters: only "
-            "ASCII letters, digits, '.', '_', '/', '-' are allowed "
-            "(no whitespace, no ':', no non-ASCII characters)"
-        )
-    if branch.startswith("-"):
-        return (
-            f"branch name {branch!r} must not start with '-' "
-            "(git would parse it as a command-line option)"
-        )
-    if ".." in branch:
-        return f"branch name {branch!r} must not contain '..'"
-    if branch.startswith("/") or branch.endswith("/") or "//" in branch:
-        return (
-            f"branch name {branch!r} must not have empty path segments "
-            "(leading '/', trailing '/', or '//')"
-        )
-    if any(seg.startswith(".") for seg in branch.split("/")):
-        return f"branch name {branch!r} must not have a path segment starting with '.'"
-    if branch.endswith("."):
-        return f"branch name {branch!r} must not end with '.'"
-    if branch.endswith(".lock"):
-        return f"branch name {branch!r} must not end with '.lock'"
-    return None
 
 
 class ComponentStatus(StrEnum):
@@ -124,6 +38,61 @@ class ComponentStatus(StrEnum):
     MERGE_PENDING = "merge_pending"
     FAILED = "failed"
     SKIPPED = "skipped"
+
+
+# Every legal ``Component.status`` value, in lifecycle order. Membership
+# is tested against this tuple rather than with ``in ComponentStatus``
+# because on Python 3.11 - the floor this project supports and the
+# version CI installs - ``str in EnumType`` raises TypeError.
+COMPONENT_STATUS_VALUES: tuple[str, ...] = tuple(s.value for s in ComponentStatus)
+
+# Every required component field that must be a string, paired with the
+# extra rule its value has to satisfy (None when "is a string" is the
+# whole rule). A table rather than five near-identical if/else blocks:
+# the blocks differed only in the key name and the extra validator.
+_COMPONENT_STRING_FIELDS: tuple[tuple[str, Callable[[str], str | None] | None], ...] = (
+    ("id", validate_component_id),
+    ("title", None),
+    ("description", None),
+    ("prdPath", None),
+    ("branchName", validate_branch_name),
+)
+
+
+def _validate_component_fields(comp: dict[str, Any], prefix: str) -> list[str]:
+    """Type-check one component's fields, returning error strings."""
+    errors: list[str] = []
+
+    for key, extra_rule in _COMPONENT_STRING_FIELDS:
+        value = comp.get(key)
+        if not isinstance(value, str):
+            errors.append(f"{prefix}.{key}: must be a string")
+            continue
+        message = extra_rule(value) if extra_rule is not None else None
+        if message:
+            errors.append(f"{prefix}.{key}: {message}")
+
+    dependencies = comp.get("dependencies")
+    if not isinstance(dependencies, list):
+        errors.append(f"{prefix}.dependencies: must be an array")
+    elif not all(isinstance(d, str) for d in dependencies):
+        errors.append(f"{prefix}.dependencies: all items must be strings")
+
+    # An off-enum status is never schedulable: get_ready_components
+    # matches PENDING exactly, so a manifest carrying one executes
+    # nothing and the run reports an empty success (#263). Reject it at
+    # the parse boundary instead.
+    if "status" in comp:
+        status = comp["status"]
+        if not isinstance(status, str):
+            errors.append(f"{prefix}.status: must be a string")
+        elif status not in COMPONENT_STATUS_VALUES:
+            errors.append(
+                f"{prefix}.status: {status!r} is not a valid status; "
+                f"must be one of: {', '.join(COMPONENT_STATUS_VALUES)}"
+            )
+
+    return errors
 
 
 @dataclass
@@ -480,28 +449,7 @@ class Manifest:
                 errors.append(f"{prefix}: unexpected keys: {', '.join(sorted(comp_extra))}")
                 continue
 
-            if not isinstance(comp.get("id"), str):
-                errors.append(f"{prefix}.id: must be a string")
-            else:
-                id_error = validate_component_id(comp["id"])
-                if id_error:
-                    errors.append(f"{prefix}.id: {id_error}")
-            if not isinstance(comp.get("title"), str):
-                errors.append(f"{prefix}.title: must be a string")
-            if not isinstance(comp.get("description"), str):
-                errors.append(f"{prefix}.description: must be a string")
-            if not isinstance(comp.get("dependencies"), list):
-                errors.append(f"{prefix}.dependencies: must be an array")
-            elif not all(isinstance(d, str) for d in comp["dependencies"]):
-                errors.append(f"{prefix}.dependencies: all items must be strings")
-            if not isinstance(comp.get("prdPath"), str):
-                errors.append(f"{prefix}.prdPath: must be a string")
-            if not isinstance(comp.get("branchName"), str):
-                errors.append(f"{prefix}.branchName: must be a string")
-            else:
-                branch_error = validate_branch_name(comp["branchName"])
-                if branch_error:
-                    errors.append(f"{prefix}.branchName: {branch_error}")
+            errors.extend(_validate_component_fields(comp, prefix))
 
         return errors
 

--- a/kstrl/manifest.py
+++ b/kstrl/manifest.py
@@ -621,6 +621,16 @@ class Manifest:
                     queue.append(dependent_id)
         return found
 
+    def retryable_component_ids(self) -> list[str]:
+        """Ids ``reset_for_retry`` will accept, in manifest order.
+
+        The one definition of "can be retried", so a caller that offers
+        `ks retry <id>` as advice cannot name an id the command refuses.
+        A SKIPPED component is deliberately absent: it becomes runnable
+        by retrying the failure that cascaded onto it, not on its own.
+        """
+        return [c.id for c in self.components if c.status == ComponentStatus.FAILED.value]
+
     def reset_for_retry(self, component_id: str) -> list[str]:
         """Reset a FAILED component and its cascade-SKIPPED dependents to
         PENDING so a factory re-run schedules them again (R3.3).

--- a/kstrl/names.py
+++ b/kstrl/names.py
@@ -1,0 +1,98 @@
+"""Input hygiene for the names a manifest carries: component ids and branches.
+
+Split out of ``manifest.py`` rather than left in it: these are pure string
+rules that know nothing about a Component, a Manifest or a DAG, and keeping
+them alongside the schema and the scheduler is what pushed that module past
+the file-length gate. ``manifest`` imports both validators, so
+``from kstrl.manifest import validate_branch_name`` keeps working.
+"""
+
+from __future__ import annotations
+
+import re
+
+# R0.6 input hygiene: component ids and branch names are LLM-emitted
+# (architect output) and flow into filesystem paths
+# (.kstrl/worktrees/<id>, scripts/kstrl/feature/<id>) and git argv
+# (git worktree add, git push -u origin <branch>). Both are validated
+# against conservative allowlists at every parse boundary. Rejection is
+# deliberate - silent sanitizing would hide architect drift.
+COMPONENT_ID_PATTERN = r"^[a-z0-9][a-z0-9._-]{0,63}$"
+_COMPONENT_ID_RE = re.compile(COMPONENT_ID_PATTERN)
+
+# ASCII allowlist for branch names. Anything outside it (whitespace,
+# ':', control characters, unicode dash confusables like U+2011) is
+# rejected wholesale rather than enumerated.
+_BRANCH_CHARSET_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+MAX_BRANCH_NAME_LENGTH = 200
+
+
+def validate_component_id(comp_id: str) -> str | None:
+    """Validate a component id, returning an error message or None.
+
+    Component ids become path segments and branch segments, so the rules
+    are strict: lowercase alphanumeric start, then letters/digits/./_/-
+    only (max 64 chars total), no '..' sequence, no '.'/'.lock' suffix
+    ('<id>.lock' would collide with the worktree lock file for id
+    '<id>', and git refuses refs ending in '.' or '.lock').
+
+    Error messages state the rule so the decompose retry loop can feed
+    them back to the architect verbatim.
+    """
+    if not comp_id:
+        return "component id must be a non-empty string"
+    if not _COMPONENT_ID_RE.match(comp_id):
+        return (
+            f"component id {comp_id!r} is invalid: ids must match "
+            f"{COMPONENT_ID_PATTERN} - start with a lowercase letter or "
+            "digit, contain only lowercase letters, digits, '.', '_', "
+            "'-', and be at most 64 characters (no '/', no spaces, no "
+            "uppercase, ASCII only); e.g. 'auth-service'"
+        )
+    if ".." in comp_id:
+        return f"component id {comp_id!r} is invalid: '..' is not allowed"
+    if comp_id.endswith("."):
+        return f"component id {comp_id!r} is invalid: must not end with '.'"
+    if comp_id.endswith(".lock"):
+        return f"component id {comp_id!r} is invalid: must not end with '.lock'"
+    return None
+
+
+def validate_branch_name(branch: str) -> str | None:
+    """Validate a git branch name, returning an error message or None.
+
+    Branch names reach git argv in ref position (git push, git worktree
+    add, git merge). The rules reject option injection (leading '-'),
+    traversal ('..'), whitespace, ':', and unicode lookalikes via an
+    ASCII allowlist, while accepting the kstrl/factory/<id> pattern and
+    ordinary user branches.
+    """
+    if not branch:
+        return "branch name must be a non-empty string"
+    if len(branch) > MAX_BRANCH_NAME_LENGTH:
+        return f"branch name is too long ({len(branch)} chars, max {MAX_BRANCH_NAME_LENGTH})"
+    if not _BRANCH_CHARSET_RE.match(branch):
+        return (
+            f"branch name {branch!r} contains disallowed characters: only "
+            "ASCII letters, digits, '.', '_', '/', '-' are allowed "
+            "(no whitespace, no ':', no non-ASCII characters)"
+        )
+    if branch.startswith("-"):
+        return (
+            f"branch name {branch!r} must not start with '-' "
+            "(git would parse it as a command-line option)"
+        )
+    if ".." in branch:
+        return f"branch name {branch!r} must not contain '..'"
+    if branch.startswith("/") or branch.endswith("/") or "//" in branch:
+        return (
+            f"branch name {branch!r} must not have empty path segments "
+            "(leading '/', trailing '/', or '//')"
+        )
+    if any(seg.startswith(".") for seg in branch.split("/")):
+        return f"branch name {branch!r} must not have a path segment starting with '.'"
+    if branch.endswith("."):
+        return f"branch name {branch!r} must not end with '.'"
+    if branch.endswith(".lock"):
+        return f"branch name {branch!r} must not end with '.lock'"
+    return None

--- a/kstrl/names.py
+++ b/kstrl/names.py
@@ -3,8 +3,13 @@
 Split out of ``manifest.py`` rather than left in it: these are pure string
 rules that know nothing about a Component, a Manifest or a DAG, and keeping
 them alongside the schema and the scheduler is what pushed that module past
-the file-length gate. ``manifest`` imports both validators, so
-``from kstrl.manifest import validate_branch_name`` keeps working.
+the file-length gate.
+
+Import them from HERE, not from ``kstrl.manifest``. ``manifest`` imports
+both validators for its own use, but that is not a re-export: the project's
+typecheck is ``mypy --strict``, which implies ``--no-implicit-reexport``, so
+``from kstrl.manifest import validate_branch_name`` fails the gate with
+"Module 'kstrl.manifest' does not explicitly export attribute".
 """
 
 from __future__ import annotations

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,8 +6,9 @@ from pathlib import Path
 
 from click.testing import CliRunner, Result
 
-from kstrl.cli import _run_structural_override_notices, cli
+from kstrl.cli import _format_component_status, _run_structural_override_notices, cli
 from kstrl.factory import FactoryConfig
+from kstrl.manifest import ComponentStatus
 from tests.spine_utils import git as spine_git
 
 
@@ -336,3 +337,20 @@ class TestDecomposeBlockerOutput:
         assert result.exit_code == 2
         assert "spec is too vague" in result.output
         assert str(artifact) in result.output
+
+
+class TestFormatComponentStatus:
+    """#263: the plan line must not echo an unschedulable status as if valid."""
+
+    def test_every_enum_status_renders_verbatim(self) -> None:
+        for status in ComponentStatus:
+            assert _format_component_status(status.value) == status.value
+
+    def test_off_enum_status_is_flagged(self) -> None:
+        # The reporter's manifest said "PENDING" and the plan printed
+        # "document-format [PENDING]" - indistinguishable from a correct
+        # manifest, so the display confirmed the very thing that was wrong.
+        assert _format_component_status("PENDING") == "PENDING (not a valid status)"
+
+    def test_missing_component_renders_question_mark(self) -> None:
+        assert _format_component_status(None) == "?"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner, Result
 
 from kstrl.cli import _format_component_status, _run_structural_override_notices, cli
 from kstrl.factory import FactoryConfig
-from kstrl.manifest import ComponentStatus
+from kstrl.manifest import Component, ComponentStatus, Manifest
 from tests.spine_utils import git as spine_git
 
 
@@ -354,3 +354,65 @@ class TestFormatComponentStatus:
 
     def test_missing_component_renders_question_mark(self) -> None:
         assert _format_component_status(None) == "?"
+
+
+class TestInboxRetryManifestLoad:
+    """#263 follow-on: a bad manifest must not traceback out of `ks inbox retry`.
+
+    Every other `Manifest.load` call site in the CLI catches OSError and
+    ValueError. This one did not, and the new status validation gives it a
+    likely trigger: a hand-edited manifest with a status typo, which is the
+    exact scenario #263 was reported from.
+    """
+
+    @staticmethod
+    def _project(tmp_path: Path, status: str) -> str:
+        from kstrl.inbox import Inbox, InboxConfig, ItemKind
+
+        scaffold = tmp_path / "scripts" / "kstrl"
+        scaffold.mkdir(parents=True)
+        # Written through Manifest.save, which serialises the schema the
+        # loader reads and does not validate, so an off-enum status lands
+        # on disk exactly as a hand-edited file would carry it.
+        Manifest(
+            version="1",
+            spec_file="spec.md",
+            project_name="t",
+            base_branch="main",
+            single_pr=False,
+            components=[Component("comp-a", "A", "", [], "p.json", "b/a", status=status)],
+        ).save(scaffold / "manifest.json")
+        box = Inbox(tmp_path, InboxConfig.load(tmp_path))
+        item = box.add(ItemKind.HALTED_RUN, "comp-a halted", component="comp-a")
+        return str(item.id)
+
+    def _run(self, tmp_path: Path, item_id: str) -> Result:
+        runner = CliRunner()
+        return runner.invoke(
+            cli,
+            [
+                "inbox",
+                "retry",
+                item_id,
+                "--root",
+                str(tmp_path),
+                "--ui",
+                "plain",
+                "--no-color",
+            ],
+        )
+
+    def test_off_enum_status_reports_cleanly(self, tmp_path: Path) -> None:
+        item_id = self._project(tmp_path, "PENDING")
+        result = self._run(tmp_path, item_id)
+        assert result.exit_code == 1
+        assert "Failed to load manifest" in result.output
+        assert "'PENDING' is not a valid status" in result.output
+        # A clean exit, not a traceback leaking past the new guard.
+        assert isinstance(result.exception, SystemExit)
+
+    def test_valid_manifest_still_retries(self, tmp_path: Path) -> None:
+        item_id = self._project(tmp_path, "failed")
+        result = self._run(tmp_path, item_id)
+        assert result.exit_code == 0
+        assert "Requeued comp-a" in result.output

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -882,14 +882,79 @@ class TestResolveExitCode:
         assert code == 1
         assert "1 did not complete: b" in out
 
-    # merge_pending: repoll_merge_pending leaves these alone when gh is
-    # unavailable and warns that dependents stay blocked; the exit code
-    # now says the same thing.
-    @pytest.mark.parametrize("status", ["skipped", "merge_pending"])
-    def test_leftover_terminal_status_rerun_fails(self, status: str) -> None:
-        manifest = _make_manifest([Component("a", "A", "", [], "a.json", "b/a", status=status)])
+    def test_leftover_skipped_rerun_fails(self) -> None:
+        manifest = _make_manifest([Component("a", "A", "", [], "a.json", "b/a", status="skipped")])
         code, _ = self._resolve(manifest, FactoryResult())
         assert code == 1
+
+    def test_merge_pending_belongs_to_the_earlier_branch(self) -> None:
+        # _run_factory_locked rebuilds factory_result.merge_pending from
+        # the manifest before calling this, so an all-merge_pending
+        # manifest can never reach the nothing-scheduled branch. Pinned
+        # with merge_pending populated the way the caller populates it,
+        # not with the empty FactoryResult that would fake a reachable
+        # state: this already returned 1 before #263.
+        manifest = _make_manifest(
+            [Component("a", "A", "", [], "a.json", "b/a", status="merge_pending")]
+        )
+        code, out = self._resolve(manifest, FactoryResult(merge_pending=["a"]))
+        assert code == 1
+        assert "No component was scheduled" not in out
+
+    @staticmethod
+    def _cascade_manifest() -> Manifest:
+        """`a` failed and cascade-skipped `b`: the common stuck re-run."""
+        return _make_manifest(
+            [
+                Component("a", "A", "", [], "a.json", "b/a", status="failed"),
+                Component("b", "B", "", ["a"], "b.json", "b/b", status="skipped"),
+            ]
+        )
+
+    def test_cascade_points_at_the_root_failure_not_the_victim(self) -> None:
+        # `ks retry b` on a cascade-skipped component exits 2, so the
+        # remedy has to name `a`. The old wording said "a component left
+        # in 'failed' or 'skipped' ... until `ks retry <component-id>`",
+        # which sent the operator at `b`.
+        manifest = self._cascade_manifest()
+        code, out = self._resolve(manifest, FactoryResult())
+        assert code == 1
+        assert "Failed here: a." in out
+        assert "Failed here: b" not in out
+
+    def test_named_retry_target_is_actually_retryable(self) -> None:
+        # The advice is only worth printing if it runs, so put the id the
+        # message names through the command's own gate.
+        manifest = self._cascade_manifest()
+        _, out = self._resolve(manifest, FactoryResult())
+        assert "Failed here: a." in out
+        reset = manifest.reset_for_retry("a")
+        # Retrying the root also frees the component it cascade-skipped.
+        assert "b" in reset
+        assert manifest.get_component("b").status == ComponentStatus.PENDING.value
+
+    def test_message_names_exactly_the_retryable_ids(self) -> None:
+        # The message and `reset_for_retry` must read one definition, so
+        # a future change to what counts as retryable cannot leave the
+        # advice naming ids the command has started refusing.
+        manifest = self._cascade_manifest()
+        _, out = self._resolve(manifest, FactoryResult())
+        assert manifest.retryable_component_ids() == ["a"]
+        assert f"Failed here: {', '.join(manifest.retryable_component_ids())}." in out
+
+    def test_retrying_the_skipped_victim_is_refused(self) -> None:
+        # The behaviour the old message walked the operator into.
+        manifest = self._cascade_manifest()
+        with pytest.raises(ValueError, match="only failed components can be retried"):
+            manifest.reset_for_retry("b")
+
+    @pytest.mark.parametrize("status", ["skipped", "PENDING"])
+    def test_no_failed_component_says_retry_will_not_help(self, status: str) -> None:
+        manifest = _make_manifest([Component("a", "A", "", [], "a.json", "b/a", status=status)])
+        code, out = self._resolve(manifest, FactoryResult())
+        assert code == 1
+        assert "accepts only a component in 'failed', and none is" in out
+        assert "Failed here" not in out
 
     def test_scheduled_run_that_completed_stays_zero(self) -> None:
         manifest = _make_manifest(

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -8,11 +8,15 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from kstrl.config import KstrlConfig
 from kstrl.factory import (
     ComponentResult,
     FactoryConfig,
+    FactoryResult,
     merge_gate_unreachable_warning,
+    resolve_exit_code,
     run_factory,
 )
 from kstrl.knowledge import Fact, write_facts
@@ -808,3 +812,262 @@ class TestEvolutionRecording:
         util = self._component_entry(root)["knowledge_utilization"]
         assert util["measured"] is False
         assert util["reason"] == "knowledge retrieval failed"
+
+
+class TestResolveExitCode:
+    """#263: the ladder branch for a run that scheduled nothing.
+
+    Unit level, because the interesting cases differ only in manifest
+    state and the counters an executed run would have left behind.
+    """
+
+    @staticmethod
+    def _ui() -> tuple[PlainUI, io.StringIO]:
+        buf = io.StringIO()
+        return PlainUI(no_color=True, file=buf), buf
+
+    def _resolve(
+        self,
+        manifest: Manifest,
+        result: FactoryResult,
+        stopped: bool = False,
+    ) -> tuple[int, str]:
+        ui, buf = self._ui()
+        code = resolve_exit_code(result, manifest, ui, stopped=stopped)
+        return code, buf.getvalue()
+
+    def test_empty_manifest_stays_zero(self) -> None:
+        code, out = self._resolve(_make_manifest([]), FactoryResult())
+        assert code == 0
+        assert out == ""
+
+    def test_finished_manifest_rerun_stays_zero(self) -> None:
+        # Idempotent re-run of a manifest whose work is done. Every
+        # counter is empty here exactly as in the bug report, which is
+        # why a counter-based predicate cannot separate the two.
+        manifest = _make_manifest(
+            [Component("a", "A", "", [], "a.json", "b/a", status="completed")]
+        )
+        code, out = self._resolve(manifest, FactoryResult())
+        assert code == 0
+        assert out == ""
+
+    def test_off_enum_status_fails_loudly(self) -> None:
+        manifest = _make_manifest([Component("a", "A", "", [], "a.json", "b/a", status="PENDING")])
+        code, out = self._resolve(manifest, FactoryResult())
+        assert code == 1
+        assert "No component was scheduled from 1 in the manifest" in out
+        assert "ComponentStatus" in out
+        for legal in ComponentStatus:
+            assert legal.value in out
+
+    def test_already_failed_rerun_fails(self) -> None:
+        # Re-running a manifest whose component failed, without `ks
+        # retry`: nothing is schedulable, so the run built nothing.
+        manifest = _make_manifest([Component("a", "A", "", [], "a.json", "b/a", status="failed")])
+        code, out = self._resolve(manifest, FactoryResult())
+        assert code == 1
+        assert "ks retry" in out
+
+    def test_partly_finished_rerun_fails(self) -> None:
+        # The case "no component ever completed" would wave through: one
+        # component IS completed, but the other never ran.
+        manifest = _make_manifest(
+            [
+                Component("a", "A", "", [], "a.json", "b/a", status="completed"),
+                Component("b", "B", "", [], "b.json", "b/b", status="failed"),
+            ]
+        )
+        code, out = self._resolve(manifest, FactoryResult())
+        assert code == 1
+        assert "1 did not complete: b" in out
+
+    # merge_pending: repoll_merge_pending leaves these alone when gh is
+    # unavailable and warns that dependents stay blocked; the exit code
+    # now says the same thing.
+    @pytest.mark.parametrize("status", ["skipped", "merge_pending"])
+    def test_leftover_terminal_status_rerun_fails(self, status: str) -> None:
+        manifest = _make_manifest([Component("a", "A", "", [], "a.json", "b/a", status=status)])
+        code, _ = self._resolve(manifest, FactoryResult())
+        assert code == 1
+
+    def test_scheduled_run_that_completed_stays_zero(self) -> None:
+        manifest = _make_manifest(
+            [Component("a", "A", "", [], "a.json", "b/a", status="completed")]
+        )
+        code, out = self._resolve(manifest, FactoryResult(completed=["a"], scheduled=["a"]))
+        assert code == 0
+        assert out == ""
+
+    def test_scheduled_run_left_unfinished_is_not_reported_here(self) -> None:
+        # A component that ran and did not finish is already named by an
+        # earlier branch; this branch must not double-report it, and must
+        # not fire for any run that actually scheduled work.
+        manifest = _make_manifest(
+            [
+                Component("a", "A", "", [], "a.json", "b/a", status="completed"),
+                Component("b", "B", "", ["a"], "b.json", "b/b", status="skipped"),
+            ]
+        )
+        code, out = self._resolve(
+            manifest,
+            FactoryResult(completed=["a"], scheduled=["a"]),
+        )
+        assert code == 0
+        assert out == ""
+
+    def test_stop_wins_over_nothing_scheduled(self) -> None:
+        manifest = _make_manifest([Component("a", "A", "", [], "a.json", "b/a", status="failed")])
+        code, out = self._resolve(manifest, FactoryResult(), stopped=True)
+        assert code == 130
+        assert out == ""
+
+    def test_failure_branch_wins_over_nothing_scheduled(self) -> None:
+        manifest = _make_manifest([Component("a", "A", "", [], "a.json", "b/a", status="failed")])
+        code, out = self._resolve(manifest, FactoryResult(failed=["a"]))
+        assert code == 1
+        assert out == ""
+
+
+class TestRunFactorySchedulesNothing:
+    """#263 end to end: a run that launches nothing must not report success."""
+
+    @staticmethod
+    def _config() -> FactoryConfig:
+        return FactoryConfig(
+            use_worktrees=False,
+            create_prs=False,
+            max_parallel=1,
+            review_mode="skip",
+        )
+
+    def _run(self, root: Path, manifest: Manifest) -> tuple[Any, str]:
+        buf = io.StringIO()
+        ui = PlainUI(no_color=True, file=buf)
+        result = run_factory(manifest, self._config(), _make_base_config(root), ui, root)
+        return result, buf.getvalue()
+
+    def test_off_enum_status_exits_nonzero(self, tmp_path: Path) -> None:
+        root = _setup_project(tmp_path)
+        manifest = _make_manifest([Component("a", "A", "", [], "a.json", "b/a", status="PENDING")])
+
+        result, out = self._run(root, manifest)
+
+        assert result.scheduled == []
+        assert result.completed == []
+        assert result.exit_code == 1
+        assert "No component was scheduled from 1 in the manifest" in out
+
+    def test_already_failed_rerun_exits_nonzero(self, tmp_path: Path) -> None:
+        root = _setup_project(tmp_path)
+        manifest = _make_manifest([Component("a", "A", "", [], "a.json", "b/a", status="failed")])
+
+        result, out = self._run(root, manifest)
+
+        assert result.scheduled == []
+        assert result.exit_code == 1
+        assert "ks retry" in out
+
+    def test_finished_manifest_rerun_exits_zero(self, tmp_path: Path) -> None:
+        root = _setup_project(tmp_path)
+        manifest = _make_manifest(
+            [Component("a", "A", "", [], "a.json", "b/a", status="completed")]
+        )
+
+        result, out = self._run(root, manifest)
+
+        assert result.scheduled == []
+        assert result.exit_code == 0
+        assert "No component was scheduled" not in out
+
+    def test_a_scheduled_run_records_what_it_launched(self, tmp_path: Path) -> None:
+        root = _setup_project(tmp_path)
+        manifest = _make_manifest(
+            [
+                Component(
+                    "comp-a",
+                    "Component A",
+                    "Desc",
+                    [],
+                    "scripts/kstrl/feature/comp-a/prd.json",
+                    "kstrl/factory/comp-a",
+                ),
+            ]
+        )
+        feature_dir = root / "scripts" / "kstrl" / "feature" / "comp-a"
+        feature_dir.mkdir(parents=True)
+        (feature_dir / "prd.json").write_text(
+            json.dumps(
+                {
+                    "branchName": "test",
+                    "userStories": [
+                        {
+                            "id": "US-001",
+                            "title": "Test",
+                            "acceptanceCriteria": ["AC1"],
+                            "priority": 1,
+                            "passes": True,
+                            "notes": "",
+                        }
+                    ],
+                }
+            )
+        )
+        config = FactoryConfig(
+            use_worktrees=False,
+            create_prs=False,
+            max_parallel=1,
+            review_mode="skip",
+            verify_config=VerifyConfig(
+                test_command="true",
+                typecheck_command="true",
+                lint_command="true",
+                check_diff_scope=False,
+                check_bad_patterns=False,
+                subprocess_timeout=5.0,
+            ),
+        )
+
+        buf = io.StringIO()
+        ui = PlainUI(no_color=True, file=buf)
+        with (
+            patch(
+                "kstrl.factory._run_component",
+                return_value=ComponentResult("comp-a", success=True, iterations=1),
+            ),
+            patch("kstrl.git.get_diff_content", return_value=""),
+        ):
+            result = run_factory(manifest, config, _make_base_config(root), ui, root)
+
+        assert result.completed == ["comp-a"]
+        assert result.scheduled == ["comp-a"]
+        assert result.exit_code == 0
+        assert "No component was scheduled" not in buf.getvalue()
+
+    def test_scheduled_records_one_entry_per_attempt(self, tmp_path: Path) -> None:
+        # `scheduled` is an attempt log, not a set: the branch that reads
+        # it only asks whether it is empty, and a per-attempt record is
+        # the more informative of the two.
+        root = _setup_project(tmp_path)
+        manifest = _make_manifest([Component("a", "A", "Desc", [], "a.json", "b/a")])
+        config = FactoryConfig(
+            use_worktrees=False,
+            create_prs=False,
+            max_parallel=1,
+            max_retries=2,
+            retry_delay=0,
+            review_mode="skip",
+        )
+
+        buf = io.StringIO()
+        ui = PlainUI(no_color=True, file=buf)
+        with patch(
+            "kstrl.factory._run_component",
+            return_value=ComponentResult("a", success=False, error="boom"),
+        ):
+            result = run_factory(manifest, config, _make_base_config(root), ui, root)
+
+        assert result.scheduled == ["a", "a", "a"]
+        assert result.failed == ["a"]
+        assert result.exit_code == 1
+        assert "No component was scheduled" not in buf.getvalue()

--- a/tests/test_input_hygiene.py
+++ b/tests/test_input_hygiene.py
@@ -29,9 +29,8 @@ from kstrl.git import (
 from kstrl.manifest import (
     Component,
     Manifest,
-    validate_branch_name,
-    validate_component_id,
 )
+from kstrl.names import validate_branch_name, validate_component_id
 from kstrl.pr import push_branch
 from kstrl.ui.plain import PlainUI
 

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -45,7 +45,8 @@ from kstrl.linear import (
     resync_components,
     sync_decompose,
 )
-from kstrl.manifest import ComponentStatus, Manifest, validate_branch_name
+from kstrl.manifest import ComponentStatus, Manifest
+from kstrl.names import validate_branch_name
 from kstrl.observability import ProgressLog
 from kstrl.pr import _generate_pr_body
 from tests.spine_utils import component, make_manifest

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -125,6 +125,45 @@ class TestManifestValidateSchema:
         data = _minimal_manifest_data([comp])
         assert Manifest.validate_schema(data) == []
 
+    @pytest.mark.parametrize("status", [s.value for s in ComponentStatus])
+    def test_component_accepts_every_enum_status(self, status: str) -> None:
+        comp = _component_data(status=status)
+        data = _minimal_manifest_data([comp])
+        assert Manifest.validate_schema(data) == []
+
+    def test_component_rejects_off_enum_status(self) -> None:
+        # #263: "PENDING" is not "pending", and get_ready_components
+        # matches the enum value exactly, so an off-enum status made the
+        # component permanently unschedulable while the manifest loaded
+        # clean and the run reported success.
+        comp = _component_data(status="PENDING")
+        data = _minimal_manifest_data([comp])
+        errors = Manifest.validate_schema(data)
+        assert len(errors) == 1
+        assert "'PENDING' is not a valid status" in errors[0]
+        # The message has to list the legal values: the reporter could
+        # not tell from the manifest alone what the right spelling was.
+        for legal in ComponentStatus:
+            assert legal.value in errors[0]
+
+    @pytest.mark.parametrize("status", [3, None, ["pending"]])
+    def test_component_rejects_non_string_status(self, status: object) -> None:
+        comp = _component_data(status=status)
+        data = _minimal_manifest_data([comp])
+        errors = Manifest.validate_schema(data)
+        assert errors == ["components[0].status: must be a string"]
+
+    def test_load_rejects_off_enum_status(self, tmp_path: Path) -> None:
+        path = tmp_path / "manifest.json"
+        path.write_text(json.dumps(_minimal_manifest_data([_component_data(status="PENDING")])))
+        with pytest.raises(ValueError, match="'PENDING' is not a valid status"):
+            Manifest.load(path)
+
+    def test_load_accepts_a_legal_status(self, tmp_path: Path) -> None:
+        path = tmp_path / "manifest.json"
+        path.write_text(json.dumps(_minimal_manifest_data([_component_data(status="failed")])))
+        assert Manifest.load(path).components[0].status == ComponentStatus.FAILED.value
+
 
 class TestManifestValidateDAG:
     """Tests for Manifest.validate_dag."""

--- a/tests/test_tui_detail.py
+++ b/tests/test_tui_detail.py
@@ -8,11 +8,13 @@ from unittest.mock import Mock
 from kstrl.agents.base import UsageTotals
 from kstrl.findings import Finding
 from kstrl.interaction import CheckpointContext, PromptKind, PromptRequest
+from kstrl.manifest import COMPONENT_STATUS_VALUES
 from kstrl.reducer import ComponentState
 from kstrl.tui.app import KstrlTuiApp, Mode
 from kstrl.tui.screens.checkpoint import CheckpointModal
 from kstrl.tui.screens.component import ComponentScreen
 from kstrl.tui.screens.overview import OverviewScreen
+from kstrl.tui.theme import STATUS_GLYPHS, status_glyph
 from kstrl.tui.widgets.findings_table import FindingsTable
 from kstrl.tui.widgets.header import RunHeader
 from kstrl.tui.widgets.phase_timeline import render_timeline
@@ -255,3 +257,20 @@ class TestPhaseTimeline:
         assert "engineer ✗" in timeline
         # The retried phase renders as the live amber chip (● marker).
         assert "engineer ●" in timeline
+
+
+class TestStatusGlyphCoverage:
+    """#263 follow-on: three enumerations of the legal statuses now exist.
+
+    ``ComponentStatus`` is the enum, ``COMPONENT_STATUS_VALUES`` is what
+    the manifest validator and the CLI plan check against, and
+    ``STATUS_GLYPHS`` is the TUI's hand-written table. A status added to
+    the enum but not to the table would render as the ``?`` fallback -
+    the glyph reserved for a status nothing recognises.
+    """
+
+    def test_glyph_table_covers_exactly_the_enum(self) -> None:
+        assert set(STATUS_GLYPHS) == set(COMPONENT_STATUS_VALUES)
+
+    def test_unknown_status_falls_back_to_question_mark(self) -> None:
+        assert status_glyph("PENDING")[0] == "?"


### PR DESCRIPTION
Fixes #263.

A factory run that scheduled zero components printed `OK` twice, the word
`error` zero times, and exited 0. The reporter's manifest said
`"status": "PENDING"`; the enum value is `"pending"`, so
`get_ready_components` matched nothing, the scheduler launched nothing,
every counter stayed empty, and no exit-code ladder branch fired.

Three things had to conspire for that, and all three are fixed.

## 1. An off-enum status is now rejected at the parse boundary

`Manifest.validate_schema` never looked at `status`: it was listed in
`component_optional`, so its presence was legal and its value was never
compared to anything. `Manifest.load` took it verbatim.

It now validates against `ComponentStatus`, naming the bad value and
listing the legal ones:

```
components[0].status: 'PENDING' is not a valid status; must be one of:
pending, running, verifying, completed, merge_pending, failed, skipped
```

Membership is tested against a new `COMPONENT_STATUS_VALUES` tuple rather
than `status in ComponentStatus`, because `str in EnumType` raises
`TypeError` on Python 3.11, which is this project's floor and the version
CI installs. Measured, not assumed.

This turns previously-loadable manifests into hard load errors, so every
fixture and golden manifest under `tests/` was checked first: all statuses
present are lowercase enum values. `test_component_with_optional_fields`
(`status="completed"`) stays green, and a new parametrized test asserts
every one of the seven enum values still validates.

## 2. The plan display no longer confirms the thing that is wrong

The plan printed `1. document-format [PENDING]`, which is exactly what a
correct manifest looks like. `_format_component_status` now renders an
unrecognised status as `document-format [PENDING (not a valid status)]`.

## 3. The exit-code ladder has a branch for it

### Why the counter-based predicate in the issue was rejected

The issue proposes:

```python
elif not factory_result.completed and not factory_result.failed \
        and not factory_result.skipped and manifest.components:
```

That is wrong. The counters below were measured by running each
scenario through `run_factory`, not reasoned about. Four scenarios all
reach the same empty-counter state:

| Scenario | completed / failed / skipped | Correct exit | Reporter's predicate fires |
|---|---|---|---|
| Empty manifest | `[] [] []` | 0 | no |
| Typo status `"PENDING"` | `[] [] []` | 1 | yes |
| Re-run of a manifest whose component already `failed` | `[] [] []` | 1 | yes |
| Idempotent re-run of a fully `completed` manifest | `[] [] []` | 0 | **yes - wrong** |

The run counters are run-scoped. They are equally empty whether the
scheduler found nothing it *could* do or nothing it *needed* to do, so no
predicate over them can separate the last two rows. A re-run of a finished
manifest would start exiting 1.

### The predicate chosen

```python
if not factory_result.scheduled and unfinished:
```

with

```python
unfinished = [
    c.id for c in manifest.components
    if c.status != ComponentStatus.COMPLETED.value
]
```

Two independent facts, each measured rather than inferred:

- **`FactoryResult.scheduled`** is a new field appended to at the single
  point where a component is handed to the executor. "Did this run launch
  anything?" is now recorded, not deduced from counters that cannot answer
  it.
- **`unfinished`** reads the manifest's own end state, which is the durable
  record and the thing a re-run will read next.

Together they mean: *the manifest held work and the scheduler launched
none of it.*

### Why not "no component ever completed"

The narrower `not any(c.status == COMPLETED for c in manifest.components)`
was considered and rejected. It waves through a partly-finished re-run: a
manifest with `a=completed, b=failed` has a completed component, so the
predicate stays quiet even though nothing ran and `b` was never built.
`test_partly_finished_rerun_fails` pins that case.

### Why not "any component is unfinished", without the `scheduled` guard

Dropping the `scheduled` guard would fire on runs that *did* schedule work
and left something short of COMPLETED - a partial run under a budget
ceiling, a cascade-skipped sibling. Those are either already named by an
earlier ladder branch or are separate questions. The guard keeps this
branch to exactly the case the issue is about.
`test_scheduled_run_left_unfinished_is_not_reported_here` pins that.

### The message mentions `ks retry`, and names a target it will accept

The already-failed re-run needs no typo to reach, so it is the most likely
real-world trigger, and its remedy is not "fix your manifest" - it is
`ks retry <component-id>`.

`Manifest.reset_for_retry` accepts a FAILED component only, and raises on
anything else, which `ks retry` surfaces as exit 2. So the message names
the failed components explicitly rather than saying "failed or skipped":
in the common cascade (`a` failed, `b` skipped behind it) the only working
command is `ks retry a`, and pointing the operator at `b` would hand them
an exit 2.

```
No component was scheduled from 2 in the manifest, and 2 did not complete: a, b
  `ks retry <component-id>` resets a failed component to 'pending', and with
  it every dependent it cascade-skipped. Failed here: a.
```

When nothing is FAILED - an off-enum status, or a manifest left all
`skipped` - there is no valid retry target, and the message says so
instead of naming a command that would refuse:

```
  Check each component's status against ComponentStatus (pending, running,
  verifying, completed, merge_pending, failed, skipped). `ks retry` accepts
  only a component in 'failed', and none is.
```

The rule has one home: `Manifest.retryable_component_ids`, which is the
definition `reset_for_retry` enforces. The message reads it rather than
re-deriving the same status filter, so the advice and the command cannot
drift apart. `test_named_retry_target_is_actually_retryable` puts the id
the message names through `reset_for_retry`, and
`test_message_names_exactly_the_retryable_ids` pins the two to the same
list, so the advice is checked against the command's own gate rather than
proof-read.

### No behaviour change beyond the reported bug

An earlier revision of this description claimed that an all-`merge_pending`
re-run went from exit 0 to exit 1. **That claim was wrong and is
withdrawn.** `_run_factory_locked` rebuilds `factory_result.merge_pending`
from the manifest before the ladder runs (`kstrl/factory.py:3467`,
unchanged from main), so `if factory_result.merge_pending: return 1` has
always owned that case and it already exited 1. Measured end to end: the
run reports `merge_pending: ['a']`, `exit_code: 1`, and the new
nothing-scheduled diagnostic is never printed.
`test_merge_pending_belongs_to_the_earlier_branch` now pins that ownership,
passing `merge_pending` populated the way the caller populates it instead
of the empty `FactoryResult` that faked a reachable state.

## 4. `ks inbox retry` no longer tracebacks on a bad manifest

`kstrl/cli.py`'s `ks inbox retry` called `Manifest.load` outside its `try`,
unlike every sibling call site (`cli.py:2126`, `3025`, `3366`,
`serve.py:876`, `tui/state.py:48`, `tui/session.py:186`). Pre-existing, but
part 1 of this PR gives it a likely new trigger, and it is exactly the #263
scenario: a hand-edited manifest with a status typo. It now prints
`Failed to load manifest <path>: ...` and exits 1 like its siblings.

Rather than paste a fourth copy of the guard, `ks inbox retry` and
`ks retry` both go through a new `_load_manifest_or_exit`, so a future
call site cannot forget it, which is how this one came to lack it. The
remaining two sites are left alone: `cli.py:2126` catches bare `Exception`
with a different message, and `cli.py:3025` returns into safe-mode
rendering instead of exiting.

## Refactors carried along

Three extractions were forced by the repo's ratchets, and each stands on
its own:

- `Manifest.validate_schema` was at cyclomatic 27 / cognitive 46; adding
  the status check took it to 30 / 52 and tripped both gates. The five
  near-identical string-field blocks became a `_COMPONENT_STRING_FIELDS`
  table read by a new `_validate_component_fields`. Result: **27 -> 18**
  cyclomatic, **46 -> 25** cognitive, new helper at 8 / 13.
- `_run_factory_locked` was at cyclomatic 114; the new `elif` took it to
  115. The exit-code ladder moved to a module-level `resolve_exit_code`,
  which is now directly unit-testable. Result: **114 -> 110**.
- Those two together took `kstrl/manifest.py` from 783 to 818 lines, past
  the 800-line gate. The component-id and branch-name rules moved to a new
  `kstrl/names.py`: pure string validation that never needed the DAG, the
  schema or the scheduler to sit beside it. `manifest.py` is now 732 lines.
  The three modules that imported those validators from `kstrl.manifest`
  now import them from `kstrl.names` directly: `mypy --strict` implies
  `--no-implicit-reexport`, so `from kstrl.manifest import
  validate_branch_name` fails the gate. `kstrl/names.py`'s docstring says
  so, to stop a contributor writing the import that does not typecheck.

## Testing

- `TestManifestValidateSchema`: every enum value accepted (parametrized),
  off-enum rejected with the value and the legal list in the message,
  non-string and null rejected, and both through `Manifest.load`.
- `TestResolveExitCode`: the full matrix - empty manifest 0, finished
  re-run 0, off-enum 1, already-failed 1, partly-finished 1, leftover
  skipped 1, merge_pending owned by the earlier branch, the cascade
  naming only the root failure, no-failed-component saying retry will
  not help,
  scheduled-and-completed 0,
  scheduled-and-left-unfinished 0, and both earlier ladder branches
  (stop, failed) still winning.
- `TestRunFactorySchedulesNothing`: the same scenarios end to end through
  `run_factory`, asserting the exit code, `result.scheduled`, and the
  diagnostic text.
- `TestFormatComponentStatus`: every enum value verbatim, off-enum
  flagged, missing component as `?`.
- `TestStatusGlyphCoverage`: this change makes three enumerations of
  the legal statuses exist at once, the third being the TUI's
  hand-written `STATUS_GLYPHS` table. One assert now pins it to the
  enum so a status added to `ComponentStatus` cannot silently render
  as the TUI's unrecognised-status `?` glyph.

Gates run locally, all green: `uv run pytest tests/ -q` (3437 passed, 28
skipped), `uv run mypy kstrl/ --strict`, `uv run ruff check kstrl/ tests/`,
`pre-commit run --all-files`. Fast-tier coverage is 87.82%, against the
79.91% ratchet.

The `/simplify` skill was run against this change. It found no reuse or
efficiency issues; its simplification findings (the status conditional's
three-way branch, `unfinished` computed above four early returns that
never read it, and two pairs of copy-paste tests) are applied. Its one
altitude finding, that `_format_component_status` could live in
`kstrl/tui/theme.py` beside `status_glyph`, was not taken: that would
make `kstrl/cli.py` import the TUI package for a non-TUI code path. The
part of that finding worth keeping, the drift risk between the enum and
`STATUS_GLYPHS`, is closed by the test above instead.

No `*_PROMPT` constant was touched, so H2/H3 do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHYpsJ8ecHLh5HdrswJtJK
