### PR TITLE
fix(init): scaffold a .gitignore, and lead next steps with the spec path

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,15 @@ uv tool install kstrl              # installs `ks` and `kstrl` (requires Python 
 # or: git clone https://github.com/0xfauzi/kstrl.git && cd kstrl && uv tool install -e .
 
 cd your-project
-ks init .                          # scaffold kstrl.toml and prompt/PRD templates
+ks init .                          # scaffold kstrl.toml, prompt/PRD templates and a .gitignore
 $EDITOR scripts/kstrl/prd.json     # define what to build (user stories + acceptance criteria)
 ks run 25                          # let the agent work for up to 25 iterations
 ```
+
+That is the single-component loop, which creates no PR. If you already have a
+spec, `ks decompose --spec <spec.md> --project-name <name>` plans it into
+components and `ks factory --spec ...` plans and builds it; `ks init` prints
+both paths when it finishes.
 
 `ks sense` runs the mechanical sensors (tests, typecheck, lint, diff scope, bad patterns) against any tree by hand, with no PRD, branch, worktree or agent spend; `ks sense --json` prints the same measurement as one JSON document for scripts.
 It is the standalone entry point to the checks the factory runs in Phase 1, so a threshold can be measured before it is automated.

--- a/examples/uv-python/.gitignore
+++ b/examples/uv-python/.gitignore
@@ -1,7 +1,19 @@
-.venv/
+# kstrl: artifacts the scope guard would otherwise count
+# The in-loop scope guard counts UNTRACKED files against a component's
+# allowed paths, so anything your test / typecheck / lint commands write
+# has to be ignored here or committed - otherwise the agent's own build
+# artifacts read as out-of-scope edits and cost an iteration.
 __pycache__/
 *.py[cod]
+.venv/
+venv/
 .pytest_cache/
+.mypy_cache/
 .ruff_cache/
-uv.lock
-.python-version
+.coverage
+htmlcov/
+build/
+dist/
+*.egg-info/
+.kstrl/
+.DS_Store

--- a/examples/uv-python/uv.lock
+++ b/examples/uv-python/uv.lock
@@ -1,0 +1,246 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "kstrl"
+version = "0.2.0"
+source = { editable = "../../" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "textual" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "claude-agent-sdk", marker = "extra == 'sdk'", specifier = ">=0.2.128,<0.3" },
+    { name = "click", specifier = ">=8.4.2" },
+    { name = "rich", specifier = ">=15.0.0" },
+    { name = "textual", specifier = ">=8.2.8,<9" },
+]
+provides-extras = ["sdk"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "claude-agent-sdk", specifier = ">=0.2.128,<0.3" },
+    { name = "mypy", specifier = ">=2.3.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-textual-snapshot", specifier = ">=1.0.0" },
+    { name = "ruff", specifier = ">=0.16.1" },
+]
+
+[[package]]
+name = "kstrl-uv-example"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "kstrl" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "kstrl", editable = "../../" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "ruff", specifier = ">=0.6.0" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/98/7a1a5f31fd5c7ba93e963b168e244b8e3dd705b3d2a718e3c3307583bf57/linkify_it_py-2.2.0.tar.gz", hash = "sha256:907acd2d17ac1fbb9ddb62c8957ccbd6158cac602231a15c3b0cd1e215f03cee", size = 32939, upload-time = "2026-08-29T07:07:08.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/d4/1152d1c7ab42d8b908be64fd200ddc870dc9d4925e951198702084aa1a7d/linkify_it_py-2.2.0-py3-none-any.whl", hash = "sha256:3adc40eb5af300b2605fcfdb968c24e1d780a90f1f2221af7c15e5111e94d443", size = 21971, upload-time = "2026-08-29T07:07:07.164Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/06/cf1564dcc2e2261c8c8c6c05628dc8b418943bdae2a4e58640ceb2f770fa/platformdirs-4.11.5.tar.gz", hash = "sha256:e8b31f4f8bcbbedef91a6b57a706255e4f148d2a4e01648382a0a47342539173", size = 34823, upload-time = "2026-08-27T21:36:37.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/12/6f3fcd5067a9cbf4f8664b32957973498da8b083455203c8d9cab83a725c/platformdirs-4.11.5-py3-none-any.whl", hash = "sha256:89f8d42695853b89c7170bd49bc3dc593f98a71e695ede88e06a3b247bc4563b", size = 23900, upload-time = "2026-08-27T21:36:36.227Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/85/c8e12473c93018f92d19dd988a294202e1c27426c47ec4de53ffb847b8d8/ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b", size = 4912003, upload-time = "2026-08-27T16:34:18.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/b6/77c90a970fe2dae17a723acbd011043ea97c98d7deacccefdc4ba74ec512/ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b", size = 10011941, upload-time = "2026-08-27T16:33:41.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/46/6cf67cf6411885a1d6f7f6d801682f155536a85176d10b605e2ceffed8bd/ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3", size = 10204049, upload-time = "2026-08-27T16:33:44.056Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fd/c8720ca7a090abf0c2fef4abe8a5ef6e5127ed15196d8886ff75a2b370e2/ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb", size = 9809037, upload-time = "2026-08-27T16:33:46.257Z" },
+    { url = "https://files.pythonhosted.org/packages/43/45/a684caacdedaca180f52bacccc40bf0789d2c5a7c75f25324853e9eaedb5/ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025", size = 9964129, upload-time = "2026-08-27T16:33:48.352Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/5d2bcdaca6b5b93d1b4dfc166cd2aebf7680143a1b38a28759df13a94d31/ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9", size = 9821518, upload-time = "2026-08-27T16:33:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ff/011cce29accf9257d5974145b733fc653a37985ed6825413a3987cefbfe0/ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7", size = 10534835, upload-time = "2026-08-27T16:33:52.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5a/f0cf109bada9bba0e96c90c21c9f9251803f57225c32d293327a03c710d6/ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde", size = 11252550, upload-time = "2026-08-27T16:33:54.521Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4d/1d481aaea2046c6a7ed7c291f9004c669cce3c087b6b376ed5b08271e3fe/ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea", size = 10777949, upload-time = "2026-08-27T16:33:56.88Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/34/ee245ca55f64443233034b3d02b03236b19242004281247c079390b7facd/ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105", size = 10311656, upload-time = "2026-08-27T16:33:59.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/c33a333e341c0a2b96c715b52d89a606f5a34cd4ac493cd9b8d0187186b8/ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29", size = 10532125, upload-time = "2026-08-27T16:34:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/a64cef78b40192497bb98a27a8aa8f2c98ee9ee15bc97f7712d94ef32937/ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf", size = 10097648, upload-time = "2026-08-27T16:34:03.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4e/4cdc9ed3c3e109d2f71e62572a37457298d7bc7501ec3138babb7ed32bbd/ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91", size = 9829344, upload-time = "2026-08-27T16:34:05.134Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/31ed35ce31729955fc583ee0d176d6e784c1290cb0b0a75cb2134c1ab72a/ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a", size = 10277117, upload-time = "2026-08-27T16:34:07.425Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a0/60356d86687b4b666d593df213f4dc3041750d024cb7bf2cfa81cfd65c2e/ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef", size = 10711653, upload-time = "2026-08-27T16:34:09.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
+]
+
+[[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/kstrl/git.py
+++ b/kstrl/git.py
@@ -442,6 +442,28 @@ def restore_file_from(
         return False
 
 
+def stage_file(
+    file: str,
+    cwd: Path | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> bool:
+    """Stage one path (``git add``), leaving history alone.
+
+    The inverse of :func:`remove_from_index`, and the smallest write that
+    makes a path TRACKED: no commit is created.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "add", "--", file],
+            cwd=cwd,
+            capture_output=True,
+            timeout=timeout,
+        )
+        return result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return False
+
+
 def remove_from_index(
     file: str,
     cwd: Path | None = None,

--- a/kstrl/git.py
+++ b/kstrl/git.py
@@ -446,22 +446,60 @@ def stage_file(
     file: str,
     cwd: Path | None = None,
     timeout: float = DEFAULT_TIMEOUT,
-) -> bool:
+) -> str | None:
     """Stage one path (``git add``), leaving history alone.
 
     The inverse of :func:`remove_from_index`, and the smallest write that
     makes a path TRACKED: no commit is created.
+
+    Returns an error message, or None on success, like
+    :func:`fetch_base_branch` and unlike the bool helpers around it. The
+    reason matters here: ``git add`` refuses an ignored path, and a
+    caller that only knows "false" ends up advising the very command
+    that just failed (#256 review).
     """
     try:
         result = subprocess.run(
             ["git", "add", "--", file],
             cwd=cwd,
             capture_output=True,
+            text=True,
             timeout=timeout,
         )
-        return result.returncode == 0
     except subprocess.TimeoutExpired:
-        return False
+        return f"git add {file} timed out after {timeout}s"
+    if result.returncode != 0:
+        return result.stderr.strip().splitlines()[0] if result.stderr.strip() else "git add failed"
+    return None
+
+
+def ignore_source(
+    file: str,
+    cwd: Path | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> str | None:
+    """Where an ignore rule for ``file`` lives, or None if not ignored.
+
+    ``git check-ignore -v`` answers with ``<source>:<line>:<pattern>``,
+    so the caller can name the file and line the operator has to edit
+    instead of reporting that git said no. Exit 1 means "not ignored"
+    and 128 means git could not answer; both read as None.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "-v", "--", file],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    # "<source>:<line>:<pattern>\t<pathname>" - the pathname is the file
+    # we asked about, so only the rule's location is worth reporting.
+    return result.stdout.strip().splitlines()[0].split("\t")[0]
 
 
 def remove_from_index(

--- a/kstrl/init_cmd.py
+++ b/kstrl/init_cmd.py
@@ -532,6 +532,98 @@ DEFAULT_KSTRL_TOML = """\
 # scheduler_backstop_margin = 60.0
 """
 
+# First line of the .gitignore block `ks init` writes. Its presence is
+# the whole idempotency test: an existing .gitignore is a user-owned
+# file, so the block is appended once and never rewritten.
+GITIGNORE_BLOCK_MARKER = "# kstrl: artifacts the scope guard would otherwise count"
+
+# The marker plus the reason, so the file explains itself to whoever
+# reads it next.
+_GITIGNORE_BLOCK_HEADER = f"""{GITIGNORE_BLOCK_MARKER}
+# The in-loop scope guard counts UNTRACKED files against a component's
+# allowed paths, so anything your test / typecheck / lint commands write
+# has to be ignored here or committed - otherwise the agent's own build
+# artifacts read as out-of-scope edits and cost an iteration.
+"""
+
+# Ignored everywhere: kstrl's own runtime state, plus the one OS artifact
+# that lands in a working tree without anybody asking for it.
+_COMMON_IGNORES = (
+    ".kstrl/",
+    ".DS_Store",
+)
+
+_JS_IGNORES = (
+    "node_modules/",
+    "dist/",
+    "build/",
+    "coverage/",
+    ".next/",
+    "*.tsbuildinfo",
+)
+
+_JVM_IGNORES = (
+    "target/",
+    "build/",
+    ".gradle/",
+)
+
+# Build output and caches per detected language, keyed like the other
+# language tables in this module (_LANGUAGE_STANDARDS,
+# _LANGUAGE_ANTIPATTERNS) on the strings _detect_project_context returns.
+# Deliberately no lockfile: for an application the lockfile belongs in
+# version control, and _ensure_lockfile_tracked puts it there instead of
+# hiding it.
+_LANGUAGE_IGNORES: dict[str, tuple[str, ...]] = {
+    "Python": (
+        "__pycache__/",
+        "*.py[cod]",
+        ".venv/",
+        "venv/",
+        ".pytest_cache/",
+        ".mypy_cache/",
+        ".ruff_cache/",
+        ".coverage",
+        "htmlcov/",
+        "build/",
+        "dist/",
+        "*.egg-info/",
+    ),
+    "TypeScript": _JS_IGNORES,
+    "JavaScript": _JS_IGNORES,
+    "Rust": ("target/",),
+    "Go": (
+        "bin/",
+        "*.test",
+        "*.out",
+    ),
+    "Java": _JVM_IGNORES,
+    "Kotlin": _JVM_IGNORES,
+}
+
+# The "Next steps" block. The spec path leads because it is the one the
+# README sells and the one the scaffold cannot suggest on its own: init
+# writes an empty userStories array, which reads as "write these by
+# hand" (#256). Not named *_PROMPT: that suffix enrols a constant in the
+# adversarial prompt version snapshot, and this is UI copy.
+NEXT_STEPS = """You have a spec (recommended):
+  ks decompose --spec <spec.md> --project-name <name>   # plan it
+  ks factory --spec <spec.md> --project-name <name>     # plan it and build it
+
+You want to drive one component by hand:
+  1. Edit scripts/kstrl/prompt.md
+  2. Add user stories to scripts/kstrl/prd.json
+  3. ks run [iterations]                                # one component, no PR
+
+Other modes:
+  ks understand [iterations]
+  ks feature [iterations] --prd scripts/kstrl/feature/<name>/prd.json
+
+Measure before you spend (no agent, no cost):
+  ks sense
+  ks sense --allowed-path '<glob>'                      # preflight the scope guard
+"""
+
 
 def run_init(directory: Path, ui: UI) -> int:
     """Initialize kstrl harness in a project directory.
@@ -583,7 +675,13 @@ def run_init(directory: Path, ui: UI) -> int:
     )
 
     # Bootstrap CLAUDE.md and AGENTS.md
-    bootstrap_claude_md(root, ui)
+    ctx = _detect_project_context(root)
+    bootstrap_claude_md(root, ui, ctx)
+
+    # Keep the agent's own build artifacts out of the scope guard (#201)
+    ui.section("Git hygiene")
+    _ensure_gitignore(root, ctx["language"], ui)
+    _ensure_lockfile_tracked(root, is_repo, ui)
 
     # Validate PRD
     ui.section("Validate PRD")
@@ -619,15 +717,8 @@ def run_init(directory: Path, ui: UI) -> int:
 
     # Next steps
     ui.section("Next steps")
-    ui.info("1. Edit scripts/kstrl/prompt.md")
-    ui.info("2. Add user stories to scripts/kstrl/prd.json")
-    ui.info("3. Run: ks run [iterations]")
-    ui.info("")
-    ui.info("For codebase understanding mode:")
-    ui.info("  ks understand [iterations]")
-    ui.info("")
-    ui.info("For feature understanding mode:")
-    ui.info("  ks feature [iterations] --prd scripts/kstrl/feature/<feature_name>/prd.json")
+    for line in NEXT_STEPS.splitlines():
+        ui.info(line)
 
     return 0
 
@@ -639,6 +730,95 @@ def _create_if_missing(path: Path, content: str, ui: UI) -> None:
     else:
         path.write_text(content)
         ui.ok(f"  Created {path.name}")
+
+
+def gitignore_block(language: str) -> str:
+    """The .gitignore block `ks init` writes for a detected language.
+
+    Public because examples/uv-python ships a copy of it, held in
+    lockstep by tests/test_gen_docs.py the way the example's prompt.md
+    is held against DEFAULT_PROMPT.
+    """
+    entries = (*_LANGUAGE_IGNORES.get(language, ()), *_COMMON_IGNORES)
+    return _GITIGNORE_BLOCK_HEADER + "\n".join(entries) + "\n"
+
+
+def has_gitignore_block(root: Path) -> bool:
+    """True when root/.gitignore already carries the kstrl block.
+
+    Shared with the TUI wizard's scaffold preview so the preview and the
+    write cannot disagree about whether a re-run would append anything.
+    """
+    try:
+        return GITIGNORE_BLOCK_MARKER in (root / ".gitignore").read_text()
+    except OSError:
+        return False
+
+
+def _ensure_gitignore(root: Path, language: str, ui: UI) -> None:
+    """Create .gitignore, or append the kstrl block to an existing one.
+
+    An existing .gitignore is a user-owned file: this only ever APPENDS,
+    inside a marked block, and skips entirely once the marker is present,
+    so re-running `ks init` cannot duplicate it or rewrite a line the
+    user wrote.
+    """
+    path = root / ".gitignore"
+    block = gitignore_block(language)
+
+    if not path.exists():
+        _create_if_missing(path, block, ui)
+        return
+
+    existing = path.read_text()
+    if GITIGNORE_BLOCK_MARKER in existing:
+        ui.info("  .gitignore already has the kstrl block")
+        return
+
+    # One blank line between the user's last rule and ours, and no
+    # leading blank when the file is empty.
+    separator = "" if not existing else "\n" if existing.endswith("\n") else "\n\n"
+    with path.open("a") as handle:
+        handle.write(separator + block)
+    ui.ok("  Appended the kstrl block to .gitignore")
+
+
+def _ensure_lockfile_tracked(root: Path, is_repo: bool, ui: UI) -> None:
+    """Stage an untracked uv.lock, and say so.
+
+    The lockfile is NOT ignored. For an application it belongs in version
+    control, so ignoring it (what examples/uv-python/.gitignore did
+    before #201) hides it from the scope guard by hiding it from git,
+    which is a workaround rather than a lockfile policy. Tracked is the
+    real fix:
+    ``git ls-files --others --exclude-standard`` cannot list a file that
+    is in the index.
+
+    Staging is as far as init goes - creating a commit in someone's
+    repository is not a scaffolder's call - so the printed instruction
+    carries the rest. It matters: a factory worktree is cut from a
+    COMMIT, so an uncommitted lockfile is absent there and `uv run`
+    writes a fresh untracked one.
+    """
+    if not is_repo or not (root / "pyproject.toml").exists():
+        return
+
+    if not (root / "uv.lock").exists():
+        ui.warn("  No uv.lock yet")
+        ui.info("    Run `uv lock` and commit the result: the first verify run")
+        ui.info("    writes one, and an untracked lockfile reads as an out-of-scope edit.")
+        return
+
+    if git.is_file_tracked("uv.lock", root):
+        ui.ok("  uv.lock is tracked")
+        return
+
+    if git.stage_file("uv.lock", root):
+        ui.ok("  Staged uv.lock (staged only, no commit was created)")
+        ui.info("    Commit it before your first run: a factory worktree is cut from")
+        ui.info("    a commit, so an uncommitted lockfile is not in it.")
+    else:
+        ui.warn("  Could not stage uv.lock; run `git add uv.lock` before your first run")
 
 
 # ---------------------------------------------------------------------------
@@ -999,12 +1179,12 @@ def _generate_claude_md(ctx: dict[str, str]) -> str:
     return "\n".join(sections) + "\n"
 
 
-def bootstrap_claude_md(root: Path, ui: UI) -> None:
+def bootstrap_claude_md(root: Path, ui: UI, ctx: dict[str, str]) -> None:
     """Generate CLAUDE.md and symlink AGENTS.md to it.
 
-    Detects project language, framework, and tooling from config files,
-    then generates agent-facing documentation with coding standards,
-    implementation principles, and verification commands.
+    ``ctx`` is :func:`_detect_project_context`'s reading of the project's
+    language, framework and tooling; the caller detects once because the
+    .gitignore block is chosen from the same reading.
 
     AGENTS.md is a symlink to CLAUDE.md so both names point to the same
     file. When the prompt tells agents to "update AGENTS.md", they are
@@ -1014,7 +1194,6 @@ def bootstrap_claude_md(root: Path, ui: UI) -> None:
 
     ui.section("Agent context files")
 
-    ctx = _detect_project_context(root)
     ui.kv("Detected language", ctx["language"])
     if ctx["framework"]:
         ui.kv("Detected framework", ctx["framework"])

--- a/kstrl/init_cmd.py
+++ b/kstrl/init_cmd.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from kstrl import git
 from kstrl.prd import PRD
@@ -532,6 +532,10 @@ DEFAULT_KSTRL_TOML = """\
 # scheduler_backstop_margin = 60.0
 """
 
+# What `ks init` does to a scaffolded file. The TUI wizard's preview
+# renders these, so the vocabulary belongs beside the code that decides.
+ScaffoldAction = Literal["create", "keep", "append"]
+
 # First line of the .gitignore block `ks init` writes. Its presence is
 # the whole idempotency test: an existing .gitignore is a user-owned
 # file, so the block is appended once and never rewritten.
@@ -562,6 +566,14 @@ _JS_IGNORES = (
     "*.tsbuildinfo",
 )
 
+# npm, yarn and pnpm each write their own; whichever exists is the one
+# this project uses.
+_JS_LOCKFILES = (
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+)
+
 _JVM_IGNORES = (
     "target/",
     "build/",
@@ -571,9 +583,11 @@ _JVM_IGNORES = (
 # Build output and caches per detected language, keyed like the other
 # language tables in this module (_LANGUAGE_STANDARDS,
 # _LANGUAGE_ANTIPATTERNS) on the strings _detect_project_context returns.
-# Deliberately no lockfile: for an application the lockfile belongs in
-# version control, and _ensure_lockfile_tracked puts it there instead of
-# hiding it.
+# Deliberately no lockfile and no .python-version: both pin a build, so
+# both belong in version control. _LANGUAGE_LOCKFILES below puts the
+# lockfile there instead of hiding it, and measured, none of `uv run`,
+# `uv sync`, `uv lock` or `uv venv` writes a .python-version, so it
+# cannot appear mid-iteration the way a lockfile can.
 _LANGUAGE_IGNORES: dict[str, tuple[str, ...]] = {
     "Python": (
         "__pycache__/",
@@ -601,19 +615,43 @@ _LANGUAGE_IGNORES: dict[str, tuple[str, ...]] = {
     "Kotlin": _JVM_IGNORES,
 }
 
+# Lockfiles per detected language: generated files that pin a build and
+# therefore belong in version control, NOT in the ignore block above.
+# Every key in _LANGUAGE_IGNORES appears here, an empty tuple meaning
+# "this toolchain has no lockfile" as a STATED policy rather than an
+# omission - tests/test_init_cmd.py fails if the two tables disagree, so
+# a language cannot quietly get build-artifact ignores and no lockfile
+# rule again (#201 review). The names are drawn from
+# policy.LOCKFILE_BASENAMES, which the merge-policy size caps already
+# key on, and the same test keeps this table inside that vocabulary.
+#
+# Measured, not assumed: with none present, `uv run pytest` writes
+# uv.lock, `cargo test` writes Cargo.lock and `npm install` writes
+# package-lock.json. Go writes go.sum only once the module requires
+# something, and Gradle/Maven have no lockfile by default.
+_LANGUAGE_LOCKFILES: dict[str, tuple[str, ...]] = {
+    "Python": ("uv.lock", "poetry.lock", "Pipfile.lock"),
+    "TypeScript": _JS_LOCKFILES,
+    "JavaScript": _JS_LOCKFILES,
+    "Rust": ("Cargo.lock",),
+    "Go": ("go.sum",),
+    "Java": (),
+    "Kotlin": (),
+}
+
 # The "Next steps" block. The spec path leads because it is the one the
 # README sells and the one the scaffold cannot suggest on its own: init
 # writes an empty userStories array, which reads as "write these by
 # hand" (#256). Not named *_PROMPT: that suffix enrols a constant in the
 # adversarial prompt version snapshot, and this is UI copy.
 NEXT_STEPS = """You have a spec (recommended):
-  ks decompose --spec <spec.md> --project-name <name>   # plan it
-  ks factory --spec <spec.md> --project-name <name>     # plan it and build it
+  ks decompose --spec <spec.md> --project-name <name>  # plan it
+  ks factory --spec <spec.md> --project-name <name>    # plan and build it
 
 You want to drive one component by hand:
   1. Edit scripts/kstrl/prompt.md
   2. Add user stories to scripts/kstrl/prd.json
-  3. ks run [iterations]                                # one component, no PR
+  3. ks run [iterations]                               # one component, no PR
 
 Other modes:
   ks understand [iterations]
@@ -621,7 +659,7 @@ Other modes:
 
 Measure before you spend (no agent, no cost):
   ks sense
-  ks sense --allowed-path '<glob>'                      # preflight the scope guard
+  ks sense --allowed-path '<glob>'                     # preflight the guard
 """
 
 
@@ -681,7 +719,7 @@ def run_init(directory: Path, ui: UI) -> int:
     # Keep the agent's own build artifacts out of the scope guard (#201)
     ui.section("Git hygiene")
     _ensure_gitignore(root, ctx["language"], ui)
-    _ensure_lockfile_tracked(root, is_repo, ui)
+    _ensure_lockfiles_tracked(root, ctx["language"], is_repo, ui)
 
     # Validate PRD
     ui.section("Validate PRD")
@@ -743,16 +781,43 @@ def gitignore_block(language: str) -> str:
     return _GITIGNORE_BLOCK_HEADER + "\n".join(entries) + "\n"
 
 
-def has_gitignore_block(root: Path) -> bool:
-    """True when root/.gitignore already carries the kstrl block.
+def _read_text_or_none(path: Path) -> str | None:
+    """``path``'s text, or None when it cannot be read as text.
 
-    Shared with the TUI wizard's scaffold preview so the preview and the
-    write cannot disagree about whether a re-run would append anything.
+    Catches ValueError alongside OSError because UnicodeDecodeError is a
+    ValueError: a .gitignore that is not UTF-8 crashed `ks init` and
+    the TUI scaffold preview with a traceback (#201 review). A
+    directory in the file's place raises IsADirectoryError, an OSError.
     """
     try:
-        return GITIGNORE_BLOCK_MARKER in (root / ".gitignore").read_text()
-    except OSError:
-        return False
+        return path.read_text()
+    except (OSError, ValueError):
+        return None
+
+
+def _gitignore_state(root: Path) -> tuple[ScaffoldAction, str | None]:
+    """What init would do to ``root``/.gitignore, and the text it read.
+
+    One decision with two consumers - the write below and the TUI
+    wizard's preview - so the preview cannot describe a write that would
+    not happen. "keep" covers both "the block is already there" and
+    "the file cannot be read as text", because init leaves both alone;
+    the second is the one where the text comes back None.
+    """
+    path = root / ".gitignore"
+    if not path.exists():
+        return "create", None
+    existing = _read_text_or_none(path)
+    if existing is None:
+        return "keep", None
+    if GITIGNORE_BLOCK_MARKER in existing:
+        return "keep", existing
+    return "append", existing
+
+
+def gitignore_plan(root: Path) -> ScaffoldAction:
+    """The scaffold preview's half of :func:`_gitignore_state`."""
+    return _gitignore_state(root)[0]
 
 
 def _ensure_gitignore(root: Path, language: str, ui: UI) -> None:
@@ -761,17 +826,23 @@ def _ensure_gitignore(root: Path, language: str, ui: UI) -> None:
     An existing .gitignore is a user-owned file: this only ever APPENDS,
     inside a marked block, and skips entirely once the marker is present,
     so re-running `ks init` cannot duplicate it or rewrite a line the
-    user wrote.
+    user wrote. A file it cannot read is left alone for the same reason:
+    without the marker check, appending could duplicate the block.
     """
     path = root / ".gitignore"
-    block = gitignore_block(language)
+    action, existing = _gitignore_state(root)
 
-    if not path.exists():
-        _create_if_missing(path, block, ui)
+    if action == "create":
+        _create_if_missing(path, gitignore_block(language), ui)
         return
 
-    existing = path.read_text()
-    if GITIGNORE_BLOCK_MARKER in existing:
+    if existing is None:
+        ui.warn("  .gitignore could not be read as text; leaving it alone")
+        ui.info("    Add the usual build-artifact rules yourself, or the scope")
+        ui.info("    guard counts what your test and lint commands write.")
+        return
+
+    if action == "keep":
         ui.info("  .gitignore already has the kstrl block")
         return
 
@@ -779,46 +850,64 @@ def _ensure_gitignore(root: Path, language: str, ui: UI) -> None:
     # leading blank when the file is empty.
     separator = "" if not existing else "\n" if existing.endswith("\n") else "\n\n"
     with path.open("a") as handle:
-        handle.write(separator + block)
+        handle.write(separator + gitignore_block(language))
     ui.ok("  Appended the kstrl block to .gitignore")
 
 
-def _ensure_lockfile_tracked(root: Path, is_repo: bool, ui: UI) -> None:
-    """Stage an untracked uv.lock, and say so.
+def _ensure_lockfiles_tracked(root: Path, language: str, is_repo: bool, ui: UI) -> None:
+    """Stage the project's untracked lockfiles, and say so.
 
-    The lockfile is NOT ignored. For an application it belongs in version
+    A lockfile is NOT ignored. For an application it belongs in version
     control, so ignoring it (what examples/uv-python/.gitignore did
     before #201) hides it from the scope guard by hiding it from git,
     which is a workaround rather than a lockfile policy. Tracked is the
-    real fix:
-    ``git ls-files --others --exclude-standard`` cannot list a file that
-    is in the index.
+    real fix: ``git ls-files --others --exclude-standard`` cannot list a
+    file that is in the index.
 
     Staging is as far as init goes - creating a commit in someone's
     repository is not a scaffolder's call - so the printed instruction
     carries the rest. It matters: a factory worktree is cut from a
-    COMMIT, so an uncommitted lockfile is absent there and `uv run`
-    writes a fresh untracked one.
+    COMMIT, so an uncommitted lockfile is absent there and the first
+    verify run writes a fresh untracked one.
     """
-    if not is_repo or not (root / "pyproject.toml").exists():
+    candidates = _LANGUAGE_LOCKFILES.get(language, ())
+    if not is_repo or not candidates:
         return
 
-    if not (root / "uv.lock").exists():
-        ui.warn("  No uv.lock yet")
-        ui.info("    Run `uv lock` and commit the result: the first verify run")
-        ui.info("    writes one, and an untracked lockfile reads as an out-of-scope edit.")
+    present = [name for name in candidates if (root / name).exists()]
+    if not present:
+        ui.warn(f"  No lockfile yet ({', '.join(candidates)})")
+        ui.info("    Your package manager writes one; create it and commit it")
+        ui.info("    before your first run, or the verify commands write it")
+        ui.info("    mid-iteration and it reads as an out-of-scope edit.")
         return
 
-    if git.is_file_tracked("uv.lock", root):
-        ui.ok("  uv.lock is tracked")
+    for name in present:
+        _track_lockfile(root, name, ui)
+
+
+def _track_lockfile(root: Path, name: str, ui: UI) -> None:
+    """Report or fix one lockfile's tracking state."""
+    if git.is_file_tracked(name, root):
+        ui.ok(f"  {name} is tracked")
         return
 
-    if git.stage_file("uv.lock", root):
-        ui.ok("  Staged uv.lock (staged only, no commit was created)")
-        ui.info("    Commit it before your first run: a factory worktree is cut from")
-        ui.info("    a commit, so an uncommitted lockfile is not in it.")
-    else:
-        ui.warn("  Could not stage uv.lock; run `git add uv.lock` before your first run")
+    error = git.stage_file(name, root)
+    if error is not None:
+        # `git add` refuses an ignored path and its message does not say
+        # WHICH rule ignored it, so the remediation has to name one.
+        ignored_by = git.ignore_source(name, root)
+        if ignored_by:
+            ui.warn(f"  {name} is ignored by {ignored_by}, so git will not track it")
+            ui.info(f"    Delete that rule and `git add {name}`: the lockfile pins")
+            ui.info("    your build, so it belongs in version control.")
+        else:
+            ui.warn(f"  Could not stage {name}: {error}")
+        return
+
+    ui.ok(f"  Staged {name} (staged only, no commit was created)")
+    ui.info("    Commit it before your first run: a factory worktree is cut from")
+    ui.info("    a commit, so an uncommitted lockfile is not in it.")
 
 
 # ---------------------------------------------------------------------------
@@ -854,23 +943,19 @@ def _detect_project_context(root: Path) -> dict[str, str]:
         ctx["typecheck_cmd"] = f"{runner}mypy src/ --strict"
         ctx["lint_cmd"] = f"{runner}ruff check src/"
         ctx["format_cmd"] = f"{runner}ruff format src/"
-        if pyproject.exists():
-            try:
-                text = pyproject.read_text()
-                if "name" in text:
-                    import re
+        pyproject_text = _read_text_or_none(pyproject) or ""
+        if "name" in pyproject_text:
+            import re
 
-                    m = re.search(r'name\s*=\s*"([^"]+)"', text)
-                    if m:
-                        ctx["name"] = m.group(1)
-                if "fastapi" in text:
-                    ctx["framework"] = "FastAPI"
-                elif "django" in text:
-                    ctx["framework"] = "Django"
-                elif "flask" in text:
-                    ctx["framework"] = "Flask"
-            except OSError:
-                pass
+            m = re.search(r'name\s*=\s*"([^"]+)"', pyproject_text)
+            if m:
+                ctx["name"] = m.group(1)
+        if "fastapi" in pyproject_text:
+            ctx["framework"] = "FastAPI"
+        elif "django" in pyproject_text:
+            ctx["framework"] = "Django"
+        elif "flask" in pyproject_text:
+            ctx["framework"] = "Flask"
         return ctx
 
     # Rust
@@ -882,19 +967,16 @@ def _detect_project_context(root: Path) -> dict[str, str]:
         ctx["typecheck_cmd"] = "cargo check"
         ctx["build_cmd"] = "cargo build"
         ctx["format_cmd"] = "cargo fmt"
-        try:
-            text = cargo_toml.read_text()
-            import re
+        import re
 
-            m = re.search(r'name\s*=\s*"([^"]+)"', text)
-            if m:
-                ctx["name"] = m.group(1)
-            if "actix" in text or "axum" in text:
-                ctx["framework"] = "Axum/Actix"
-            elif "rocket" in text:
-                ctx["framework"] = "Rocket"
-        except OSError:
-            pass
+        cargo_text = _read_text_or_none(cargo_toml) or ""
+        m = re.search(r'name\s*=\s*"([^"]+)"', cargo_text)
+        if m:
+            ctx["name"] = m.group(1)
+        if "actix" in cargo_text or "axum" in cargo_text:
+            ctx["framework"] = "Axum/Actix"
+        elif "rocket" in cargo_text:
+            ctx["framework"] = "Rocket"
         return ctx
 
     # TypeScript / JavaScript
@@ -904,7 +986,7 @@ def _detect_project_context(root: Path) -> dict[str, str]:
         try:
             import json as _json
 
-            pkg = _json.loads(pkg_json.read_text())
+            pkg = _json.loads(_read_text_or_none(pkg_json) or "{}")
             ctx["name"] = pkg.get("name", root.name)
             scripts = pkg.get("scripts", {})
             ctx["test_cmd"] = (
@@ -939,13 +1021,10 @@ def _detect_project_context(root: Path) -> dict[str, str]:
         ctx["typecheck_cmd"] = "go vet ./..."
         ctx["build_cmd"] = "go build ./..."
         ctx["format_cmd"] = "gofmt -w ."
-        try:
-            text = go_mod.read_text()
-            first_line = text.strip().splitlines()[0] if text.strip() else ""
-            if first_line.startswith("module "):
-                ctx["name"] = first_line.split()[-1].split("/")[-1]
-        except OSError:
-            pass
+        go_text = (_read_text_or_none(go_mod) or "").strip()
+        first_line = go_text.splitlines()[0] if go_text else ""
+        if first_line.startswith("module "):
+            ctx["name"] = first_line.split()[-1].split("/")[-1]
         return ctx
 
     # Java / Kotlin

--- a/kstrl/init_wizard.py
+++ b/kstrl/init_wizard.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
-from kstrl.init_cmd import _detect_project_context
+from kstrl.init_cmd import _detect_project_context, has_gitignore_block
 
 # The documented kstrl.toml [agent] type vocabulary (empty = auto).
 AGENT_TYPES = ("", "claude-code", "claude-sdk", "codex")
@@ -30,14 +31,26 @@ _AGENT_STOCK_PREFIXES = {
 }
 
 
+ScaffoldAction = Literal["create", "keep", "append"]
+
+
 @dataclass(frozen=True)
 class ScaffoldEntry:
     path: Path
-    exists: bool  # True -> "exists - kept"; False -> "will create"
+    action: ScaffoldAction  # create = written; keep = left alone; append = added to
 
 
 def plan_scaffold(root: Path) -> list[ScaffoldEntry]:
-    """The exact file set run_init touches, with existence markers."""
+    """The exact file set run_init touches, with the action for each.
+
+    .gitignore is the one entry that is not create-or-keep: run_init
+    appends its block to an existing file, so an existing .gitignore
+    without that block is reported as ``append``. Saying "exists - kept"
+    there would be a preview that does not match the write (#201).
+
+    Files only. run_init has one non-file side effect, staging an
+    untracked uv.lock, and it reports that in its own transcript.
+    """
     kstrl_dir = root / "scripts" / "kstrl"
     paths = [
         root / "kstrl.toml",
@@ -50,7 +63,16 @@ def plan_scaffold(root: Path) -> list[ScaffoldEntry]:
         root / "CLAUDE.md",
         root / "AGENTS.md",
     ]
-    return [ScaffoldEntry(path=p, exists=p.exists()) for p in paths]
+    entries = [ScaffoldEntry(path=p, action="keep" if p.exists() else "create") for p in paths]
+    gitignore = root / ".gitignore"
+    entries.append(ScaffoldEntry(path=gitignore, action=_gitignore_action(root)))
+    return entries
+
+
+def _gitignore_action(root: Path) -> ScaffoldAction:
+    if not (root / ".gitignore").exists():
+        return "create"
+    return "keep" if has_gitignore_block(root) else "append"
 
 
 def detect_context(root: Path) -> dict[str, str]:

--- a/kstrl/init_wizard.py
+++ b/kstrl/init_wizard.py
@@ -15,9 +15,8 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
 
-from kstrl.init_cmd import _detect_project_context, has_gitignore_block
+from kstrl.init_cmd import ScaffoldAction, _detect_project_context, gitignore_plan
 
 # The documented kstrl.toml [agent] type vocabulary (empty = auto).
 AGENT_TYPES = ("", "claude-code", "claude-sdk", "codex")
@@ -29,9 +28,6 @@ _AGENT_STOCK_PREFIXES = {
     "model": '# model = ""',
     "reasoning_effort": '# reasoning_effort = ""',
 }
-
-
-ScaffoldAction = Literal["create", "keep", "append"]
 
 
 @dataclass(frozen=True)
@@ -49,7 +45,7 @@ def plan_scaffold(root: Path) -> list[ScaffoldEntry]:
     there would be a preview that does not match the write (#201).
 
     Files only. run_init has one non-file side effect, staging an
-    untracked uv.lock, and it reports that in its own transcript.
+    untracked lockfile, and it reports that in its own transcript.
     """
     kstrl_dir = root / "scripts" / "kstrl"
     paths = [
@@ -64,15 +60,8 @@ def plan_scaffold(root: Path) -> list[ScaffoldEntry]:
         root / "AGENTS.md",
     ]
     entries = [ScaffoldEntry(path=p, action="keep" if p.exists() else "create") for p in paths]
-    gitignore = root / ".gitignore"
-    entries.append(ScaffoldEntry(path=gitignore, action=_gitignore_action(root)))
+    entries.append(ScaffoldEntry(path=root / ".gitignore", action=gitignore_plan(root)))
     return entries
-
-
-def _gitignore_action(root: Path) -> ScaffoldAction:
-    if not (root / ".gitignore").exists():
-        return "create"
-    return "keep" if has_gitignore_block(root) else "append"
 
 
 def detect_context(root: Path) -> dict[str, str]:

--- a/kstrl/tui/screens/init_wizard.py
+++ b/kstrl/tui/screens/init_wizard.py
@@ -69,7 +69,7 @@ class InitWizardScreen(Screen[None]):
     def compose(self) -> ComposeResult:
         yield ContextBar(
             "init",
-            "scaffold is non-destructive - existing files are kept",
+            "rewrites nothing - files kept, .gitignore appended, uv.lock staged",
         )
         with Vertical(classes="dialog-host"):
             panel = Vertical(classes="dialog-panel", id="wizard-root")
@@ -162,9 +162,12 @@ class InitWizardScreen(Screen[None]):
                 display = entry.path.relative_to(directory)
             except ValueError:
                 display = entry.path
-            if entry.exists:
+            if entry.action == "keep":
                 plan.append("  · exists - kept   ", style=theme.MUTED)
                 plan.append(f"{display}\n", style=theme.MUTED)
+            elif entry.action == "append":
+                plan.append("  ~ append block    ", style=f"bold {theme.ACCENT}")
+                plan.append(f"{display}\n")
             else:
                 plan.append("  + will create    ", style=f"bold {theme.ACCENT}")
                 plan.append(f"{display}\n")

--- a/kstrl/tui/screens/init_wizard.py
+++ b/kstrl/tui/screens/init_wizard.py
@@ -69,7 +69,7 @@ class InitWizardScreen(Screen[None]):
     def compose(self) -> ComposeResult:
         yield ContextBar(
             "init",
-            "rewrites nothing - files kept, .gitignore appended, uv.lock staged",
+            "rewrites nothing - files kept, .gitignore appended, lockfile staged",
         )
         with Vertical(classes="dialog-host"):
             panel = Vertical(classes="dialog-panel", id="wizard-root")

--- a/kstrl/ui/rich_ui.py
+++ b/kstrl/ui/rich_ui.py
@@ -65,6 +65,13 @@ class RichUI:
             file=self._file,
             no_color=no_color,
             force_terminal=True,
+            # The UI protocol carries PLAIN TEXT, never Rich markup, and
+            # this is the seam that says so once for every method rather
+            # than per call: `ks init` printed `ks run [iterations]` as
+            # `ks run`, the argument silently swallowed as a style tag
+            # (#256 review). Styling is applied through Text objects,
+            # which are not re-parsed.
+            markup=False,
         )
         self._hr_char = "-" if ascii_only else "\u2500"
         self._block_tl = "+" if ascii_only else "\u250c"
@@ -144,21 +151,26 @@ class RichUI:
         padded_key = f"  {key}:".ljust(16)
         self.console.print(Text(padded_key, style="dim") + Text(value))
 
+    # These four wrap their text in Text as well as relying on the
+    # console's markup=False, because Text also skips the repr
+    # highlighter: help text like `--prd <name>/prd.json` is a command to
+    # copy, not a value to colour by type.
+
     def info(self, text: str) -> None:
         """Display info message (dim)."""
-        self.console.print(text, style="dim")
+        self.console.print(Text(text, style="dim"))
 
     def ok(self, text: str) -> None:
         """Display success message (green)."""
-        self.console.print(f"OK: {text}", style="green")
+        self.console.print(Text(f"OK: {text}", style="green"))
 
     def warn(self, text: str) -> None:
         """Display warning message (yellow)."""
-        self.console.print(f"WARN: {text}", style="yellow")
+        self.console.print(Text(f"WARN: {text}", style="yellow"))
 
     def err(self, text: str) -> None:
         """Display error message (red)."""
-        self.console.print(f"ERROR: {text}", style="red bold")
+        self.console.print(Text(f"ERROR: {text}", style="red bold"))
 
     def channel_header(self, channel: str, title: str = "") -> None:
         """Display channel header with optional title."""
@@ -181,7 +193,7 @@ class RichUI:
         if line_style:
             self.console.print(Text(line, style=line_style))
         else:
-            self.console.print(line, markup=False)
+            self.console.print(line)
 
     def choose(self, header: str, options: list[str], default: int = 0) -> int:
         """Interactive choice, returns selected index."""

--- a/tests/test_gen_docs.py
+++ b/tests/test_gen_docs.py
@@ -143,6 +143,24 @@ class TestExampleProjectContract:
         example = (REPO_ROOT / "examples" / "uv-python" / ".gitignore").read_text(encoding="utf-8")
         assert example == gitignore_block("Python")
 
+    def test_example_lockfile_is_tracked(self) -> None:
+        """The example stopped ignoring uv.lock in #201, so the file has
+        to be IN GIT: an un-ignored untracked lockfile is the exact
+        condition #201 is about, and leaving one in kstrl's own tree
+        would have the fix reproduce the bug it fixes. Existence is not
+        enough - an untracked file exists too."""
+        import subprocess
+
+        relative = "examples/uv-python/uv.lock"
+        tracked = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", "--", relative],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            timeout=30,
+        )
+
+        assert tracked.returncode == 0, f"run `uv lock` in examples/uv-python and commit {relative}"
+
     def test_example_prd_prompt_allows_allowed_paths(self) -> None:
         text = (
             REPO_ROOT / "examples" / "uv-python" / "scripts" / "kstrl" / "prd_prompt.txt"

--- a/tests/test_gen_docs.py
+++ b/tests/test_gen_docs.py
@@ -133,6 +133,16 @@ class TestExampleProjectContract:
         ).read_text(encoding="utf-8")
         assert example == DEFAULT_PROMPT
 
+    def test_example_gitignore_is_the_one_init_scaffolds(self) -> None:
+        """examples/uv-python ships the same ignore block `ks init`
+        writes. Before #201 it ignored uv.lock, which hid the lockfile
+        from the scope guard by hiding it from git - a workaround the
+        example then taught to everyone who copied it."""
+        from kstrl.init_cmd import gitignore_block
+
+        example = (REPO_ROOT / "examples" / "uv-python" / ".gitignore").read_text(encoding="utf-8")
+        assert example == gitignore_block("Python")
+
     def test_example_prd_prompt_allows_allowed_paths(self) -> None:
         text = (
             REPO_ROOT / "examples" / "uv-python" / "scripts" / "kstrl" / "prd_prompt.txt"

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -1,0 +1,278 @@
+"""Direct tests for ``run_init`` - the scaffold `ks init` writes.
+
+Nothing exercised ``run_init`` itself before this file: the wizard tests
+cover ``plan_scaffold`` and the agent-settings write, and the TUI screen
+test patches ``run_init`` out. Both issues fixed here (#201 .gitignore,
+#256 next steps) are properties of what init WRITES and PRINTS, so they
+are tested against the real function with a real UI.
+"""
+
+from __future__ import annotations
+
+import inspect
+import io
+import re
+from pathlib import Path
+
+import pytest
+
+from kstrl.cli import cli
+from kstrl.init_cmd import (
+    _LANGUAGE_IGNORES,
+    GITIGNORE_BLOCK_MARKER,
+    NEXT_STEPS,
+    _detect_project_context,
+    run_init,
+)
+from kstrl.init_wizard import plan_scaffold
+from kstrl.ui.plain import PlainUI
+from tests.spine_utils import git
+
+
+def run_init_capturing(root: Path) -> tuple[int, str]:
+    """Run init against ``root``, returning (exit code, printed output)."""
+    buffer = io.StringIO()
+    code = run_init(root, PlainUI(no_color=True, file=buffer))
+    return code, buffer.getvalue()
+
+
+@pytest.fixture
+def python_repo(tmp_path: Path) -> Path:
+    """A git repo with one commit and a uv-style Python project in it."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git("init", "-q", "-b", "main", cwd=repo)
+    git("config", "user.email", "t@t", cwd=repo)
+    git("config", "user.name", "t", cwd=repo)
+    (repo / "pyproject.toml").write_text('[project]\nname = "demo"\n')
+    git("add", "pyproject.toml", cwd=repo)
+    git("commit", "-qm", "init", cwd=repo)
+    return repo
+
+
+class TestGitignoreScaffold:
+    def test_python_project_gets_build_artifacts_and_kstrl_state(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "demo"\n')
+
+        code, _ = run_init_capturing(tmp_path)
+
+        assert code == 0
+        content = (tmp_path / ".gitignore").read_text()
+        for entry in (
+            "__pycache__/",
+            "*.py[cod]",
+            ".venv/",
+            ".pytest_cache/",
+            ".mypy_cache/",
+            ".ruff_cache/",
+            "dist/",
+            ".kstrl/",
+        ):
+            assert entry in content, entry
+
+    def test_lockfile_is_never_ignored(self, tmp_path: Path) -> None:
+        """#201: uv.lock belongs in version control, not in .gitignore."""
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "demo"\n')
+
+        run_init_capturing(tmp_path)
+
+        assert "uv.lock" not in (tmp_path / ".gitignore").read_text()
+
+    def test_block_follows_the_detected_language(self, tmp_path: Path) -> None:
+        (tmp_path / "package.json").write_text('{"name": "demo"}')
+
+        run_init_capturing(tmp_path)
+
+        content = (tmp_path / ".gitignore").read_text()
+        assert "node_modules/" in content
+        assert "__pycache__/" not in content
+
+    def test_unknown_language_still_ignores_kstrl_runtime_state(self, tmp_path: Path) -> None:
+        run_init_capturing(tmp_path)
+
+        content = (tmp_path / ".gitignore").read_text()
+        assert ".kstrl/" in content
+        assert "__pycache__/" not in content
+
+    def test_rerun_does_not_duplicate_the_block(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "demo"\n')
+
+        run_init_capturing(tmp_path)
+        after_first = (tmp_path / ".gitignore").read_text()
+        _, output = run_init_capturing(tmp_path)
+
+        assert (tmp_path / ".gitignore").read_text() == after_first
+        assert after_first.count(GITIGNORE_BLOCK_MARKER) == 1
+        assert "already has the kstrl block" in output
+
+    def test_existing_gitignore_is_appended_to_not_rewritten(self, tmp_path: Path) -> None:
+        existing = "# mine\nsecrets.env\ndist/\n"
+        (tmp_path / ".gitignore").write_text(existing)
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "demo"\n')
+
+        _, output = run_init_capturing(tmp_path)
+
+        content = (tmp_path / ".gitignore").read_text()
+        assert content.startswith(existing)
+        assert GITIGNORE_BLOCK_MARKER in content
+        assert ".kstrl/" in content
+        assert "Appended the kstrl block" in output
+
+    def test_append_separates_from_a_file_with_no_trailing_newline(self, tmp_path: Path) -> None:
+        (tmp_path / ".gitignore").write_text("secrets.env")
+
+        run_init_capturing(tmp_path)
+
+        lines = (tmp_path / ".gitignore").read_text().splitlines()
+        assert lines[0] == "secrets.env"
+        assert GITIGNORE_BLOCK_MARKER in lines
+
+    def test_empty_gitignore_gains_the_block_without_leading_blanks(self, tmp_path: Path) -> None:
+        (tmp_path / ".gitignore").write_text("")
+
+        run_init_capturing(tmp_path)
+
+        assert (tmp_path / ".gitignore").read_text().startswith(GITIGNORE_BLOCK_MARKER)
+
+    def test_user_edits_below_the_block_survive_a_rerun(self, tmp_path: Path) -> None:
+        run_init_capturing(tmp_path)
+        path = tmp_path / ".gitignore"
+        path.write_text(path.read_text() + "\n# added later\nmy-scratch/\n")
+        before = path.read_text()
+
+        run_init_capturing(tmp_path)
+
+        assert path.read_text() == before
+
+
+class TestLockfileTracking:
+    def test_untracked_lockfile_is_staged_and_reported(self, python_repo: Path) -> None:
+        (python_repo / "uv.lock").write_text("version = 1\n")
+        commits_before = git("rev-list", "--count", "HEAD", cwd=python_repo)
+
+        _, output = run_init_capturing(python_repo)
+
+        untracked = git("ls-files", "--others", "--exclude-standard", cwd=python_repo)
+        assert git("ls-files", "--", "uv.lock", cwd=python_repo) == "uv.lock"
+        assert "uv.lock" not in untracked.split()
+        assert "Staged uv.lock" in output
+        assert "no commit was created" in output
+        assert git("rev-list", "--count", "HEAD", cwd=python_repo) == commits_before
+
+    def test_tracked_lockfile_is_left_alone(self, python_repo: Path) -> None:
+        (python_repo / "uv.lock").write_text("version = 1\n")
+        git("add", "uv.lock", cwd=python_repo)
+        git("commit", "-qm", "lock", cwd=python_repo)
+
+        _, output = run_init_capturing(python_repo)
+
+        assert "uv.lock is tracked" in output
+        assert "Staged uv.lock" not in output
+
+    def test_missing_lockfile_is_a_warning_with_the_fix(self, python_repo: Path) -> None:
+        _, output = run_init_capturing(python_repo)
+
+        assert "No uv.lock yet" in output
+        assert "uv lock" in output
+
+    def test_non_git_directory_skips_the_lockfile_step(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "demo"\n')
+        (tmp_path / "uv.lock").write_text("version = 1\n")
+
+        _, output = run_init_capturing(tmp_path)
+
+        assert "uv.lock" not in output
+
+    def test_non_python_repo_skips_the_lockfile_step(self, python_repo: Path) -> None:
+        (python_repo / "pyproject.toml").unlink()
+
+        _, output = run_init_capturing(python_repo)
+
+        assert "uv.lock" not in output
+
+
+class TestNextSteps:
+    def test_leads_with_the_spec_workflow(self, tmp_path: Path) -> None:
+        """#256: the two commands implementing the README headline."""
+        _, output = run_init_capturing(tmp_path)
+
+        assert "ks decompose --spec" in output
+        assert "ks factory --spec" in output
+        spec_at = output.index("ks decompose --spec")
+        assert spec_at < output.index("ks run [iterations]")
+
+    def test_single_component_path_is_labelled_as_such(self, tmp_path: Path) -> None:
+        _, output = run_init_capturing(tmp_path)
+
+        assert "ks run [iterations]" in output
+        assert "no PR" in output
+
+    def test_names_the_free_measurement(self, tmp_path: Path) -> None:
+        _, output = run_init_capturing(tmp_path)
+
+        assert "ks sense" in output
+        assert "ks understand [iterations]" in output
+        assert "ks feature [iterations]" in output
+
+
+class TestScaffoldContract:
+    def test_plan_scaffold_lists_exactly_what_run_init_writes(self, tmp_path: Path) -> None:
+        """The wizard preview and the write cannot drift apart silently."""
+        code, _ = run_init_capturing(tmp_path)
+
+        assert code == 0
+        written = {p for p in tmp_path.rglob("*") if p.is_file()}
+        assert written == {entry.path for entry in plan_scaffold(tmp_path)}
+
+    def test_plan_stops_calling_gitignore_an_append_once_init_ran(self, tmp_path: Path) -> None:
+        (tmp_path / ".gitignore").write_text("secrets.env\n")
+
+        run_init_capturing(tmp_path)
+
+        planned = {e.path.name: e for e in plan_scaffold(tmp_path)}
+        assert planned[".gitignore"].action == "keep"
+
+    def test_every_detected_language_has_an_ignore_block(self) -> None:
+        """A language the detector can return but the ignore table cannot
+        is #201 recurring in the way that is hardest to see: the scaffold
+        writes a block with no build artifacts in it."""
+        source = inspect.getsource(_detect_project_context)
+        assigned = set(re.findall(r'ctx\["language"\] = "([^"]+)"', source))
+
+        assert assigned, "the language-assignment shape changed; fix this test"
+        assert assigned - {"unknown"} <= set(_LANGUAGE_IGNORES)
+
+    def test_every_command_named_in_next_steps_is_real(self) -> None:
+        """The block is the first thing a new user reads; a renamed
+        command or flag must not leave it printing something that errors."""
+        checked = 0
+        for line in NEXT_STEPS.splitlines():
+            match = re.search(r"\bks ([a-z]+)(.*)", line)
+            if not match:
+                continue
+            name, rest = match.group(1), match.group(2)
+            command = cli.commands.get(name)
+            assert command is not None, f"`ks {name}` is not a command"
+            known = {opt for param in command.params for opt in param.opts}
+            assert set(re.findall(r"--[a-z-]+", rest)) <= known, line
+            checked += 1
+
+        assert checked >= 5
+
+
+class TestExitCodes:
+    def test_missing_directory_returns_2(self, tmp_path: Path) -> None:
+        code, output = run_init_capturing(tmp_path / "nope")
+
+        assert code == 2
+        assert "Directory not found" in output
+
+    def test_unparseable_prd_returns_1(self, tmp_path: Path) -> None:
+        kstrl_dir = tmp_path / "scripts" / "kstrl"
+        kstrl_dir.mkdir(parents=True)
+        (kstrl_dir / "prd.json").write_text("{not json")
+
+        code, output = run_init_capturing(tmp_path)
+
+        assert code == 1
+        assert "Invalid JSON" in output

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -19,13 +19,16 @@ import pytest
 from kstrl.cli import cli
 from kstrl.init_cmd import (
     _LANGUAGE_IGNORES,
+    _LANGUAGE_LOCKFILES,
     GITIGNORE_BLOCK_MARKER,
     NEXT_STEPS,
     _detect_project_context,
     run_init,
 )
 from kstrl.init_wizard import plan_scaffold
+from kstrl.policy import LOCKFILE_BASENAMES
 from kstrl.ui.plain import PlainUI
+from kstrl.ui.rich_ui import RichUI
 from tests.spine_utils import git
 
 
@@ -36,18 +39,27 @@ def run_init_capturing(root: Path) -> tuple[int, str]:
     return code, buffer.getvalue()
 
 
-@pytest.fixture
-def python_repo(tmp_path: Path) -> Path:
-    """A git repo with one commit and a uv-style Python project in it."""
-    repo = tmp_path / "repo"
+def make_repo(parent: Path, name: str, manifest: str, contents: str) -> Path:
+    """A git repo with one commit, holding one project manifest.
+
+    The manifest is what `_detect_project_context` keys on, so it is the
+    only thing that differs between a Python, Rust or Java fixture.
+    """
+    repo = parent / name
     repo.mkdir()
     git("init", "-q", "-b", "main", cwd=repo)
     git("config", "user.email", "t@t", cwd=repo)
     git("config", "user.name", "t", cwd=repo)
-    (repo / "pyproject.toml").write_text('[project]\nname = "demo"\n')
-    git("add", "pyproject.toml", cwd=repo)
+    (repo / manifest).write_text(contents)
+    git("add", manifest, cwd=repo)
     git("commit", "-qm", "init", cwd=repo)
     return repo
+
+
+@pytest.fixture
+def python_repo(tmp_path: Path) -> Path:
+    """A git repo with one commit and a uv-style Python project in it."""
+    return make_repo(tmp_path, "repo", "pyproject.toml", '[project]\nname = "demo"\n')
 
 
 class TestGitignoreScaffold:
@@ -172,8 +184,46 @@ class TestLockfileTracking:
     def test_missing_lockfile_is_a_warning_with_the_fix(self, python_repo: Path) -> None:
         _, output = run_init_capturing(python_repo)
 
-        assert "No uv.lock yet" in output
-        assert "uv lock" in output
+        assert "No lockfile yet (uv.lock, poetry.lock, Pipfile.lock)" in output
+        assert "create it and commit it" in output
+
+    def test_an_ignored_lockfile_names_the_rule_rather_than_failing(
+        self,
+        python_repo: Path,
+    ) -> None:
+        """`git add` refuses an ignored path, so advising `git add
+        uv.lock` there is advising the command that just failed. The
+        population this hits is the one that copied the old example
+        .gitignore, which ignored uv.lock (#201 review)."""
+        (python_repo / ".gitignore").write_text("uv.lock\n")
+        (python_repo / "uv.lock").write_text("version = 1\n")
+
+        _, output = run_init_capturing(python_repo)
+
+        assert "uv.lock is ignored by .gitignore:1" in output
+        assert "Delete that rule and `git add uv.lock`" in output
+        assert "Staged uv.lock" not in output
+        assert git("ls-files", "--", "uv.lock", cwd=python_repo) == ""
+
+    def test_a_rust_project_stages_cargo_lock(self, tmp_path: Path) -> None:
+        """Measured: `cargo test` writes Cargo.lock when it is absent, so
+        Rust has the same untracked out-of-scope file Python had."""
+        repo = make_repo(tmp_path, "rust", "Cargo.toml", '[package]\nname = "demo"\n')
+        (repo / "Cargo.lock").write_text("version = 3\n")
+
+        _, output = run_init_capturing(repo)
+
+        assert "Staged Cargo.lock" in output
+        assert git("ls-files", "--", "Cargo.lock", cwd=repo) == "Cargo.lock"
+
+    def test_a_language_with_no_lockfile_says_nothing(self, tmp_path: Path) -> None:
+        """Java's empty tuple is a stated policy, not an omission: no
+        warning, because there is no lockfile to be missing."""
+        repo = make_repo(tmp_path, "java", "pom.xml", "<project/>\n")
+
+        _, output = run_init_capturing(repo)
+
+        assert "No lockfile yet" not in output
 
     def test_non_git_directory_skips_the_lockfile_step(self, tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "demo"\n')
@@ -207,12 +257,58 @@ class TestNextSteps:
         assert "ks run [iterations]" in output
         assert "no PR" in output
 
+    def test_the_block_fits_an_eighty_column_terminal(self) -> None:
+        """Rich word-wraps to the console width, so a longer line
+        arrives split across two rows with its comment orphaned.
+        80 columns is the narrowest terminal kstrl designs for."""
+        longest = max(NEXT_STEPS.splitlines(), key=len)
+
+        assert len(longest) <= 80, longest
+
     def test_names_the_free_measurement(self, tmp_path: Path) -> None:
         _, output = run_init_capturing(tmp_path)
 
         assert "ks sense" in output
         assert "ks understand [iterations]" in output
         assert "ks feature [iterations]" in output
+
+
+class TestRichRendering:
+    """The default UI is Rich, so the block has to survive Rich.
+
+    tests/test_rich_ui.py owns the invariant for every method; this is
+    the one command whose transcript regressed on it (#256 review).
+    """
+
+    def test_the_block_reaches_the_default_ui_intact(self, tmp_path: Path) -> None:
+        buffer = io.StringIO()
+        run_init(tmp_path, RichUI(no_color=True, file=buffer))
+
+        assert "ks run [iterations]" in buffer.getvalue()
+
+
+class TestUnreadableGitignore:
+    def test_a_non_utf8_gitignore_is_left_alone(self, tmp_path: Path) -> None:
+        """UnicodeDecodeError is a ValueError, not an OSError, so an
+        unguarded read_text killed `ks init` with a traceback instead of
+        an exit code (#201 review)."""
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_bytes(b"build\xff/\n")
+
+        code, output = run_init_capturing(tmp_path)
+
+        assert code == 0
+        assert "could not be read as text" in output
+        assert gitignore.read_bytes() == b"build\xff/\n"
+
+    def test_a_gitignore_directory_is_left_alone(self, tmp_path: Path) -> None:
+        (tmp_path / ".gitignore").mkdir()
+
+        code, output = run_init_capturing(tmp_path)
+
+        assert code == 0
+        assert "could not be read as text" in output
+        assert (tmp_path / ".gitignore").is_dir()
 
 
 class TestScaffoldContract:
@@ -241,6 +337,21 @@ class TestScaffoldContract:
 
         assert assigned, "the language-assignment shape changed; fix this test"
         assert assigned - {"unknown"} <= set(_LANGUAGE_IGNORES)
+
+    def test_every_detected_language_has_a_lockfile_policy(self) -> None:
+        """Ignoring a language's build output while saying nothing about
+        its lockfile is #201 half-fixed, which is how it survived the
+        first pass. An empty tuple is a policy; a missing key is not."""
+        assert set(_LANGUAGE_LOCKFILES) == set(_LANGUAGE_IGNORES)
+
+    def test_lockfile_names_come_from_the_policy_vocabulary(self) -> None:
+        """policy.LOCKFILE_BASENAMES already decides what counts as a
+        lockfile, for the merge-policy size caps. Two lists would drift:
+        a name init stages but policy does not know still counts against
+        max_lines_changed."""
+        named = {name for names in _LANGUAGE_LOCKFILES.values() for name in names}
+
+        assert named <= LOCKFILE_BASENAMES
 
     def test_every_command_named_in_next_steps_is_real(self) -> None:
         """The block is the first thing a new user reads; a renamed

--- a/tests/test_init_wizard.py
+++ b/tests/test_init_wizard.py
@@ -41,6 +41,15 @@ class TestPlanScaffold:
         planned = {e.path.name: e for e in plan_scaffold(tmp_path)}
         assert planned[".gitignore"].action == "append"
 
+    def test_an_unreadable_gitignore_is_planned_as_kept(self, tmp_path: Path) -> None:
+        """The preview must not promise a write init will not make: a
+        .gitignore it cannot read is left alone, and reading it used to
+        crash the preview with UnicodeDecodeError (#201 review)."""
+        (tmp_path / ".gitignore").write_bytes(b"build\xff/\n")
+
+        planned = {e.path.name: e for e in plan_scaffold(tmp_path)}
+        assert planned[".gitignore"].action == "keep"
+
     def test_only_gitignore_is_ever_planned_as_an_append(self, tmp_path: Path) -> None:
         (tmp_path / ".gitignore").write_text("secrets.env\n")
         (tmp_path / "kstrl.toml").write_text("")

--- a/tests/test_init_wizard.py
+++ b/tests/test_init_wizard.py
@@ -21,17 +21,32 @@ from kstrl.tui.screens.init_wizard import InitWizardScreen
 class TestPlanScaffold:
     def test_markers_flip_after_init(self, tmp_path: Path) -> None:
         before = plan_scaffold(tmp_path)
-        assert all(not entry.exists for entry in before)
+        assert all(entry.action == "create" for entry in before)
         names = [entry.path.name for entry in before]
         assert "kstrl.toml" in names
         assert "prompt.md" in names
         assert "CLAUDE.md" in names
+        assert ".gitignore" in names
 
         (tmp_path / "kstrl.toml").write_text("")
         after = plan_scaffold(tmp_path)
-        by_name = {e.path.name: e.exists for e in after}
-        assert by_name["kstrl.toml"] is True
-        assert by_name["prd.json"] is False
+        by_name = {e.path.name: e for e in after}
+        assert by_name["kstrl.toml"].action == "keep"
+        assert by_name["prd.json"].action == "create"
+
+    def test_existing_gitignore_is_planned_as_an_append(self, tmp_path: Path) -> None:
+        """An existing .gitignore is added to, not kept as-is (#201)."""
+        (tmp_path / ".gitignore").write_text("secrets.env\n")
+
+        planned = {e.path.name: e for e in plan_scaffold(tmp_path)}
+        assert planned[".gitignore"].action == "append"
+
+    def test_only_gitignore_is_ever_planned_as_an_append(self, tmp_path: Path) -> None:
+        (tmp_path / ".gitignore").write_text("secrets.env\n")
+        (tmp_path / "kstrl.toml").write_text("")
+
+        appending = [e.path.name for e in plan_scaffold(tmp_path) if e.action == "append"]
+        assert appending == [".gitignore"]
 
 
 class TestApplyAgentSettings:

--- a/tests/test_rich_ui.py
+++ b/tests/test_rich_ui.py
@@ -1,0 +1,68 @@
+"""RichUI renders PLAIN TEXT, never Rich markup.
+
+The UI protocol (kstrl/ui/base.py) carries strings a caller wants shown.
+Rich's `console.print(str)` parses those as MARKUP, so anything in
+square brackets is read as a style tag and dropped: `ks init` printed
+its `ks run [iterations]` help line as `ks run`, losing the argument the
+line exists to teach (#256 review). PlainUI never had the problem, so a
+test written against PlainUI could not see it.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+
+import pytest
+
+from kstrl.ui.rich_ui import RichUI
+
+# Rich still emits style codes with no_color=True (dim, bold), and the
+# repr highlighter splits a styled run at the brackets, so a substring
+# check has to compare what a reader would SEE.
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+# One line of real help text: a bracketed argument, an angle-bracket
+# placeholder, and a flag.
+SAMPLE = "ks feature [iterations] --prd scripts/kstrl/feature/<name>/prd.json"
+
+TEXT_METHODS = ("title", "section", "subsection", "info", "ok", "warn", "err")
+
+
+def visible(rendered: str) -> str:
+    """The rendered text with style codes removed."""
+    return _ANSI.sub("", rendered)
+
+
+@pytest.mark.parametrize("method", TEXT_METHODS)
+@pytest.mark.parametrize("ascii_only", [False, True])
+def test_text_methods_do_not_eat_markup(method: str, ascii_only: bool) -> None:
+    buffer = io.StringIO()
+    ui = RichUI(no_color=True, ascii_only=ascii_only, file=buffer)
+
+    getattr(ui, method)(SAMPLE)
+
+    assert SAMPLE in visible(buffer.getvalue())
+
+
+def test_kv_and_stream_line_keep_their_argument() -> None:
+    # Short enough that neither line wraps at the 80-column default,
+    # which is a different failure from markup eating the argument.
+    short = "ks run [iterations]"
+    buffer = io.StringIO()
+    ui = RichUI(no_color=True, file=buffer)
+
+    ui.kv("mode", short)
+    ui.stream_line("SYS", short)
+
+    assert visible(buffer.getvalue()).count(short) == 2
+
+
+def test_a_lone_style_tag_is_printed_not_interpreted() -> None:
+    """The failure mode in miniature: `[dim]` is text, not a style."""
+    buffer = io.StringIO()
+    ui = RichUI(no_color=True, file=buffer)
+
+    ui.info("[dim]not a style[/dim]")
+
+    assert "[dim]not a style[/dim]" in visible(buffer.getvalue())


### PR DESCRIPTION
Fixes #201
Fixes #256

Two defects in the first thing a new user sees, both in `ks init`, in disjoint
regions of `kstrl/init_cmd.py`. They ship together because neither touches the
verification gate and both needed the same missing thing: a direct test for
`run_init`. Nothing in `tests/` called it before this PR.

## #201: init scaffolds no .gitignore

The in-loop scope guard counts untracked files (`git ls-files --others
--exclude-standard`) against a component's allowed paths, so `__pycache__/` and
`uv.lock`, written by the verify commands themselves, read as out-of-scope
edits. Measured on the issue: one wasted engineer iteration, then a ceiling
breach. kstrl's own `.gitignore` has always carried that block; the project
protected itself and not its users.

`ks init` now writes a marked block, chosen from the language it already
detects for CLAUDE.md:

```
# kstrl: artifacts the scope guard would otherwise count
# The in-loop scope guard counts UNTRACKED files against a component's
# allowed paths, so anything your test / typecheck / lint commands write
# has to be ignored here or committed - otherwise the agent's own build
# artifacts read as out-of-scope edits and cost an iteration.
__pycache__/
...
.kstrl/
.DS_Store
```

An existing `.gitignore` is a user-owned file, so it is **appended to, never
rewritten**, and the marker line is the idempotency test: a second `ks init` is
a no-op, and edits made below the block survive.

## The uv.lock question

The block does **not** ignore `uv.lock`. Ignoring the lockfile, which
`examples/uv-python/.gitignore` did, hides it from the scope guard by hiding it
from git; that is a workaround, not a lockfile policy. For an application the
lockfile belongs in version control.

So init makes it **tracked** instead, and the mechanism is `git add` with no
commit:

- `git ls-files --others --exclude-standard` never lists a path that is in the
  index, so staging alone removes the failure mode this issue is about.
- Creating a commit in someone's repository is not a scaffolder's call.
  Init stages and then says exactly that: `Staged uv.lock (staged only, no
  commit was created)`, followed by the instruction to commit it, and why - a
  factory worktree is cut from a **commit**, so an uncommitted lockfile is not
  in it and `uv run` writes a fresh untracked one there.
- With `pyproject.toml` but no lockfile yet (a fresh `uv init`, the case the
  issue reproduces), it warns and points at `uv lock`. There is no silent write
  and no silent commit; every branch prints what it did.

## #256: init never names the spec workflow

The next-steps block was hardcoded with no branch and named `ks run`,
`ks understand`, `ks feature` only, so a user following it hand-writes user
stories and never learns the tool can decompose the spec they already have.
It now leads with the spec path, labels the single-component path as such, and
names the free measurement:

```
You have a spec (recommended):
  ks decompose --spec <spec.md> --project-name <name>   # plan it
  ks factory --spec <spec.md> --project-name <name>     # plan it and build it

