### PR TITLE
feat(decompose): meter the architect, and report what it cost (#257)

### DIFF
--- a/kstrl/agents/base.py
+++ b/kstrl/agents/base.py
@@ -584,19 +584,55 @@ def _as_float(value: object) -> float | None:
     return float(value) if value >= 0 else None
 
 
-def collect_usage(agent: object) -> UsageTotals:
+def usage_cursor(agent: object) -> int:
+    """How many records the agent already holds, for a later ``since=``.
+
+    Deliberately NOT ``collect_usage(agent).calls``. Those agree only
+    because ``add_record`` increments ``calls`` unconditionally, which is
+    an accident of that method and not a stated contract - and they
+    diverge in exactly the case the meter exists to survive.
+
+    Measured (2026-08-30) on four records whose second raises on field
+    access: ``collect_usage`` aborts the walk and reports ``calls=2``,
+    while four records are present. Seeding the next call with 2 folds
+    records 2 and 3 - which belong to the FIRST unit of work and went
+    unreported there - into the SECOND one's total. A cursor of 4 folds
+    nothing, which is correct: records the meter could not read are lost
+    from the report, not silently re-attributed to whoever ran next.
+
+    Degrades to 0 (fold everything, the pre-``since`` behavior) rather
+    than raising: a cursor is accounting, and accounting never gates a
+    run.
+    """
+    try:
+        records = getattr(agent, "usage_records", None)
+        return 0 if records is None else len(list(records))
+    except Exception as exc:  # noqa: BLE001 - meter must never crash a run
+        logger.warning("Failed to read agent usage cursor: %s", exc)
+        return 0
+
+
+def collect_usage(agent: object, *, since: int = 0) -> UsageTotals:
     """Aggregate an agent's accumulated ``usage_records`` defensively.
 
     Works on ANY object: an agent without the attribute (a third-party
     Agent implementation predating R3.1, or a test fake) yields empty
     totals rather than an error - the meter must never gate correctness.
+
+    ``usage_records`` is CUMULATIVE for the life of the agent instance,
+    so the default folds every call the instance ever made. Callers that
+    hand out a fresh agent per unit of work want exactly that. A caller
+    that cannot rely on freshness passes ``since`` - the record count
+    taken before the work by :func:`usage_cursor` - and gets only the
+    tail. Sliced rather than indexed so a list that shrank or was
+    replaced underneath degrades to empty totals instead of raising.
     """
     totals = UsageTotals()
     try:
         records = getattr(agent, "usage_records", None)
         if records is None:
             return totals
-        for record in list(records):
+        for record in list(records)[since:]:
             totals.add_record(record)
     except Exception as exc:  # noqa: BLE001 - meter must never crash a run
         logger.warning("Failed to collect agent usage records: %s", exc)

--- a/kstrl/agents/base.py
+++ b/kstrl/agents/base.py
@@ -1,4 +1,4 @@
-"""Base agent protocol and usage metering types for kstrl."""
+"""Base agent protocol, usage metering types, and the usage rollup."""
 
 from __future__ import annotations
 
@@ -6,7 +6,10 @@ import logging
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Final, Protocol
+from typing import TYPE_CHECKING, Any, Final, Protocol
+
+if TYPE_CHECKING:
+    from kstrl.ui.base import UI
 
 logger = logging.getLogger(__name__)
 
@@ -416,6 +419,154 @@ def usage_coverage(
         roles=tuple(roles),
         ceiling=ceiling,
     )
+
+
+#: The architect's role name, which is also its pseudo-component id
+#: (``decompose.ARCHITECT_COMPONENT`` aliases this). Stated HERE because
+#: the ordering tuple below has to agree with it and cannot import
+#: ``decompose`` - the dependency runs the other way. The same reasoning
+#: as ``CEILING_AXES`` above: a name re-derived locally is a name two
+#: surfaces can disagree about, and here the disagreement would be
+#: silent, dropping the architect to the tail of the rollup.
+ARCHITECT_ROLE: Final = "architect"
+
+# Rollup row order for the R3.1 usage table, in the order the roles run:
+# the architect decomposes the spec before any component's engineer loop
+# starts (#257). Phases outside this list (future additions) sort after,
+# alphabetically.
+_USAGE_PHASE_ORDER: Final[tuple[str, ...]] = (
+    ARCHITECT_ROLE,
+    "engineer",
+    "review",
+    "security",
+    "distill",
+)
+
+
+def format_usage_rollup(
+    usage_meter: Mapping[str, Mapping[str, UsageTotals]],
+    run_usage: UsageTotals,
+) -> list[str]:
+    """Render the per-component, per-phase usage table (R3.1).
+
+    Token and cost columns are sums of CLI self-reports: codex reports
+    only a total (in/out columns stay 0), CustomAgent reports nothing.
+    Whenever some calls reported no usage the footer says so explicitly -
+    the totals are then lower bounds, not measurements (H4).
+
+    R8 (measured): the ``unreported_calls`` footer alone was not enough.
+    It fires only when a call reported NOTHING, so a cross-family
+    reviewer that reports tokens and no cost left it at 0 while
+    contributing $0 to a run whose cost total covered 8 of 13 calls -
+    the footer stayed silent on exactly the run it existed for. Each
+    axis now reports its own coverage, and names the roles that are
+    missing from it.
+
+    Lives here rather than in ``factory`` because ``ks decompose`` prints
+    the same table for the architect alone, and a second renderer would
+    be a second place for the coverage rules to drift (#257).
+    """
+    header = (
+        f"{'component':<24} {'phase':<10} {'calls':>5} "
+        f"{'tokens_in':>11} {'tokens_out':>11} {'tokens_total':>13} "
+        f"{'cost_usd':>9} {'time_s':>8}"
+    )
+    lines = [header]
+
+    def _phase_sort_key(phase: str) -> tuple[int, str]:
+        try:
+            return (_USAGE_PHASE_ORDER.index(phase), phase)
+        except ValueError:
+            return (len(_USAGE_PHASE_ORDER), phase)
+
+    def _row(label: str, phase: str, totals: UsageTotals) -> str:
+        # Each cell is gated by ITS OWN axis, never by known_calls (R8
+        # review finding 2). known_calls means only "reported
+        # something", so a cost-only invocation (known_calls=1,
+        # token_calls=0) printed `0 0 0` tokens while the footer said
+        # token coverage was EMPTY and the total was a lower bound - the
+        # row contradicted the footer directly under it.
+        #
+        # "-" means "no call in this row reported this figure", never
+        # "it was zero". Keyed on the call counters rather than on the
+        # totals so a genuinely reported 0 tokens / $0.0000 is not
+        # rendered as silence - the same distinction the ceilings make.
+        if totals.token_calls > 0:
+            tokens_in = f"{totals.input_tokens:,}"
+            tokens_out = f"{totals.output_tokens:,}"
+            tokens_total = f"{totals.total_tokens:,}"
+        else:
+            tokens_in = tokens_out = tokens_total = "-"
+        cost = f"{totals.cost_usd:.4f}" if totals.cost_calls > 0 else "-"
+        return (
+            f"{label:<24} {phase:<10} {totals.calls:>5} "
+            f"{tokens_in:>11} {tokens_out:>11} {tokens_total:>13} "
+            f"{cost:>9} {totals.duration_seconds:>8.0f}"
+        )
+
+    for comp_id in sorted(usage_meter):
+        phases = usage_meter[comp_id]
+        for phase in sorted(phases, key=_phase_sort_key):
+            lines.append(_row(comp_id, phase, phases[phase]))
+    lines.append(_row("TOTAL", "", run_usage))
+    lines.extend(_usage_rollup_notes(usage_meter, run_usage))
+    return lines
+
+
+def _usage_rollup_notes(
+    usage_meter: Mapping[str, Mapping[str, UsageTotals]],
+    run_usage: UsageTotals,
+) -> list[str]:
+    """The rollup's footer: what the table above does NOT account for.
+
+    Split from the renderer because measured: inlined, ``complexipy``
+    scores ``format_usage_rollup`` at 17 against the repo's gate of 15.
+    """
+    notes: list[str] = []
+    if run_usage.unreported_calls > 0:
+        notes.append(
+            f"note: {run_usage.unreported_calls} of {run_usage.calls} "
+            "call(s) reported no token/cost data; token and cost totals "
+            "are lower bounds"
+        )
+    # Per-axis coverage, which the note above cannot express: a call can
+    # report tokens and no cost. Suppressed when nothing at all was
+    # reported, because the note above already says precisely that and
+    # three lines for one fact reads as noise.
+    if run_usage.known_calls > 0:
+        for axis in ("token", "cost"):
+            note = usage_coverage(usage_meter, axis=axis).note()
+            if note:
+                notes.append(f"note: {note}")
+    return notes
+
+
+def print_usage_rollup(
+    ui: UI,
+    usage_meter: Mapping[str, Mapping[str, UsageTotals]],
+    run_usage: UsageTotals,
+    *,
+    title: str,
+) -> None:
+    """Put the rollup on a terminal, or print nothing at all.
+
+    The guard, the heading and the indent live here with the renderer so
+    the two commands that report spend cannot drift apart in the half the
+    operator actually reads. ``title`` is a parameter rather than a
+    constant because the two callers are NOT reporting the same thing:
+    ``ks factory`` renders a whole run, ``ks decompose`` renders one role,
+    and giving both the same heading would invite reading the run's total
+    as though it included the architect (#257 - it does not, until the
+    architect is metered inside the factory run).
+
+    Zero calls prints nothing: an empty table says "this ran and cost
+    nothing", which is the opposite of "this never ran".
+    """
+    if run_usage.calls == 0:
+        return
+    ui.subsection(title)
+    for line in format_usage_rollup(usage_meter, run_usage):
+        ui.info(f"  {line}")
 
 
 def _as_int(value: object) -> int | None:

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -13,11 +13,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from kstrl.agents.base import (
+    ARCHITECT_ROLE,
+    Agent,
+    collect_usage,
+    print_usage_rollup,
+)
 from kstrl.events import (
     ArtifactWritten,
     ComponentCompleted,
     ComponentFailed,
     ComponentStarted,
+    ComponentUsage,
     Event,
     EventBus,
     PhaseCompleted,
@@ -43,7 +50,6 @@ from kstrl.names import validate_branch_name, validate_component_id
 from kstrl.prd import PRD
 
 if TYPE_CHECKING:
-    from kstrl.agents.base import Agent
     from kstrl.evolution import EvolutionJournal
     from kstrl.ui.base import UI
 
@@ -1158,7 +1164,50 @@ def _generate_component_prd(
     return prd_path
 
 
-ARCHITECT_COMPONENT = "architect"
+#: The architect is a one-role pseudo-component, so its component id and
+#: its role name are deliberately the same string. Aliased rather than
+#: restated so a rename cannot move one without the other and silently
+#: drop the architect to the tail of the usage rollup.
+ARCHITECT_COMPONENT = ARCHITECT_ROLE
+
+
+def _report_architect_usage(agent: Agent, ui: UI, bus: EventBus | None) -> None:
+    """Publish what the architect's LLM calls cost, to the bus and the
+    terminal (#257).
+
+    The component id is the pseudo-component ``_decompose_spec_impl``
+    already announced in the plan, so the event lands on an existing row
+    rather than conjuring one. The PHASE key is that same word because a
+    meter's phase key is the ROLE name - it is what the coverage footer
+    prints - and the taxonomy's fifth role is the architect. It is
+    deliberately not ``decompose``/``audit``, the lifecycle phases this
+    component reports elsewhere, which name steps rather than roles.
+
+    Called from a ``finally``, so it must not raise: ``collect_usage``
+    already swallows a malformed record set, and zero calls (an agent
+    predating R3.1, or one that never ran) reports nothing at all.
+    """
+    totals = collect_usage(agent)
+    if totals.calls == 0:
+        return
+    if bus is not None:
+        bus.emit(
+            ComponentUsage(
+                component=ARCHITECT_COMPONENT,
+                phase=ARCHITECT_ROLE,
+                **totals.to_dict(),
+            )
+        )
+    print_usage_rollup(
+        ui,
+        {ARCHITECT_COMPONENT: {ARCHITECT_ROLE: totals}},
+        totals,
+        # NOT "Usage rollup": `ks factory` decomposes and then prints its
+        # own run-level rollup, whose total excludes the architect until
+        # piece B. Two tables under one heading would invite reading the
+        # later one as the run's whole spend.
+        title="Architect usage",
+    )
 
 
 def _decompose_spec_impl(
@@ -1657,7 +1706,22 @@ def decompose_spec(
     bus: EventBus | None = None,
     transcript: Callable[[str], None] | None = None,
 ) -> Manifest:
-    """Run decomposition and guarantee a terminal event on every exit."""
+    """Run decomposition, guaranteeing a ``RunCompleted`` and a usage
+    capture on every exit.
+
+    #257: the capture sits in a ``finally`` because the blocker halt is
+    the COMMON outcome on a first spec, and it is the path where the
+    operator most needs the number before editing and re-running. An
+    emit-after-return would miss exactly that case.
+
+    Consequence, stated plainly: ``RunCompleted`` is emitted by the impl
+    (both the halt site and the success tail) or by the ``except`` below,
+    so ``ComponentUsage`` trails it on EVERY path, not just the halt. No
+    consumer treats ``RunCompleted`` as a stream terminator - the reducer
+    sets a flag and keeps folding - and every reader folds the whole
+    stream, so position changes no total. A consumer that ever does stop
+    there has to move this emit, not just handle it.
+    """
     started = time.monotonic()
     try:
         return _decompose_spec_impl(
@@ -1692,3 +1756,5 @@ def decompose_spec(
                 )
             )
         raise
+    finally:
+        _report_architect_usage(agent, ui, bus)

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import secrets
@@ -18,6 +19,7 @@ from kstrl.agents.base import (
     Agent,
     collect_usage,
     print_usage_rollup,
+    usage_cursor,
 )
 from kstrl.events import (
     ArtifactWritten,
@@ -48,6 +50,8 @@ from kstrl.manifest import (
 )
 from kstrl.names import validate_branch_name, validate_component_id
 from kstrl.prd import PRD
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from kstrl.evolution import EvolutionJournal
@@ -1171,9 +1175,23 @@ def _generate_component_prd(
 ARCHITECT_COMPONENT = ARCHITECT_ROLE
 
 
-def _report_architect_usage(agent: Agent, ui: UI, bus: EventBus | None) -> None:
+def _report_architect_usage(
+    agent: Agent,
+    ui: UI,
+    bus: EventBus | None,
+    *,
+    since: int,
+) -> None:
     """Publish what the architect's LLM calls cost, to the bus and the
     terminal (#257).
+
+    ``since`` is the agent's record count before this decomposition ran.
+    ``decompose_spec`` is public and takes an ``Agent``, so a caller can
+    hold one across two calls - re-running after editing the spec is the
+    obvious way - and would then see run 1 folded into run 2's event AND
+    its table. Every in-tree caller passes a fresh agent; the offset
+    removes the dependency rather than documenting an invariant a caller
+    cannot see (#257 review).
 
     The component id is the pseudo-component ``_decompose_spec_impl``
     already announced in the plan, so the event lands on an existing row
@@ -1187,7 +1205,7 @@ def _report_architect_usage(agent: Agent, ui: UI, bus: EventBus | None) -> None:
     already swallows a malformed record set, and zero calls (an agent
     predating R3.1, or one that never ran) reports nothing at all.
     """
-    totals = collect_usage(agent)
+    totals = collect_usage(agent, since=since)
     if totals.calls == 0:
         return
     if bus is not None:
@@ -1723,6 +1741,8 @@ def decompose_spec(
     there has to move this emit, not just handle it.
     """
     started = time.monotonic()
+    # Read BEFORE the work so the report covers this call only.
+    usage_before = usage_cursor(agent)
     try:
         return _decompose_spec_impl(
             spec_path=spec_path,
@@ -1757,4 +1777,25 @@ def decompose_spec(
             )
         raise
     finally:
-        _report_architect_usage(agent, ui, bus)
+        # Isolated because a `finally` that raises REPLACES the exception
+        # propagating through it, which here would destroy the very halt
+        # this reporting exists to cover: the SpecBlockerError becomes a
+        # BrokenPipeError traceback and the documented exit code 2 is
+        # lost.
+        #
+        # Measured (2026-08-30), because the obvious repro is the wrong
+        # one: `ks decompose | head -5` does NOT do it. Both UIs default
+        # to sys.stderr (ui/plain.py, ui/rich_ui.py), so piping stdout
+        # leaves the stream the rollup writes to untouched. The shape
+        # that fires is `ks decompose 2>&1 | head -5`, which raises
+        # BrokenPipeError out of PlainUI._print's `print(...)` once the
+        # writes pass the pipe buffer.
+        #
+        # `collect_usage` and `EventBus.emit` are already defensive; the
+        # UI writes are not, and must not be made so inside
+        # `print_usage_rollup` - the factory epilogue shares it and a
+        # failed write there should be loud.
+        try:
+            _report_architect_usage(agent, ui, bus, since=usage_before)
+        except Exception as exc:  # noqa: BLE001 - accounting never gates a run
+            logger.warning("Failed to report architect usage: %s", exc)

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, TextIO
 
-from kstrl.agents.base import UsageTotals, collect_usage, usage_coverage
+from kstrl.agents.base import UsageTotals, collect_usage, print_usage_rollup
 from kstrl.agents.proc import kill_active_process_groups
 from kstrl.autonomy import (
     AutonomyConfig,
@@ -2282,91 +2282,6 @@ def _expired_futures(
     return [f for f in running if not f.done() and f in deadlines and now >= deadlines[f]]
 
 
-# Rollup row order for the R3.1 usage table; phases outside this list
-# (future additions) sort after, alphabetically.
-_USAGE_PHASE_ORDER = ("engineer", "review", "security", "distill")
-
-
-def _format_usage_rollup(
-    usage_meter: Mapping[str, Mapping[str, UsageTotals]],
-    run_usage: UsageTotals,
-) -> list[str]:
-    """Render the per-component, per-phase usage table (R3.1).
-
-    Token and cost columns are sums of CLI self-reports: codex reports
-    only a total (in/out columns stay 0), CustomAgent reports nothing.
-    Whenever some calls reported no usage the footer says so explicitly -
-    the totals are then lower bounds, not measurements (H4).
-
-    R8 (measured): the ``unreported_calls`` footer alone was not enough.
-    It fires only when a call reported NOTHING, so a cross-family
-    reviewer that reports tokens and no cost left it at 0 while
-    contributing $0 to a run whose cost total covered 8 of 13 calls -
-    the footer stayed silent on exactly the run it existed for. Each
-    axis now reports its own coverage, and names the roles that are
-    missing from it.
-    """
-    header = (
-        f"{'component':<24} {'phase':<10} {'calls':>5} "
-        f"{'tokens_in':>11} {'tokens_out':>11} {'tokens_total':>13} "
-        f"{'cost_usd':>9} {'time_s':>8}"
-    )
-    lines = [header]
-
-    def _phase_sort_key(phase: str) -> tuple[int, str]:
-        try:
-            return (_USAGE_PHASE_ORDER.index(phase), phase)
-        except ValueError:
-            return (len(_USAGE_PHASE_ORDER), phase)
-
-    def _row(label: str, phase: str, totals: UsageTotals) -> str:
-        # Each cell is gated by ITS OWN axis, never by known_calls (R8
-        # review finding 2). known_calls means only "reported
-        # something", so a cost-only invocation (known_calls=1,
-        # token_calls=0) printed `0 0 0` tokens while the footer said
-        # token coverage was EMPTY and the total was a lower bound - the
-        # row contradicted the footer directly under it.
-        #
-        # "-" means "no call in this row reported this figure", never
-        # "it was zero". Keyed on the call counters rather than on the
-        # totals so a genuinely reported 0 tokens / $0.0000 is not
-        # rendered as silence - the same distinction the ceilings make.
-        if totals.token_calls > 0:
-            tokens_in = f"{totals.input_tokens:,}"
-            tokens_out = f"{totals.output_tokens:,}"
-            tokens_total = f"{totals.total_tokens:,}"
-        else:
-            tokens_in = tokens_out = tokens_total = "-"
-        cost = f"{totals.cost_usd:.4f}" if totals.cost_calls > 0 else "-"
-        return (
-            f"{label:<24} {phase:<10} {totals.calls:>5} "
-            f"{tokens_in:>11} {tokens_out:>11} {tokens_total:>13} "
-            f"{cost:>9} {totals.duration_seconds:>8.0f}"
-        )
-
-    for comp_id in sorted(usage_meter):
-        phases = usage_meter[comp_id]
-        for phase in sorted(phases, key=_phase_sort_key):
-            lines.append(_row(comp_id, phase, phases[phase]))
-    lines.append(_row("TOTAL", "", run_usage))
-    if run_usage.unreported_calls > 0:
-        lines.append(
-            f"note: {run_usage.unreported_calls} of {run_usage.calls} "
-            "call(s) reported no token/cost data; token and cost totals "
-            "are lower bounds"
-        )
-    # Per-axis coverage, which the note above cannot express: a call can
-    # report tokens and no cost. Suppressed when nothing at all was
-    # reported, because the note above already says precisely that and
-    # three lines for one fact reads as noise.
-    if run_usage.known_calls > 0:
-        for axis in ("token", "cost"):
-            note = usage_coverage(usage_meter, axis=axis).note()
-            if note:
-                lines.append(f"note: {note}")
-    return lines
-
-
 def _record_autonomy_outcome(
     *,
     root_dir: Path,
@@ -3720,10 +3635,12 @@ def _run_factory_locked(
         ui.kv("Merge pending", str(len(factory_result.merge_pending)))
     ui.kv("Duration", f"{factory_duration:.0f}s")
     # R3.1 usage rollup: per component, per phase, plus the run total.
-    if pipeline.run_usage.calls > 0:
-        ui.subsection("Usage rollup")
-        for line in _format_usage_rollup(pipeline.usage_meter, pipeline.run_usage):
-            ui.info(f"  {line}")
+    print_usage_rollup(
+        ui,
+        pipeline.usage_meter,
+        pipeline.run_usage,
+        title="Usage rollup",
+    )
     if pipeline.token_budget_exceeded():
         ui.err(
             f"TOKEN BUDGET EXCEEDED: {pipeline.run_usage.total_tokens} total tokens "

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -66,8 +66,9 @@ from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Final, Protocol
 
+from kstrl.runid import run_kind
 from kstrl.statedir import (
     CONTROL_SPEND,
     control_file,
@@ -669,14 +670,62 @@ def read_run_spend(root_dir: Path, run_id: str) -> RunSpend:
     )
 
 
+#: Run-id kind prefix of the runs this daemon's own child produces;
+#: ``owned_run_spend`` charges only these.
+#:
+#: Coupled to the spawned argv by CONVENTION, not derivation: `ks factory`
+#: gets this prefix from ``mint_run_id``'s default, not from its command
+#: name. Changing either without the other silently empties the charge,
+#: so a test pins the two together.
+SPAWNED_RUN_KIND: Final = "factory"
+
+
+def owned_run_spend(
+    root_dir: Path,
+    runs_before: frozenset[str],
+) -> tuple[list[str], RunSpend]:
+    """The run dirs a launch produced, and the spend they reported.
+
+    "Produced" is narrower than "new" (#257 review). `ks decompose` takes
+    no factory.lock, so an operator can start one on this repo at any
+    time and its dir appears inside the window. That was harmless while
+    decompose emitted no usage events; #257 gave it real spend, so
+    without the kind filter the daemon would charge the queue item for
+    money an operator spent by hand, and `max_daily_spend` could halt the
+    queue on it.
+
+    What the filter does and does not buy, stated honestly: it removes
+    the decompose class completely, but it does NOT make the remaining
+    attribution exact. ``.kstrl/factory.lock`` excludes concurrent
+    factory EXECUTION, not concurrent factory DIRS - ``--force-lock``
+    runs a second factory by design, and the embedded dashboard mkdirs
+    its run dir in ``run_embedded`` before ``run_factory`` takes the
+    lock. A foreign factory-kind dir can still land in the window. That
+    hole predates #257 and is unchanged by it; what #257 changed, and
+    this restores, is that decompose dirs now carry real money.
+    """
+    owned = sorted(
+        rid for rid in run_dir_names(root_dir) - runs_before if run_kind(rid) == SPAWNED_RUN_KIND
+    )
+    total = RunSpend()
+    for rid in owned:
+        spend = read_run_spend(root_dir, rid)
+        total = RunSpend(
+            cost_usd=total.cost_usd + spend.cost_usd,
+            cost_calls=total.cost_calls + spend.cost_calls,
+            usage_calls=total.usage_calls + spend.usage_calls,
+        )
+    return owned, total
+
+
 def run_dir_names(root_dir: Path) -> frozenset[str]:
     """Names of every run directory currently on disk.
 
-    Snapshotted before and after a launch so the daemon charges only the
-    runs THIS invocation created (#186 F2). A decompose-kind run dir
-    carries the architect's usage event since #257, but the daemon's own
-    `ks factory` decomposes outside any run dir; see ``serve_cycle`` for
-    why that still leaves the architect unmetered here (#186 F3).
+    Every kind, deliberately: this is the raw disk fact. Snapshotted
+    before and after a launch so the daemon can tell which dirs are new
+    (#186 F2), but "new" alone does not mean "ours" - ``owned_run_spend``
+    narrows the difference to ``SPAWNED_RUN_KIND`` before charging it,
+    and states why there.
     """
     runs_root = state_dir(root_dir) / "runs"
     try:
@@ -2162,28 +2211,26 @@ def serve_cycle(
         return result
 
     # 7. Charge the spend before deciding anything, so a classification
-    #    bug cannot also lose the accounting. Only NEW run dirs count.
-    owned_runs = sorted(run_dir_names(root_dir) - runs_before)
-    total = 0.0
-    covered_calls = 0
-    total_calls = 0
-    for rid in owned_runs:
-        spend = read_run_spend(root_dir, rid)
-        total += spend.cost_usd
-        covered_calls += spend.cost_calls
-        total_calls += spend.usage_calls
+    #    bug cannot also lose the accounting. NEW run dirs are not enough
+    #    to go on; `owned_run_spend` says why.
+    owned_runs, owned = owned_run_spend(root_dir, runs_before)
+    total = owned.cost_usd
+    covered_calls = owned.cost_calls
+    total_calls = owned.usage_calls
 
     # The one statement of why the architect is unmetered HERE, which
-    # the two docstrings above point at rather than restate.
+    # the docstrings above point at rather than restate.
     #
     # #257 gave decompose_spec a ComponentUsage event, but it reaches a
     # run directory only when a bus is passed, and the `ks factory` this
     # daemon spawns decomposes BEFORE any run directory exists, so it
-    # passes none. The architect's spend is therefore still real and
-    # still invisible to a charge that reads run dirs off disk. Closing
-    # it needs the architect metered inside the factory run (#257 piece
-    # B). Until then, naming it keeps the day's total honestly labelled
-    # a floor instead of estimating it (#186 F3).
+    # passes none. Nor does the kind filter above recover it from
+    # somewhere else: a `ks decompose` an operator ran by hand is a
+    # DIFFERENT spend, correctly excluded, not this run's architect.
+    # So the architect's spend here is still real and still invisible.
+    # Closing it needs the architect metered inside the factory run
+    # (#257 piece B). Until then, naming it keeps the day's total
+    # honestly labelled a floor instead of estimating it (#186 F3).
     unmetered = ("architect",)
     charged = ledger.charge(
         total,

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -377,10 +377,9 @@ class DailySpend:
     Only the third is unenforceable.
 
     ``unmetered_phases`` names phases known to spend without reporting
-    anything. The architect is always in it for a spec-decomposed item:
-    ``decompose_spec`` calls the agent but emits no usage events at all,
-    so its spend is real and invisible (#186 F3). Naming it is the honest
-    alternative to estimating it.
+    anything. The architect is always in it for a spec-decomposed item;
+    ``serve_cycle`` states why at the one place that fills this field.
+    Naming it is the honest alternative to estimating it (#186 F3).
     """
 
     date: str = ""
@@ -674,10 +673,10 @@ def run_dir_names(root_dir: Path) -> frozenset[str]:
     """Names of every run directory currently on disk.
 
     Snapshotted before and after a launch so the daemon charges only the
-    runs THIS invocation created (#186 F2). It also picks up a
-    decompose-kind run dir when one exists, which is the only way the
-    architect phase could ever be charged without changing the
-    architect's own instrumentation (#186 F3).
+    runs THIS invocation created (#186 F2). A decompose-kind run dir
+    carries the architect's usage event since #257, but the daemon's own
+    `ks factory` decomposes outside any run dir; see ``serve_cycle`` for
+    why that still leaves the architect unmetered here (#186 F3).
     """
     runs_root = state_dir(root_dir) / "runs"
     try:
@@ -2174,10 +2173,17 @@ def serve_cycle(
         covered_calls += spend.cost_calls
         total_calls += spend.usage_calls
 
-    # The architect always spends and never reports: decompose_spec calls
-    # the agent but emits no usage events at all, so its cost is real and
-    # invisible. Naming it keeps the day's total honestly labelled a
-    # floor instead of estimating it (#186 F3).
+    # The one statement of why the architect is unmetered HERE, which
+    # the two docstrings above point at rather than restate.
+    #
+    # #257 gave decompose_spec a ComponentUsage event, but it reaches a
+    # run directory only when a bus is passed, and the `ks factory` this
+    # daemon spawns decomposes BEFORE any run directory exists, so it
+    # passes none. The architect's spend is therefore still real and
+    # still invisible to a charge that reads run dirs off disk. Closing
+    # it needs the architect metered inside the factory run (#257 piece
+    # B). Until then, naming it keeps the day's total honestly labelled
+    # a floor instead of estimating it (#186 F3).
     unmetered = ("architect",)
     charged = ledger.charge(
         total,

--- a/tests/test_decompose_run.py
+++ b/tests/test_decompose_run.py
@@ -80,9 +80,10 @@ class ExplodingAgent:
 
 
 def _spec_root(tmp_path: Path) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
     spec_file = tmp_path / "spec.md"
     spec_file.write_text("# Spec\nBuild it.")
-    (tmp_path / "scripts" / "kstrl").mkdir(parents=True)
+    (tmp_path / "scripts" / "kstrl").mkdir(parents=True, exist_ok=True)
     return spec_file
 
 
@@ -460,3 +461,89 @@ class TestArchitectUsageIsPrinted:
         # nothing at all.
         assert "Architect usage" in console.getvalue()
         assert "coverage is" not in console.getvalue()
+
+
+class BrokenPipeUI(PlainUI):
+    """A terminal that has gone away, which is what `| head -5` leaves."""
+
+    def subsection(self, text: str) -> None:
+        raise BrokenPipeError(32, "Broken pipe")
+
+
+class TestReportingNeverReplacesTheHalt:
+    """#257 review: a ``finally`` that raises REPLACES the exception
+    propagating through it, so the usage report could destroy the very
+    halt it was written to cover."""
+
+    def test_a_broken_pipe_does_not_swallow_the_blocker_halt(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`ks decompose | head -5` on a spec with blockers: the pipe
+        closes, the rollup's write raises, and without isolation the
+        BrokenPipeError displaces SpecBlockerError - turning the
+        documented exit code 2 into a traceback."""
+        spec_file = _spec_root(tmp_path)
+        with pytest.raises(SpecBlockerError):
+            decompose_spec(
+                spec_path=spec_file,
+                project_name="test",
+                base_branch="main",
+                single_pr=False,
+                agent=MeteringAgent(BLOCKER_OUTPUT),  # type: ignore[arg-type]
+                ui=BrokenPipeUI(no_color=True, file=io.StringIO()),
+                root_dir=tmp_path,
+            )
+
+    def test_a_broken_pipe_does_not_swallow_a_success(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The other direction: a dead terminal must not turn a
+        successful decomposition into a failure either."""
+        spec_file = _spec_root(tmp_path)
+        manifest = decompose_spec(
+            spec_path=spec_file,
+            project_name="test",
+            base_branch="main",
+            single_pr=False,
+            agent=MeteringAgent(MINOR_ISSUE_OUTPUT),  # type: ignore[arg-type]
+            ui=BrokenPipeUI(no_color=True, file=io.StringIO()),
+            root_dir=tmp_path,
+        )
+        assert len(manifest.components) == 2
+
+
+class TestUsageIsPerCallNotCumulative:
+    """#257 review: ``usage_records`` is cumulative for the life of the
+    agent instance. Reading it at a call boundary is correct only while
+    every caller passes a fresh agent, and ``decompose_spec`` is public,
+    so that invariant is invisible to the caller who would break it."""
+
+    def test_a_reused_agent_reports_only_the_second_run(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Re-running decompose after editing the spec, holding the
+        agent. Run 2 must report run 2, not run 1 plus run 2."""
+        agent = MeteringAgent(MINOR_ISSUE_OUTPUT)
+        first, second = io.StringIO(), io.StringIO()
+        _decompose(tmp_path / "a", agent, first)
+        _decompose(tmp_path / "b", agent, second)
+
+        # The agent really did accumulate; the report is what must not.
+        assert len(agent.usage_records) == 2
+        for console in (first, second):
+            printed = console.getvalue()
+            assert "0.5000" in printed
+            assert "1.0000" not in printed, printed
+
+    def test_the_event_is_per_call_too(self, tmp_path: Path) -> None:
+        """Not just the printed table: the ComponentUsage payload the
+        reducer and `serve.read_run_spend` fold must be per-call."""
+        agent = MeteringAgent(MINOR_ISSUE_OUTPUT)
+        _decompose(tmp_path / "a", agent)
+        _decompose(tmp_path / "b", agent)
+        state, _ = load_run_state(tmp_path / "b")
+        assert state.usage_calls == 1
+        assert state.cost_usd == pytest.approx(0.5)

--- a/tests/test_decompose_run.py
+++ b/tests/test_decompose_run.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
+from kstrl.agents.base import UsageRecord
 from kstrl.commandrun import open_command_run
 from kstrl.decompose import SpecBlockerError, decompose_spec
 from kstrl.reducer import load_run_state
@@ -85,9 +86,13 @@ def _spec_root(tmp_path: Path) -> Path:
     return spec_file
 
 
-def _decompose(tmp_path: Path, agent: object) -> object:
+def _decompose(
+    tmp_path: Path,
+    agent: object,
+    console: io.StringIO | None = None,
+) -> object:
     spec_file = _spec_root(tmp_path)
-    ui = PlainUI(no_color=True, file=io.StringIO())
+    ui = PlainUI(no_color=True, file=console if console is not None else io.StringIO())
     run = open_command_run(
         ui,
         tmp_path,
@@ -257,3 +262,201 @@ class TestDecomposeRun:
         )
         assert len(manifest.components) == 2
         assert not (tmp_path / ".kstrl" / "runs").exists()
+
+
+class MeteringAgent:
+    """A decompose agent that reports usage the way a real adapter does.
+
+    One double for every case #257 cares about, because the alternative
+    was three that each re-implemented an existing one in this file:
+
+    - ``cost=None`` is the codex shape, a token total and no price, which
+      is what the coverage footer exists for.
+    - several ``outputs`` drive the retry path, one record per attempt.
+    - ``crash=True`` is the agent that dies AFTER the call was billed.
+
+    The record is appended when the stream ends, where a real adapter
+    appends it (``kstrl/agents/claude_code.py``), except on the crash
+    path, where the money is spent before the failure.
+    """
+
+    def __init__(
+        self,
+        *outputs: str,
+        cost: float | None = 0.5,
+        crash: bool = False,
+    ) -> None:
+        self._outputs = list(outputs)
+        self._cost = cost
+        self._crash = crash
+        self.final_message: str | None = None
+        self.usage_records: list[UsageRecord] = []
+
+    @property
+    def name(self) -> str:
+        return "metering"
+
+    def _bill(self, total_tokens: int = 120) -> None:
+        self.usage_records.append(
+            UsageRecord(
+                input_tokens=100,
+                output_tokens=20,
+                total_tokens=total_tokens,
+                cost_usd=self._cost,
+                duration_seconds=1.5,
+                source="claude-stream-json",
+            )
+        )
+
+    def run(self, prompt: str, cwd: Path | None = None) -> Iterator[str]:
+        # Attempt N reads output N, and the last one repeats if the
+        # architect retries more times than the test scripted.
+        output = self._outputs[min(len(self.usage_records), len(self._outputs) - 1)]
+        if self._crash:
+            self._bill()
+            raise RuntimeError("architect exploded")
+        yield from output.splitlines()
+        if output.strip():
+            self.final_message = output.splitlines()[-1]
+        self._bill()
+
+
+class TestArchitectUsageIsRecorded:
+    """#257: the architect was the one paid role with no meter, so five
+    real ``ks decompose`` runs each reported $0.00."""
+
+    def test_the_blocker_halt_still_records_the_spend(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The halt is the COMMON outcome on a first spec, so an
+        emit-after-success would have missed exactly the case the issue is
+        about."""
+        with pytest.raises(SpecBlockerError):
+            _decompose(tmp_path, MeteringAgent(BLOCKER_OUTPUT))
+
+        state, _ = load_run_state(tmp_path)
+        assert state.usage_calls == 1
+        assert state.cost_calls == 1
+        assert state.cost_usd == pytest.approx(0.5)
+        assert state.total_tokens == 120
+        architect = state.components["architect"]
+        assert architect.usage_calls == 1
+        assert architect.cost_usd == pytest.approx(0.5)
+
+    def test_the_success_path_records_the_spend(self, tmp_path: Path) -> None:
+        _decompose(tmp_path, MeteringAgent(MINOR_ISSUE_OUTPUT))
+        state, _ = load_run_state(tmp_path)
+        assert state.usage_calls == 1
+        assert state.cost_usd == pytest.approx(0.5)
+
+    def test_every_retry_is_charged(self, tmp_path: Path) -> None:
+        """A failed attempt cost real tokens; the meter never forgets it."""
+        _decompose(
+            tmp_path,
+            MeteringAgent("this is not json at all", VALID_DECOMPOSE_OUTPUT),
+        )
+        state, _ = load_run_state(tmp_path)
+        assert state.usage_calls == 2
+        assert state.cost_usd == pytest.approx(1.0)
+
+    def test_a_crash_after_the_call_still_records_the_spend(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        with pytest.raises(RuntimeError, match="architect exploded"):
+            _decompose(tmp_path, MeteringAgent("", crash=True))
+        state, _ = load_run_state(tmp_path)
+        assert state.cost_usd == pytest.approx(0.5)
+
+    def test_the_usage_event_names_the_architect_role(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The meter's phase key is the ROLE name, which is what the
+        coverage footer prints. It must be the fifth role's name, not the
+        ``decompose``/``audit`` lifecycle phases this component reports
+        elsewhere."""
+        _decompose(tmp_path, MeteringAgent(MINOR_ISSUE_OUTPUT))
+        run_dir = next(iter((tmp_path / ".kstrl" / "runs").iterdir()))
+        events = [json.loads(line) for line in (run_dir / "events.jsonl").read_text().splitlines()]
+        usage = [e for e in events if e.get("event") == "component_usage"]
+        assert len(usage) == 1
+        assert usage[0]["component"] == "architect"
+        assert usage[0]["data"]["phase"] == "architect"
+
+    def test_an_agent_that_reports_nothing_adds_no_phantom_row(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Zero calls means the architect never ran, and an empty table
+        says the opposite. ``MockDecomposeAgent`` has no ``usage_records``
+        at all, which is also every pre-R3.1 third-party agent."""
+        console = io.StringIO()
+        _decompose(tmp_path, MockDecomposeAgent(MINOR_ISSUE_OUTPUT), console)
+        assert "Architect usage" not in console.getvalue()
+        state, _ = load_run_state(tmp_path)
+        assert state.usage_calls == 0
+
+
+class TestArchitectUsageIsPrinted:
+    """The second half of #257: the number has to reach the operator, not
+    just the event stream."""
+
+    def test_the_rollup_prints_on_the_halt_path(self, tmp_path: Path) -> None:
+        console = io.StringIO()
+        with pytest.raises(SpecBlockerError):
+            _decompose(tmp_path, MeteringAgent(BLOCKER_OUTPUT), console)
+        printed = console.getvalue()
+        assert "Architect usage" in printed
+        rows = [line for line in printed.splitlines() if "architect" in line and "0.5000" in line]
+        assert len(rows) == 1, printed
+        assert "120" in rows[0]
+
+    def test_the_rollup_prints_on_the_success_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        console = io.StringIO()
+        _decompose(tmp_path, MeteringAgent(MINOR_ISSUE_OUTPUT), console)
+        assert "Architect usage" in console.getvalue()
+        assert "0.5000" in console.getvalue()
+
+    def test_the_heading_is_not_the_factory_run_heading(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`ks factory` decomposes and then prints its own "Usage rollup",
+        whose total EXCLUDES the architect until piece B. Two tables under
+        one heading would invite reading the later one as the whole
+        spend."""
+        console = io.StringIO()
+        _decompose(tmp_path, MeteringAgent(MINOR_ISSUE_OUTPUT), console)
+        assert "Usage rollup" not in console.getvalue()
+
+    def test_an_unpriced_call_gets_the_coverage_warning(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The codex case: tokens reported, no price. Without the footer
+        the operator reads a $0.00 total as "it was free"."""
+        console = io.StringIO()
+        _decompose(tmp_path, MeteringAgent(MINOR_ISSUE_OUTPUT, cost=None), console)
+        printed = console.getvalue()
+        assert "cost coverage is EMPTY" in printed
+        assert "0 of 1 metered call(s) reported a cost" in printed
+        assert "architect (1 of 1 call(s), 120 token(s) unpriced)" in printed
+        assert "lower bound" in printed
+        # No price is inferred for an uncovered call.
+        assert "0.0000" not in printed
+
+    def test_a_priced_call_gets_no_coverage_warning(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        console = io.StringIO()
+        _decompose(tmp_path, MeteringAgent(MINOR_ISSUE_OUTPUT), console)
+        # Anchored on a printed table, so this cannot pass by printing
+        # nothing at all.
+        assert "Architect usage" in console.getvalue()
+        assert "coverage is" not in console.getvalue()

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -26,6 +26,7 @@ from kstrl.inbox import Inbox, InboxConfig, ItemKind
 from kstrl.manifest import Component, ComponentStatus, Manifest
 from kstrl.serve import (
     BACKOFF_CAP_SECONDS,
+    SPAWNED_RUN_KIND,
     DailySpend,
     RunOutcome,
     RunSpend,
@@ -160,6 +161,7 @@ def _stub_runner(
     run_id: str = "factory-20260730-000000.000000-aaa",
     make_run_dir: bool = True,
     child_pid: int | None = None,
+    extra_run_ids: tuple[str, ...] = (),
 ):
     """A factory stand-in that leaves the artifacts a real run would.
 
@@ -167,6 +169,10 @@ def _stub_runner(
     models a launch that died before producing anything, which serve must
     treat as having no artifacts of its own rather than reading the
     newest run on disk.
+
+    ``extra_run_ids`` are run dirs that appear DURING the launch window
+    without belonging to it - an operator running another kstrl command
+    by hand on the same repo (#257 review).
     """
 
     def runner(
@@ -191,6 +197,8 @@ def _stub_runner(
             on_spawn(child_pid)
         if make_run_dir:
             _make_run_dir(root_dir, run_id)
+        for extra in extra_run_ids:
+            _make_run_dir(root_dir, extra)
         return outcome
 
     return runner
@@ -2040,6 +2048,56 @@ class TestRunOwnership:
             spend = REAL_READ_RUN_SPEND(tmp_path, "factory-abc")
         assert spend.cost_usd == 1.25
         assert spend.uncovered_calls == 1
+
+    def test_a_concurrent_decompose_is_not_charged_to_the_queue(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """#257 review: `ks decompose` takes no factory.lock, so an
+        operator can start one on this repo while a queue item is
+        executing. Its run dir appears inside the launch window, and
+        since #257 it carries REAL spend. Charging it would bill the
+        queue for money the daemon never spent, and could halt the queue
+        on `max_daily_spend` because of it.
+        """
+        queue = _queue(tmp_path)
+        _add(queue)
+        seen: list[str] = []
+
+        def fake_spend(root: Path, run_id: str) -> RunSpend:
+            seen.append(run_id)
+            return RunSpend(cost_usd=4.0, cost_calls=1, usage_calls=1)
+
+        # The operator's decompose lands mid-run, so it is NEW since the
+        # snapshot and the set difference alone would take it.
+        runner = _stub_runner(
+            RunOutcome(0),
+            extra_run_ids=("decompose-20260730-000001.000000-bbb",),
+        )
+        with patch("kstrl.serve.read_run_spend", side_effect=fake_spend):
+            serve_cycle(tmp_path, runner=runner)
+
+        assert seen == ["factory-20260730-000000.000000-aaa"]
+        # Charged once, not twice: the hand-run decompose is someone
+        # else's spend even though it is inside the window.
+        assert SpendLedger(tmp_path).read().spent_usd == pytest.approx(4.0)
+
+    def test_the_charged_kind_matches_what_a_factory_actually_mints(
+        self,
+    ) -> None:
+        """#257 review: the filter and the spawned argv agree with each
+        other by convention, not by derivation - the kind on disk comes
+        from ``mint_run_id``'s default, a third literal. If that ever
+        moved, both would still agree and both would disagree with the
+        disk, and the daemon would charge $0.00 for every queue item
+        forever. Silent under-billing is exactly what max_daily_spend
+        exists to catch, so pin the third leg.
+        """
+        from kstrl.knowledge import current_run_id
+        from kstrl.runid import KNOWN_KINDS, run_kind
+
+        assert SPAWNED_RUN_KIND in KNOWN_KINDS
+        assert run_kind(current_run_id()) == SPAWNED_RUN_KIND
 
     def test_the_architect_is_recorded_as_unmetered(
         self,

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -29,7 +29,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kstrl.agents.base import UsageRecord, UsageTotals, collect_usage
+from kstrl.agents.base import (
+    UsageRecord,
+    UsageTotals,
+    collect_usage,
+    format_usage_rollup,
+)
 from kstrl.agents.claude_code import ClaudeCodeAgent, _usage_from_result_event
 from kstrl.agents.codex import CodexAgent
 from kstrl.agents.custom import CustomAgent
@@ -39,7 +44,6 @@ from kstrl.factory import (
     ComponentResult,
     FactoryConfig,
     _clear_partial_usage,
-    _format_usage_rollup,
     _read_partial_usage,
     _run_component,
     _salvage_aborted_usage,
@@ -2480,7 +2484,7 @@ class TestRollupRendering:
         run_usage.merge(engineer)
         run_usage.merge(review)
 
-        lines = _format_usage_rollup(
+        lines = format_usage_rollup(
             {"comp-a": {"review": review, "engineer": engineer}},
             run_usage,
         )
@@ -2500,7 +2504,7 @@ class TestRollupRendering:
     def test_unknown_usage_rendered_as_dash_with_note(self) -> None:
         unknown = UsageTotals()
         unknown.add_record(UsageRecord(duration_seconds=3.0))
-        lines = _format_usage_rollup({"comp-a": {"engineer": unknown}}, unknown)
+        lines = format_usage_rollup({"comp-a": {"engineer": unknown}}, unknown)
         assert "-" in lines[1]
         assert any("lower bounds" in line for line in lines)
 
@@ -4463,7 +4467,7 @@ class TestRollupReportsPerAxisCoverage:
 
     def test_the_measured_run_gets_a_cost_coverage_note(self) -> None:
         meter, run_usage = _measured_meter()
-        lines = _format_usage_rollup(meter, run_usage)
+        lines = format_usage_rollup(meter, run_usage)
         notes = [line for line in lines if line.startswith("note:")]
         assert len(notes) == 1
         assert "cost coverage is PARTIAL" in notes[0]
@@ -4475,7 +4479,7 @@ class TestRollupReportsPerAxisCoverage:
     def test_an_uncosted_row_renders_a_dash_not_a_zero(self) -> None:
         """`-` means "no call here reported a cost", never "free"."""
         meter, run_usage = _measured_meter()
-        lines = _format_usage_rollup(meter, run_usage)
+        lines = format_usage_rollup(meter, run_usage)
         review_rows = [line for line in lines if " review " in line]
         assert review_rows
         for row in review_rows:
@@ -4490,7 +4494,7 @@ class TestRollupReportsPerAxisCoverage:
             total_tokens=10,
             cost_usd=0.0,
         )
-        lines = _format_usage_rollup({"comp-a": {"engineer": totals}}, totals)
+        lines = format_usage_rollup({"comp-a": {"engineer": totals}}, totals)
         assert "0.0000" in lines[1]
 
     def test_a_cost_only_row_renders_dashes_not_zero_tokens(self) -> None:
@@ -4508,7 +4512,7 @@ class TestRollupReportsPerAxisCoverage:
             )
         )
         assert (totals.known_calls, totals.token_calls) == (1, 0)
-        lines = _format_usage_rollup({"comp-a": {"engineer": totals}}, totals)
+        lines = format_usage_rollup({"comp-a": {"engineer": totals}}, totals)
         rows = [line for line in lines if not line.startswith("note:")]
         # Both the component row and the TOTAL row showed numeric zeros.
         assert len(rows) == 3
@@ -4529,7 +4533,7 @@ class TestRollupReportsPerAxisCoverage:
             total_tokens=0,
             cost_usd=1.0,
         )
-        lines = _format_usage_rollup({"comp-a": {"engineer": totals}}, totals)
+        lines = format_usage_rollup({"comp-a": {"engineer": totals}}, totals)
         assert lines[1].split()[-4:-2] == ["0", "0"]
 
     def test_a_fully_covered_run_gets_no_coverage_note(self) -> None:
@@ -4541,7 +4545,7 @@ class TestRollupReportsPerAxisCoverage:
             total_tokens=10,
             cost_usd=1.0,
         )
-        lines = _format_usage_rollup({"comp-a": {"engineer": totals}}, totals)
+        lines = format_usage_rollup({"comp-a": {"engineer": totals}}, totals)
         assert not [line for line in lines if line.startswith("note:")]
 
     def test_a_silent_run_keeps_exactly_one_note(self) -> None:
@@ -4549,10 +4553,62 @@ class TestRollupReportsPerAxisCoverage:
         so precisely; three lines for one fact would read as noise."""
         unknown = UsageTotals()
         unknown.add_record(UsageRecord(duration_seconds=3.0))
-        lines = _format_usage_rollup({"comp-a": {"engineer": unknown}}, unknown)
+        lines = format_usage_rollup({"comp-a": {"engineer": unknown}}, unknown)
         notes = [line for line in lines if line.startswith("note:")]
         assert len(notes) == 1
         assert "lower bounds" in notes[0]
+
+
+class TestRollupRowsFollowTheOrderTheRolesRun:
+    """#257: the architect was missing from ``_USAGE_PHASE_ORDER``, and
+    unlisted phases sort last, so the role that runs FIRST printed after
+    distill."""
+
+    @staticmethod
+    def _phase_column(lines: list[str]) -> list[str]:
+        """Phase cells of the component rows, top to bottom."""
+        return [line.split()[1] for line in lines if line.startswith("comp-a ")]
+
+    @staticmethod
+    def _meter(*phases: str) -> tuple[dict[str, dict[str, UsageTotals]], UsageTotals]:
+        rows = {
+            phase: UsageTotals(
+                calls=1,
+                known_calls=1,
+                token_calls=1,
+                cost_calls=1,
+                total_tokens=1,
+            )
+            for phase in phases
+        }
+        run_usage = UsageTotals()
+        for totals in rows.values():
+            run_usage.merge(totals)
+        return {"comp-a": rows}, run_usage
+
+    def test_the_architect_prints_first(self) -> None:
+        meter, run_usage = self._meter(
+            "distill",
+            "security",
+            "review",
+            "engineer",
+            "architect",
+        )
+        lines = format_usage_rollup(meter, run_usage)
+        assert self._phase_column(lines) == [
+            "architect",
+            "engineer",
+            "review",
+            "security",
+            "distill",
+        ]
+
+    def test_an_unlisted_phase_still_sorts_last(self) -> None:
+        """The listed order is a whitelist, not a total order: a phase
+        added later must not silently displace a known one."""
+        meter, run_usage = self._meter("zeta", "architect", "engineer")
+        lines = format_usage_rollup(meter, run_usage)
+        assert self._phase_column(lines) == ["architect", "engineer", "zeta"]
 
 
 class TestCoverageReachesTheAuditTrail:

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -24,6 +24,7 @@ import time
 from collections.abc import Callable, Iterator
 from concurrent.futures import Future
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -34,6 +35,7 @@ from kstrl.agents.base import (
     UsageTotals,
     collect_usage,
     format_usage_rollup,
+    usage_cursor,
 )
 from kstrl.agents.claude_code import ClaudeCodeAgent, _usage_from_result_event
 from kstrl.agents.codex import CodexAgent
@@ -4557,6 +4559,65 @@ class TestRollupReportsPerAxisCoverage:
         notes = [line for line in lines if line.startswith("note:")]
         assert len(notes) == 1
         assert "lower bounds" in notes[0]
+
+
+class TestUsageCursorIsRecordsNotCalls:
+    """#257 review: ``since`` is an index into ``usage_records``, so the
+    cursor must count RECORDS. ``collect_usage(...).calls`` happens to
+    equal that only because ``add_record`` increments unconditionally."""
+
+    class _Hostile:
+        """A record whose field access blows up mid-walk.
+
+        Not contrived: ``collect_usage`` wraps its whole loop in a
+        try/except precisely because a foreign or malformed record can do
+        this, and that guard is what makes ``calls`` disagree with
+        ``len(records)``.
+        """
+
+        @property
+        def input_tokens(self) -> int:
+            raise RuntimeError("malformed record")
+
+    @staticmethod
+    def _agent() -> SimpleNamespace:
+        """Four records; the second raises on field access."""
+        good = UsageRecord(total_tokens=5, source="claude-stream-json")
+        return SimpleNamespace(
+            usage_records=[good, TestUsageCursorIsRecordsNotCalls._Hostile(), good, good]
+        )
+
+    def test_a_walk_that_dies_partway_leaves_calls_short(self) -> None:
+        agent = self._agent()
+        # `calls` increments BEFORE the fields are read, so the record
+        # that raised is counted and the two after it are not.
+        assert collect_usage(agent).calls == 2
+        assert usage_cursor(agent) == 4
+
+    def test_the_short_offset_misattributes_the_unread_tail(self) -> None:
+        """Why the distinction is worth its own helper: seeding `since`
+        from `calls` hands the FIRST unit of work's unread records to the
+        SECOND one."""
+        agent = self._agent()
+        short = collect_usage(agent).calls
+        assert collect_usage(agent, since=short).calls == 2, "tail re-folded"
+        assert collect_usage(agent, since=usage_cursor(agent)).calls == 0
+
+    def test_a_cursor_over_a_normal_agent_is_the_record_count(self) -> None:
+        agent = SimpleNamespace(usage_records=[UsageRecord(), UsageRecord()])
+        assert usage_cursor(agent) == 2
+
+    def test_an_agent_without_records_has_a_zero_cursor(self) -> None:
+        """Folds everything, which is the pre-``since`` behavior."""
+        assert usage_cursor(object()) == 0
+
+    def test_a_hostile_records_attribute_degrades_to_zero(self) -> None:
+        class Boom:
+            @property
+            def usage_records(self) -> list[UsageRecord]:
+                raise RuntimeError("no records for you")
+
+        assert usage_cursor(Boom()) == 0
 
 
 class TestRollupRowsFollowTheOrderTheRolesRun:


### PR DESCRIPTION
Piece A of #257. The architect is the fifth paid LLM role and was the only one kstrl never metered: five real `ks decompose` runs each recorded `$0.00`, and there was nowhere to look the number up. It was not an *uncovered* metered call, it was absent from the accounting entirely.

Piece B, threading a seed through `run_factory` so `max_cost_usd` bounds the architect, is scheduled separately. This change deliberately does not attempt it, and does not touch `run_factory`'s signature.

## What changed

`decompose_spec` captures `collect_usage(agent)` in a `finally`, emits it as a `ComponentUsage` event, and prints the rollup with its coverage footer.

The `finally` is the whole point. The common outcome on a first spec is a blocker halt, which raises `SpecBlockerError` from the audit site. That is exactly the path where the operator has already spent the money and needs the number before editing and re-running, so an emit-after-return would have missed the case the issue is about. There is a test on that path specifically.

No plumbing was needed for the event: both `ks decompose` call sites already pass a bus, so the reducer, the TUI cost meter and `serve.read_run_spend` pick it up for free.

## Two design decisions

**`ComponentUsage` needs a component id, and "architect" is not in the manifest.** Used the architect's existing pseudo-component id. The reducer does create components lazily from any id, but no phantom row appears here: `_decompose_spec_impl` already emits `ComponentStarted` and a `RunPlan` row for `architect` before any of this, so the usage folds onto a row that exists. The one path that could have conjured a row, `ks factory`, passes no bus and emits nothing. The event's phase key is that same word, because a meter's phase key is the ROLE name and that is what the coverage footer prints; it is deliberately not `decompose`/`audit`, the lifecycle phases this component reports elsewhere, which name steps rather than roles. `ARCHITECT_COMPONENT` is now an alias of a single `ARCHITECT_ROLE` constant in `agents/base.py` so a rename cannot move one without the other.

**`_USAGE_PHASE_ORDER` omitted `architect`.** Unlisted phases sort last, so the role that runs before every engineer loop would have printed after distill. It is now first in the tuple, built from `ARCHITECT_ROLE`, with a test pinning the order and a second test pinning that an unlisted phase still sorts last.

## On `test_the_architect_is_recorded_as_unmetered`

Left alone, along with `serve.py`'s hardcoded `unmetered = ("architect",)`. Both stay correct after this change.

`serve_cycle` spends through `subprocess_factory_runner`, which spawns `ks factory`. That path calls `decompose_spec` at `cli.py:2164` with no bus, and does so before `run_factory` creates any run directory. `read_run_spend` reads run directories off disk, so it still sees nothing from the architect. Deleting a test that asserts a real remaining gap would have been worse than leaving it. The stale comments claiming the event does not exist are corrected to say why it does not reach that charge, stated once at the `unmetered` definition rather than three times.

## Refactor

`_format_usage_rollup` and `_USAGE_PHASE_ORDER` moved from `factory.py` to `agents/base.py`, which is a stdlib-only leaf and the only existing common ancestor of the two callers. A shared `print_usage_rollup` owns the frame (zero-call guard, heading, indent) so the two commands cannot drift in the half the operator reads.

The heading differs on purpose. `ks factory` decomposes and then prints its own run-level rollup whose total still excludes the architect until piece B, so a second table also titled "Usage rollup" would invite reading the later one as the run's whole spend. The architect's table is titled "Architect usage", with a test pinning that.

`_usage_rollup_notes` is split out because measured, not for style: inlined, `complexipy` scores the renderer at 17 against the repo's gate of 15.

## Testing

Eleven new tests. Verified falsifiable: with the `finally` removed, 9 of the 11 fail. The 2 that pass either way are the deliberate absence assertions.

- halt path records the spend and the run state folds it
- success path records the spend
- every retry is charged, not just the last attempt
- a crash after the call still records the spend
- the event names the architect role, not the lifecycle phase
- an agent with no `usage_records` prints no empty table
- the rollup prints on both the halt and the success path
- the heading is not the factory's run-level heading
- an unpriced call gets the coverage warning naming the role and the unpriced tokens, with no inferred price
- a priced call gets no warning
- the architect sorts first, and an unlisted phase still sorts last

Local gate green: `pytest tests/ -q` (3644 passed, 28 skipped), `mypy kstrl/ --strict`, `ruff check kstrl/ tests/`, `pre-commit run --all-files`.

The `atlas` check is expected to fail and is accepted; `docs/atlas/` is byte-identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHYpsJ8ecHLh5HdrswJtJK