### PR TITLE
feat(decompose): report how this spec audit compares with the last one

### DIFF
--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -868,18 +868,27 @@ def persist_spec_issues(
     return path
 
 
-def _spec_audit_journal(root_dir: Path) -> EvolutionJournal | None:
-    """The evolution journal for this root, or None when it is off.
+def _spec_audit_journal(root_dir: Path, ui: UI) -> EvolutionJournal | None:
+    """The evolution journal for this root, or None when it is unusable.
 
     One loader for both directions of the audit trail: the read that
     builds the convergence report and the write that records this run.
     ``EvolutionConfig.load`` already anchors a relative journal path to
     ``root_dir``, so the path it hands back is absolute.
+
+    A config that will not parse degrades to "no journal" - the
+    convergence report goes quiet and the journal entry is skipped -
+    rather than raising, because a typo in an optional journal knob
+    must not cost the operator the findings of a paid architect run.
+    Which exceptions that covers is ``load_or_none``'s to know, not
+    this call site's.
     """
     from kstrl.evolution import EvolutionConfig, EvolutionJournal
 
-    config = EvolutionConfig.load(root_dir)
-    return EvolutionJournal(config) if config.enabled else None
+    config = EvolutionConfig.load_or_none(root_dir, warn=ui.warn)
+    if config is None or not config.enabled:
+        return None
+    return EvolutionJournal(config)
 
 
 def _record_spec_issues_event(
@@ -926,9 +935,16 @@ def _record_spec_issues_event(
 class SpecConvergence:
     """This spec audit measured against earlier audits of the same project.
 
-    ``repeated`` counts this run's issues whose text is unchanged from
-    the previous run. It is a floor on what carried over and never a
-    claim about which issues the architect considers resolved.
+    ``repeated`` counts the PREVIOUS run's issues whose text reappears
+    in this one, which is the side the report renders it as. Counting
+    the current side instead lets two current issues match one previous
+    issue and makes "did not come back" negative, because
+    ``_issue_identity`` drops severity and normalizes text while
+    ``_parse_spec_issues`` de-duplicates nothing. Counting the previous
+    list bounds the number by ``previous_total`` by construction.
+
+    It is a floor on what carried over and never a claim about which
+    issues the architect considers resolved.
     """
 
     current_counts: dict[str, int]
@@ -999,14 +1015,14 @@ def _build_convergence(
         return None
 
     previous_spec_file, previous_issues = audits[-1]
-    previous_ids = {_issue_identity(i) for i in previous_issues}
+    current_ids = {_issue_identity(i) for i in issues}
     current_counts = _issue_counts(issues)
     return SpecConvergence(
         current_counts=current_counts,
         previous_counts=_issue_counts(previous_issues),
         current_spec_file=spec_file,
         previous_spec_file=previous_spec_file,
-        repeated=sum(1 for i in issues if _issue_identity(i) in previous_ids),
+        repeated=sum(1 for i in previous_issues if _issue_identity(i) in current_ids),
         blocker_trend=(*trend, current_counts["blocker"]),
     )
 
@@ -1357,15 +1373,12 @@ def _decompose_spec_impl(
                 suggestion=issue.suggestion,
             )
         )
-    # #260: what this audit says about the previous one, read BEFORE
-    # this run is appended to the journal below - otherwise the
-    # "previous run" the report compares against would be this one.
-    journal = _spec_audit_journal(root_dir)
-    _surface_convergence(
-        _spec_convergence(spec_issues, journal, project_name, spec_path.name),
-        ui,
-    )
     blockers = [i for i in spec_issues if i.severity == "blocker"]
+    # The R1.7 artifact is written FIRST, before any optional journal
+    # work. On the halt path it is the only durable record the operator
+    # gets, so nothing that can fail is allowed upstream of it: #260
+    # briefly put a config load in front of this and a typo in an
+    # unrelated journal knob destroyed the findings of a paid run.
     artifact_path: Path | None = None
     try:
         artifact_path = persist_spec_issues(
@@ -1386,6 +1399,14 @@ def _decompose_spec_impl(
         # Loud but non-masking: the blocker halt (or the decompose
         # result) matters more than the artifact write failing.
         ui.err(f"Failed to persist spec issues to disk: {exc}")
+    # #260: what this audit says about the previous one, read BEFORE
+    # this run is appended to the journal below - otherwise the
+    # "previous run" the report compares against would be this one.
+    journal = _spec_audit_journal(root_dir, ui)
+    _surface_convergence(
+        _spec_convergence(spec_issues, journal, project_name, spec_path.name),
+        ui,
+    )
     _record_spec_issues_event(
         spec_issues,
         journal=journal,

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -44,6 +44,7 @@ from kstrl.prd import PRD
 
 if TYPE_CHECKING:
     from kstrl.agents.base import Agent
+    from kstrl.evolution import EvolutionJournal
     from kstrl.ui.base import UI
 
 
@@ -711,7 +712,12 @@ def _validate_decompose_output(data: Any) -> list[str]:
     return errors
 
 
-_VALID_SEVERITIES = frozenset({"blocker", "major", "minor"})
+# Severities, worst first. The order ``_issue_counts`` counts in and
+# the convergence report renders in. ``_surface_spec_issues`` below
+# still enumerates its own three groups, because it pairs each with a
+# different UI emitter and a label that is not the severity name.
+_SEVERITY_ORDER = ("blocker", "major", "minor")
+_VALID_SEVERITIES = frozenset(_SEVERITY_ORDER)
 _VALID_KINDS = frozenset(
     {
         "ambiguity",
@@ -824,9 +830,12 @@ def _issue_dicts(issues: list[SpecIssue]) -> list[dict[str, str]]:
 
 
 def _issue_counts(issues: list[SpecIssue]) -> dict[str, int]:
-    return {
-        sev: sum(1 for i in issues if i.severity == sev) for sev in ("blocker", "major", "minor")
-    }
+    """Per-severity counts, in ``_SEVERITY_ORDER``.
+
+    Counts this run's issues and a previous run's (rehydrated from the
+    journal by ``_stored_issues``) with the same code.
+    """
+    return {sev: sum(1 for i in issues if i.severity == sev) for sev in _SEVERITY_ORDER}
 
 
 def persist_spec_issues(
@@ -859,9 +868,23 @@ def persist_spec_issues(
     return path
 
 
+def _spec_audit_journal(root_dir: Path) -> EvolutionJournal | None:
+    """The evolution journal for this root, or None when it is off.
+
+    One loader for both directions of the audit trail: the read that
+    builds the convergence report and the write that records this run.
+    ``EvolutionConfig.load`` already anchors a relative journal path to
+    ``root_dir``, so the path it hands back is absolute.
+    """
+    from kstrl.evolution import EvolutionConfig, EvolutionJournal
+
+    config = EvolutionConfig.load(root_dir)
+    return EvolutionJournal(config) if config.enabled else None
+
+
 def _record_spec_issues_event(
     issues: list[SpecIssue],
-    root_dir: Path,
+    journal: EvolutionJournal | None,
     project_name: str,
     spec_file: str,
     halted: bool,
@@ -872,16 +895,12 @@ def _record_spec_issues_event(
     Non-fatal on I/O errors, matching ``EvolutionJournal.record_run``,
     but the failure is surfaced as a warning rather than swallowed:
     the journal is an audit trail, so a silent skip would defeat it.
-    No ``run_id`` field: decompose runs before a factory run id exists.
+    No ``run_id`` field: decompose runs before a factory run id exists,
+    which is why ``EvolutionJournal.get_spec_issue_runs`` reads these
+    entries rather than the run-windowed reader.
     """
-    from kstrl.evolution import EvolutionConfig
-
-    evo_config = EvolutionConfig.load(root_dir)
-    if not evo_config.enabled:
+    if journal is None:
         return
-    journal_path = evo_config.journal_path
-    if not journal_path.is_absolute():
-        journal_path = root_dir / journal_path
     entry: dict[str, Any] = {
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "project": project_name,
@@ -893,11 +912,177 @@ def _record_spec_issues_event(
         "artifact": SPEC_ISSUES_REL_PATH.as_posix(),
     }
     try:
-        journal_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(journal_path, "a") as f:
-            f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+        journal.append_entries([entry])
     except OSError as exc:
         ui.warn(f"Failed to record spec_issues journal event: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Convergence report (#260)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SpecConvergence:
+    """This spec audit measured against earlier audits of the same project.
+
+    ``repeated`` counts this run's issues whose text is unchanged from
+    the previous run. It is a floor on what carried over and never a
+    claim about which issues the architect considers resolved.
+    """
+
+    current_counts: dict[str, int]
+    previous_counts: dict[str, int]
+    current_spec_file: str
+    previous_spec_file: str
+    repeated: int
+    blocker_trend: tuple[int, ...]
+
+    @property
+    def previous_total(self) -> int:
+        return sum(self.previous_counts.values())
+
+
+def _issue_identity(issue: SpecIssue) -> tuple[str, str]:
+    """Match key for one issue: kind plus normalized summary text.
+
+    Whitespace is collapsed and case folded, which is all the
+    normalization the stored text supports. Severity is deliberately
+    not part of the key, so the same finding re-raised at a different
+    severity still matches.
+    """
+    return (issue.kind, " ".join(issue.summary.split()).casefold())
+
+
+def _stored_issues(entry: dict[str, Any]) -> list[SpecIssue] | None:
+    """Rehydrate one journal entry's issue list into ``SpecIssue``.
+
+    Returns None when the entry carries no issue list at all, the one
+    shape that cannot be compared. Every other malformation (a non-dict
+    issue, a missing field, a non-string value) is normalized here, so
+    a journal written by an older version reads without crashing.
+    ``location`` and ``suggestion`` are not read back: the report
+    compares counts and issue text only.
+    """
+    raw = entry.get("issues")
+    if not isinstance(raw, list):
+        return None
+    return [
+        SpecIssue(
+            severity=str(i.get("severity", "")),
+            kind=str(i.get("kind", "")),
+            summary=str(i.get("summary", "")),
+        )
+        for i in raw
+        if isinstance(i, dict)
+    ]
+
+
+def _build_convergence(
+    issues: list[SpecIssue],
+    spec_file: str,
+    history: list[dict[str, Any]],
+) -> SpecConvergence | None:
+    """Compare this run's issues with prior audits (``history``, oldest first).
+
+    Returns None when there is no comparable prior audit, so the first
+    run on a spec prints nothing.
+    """
+    audits: list[tuple[str, list[SpecIssue]]] = []
+    trend: list[int] = []
+    for entry in history:
+        stored = _stored_issues(entry)
+        if stored is not None:
+            audits.append((str(entry.get("spec_file", "")), stored))
+            trend.append(sum(1 for i in stored if i.severity == "blocker"))
+    if not audits:
+        return None
+
+    previous_spec_file, previous_issues = audits[-1]
+    previous_ids = {_issue_identity(i) for i in previous_issues}
+    current_counts = _issue_counts(issues)
+    return SpecConvergence(
+        current_counts=current_counts,
+        previous_counts=_issue_counts(previous_issues),
+        current_spec_file=spec_file,
+        previous_spec_file=previous_spec_file,
+        repeated=sum(1 for i in issues if _issue_identity(i) in previous_ids),
+        blocker_trend=(*trend, current_counts["blocker"]),
+    )
+
+
+def _spec_convergence(
+    issues: list[SpecIssue],
+    journal: EvolutionJournal | None,
+    project_name: str,
+    spec_file: str,
+) -> SpecConvergence | None:
+    """Read this project's audit history and compare this run to it.
+
+    Runs are matched by project name, not by spec path or content
+    hash: the spec is edited between every round by construction (so a
+    content hash never matches), and the recorded loop in #260 renamed
+    the file mid-loop (so the path does not either). A previous audit
+    of a different file is still reported, with the file names named.
+
+    MUST be called before this run's own entry is appended to the
+    journal, or the "previous run" it compares against is this one.
+    """
+    if journal is None:
+        return None
+    return _build_convergence(
+        issues,
+        spec_file,
+        # How far back the trend line reaches. The journal's existing
+        # lookback knob rather than a number invented here, read as
+        # "the last N spec audits" - decompose writes one audit per
+        # run, with or without a factory run behind it.
+        journal.get_spec_issue_runs(project_name, last_n=journal.config.lookback_runs),
+    )
+
+
+def _surface_convergence(report: SpecConvergence | None, ui: UI) -> None:
+    """Render the convergence report, or nothing on the first run.
+
+    ``None`` (no journal, or no previous audit of this project) renders
+    silently, so the common first-run case prints no noise and the
+    caller has no branch to carry.
+
+    Counts, deltas and the trend, with no "this spec is converging"
+    verdict attached: no measured threshold separates converging from
+    not. The recorded blocker counts for one spec went 7, 11, 1, 3, 4,
+    and the rise from 1 to 3 happened while the operator was resolving
+    real issues. The numbers are the evidence; the judgement about
+    whether to pay for another round is the operator's.
+    """
+    if report is None:
+        return
+    ui.section("Spec Convergence")
+    for severity in _SEVERITY_ORDER:
+        current = report.current_counts[severity]
+        previous = report.previous_counts[severity]
+        delta = current - previous
+        ui.kv(
+            severity.capitalize(),
+            f"{current} (previous run: {previous}, {f'{delta:+d}' if delta else 'no change'})",
+        )
+    ui.kv(
+        "Trend",
+        ", ".join(str(n) for n in report.blocker_trend) + " (blockers, oldest run first)",
+    )
+    ui.info(
+        f"Previous run raised {report.previous_total} issue(s): {report.repeated} "
+        f"reappear verbatim, {report.previous_total - report.repeated} do not."
+    )
+    ui.info(
+        "Matched on issue text, so a reworded issue counts as new: a floor on "
+        "what carried over, not a count of what the architect resolved."
+    )
+    if report.previous_spec_file and report.previous_spec_file != report.current_spec_file:
+        ui.info(
+            f"Runs are matched by project name: the previous audit read "
+            f"{report.previous_spec_file}, this one read {report.current_spec_file}."
+        )
 
 
 def _component_branch(comp_id: str, project_name: str, single_pr: bool) -> str:
@@ -1172,6 +1357,14 @@ def _decompose_spec_impl(
                 suggestion=issue.suggestion,
             )
         )
+    # #260: what this audit says about the previous one, read BEFORE
+    # this run is appended to the journal below - otherwise the
+    # "previous run" the report compares against would be this one.
+    journal = _spec_audit_journal(root_dir)
+    _surface_convergence(
+        _spec_convergence(spec_issues, journal, project_name, spec_path.name),
+        ui,
+    )
     blockers = [i for i in spec_issues if i.severity == "blocker"]
     artifact_path: Path | None = None
     try:
@@ -1195,7 +1388,7 @@ def _decompose_spec_impl(
         ui.err(f"Failed to persist spec issues to disk: {exc}")
     _record_spec_issues_event(
         spec_issues,
-        root_dir=root_dir,
+        journal=journal,
         project_name=project_name,
         spec_file=spec_path.name,
         halted=bool(blockers),

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -509,10 +509,7 @@ class EvolutionJournal:
             entries.append(entry)
 
         try:
-            self.config.journal_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(self.config.journal_path, "a") as f:
-                for entry in entries:
-                    f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+            self.append_entries(entries)
         except OSError as exc:
             logger.warning(
                 "evolution journal write failed (non-fatal): %s: %s",
@@ -1118,26 +1115,77 @@ class EvolutionJournal:
         return rows[-last_n:]
 
     # ------------------------------------------------------------------
+    # get_spec_issue_runs
+    # ------------------------------------------------------------------
+
+    def get_spec_issue_runs(self, project: str, last_n: int = 10) -> list[dict[str, Any]]:
+        """The last N recorded spec audits for ``project``, oldest first (#260).
+
+        Deliberately NOT routed through :meth:`_read_journal_entries`:
+        that reader keeps only entries whose ``run_id`` is among the
+        last N distinct run ids, and a ``spec_issues`` entry carries no
+        ``run_id`` at all (decompose runs before a factory run id
+        exists), so every one of them is dropped there. Reading the raw
+        entries is what makes the architect's own history readable.
+
+        ``last_n`` counts spec audits, not factory runs - a spec audit
+        happens once per decompose, whether or not a factory run
+        follows. Windowed here rather than by the caller, matching
+        :meth:`get_experiment_trends`.
+
+        Nothing is assumed about an entry beyond it being a JSON
+        object, so journals written by older versions read cleanly.
+        """
+        runs = [
+            entry
+            for entry in self._read_all_entries()
+            if entry.get("event_type") == "spec_issues" and entry.get("project") == project
+        ]
+        return runs[-last_n:] if last_n > 0 else []
+
+    # ------------------------------------------------------------------
+    # append_entries
+    # ------------------------------------------------------------------
+
+    def append_entries(self, entries: list[dict[str, Any]]) -> None:
+        """Append entries to the journal in JSONL form.
+
+        The one writer of the journal's line format. Raises ``OSError``
+        rather than handling it, because the two callers surface a
+        failed write differently: :meth:`record_run` logs it, while
+        decompose warns through the run's UI.
+        """
+        self.config.journal_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.config.journal_path, "a") as f:
+            for entry in entries:
+                f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+
+    # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _read_all_entries(self) -> list[dict[str, Any]]:
+        """Every well-formed JSON object in the journal, in file order.
+
+        Delegates to ``observability.read_progress_events``: the
+        journal and the progress log are the same JSONL-of-objects
+        convention, and the tolerant-read policy (missing file, blank
+        line, torn line, non-object line - all skipped) should be one
+        policy rather than two. One unreadable line must not cost the
+        reader the rest of the history.
+        """
+        from kstrl.observability import read_progress_events
+
+        return read_progress_events(self.config.journal_path)
+
     def _read_journal_entries(self, lookback_runs: int = 10) -> list[dict[str, Any]]:
-        """Read JSONL journal and return entries from the last N distinct runs."""
-        try:
-            lines = self.config.journal_path.read_text().strip().splitlines()
-        except OSError:
-            return []
+        """Read JSONL journal and return entries from the last N distinct runs.
 
-        entries: list[dict[str, Any]] = []
-        for line in lines:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entries.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
-
+        Entries without a ``run_id`` are dropped, because the window is
+        defined in terms of runs. ``spec_issues`` entries are exactly
+        that case; :meth:`get_spec_issue_runs` reads those instead.
+        """
+        entries = self._read_all_entries()
         if not entries:
             return []
 

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -12,7 +12,7 @@ import json
 import logging
 import os
 import re
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -113,6 +113,34 @@ class EvolutionConfig:
         _apply_env_overrides(config, root_dir)
         _resolve_relative_paths(config, root_dir)
         return config
+
+    @classmethod
+    def load_or_none(
+        cls,
+        root_dir: Path,
+        warn: Callable[[str], None],
+    ) -> EvolutionConfig | None:
+        """:meth:`load`, but a config that will not parse returns None.
+
+        The journal is an optional audit trail and every caller loads it
+        in the middle of work that has already been paid for, so a typo
+        in one of its knobs should cost the journal, not the run.
+
+        Which exceptions that means is stated here rather than at a call
+        site, because it is a fact about :meth:`load`: ``ValueError``
+        from malformed TOML or a non-integer ``lookback_runs`` (from the
+        file or from ``KSTRL_EVOLUTION_LOOKBACK_RUNS``), and ``OSError``
+        from an unreadable ``kstrl.toml``. A future coercion added to
+        ``load`` is then covered here instead of silently escaping a
+        guard somebody wrote around a call.
+
+        Degrades loudly: ``warn`` is called with the parse failure.
+        """
+        try:
+            return cls.load(root_dir)
+        except (ValueError, OSError) as exc:
+            warn(f"Evolution config unreadable, skipping journal: {exc}")
+            return None
 
 
 def _apply_env_overrides(config: EvolutionConfig, root_dir: Path) -> None:

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 from collections.abc import Iterator
 from pathlib import Path
@@ -10,7 +11,10 @@ import pytest
 
 from kstrl.decompose import (
     SpecBlockerError,
+    SpecIssue,
+    _build_convergence,
     _extract_json,
+    _issue_dicts,
     _parse_spec_issues,
     _validate_decompose_output,
     decompose_spec,
@@ -738,26 +742,49 @@ MINOR_ISSUE: dict[str, object] = {
 }
 
 
-class TestSpecIssuesPersistence:
-    """R1.7: red-team output becomes a durable artifact + journal event."""
+def _run_decompose(
+    tmp_path: Path,
+    output: str,
+    *,
+    spec_name: str = "spec.md",
+    project_name: str = "test",
+) -> str:
+    """Decompose a spec against a mock agent; returns the UI output.
 
-    def _run(
-        self,
-        tmp_path: Path,
-        output: str,
-    ) -> Path:
-        spec_file = tmp_path / "spec.md"
-        spec_file.write_text("# Spec\nBuild it.")
-        (tmp_path / "scripts" / "kstrl").mkdir(parents=True, exist_ok=True)
+    A blocker halt is swallowed, because what decompose printed and
+    wrote before raising is what these tests are about.
+    """
+    spec_file = tmp_path / spec_name
+    spec_file.write_text("# Spec\nBuild it.")
+    (tmp_path / "scripts" / "kstrl").mkdir(parents=True, exist_ok=True)
+    buffer = io.StringIO()
+    try:
         decompose_spec(
             spec_path=spec_file,
-            project_name="test",
+            project_name=project_name,
             base_branch="main",
             single_pr=False,
             agent=MockDecomposeAgent(output),
-            ui=PlainUI(no_color=True),
+            ui=PlainUI(no_color=True, file=buffer),
             root_dir=tmp_path,
         )
+    except SpecBlockerError:
+        pass
+    return buffer.getvalue()
+
+
+def _read_spec_issue_events(tmp_path: Path) -> list[dict[str, object]]:
+    journal = tmp_path / ".kstrl" / "evolution.jsonl"
+    assert journal.exists(), "journal event was not written"
+    entries = [json.loads(line) for line in journal.read_text().splitlines() if line.strip()]
+    return [e for e in entries if e.get("event_type") == "spec_issues"]
+
+
+class TestSpecIssuesPersistence:
+    """R1.7: red-team output becomes a durable artifact + journal event."""
+
+    def _run(self, tmp_path: Path, output: str) -> Path:
+        _run_decompose(tmp_path, output)
         return tmp_path / "scripts" / "kstrl" / "spec-issues.json"
 
     def test_artifact_written_on_halt(self, tmp_path: Path) -> None:
@@ -820,12 +847,6 @@ class TestSpecIssuesPersistence:
         assert content["halted"] is False
         assert content["issues"] == []
 
-    def _read_journal_events(self, tmp_path: Path) -> list[dict[str, object]]:
-        journal = tmp_path / ".kstrl" / "evolution.jsonl"
-        assert journal.exists(), "journal event was not written"
-        entries = [json.loads(line) for line in journal.read_text().splitlines() if line.strip()]
-        return [e for e in entries if e.get("event_type") == "spec_issues"]
-
     def test_journal_event_on_halt(self, tmp_path: Path) -> None:
         spec_file = tmp_path / "spec.md"
         spec_file.write_text("# Vague spec")
@@ -843,7 +864,7 @@ class TestSpecIssuesPersistence:
                 root_dir=tmp_path,
             )
 
-        events = self._read_journal_events(tmp_path)
+        events = _read_spec_issue_events(tmp_path)
         assert len(events) == 1
         assert events[0]["halted"] is True
         assert events[0]["counts"] == {"blocker": 1, "major": 0, "minor": 0}
@@ -854,7 +875,7 @@ class TestSpecIssuesPersistence:
             tmp_path,
             _single_component_output([_story()], spec_issues=[MINOR_ISSUE]),
         )
-        events = self._read_journal_events(tmp_path)
+        events = _read_spec_issue_events(tmp_path)
         assert len(events) == 1
         assert events[0]["halted"] is False
         assert events[0]["counts"] == {"blocker": 0, "major": 0, "minor": 1}
@@ -964,3 +985,243 @@ class TestPrdValidationInsideRetryLoop:
         assert not (tmp_path / "scripts" / "kstrl" / "manifest.json").exists()
         # The audit artifact is deliberately kept.
         assert (tmp_path / "scripts" / "kstrl" / "spec-issues.json").exists()
+
+
+class TestSpecConvergenceReport:
+    """#260: what this audit says about the previous one."""
+
+    def _issue(self, severity: str, kind: str, summary: str) -> SpecIssue:
+        return SpecIssue(severity=severity, kind=kind, summary=summary)
+
+    def _entry(
+        self,
+        issues: list[SpecIssue] | None,
+        spec_file: str = "spec.md",
+    ) -> dict[str, object]:
+        """One prior journal entry, in the shape decompose writes."""
+        entry: dict[str, object] = {"event_type": "spec_issues", "spec_file": spec_file}
+        if issues is not None:
+            entry["issues"] = _issue_dicts(issues)
+        return entry
+
+    def test_first_run_has_nothing_to_compare(self) -> None:
+        assert _build_convergence([self._issue("blocker", "ambiguity", "a")], "spec.md", []) is None
+
+    def test_entry_without_an_issue_list_is_not_a_comparison(self) -> None:
+        """An entry that cannot be counted is not evidence, and a
+        journal holding only such entries reads as no history."""
+        assert _build_convergence([], "spec.md", [self._entry(None)]) is None
+
+    def test_counts_and_deltas_against_the_previous_run(self) -> None:
+        report = _build_convergence(
+            [
+                self._issue("blocker", "ambiguity", "new one"),
+                self._issue("blocker", "contradiction", "another"),
+                self._issue("minor", "other", "small"),
+            ],
+            "spec.md",
+            [self._entry([self._issue("blocker", "ambiguity", "old one")])],
+        )
+
+        assert report is not None
+        assert report.current_counts == {"blocker": 2, "major": 0, "minor": 1}
+        assert report.previous_counts == {"blocker": 1, "major": 0, "minor": 0}
+        assert report.previous_total == 1
+
+    def test_repeats_match_on_normalized_text(self) -> None:
+        """Collapsed whitespace and folded case still match, and so does
+        a changed severity; different wording does not."""
+        report = _build_convergence(
+            [
+                self._issue("major", "ambiguity", "What   'FAST' means\nis not defined"),
+                self._issue("blocker", "ambiguity", "What fast means is undefined"),
+            ],
+            "spec.md",
+            [
+                self._entry(
+                    [
+                        self._issue("blocker", "ambiguity", "What 'fast' means is not defined"),
+                        self._issue("minor", "other", "gone"),
+                    ]
+                )
+            ],
+        )
+
+        assert report is not None
+        assert report.repeated == 1
+        assert report.previous_total == 2
+
+    def test_same_summary_under_a_different_kind_is_not_a_repeat(self) -> None:
+        report = _build_convergence(
+            [self._issue("blocker", "contradiction", "same words")],
+            "spec.md",
+            [self._entry([self._issue("blocker", "ambiguity", "same words")])],
+        )
+
+        assert report is not None
+        assert report.repeated == 0
+
+    def test_trend_spans_every_recorded_run_and_ends_with_this_one(self) -> None:
+        history = [
+            self._entry([self._issue("blocker", "ambiguity", f"r1-{n}") for n in range(7)]),
+            self._entry([self._issue("blocker", "ambiguity", f"r2-{n}") for n in range(11)]),
+            self._entry([self._issue("blocker", "ambiguity", "r3-0")]),
+            self._entry([self._issue("blocker", "ambiguity", f"r4-{n}") for n in range(3)]),
+        ]
+
+        report = _build_convergence(
+            [self._issue("blocker", "ambiguity", f"r5-{n}") for n in range(4)],
+            "spec-slice-1.md",
+            history,
+        )
+
+        assert report is not None
+        assert report.blocker_trend == (7, 11, 1, 3, 4)
+
+    def test_previous_spec_file_is_carried_for_the_rename_case(self) -> None:
+        report = _build_convergence(
+            [],
+            "spec-slice-1.md",
+            [self._entry([], spec_file="spec.md")],
+        )
+
+        assert report is not None
+        assert report.previous_spec_file == "spec.md"
+        assert report.current_spec_file == "spec-slice-1.md"
+
+    def test_malformed_stored_issues_do_not_crash_the_reader(self) -> None:
+        """Journals written by older versions, and any entry an
+        operator hand-edited, must read rather than raise."""
+        history: list[dict[str, object]] = [
+            {
+                "event_type": "spec_issues",
+                "issues": [
+                    "not a dict",
+                    {"severity": "blocker"},
+                    {"summary": None, "kind": 7, "severity": "major"},
+                ],
+            }
+        ]
+
+        report = _build_convergence([], "spec.md", history)
+
+        assert report is not None
+        assert report.previous_counts == {"blocker": 1, "major": 1, "minor": 0}
+        assert report.previous_spec_file == ""
+
+
+class TestSpecConvergenceThroughDecompose:
+    """The report as the operator meets it, on the real code path."""
+
+    def _run(
+        self,
+        tmp_path: Path,
+        issues: list[dict[str, object]],
+        spec_name: str = "spec.md",
+        project_name: str = "writers-room",
+    ) -> str:
+        return _run_decompose(
+            tmp_path,
+            _single_component_output([_story()], spec_issues=issues),
+            spec_name=spec_name,
+            project_name=project_name,
+        )
+
+    def test_first_run_prints_no_report(self, tmp_path: Path) -> None:
+        output = self._run(tmp_path, [BLOCKER_ISSUE])
+        assert "Spec Convergence" not in output
+
+    def test_second_run_compares_against_the_first(self, tmp_path: Path) -> None:
+        """Also pins the ordering: the history is read before this run
+        is appended, so "previous run" is never this run."""
+        self._run(tmp_path, [BLOCKER_ISSUE])
+        output = self._run(
+            tmp_path,
+            [
+                BLOCKER_ISSUE,
+                {
+                    "severity": "blocker",
+                    "kind": "contradiction",
+                    "summary": "Stage is recorded twice",
+                    "location": "",
+                    "suggestion": "",
+                },
+                MINOR_ISSUE,
+            ],
+        )
+
+        assert "Spec Convergence" in output
+        assert "Blocker:" in output
+        assert "2 (previous run: 1, +1)" in output
+        assert "Minor:" in output
+        assert "1 (previous run: 0, +1)" in output
+        assert "1, 2 (blockers, oldest run first)" in output
+        assert "Previous run raised 1 issue(s): 1 reappear verbatim, 0 do not." in output
+
+    def test_journal_entries_still_carry_no_run_id(self, tmp_path: Path) -> None:
+        """The report reads entries the run-windowed reader drops; if a
+        run_id ever appears here, that reader would start windowing
+        spec audits by factory run and this feature would go quiet."""
+        self._run(tmp_path, [BLOCKER_ISSUE])
+        events = _read_spec_issue_events(tmp_path)
+
+        assert events and all("run_id" not in e for e in events)
+
+    def test_a_legacy_entry_without_run_id_does_not_break_the_read(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        journal = tmp_path / ".kstrl" / "evolution.jsonl"
+        journal.parent.mkdir(parents=True)
+        journal.write_text(
+            json.dumps({"event_type": "component_result", "component": "legacy"}) + "\n"
+        )
+
+        self._run(tmp_path, [BLOCKER_ISSUE])
+        output = self._run(tmp_path, [BLOCKER_ISSUE])
+
+        assert "1 (previous run: 1, no change)" in output
+        assert "1, 1 (blockers, oldest run first)" in output
+
+    def test_a_rename_is_reported_rather_than_hidden(self, tmp_path: Path) -> None:
+        self._run(tmp_path, [BLOCKER_ISSUE], spec_name="spec.md")
+        output = self._run(tmp_path, [BLOCKER_ISSUE], spec_name="spec-slice-1.md")
+
+        assert "the previous audit read spec.md, this one read spec-slice-1.md" in output
+
+    def test_a_different_project_has_its_own_history(self, tmp_path: Path) -> None:
+        self._run(tmp_path, [BLOCKER_ISSUE], project_name="writers-room")
+        output = self._run(tmp_path, [BLOCKER_ISSUE], project_name="deckgen")
+
+        assert "Spec Convergence" not in output
+
+    def test_a_clean_audit_still_reports_the_drop(self, tmp_path: Path) -> None:
+        self._run(tmp_path, [BLOCKER_ISSUE])
+        output = self._run(tmp_path, [])
+
+        assert "0 (previous run: 1, -1)" in output
+        assert "1, 0 (blockers, oldest run first)" in output
+        assert "Previous run raised 1 issue(s): 0 reappear verbatim, 1 do not." in output
+
+    def test_the_window_is_the_journal_lookback(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "2")
+        for _ in range(3):
+            self._run(tmp_path, [BLOCKER_ISSUE])
+        output = self._run(tmp_path, [BLOCKER_ISSUE])
+
+        assert "1, 1, 1 (blockers, oldest run first)" in output
+
+    def test_no_report_when_the_journal_is_off(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._run(tmp_path, [BLOCKER_ISSUE])
+        monkeypatch.setenv("KSTRL_EVOLUTION_ENABLED", "0")
+        output = self._run(tmp_path, [BLOCKER_ISSUE])
+
+        assert "Spec Convergence" not in output

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -1109,6 +1109,43 @@ class TestSpecConvergenceReport:
         assert report.previous_counts == {"blocker": 1, "major": 1, "minor": 0}
         assert report.previous_spec_file == ""
 
+    def test_two_current_issues_matching_one_previous_cannot_overcount(self) -> None:
+        """`repeated` is rendered as a statement about the previous
+        run, so it must be counted over that side. Counting the current
+        side let two current issues match one previous issue and made
+        "did not come back" negative: `_issue_identity` drops severity
+        and normalizes text, and `_parse_spec_issues` de-duplicates
+        nothing, so this shape is reachable from real architect output.
+        """
+        report = _build_convergence(
+            [
+                self._issue("blocker", "ambiguity", "What fast means is undefined"),
+                self._issue("major", "ambiguity", "What  FAST  means is undefined"),
+            ],
+            "spec.md",
+            [self._entry([self._issue("blocker", "ambiguity", "What fast means is undefined")])],
+        )
+
+        assert report is not None
+        assert report.previous_total == 1
+        assert report.repeated == 1
+        assert report.previous_total - report.repeated == 0
+
+    def test_a_previous_issue_raised_twice_counts_twice_when_it_returns(self) -> None:
+        """The mirror case, and why this counts the previous list
+        rather than intersecting two identity sets: both of the
+        previous run's issues did come back, so 0 of 2 did not."""
+        duplicated = self._issue("blocker", "ambiguity", "same finding, said twice")
+        report = _build_convergence(
+            [self._issue("blocker", "ambiguity", "same finding, said twice")],
+            "spec.md",
+            [self._entry([duplicated, duplicated])],
+        )
+
+        assert report is not None
+        assert report.previous_total == 2
+        assert report.repeated == 2
+
 
 class TestSpecConvergenceThroughDecompose:
     """The report as the operator meets it, on the real code path."""
@@ -1225,3 +1262,89 @@ class TestSpecConvergenceThroughDecompose:
         output = self._run(tmp_path, [BLOCKER_ISSUE])
 
         assert "Spec Convergence" not in output
+
+    def test_the_rendered_overlap_never_goes_negative(self, tmp_path: Path) -> None:
+        """The end-to-end guard on the count: two current issues that
+        normalize to the previous run's single issue must not print
+        "2 reappear verbatim, -1 do not"."""
+        self._run(tmp_path, [BLOCKER_ISSUE])
+        restated = dict(BLOCKER_ISSUE)
+        restated["severity"] = "major"
+        restated["summary"] = "  What   'FAST'  MEANS is not   defined  "
+        output = self._run(tmp_path, [BLOCKER_ISSUE, restated])
+
+        assert "Previous run raised 1 issue(s): 1 reappear verbatim, 0 do not." in output
+        assert "-1 do not" not in output
+
+    def test_a_bad_evolution_config_does_not_cost_the_audit_artifact(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """R1.7 says the artifact is written for halt, success and
+        clean-audit alike. Loading the journal config happens before
+        that write, so a config that will not parse must degrade to
+        "no journal", never abort the audit."""
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "many")
+
+        output = self._run(tmp_path, [BLOCKER_ISSUE])
+
+        assert (tmp_path / "scripts" / "kstrl" / "spec-issues.json").exists()
+        assert "Evolution config unreadable" in output
+        assert "Spec Convergence" not in output
+
+    def test_malformed_toml_does_not_cost_the_audit_artifact_either(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The other ValueError path into EvolutionConfig.load.
+
+        Scoped to the halt path on purpose: a malformed kstrl.toml also
+        fails LinearConfig.load further down decompose, which is
+        pre-existing behaviour this change does not touch. The halt
+        raises before that point, and the halt is the case where the
+        artifact is the only record the operator gets.
+        """
+        (tmp_path / "kstrl.toml").write_text("[evolution\nenabled = true\n")
+
+        output = self._run(tmp_path, [BLOCKER_ISSUE])
+
+        assert (tmp_path / "scripts" / "kstrl" / "spec-issues.json").exists()
+        assert "Evolution config unreadable" in output
+
+    def test_the_artifact_is_written_before_any_journal_work(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The structural version of the two tests above, independent of
+        which exceptions the config guard happens to catch.
+
+        R1.7's artifact is the only durable record on the halt path, so
+        nothing that can fail belongs upstream of it. An error the guard
+        does not catch still leaves the artifact on disk.
+        """
+        import kstrl.evolution
+
+        def _explode(root_dir: Path | None = None) -> None:
+            raise RuntimeError("journal config exploded")
+
+        monkeypatch.setattr(kstrl.evolution.EvolutionConfig, "load", _explode)
+
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Spec")
+        (tmp_path / "scripts" / "kstrl").mkdir(parents=True, exist_ok=True)
+        with pytest.raises(RuntimeError, match="journal config exploded"):
+            decompose_spec(
+                spec_path=spec_file,
+                project_name="writers-room",
+                base_branch="main",
+                single_pr=False,
+                agent=MockDecomposeAgent(
+                    _single_component_output([_story()], spec_issues=[BLOCKER_ISSUE])
+                ),
+                ui=PlainUI(no_color=True, file=io.StringIO()),
+                root_dir=tmp_path,
+            )
+
+        assert (tmp_path / "scripts" / "kstrl" / "spec-issues.json").exists()

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -969,3 +969,92 @@ class TestProposalIdMonotonicity:
         written = journal.save_proposals(clashing, output_dir)
         assert written == []
         assert (output_dir / "prop-001.md").read_text() == "# PROP-001: original\n"
+
+
+# ---------------------------------------------------------------------------
+# get_spec_issue_runs (#260)
+# ---------------------------------------------------------------------------
+
+
+class TestSpecIssueRuns:
+    """#260: the architect's own history, which carries no run_id."""
+
+    def _journal(self, tmp_path: Path, lines: list[str]) -> EvolutionJournal:
+        journal_path = tmp_path / "evolution.jsonl"
+        journal_path.write_text("".join(line + "\n" for line in lines))
+        return EvolutionJournal(EvolutionConfig(journal_path=journal_path))
+
+    def _spec_entry(self, project: str, blockers: int) -> str:
+        return json.dumps(
+            {
+                "timestamp": "2026-08-29T00:00:00Z",
+                "project": project,
+                "event_type": "spec_issues",
+                "spec_file": "spec.md",
+                "halted": blockers > 0,
+                "counts": {"blocker": blockers, "major": 0, "minor": 0},
+                "issues": [
+                    {"severity": "blocker", "kind": "ambiguity", "summary": f"issue {n}"}
+                    for n in range(blockers)
+                ],
+            }
+        )
+
+    def test_entries_without_run_id_are_returned(self, tmp_path: Path) -> None:
+        """The reason this method exists: a spec_issues entry is written
+        before a run id exists, so the run-windowed reader drops it."""
+        journal = self._journal(
+            tmp_path,
+            [self._spec_entry("writers-room", 7), self._spec_entry("writers-room", 11)],
+        )
+
+        assert journal._read_journal_entries() == []
+        runs = journal.get_spec_issue_runs("writers-room")
+        assert [r["counts"]["blocker"] for r in runs] == [7, 11]
+
+    def test_other_projects_and_event_types_are_excluded(self, tmp_path: Path) -> None:
+        journal = self._journal(
+            tmp_path,
+            [
+                self._spec_entry("writers-room", 7),
+                self._spec_entry("deckgen", 1),
+                json.dumps({"project": "writers-room", "event_type": "component_result"}),
+            ],
+        )
+
+        runs = journal.get_spec_issue_runs("writers-room")
+        assert len(runs) == 1
+        assert runs[0]["counts"]["blocker"] == 7
+
+    def test_torn_and_non_object_lines_are_skipped(self, tmp_path: Path) -> None:
+        """One unreadable line must not cost the reader the history."""
+        journal = self._journal(
+            tmp_path,
+            [
+                "{not json",
+                "[1, 2, 3]",
+                '"a bare string"',
+                "",
+                self._spec_entry("writers-room", 4),
+            ],
+        )
+
+        assert [r["counts"]["blocker"] for r in journal.get_spec_issue_runs("writers-room")] == [4]
+
+    def test_missing_journal_reads_as_empty(self, tmp_path: Path) -> None:
+        config = EvolutionConfig(journal_path=tmp_path / "absent.jsonl")
+        assert EvolutionJournal(config).get_spec_issue_runs("writers-room") == []
+
+    def test_run_windowed_reader_survives_non_object_lines(self, tmp_path: Path) -> None:
+        """A JSON array on its own line used to enter the entry list and
+        then blow up the ``.get("run_id")`` that follows."""
+        journal = self._journal(
+            tmp_path,
+            [
+                "[1, 2, 3]",
+                json.dumps({"run_id": "r1", "event_type": "component_result", "component": "a"}),
+            ],
+        )
+
+        entries = journal._read_journal_entries()
+        assert [e["component"] for e in entries] == ["a"]


### PR DESCRIPTION
Builds proposal 2 of the five in #260, and only that one. The other four
(a declared scope narrowing the audit, `--accept-blockers`, the architect
emitting spec patches, the architect resolving what it can measure) all
need a `DECOMPOSE_PROMPT` edit, which triggers H2/H3: a paid calibration
re-run, a version bump and a snapshot hash. Nothing in this PR touches any
`*_PROMPT` constant.

## What it does

The architect already wrote a `spec_issues` record per decompose to
`.kstrl/evolution.jsonl`, carrying the per-severity counts and the full
issue list. Nothing read it back. So an operator paying for round 3 was
told what round 3 found and never that round 2 had found fewer.

`ks decompose`, and the decompose phase of `ks factory`, now print a
convergence block next to the audit findings. Real output, from a
three-round smoke over the real code path:

```
== Spec Audit Findings ==
  Blockers:     2
ERROR:   [ambiguity] Dispatch kinds cannot cover six stages
ERROR:   [contradiction] Stage is in front matter and in state.json
  Major:        1
WARN:   [missing_detail] Judge family is never recorded

== Spec Convergence ==
  Blocker:      2 (previous run: 1, +1)
  Major:        1 (previous run: 1, no change)
  Minor:        0 (previous run: 0, no change)
  Trend:        1, 2 (blockers, oldest run first)
Previous run raised 2 issue(s): 1 reappear verbatim, 1 do not.
Matched on issue text, so a reworded issue counts as new: a floor on what
carried over, not a count of what the architect resolved.
```

and on a later round that renamed the spec and came back clean:

```
== Spec Convergence ==
  Blocker:      0 (previous run: 2, -2)
  Major:        0 (previous run: 1, -1)
  Minor:        0 (previous run: 0, no change)
  Trend:        1, 2, 0 (blockers, oldest run first)
Previous run raised 3 issue(s): 0 reappear verbatim, 3 do not.
Matched on issue text, so a reworded issue counts as new: a floor on what
carried over, not a count of what the architect resolved.
Runs are matched by project name: the previous audit read spec.md, this one
read spec-slice-1.md.
```

The gate is unchanged. A blocker still halts. What changes is what the
operator knows when deciding whether to pay for the next round.

## The four design questions

**1. What identifies "the same spec"?** The project name, plus the fact
that the journal is already per-repo (`.kstrl/evolution.jsonl` under the
root).

The other two candidates both fail on the loop this feature exists to
describe. A content hash never matches, because the spec is edited between
every round by construction, so the report would print on round 2 and
never again. The file path fails too: the recorded loop in #260 renamed
`spec.md` to `spec-slice-1.md` mid-loop while it was recognisably the same
project, and keying on the path would have gone silent exactly when the
trend became interesting.

What project name fails on, stated plainly: two genuinely different specs
decomposed under one project name in one repo interleave their histories,
and renaming the project resets the history to nothing. The second failure
is quiet and safe (the report just does not print). The first is made
visible rather than hidden: whenever the previous audit read a different
file, the report names both files, so an operator who sees
`spec.md` -> `unrelated-thing.md` can tell the comparison is not
like-for-like.

**2. What counts as convergence?** Deliberately not decided here. The
report prints three things and claims nothing beyond them:

- per-severity counts with the delta against the previous audit,
- the blocker count of every recorded audit for the project, oldest first,
- the two-sided verbatim overlap with the previous run.

On issue identity: I match on `(kind, summary)` with whitespace collapsed
and case folded. That is all the normalization the stored text supports.
Severity is deliberately not part of the key, so the same finding re-raised
at a different severity still counts as carried over. A reworded issue
counts as new, which means the "reappear verbatim" number is a floor on
what carried over and never a count of what the architect resolved. The UI
says exactly that, on its own line, rather than printing a confident
"Resolved: 7" that the data cannot support. #260's own round 2 is the
proof: all seven blockers were genuinely resolved and eleven new ones
appeared, so a naive count-based "resolved" number would have been right
by accident there and wrong the moment an issue came back reworded.

**3. What does it say when there is no previous run?** Nothing at all. The
first run on a spec is the common case and prints no extra line. The same
silence covers a disabled evolution journal, a journal that cannot be read,
and a first run under a new project name. `_surface_convergence(None, ui)`
returns immediately, so the caller carries no branch either.

**4. Is the advice line earned?** No, and it is not printed. The proposed
line in #260 was "This spec is not converging. Consider narrowing the
version 1 scope." I cannot justify a threshold that separates converging
from not: the recorded blocker counts for one spec went 7, 11, 1, 3, 4, and
the rise from 1 to 3 in rounds 3 to 4 happened while the operator was
cutting scope and resolving real things. A rule that fires on "blockers
went up" would have called that progress a failure. CLAUDE.md is explicit
that inventing numerical values is prohibited, so the report prints the
numbers, including the whole trend on one line, and leaves the judgement
where the evidence is: with the operator. The trend line is what makes the
point on round 2 that took five rounds to see.

## The gotcha in the issue, confirmed

`EvolutionJournal._read_journal_entries` windows by `run_id` and returns
only entries whose `run_id` is among the last N distinct runs. Every
`spec_issues` entry lacks a `run_id`, because decompose runs before a
factory run id exists, so the existing reader returns none of them. A test
pins this: `test_entries_without_run_id_are_returned` asserts
`_read_journal_entries() == []` on a journal made entirely of spec audits,
next to `get_spec_issue_runs` returning both.

I did not add a `run_id` to the entries. Doing so would have made them
visible to the run-windowed reader, which would then window spec audits by
factory run, and a decompose that halts produces no factory run at all. A
second test (`test_journal_entries_still_carry_no_run_id`) fails if a
`run_id` ever appears on these entries, so the coupling is recorded rather
than assumed.

Old entries do not crash the reader. `_stored_issues` rehydrates whatever
is on disk, returning `None` only when there is no issue list at all;
non-dict issues, missing fields and non-string values are all normalized.
Torn lines, blank lines and non-object lines are skipped by the shared
tolerant reader.

## Two cleanups the change made possible

`_read_all_entries` delegates to `observability.read_progress_events`
rather than reimplementing the tolerant JSONL read. The two files are the
same convention and the skip policy should be one policy, not two. It also
fixes a latent hole in the old reader: a JSON array on its own line entered
the entry list and would then blow up the `.get("run_id")` that follows.
`test_run_windowed_reader_survives_non_object_lines` covers it.

`EvolutionJournal.append_entries` is now the one writer of the journal's
line format. `record_run` and the decompose recorder both go through it and
keep their own error surface (one logs, one warns through the run UI).

## Cost of the read

Measured in this worktree, not estimated. `get_spec_issue_runs` on the real
36 KB journal: median 0.092 ms. On a synthetic journal 1000x that size
(35.9 MB): 120 ms. It runs once per decompose, next to an architect call
measured at 119 to 210 seconds in #260.

## Testing

23 new tests. `TestSpecConvergenceReport` covers the pure comparison (no
previous run, an entry with no issue list, counts and deltas, normalized
repeat matching, a same-summary-different-kind non-match, a five-point
trend reproducing #260's own 7, 11, 1, 3, 4, the rename case, and malformed
stored issues). `TestSpecConvergenceThroughDecompose` covers the real code
path (first run silent, second run's deltas, no run_id on the entries, a
legacy entry with no run_id in the journal, the rename line, project
isolation, a clean audit after a halt, the lookback window, and the journal
disabled). `TestSpecIssueRuns` in test_evolution.py covers the reader.

The ordering requirement (the history must be read before this run is
appended, or "previous run" is this run) was verified by mutation: moving
the call after `_record_spec_issues_event` fails five of these tests.

Local gate, all green on the rebased tree:

- `uv run pytest tests/ -q`: 3535 passed, 28 skipped
- `uv run mypy kstrl/ --strict`: clean
- `uv run ruff check kstrl/ tests/`: clean
- `pre-commit run --all-files`: clean
- coverage: 88.08% total against the 79.91% ratchet; decompose.py 90.29%,
  evolution.py 91.21%

`/simplify` was run over the change and its findings applied: the report
keeps `SpecIssue` as its currency instead of introducing a second dict
shape, the journal read is windowed inside the reader like
`get_experiment_trends`, the trend is computed in one pass, and the test
harness is now one shared helper instead of two.

## Review fixes (second commit)

Two defects an independent review found, both reproduced by execution
before and after the fix.

**`repeated` could print a negative number.** It was counted over this
run's issues but rendered as a sentence about the previous run. Those
agree only when no two issues on either side share an identity, and
`_issue_identity` deliberately drops severity and normalizes whitespace
and case while `_parse_spec_issues` de-duplicates nothing. Reproduced:
one previous blocker, restated this run as a blocker and again as a
major with different spacing and case, printed `Previous run raised 1
issue(s): 2 reappear verbatim, -1 do not.`

It now counts the previous list, which bounds the number by
`previous_total` by construction. I chose that over intersecting two
identity sets, which was the other correct fix for the negative number,
because it also matches the sentence in the mirror case: a previous
issue raised twice and answered once is two of the previous run's
issues that came back, which the intersection would report as one. Both
cases have a test.

**A bad journal config destroyed the audit artifact.** Loading the
evolution config had moved ahead of `persist_spec_issues`, and
`EvolutionConfig.load` raises `ValueError` on malformed TOML or a
non-integer `lookback_runs`. Reproduced with
`KSTRL_EVOLUTION_LOOKBACK_RUNS=many` on a blocker-raising decompose:
`main` writes `spec-issues.json` and then raises, this branch raised
with no artifact on disk. On the halt path that artifact is the only
durable record the operator gets, so a typo in an optional journal knob
cost them the findings of a paid architect run. That inverts the point
of the feature.

Fixed at two levels rather than one. `EvolutionConfig.load_or_none` is
a tolerant loader beside the config, so the knowledge of what a bad
journal config raises lives where `load` lives instead of being guessed
at a call site; a coercion added to `load` later is covered there rather
than silently escaping a guard someone wrote around a call. It is also
ready for the two other unguarded callers (`factory._record_contract_event`
and `autonomy`, which catches only `OSError`), which have the same
failure today and are out of scope here. Separately, the artifact write
now runs before any journal work at all, so it is structurally
independent of that path rather than only independent of today's known
raise. A test pins that with an exception the guard does not catch.

One thing the review surfaced that this PR does not fix: a malformed
`kstrl.toml` still aborts decompose further down at `LinearConfig.load`,
after the architect has been paid for. That is pre-existing on `main`
and the real fix is parsing `kstrl.toml` once at command entry, before
the spend. The new test says so in its docstring rather than pretending
the file is safe.

## Deliberately not done

No typed event. `SpecIssueRecorded` exists because the TUI decompose screen
draws it; a `SpecConvergenceMeasured` event with no reducer fold and no
widget would be scaffolding. The report already reaches `events.jsonl` as
`Log` events through the UI bridge. If the TUI should draw the trend, that
is a follow-up with a consumer attached.

Refs #260. The issue stays open: this is one of five proposals, and the
prompt-edit half is the one the owner has scheduled next.