You want to drive one component by hand:
  1. Edit scripts/kstrl/prompt.md
  2. Add user stories to scripts/kstrl/prd.json
  3. ks run [iterations]                                # one component, no PR

Other modes:
  ks understand [iterations]
  ks feature [iterations] --prd scripts/kstrl/feature/<name>/prd.json

Measure before you spend (no agent, no cost):
  ks sense
  ks sense --allowed-path '<glob>'                      # preflight the scope guard
```

The `ks sense --allowed-path` line is the preflight the R10 review comment on
#201 asked for: it reproduces a `diff_scope` failure on a fresh clone in
seconds, with no agent spend.

## Also in this PR

- **`tests/test_init_cmd.py`**, the first direct tests for `run_init`: block
  contents per language, idempotency on re-run, append to an existing file
  (including one with no trailing newline, and an empty one), user edits below
  the block surviving, staging with no new commit, the tracked and missing
  lockfile branches, the printed text, and the two exit codes.
  Two are mechanisms rather than assertions on copy: every language
  `_detect_project_context` can return has a row in the ignore table, and every
  `ks <cmd> --flag` named in the block resolves against the click tree.
- **The wizard preview stops lying.** `init_wizard.plan_scaffold` claimed to
  list "the exact file set run_init touches" and omitted `.gitignore`; its
  entries now carry a `create` / `keep` / `append` action, so the preview cannot
  say "exists - kept" about a file init appends to. One field, three mutually
  exclusive states, instead of two booleans with an illegal combination.
- **`examples/uv-python/.gitignore` is regenerated from the same block** and
  held in lockstep by a test, the way that example's `prompt.md` is already held
  against `DEFAULT_PROMPT`. It used to ignore `uv.lock`, so the shipped example
  taught the workaround this change argues against.

## Review round two

Five findings, four reproduced by running the branch rather than reading it.

1. **The default UI ate the argument the block exists to teach.** Rich parses a
   printed `str` as MARKUP, so `ks run [iterations]` rendered as `ks run` on
   every line, and the plain-text tests could not see it. Fixed at the seam:
   the `Console` is built with `markup=False`, because the UI protocol carries
   plain text and no method of it should parse tags. The four line printers
   additionally wrap in `Text`, which also skips the repr highlighter, so help
   text is not recoloured by type. `tests/test_rich_ui.py` parametrizes the
   invariant over every text method in both ascii modes; measured, `title` and
   ascii-mode `section` had the same defect and a per-method fix would have
   left them. The longest `NEXT_STEPS` line is 77 columns now, so Rich no
   longer wraps the trailing comment onto its own row at 80.

2. **The remediation was the command that had just failed.** With the lockfile
   already ignored, `git add` refuses the path, so advising `git add uv.lock`
   advised the failure again. `git.stage_file` now returns git's message rather
   than a bool, and on failure init asks `git check-ignore -v` and names the
   rule to delete, which git's own stderr never does: `uv.lock is ignored by
   .gitignore:1:*.lock`. Probing failure-first keeps a subprocess off the
   common path.

3. **The fix reproduced #201 in kstrl's own tree.** Un-ignoring `uv.lock` in
   `examples/uv-python` left an un-ignored untracked lockfile there. It is
   committed now, and the guard asserts `git ls-files` knows it rather than
   that the file exists, since an untracked file exists too.

4. **One of seven detected languages was covered.** `_LANGUAGE_LOCKFILES` now
   states a policy for every language `_LANGUAGE_IGNORES` covers, an empty
   tuple meaning "this toolchain has no lockfile", and its names come from
   `policy.LOCKFILE_BASENAMES`, the vocabulary the merge-policy size caps
   already key on. Tests keep the three sets from drifting. Measured: `cargo
   test` writes `Cargo.lock`, `npm install` writes `package-lock.json`, `uv run
   pytest` writes `uv.lock`; `go.sum` appears only once a module requires
   something, and Gradle/Maven have no lockfile. Python gained `poetry.lock`
   and `Pipfile.lock`, so a poetry project is no longer told its lockfile is
   missing.

5. **An unreadable `.gitignore` was an uncaught traceback.** `UnicodeDecodeError`
   is a `ValueError`, not an `OSError`. Reads go through `_read_text_or_none`
   and an unreadable file is left alone rather than appended to blind. The same
   helper now covers `pyproject.toml`, `Cargo.toml`, `go.mod` and
   `package.json` in `_detect_project_context`, which runs BEFORE the
   `.gitignore` step and had the identical crash.

`.python-version` was deliberately not re-ignored, which is the one push-back:
measured, none of `uv run`, `uv sync`, `uv lock` or `uv venv` writes one (only
`uv init` and `uv python pin` do, before `ks init` runs), so it cannot appear
mid-iteration, and a pin belongs in version control for the same reason a
lockfile does.

## Verification

`uv run pytest tests/ -q`, `uv run mypy kstrl/ --strict`,
`uv run ruff check kstrl/ tests/` and `pre-commit run --all-files` all green
locally. No `*_PROMPT` constant was touched, so no calibration is implicated
(H2/H3); the new copy constant is deliberately named `NEXT_STEPS`.

## Notes

- Issue #256 says "three of the seventeen commands". `ks --help` lists 16.
- Follow-up worth filing, deliberately not done here because it is guard-side:
  `.kstrl/` is kstrl's own runtime state and is currently kept out of the
  untracked walk by asking the user's `.gitignore` to do it. `loop.py` already
  carves out `.kstrl/runs/<run_id>/` at the guard; widening that to `.kstrl/`
  would fix every repo scaffolded before this change, which cannot be reached by
  a `.gitignore` written today.

