### PR TITLE
fix: ask the repo for its base branch, and stop labelling foreign tool output [pytest]

### DIFF
--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -61,6 +61,7 @@ from kstrl.factory import (
     validate_token_ceiling,
 )
 from kstrl.feature_cmd import FeatureParams, run_feature
+from kstrl.git import detect_base_branch, resolve_base_branch
 from kstrl.init_cmd import DEFAULT_FEATURE_UNDERSTAND, run_init
 from kstrl.interaction import (
     PromptKind,
@@ -145,31 +146,6 @@ def _console_ui(
 
 def _use_cli_value(ctx: click.Context, name: str) -> bool:
     return ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE
-
-
-def _detect_base_branch(cwd: Path) -> str:
-    """Base branch of the repo at ``cwd``: ``origin/HEAD``'s target, else main.
-
-    Shared by ``ks run`` (manifest base) and ``ks sense`` (diff base).
-    Any failure to ask git - no repo, no remote, git missing, timeout -
-    falls back to ``main``; the caller can always override with a flag.
-    """
-    import subprocess as _sp
-
-    try:
-        head_ref = _sp.run(
-            ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if head_ref.returncode == 0:
-            # "refs/remotes/origin/main" -> "main"
-            return head_ref.stdout.strip().rsplit("/", 1)[-1]
-    except Exception:
-        pass
-    return "main"
 
 
 # Accepted spellings for the agent type across the config surface.
@@ -704,7 +680,7 @@ def run(
     effective_branch = config.kstrl_branch or prd_branch or "kstrl/run"
 
     # Detect base branch from git
-    detected_base = _detect_base_branch(root_dir)
+    detected_base = detect_base_branch(root_dir)
 
     # Build single-component manifest from PRD
     rel_prd = str(config.prd_file)
@@ -1586,8 +1562,8 @@ def feature(
 )
 @click.option(
     "--base-branch",
-    default="main",
-    help="Base git branch",
+    default=None,
+    help="Base git branch (default: auto-detected from the repository)",
 )
 @click.option(
     "--single-pr",
@@ -1635,7 +1611,7 @@ def decompose(
     spec: Path,
     root: Path | None,
     project_name: str,
-    base_branch: str,
+    base_branch: str | None,
     single_pr: bool,
     agent_cmd: str | None,
     model: str | None,
@@ -1680,12 +1656,17 @@ def decompose(
 
     agent = get_agent(effective_cmd, effective_model, effective_reasoning, effective_type)
 
+    # decompose_spec takes a `str` base and runs it through
+    # validate_branch_name, so the flag's None is resolved here rather
+    # than deeper, the way `ks sense` already resolves --base (#259).
+    effective_base = resolve_base_branch(base_branch, root_dir)
+
     def _decompose_core(core_ui: UI, command_run: CommandRun) -> int:
         try:
             manifest = decompose_spec(
                 spec_path=spec,
                 project_name=project_name,
-                base_branch=base_branch,
+                base_branch=effective_base,
                 single_pr=single_pr,
                 agent=agent,
                 ui=core_ui,
@@ -1789,8 +1770,8 @@ def decompose(
 )
 @click.option(
     "--base-branch",
-    default="main",
-    help="Base git branch",
+    default=None,
+    help="Base git branch (default: auto-detected from the repository)",
 )
 @click.option(
     "--single-pr",
@@ -2047,7 +2028,7 @@ def factory(
     manifest_path: Path | None,
     root: Path | None,
     project_name: str | None,
-    base_branch: str,
+    base_branch: str | None,
     single_pr: bool,
     max_parallel: int | None,
     max_retries: int | None,
@@ -2166,7 +2147,11 @@ def factory(
             manifest = decompose_spec(
                 spec_path=spec,
                 project_name=project_name,
-                base_branch=base_branch,
+                # The --manifest path above is untouched: a manifest
+                # already carries its own base_branch. Only the --spec
+                # path has a flag to resolve, and detection is the
+                # default rather than the literal "main" (#259).
+                base_branch=resolve_base_branch(base_branch, root_dir),
                 single_pr=single_pr,
                 agent=agent,
                 ui=ui_impl,
@@ -3125,7 +3110,7 @@ def _sense_error(message: str, as_json: bool) -> NoReturn:
     type=str,
     default=None,
     help="Base branch for the diff-scope and bad-pattern checks "
-    "(default: the branch origin/HEAD points at, else main)",
+    "(default: auto-detected from the repository)",
 )
 @click.option(
     "--prd",
@@ -3213,7 +3198,7 @@ def sense(
         # loaders' own validation errors (PolicyConfigError is one).
         _sense_error(f"could not load kstrl.toml from {root_dir}: {exc}", as_json)
 
-    base = base_branch or _detect_base_branch(path)
+    base = resolve_base_branch(base_branch, path)
 
     # Every check below that consumes the diff reads it through the
     # LENIENT git helpers, which map a bad ref, a missing base or a

--- a/kstrl/git.py
+++ b/kstrl/git.py
@@ -128,12 +128,20 @@ def detect_base_branch(cwd: Path) -> str:
     present: set[str] = set()
     for line in listing.stdout.splitlines():
         refname, _, symref = line.partition("\t")
-        if refname == _ORIGIN_HEAD_REF:
-            # "refs/remotes/origin/main" -> "main". Stripping the known
-            # prefix rather than splitting on the last "/", because a
-            # remote may well default to a slashed branch and rsplit
-            # turns "release/2.0" into "2.0".
-            remote_default = symref.strip().removeprefix(_ORIGIN_REF_PREFIX)
+        symref = symref.strip()
+        # "refs/remotes/origin/main" -> "main". Stripping the known
+        # prefix rather than splitting on the last "/", because a remote
+        # may well default to a slashed branch and rsplit turns
+        # "release/2.0" into "2.0". The startswith is not decoration: an
+        # unguarded removeprefix returns its input untouched, so an
+        # origin/HEAD symrefing outside refs/remotes/origin/ (measured:
+        # one pointing at refs/heads/dev) yielded the whole refname as
+        # the answer. Every character in it passes validate_branch_name,
+        # so it reached the manifest and `gh pr create --base` before
+        # anything noticed. Leaving remote_default empty demotes it to
+        # the candidate rung instead.
+        if refname == _ORIGIN_HEAD_REF and symref.startswith(_ORIGIN_REF_PREFIX):
+            remote_default = symref.removeprefix(_ORIGIN_REF_PREFIX)
         elif refname in _BASE_BRANCH_REFS:
             present.add(_BASE_BRANCH_REFS[refname])
 

--- a/kstrl/git.py
+++ b/kstrl/git.py
@@ -17,6 +17,92 @@ DEFAULT_TIMEOUT = 30.0
 # Network fetches get a longer budget than local plumbing calls.
 FETCH_TIMEOUT = 120.0
 
+# Long-lived branch names `detect_base_branch` tries, in order, when the
+# remote has not recorded a default. `main` first because it is the
+# modern default and a renamed repo keeps only that name; `master` next
+# because it is what `git init` still produces when `init.defaultBranch`
+# is unset (#259).
+BASE_BRANCH_CANDIDATES = ("main", "master", "trunk", "develop")
+
+# Answer when no candidate resolves. Deliberately still a guess, and the
+# callers surface it as one.
+BASE_BRANCH_FALLBACK = "main"
+
+# Local plumbing, called on the way into a command.
+_BASE_BRANCH_PROBE_TIMEOUT = 5.0
+
+
+def detect_base_branch(cwd: Path) -> str:
+    """Base branch of the repo at ``cwd``, asked of the repo itself (#259).
+
+    Used by ``ks run`` (manifest base), ``ks decompose`` and
+    ``ks factory`` (worktree base), ``ks sense`` (diff base) and the TUI
+    launch forms.
+
+    The ladder, and what each rung fails on:
+
+    1. ``origin/HEAD``: the remote's own answer, so it outranks any
+       guess. Only ``git clone`` and an explicit ``git remote set-head``
+       ever write it, so a repo that grew a remote by hand does not have
+       it, and neither does a plain ``git init``. It can also go stale
+       when the remote renames its default branch.
+    2. The first of ``main``, ``master``, ``trunk``, ``develop`` that
+       resolves. Fails when the project's long-lived branch is named
+       something else (``release``, ``stable``), and picks the earlier
+       name when a repo carries two of them mid-migration.
+    3. The literal ``main``.
+
+    Every rung above the fallback is confirmed with :func:`resolve_ref`
+    before it is returned. That is deliberately the same resolver the
+    consumers use - :func:`get_diff_names` and the worktree cut both go
+    through :func:`resolve_base_ref`, which prefers ``origin/<name>`` -
+    so a name this ladder accepts is one they can actually diff,
+    including in a clone that carries the remote-tracking ref only. It
+    is also what demotes a stale ``origin/HEAD`` to the rung below it.
+
+    Deliberately NOT a rung: the branch HEAD is on. It always resolves,
+    so it would end the ladder every time, and diffing a branch against
+    itself is empty - which the diff-scope and bad-pattern checks read
+    as "nothing changed, all within scope". That converts a loud
+    cannot-measure (`ks sense` exit 2, naming ``--base``) into a silent
+    green on a tree nobody measured, and cannot-measure is never a pass.
+    A guess the caller reports as a guess beats a wrong answer delivered
+    as a measurement.
+
+    Any failure to ask git - no repo, git missing, timeout - falls back
+    to ``main``; the caller can always override with a flag.
+    """
+    remote_default = ""
+    try:
+        head_ref = subprocess.run(
+            ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=_BASE_BRANCH_PROBE_TIMEOUT,
+        )
+        if head_ref.returncode == 0:
+            # "refs/remotes/origin/main" -> "main"
+            remote_default = head_ref.stdout.strip().rsplit("/", 1)[-1]
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+    for name in (remote_default, *BASE_BRANCH_CANDIDATES):
+        if name and resolve_ref(name, cwd, timeout=_BASE_BRANCH_PROBE_TIMEOUT):
+            return name
+    return BASE_BRANCH_FALLBACK
+
+
+def resolve_base_branch(base_branch: str | None, cwd: Path) -> str:
+    """An explicit base branch, else the one :func:`detect_base_branch` finds.
+
+    One spelling for the "the flag wins, otherwise ask the repo" rule
+    every entry point needs: the two CLI commands that take
+    ``--base-branch``, ``ks sense``'s ``--base``, and the TUI launch
+    form's branch field (#259).
+    """
+    return base_branch or detect_base_branch(cwd)
+
 
 def resolve_base_ref(
     base_branch: str,
@@ -323,6 +409,11 @@ def resolve_ref(
 
     Tries the local ref first, then ``origin/<ref>``: a fresh worktree
     may carry the remote-tracking ref only.
+
+    OSError is caught alongside the timeout, matching
+    :func:`resolve_base_ref` next door: "git is not installed" is one of
+    the ways a ref does not resolve, and a function whose contract is
+    already "the sha, or None" should not make its callers guard it.
     """
     for candidate in (ref, f"origin/{ref}"):
         try:
@@ -333,7 +424,7 @@ def resolve_ref(
                 text=True,
                 timeout=timeout,
             )
-        except subprocess.TimeoutExpired:
+        except (subprocess.TimeoutExpired, OSError):
             return None
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()

--- a/kstrl/git.py
+++ b/kstrl/git.py
@@ -28,8 +28,22 @@ BASE_BRANCH_CANDIDATES = ("main", "master", "trunk", "develop")
 # callers surface it as one.
 BASE_BRANCH_FALLBACK = "main"
 
-# Local plumbing, called on the way into a command.
+# Local plumbing, called on the way into a command and on the Textual
+# event loop when the decompose launch form composes.
 _BASE_BRANCH_PROBE_TIMEOUT = 5.0
+
+_ORIGIN_REF_PREFIX = "refs/remotes/origin/"
+_ORIGIN_HEAD_REF = f"{_ORIGIN_REF_PREFIX}HEAD"
+
+# The exact refs a candidate may live at, mapped back to its name.
+# ``refs/heads/<name>`` and ``refs/remotes/origin/<name>`` are the two
+# :func:`resolve_base_ref` consults, so asking about exactly these asks
+# the question the consumers will ask. Frozen at import: the inputs are.
+_BASE_BRANCH_REFS: dict[str, str] = {
+    ref: name
+    for name in BASE_BRANCH_CANDIDATES
+    for ref in (f"refs/heads/{name}", f"{_ORIGIN_REF_PREFIX}{name}")
+}
 
 
 def detect_base_branch(cwd: Path) -> str:
@@ -47,18 +61,30 @@ def detect_base_branch(cwd: Path) -> str:
        it, and neither does a plain ``git init``. It can also go stale
        when the remote renames its default branch.
     2. The first of ``main``, ``master``, ``trunk``, ``develop`` that
-       resolves. Fails when the project's long-lived branch is named
+       exists. Fails when the project's long-lived branch is named
        something else (``release``, ``stable``), and picks the earlier
        name when a repo carries two of them mid-migration.
     3. The literal ``main``.
 
-    Every rung above the fallback is confirmed with :func:`resolve_ref`
-    before it is returned. That is deliberately the same resolver the
-    consumers use - :func:`get_diff_names` and the worktree cut both go
-    through :func:`resolve_base_ref`, which prefers ``origin/<name>`` -
-    so a name this ladder accepts is one they can actually diff,
-    including in a clone that carries the remote-tracking ref only. It
-    is also what demotes a stale ``origin/HEAD`` to the rung below it.
+    All of it is ONE ``git for-each-ref`` over the candidates' two
+    possible refs plus ``origin/HEAD``, which is what makes the whole
+    ladder cost a single subprocess. Three measured properties of that
+    command carry the rungs above:
+
+    - It lists a ref only when the ref resolves, and a symbolic ref only
+      when its target resolves. So a stale ``origin/HEAD`` naming a
+      deleted branch is simply absent, which is rung 1's demotion, and
+      a listed ``origin/HEAD`` needs no confirming call even when its
+      target is outside the candidate set.
+    - ``%(symref)`` reports ``origin/HEAD``'s target in the same
+      listing, folding rung 1 in for free.
+    - Asking for ``refs/heads/<name>`` and ``refs/remotes/origin/<name>``
+      by exact path asks about BRANCHES. A bare-name ``rev-parse`` would
+      also match a TAG (git's search order puts ``refs/tags`` ahead of
+      ``refs/heads``), and a tag is not something to cut a worktree
+      from. The listing is filtered on exact refnames because a pattern
+      also matches at a slash boundary: with no ``main`` branch but a
+      ``main/sub`` one, ``refs/heads/main`` matches ``refs/heads/main/sub``.
 
     Deliberately NOT a rung: the branch HEAD is on. It always resolves,
     so it would end the ladder every time, and diffing a branch against
@@ -71,24 +97,50 @@ def detect_base_branch(cwd: Path) -> str:
 
     Any failure to ask git - no repo, git missing, timeout - falls back
     to ``main``; the caller can always override with a flag.
+
+    Measured on macOS with a warm cache: one subprocess and 3.0 to
+    4.0 ms in every repo shape, flat because the shape no longer decides
+    how many calls run. The rung-at-a-time version this replaced took 2
+    to 9 subprocesses and 8 to 31 ms, and its nine sequential 5 s
+    timeouts stacked into a 45 s ceiling - which the decompose launch
+    form would have paid on the UI thread.
     """
-    remote_default = ""
     try:
-        head_ref = subprocess.run(
-            ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+        listing = subprocess.run(
+            [
+                "git",
+                "for-each-ref",
+                "--format=%(refname)%09%(symref)",
+                _ORIGIN_HEAD_REF,
+                *_BASE_BRANCH_REFS,
+            ],
             cwd=cwd,
             capture_output=True,
             text=True,
             timeout=_BASE_BRANCH_PROBE_TIMEOUT,
         )
-        if head_ref.returncode == 0:
-            # "refs/remotes/origin/main" -> "main"
-            remote_default = head_ref.stdout.strip().rsplit("/", 1)[-1]
     except (subprocess.TimeoutExpired, OSError):
-        pass
+        return BASE_BRANCH_FALLBACK
+    if listing.returncode != 0:
+        return BASE_BRANCH_FALLBACK
 
-    for name in (remote_default, *BASE_BRANCH_CANDIDATES):
-        if name and resolve_ref(name, cwd, timeout=_BASE_BRANCH_PROBE_TIMEOUT):
+    remote_default = ""
+    present: set[str] = set()
+    for line in listing.stdout.splitlines():
+        refname, _, symref = line.partition("\t")
+        if refname == _ORIGIN_HEAD_REF:
+            # "refs/remotes/origin/main" -> "main". Stripping the known
+            # prefix rather than splitting on the last "/", because a
+            # remote may well default to a slashed branch and rsplit
+            # turns "release/2.0" into "2.0".
+            remote_default = symref.strip().removeprefix(_ORIGIN_REF_PREFIX)
+        elif refname in _BASE_BRANCH_REFS:
+            present.add(_BASE_BRANCH_REFS[refname])
+
+    if remote_default:
+        return remote_default
+    for name in BASE_BRANCH_CANDIDATES:
+        if name in present:
             return name
     return BASE_BRANCH_FALLBACK
 
@@ -409,11 +461,6 @@ def resolve_ref(
 
     Tries the local ref first, then ``origin/<ref>``: a fresh worktree
     may carry the remote-tracking ref only.
-
-    OSError is caught alongside the timeout, matching
-    :func:`resolve_base_ref` next door: "git is not installed" is one of
-    the ways a ref does not resolve, and a function whose contract is
-    already "the sha, or None" should not make its callers guard it.
     """
     for candidate in (ref, f"origin/{ref}"):
         try:
@@ -424,7 +471,7 @@ def resolve_ref(
                 text=True,
                 timeout=timeout,
             )
-        except (subprocess.TimeoutExpired, OSError):
+        except subprocess.TimeoutExpired:
             return None
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()

--- a/kstrl/launch.py
+++ b/kstrl/launch.py
@@ -34,7 +34,11 @@ class FactoryLaunch:
 class DecomposeLaunch:
     spec_path: Path = Path("scripts/kstrl/spec.md")
     project_name: str = ""
-    base_branch: str = "main"
+    # Empty means "ask the repo": a data container cannot know the base
+    # branch, and the literal `main` it used to carry is a branch a
+    # plain `git init` repo does not have (#259). The session layer
+    # resolves it through git.detect_base_branch.
+    base_branch: str = ""
     single_pr: bool = False
 
 

--- a/kstrl/parsers.py
+++ b/kstrl/parsers.py
@@ -31,6 +31,25 @@ class ParsedOutput:
     total_errors: int = 0
     failures: list[ParsedFailure] = field(default_factory=list)
     raw_summary: str = ""  # last line(s) summary from the tool
+    # The command the gate actually ran, when the caller knows it. Only
+    # used to label a passthrough; the parser identity stays `tool`.
+    command: str = ""
+
+    @property
+    def prompt_label(self) -> str:
+        """What to call the output in the retry prompt.
+
+        Parsed failures prove this parser understood the output, so the
+        tool name is earned. With none, the parser may simply be the
+        wrong one: `check_test_suite` runs whatever `test_command` is
+        configured and always parses it as pytest, so a vitest failure
+        reached the engineer tagged ``[pytest]`` and pointed it at the
+        wrong toolchain (#258). Naming the command that actually ran is
+        the one label that cannot be wrong.
+        """
+        if self.failures or not self.command:
+            return self.tool
+        return self.command
 
     def format_for_prompt(self, max_failures: int = 10, include_source: bool = True) -> list[str]:
         """Format failures as structured lines optimized for LLM consumption.
@@ -40,7 +59,7 @@ class ParsedOutput:
         lines: list[str] = []
 
         if self.raw_summary:
-            lines.append(f"[{self.tool}] {self.raw_summary}")
+            lines.append(f"[{self.prompt_label}] {self.raw_summary}")
 
         if not self.failures:
             return lines
@@ -148,6 +167,23 @@ def parse_pytest_output(raw: str) -> ParsedOutput:
         if m:
             result.raw_summary = m.group("summary").strip()
 
+    # Fallback: if we parsed nothing useful, preserve raw tail as summary.
+    # This runs BEFORE the count below because the count reads
+    # raw_summary. The other order reported total_errors == 0 on output
+    # whose own tail said "1 failed" - measured on real vitest output
+    # (#258). Preemptive, not a live misread: nothing in kstrl/ reads
+    # total_errors today (the gate's verdict is the exit code), so this
+    # stops a future reader taking 0 for "clean" rather than fixing a
+    # current one. The mypy and ruff parsers never had the bug; they set
+    # summary and count together in their line loops.
+    # The tail is still only the last few lines, so a foreign tool's
+    # file, line and assertion detail is dropped either way; recovering
+    # that needs a parser that knows the tool, which is the other half
+    # of #258.
+    if not result.failures and not result.raw_summary:
+        tail = lines[-5:] if len(lines) > 5 else lines
+        result.raw_summary = "\n".join(tail)
+
     # Extract total error count from summary
     if result.raw_summary:
         failed_m = _PYTEST_FAILED_COUNT_RE.search(result.raw_summary)
@@ -160,11 +196,6 @@ def parse_pytest_output(raw: str) -> ParsedOutput:
         result.total_errors = count
     else:
         result.total_errors = len(result.failures)
-
-    # Fallback: if we parsed nothing useful, preserve raw tail as summary
-    if not result.failures and not result.raw_summary:
-        tail = lines[-5:] if len(lines) > 5 else lines
-        result.raw_summary = "\n".join(tail)
 
     return result
 

--- a/kstrl/parsers.py
+++ b/kstrl/parsers.py
@@ -110,6 +110,18 @@ _PYTEST_FAILED_COUNT_RE = re.compile(r"(\d+)\s+failed")
 _PYTEST_ERROR_COUNT_RE = re.compile(r"(\d+)\s+error")
 
 
+def _pytest_failure_count(summary: str) -> int:
+    """Failures plus errors reported by a pytest-shaped summary line."""
+    count = 0
+    failed_m = _PYTEST_FAILED_COUNT_RE.search(summary)
+    if failed_m:
+        count += int(failed_m.group(1))
+    error_m = _PYTEST_ERROR_COUNT_RE.search(summary)
+    if error_m:
+        count += int(error_m.group(1))
+    return count
+
+
 def parse_pytest_output(raw: str) -> ParsedOutput:
     """Parse pytest output into structured failures.
 
@@ -167,35 +179,33 @@ def parse_pytest_output(raw: str) -> ParsedOutput:
         if m:
             result.raw_summary = m.group("summary").strip()
 
-    # Fallback: if we parsed nothing useful, preserve raw tail as summary.
-    # This runs BEFORE the count below because the count reads
-    # raw_summary. The other order reported total_errors == 0 on output
-    # whose own tail said "1 failed" - measured on real vitest output
-    # (#258). Preemptive, not a live misread: nothing in kstrl/ reads
-    # total_errors today (the gate's verdict is the exit code), so this
-    # stops a future reader taking 0 for "clean" rather than fixing a
-    # current one. The mypy and ruff parsers never had the bug; they set
-    # summary and count together in their line loops.
+    # Nothing structured parsed AND no summary reporting a failure: what
+    # we matched, if anything, is not describing whatever failed this
+    # gate, so prefer the raw tail. Two measured cases (#258), both from
+    # a polyglot repo running `uv run pytest && npm test`:
+    #
+    # - vitest alone: nothing matched at all, so there is no summary.
+    # - pytest PASSING then vitest failing: `_PYTEST_SUMMARY_RE` matches
+    #   pytest's footer, so the summary became "5 passed in 0.00s" and
+    #   the failed gate's entire retry detail told the engineer that
+    #   five tests passed, with the vitest failure dropped.
+    #
+    # The consequence for purely passing input is deliberate: the tail
+    # replaces a clean footer. Only `check_test_suite` calls this, and
+    # only on a nonzero exit, so "no failure in sight" always means the
+    # parse missed it.
+    #
     # The tail is still only the last few lines, so a foreign tool's
     # file, line and assertion detail is dropped either way; recovering
     # that needs a parser that knows the tool, which is the other half
     # of #258.
-    if not result.failures and not result.raw_summary:
+    if not result.failures and _pytest_failure_count(result.raw_summary) == 0:
         tail = lines[-5:] if len(lines) > 5 else lines
         result.raw_summary = "\n".join(tail)
 
-    # Extract total error count from summary
-    if result.raw_summary:
-        failed_m = _PYTEST_FAILED_COUNT_RE.search(result.raw_summary)
-        error_m = _PYTEST_ERROR_COUNT_RE.search(result.raw_summary)
-        count = 0
-        if failed_m:
-            count += int(failed_m.group(1))
-        if error_m:
-            count += int(error_m.group(1))
-        result.total_errors = count
-    else:
-        result.total_errors = len(result.failures)
+    result.total_errors = (
+        _pytest_failure_count(result.raw_summary) if result.raw_summary else len(result.failures)
+    )
 
     return result
 

--- a/kstrl/tui/screens/launch.py
+++ b/kstrl/tui/screens/launch.py
@@ -140,6 +140,15 @@ class DecomposeLaunchForm(Screen[None]):
                     # Detected, not the literal `main`: this form used to
                     # pre-fill a branch a plain `git init` repo does not
                     # have, which is #259 arriving through the TUI.
+                    #
+                    # Synchronous on the event loop, deliberately. It is
+                    # ONE local `git for-each-ref` with one 5s timeout,
+                    # the same exposure as home.py's `_git_branch`
+                    # masthead probe, and measured at +4 to +8 ms on an
+                    # 85 ms screen open. A thread worker would buy back
+                    # single-digit milliseconds and add a way for a slow
+                    # probe to land on top of a branch the user has
+                    # already typed.
                     Input(value=detect_base_branch(self._root_dir()), id="decompose-branch"),
                 )
                 yield FormField(

--- a/kstrl/tui/screens/launch.py
+++ b/kstrl/tui/screens/launch.py
@@ -22,6 +22,7 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import Screen
 from textual.widgets import Button, Footer, Input, Select, Switch
 
+from kstrl.git import detect_base_branch, resolve_base_branch
 from kstrl.launch import DecomposeLaunch, FactoryLaunch
 from kstrl.tui.widgets.context_bar import ContextBar
 from kstrl.tui.widgets.form import FormErrors, FormField
@@ -113,6 +114,9 @@ class FactoryLaunchForm(Screen[None]):
 class DecomposeLaunchForm(Screen[None]):
     BINDINGS = [Binding("escape", "app.pop_screen", "Back")]
 
+    def _root_dir(self) -> Path:
+        return Path(getattr(self.app, "root_dir", Path.cwd()))
+
     def compose(self) -> ComposeResult:
         yield ContextBar(
             "launch",
@@ -133,7 +137,10 @@ class DecomposeLaunchForm(Screen[None]):
                 )
                 yield FormField(
                     "base branch",
-                    Input(value="main", id="decompose-branch"),
+                    # Detected, not the literal `main`: this form used to
+                    # pre-fill a branch a plain `git init` repo does not
+                    # have, which is #259 arriving through the TUI.
+                    Input(value=detect_base_branch(self._root_dir()), id="decompose-branch"),
                 )
                 yield FormField(
                     "single PR",
@@ -148,10 +155,12 @@ class DecomposeLaunchForm(Screen[None]):
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id != "decompose-start":
             return
-        root_dir = getattr(self.app, "root_dir", Path.cwd())
+        root_dir = self._root_dir()
         raw_spec = self.query_one("#decompose-spec", Input).value.strip()
         project = self.query_one("#decompose-project", Input).value.strip()
-        branch = self.query_one("#decompose-branch", Input).value.strip() or "main"
+        branch = resolve_base_branch(
+            self.query_one("#decompose-branch", Input).value.strip(), root_dir
+        )
         errors: list[str] = []
         spec_path = (
             (Path(raw_spec) if Path(raw_spec).is_absolute() else root_dir / raw_spec)

--- a/kstrl/tui/session.py
+++ b/kstrl/tui/session.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 from kstrl.commandrun import open_command_run
 from kstrl.config import KstrlConfig
 from kstrl.events import CallbackSink, EventBus, RunPaths
+from kstrl.git import resolve_base_branch
 from kstrl.interaction import QueueInteractionChannel
 from kstrl.launch import (
     DecomposeLaunch,
@@ -274,7 +275,7 @@ def _prepare_decompose(
                     manifest = decompose_spec(
                         spec_path=spec_path,
                         project_name=spec.project_name,
-                        base_branch=spec.base_branch,
+                        base_branch=resolve_base_branch(spec.base_branch, root_dir),
                         single_pr=spec.single_pr,
                         agent=agent,
                         ui=ui,

--- a/kstrl/verify.py
+++ b/kstrl/verify.py
@@ -792,6 +792,36 @@ def scrub_project_claude_md(
     return scrub_stale_verify_commands(claude_md, commands)
 
 
+def _failed_gate_result(
+    name: str,
+    message: str,
+    parsed: ParsedOutput,
+    cmd: str,
+    cwd: Path,
+    start: float,
+) -> CheckResult:
+    """Enrich a parse and package it as the gate's failing CheckResult.
+
+    One home for all three gates because the enrichment has to happen at
+    every one of them and forgetting a step is SILENT: without
+    ``parsed.command`` the prompt label falls back to the parser name,
+    which is exactly the #258 mislabel returning unannounced.
+    """
+    parsed.command = cmd
+    for failure in parsed.failures:
+        add_source_context(failure, cwd)
+        if not failure.fix_hint:
+            failure.fix_hint = generate_fix_hint(failure)
+    return CheckResult(
+        name=name,
+        passed=False,
+        message=message,
+        details=parsed.format_for_prompt(),
+        duration_seconds=time.monotonic() - start,
+        parsed=parsed,
+    )
+
+
 def check_test_suite(
     cwd: Path,
     command: str | None = None,
@@ -813,18 +843,17 @@ def check_test_suite(
 
     if result.returncode != 0:
         output = (result.stdout + result.stderr).strip()
-        parsed = parse_pytest_output(output)
-        for failure in parsed.failures:
-            add_source_context(failure, cwd)
-            if not failure.fix_hint:
-                failure.fix_hint = generate_fix_hint(failure)
-        return CheckResult(
-            name="test_suite",
-            passed=False,
-            message=f"Tests failed (exit code {result.returncode})",
-            details=parsed.format_for_prompt(),
-            duration_seconds=time.monotonic() - start,
-            parsed=parsed,
+        # Whatever `cmd` is, it is parsed as pytest: there is no
+        # dispatch. Recording the command lets an unparsed passthrough
+        # be labelled with what actually ran instead of claiming pytest
+        # produced output pytest never saw (#258).
+        return _failed_gate_result(
+            "test_suite",
+            f"Tests failed (exit code {result.returncode})",
+            parse_pytest_output(output),
+            cmd,
+            cwd,
+            start,
         )
 
     return CheckResult(
@@ -856,18 +885,13 @@ def check_typecheck(
 
     if result.returncode != 0:
         output = (result.stdout + result.stderr).strip()
-        parsed = parse_mypy_output(output)
-        for failure in parsed.failures:
-            add_source_context(failure, cwd)
-            if not failure.fix_hint:
-                failure.fix_hint = generate_fix_hint(failure)
-        return CheckResult(
-            name="typecheck",
-            passed=False,
-            message=f"Typecheck failed (exit code {result.returncode})",
-            details=parsed.format_for_prompt(),
-            duration_seconds=time.monotonic() - start,
-            parsed=parsed,
+        return _failed_gate_result(
+            "typecheck",
+            f"Typecheck failed (exit code {result.returncode})",
+            parse_mypy_output(output),
+            cmd,
+            cwd,
+            start,
         )
 
     return CheckResult(
@@ -899,18 +923,13 @@ def check_linter(
 
     if result.returncode != 0:
         output = (result.stdout + result.stderr).strip()
-        parsed = parse_ruff_output(output)
-        for failure in parsed.failures:
-            add_source_context(failure, cwd)
-            if not failure.fix_hint:
-                failure.fix_hint = generate_fix_hint(failure)
-        return CheckResult(
-            name="linter",
-            passed=False,
-            message=f"Linter failed (exit code {result.returncode})",
-            details=parsed.format_for_prompt(),
-            duration_seconds=time.monotonic() - start,
-            parsed=parsed,
+        return _failed_gate_result(
+            "linter",
+            f"Linter failed (exit code {result.returncode})",
+            parse_ruff_output(output),
+            cmd,
+            cwd,
+            start,
         )
 
     return CheckResult(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -513,6 +513,18 @@ class TestDetectBaseBranch:
         spine_git("branch", "main", cwd=clone)
         assert detect_base_branch(clone) == remote_default
 
+    def test_origin_head_pointing_outside_the_remote_is_demoted(self, tmp_path: Path) -> None:
+        # origin/HEAD is normally a symref into refs/remotes/origin/;
+        # this one is hand-built to point straight at a local head, the
+        # shape that made an unguarded removeprefix answer with a whole
+        # refname. See git.detect_base_branch for why that got so far.
+        root = _repo_on(tmp_path, "master")
+        (root / ".git" / "refs" / "remotes" / "origin").mkdir(parents=True)
+        (root / ".git" / "refs" / "remotes" / "origin" / "HEAD").write_text(
+            "ref: refs/heads/master\n"
+        )
+        assert detect_base_branch(root) == "master"
+
     def test_a_tag_is_not_a_base_branch(self, tmp_path: Path) -> None:
         # A bare-name `rev-parse` resolves refs/tags before refs/heads,
         # so a tag called `main` shadows the branch we mean. Only

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner, Result
@@ -486,14 +488,64 @@ class TestDetectBaseBranch:
     def test_stale_origin_head_is_demoted(self, tmp_path: Path) -> None:
         # origin/HEAD is only rewritten by an explicit `git remote
         # set-head`, so it survives a rename on the remote and can name
-        # a branch that no longer resolves. Verifying it before
-        # returning is what drops it to the rung below.
+        # a branch that no longer resolves. for-each-ref omits a
+        # symbolic ref whose target does not resolve, which is what
+        # drops it to the rung below.
         root = _repo_on(tmp_path, "master")
         (root / ".git" / "refs" / "remotes" / "origin").mkdir(parents=True)
         (root / ".git" / "refs" / "remotes" / "origin" / "HEAD").write_text(
             "ref: refs/remotes/origin/gone\n"
         )
         assert detect_base_branch(root) == "master"
+
+    @pytest.mark.parametrize("remote_default", ["release-2.0", "release/2.0"])
+    def test_origin_head_outside_the_candidate_set_still_wins(
+        self, tmp_path: Path, remote_default: str
+    ) -> None:
+        # The remote's answer does not have to be one of the four names
+        # we would otherwise guess, and it needs no confirming call:
+        # for-each-ref listed it, so its target resolves. The slashed
+        # case is here because %(symref) reports a full refname, and
+        # splitting it on the last "/" would answer "2.0".
+        upstream = _repo_on(tmp_path, remote_default, name="upstream")
+        clone = tmp_path / "clone"
+        spine_git("clone", "-q", str(upstream), str(clone), cwd=tmp_path)
+        spine_git("branch", "main", cwd=clone)
+        assert detect_base_branch(clone) == remote_default
+
+    def test_a_tag_is_not_a_base_branch(self, tmp_path: Path) -> None:
+        # A bare-name `rev-parse` resolves refs/tags before refs/heads,
+        # so a tag called `main` shadows the branch we mean. Only
+        # refs/heads/<name> and refs/remotes/origin/<name> are asked
+        # about, so the tag is invisible and `master` wins. The tag is
+        # `main` rather than a later candidate on purpose: `master` is
+        # hit at index 1, so tagging `develop` would never be consulted
+        # and the test would pass against the bug.
+        root = _repo_on(tmp_path, "master")
+        spine_git("tag", "main", cwd=root)
+        assert detect_base_branch(root) == "master"
+
+    def test_a_branch_below_a_candidate_name_does_not_count(self, tmp_path: Path) -> None:
+        # `git for-each-ref refs/heads/main` also matches
+        # `refs/heads/main/sub`; only an exact refname is a hit, so a
+        # repo with no `main` branch does not claim to have one. Built
+        # on `master` so the right answer is not the fallback, which
+        # would make a prefix-matching bug indistinguishable.
+        root = _repo_on(tmp_path, "master")
+        spine_git("branch", "main/sub", cwd=root)
+        assert detect_base_branch(root) == "master"
+
+    def test_detection_is_one_git_subprocess(self, tmp_path: Path) -> None:
+        # It runs on the Textual event loop when the decompose launch
+        # form composes, so the call count is the ceiling on how long
+        # the UI can freeze. One call, one timeout.
+        root = _repo_on(tmp_path, "release-2.0")  # the worst case: no candidate hits
+
+        with patch("kstrl.git.subprocess.run", wraps=subprocess.run) as run:
+            assert detect_base_branch(root) == "main"
+
+        assert run.call_count == 1
+        assert run.call_args.args[0][1] == "for-each-ref"
 
 
 class TestResolveBaseBranch:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner, Result
 
 from kstrl.cli import _format_component_status, _run_structural_override_notices, cli
 from kstrl.factory import FactoryConfig
+from kstrl.git import BASE_BRANCH_CANDIDATES, detect_base_branch, resolve_base_branch
 from kstrl.manifest import Component, ComponentStatus, Manifest
 from tests.spine_utils import git as spine_git
 
@@ -416,3 +418,168 @@ class TestInboxRetryManifestLoad:
         result = self._run(tmp_path, item_id)
         assert result.exit_code == 0
         assert "Requeued comp-a" in result.output
+
+
+def _repo_on(tmp_path: Path, branch: str, name: str = "proj") -> Path:
+    """One-commit git repo whose only branch is ``branch``, with no remote."""
+    root = tmp_path / name
+    root.mkdir()
+    spine_git("init", "-q", "-b", branch, cwd=root)
+    spine_git("config", "user.email", "base@test", cwd=root)
+    spine_git("config", "user.name", "Base Test", cwd=root)
+    (root / "a.txt").write_text("a\n")
+    spine_git("add", "-A", cwd=root)
+    spine_git("commit", "-q", "-m", "init", cwd=root)
+    return root
+
+
+class TestDetectBaseBranch:
+    """#259: the ladder asks the repository instead of guessing `main`.
+
+    Every case builds a real repo; none of them mock git, because the
+    bug being fixed was precisely that the code never asked git.
+    """
+
+    @pytest.mark.parametrize("branch", BASE_BRANCH_CANDIDATES)
+    def test_every_candidate_is_detected_when_it_is_the_only_branch(
+        self, tmp_path: Path, branch: str
+    ) -> None:
+        # `master` is the reported repro: `git init` with
+        # init.defaultBranch unset gives it, and kstrl answered `main`
+        # in two seconds. The whole tuple is covered so a name added to
+        # it cannot ship untested.
+        assert detect_base_branch(_repo_on(tmp_path, branch)) == branch
+
+    def test_main_wins_when_both_names_exist(self, tmp_path: Path) -> None:
+        root = _repo_on(tmp_path, "master")
+        spine_git("branch", "main", cwd=root)
+        assert detect_base_branch(root) == "main"
+
+    def test_current_branch_is_not_the_answer(self, tmp_path: Path) -> None:
+        # Standing on a feature branch must not make that branch the
+        # base: diffing it against itself is empty, which the diff-scope
+        # and bad-pattern checks would read as a clean tree.
+        root = _repo_on(tmp_path, "master")
+        spine_git("checkout", "-q", "-b", "feature/x", cwd=root)
+        assert detect_base_branch(root) == "master"
+
+    def test_unknown_branch_name_falls_back_to_main(self, tmp_path: Path) -> None:
+        # No candidate resolves, so the answer stays the guess the
+        # callers report as a guess: `ks sense` exits 2 naming --base
+        # rather than measuring an empty diff and calling it clean.
+        assert detect_base_branch(_repo_on(tmp_path, "release-2.0")) == "main"
+
+    def test_not_a_repository_falls_back_to_main(self, tmp_path: Path) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        assert detect_base_branch(plain) == "main"
+
+    def test_origin_head_outranks_local_candidates(self, tmp_path: Path) -> None:
+        upstream = _repo_on(tmp_path, "trunk", name="upstream")
+        clone = tmp_path / "clone"
+        spine_git("clone", "-q", str(upstream), str(clone), cwd=tmp_path)
+        # A local `main` exists too; the remote's own answer still wins.
+        spine_git("branch", "main", cwd=clone)
+        assert spine_git("symbolic-ref", "refs/remotes/origin/HEAD", cwd=clone).endswith("/trunk")
+        assert detect_base_branch(clone) == "trunk"
+
+    def test_stale_origin_head_is_demoted(self, tmp_path: Path) -> None:
+        # origin/HEAD is only rewritten by an explicit `git remote
+        # set-head`, so it survives a rename on the remote and can name
+        # a branch that no longer resolves. Verifying it before
+        # returning is what drops it to the rung below.
+        root = _repo_on(tmp_path, "master")
+        (root / ".git" / "refs" / "remotes" / "origin").mkdir(parents=True)
+        (root / ".git" / "refs" / "remotes" / "origin" / "HEAD").write_text(
+            "ref: refs/remotes/origin/gone\n"
+        )
+        assert detect_base_branch(root) == "master"
+
+
+class TestResolveBaseBranch:
+    """The one spelling of "the flag wins, otherwise ask the repo"."""
+
+    def test_explicit_value_is_returned_unasked(self, tmp_path: Path) -> None:
+        root = _repo_on(tmp_path, "master")
+        assert resolve_base_branch("release-2.0", root) == "release-2.0"
+
+    @pytest.mark.parametrize("absent", [None, ""])
+    def test_absent_value_detects(self, tmp_path: Path, absent: str | None) -> None:
+        root = _repo_on(tmp_path, "master")
+        assert resolve_base_branch(absent, root) == "master"
+
+
+class TestBaseBranchFlagDefaults:
+    """#259: --base-branch defaults to detection, not the literal `main`.
+
+    `ks factory` is the command that spends money, and it had the
+    literal default without even the detection call.
+    """
+
+    @staticmethod
+    def _capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+        import kstrl.cli as cli_mod
+        from kstrl.decompose import SpecBlockerError, SpecIssue
+
+        seen: dict[str, object] = {}
+
+        def fake_decompose(**kwargs: object) -> None:
+            seen.update(kwargs)
+            # Halt before anything is provisioned; the assertion is on
+            # what the CLI resolved, not on what decompose does with it.
+            raise SpecBlockerError(
+                [SpecIssue(severity="blocker", kind="ambiguity", summary="halt")]
+            )
+
+        monkeypatch.setattr(cli_mod, "decompose_spec", fake_decompose)
+        return seen
+
+    @staticmethod
+    def _spec(root: Path) -> Path:
+        spec = root / "spec.md"
+        spec.write_text("# Spec\n")
+        return spec
+
+    def _invoke(self, command: str, root: Path, *extra: str) -> Result:
+        return CliRunner().invoke(
+            cli,
+            [
+                command,
+                "--spec",
+                str(self._spec(root)),
+                "--project-name",
+                "test",
+                "--root",
+                str(root),
+                "--agent-cmd",
+                "true",
+                "--ui",
+                "plain",
+                "--no-color",
+                *extra,
+            ],
+        )
+
+    def test_decompose_detects_when_flag_is_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = self._capture(monkeypatch)
+        root = _repo_on(tmp_path, "master")
+        assert self._invoke("decompose", root).exit_code == 2
+        assert seen["base_branch"] == "master"
+
+    def test_factory_detects_when_flag_is_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = self._capture(monkeypatch)
+        root = _repo_on(tmp_path, "master")
+        assert self._invoke("factory", root).exit_code == 2
+        assert seen["base_branch"] == "master"
+
+    def test_explicit_flag_still_wins(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = self._capture(monkeypatch)
+        root = _repo_on(tmp_path, "master")
+        assert self._invoke("factory", root, "--base-branch", "trunk").exit_code == 2
+        assert seen["base_branch"] == "trunk"

--- a/tests/test_launch_session.py
+++ b/tests/test_launch_session.py
@@ -310,6 +310,10 @@ class TestStartRunSession:
         assert session.kind == "decompose"
         assert (session.run_dir / "events.jsonl").exists()
         assert (session.run_dir / "orchestrator.log").exists()
+        manifest = json.loads(
+            (tmp_path / "scripts" / "kstrl" / "manifest.json").read_text(),
+        )
+        assert len(manifest["components"]) == 2
 
     def test_decompose_session_resolves_an_unset_base_branch(self, tmp_path: Path) -> None:
         """#259: DecomposeLaunch carries no base branch of its own, so
@@ -337,12 +341,8 @@ class TestStartRunSession:
             assert session.handle.exit_code == 0
         finally:
             session.close()
-        manifest = Manifest.load(tmp_path / "scripts" / "kstrl" / "manifest.json")
-        assert manifest.base_branch == "trunk"
-        manifest = json.loads(
-            (tmp_path / "scripts" / "kstrl" / "manifest.json").read_text(),
-        )
-        assert len(manifest["components"]) == 2
+        written = Manifest.load(tmp_path / "scripts" / "kstrl" / "manifest.json")
+        assert written.base_branch == "trunk"
 
 
 class TestLaunchForms:

--- a/tests/test_launch_session.py
+++ b/tests/test_launch_session.py
@@ -27,6 +27,7 @@ from kstrl.tui.screens.options import OptionsModal
 from kstrl.tui.screens.overview import OverviewScreen
 from kstrl.tui.screens.retry import RetryScreen
 from kstrl.tui.session import LaunchError, start_run_session
+from tests.spine_utils import git as spine_git
 from tests.test_decompose import VALID_DECOMPOSE_OUTPUT, MockDecomposeAgent
 
 
@@ -76,6 +77,17 @@ class FakeSession:
     def close(self) -> None:
         self.closed = True
         self.channel.detach()
+
+
+def _git_repo_on(root: Path, branch: str) -> Path:
+    """One-commit repo at ``root`` whose only branch is ``branch``."""
+    spine_git("init", "-q", "-b", branch, cwd=root)
+    spine_git("config", "user.email", "launch@test", cwd=root)
+    spine_git("config", "user.name", "Launch Test", cwd=root)
+    (root / "a.txt").write_text("a\n")
+    spine_git("add", "-A", cwd=root)
+    spine_git("commit", "-q", "-m", "init", cwd=root)
+    return root
 
 
 def _home_app(tmp_path: Path) -> KstrlTuiApp:
@@ -298,6 +310,35 @@ class TestStartRunSession:
         assert session.kind == "decompose"
         assert (session.run_dir / "events.jsonl").exists()
         assert (session.run_dir / "orchestrator.log").exists()
+
+    def test_decompose_session_resolves_an_unset_base_branch(self, tmp_path: Path) -> None:
+        """#259: DecomposeLaunch carries no base branch of its own, so
+        the session asks the repo instead of writing a manifest against
+        a `main` that a `git init` repo on `master` does not have."""
+        _git_repo_on(tmp_path, "trunk")
+        spec_file = tmp_path / "spec.md"
+        spec_file.write_text("# Spec\nBuild it.")
+        (tmp_path / "scripts" / "kstrl").mkdir(parents=True)
+        (tmp_path / "kstrl.toml").write_text(
+            '[agent]\ncommand = "fake-agent"\n',
+            encoding="utf-8",
+        )
+        assert DecomposeLaunch().base_branch == ""
+        with patch(
+            "kstrl.agents.get_agent",
+            return_value=MockDecomposeAgent(VALID_DECOMPOSE_OUTPUT),
+        ):
+            session = start_run_session(
+                DecomposeLaunch(spec_path=spec_file, project_name="demo"),
+                tmp_path,
+            )
+        try:
+            session.handle.join(timeout=15)
+            assert session.handle.exit_code == 0
+        finally:
+            session.close()
+        manifest = Manifest.load(tmp_path / "scripts" / "kstrl" / "manifest.json")
+        assert manifest.base_branch == "trunk"
         manifest = json.loads(
             (tmp_path / "scripts" / "kstrl" / "manifest.json").read_text(),
         )
@@ -373,6 +414,35 @@ class TestLaunchForms:
             await pilot.pause(0.3)
             assert len(specs) == 1
             assert specs[0].project_name == "demo"
+
+    async def test_decompose_form_offers_the_detected_base_branch(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """#259 through the TUI: the field used to pre-fill the literal
+        `main`, so a plain `git init` repo on `master` launched a run
+        whose every worktree cut names a branch that does not exist."""
+        _git_repo_on(tmp_path, "master")
+        app = _home_app(tmp_path)
+        specs: list[Any] = []
+        app.start_session = lambda spec: specs.append(spec) or FakeSession(tmp_path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(DecomposeLaunchForm())
+            await pilot.pause(0.2)
+            from textual.widgets import Button, Input
+
+            form = app.screen
+            assert form.query_one("#decompose-branch", Input).value == "master"
+
+            (tmp_path / "spec.md").write_text("# spec")
+            form.query_one("#decompose-spec", Input).value = "spec.md"
+            form.query_one("#decompose-project", Input).value = "demo"
+            # Clearing the field must not resurrect the literal either.
+            form.query_one("#decompose-branch", Input).value = ""
+            form.query_one("#decompose-start", Button).press()
+            await pilot.pause(0.3)
+            assert specs[0].base_branch == "master"
 
 
 class TestRetryScreen:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -328,6 +328,21 @@ AssertionError: expected false to be true // Object.is equality
 """
 
 
+# Captured verbatim from a real `pytest` run where every test PASSED.
+# The polyglot gate chains toolchains (`uv run pytest && npm test`), so
+# the half that passes can be the half the parser understands.
+PYTEST_PASSING_OUTPUT = """\
+============================= test session starts ==============================
+platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0
+rootdir: /tmp/writers-room
+collected 5 items
+
+tests/test_ok.py .....                                                   [100%]
+
+============================== 5 passed in 0.00s ===============================
+"""
+
+
 class TestNonPythonToolOutput:
     """The pytest parser is applied to whatever `test_command` ran.
 
@@ -387,3 +402,42 @@ class TestNonPythonToolOutput:
         parsed = parse_pytest_output(VITEST_FAILURE_OUTPUT)
         assert parsed.command == ""
         assert parsed.format_for_prompt()[0].startswith("[pytest]")
+
+    def test_a_passing_half_does_not_become_the_failure_detail(self) -> None:
+        """A failed gate must not report the passing toolchain's summary.
+
+        The measured shape from the polyglot repo behind #258: pytest
+        passes, vitest fails, `test_command` chains them. `_PYTEST_
+        SUMMARY_RE` matches pytest's footer, so the summary became
+        "5 passed in 0.00s" and, with the tail fallback suppressed by a
+        summary already being set, that single line was the whole retry
+        detail. The engineer was told five tests passed by a gate that
+        had just failed, and the vitest failure was gone.
+        """
+        combined = PYTEST_PASSING_OUTPUT + VITEST_FAILURE_OUTPUT
+
+        parsed = parse_pytest_output(combined)
+        parsed.command = "uv run pytest && npm test"
+        detail = "".join(parsed.format_for_prompt())
+
+        assert parsed.failures == []
+        assert "5 passed" not in detail
+        # What survives is the failing half's own summary.
+        assert "1 failed" in detail
+        assert parsed.total_errors == 1
+
+    def test_a_summary_reporting_failures_is_kept(self) -> None:
+        # The guard is "no failure in sight", not "no parsed failures":
+        # a real pytest footer that reports failures still wins over the
+        # tail even when no FAILED line was parseable from it.
+        raw = (
+            "collected 5 items\n"
+            "============================= 2 failed, 3 passed in 1.23s ==============================\n"
+        )
+        parsed = parse_pytest_output(raw)
+        assert parsed.failures == []
+        # The tail always contains the last line, so the discriminator is
+        # the "=" padding: the extracted summary has none, the raw tail
+        # keeps it. Taking the tail here would lose the count as well.
+        assert parsed.raw_summary == "2 failed, 3 passed in 1.23s"
+        assert parsed.total_errors == 2

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -284,3 +284,106 @@ class TestFormatForPrompt:
         )
         lines = output.format_for_prompt(include_source=False)
         assert not any("|" in line for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# Non-Python tool output (#258)
+# ---------------------------------------------------------------------------
+
+# Captured verbatim from a real `vitest run` (vitest 2.1.9) with one
+# deliberately failing test, ANSI escapes stripped. Every fixture in this
+# suite was Python tool output before this one, which is why the pytest
+# parser was never measured against anything it could not read.
+VITEST_FAILURE_OUTPUT = """\
+ RUN  v2.1.9 /tmp/writers-room/web
+ ❯ tests/failing.test.ts (2 tests | 1 failed) 3ms
+   × deliberate failure > shows what a real vitest failure looks like 2ms
+     → expected false to be true // Object.is equality
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  tests/failing.test.ts > deliberate failure > shows what a real vitest failure looks like
+AssertionError: expected false to be true // Object.is equality
+
+- Expected
++ Received
+
+- true
++ false
+
+ ❯ tests/failing.test.ts:5:19
+      3| describe("deliberate failure", () => {
+      4|   it("shows what a real vitest failure looks like", () => {
+      5|     expect(false).toBe(true);
+       |                   ^
+      6|   });
+      7|   it("passes", () => {
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+ Test Files  1 failed (1)
+      Tests  1 failed | 1 passed (2)
+   Start at  18:13:20
+   Duration  181ms (transform 16ms, setup 0ms, collect 11ms, tests 3ms, environment 0ms, prepare 31ms)
+"""
+
+
+class TestNonPythonToolOutput:
+    """The pytest parser is applied to whatever `test_command` ran.
+
+    `check_test_suite` has no dispatch, so a polyglot repo's
+    `uv run pytest && (cd web && npm run test)` sends vitest output
+    through `parse_pytest_output`. These tests pin what that actually
+    does, measured rather than reasoned.
+    """
+
+    def test_vitest_output_parses_no_structured_failures(self) -> None:
+        # The known gap, recorded rather than asserted as desirable: the
+        # failing file, line, test name, assertion message and the
+        # expected-versus-received diff are all in the raw output and
+        # none of them survive. Closing that needs a parser that knows
+        # vitest, which is the other half of #258.
+        parsed = parse_pytest_output(VITEST_FAILURE_OUTPUT)
+        assert parsed.failures == []
+
+    def test_total_errors_is_not_zero_when_the_summary_says_failed(self) -> None:
+        # Measured before the fix: 0, because total_errors was computed
+        # from raw_summary BEFORE the tail fallback populated it, so the
+        # field disagreed with the summary sitting next to it. Nothing
+        # in kstrl/ reads total_errors today, so this pins a trap rather
+        # than a live misread.
+        parsed = parse_pytest_output(VITEST_FAILURE_OUTPUT)
+        assert "1 failed" in parsed.raw_summary
+        assert parsed.total_errors == 1
+
+    def test_passthrough_is_labelled_with_the_command_that_ran(self) -> None:
+        parsed = parse_pytest_output(VITEST_FAILURE_OUTPUT)
+        parsed.command = "npm run test"
+        lines = parsed.format_for_prompt()
+        assert lines[0].startswith("[npm run test]")
+        assert "[pytest]" not in "".join(lines)
+
+    def test_tool_identity_is_unchanged(self) -> None:
+        # evolution.signatures_from_verification switches on
+        # `parsed.tool` by exact string, so the label change must not
+        # move it. Only the prompt label is command-derived.
+        parsed = parse_pytest_output(VITEST_FAILURE_OUTPUT)
+        parsed.command = "npm run test"
+        assert parsed.tool == "pytest"
+
+    def test_parsed_failures_keep_the_tool_label(self) -> None:
+        # Failures prove the parser understood the output, so `[pytest]`
+        # is earned even when the command is recorded.
+        raw = (
+            "=========================== short test summary info ===========================\n"
+            "FAILED tests/test_foo.py::test_bar - AssertionError: expected 1, got 2\n"
+            "============================= 1 failed in 0.10s =============================\n"
+        )
+        parsed = parse_pytest_output(raw)
+        parsed.command = "uv run pytest"
+        assert parsed.format_for_prompt()[0].startswith("[pytest]")
+
+    def test_label_falls_back_to_the_tool_without_a_command(self) -> None:
+        parsed = parse_pytest_output(VITEST_FAILURE_OUTPUT)
+        assert parsed.command == ""
+        assert parsed.format_for_prompt()[0].startswith("[pytest]")

--- a/tests/test_sense_cli.py
+++ b/tests/test_sense_cli.py
@@ -173,8 +173,8 @@ def test_sense_enforces_allowed_path(tmp_path: Path) -> None:
     result, document = _sense_json(root, "--allowed-path", "docs/**")
 
     assert result.exit_code == 1
-    # No origin in this repo: detection falls back to main, which is
-    # the branch the feature commit diverged from.
+    # No origin in this repo, so detection reaches the candidate rung
+    # and finds the local `main` the feature commit diverged from.
     assert document["base_branch"] == "main"
     scope = _check(document, "diff_scope")
     assert scope["passed"] is False
@@ -337,10 +337,38 @@ def test_sense_exit_2_when_explicit_base_is_unreachable(tmp_path: Path) -> None:
     assert "checks" not in document
 
 
-def test_sense_exit_2_when_detected_base_is_missing(tmp_path: Path) -> None:
-    """No origin and no `main`: detection falls back to a branch that
-    does not exist, and the fallback must not read as a clean diff."""
+def test_sense_detects_the_base_branch_that_exists(tmp_path: Path) -> None:
+    """No origin, and the base is `trunk` rather than `main` (#259).
+
+    This repo used to be the exit-2 fixture below: detection returned
+    the literal `main`, the diff failed, and the test pinned that as
+    correct. The ladder now asks the repo, so the diff is real and the
+    measurement is against the branch that exists.
+    """
     root = _diverged_repo(tmp_path, base="trunk")
+
+    result, document = _sense_json(root, "--allowed-path", "docs/**")
+
+    assert document["base_branch"] == "trunk"
+    # A real diff was read against trunk: the out-of-scope file is
+    # named, rather than a clean tree nobody managed to measure.
+    scope = _check(document, "diff_scope")
+    assert scope["passed"] is False
+    assert "src/a.py" in "".join(scope["details"])
+    assert result.exit_code == 1
+
+
+def test_sense_exit_2_when_detected_base_is_missing(tmp_path: Path) -> None:
+    """No origin and no branch the ladder knows: detection falls back to
+    a branch that does not exist, and the fallback must not read as a
+    clean diff.
+
+    `release-2.0` is deliberately outside the candidate set, which is
+    the only way the fallback is still reachable now that the ladder
+    checks the repo (#259). The branch HEAD is on is NOT a rung, so
+    standing on `feature` cannot rescue this into a silent empty diff.
+    """
+    root = _diverged_repo(tmp_path, base="release-2.0")
 
     result = _invoke("--root", str(root), "--json")
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import patch
@@ -22,6 +23,7 @@ from kstrl.verify import (
     check_typecheck,
     run_mechanical_verification,
 )
+from tests.test_parsers import VITEST_FAILURE_OUTPUT
 
 
 class TestCheckPrdStories:
@@ -105,6 +107,43 @@ class TestCheckTestSuite:
         assert result.passed is False
         assert "timed out" in result.message
 
+    def test_unparsed_output_is_labelled_with_the_command(self, tmp_path: Path) -> None:
+        """#258: a vitest failure reached the engineer tagged [pytest].
+
+        `check_test_suite` parses every gate as pytest whatever the
+        configured command was, so the label pointed the implementing
+        agent at the wrong toolchain and the wrong half of the repo.
+        The command is the one name that cannot be wrong.
+        """
+        script = tmp_path / "fake_vitest.py"
+        script.write_text(f"import sys\nsys.stdout.write({VITEST_FAILURE_OUTPUT!r})\nsys.exit(1)\n")
+        command = f"{sys.executable} {script}"
+
+        result = check_test_suite(tmp_path, command=command, timeout=30.0)
+
+        assert result.passed is False
+        assert result.details[0].startswith(f"[{command}]")
+        assert "[pytest]" not in "".join(result.details)
+        # The parser identity is untouched, so evolution's exact-string
+        # switch on parsed.tool still resolves.
+        assert result.parsed is not None
+        assert result.parsed.tool == "pytest"
+
+    def test_parsed_pytest_output_keeps_the_tool_label(self, tmp_path: Path) -> None:
+        script = tmp_path / "fake_pytest.py"
+        script.write_text(
+            "import sys\n"
+            "print('=========== short test summary info ===========')\n"
+            "print('FAILED tests/test_a.py::test_x - AssertionError: nope')\n"
+            "print('=========== 1 failed in 0.10s ===========')\n"
+            "sys.exit(1)\n"
+        )
+
+        result = check_test_suite(tmp_path, command=f"{sys.executable} {script}", timeout=30.0)
+
+        assert result.passed is False
+        assert result.details[0].startswith("[pytest]")
+
 
 class TestCheckTypecheck:
     def test_passing(self, tmp_path: Path) -> None:
@@ -114,6 +153,23 @@ class TestCheckTypecheck:
     def test_failing(self, tmp_path: Path) -> None:
         result = check_typecheck(tmp_path, command="false", timeout=5.0)
         assert result.passed is False
+
+    def test_unparsed_output_is_labelled_with_the_command(self, tmp_path: Path) -> None:
+        """The typecheck gate runs whatever `typecheck_command` is and
+        parses it as mypy, so a `tsc` failure had the same #258
+        mislabel. All three gates go through one builder now; this pins
+        that the second one is not left behind."""
+        script = tmp_path / "fake_tsc.py"
+        script.write_text(
+            "import sys\nprint('src/a.ts(5,3): error TS2322: not assignable')\nsys.exit(2)\n"
+        )
+        command = f"{sys.executable} {script}"
+
+        result = check_typecheck(tmp_path, command=command, timeout=30.0)
+
+        assert result.passed is False
+        assert result.details[0].startswith(f"[{command}]")
+        assert "[mypy]" not in "".join(result.details)
 
 
 class TestDefaultTypecheckCommand:


### PR DESCRIPTION
Fixes #259. Also the labelling half of #258; the parser-dispatch half stays open.

## #259: base-branch detection never asked the repo

`_detect_base_branch` made exactly one git call, `git symbolic-ref refs/remotes/origin/HEAD`, and otherwise returned the literal `"main"`. Confirmed while working on this: only `git clone` and an explicit `git remote set-head` ever write that ref, and **this repo does not have it**, so even here the answer came from the hardcoded fallback. A plain `git init` repo on `master` failed `ks sense` in two seconds.

Broader than the issue said: `ks decompose` had the identical literal flag default, not just `ks factory`. Both are fixed. And broader again: the TUI decompose launch form pre-filled the literal `"main"` and re-applied it when the field was cleared, which is the same bug arriving through a second entry point.

### The ladder, and what each rung fails on

1. **`origin/HEAD`** - the remote's own answer, so it outranks any guess. Fails whenever the ref was never written (a repo that grew a remote by hand, a plain `git init`), and can go stale when the remote renames its default branch.
2. **The first of `main`, `master`, `trunk`, `develop` that resolves.** Fails when the project's long-lived branch is named something else (`release`, `stable`), and picks the earlier name when a repo carries two of them mid-migration.
3. **The literal `main`.** Still a guess, and the callers still report it as one.

All of it is **one `git for-each-ref`** over `origin/HEAD` plus each candidate's two possible refs, `refs/heads/<name>` and `refs/remotes/origin/<name>` - the two `resolve_base_ref` consults, so a name this accepts is one `get_diff_names` and the worktree cut can actually resolve, including in a clone carrying the remote-tracking ref only. Three properties of that command, each measured rather than assumed, carry the rungs:

- **It lists a ref only when the ref resolves, and a symbolic ref only when its target resolves.** So a stale `origin/HEAD` naming a deleted branch is simply absent, which *is* rung 1's demotion, and a listed `origin/HEAD` needs no confirming call even when its target is outside the candidate set.
- **`%(symref)` reports origin/HEAD's target in the same listing**, folding rung 1 in for free.
- **Asking by exact ref path asks about BRANCHES.** This is a correctness gain, not only a speed one: a bare-name `rev-parse` resolves `refs/tags` *before* `refs/heads`, so a tag named `main` shadowed the branch, and a tag is not something to cut a worktree from.

The first draft of this fix walked the ladder a rung at a time, which measured up to 9 subprocesses and 31 ms. Three second-order bugs fell out of collapsing it: `for-each-ref refs/heads/main` also matches `refs/heads/main/sub` (so the listing is filtered on exact refnames, or a repo with no `main` branch would claim to have one); `%(symref)` yields a full refname, so splitting on the last `/` turned a remote defaulting to `release/2.0` into `2.0`; and `removeprefix` returns its input untouched when the prefix is absent, so an `origin/HEAD` symrefing at `refs/heads/dev` answered with the literal string `'refs/heads/dev'` - which `validate_branch_name` accepts, so it would have reached the manifest and `gh pr create --base`. A `startswith` guard demotes that to the candidate rung.

### The rung I deliberately left out

**The branch HEAD is on is not a rung**, even though the issue proposed it. It always resolves, so it would end the ladder every time, and diffing a branch against itself is empty - which `diff_scope` reports as "0 files, all within scope" and `bad_patterns` as "scanned 0 Python files". That converts a loud cannot-measure (exit 2, naming `--base`) into a silent green on a tree nobody measured, and `ks sense` treats cannot-measure as never a pass. A guess the caller reports as a guess beats a wrong answer delivered as a measurement. The cost is that a repo whose base is `release-2.0` still gets the fallback, which is the correct answer: kstrl genuinely cannot tell, and the error message already says so well.

### Where it lives now

The detection moved to `kstrl/git.py` as `detect_base_branch`, next to `resolve_ref` and `resolve_base_ref`. It was the only code in `cli.py` shelling out to git directly, and the TUI needs it too. One `resolve_base_branch(flag, cwd)` helper is now the single spelling of "the flag wins, otherwise ask the repo" across all five call sites. `DecomposeLaunch.base_branch` defaults to `""` rather than carrying a hardcoded guess in a data container; the session layer resolves it.

Measured on this machine: **one subprocess and 3.0 to 4.0 ms in every repo shape**, flat, because the shape no longer decides how many calls run. Called once per command invocation, confirmed by instrumenting real runs of `ks sense`, `ks decompose` and `ks factory`.

It also runs on the Textual event loop when the decompose form composes, so the call count is the ceiling on how long the UI can freeze. Measured push_screen to mounted: **+4 to +8 ms on an 85 ms screen open**, and one 5 s timeout rather than nine stacked into 45 s. It stays synchronous deliberately: that is the same exposure as the existing `home.py::_git_branch` masthead probe on the same event loop, and a thread worker would buy back single-digit milliseconds while adding a way for a slow probe to land on top of a branch the user has already typed.

## #258: the mislabel only

`check_test_suite` calls `parse_pytest_output` unconditionally whatever the configured command was, and `format_for_prompt` prefixed the passthrough with `[pytest]`. Reproduced against **real vitest 2.1.9 output** rather than reasoning from the code: 0 parsed failures, and what survived into the retry prompt was a timing block labelled `[pytest]`.

`ParsedOutput` gains a `command` field and a `prompt_label` property. With parsed failures the parser clearly understood the output, so the tool name is earned; with none, the label is the command that actually ran, which is the one name that cannot be wrong. `parsed.tool` is untouched, so `evolution.signatures_from_verification`'s exact-string switch still resolves - and that is pinned by a test.

All three gates now build their failing `CheckResult` through one `_failed_gate_result` helper. Forgetting the command assignment in a fourth gate would silently reinstate the mislabel, so it should not be a line anyone can forget.

**Second-order bugs, fixed.** `parse_pytest_output` computed `total_errors` from `raw_summary` *before* the tail fallback populated it, so it reported `0` on output whose own tail said "1 failed". Being honest about the stakes: nothing in `kstrl/` reads `total_errors` today, so that half is preemptive rather than a live misread, and the comment says so.

The tail fallback itself was then found to be too narrow, by review. It only fired when *no* summary had matched, but `raw_summary` can be set by a **successful** match. Measured with real passing pytest output concatenated with the real failing vitest output, the way `uv run pytest && npm test` emits them: `_PYTEST_SUMMARY_RE` matched pytest's footer, so the summary became `"5 passed in 0.00s"`, the fallback was suppressed, and the failed gate's entire retry detail read

```
[uv run pytest && npm test] 5 passed in 0.00s
```

A failed gate telling the engineer five tests passed, with the vitest failure dropped entirely - and worse than what it replaced in one specific way, since the old `[pytest]` prefix at least did not attribute that line to the npm half. The rule is now "no parsed failures **and no summary reporting a failure**", so the same input carries vitest's own "1 failed" summary instead. `_pytest_failure_count` states the count rule once, which also takes `parse_pytest_output` from cognitive 26 to 21.

**What is deliberately NOT fixed here:** the information loss. The tail is still five lines, so a foreign tool's file, line, test name and assertion diff are dropped either way. Recovering those needs a parser that knows the tool, which is the parser-dispatch half of #258 and is scheduled separately. The code says so at the point where it happens.

## Tests

- `test_sense_exit_2_when_detected_base_is_missing` **pinned the wrong behaviour**: it built a repo whose only branch was `trunk` and asserted the error names `'main'`. Rewritten onto a `release-2.0` repo, which is the only way the fallback is still reachable now that the ladder asks the repo. The `trunk` fixture becomes a positive test that sense measures a real diff against `trunk`.
- First direct unit tests for the ladder: every candidate parametrized (so a name added to the tuple cannot ship untested), both-names precedence, the current branch NOT winning, an unknown branch falling back, a non-repository, `origin/HEAD` outranking local candidates (including a slashed and an unslashed name outside the candidate set), a stale `origin/HEAD` being demoted, a tag not counting as a branch, a `main/sub` branch not counting as `main`, and a call-count assertion pinning the single subprocess. All build real repos; none mock git, because the bug was that the code never asked git.
- Each of the four subtlest cases was **verified to fail against a mutation that reintroduces the specific defect it guards** (prefix matching, bare-name `rev-parse` resolving a tag, rsplit on the symref, extra probes). Two earlier drafts were rewritten because they did not discriminate: the tag test used `develop`, which `master` beats at index 1 before the tag is consulted, and the slash-boundary test asserted `main`, which is also the fallback.
- CLI flag defaults for both `ks decompose` and `ks factory`, plus the explicit flag still winning.
- **The first non-Python fixture in the suite**: real vitest output captured verbatim, covering the zero-failure parse, the `total_errors` fix, the command label, the tool identity, and both arms of the label condition. Plus gate-level tests that the label reaches `CheckResult.details` for the test and typecheck gates.
- TUI coverage: the form offers the detected branch and does not resurrect the literal when cleared; the session resolves an unset base.

## Gate

`pytest tests/ -q` 3667 passed / 28 skipped, `mypy kstrl/ --strict` clean, `ruff check` clean, `pre-commit run --all-files` clean, `scripts/gen_docs.py --check` clean. Combined fast + spine coverage **88.75%** against the 79.91% ratchet.

`/simplify` was run over both rounds of the change and its findings applied: one `resolve_base_branch` spelling instead of three, one `_failed_gate_result` builder instead of three copies, `_BASE_BRANCH_REFS` as a module constant rather than a per-call rebuild, parametrized candidate tests, `wraps=` instead of a hand-rolled counting stub, a corrected `total_errors` comment that had overclaimed a live consumer, and the two non-discriminating tests above. Every behavioural test in the diff was then verified to fail against a mutation reintroducing the specific defect it guards, in both directions where the fix has a boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHYpsJ8ecHLh5HdrswJtJK
