### PR TITLE
fix(budget): --max-cost-usd bounds the architect too (#257 piece B)

### DIFF
--- a/kstrl/autonomy.py
+++ b/kstrl/autonomy.py
@@ -808,11 +808,20 @@ def commit_transition(
         "reason": record.reason,
         "evidence": record.evidence,
     }
+    # load_or_none, not load: a typo in an [evolution] knob raises
+    # ValueError, which this OSError guard does not catch, and the
+    # ladder would then fail to record a transition it has already
+    # SAVED - the exact drift this function exists to prevent.
+    config = EvolutionConfig.load_or_none(
+        root_dir,
+        warn=lambda message: warnings.warn(message, RuntimeWarning, stacklevel=2),
+    )
     try:
-        journal_path = EvolutionConfig.load(root_dir).journal_path
-        journal_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(journal_path, "a") as handle:
-            handle.write(json.dumps(entry, separators=(",", ":")) + "\n")
+        if config is not None:
+            journal_path = config.journal_path
+            journal_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(journal_path, "a") as handle:
+                handle.write(json.dumps(entry, separators=(",", ":")) + "\n")
     except OSError as exc:
         warnings.warn(
             f"autonomy: journal append failed (non-fatal): {exc}",

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -398,6 +398,59 @@ def _collect_toml_notes(
             )
 
 
+def _collect_evolution_notes(
+    notes: list[str],
+    root_dir: Path,
+    ui_impl: UI,
+) -> None:
+    """The evolution section's NOTE sweep, guarded against a bad knob.
+
+    Its own function because the guard has to sit BETWEEN the two loads:
+    ``from_env`` applies the same env overrides as ``load``, so passing
+    both as arguments to :func:`_collect_toml_notes` would evaluate the
+    unguarded one first and raise before the guard could run.
+
+    Why this section and not the others, stated precisely because the
+    obvious reading is wrong (#257 review): evolution is NOT the only
+    loader here that can raise. Measured on this tree, `ks factory`
+    exits 1 with a raw ValueError traceback under
+    ``KSTRL_MUTATION_THRESHOLD=many`` and ``KSTRL_SECURITY_TIMEOUT=many``
+    too, and the toml paths of verify, security, contract, feedforward
+    and timeout raise the same way. Five sibling loads in this command
+    are still unguarded.
+
+    What separates evolution is what a failure MAY cost. The journal is
+    an optional audit trail, so "unreadable, carry on without it" is an
+    honest degrade. For verify, security, contract and timeout it is
+    not: silently substituting defaults for the checks an operator
+    configured is a semantic substitution, and those need an error
+    boundary - a typed parse error caught where
+    ``_KstrlGroup.invoke`` already catches ``BudgetConfigError`` - not a
+    fallback. That boundary is a change to six config modules and is
+    left out of #257.
+
+    So this is one exit plugged, not the class closed. It is the exit
+    worth plugging first: it runs AFTER the architect has been paid for
+    and BEFORE ``run_factory``, with the spend live only in a local
+    variable. It is not the only exit in that window either - the
+    confirm prompt's "Quit" is an ordinary one - which is the honest
+    argument for eventually making the architect's spend durable where
+    it is earned rather than plugging exits one at a time.
+    """
+    from kstrl.evolution import EvolutionConfig
+
+    config = EvolutionConfig.load_or_none(root_dir, warn=ui_impl.warn)
+    if config is None:
+        return
+    _collect_toml_notes(
+        notes,
+        "evolution",
+        config,
+        EvolutionConfig.from_env(root_dir),
+        flag_overridden=set(),
+    )
+
+
 def _resolve_root(root: Path | None, prompt: Path | None, prd: Path | None) -> Path:
     if root is not None:
         return root.resolve()
@@ -2206,7 +2259,6 @@ def factory(
     # sentinels so "not passed" is distinguishable from "passed the
     # default value", and an explicitly-passed flag is applied on top.
     from kstrl.contract import ContractConfig
-    from kstrl.evolution import EvolutionConfig
     from kstrl.feedforward import FeedforwardConfig
     from kstrl.security import SecurityConfig
     from kstrl.verify import VerifyConfig
@@ -2374,14 +2426,10 @@ def factory(
     )
 
     # Evolution config is consumed inside run_factory via
-    # EvolutionConfig.load(root_dir); loaded here only for the NOTE sweep.
-    _collect_toml_notes(
-        toml_notes,
-        "evolution",
-        EvolutionConfig.load(root_dir),
-        EvolutionConfig.from_env(root_dir),
-        flag_overridden=set(),
-    )
+    # EvolutionJournal.open; swept here only for the NOTE lines, and by
+    # a helper because a failed load must not cost the run. The helper
+    # says why this section and not its five raising siblings.
+    _collect_evolution_notes(toml_notes, root_dir, ui_impl)
 
     # R0.1: TimeoutConfig is the single source for timeout values.
     timeout_config = TimeoutConfig.load(root_dir)

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -29,7 +29,7 @@ from kstrl.agents import (
     CodexAgent,
     get_agent,
 )
-from kstrl.agents.base import Agent
+from kstrl.agents.base import Agent, UsageTotals, collect_usage, usage_cursor
 from kstrl.agents.logging import LoggingAgent
 from kstrl.breaker import BreakerConfig
 from kstrl.commandrun import CommandRun, open_command_run
@@ -2149,7 +2149,17 @@ def factory(
     if max_total_tokens is not None:
         validate_token_ceiling(max_total_tokens, "--max-total-tokens")
 
-    # Get or create manifest
+    # Get or create manifest.
+    #
+    # #257: a --spec run also pays for the architect here, before any run
+    # id or run directory exists, so what it cost has to be carried into
+    # the run by hand for `--max-cost-usd` to bound five roles instead of
+    # four. A --manifest resume ran no architect and leaves this empty.
+    #
+    # Only the paths that reach run_factory are covered: a blocker halt
+    # exits below, before there is anywhere on disk to record it.
+    # `decompose_spec` prints the number to the terminal on that path.
+    architect_usage = UsageTotals()
     if manifest_path:
         try:
             manifest = Manifest.load(manifest_path)
@@ -2162,6 +2172,11 @@ def factory(
             ui_impl.err("--project-name is required with --spec")
             sys.exit(2)
 
+        # Read BEFORE the work, and sliced from there afterwards, the
+        # same way `decompose_spec` reports it - so the two derivations
+        # of "what the architect spent" cannot disagree, and neither
+        # rests on an invariant about who else touched this agent.
+        usage_before = usage_cursor(agent)
         try:
             manifest = decompose_spec(
                 spec_path=spec,
@@ -2183,6 +2198,7 @@ def factory(
         except ValueError as exc:
             ui_impl.err(str(exc))
             sys.exit(1)
+        architect_usage = collect_usage(agent, since=usage_before)
 
     # Build configs (R2.1). Resolution order for every phase config:
     # explicit CLI flag > env > kstrl.toml > dataclass default. The
@@ -2507,6 +2523,7 @@ def factory(
                 base_config,
                 root_dir,
                 manifest_path,
+                architect_usage=architect_usage,
             )
         )
 
@@ -2521,6 +2538,7 @@ def factory(
             root_dir,
             manifest_path=manifest_path,
             stop=stop,
+            architect_usage=architect_usage,
         )
     finally:
         uninstall()

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -430,6 +430,30 @@ class EvolutionJournal:
     def __init__(self, config: EvolutionConfig) -> None:
         self.config = config
 
+    @classmethod
+    def open(
+        cls,
+        root_dir: Path,
+        warn: Callable[[str], None],
+    ) -> EvolutionJournal | None:
+        """The journal for ``root_dir``, or None when it is unusable.
+
+        Every writer asks the same two questions in the same order -
+        does the config parse, and is the journal switched on - and does
+        the same thing on either No. Asking them here rather than at each
+        site is what stops the pair drifting: measured, the four writers
+        that existed before #257 disagreed, with two of them omitting the
+        parse guard entirely and raising a config typo into work that had
+        already been paid for.
+
+        Which exceptions "does not parse" covers is ``load_or_none``'s to
+        know, not a call site's. Degrades loudly through ``warn``.
+        """
+        config = EvolutionConfig.load_or_none(root_dir, warn=warn)
+        if config is None or not config.enabled:
+            return None
+        return cls(config)
+
     # ------------------------------------------------------------------
     # record_run
     # ------------------------------------------------------------------

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -426,6 +426,45 @@ def _summarize_findings(findings: list[Finding]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _role_usage_entries(
+    usage_by_component: dict[str, dict[str, dict[str, Any]]],
+    *,
+    manifest: Manifest,
+    run_id: str,
+    timestamp: str,
+) -> list[dict[str, Any]]:
+    """Journal rows for spend that belongs to no manifest component.
+
+    ``record_run`` builds its rows by walking the MANIFEST, so a usage
+    key with no component was dropped on the floor while ``run_usage`` -
+    which does include it - fed the TSV's ``total_cost_usd``. The
+    journal's per-component rows then did not sum to its own run total
+    (#257 review). The architect is what made that reachable: a one-role
+    pseudo-component that spends before any component exists and never
+    appears in a manifest.
+
+    A distinct ``event_type`` rather than a synthetic
+    ``component_result``, because every field that row carries - status,
+    retries, findings, failed_phase - is meaningless for something that
+    is not a component, and three readers in this module aggregate over
+    ``component_result`` specifically. They ignore this type, which is
+    the point: the row records spend without inventing an outcome.
+    """
+    component_ids = {comp.id for comp in manifest.components}
+    return [
+        {
+            "schema_version": JOURNAL_SCHEMA_VERSION,
+            "timestamp": timestamp,
+            "run_id": run_id,
+            "project": manifest.project_name,
+            "component_id": role,
+            "event_type": "role_usage",
+            "usage": usage_by_component[role],
+        }
+        for role in sorted(set(usage_by_component) - component_ids)
+    ]
+
+
 class EvolutionJournal:
     def __init__(self, config: EvolutionConfig) -> None:
         self.config = config
@@ -559,6 +598,15 @@ class EvolutionJournal:
                 ),
             }
             entries.append(entry)
+
+        entries.extend(
+            _role_usage_entries(
+                usage_by_component,
+                manifest=manifest,
+                run_id=run_id,
+                timestamp=timestamp,
+            )
+        )
 
         try:
             self.append_entries(entries)

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -2479,6 +2479,7 @@ def run_factory(
     stop: StopController | None = None,
     run_id: str | None = None,
     notify_capture_output: bool = False,
+    architect_usage: UsageTotals | None = None,
 ) -> FactoryResult:
     """Run the factory orchestrator with 3-phase verification.
 
@@ -2495,6 +2496,16 @@ def run_factory(
     Holds the run-level ``.kstrl/factory.lock`` flock for the whole run
     (R0.5, H-7); a contending invocation is refused with exit code 2
     unless it passes ``--force-lock``.
+
+    ``architect_usage`` is what the caller already spent ON THIS RUN's
+    behalf, before the run existed: `ks factory` decomposes the spec
+    itself and only then calls this (#257). Passing it is what makes
+    ``max_cost_usd`` bound the architect - see
+    :meth:`ComponentPipeline.record_architect_usage`. Named for the role
+    rather than generically, because the body records it as the
+    architect unconditionally: a second pre-run role would have to grow
+    the signature rather than quietly borrow this one's row. None for
+    every caller that resumes from a manifest, which ran no architect.
     """
     # The ceilings are validated at every CONFIG path, but a FactoryConfig
     # can also be constructed programmatically (tests, embedders, the SDK
@@ -2528,6 +2539,7 @@ def run_factory(
             stop=stop,
             run_id_override=run_id,
             notify_capture_output=notify_capture_output,
+            architect_usage=architect_usage,
         )
     finally:
         run_lock.release()
@@ -2545,6 +2557,7 @@ def _run_factory_locked(
     stop: StopController | None = None,
     run_id_override: str | None = None,
     notify_capture_output: bool = False,
+    architect_usage: UsageTotals | None = None,
 ) -> FactoryResult:
     """run_factory body; runs with the run-level lock resolved (held, or
     explicitly degraded via --force-lock / no-fcntl platforms)."""
@@ -2878,6 +2891,17 @@ def _run_factory_locked(
         fresh_base_retry_ids=fresh_base_retry_ids,
         component_failure_signatures=component_failure_signatures,
     )
+
+    # #257: the architect's spend, incurred by the caller before this run
+    # existed, enters the meter here. Deliberately the FIRST thing done
+    # to the pipeline, ahead of the preflights and the ceiling banner:
+    # the money is already gone, and every path from here that returns
+    # early - a failed preflight, a blown ceiling at the scheduling gate
+    # - must still leave it recorded in the run directory rather than
+    # reporting a run that cost nothing. The cost of that ordering is
+    # that a coverage warning about an unpriced architect prints just
+    # ahead of the "Cost ceiling" line rather than just after it.
+    pipeline.record_architect_usage(architect_usage)
 
     # R0.2 crash recovery: MERGE_PENDING is re-pollable, not failed.
     # Re-poll before scheduling so confirmed merges unblock dependents.
@@ -3454,12 +3478,12 @@ def _run_factory_locked(
         that a breaker retry later resolves. Non-fatal on I/O errors,
         matching EvolutionJournal.record_run.
         """
-        from kstrl.evolution import JOURNAL_SCHEMA_VERSION, EvolutionConfig
+        from kstrl.evolution import JOURNAL_SCHEMA_VERSION, EvolutionJournal
 
         # R2.1: honor [evolution] in kstrl.toml + env, resolved against
         # the factory root rather than whatever the process CWD is.
-        evo_config = EvolutionConfig.load(root_dir)
-        if not evo_config.enabled:
+        journal = EvolutionJournal.open(root_dir, warn=ui.warn)
+        if journal is None:
             return
         entry = {
             "schema_version": JOURNAL_SCHEMA_VERSION,
@@ -3476,9 +3500,7 @@ def _run_factory_locked(
             "duration_seconds": round(cr.duration_seconds, 2),
         }
         try:
-            evo_config.journal_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(evo_config.journal_path, "a") as f:
-                f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+            journal.append_entries([entry])
         except OSError as exc:
             # Evolution recording is non-fatal, but never silent (R6.1).
             ui.warn(f"  Evolution journal write failed (non-fatal): {exc}")

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -2732,6 +2732,96 @@ def _run_factory_locked(
             )
         )
 
+    if manifest_path is None:
+        manifest_path = root_dir / "scripts" / "kstrl" / "manifest.json"
+
+    # Load knowledge config once for the entire factory run, BEFORE the
+    # pipeline is constructed. Binding it at construction removes the
+    # late-binding accident where the old _handle_result closure read a
+    # name that was only assigned further down the function (R7.3).
+    knowledge_config = KnowledgeConfig.load(root_dir)
+
+    # Scheduling state shared between the scheduler and the pipeline.
+    worktree_paths: dict[str, Path] = {}
+    component_contexts: dict[str, str] = {}  # comp_id -> context JSON
+    # Components whose last failure was a timeout kill: their retry must
+    # not trust the surviving worktree/branch state (R0.1 requirement 5).
+    fresh_base_retry_ids: set[str] = set()
+    # Components abandoned by the scheduler backstop; their workers may
+    # still be alive, so their worktrees are never cleaned up here.
+    leaked_component_ids: set[str] = set()
+
+    # R7.3: the per-component phase chain and every component state
+    # transition live in ComponentPipeline. Hooks are resolved from this
+    # module's globals HERE, at run start, so tests patching
+    # kstrl.factory.run_review (and friends) keep intercepting the
+    # phase functions.
+    #
+    # Constructed BEFORE the DAG check below, and that placement is
+    # load-bearing rather than incidental: the pipeline owns the meter,
+    # so the meter's lifetime has to start with the run directory's
+    # rather than with the first phase's. The record just below says
+    # what breaks otherwise (#257 review). Construction is pure
+    # attribute assignment, so doing it ahead of a check that can reject
+    # the run costs nothing.
+    pipeline = ComponentPipeline(
+        manifest=manifest,
+        manifest_path=manifest_path,
+        factory_config=factory_config,
+        base_config=base_config,
+        ui=ui,
+        root_dir=root_dir,
+        run_id=run_id,
+        bus=bus,
+        journal_path=journal_path,
+        run_paths=run_paths,
+        usage_paths=usage_paths,
+        interaction=interaction,
+        notify=notify,
+        review_selection=review_selection,
+        security_selection=security_selection,
+        knowledge_config=knowledge_config,
+        factory_result=factory_result,
+        hooks=PipelineHooks(
+            run_mechanical_verification=run_mechanical_verification,
+            run_review=run_review,
+            run_chunked_review=run_chunked_review,
+            run_security_review=run_security_review,
+            run_chunked_security_review=run_chunked_security_review,
+            distill_facts=distill_facts,
+            measure_fact_utilization=measure_fact_utilization,
+            cleanup_worktree=_cleanup_worktree,
+        ),
+        worktree_paths=worktree_paths,
+        component_contexts=component_contexts,
+        fresh_base_retry_ids=fresh_base_retry_ids,
+        component_failure_signatures=component_failure_signatures,
+    )
+
+    # #257: the architect's spend, incurred by the caller before this run
+    # existed, enters the meter here - the first thing done to the
+    # pipeline, and deliberately AHEAD of the DAG check below.
+    #
+    # The money is already gone by this point, so every early exit from
+    # here has to leave it recorded rather than report a run that cost
+    # nothing. That is not a hypothetical: `decompose_spec` only WARNS on
+    # DAG errors and returns the manifest anyway, so an LLM-produced
+    # cyclic or dangling-dependency manifest reaches the return below on
+    # an ordinary `--spec` run. With the meter built after it, the run
+    # directory existed, the architect row did not, and `serve` charged
+    # $0 for a launch that had spent real money (#257 review).
+    #
+    # The invariant this rests on - nothing between the run directory's
+    # sinks and this line returns early - holds today and is checked by
+    # hand, not by a mechanism. An early exit inserted above would break
+    # it silently; the cyclic-manifest test pins only the case that was
+    # actually reachable.
+    #
+    # The cost of the ordering is cosmetic: a coverage warning about an
+    # unpriced architect prints just ahead of the "Cost ceiling" line
+    # rather than just after it.
+    pipeline.record_architect_usage(architect_usage)
+
     # Validate DAG
     ui.section("Factory: Validating DAG")
     dag_errors = manifest.validate_dag()
@@ -2752,9 +2842,6 @@ def _run_factory_locked(
         ):
             ui.info(f"  Resetting '{comp.id}' from {comp.status} to PENDING")
             comp.status = ComponentStatus.PENDING.value
-
-    if manifest_path is None:
-        manifest_path = root_dir / "scripts" / "kstrl" / "manifest.json"
 
     # R3.3: persist which run owns this manifest state. completed_at is
     # blanked while the run is in flight and stamped in the summary
@@ -2836,72 +2923,6 @@ def _run_factory_locked(
 
     manifest.policy_hash = policy_config.envelope_hash()
     manifest.save(manifest_path)
-
-    # Load knowledge config once for the entire factory run, BEFORE the
-    # pipeline is constructed. Binding it at construction removes the
-    # late-binding accident where the old _handle_result closure read a
-    # name that was only assigned further down the function (R7.3).
-    knowledge_config = KnowledgeConfig.load(root_dir)
-
-    # Scheduling state shared between the scheduler and the pipeline.
-    worktree_paths: dict[str, Path] = {}
-    component_contexts: dict[str, str] = {}  # comp_id -> context JSON
-    # Components whose last failure was a timeout kill: their retry must
-    # not trust the surviving worktree/branch state (R0.1 requirement 5).
-    fresh_base_retry_ids: set[str] = set()
-    # Components abandoned by the scheduler backstop; their workers may
-    # still be alive, so their worktrees are never cleaned up here.
-    leaked_component_ids: set[str] = set()
-
-    # R7.3: the per-component phase chain and every component state
-    # transition live in ComponentPipeline. Hooks are resolved from this
-    # module's globals HERE, at run start, so tests patching
-    # kstrl.factory.run_review (and friends) keep intercepting the
-    # phase functions.
-    pipeline = ComponentPipeline(
-        manifest=manifest,
-        manifest_path=manifest_path,
-        factory_config=factory_config,
-        base_config=base_config,
-        ui=ui,
-        root_dir=root_dir,
-        run_id=run_id,
-        bus=bus,
-        journal_path=journal_path,
-        run_paths=run_paths,
-        usage_paths=usage_paths,
-        interaction=interaction,
-        notify=notify,
-        review_selection=review_selection,
-        security_selection=security_selection,
-        knowledge_config=knowledge_config,
-        factory_result=factory_result,
-        hooks=PipelineHooks(
-            run_mechanical_verification=run_mechanical_verification,
-            run_review=run_review,
-            run_chunked_review=run_chunked_review,
-            run_security_review=run_security_review,
-            run_chunked_security_review=run_chunked_security_review,
-            distill_facts=distill_facts,
-            measure_fact_utilization=measure_fact_utilization,
-            cleanup_worktree=_cleanup_worktree,
-        ),
-        worktree_paths=worktree_paths,
-        component_contexts=component_contexts,
-        fresh_base_retry_ids=fresh_base_retry_ids,
-        component_failure_signatures=component_failure_signatures,
-    )
-
-    # #257: the architect's spend, incurred by the caller before this run
-    # existed, enters the meter here. Deliberately the FIRST thing done
-    # to the pipeline, ahead of the preflights and the ceiling banner:
-    # the money is already gone, and every path from here that returns
-    # early - a failed preflight, a blown ceiling at the scheduling gate
-    # - must still leave it recorded in the run directory rather than
-    # reporting a run that cost nothing. The cost of that ordering is
-    # that a coverage warning about an unpriced architect prints just
-    # ahead of the "Cost ceiling" line rather than just after it.
-    pipeline.record_architect_usage(architect_usage)
 
     # R0.2 crash recovery: MERGE_PENDING is re-pollable, not failed.
     # Re-poll before scheduling so confirmed merges unblock dependents.

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -29,7 +29,6 @@ for the same reason.
 
 from __future__ import annotations
 
-import json
 import time
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
@@ -42,6 +41,7 @@ from kstrl import events as ev
 from kstrl import git
 from kstrl.adequacy import AdequacyConfig
 from kstrl.agents.base import (
+    ARCHITECT_ROLE,
     CEILING_AXES,
     CeilingCoverage,
     UsageTotals,
@@ -663,6 +663,38 @@ class ComponentPipeline:
         never double count with the normal path."""
         self._record_usage(comp_id, "engineer", totals)
 
+    def record_architect_usage(self, totals: UsageTotals | None) -> None:
+        """Fold the architect's spend into this run before it starts (#257).
+
+        Every other role is metered by a phase this pipeline drives. The
+        architect is not: `ks factory` decomposes the spec in the command
+        itself, before any run id or run directory exists, and only then
+        builds this pipeline. Its spend therefore has to be handed in
+        rather than captured, which is what ``architect_usage`` on
+        ``run_factory`` carries.
+
+        It goes through the ordinary ``_record_usage`` path, and that is
+        the entire point of the seat. ``run_usage`` is what
+        :meth:`cost_budget_exceeded` reads, so an operator's
+        ``--max-cost-usd`` now bounds the architect too instead of
+        bounding the four roles that follow it; the meter gains a fifth
+        row; and ``_announce_coverage_gaps`` counts the architect as a
+        metered call rather than leaving it invisible to the coverage
+        accounting.
+
+        Component id and phase are both ``ARCHITECT_ROLE``, which is the
+        key `ks decompose` already writes (``ARCHITECT_COMPONENT``) and
+        the one ``serve.read_run_spend`` reads. Pairing them HERE is why
+        the constant exists rather than a literal per surface.
+
+        ``None`` or zero calls records nothing: a run resumed from a
+        manifest never ran an architect, and an agent that reported no
+        usage must not become a phantom row claiming it cost nothing.
+        """
+        if totals is None:
+            return
+        self._record_usage(ARCHITECT_ROLE, ARCHITECT_ROLE, totals)
+
     def record_injected_knowledge(
         self,
         comp_id: str,
@@ -1231,10 +1263,10 @@ class ComponentPipeline:
         Non-fatal on I/O errors, matching _record_contract_event."""
         if not comp.findings:
             return
-        from kstrl.evolution import JOURNAL_SCHEMA_VERSION, EvolutionConfig
+        from kstrl.evolution import JOURNAL_SCHEMA_VERSION, EvolutionJournal
 
-        evo_config = EvolutionConfig.load(self.root_dir)
-        if not evo_config.enabled:
+        journal = EvolutionJournal.open(self.root_dir, warn=self.ui.warn)
+        if journal is None:
             return
         entry = {
             "schema_version": JOURNAL_SCHEMA_VERSION,
@@ -1251,9 +1283,7 @@ class ComponentPipeline:
             "findings": [f.to_dict() for f in comp.findings],
         }
         try:
-            evo_config.journal_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(evo_config.journal_path, "a") as f:
-                f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+            journal.append_entries([entry])
         except OSError as exc:
             # Evolution recording is non-fatal, but never silent (R6.1).
             self.ui.warn(f"  Evolution journal write failed (non-fatal): {exc}")

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -650,14 +650,21 @@ class RunSpend:
 
     @property
     def unmetered_phases(self) -> tuple[str, ...]:
-        """Roles that spent on this launch without reaching the meter.
+        """Roles that spent on THIS RUN without reaching the meter.
+
+        The one member of this class that does not survive summation,
+        which is why a launch spanning several runs is a
+        :class:`LaunchSpend` and not a bigger ``RunSpend``: the answer is
+        all-or-nothing, so on a sum one run's architect would clear
+        another's (#257 review). ``cost_usd`` and ``uncovered_calls``
+        add up fine; this does not.
 
         It stopped being a constant in #257 piece B. `ks factory` now
         hands the architect's spend to the run it decomposed for, so a
-        launch that got as far as executing carries an architect row
-        inside the run dir the daemon just charged - already counted in
-        ``cost_usd``, and naming it unmetered on top of that would brand
-        every honest day's figure a floor.
+        run that got as far as executing carries an architect row inside
+        the dir the daemon just charged - already counted in
+        ``cost_usd``, and naming it unmetered on top of that would call
+        a measured figure a floor.
 
         Zero calls does NOT mean zero spend, which is why the fallback is
         the pessimistic one. Three separate cases land on it and all
@@ -668,6 +675,47 @@ class RunSpend:
         labelled a floor rather than estimated (#186 F3).
         """
         return () if self.architect_calls > 0 else (ARCHITECT_ROLE,)
+
+
+@dataclass(frozen=True)
+class LaunchSpend:
+    """What ONE launch spent, across every run directory it produced.
+
+    Separate from :class:`RunSpend` because a launch is not simply a
+    bigger run. The dollar and call figures add up; ``unmetered_phases``
+    does not, so summing runs into a single ``RunSpend`` and reading the
+    property off the total let a run that reported an architect clear
+    the claim for a sibling that had none, and the day was reported
+    exact on the strength of a different run's spend (#257 review).
+
+    Stating it as its own type is what makes that misuse unreachable
+    rather than merely documented: there is no ``architect_calls`` here
+    to sum, and ``unmetered_phases`` is correct by construction.
+    """
+
+    cost_usd: float = 0.0
+    cost_calls: int = 0
+    usage_calls: int = 0
+    unmetered_phases: tuple[str, ...] = ()
+
+    @classmethod
+    def over(cls, spends: Sequence[RunSpend]) -> LaunchSpend:
+        """Fold each run's reading into the launch's."""
+        # A launch that produced no directory at all is accounted for as
+        # one empty run rather than as nothing: it spent nothing this
+        # code can see, but a blocker halt spends an architect's worth of
+        # money and leaves it nowhere on disk. An empty RunSpend reports
+        # exactly that, so the pessimistic answer arrives by the same
+        # path as every other one.
+        readings = list(spends) or [RunSpend()]
+        return cls(
+            cost_usd=sum(reading.cost_usd for reading in readings),
+            cost_calls=sum(reading.cost_calls for reading in readings),
+            usage_calls=sum(reading.usage_calls for reading in readings),
+            unmetered_phases=tuple(
+                sorted({phase for reading in readings for phase in reading.unmetered_phases})
+            ),
+        )
 
 
 def read_run_spend(root_dir: Path, run_id: str) -> RunSpend:
@@ -710,8 +758,8 @@ SPAWNED_RUN_KIND: Final = "factory"
 def owned_run_spend(
     root_dir: Path,
     runs_before: frozenset[str],
-) -> tuple[list[str], RunSpend]:
-    """The run dirs a launch produced, and the spend they reported.
+) -> tuple[list[str], LaunchSpend]:
+    """The run dirs a launch produced, and what they add up to.
 
     "Produced" is narrower than "new" (#257 review). `ks decompose` takes
     no factory.lock, so an operator can start one on this repo at any
@@ -730,20 +778,15 @@ def owned_run_spend(
     lock. A foreign factory-kind dir can still land in the window. That
     hole predates #257 and is unchanged by it; what #257 changed, and
     this restores, is that decompose dirs now carry real money.
+
+    That the window can hold more than one dir is exactly why the return
+    is a :class:`LaunchSpend`: see its docstring for what does and does
+    not survive being added together.
     """
     owned = sorted(
         rid for rid in run_dir_names(root_dir) - runs_before if run_kind(rid) == SPAWNED_RUN_KIND
     )
-    total = RunSpend()
-    for rid in owned:
-        spend = read_run_spend(root_dir, rid)
-        total = RunSpend(
-            cost_usd=total.cost_usd + spend.cost_usd,
-            cost_calls=total.cost_calls + spend.cost_calls,
-            usage_calls=total.usage_calls + spend.usage_calls,
-            architect_calls=total.architect_calls + spend.architect_calls,
-        )
-    return owned, total
+    return owned, LaunchSpend.over([read_run_spend(root_dir, rid) for rid in owned])
 
 
 def run_dir_names(root_dir: Path) -> frozenset[str]:
@@ -2250,9 +2293,10 @@ def serve_cycle(
         total,
         covered_calls=covered_calls,
         total_calls=total_calls,
-        # Derived, not asserted: since #257 piece B the architect reaches
-        # the meter on a launch that executed, and `RunSpend` states what
-        # zero calls does and does not prove.
+        # Derived per run and unioned, not asserted: since #257 piece B
+        # the architect reaches the meter on a run that executed, and
+        # `RunSpend.unmetered_phases` states what zero calls does and
+        # does not prove.
         unmetered_phases=owned.unmetered_phases,
         metered_run=bool(owned_runs),
     )

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -68,6 +68,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Final, Protocol
 
+from kstrl.agents.base import ARCHITECT_ROLE
 from kstrl.runid import run_kind
 from kstrl.statedir import (
     CONTROL_SPEND,
@@ -378,9 +379,9 @@ class DailySpend:
     Only the third is unenforceable.
 
     ``unmetered_phases`` names phases known to spend without reporting
-    anything. The architect is always in it for a spec-decomposed item;
-    ``serve_cycle`` states why at the one place that fills this field.
-    Naming it is the honest alternative to estimating it (#186 F3).
+    anything. What goes in it is derived per launch by
+    :attr:`RunSpend.unmetered_phases`, which states when and why. Naming
+    a phase there is the honest alternative to estimating it (#186 F3).
     """
 
     date: str = ""
@@ -635,6 +636,9 @@ class RunSpend:
     cost_usd: float = 0.0
     cost_calls: int = 0
     usage_calls: int = 0
+    #: Calls the run recorded against the architect, read for one
+    #: question only: see :attr:`unmetered_phases`.
+    architect_calls: int = 0
 
     @property
     def uncovered_calls(self) -> int:
@@ -643,6 +647,27 @@ class RunSpend:
     @property
     def lower_bound(self) -> bool:
         return self.uncovered_calls > 0
+
+    @property
+    def unmetered_phases(self) -> tuple[str, ...]:
+        """Roles that spent on this launch without reaching the meter.
+
+        It stopped being a constant in #257 piece B. `ks factory` now
+        hands the architect's spend to the run it decomposed for, so a
+        launch that got as far as executing carries an architect row
+        inside the run dir the daemon just charged - already counted in
+        ``cost_usd``, and naming it unmetered on top of that would brand
+        every honest day's figure a floor.
+
+        Zero calls does NOT mean zero spend, which is why the fallback is
+        the pessimistic one. Three separate cases land on it and all
+        three deserve it: a blocker halt, which exits `ks factory` before
+        any run directory exists so the decompose bill is nowhere on disk
+        to charge; an adapter that reports no usage; and a resume that
+        ran no architect at all. Naming the role keeps the day's total
+        labelled a floor rather than estimated (#186 F3).
+        """
+        return () if self.architect_calls > 0 else (ARCHITECT_ROLE,)
 
 
 def read_run_spend(root_dir: Path, run_id: str) -> RunSpend:
@@ -663,10 +688,12 @@ def read_run_spend(root_dir: Path, run_id: str) -> RunSpend:
         state, _source = load_run_state(root_dir, run_id)
     except OSError:
         return RunSpend()
+    architect = state.components.get(ARCHITECT_ROLE)
     return RunSpend(
         cost_usd=state.cost_usd,
         cost_calls=state.cost_calls,
         usage_calls=state.usage_calls,
+        architect_calls=architect.usage_calls if architect is not None else 0,
     )
 
 
@@ -714,6 +741,7 @@ def owned_run_spend(
             cost_usd=total.cost_usd + spend.cost_usd,
             cost_calls=total.cost_calls + spend.cost_calls,
             usage_calls=total.usage_calls + spend.usage_calls,
+            architect_calls=total.architect_calls + spend.architect_calls,
         )
     return owned, total
 
@@ -2218,25 +2246,14 @@ def serve_cycle(
     covered_calls = owned.cost_calls
     total_calls = owned.usage_calls
 
-    # The one statement of why the architect is unmetered HERE, which
-    # the docstrings above point at rather than restate.
-    #
-    # #257 gave decompose_spec a ComponentUsage event, but it reaches a
-    # run directory only when a bus is passed, and the `ks factory` this
-    # daemon spawns decomposes BEFORE any run directory exists, so it
-    # passes none. Nor does the kind filter above recover it from
-    # somewhere else: a `ks decompose` an operator ran by hand is a
-    # DIFFERENT spend, correctly excluded, not this run's architect.
-    # So the architect's spend here is still real and still invisible.
-    # Closing it needs the architect metered inside the factory run
-    # (#257 piece B). Until then, naming it keeps the day's total
-    # honestly labelled a floor instead of estimating it (#186 F3).
-    unmetered = ("architect",)
     charged = ledger.charge(
         total,
         covered_calls=covered_calls,
         total_calls=total_calls,
-        unmetered_phases=unmetered,
+        # Derived, not asserted: since #257 piece B the architect reaches
+        # the meter on a launch that executed, and `RunSpend` states what
+        # zero calls does and does not prove.
+        unmetered_phases=owned.unmetered_phases,
         metered_run=bool(owned_runs),
     )
     result.charged_usd = total

--- a/kstrl/tui/embed.py
+++ b/kstrl/tui/embed.py
@@ -47,6 +47,7 @@ from kstrl.ui.bridge import EventBridgeUI, NullPrompter
 from kstrl.ui.plain import PlainUI
 
 if TYPE_CHECKING:
+    from kstrl.agents.base import UsageTotals
     from kstrl.config import KstrlConfig
     from kstrl.factory import FactoryConfig
     from kstrl.manifest import Manifest
@@ -192,7 +193,14 @@ def run_factory_embedded(
     manifest_path: Path | None,
     *,
     poll_interval: float = 0.2,
+    architect_usage: UsageTotals | None = None,
 ) -> int:
+    """`ks factory --tui`: the same run, rendered in the dashboard.
+
+    ``architect_usage`` carries the architect's spend the way the plain path
+    does (#257); without it the ceiling would bound one fewer role in
+    the TUI than on a terminal, for no reason an operator could see.
+    """
     from kstrl.factory import run_factory
 
     def _target(ctx: EmbeddedContext) -> int:
@@ -207,6 +215,7 @@ def run_factory_embedded(
             stop=ctx.stop,
             run_id=ctx.run_id,
             notify_capture_output=True,
+            architect_usage=architect_usage,
         ).exit_code
 
     return run_embedded(

--- a/tests/test_autonomy_ladder.py
+++ b/tests/test_autonomy_ladder.py
@@ -862,6 +862,28 @@ class TestTransitionAudit:
             commit_transition(state, record, tmp_path)
         assert AutonomyState.load(tmp_path).level == int(AutonomyLevel.L2_GATED_MERGE)
 
+    def test_an_unparseable_journal_config_is_not_fatal_either(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """#257 sweep: the guard here caught only OSError, and
+        ``EvolutionConfig.load`` raises ValueError on a malformed
+        [evolution] section. The state save has already happened by
+        then, so a typo in an unrelated knob would leave the ladder
+        saved and unjournaled - exactly the drift this function exists
+        to prevent.
+        """
+        from kstrl.autonomy import commit_transition
+
+        (tmp_path / "kstrl.toml").write_text("[evolution\nenabled = true\n")
+        state = _eligible_state()
+        record = state.promote(actor="human", ack="ok")
+
+        with pytest.warns(RuntimeWarning, match="Evolution config unreadable"):
+            commit_transition(state, record, tmp_path)
+
+        assert AutonomyState.load(tmp_path).level == int(AutonomyLevel.L2_GATED_MERGE)
+
 
 class TestPromotionAuthority:
     """A caller-supplied string is not a human acknowledgement."""

--- a/tests/test_contract_safety.py
+++ b/tests/test_contract_safety.py
@@ -19,6 +19,7 @@ Real-git tests (no LLM):
 
 from __future__ import annotations
 
+import io
 import json
 import subprocess
 from pathlib import Path
@@ -165,6 +166,42 @@ def _tracked_changes(root: Path) -> list[str]:
     ]
 
 
+def _marker_run_configs(root: Path) -> tuple[FactoryConfig, KstrlConfig]:
+    """A no-retry deferred-merge run against ``MARKER_TEST_CMD``.
+
+    Two tests drive the same failing tier and differ only in what they
+    assert about the aftermath, so the setup is stated once. Extracted
+    rather than copied a third time (#257 review); the other tests in
+    this file vary the factory config in ways this cannot express and
+    keep building their own.
+    """
+    return (
+        FactoryConfig(
+            use_worktrees=True,
+            create_prs=False,
+            max_parallel=1,
+            max_retries=0,
+            retry_delay=0,
+            review_mode="skip",
+            contract_config=ContractConfig(
+                mode=ContractMode.TIER.value,
+                test_command=MARKER_TEST_CMD,
+                timeout=60,
+            ),
+        ),
+        KstrlConfig(
+            prompt_file=root / "scripts" / "kstrl" / "prompt.md",
+            prd_file=root / "scripts" / "kstrl" / "prd.json",
+            sleep_seconds=0,
+            agent_cmd="echo unused",
+            kstrl_branch="",
+            kstrl_branch_explicit=True,
+            ui_mode="plain",
+            no_color=True,
+        ),
+    )
+
+
 def _read_journal_events(root: Path, event_type: str) -> list[dict[str, object]]:
     """Read evolution-journal entries of one event type. Since R2.1
     run_factory loads EvolutionConfig via ``load(root_dir)``, which
@@ -274,29 +311,7 @@ class TestContractFailureExitsNonzero:
         _init_repo(root)
         _commit_on_branch(root, "kstrl/factory/a", {"bad_marker.txt": "boom\n"})
         manifest = _make_manifest([_component("a", "kstrl/factory/a")])
-        factory_config = FactoryConfig(
-            use_worktrees=True,
-            create_prs=False,
-            max_parallel=1,
-            max_retries=0,
-            retry_delay=0,
-            review_mode="skip",
-            contract_config=ContractConfig(
-                mode=ContractMode.TIER.value,
-                test_command=MARKER_TEST_CMD,
-                timeout=60,
-            ),
-        )
-        base = KstrlConfig(
-            prompt_file=root / "scripts" / "kstrl" / "prompt.md",
-            prd_file=root / "scripts" / "kstrl" / "prd.json",
-            sleep_seconds=0,
-            agent_cmd="echo unused",
-            kstrl_branch="",
-            kstrl_branch_explicit=True,
-            ui_mode="plain",
-            no_color=True,
-        )
+        factory_config, base = _marker_run_configs(root)
 
         result = run_factory(
             manifest,
@@ -324,6 +339,46 @@ class TestContractFailureExitsNonzero:
         assert _tracked_changes(root) == []
         assert not (root / ".git" / "MERGE_HEAD").exists()
         assert not (root / "bad_marker.txt").exists()
+
+    def test_an_unparseable_journal_config_does_not_abort_the_run(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """#257 sweep: ``_record_contract_event`` loaded the journal
+        config unguarded, and ``EvolutionConfig.load`` raises ValueError
+        on a bad knob. That propagates straight out of the contract loop,
+        so a typo would abort a run whose work is already paid for and
+        already sitting on a branch. The journal is an audit trail: it
+        may be lost, it may not take the run with it.
+
+        ``KSTRL_EVOLUTION_LOOKBACK_RUNS`` rather than a malformed
+        kstrl.toml on purpose - it breaks the evolution config and
+        nothing else on this path, so the test measures the guard rather
+        than the first loader to notice.
+        """
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "many")
+        root = tmp_path / "repo"
+        _init_repo(root)
+        _commit_on_branch(root, "kstrl/factory/a", {"bad_marker.txt": "boom\n"})
+        manifest = _make_manifest([_component("a", "kstrl/factory/a")])
+        factory_config, base = _marker_run_configs(root)
+        console = io.StringIO()
+
+        result = run_factory(
+            manifest,
+            factory_config,
+            base,
+            PlainUI(no_color=True, file=console),
+            root,
+        )
+
+        # The contract phase still ran and still reported, loudly.
+        assert result.exit_code == 1
+        assert result.contract_failures
+        # The journal was skipped, and said so.
+        assert "Evolution config unreadable" in console.getvalue()
+        assert _read_journal_events(root, "contract_result") == []
 
 
 class TestBreakerRetryReentersScheduling:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -29,6 +29,7 @@ from kstrl.factory import (
     FactoryConfig,
     FactoryResult,
 )
+from kstrl.findings import Finding
 from kstrl.fixtures import FixturesConfig
 from kstrl.inbox import Inbox, InboxConfig, ItemKind
 from kstrl.knowledge import Fact, KnowledgeConfig, measure_fact_utilization
@@ -2051,3 +2052,42 @@ class TestFactUtilizationRecording:
         assert outcome is not None
         assert outcome.distill.utilization.measured is False
         assert "utilization" not in calls
+
+
+class TestJournalConfigNeverGatesAnAttempt:
+    """#257 sweep: the third caller of ``EvolutionConfig.load`` that
+    could raise ValueError into work already paid for."""
+
+    def test_an_unparseable_journal_config_does_not_break_a_retry(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``journal_superseded_findings`` runs between a failed attempt
+        and the retry that supersedes it. A bad [evolution] knob raised
+        straight through it, so a typo turned a normal retry into a
+        crashed run. The entry is an audit trail; losing it is the
+        acceptable outcome, losing the retry is not.
+        """
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "many")
+        console = io.StringIO()
+        pipeline, manifest, _, _ = _make_pipeline(
+            tmp_path,
+            ui=PlainUI(no_color=True, file=console),
+        )
+        comp = manifest.get_component("comp-a")
+        assert comp is not None
+        comp.findings = [
+            Finding(
+                phase="review",
+                category="scope_creep",
+                severity="major",
+                location="a.py",
+                explanation="unrelated refactor",
+            )
+        ]
+
+        pipeline.journal_superseded_findings(comp)
+
+        assert "Evolution config unreadable" in console.getvalue()
+        assert not (tmp_path / ".kstrl" / "evolution.jsonl").exists()

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -29,6 +29,7 @@ from kstrl.serve import (
     BACKOFF_CAP_SECONDS,
     SPAWNED_RUN_KIND,
     DailySpend,
+    LaunchSpend,
     RunOutcome,
     RunSpend,
     ServeConfig,
@@ -47,6 +48,7 @@ from kstrl.serve import (
     consecutive_poison_count,
     factory_lock_held,
     next_local_midnight,
+    owned_run_spend,
     process_group_alive,
     reap_leases,
     resolve_merge_gate,
@@ -2204,6 +2206,57 @@ class TestRunOwnership:
         spend = SpendLedger(tmp_path).read()
         assert "architect" in spend.unmetered_phases
         assert spend.spent_usd == pytest.approx(1.0)
+
+    def test_one_runs_architect_cannot_clear_anothers(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """#257 review: ``unmetered_phases`` is all-or-nothing, so
+        reading it off the SUM let a sibling borrow an architect it never
+        had.
+
+        Two factory-kind dirs land in one launch window - a documented
+        hole this module already names (``--force-lock``, the embedded
+        dashboard's early mkdir). One reports an architect, one does not.
+        The day must stay a floor, because half its money is still
+        unaccounted for.
+        """
+        queue = _queue(tmp_path)
+        _add(queue)
+
+        def fake_spend(root: Path, run_id: str) -> RunSpend:
+            metered = run_id.endswith("aaa")
+            return RunSpend(
+                cost_usd=2.0,
+                cost_calls=1,
+                usage_calls=1,
+                architect_calls=1 if metered else 0,
+            )
+
+        runner = _stub_runner(
+            RunOutcome(0),
+            extra_run_ids=("factory-20260730-000001.000000-ccc",),
+        )
+        with patch("kstrl.serve.read_run_spend", side_effect=fake_spend):
+            serve_cycle(tmp_path, runner=runner)
+
+        spend = SpendLedger(tmp_path).read()
+        assert "architect" in spend.unmetered_phases
+        assert spend.lower_bound
+        # Both dirs are still charged; only the CLAIM is per run.
+        assert spend.spent_usd == pytest.approx(4.0)
+
+    def test_a_launch_with_no_run_dir_still_names_the_architect(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The fold is over an empty list on the halt path, and an empty
+        union would say "nothing unmetered" about a launch that may have
+        spent an architect's worth of money."""
+        runs, launch = owned_run_spend(tmp_path, frozenset())
+
+        assert runs == []
+        assert launch == LaunchSpend(unmetered_phases=("architect",))
 
 
 class TestPauseIsAtomic:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -24,6 +24,7 @@ import pytest
 from kstrl.findings import Finding
 from kstrl.inbox import Inbox, InboxConfig, ItemKind
 from kstrl.manifest import Component, ComponentStatus, Manifest
+from kstrl.reducer import ComponentState, RunState
 from kstrl.serve import (
     BACKOFF_CAP_SECONDS,
     SPAWNED_RUN_KIND,
@@ -2031,23 +2032,22 @@ class TestRunOwnership:
             assert load.call_count == 0, "must not read another run"
 
     def test_read_run_spend_reads_a_named_run(self, tmp_path: Path) -> None:
-        """The positive case, so the guard cannot be over-broad."""
+        """The positive case, so the guard cannot be over-broad.
+
+        The double is a REAL ``RunState``: a hand-rolled object carrying
+        only the three fields this function read at the time silently
+        became wrong the moment it read a fourth (#257 piece B).
+        """
         with patch("kstrl.reducer.load_run_state") as load:
             load.return_value = (
-                type(
-                    "S",
-                    (),
-                    {
-                        "cost_usd": 1.25,
-                        "cost_calls": 2,
-                        "usage_calls": 3,
-                    },
-                )(),
+                RunState(cost_usd=1.25, cost_calls=2, usage_calls=3),
                 None,
             )
             spend = REAL_READ_RUN_SPEND(tmp_path, "factory-abc")
         assert spend.cost_usd == 1.25
         assert spend.uncovered_calls == 1
+        # No architect row on this run, so nothing claims one.
+        assert spend.architect_calls == 0
 
     def test_a_concurrent_decompose_is_not_charged_to_the_queue(
         self,
@@ -2099,17 +2099,111 @@ class TestRunOwnership:
         assert SPAWNED_RUN_KIND in KNOWN_KINDS
         assert run_kind(current_run_id()) == SPAWNED_RUN_KIND
 
-    def test_the_architect_is_recorded_as_unmetered(
+    def test_an_architect_that_reached_no_run_dir_is_named_unmetered(
         self,
         tmp_path: Path,
     ) -> None:
-        """#186 F3: decompose spends and emits no usage events at all."""
+        """#186 F3, and still true after #257 piece B.
+
+        This launch left a run dir with no architect row, which is what
+        every case in ``RunSpend.unmetered_phases`` looks like from here:
+        the daemon cannot see the spend, so it must not pretend the day's
+        figure is exact.
+        """
         queue = _queue(tmp_path)
         _add(queue)
         serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0)))
         spend = SpendLedger(tmp_path).read()
         assert "architect" in spend.unmetered_phases
         assert spend.lower_bound, "unmetered architect spend makes it a floor"
+
+    def test_a_metered_architect_is_not_also_named_unmetered(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """#257 piece B: the claim stopped being a constant.
+
+        `ks factory` now seeds the architect's spend into the run it
+        decomposed for, so a launch that executed carries an architect
+        row inside the very run dir this daemon charged. Repeating
+        "unmetered: architect" on top of that would brand every honest
+        day's total a floor, which is the failure mode ``lower_bound``
+        exists to flag.
+        """
+        queue = _queue(tmp_path)
+        _add(queue)
+
+        def fake_spend(root: Path, run_id: str) -> RunSpend:
+            return RunSpend(
+                cost_usd=3.0,
+                cost_calls=2,
+                usage_calls=2,
+                architect_calls=1,
+            )
+
+        with patch("kstrl.serve.read_run_spend", side_effect=fake_spend):
+            serve_cycle(tmp_path, runner=_stub_runner(RunOutcome(0)))
+
+        spend = SpendLedger(tmp_path).read()
+        assert spend.unmetered_phases == ()
+        assert not spend.lower_bound
+        # Charged ONCE. The architect's dollars are already inside the
+        # run's cost_usd; architect_calls only answers "did it report".
+        assert spend.spent_usd == pytest.approx(3.0)
+
+    def test_the_architect_row_is_read_off_the_run_state(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The seat #257 piece B writes to and the one serve reads from
+        are the same key, which is the only reason the check above can
+        distinguish a metered architect from a silent one."""
+        state = RunState(cost_usd=2.0, cost_calls=1, usage_calls=1)
+        state.components["architect"] = ComponentState(
+            component_id="architect",
+            usage_calls=1,
+            cost_calls=1,
+            cost_usd=2.0,
+        )
+        with patch("kstrl.reducer.load_run_state") as load:
+            load.return_value = (state, None)
+            spend = REAL_READ_RUN_SPEND(tmp_path, "factory-abc")
+        assert spend.architect_calls == 1
+
+    def test_a_decompose_run_dir_never_supplies_the_architect_row(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The kind filter and the unmetered claim must not fight.
+
+        An operator's hand-run `ks decompose` reports an architect and
+        is deliberately NOT charged (piece A). It must not silently
+        satisfy this launch's architect claim either, or the daemon
+        would call the day exact on the strength of somebody else's
+        spend.
+        """
+        queue = _queue(tmp_path)
+        _add(queue)
+
+        def fake_spend(root: Path, run_id: str) -> RunSpend:
+            architect = 1 if run_id.startswith("decompose-") else 0
+            return RunSpend(
+                cost_usd=1.0,
+                cost_calls=1,
+                usage_calls=1,
+                architect_calls=architect,
+            )
+
+        runner = _stub_runner(
+            RunOutcome(0),
+            extra_run_ids=("decompose-20260730-000001.000000-bbb",),
+        )
+        with patch("kstrl.serve.read_run_spend", side_effect=fake_spend):
+            serve_cycle(tmp_path, runner=runner)
+
+        spend = SpendLedger(tmp_path).read()
+        assert "architect" in spend.unmetered_phases
+        assert spend.spent_usd == pytest.approx(1.0)
 
 
 class TestPauseIsAtomic:

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -23,6 +23,7 @@ import stat
 import time
 from collections.abc import Callable, Iterator
 from concurrent.futures import Future
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -45,6 +46,7 @@ from kstrl.events import RunPaths
 from kstrl.factory import (
     ComponentResult,
     FactoryConfig,
+    FactoryResult,
     _clear_partial_usage,
     _read_partial_usage,
     _run_component,
@@ -783,18 +785,33 @@ def _engineer_usage(total: int, cost: float = 0.0) -> UsageTotals:
     return totals
 
 
+def _architect_usage(cost: float | None, tokens: int = 1000) -> UsageTotals:
+    """What `ks factory`'s decompose leaves on its agent (#257).
+
+    The architect's record has the same shape as any other role's, so
+    this is ``_engineer_usage`` under the name that makes the call sites
+    readable. ``cost=None`` is the codex shape - a token count and no
+    price - which is what the coverage accounting exists to describe.
+    """
+    return _engineer_usage(tokens, cost=cost or 0.0)
+
+
+def _usage_events(root: Path, phase: str) -> list[dict[str, Any]]:
+    """Every usage event one phase recorded, in order."""
+    return [
+        e
+        for e in ProgressLog(root / "progress.jsonl").read_events()
+        if e["event"] == "component_usage" and e["data"]["phase"] == phase
+    ]
+
+
 def _engineer_usage_events(root: Path) -> list[int]:
     """Every engineer-phase usage total the run recorded, in order.
 
     A list (not a sum) on purpose: a double count and a correct total
     are the same number of tokens but a different number of events.
     """
-    events = ProgressLog(root / "progress.jsonl").read_events()
-    return [
-        int(e["data"]["total_tokens"])
-        for e in events
-        if e["event"] == "component_usage" and e["data"]["phase"] == "engineer"
-    ]
+    return [int(e["data"]["total_tokens"]) for e in _usage_events(root, "engineer")]
 
 
 def _read_journal(tmp_path: Path) -> list[dict[str, Any]]:
@@ -5146,3 +5163,373 @@ class TestEveryConfiguredCeilingRecordsItsCoverage:
         assert halts
         coverage = halts[-1]["data"]["coverage"]
         assert [entry["ceiling"] for entry in coverage] == ["max_total_tokens"]
+
+
+@dataclass(frozen=True)
+class _SeededRun:
+    """One `ks factory` run and everything a #257 assertion reads off it."""
+
+    root: Path
+    manifest: Manifest
+    launched: list[str]
+    console: io.StringIO
+    result: FactoryResult
+
+    @property
+    def printed(self) -> str:
+        return self.console.getvalue()
+
+    def usage_events(self, phase: str) -> list[dict[str, Any]]:
+        return _usage_events(self.root, phase)
+
+
+def _run_with_architect_spend(
+    tmp_path: Path,
+    architect_usage: UsageTotals | None,
+    **config: Any,
+) -> _SeededRun:
+    """A one-component run whose engineer is cheap and whose architect
+    already spent whatever the caller says `ks factory` paid it.
+
+    The scaffolding lives here rather than at each call site because only
+    the architect's spend and the ceiling ever vary between them.
+    """
+    root = _setup_project(tmp_path, ["comp-a"])
+    manifest = _make_manifest([_component("comp-a")])
+    launched: list[str] = []
+    console = io.StringIO()
+
+    def fake_run_component(*args: Any, **kwargs: Any) -> ComponentResult:
+        launched.append(str(args[0]))
+        return ComponentResult(
+            str(args[0]),
+            success=True,
+            iterations=1,
+            usage=_engineer_usage(100, cost=0.01),
+        )
+
+    with (
+        patch("kstrl.factory._run_component", side_effect=fake_run_component),
+        patch("kstrl.git.get_diff_content", return_value=""),
+    ):
+        result = run_factory(
+            manifest,
+            _factory_config(root, **config),
+            _make_base_config(root),
+            PlainUI(no_color=True, file=console),
+            root,
+            architect_usage=architect_usage,
+        )
+    return _SeededRun(root, manifest, launched, console, result)
+
+
+class TestArchitectSpendCountsAgainstTheCeiling:
+    """#257 piece B: ``max_cost_usd`` is enforced against
+    ``pipeline.run_usage``, which only ``_record_usage`` feeds, and the
+    architect never called it. An operator who set a ceiling was bounding
+    engineer + review + security + distill, and the role that runs FIRST
+    ran outside the bound entirely.
+    """
+
+    def test_the_ceiling_trips_before_any_engineer_launches(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The property the issue is about: an operator who set $5 and
+        whose architect spent $6 must not get an engineer at all.
+
+        Before this the architect's $6 was not in ``run_usage``, the
+        scheduling gate read $0.00, and the run went on to spend the
+        whole ceiling again on top of it.
+        """
+        run = _run_with_architect_spend(
+            tmp_path,
+            _architect_usage(6.0),
+            max_cost_usd=5.0,
+        )
+
+        assert run.launched == [], "the engineer must never start"
+        assert "comp-a" in run.result.failed
+        comp = run.manifest.get_component("comp-a")
+        assert comp is not None
+        assert comp.status == ComponentStatus.FAILED.value
+        assert "max_cost_usd" in (comp.error or "")
+
+    def test_the_ceiling_does_not_trip_on_spend_below_it(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The other direction, so the gate above cannot pass by halting
+        everything: an architect comfortably under the ceiling changes
+        nothing about the run."""
+        run = _run_with_architect_spend(
+            tmp_path,
+            _architect_usage(1.0),
+            max_cost_usd=5.0,
+        )
+
+        assert run.launched == ["comp-a"]
+        assert run.result.failed == []
+        # It is in the total the ceiling reads all the same.
+        assert run.usage_events("architect")
+
+    def test_an_unbounded_run_is_not_given_a_bound(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``max_cost_usd = 0`` means unbounded. Seeding real spend into
+        an unbounded run must not invent a ceiling for it."""
+        run = _run_with_architect_spend(tmp_path, _architect_usage(999.0))
+
+        assert run.launched == ["comp-a"]
+        assert run.result.failed == []
+
+    def test_the_architect_is_a_row_in_the_meter_and_the_stream(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """One ``component_usage`` event, under the role name, on the
+        pseudo-component `ks decompose` already reports under - so both
+        commands write the architect to the same key."""
+        run = _run_with_architect_spend(
+            tmp_path,
+            _architect_usage(1.5),
+            max_cost_usd=50.0,
+        )
+
+        events = run.usage_events("architect")
+        assert len(events) == 1
+        assert events[0]["component"] == "architect"
+        assert events[0]["data"]["cost_usd"] == pytest.approx(1.5)
+
+    def test_a_run_with_no_architect_records_no_phantom_row(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`ks factory --manifest` resumes a run that never decomposed,
+        and every other ``run_factory`` caller passes nothing. An empty
+        architect row would claim the role ran and cost nothing."""
+        run = _run_with_architect_spend(tmp_path, None)
+
+        assert run.launched == ["comp-a"]
+        assert run.usage_events("architect") == []
+
+    def test_an_architect_that_reported_nothing_records_no_row(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A ``CustomAgent``, or any adapter predating R3.1, reports no
+        usage records at all. ``collect_usage`` then yields zero calls,
+        and zero calls must stay silent rather than become a $0.00 row
+        that reads as "the architect was free"."""
+        run = _run_with_architect_spend(tmp_path, UsageTotals())
+
+        assert run.usage_events("architect") == []
+
+
+class TestCoverageCountsTheArchitect:
+    """#257: the architect was not an UNCOVERED metered call, it was not
+    a metered call at all - so the "N of M metered call(s)" line the
+    factory prints was short by a whole role, silently."""
+
+    def test_the_uncovered_line_names_the_architect(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A codex-shaped architect under a cost ceiling: tokens, no
+        price. The warning has to name it, because a ceiling that cannot
+        see the run's first call is a ceiling the operator misreads."""
+        run = _run_with_architect_spend(
+            tmp_path,
+            _architect_usage(None),
+            max_cost_usd=50.0,
+        )
+
+        assert "cost coverage is" in run.printed
+        assert "architect (1 of 1 call(s), 1,000 token(s) unpriced)" in run.printed
+        assert "lower bound" in run.printed
+
+    def test_the_metered_call_count_includes_the_architect(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The issue's line verbatim: "2 of 4 metered call(s)" would have
+        been 2 of 5 with the architect enrolled. Asserted on the
+        DENOMINATOR, which is the whole claim - one engineer call plus
+        one architect call is two metered calls, not one."""
+        run = _run_with_architect_spend(
+            tmp_path,
+            _architect_usage(None),
+            max_cost_usd=50.0,
+        )
+
+        assert "1 of 2 metered call(s) reported a cost" in run.printed
+
+    def test_the_rollup_prints_the_architect_in_the_run_total(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The end-of-run table, where the operator reads what the run
+        cost. The architect is a row, and the TOTAL covers it."""
+        run = _run_with_architect_spend(
+            tmp_path,
+            _architect_usage(1.5),
+            max_cost_usd=50.0,
+        )
+
+        assert "Usage rollup" in run.printed
+        rows = [line for line in run.printed.splitlines() if " architect " in line]
+        assert len(rows) == 1, run.printed
+        assert "1.5000" in rows[0]
+        total = next(line for line in run.printed.splitlines() if "TOTAL" in line)
+        assert "1.5100" in total, total
+
+
+class TestFactoryHandsTheArchitectSpendToTheRun:
+    """The wiring, at the one command that has both an architect and a
+    run. Without it every property above is true of a seat that nothing
+    ever sits in.
+    """
+
+    @staticmethod
+    def _install(
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        halt: bool = False,
+    ) -> dict[str, Any]:
+        """Stand in for the two halves `ks factory` joins.
+
+        The fake decompose bills its agent where a real adapter does -
+        appending to ``usage_records`` when the call ends - so the test
+        exercises the capture rather than a value handed straight
+        through.
+        """
+        from kstrl import cli as cli_mod
+        from kstrl.decompose import SpecBlockerError, SpecIssue
+
+        captured: dict[str, Any] = {}
+        agent = SimpleNamespace(name="fake", usage_records=[])
+
+        def fake_get_agent(*args: Any, **kwargs: Any) -> Any:
+            return agent
+
+        def fake_decompose(**kwargs: Any) -> Manifest:
+            agent.usage_records.append(
+                UsageRecord(
+                    input_tokens=500,
+                    output_tokens=500,
+                    total_tokens=1000,
+                    cost_usd=2.25,
+                    duration_seconds=2.0,
+                    source="claude-stream-json",
+                )
+            )
+            if halt:
+                raise SpecBlockerError(
+                    [
+                        SpecIssue(
+                            severity="blocker",
+                            kind="ambiguity",
+                            summary="the spec does not say",
+                        )
+                    ]
+                )
+            return _make_manifest([_component("comp-a")])
+
+        def fake_run_factory(*args: Any, **kwargs: Any) -> Any:
+            captured["architect_usage"] = kwargs.get("architect_usage")
+            captured["called"] = True
+            return FactoryResult()
+
+        monkeypatch.setattr(cli_mod, "get_agent", fake_get_agent)
+        monkeypatch.setattr(cli_mod, "decompose_spec", fake_decompose)
+        monkeypatch.setattr(cli_mod, "run_factory", fake_run_factory)
+        return captured
+
+    @staticmethod
+    def _invoke(args: list[str]) -> Any:
+        from click.testing import CliRunner
+
+        from kstrl.cli import cli
+
+        runner = CliRunner()
+        with runner.isolated_filesystem() as fs:
+            root = Path(fs)
+            (root / "s.md").write_text("# spec\n")
+            _make_manifest([_component("comp-a")]).save(root / "m.json")
+            return runner.invoke(cli, args, catch_exceptions=False)
+
+    def test_the_spec_path_passes_what_the_decompose_agent_spent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured = self._install(monkeypatch)
+
+        result = self._invoke(
+            [
+                "factory",
+                "--spec",
+                "s.md",
+                "--project-name",
+                "p",
+                "--agent-cmd",
+                "true",
+                "--yes",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        spent = captured["architect_usage"]
+        assert spent is not None
+        assert spent.calls == 1
+        assert spent.cost_usd == pytest.approx(2.25)
+        assert spent.total_tokens == 1000
+
+    def test_the_manifest_path_passes_no_architect_spend(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A resume ran no architect, so there is nothing to hand over -
+        and the seat must not be filled from an agent that never ran."""
+        captured = self._install(monkeypatch)
+
+        result = self._invoke(
+            [
+                "factory",
+                "--manifest",
+                "m.json",
+                "--agent-cmd",
+                "true",
+                "--yes",
+            ]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert captured["architect_usage"].calls == 0
+
+    def test_the_blocker_halt_reaches_no_run_at_all(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The accepted residue of #257 piece B, pinned so it cannot
+        change silently. ``serve.RunSpend.unmetered_phases`` states why
+        the halt leaves the spend nowhere on disk.
+        """
+        captured = self._install(monkeypatch, halt=True)
+
+        result = self._invoke(
+            [
+                "factory",
+                "--spec",
+                "s.md",
+                "--project-name",
+                "p",
+                "--agent-cmd",
+                "true",
+                "--yes",
+            ]
+        )
+
+        assert result.exit_code == 2
+        assert "called" not in captured, "no run may start after a blocker halt"

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -46,6 +46,7 @@ from kstrl.events import RunPaths
 from kstrl.factory import (
     ComponentResult,
     FactoryConfig,
+    FactoryLockHeldError,
     FactoryResult,
     _clear_partial_usage,
     _read_partial_usage,
@@ -5385,6 +5386,33 @@ class TestCoverageCountsTheArchitect:
         assert "1.5100" in total, total
 
 
+def _invoke_factory_cli(
+    args: list[str],
+    *,
+    setup: Callable[[Path], None] | None = None,
+    catch_exceptions: bool = False,
+) -> Any:
+    """`ks factory` in an isolated filesystem holding a spec and a manifest.
+
+    ``setup`` seeds anything else the case needs (a kstrl.toml, say).
+    ``catch_exceptions`` is for the tests that assert an exception did
+    NOT escape - with the default, an escaping one fails the test as a
+    traceback rather than as the assertion that explains it.
+    """
+    from click.testing import CliRunner
+
+    from kstrl.cli import cli
+
+    runner = CliRunner()
+    with runner.isolated_filesystem() as fs:
+        root = Path(fs)
+        (root / "s.md").write_text("# spec\n")
+        _make_manifest([_component("comp-a")]).save(root / "m.json")
+        if setup is not None:
+            setup(root)
+        return runner.invoke(cli, args, catch_exceptions=catch_exceptions)
+
+
 class TestFactoryHandsTheArchitectSpendToTheRun:
     """The wiring, at the one command that has both an architect and a
     run. Without it every property above is true of a seat that nothing
@@ -5446,26 +5474,13 @@ class TestFactoryHandsTheArchitectSpendToTheRun:
         monkeypatch.setattr(cli_mod, "run_factory", fake_run_factory)
         return captured
 
-    @staticmethod
-    def _invoke(args: list[str]) -> Any:
-        from click.testing import CliRunner
-
-        from kstrl.cli import cli
-
-        runner = CliRunner()
-        with runner.isolated_filesystem() as fs:
-            root = Path(fs)
-            (root / "s.md").write_text("# spec\n")
-            _make_manifest([_component("comp-a")]).save(root / "m.json")
-            return runner.invoke(cli, args, catch_exceptions=False)
-
     def test_the_spec_path_passes_what_the_decompose_agent_spent(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         captured = self._install(monkeypatch)
 
-        result = self._invoke(
+        result = _invoke_factory_cli(
             [
                 "factory",
                 "--spec",
@@ -5493,7 +5508,7 @@ class TestFactoryHandsTheArchitectSpendToTheRun:
         and the seat must not be filled from an agent that never ran."""
         captured = self._install(monkeypatch)
 
-        result = self._invoke(
+        result = _invoke_factory_cli(
             [
                 "factory",
                 "--manifest",
@@ -5518,7 +5533,7 @@ class TestFactoryHandsTheArchitectSpendToTheRun:
         """
         captured = self._install(monkeypatch, halt=True)
 
-        result = self._invoke(
+        result = _invoke_factory_cli(
             [
                 "factory",
                 "--spec",
@@ -5533,3 +5548,201 @@ class TestFactoryHandsTheArchitectSpendToTheRun:
 
         assert result.exit_code == 2
         assert "called" not in captured, "no run may start after a blocker halt"
+
+
+class TestNothingBetweenTheRunDirAndTheMeterCanLoseTheSpend:
+    """#257 review: the architect record claimed to precede every early
+    exit, and two reachable ones preceded IT."""
+
+    @staticmethod
+    def _cyclic_manifest() -> Manifest:
+        """What an LLM architect can hand back and `ks factory` accepts
+        (`decompose.py` warns on DAG errors and returns anyway)."""
+        return _make_manifest(
+            [
+                _component("comp-a", deps=["comp-b"]),
+                _component("comp-b", deps=["comp-a"]),
+            ]
+        )
+
+    @staticmethod
+    def _run(root: Path, manifest: Manifest, manifest_path: Path | None = None) -> Any:
+        with patch("kstrl.git.get_diff_content", return_value=""):
+            return run_factory(
+                manifest,
+                _factory_config(root),
+                _make_base_config(root),
+                PlainUI(no_color=True, file=io.StringIO()),
+                root,
+                manifest_path,
+                architect_usage=_architect_usage(4.0),
+            )
+
+    def test_a_cyclic_manifest_still_records_the_architect(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The run directory exists, so the spend has somewhere to go.
+
+        The reachability argument lives at the record site in
+        `factory._run_factory_locked`; this pins the outcome.
+        """
+        root = _setup_project(tmp_path, ["comp-a", "comp-b"])
+        result = self._run(root, self._cyclic_manifest())
+
+        assert result.exit_code == 1, "the cyclic DAG must still fail the run"
+        events = _usage_events(root, "architect")
+        assert len(events) == 1, "the spend must reach the run directory"
+        assert events[0]["data"]["cost_usd"] == pytest.approx(4.0)
+
+    def test_the_dag_check_still_rejects_before_the_manifest_is_stamped(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Moving the meter up must not drag manifest mutation with it.
+
+        A rejected DAG leaves the manifest unstamped and unsaved, so it
+        cannot read afterwards as a run that is still in flight.
+        """
+        root = _setup_project(tmp_path, ["comp-a", "comp-b"])
+        manifest = self._cyclic_manifest()
+        manifest_path = root / "scripts" / "kstrl" / "manifest.json"
+
+        self._run(root, manifest, manifest_path)
+
+        assert manifest.run_id == ""
+        assert not manifest_path.exists()
+
+    def test_a_refused_lock_records_nothing_because_no_run_exists(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The other early exit, and accepted residue rather than a fix:
+        the lock is refused before a run id is minted, so there is
+        nowhere on disk to write. `serve.RunSpend.unmetered_phases` says
+        how the daemon accounts for that."""
+        root = _setup_project(tmp_path, ["comp-a"])
+        manifest = _make_manifest([_component("comp-a")])
+
+        with patch(
+            "kstrl.factory._acquire_run_lock",
+            side_effect=FactoryLockHeldError("held by another run"),
+        ):
+            result = self._run(root, manifest)
+
+        assert result.exit_code == 2
+        assert not (root / ".kstrl" / "runs").exists()
+
+
+class TestTheJournalKeepsTheArchitectRow:
+    """#257 review: ``record_run`` iterates the MANIFEST, so an architect
+    key in ``usage_by_component`` was silently dropped while
+    ``run_usage`` - which includes it - fed the TSV's total_cost_usd. The
+    journal's rows stopped summing to its own total."""
+
+    def test_the_architect_reaches_the_journal(self, tmp_path: Path) -> None:
+        run = _run_with_architect_spend(tmp_path, _architect_usage(1.5))
+
+        roles = [e for e in _read_journal(run.root) if e.get("event_type") == "role_usage"]
+        assert len(roles) == 1
+        assert roles[0]["component_id"] == "architect"
+        assert roles[0]["usage"]["architect"]["cost_usd"] == pytest.approx(1.5)
+
+    def test_the_journal_rows_sum_to_the_run_total(self, tmp_path: Path) -> None:
+        """The property that was broken, asserted as arithmetic rather
+        than as the presence of a key."""
+        run = _run_with_architect_spend(tmp_path, _architect_usage(1.5))
+
+        rows = sum(
+            phase["cost_usd"]
+            for e in _read_journal(run.root)
+            if e.get("event_type") in ("component_result", "role_usage")
+            for phase in e.get("usage", {}).values()
+        )
+        tsv = (run.root / ".kstrl" / "experiments.tsv").read_text().splitlines()
+        # Keyed by header, not by index: a column appended to the TSV
+        # must not silently move what this reads.
+        totals = dict(zip(tsv[0].split("\t"), tsv[-1].split("\t"), strict=True))
+        assert rows == pytest.approx(1.51)
+        assert rows == pytest.approx(float(totals["total_cost_usd"]))
+
+    def test_a_run_with_no_extra_role_adds_no_row(self, tmp_path: Path) -> None:
+        """A resume has no architect, and every other usage key IS a
+        manifest component. The new branch must add nothing."""
+        run = _run_with_architect_spend(tmp_path, None)
+
+        assert [e for e in _read_journal(run.root) if e.get("event_type") == "role_usage"] == []
+
+    def test_the_role_row_is_not_counted_as_a_component_outcome(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Three readers in evolution.py aggregate over component_result.
+        The architect has no status, no retries and no findings, so it
+        must not arrive wearing that type and skew them."""
+        run = _run_with_architect_spend(tmp_path, _architect_usage(1.5))
+
+        results = [e for e in _read_journal(run.root) if e.get("event_type") == "component_result"]
+        assert [e["component_id"] for e in results] == ["comp-a"]
+
+
+class TestNoConfigLoadStandsBetweenTheMoneyAndTheRun:
+    """#257 review: the toml-notes sweep loaded the evolution config
+    unguarded, between `decompose_spec` being paid for and `run_factory`
+    being entered, where the spend exists only in a local variable.
+
+    ``cli._collect_evolution_notes`` carries the reasoning, including
+    what this does NOT fix.
+    """
+
+    @staticmethod
+    def _captured_run(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+        """Stop at the factory boundary and record whether we got there."""
+        from kstrl import cli as cli_mod
+
+        captured: dict[str, Any] = {}
+
+        def fake_run_factory(*args: Any, **kwargs: Any) -> Any:
+            captured["called"] = True
+            return FactoryResult()
+
+        monkeypatch.setattr(cli_mod, "run_factory", fake_run_factory)
+        return captured
+
+    ARGS = ["factory", "--manifest", "m.json", "--agent-cmd", "true", "--yes"]
+
+    def test_a_bad_evolution_knob_does_not_leak_a_traceback(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reproduced against the real CLI before the fix: exit 1 with a
+        raw ValueError traceback and no error line."""
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "many")
+        captured = self._captured_run(monkeypatch)
+
+        result = _invoke_factory_cli(self.ARGS, catch_exceptions=True)
+
+        assert not isinstance(result.exception, ValueError), result.exception
+        assert result.exit_code == 0, result.output
+        assert "Evolution config unreadable" in result.output
+        # The run still happens: an unreadable audit knob costs the NOTE
+        # line, never the work the operator asked for.
+        assert captured.get("called") is True
+
+    def test_a_readable_config_still_produces_its_notes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The guard must not silence the sweep it wraps, or a toml
+        section that takes effect would stop announcing itself (R2.1)."""
+        monkeypatch.delenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", raising=False)
+        self._captured_run(monkeypatch)
+
+        result = _invoke_factory_cli(
+            self.ARGS,
+            setup=lambda root: (root / "kstrl.toml").write_text("[evolution]\nlookback_runs = 7\n"),
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "lookback_runs" in result.output
+        assert "Evolution config unreadable" not in result.output


### PR DESCRIPTION
Fixes #257. Piece B, built directly on piece A (#277).

## What was wrong

`--max-cost-usd` is enforced against `pipeline.run_usage`, which is fed only by `_record_usage`, and the architect never called it. An operator who set a ceiling was bounding engineer + review + security + distill; the role that runs FIRST, and on a real run costs more than several of them, ran outside the bound entirely. It was not even an *uncovered* metered call - it was invisible to the coverage accounting, which is why the "2 of 4 metered call(s)" warning was short by a whole role.

## What this does

`ks factory` is the only command with both an architect and a run, and it decomposes before any run id or run directory exists. So the spend is handed in rather than captured:

- `ks factory` takes `usage_cursor(agent)` before `decompose_spec` and `collect_usage(agent, since=...)` after - the same derivation `decompose_spec` itself reports with, so the two numbers cannot disagree and neither rests on an invariant about who else touched the agent.
- `architect_usage` threads `run_factory` -> `_run_factory_locked` -> `ComponentPipeline.record_architect_usage`, which records it through the ordinary `_record_usage` path at run start, before the preflights, so an early return still leaves it on disk.
- Component id and phase are both `ARCHITECT_ROLE`, the key `ks decompose` already writes and `serve.read_run_spend` reads.

One call buys three things: `cost_budget_exceeded()` covers the architect, the rollup gains a fifth row, and `_announce_coverage_gaps()` counts it.

`ks factory --tui` carries the same value through `run_factory_embedded`, so the ceiling does not bound one fewer role in the dashboard than on a terminal.

## The structural decision, and why

On the architect-halt path `ks factory` exits before any run directory exists, so no seed can ever be recorded there. **Accepted, not closed**, for three reasons:

1. On the halt there is no run and no further spending for a ceiling to bound. The ceiling's job is to stop the next dollar; there is no next dollar.
2. Opening a command run around the factory's decompose would not help the ceiling anyway. A separate run dir does not feed `pipeline.run_usage`, so the hand-off is required either way.
3. It would break what piece A fixed. A decompose-kind run dir produced by `ks factory` is indistinguishable from an operator's hand-run `ks decompose`, which is exactly the class `owned_run_spend`'s kind filter exists to exclude. Reopening that hole to recover the halt-path number would let a hand-run decompose bill the daemon's queue item again.

Piece A already prints the number to the terminal on that path, so the operator is not left guessing. The residue is pinned by `test_the_blocker_halt_reaches_no_run_at_all`.

## `serve.py`: the hardcoded tuple had to go

`unmetered_phases = ("architect",)` stopped being correct as a constant the moment this landed. On a launch that executed, the architect is now a metered row inside the factory run dir the daemon just charged, so asserting the opposite is asserting something the daemon can now actually check and would get wrong.

**What that does and does not buy, stated precisely.** `SpendLedger.charge` unions `unmetered_phases` into the day's set and never removes an entry, so a single blocker halt - which `decompose_spec`'s own docstring calls the common outcome on a first spec - permanently marks the rest of that day a floor regardless. The derivation therefore does not deliver "an exact day" in general; it delivers an exact day only where no launch ever halts and every launch's architect reports a cost. What it buys unconditionally is that the daemon stops asserting an unmetered architect it has evidence against, which is the honesty property, not the arithmetic one.

`RunSpend` carries `architect_calls` and derives `unmetered_phases` per RUN, keeping the pessimistic answer for the three cases where zero calls does not prove zero spend: a blocker halt, an adapter that reports no usage, and a resume with no architect. A launch spanning several run dirs folds those readings through `LaunchSpend`, which adds the dollar figures and unions the phases - `unmetered_phases` is the one member that does not survive summation, and reading it off a sum let one run's architect clear a sibling's. No double counting: the dollars are already inside `cost_usd`, and `architect_calls` only answers "did it report". Tests pin that a concurrent hand-run `ks decompose` cannot satisfy this launch's claim, and that one metered run cannot clear an unmetered sibling.

`test_the_architect_is_recorded_as_unmetered` was correct as written and is kept, renamed to say what it actually observes (a run with no architect row), with a new sibling for the metered case.

## Also swept

The verification pass flagged `EvolutionConfig.load` callers that would raise `ValueError` into work already paid for. Rather than guard each site, `EvolutionJournal.open` states the parse-and-enabled pair once; `factory._record_contract_event` and `pipeline.journal_superseded_findings` route through it plus the existing `append_entries`, which also removes two hand-rolled copies of the journal's line format. `autonomy.commit_transition` gets `load_or_none` only: it deliberately writes regardless of `[evolution] enabled`, and changing that is not this change's business.

## Verification

- 3739 passed, 28 skipped. New tests: the ceiling tripping on architect spend before any engineer launches; the ceiling not tripping below it; an unbounded run staying unbounded; the coverage line counting the architect (`1 of 2 metered call(s)`); the architect as a rollup row inside the run TOTAL; no phantom row for a resume or a silent adapter; the CLI wiring on both the `--spec` and `--manifest` paths; the halt path reaching no run; and the serve cases above.
- Each new assertion was checked against the unpatched code: reverting the `cli.py` hand-off fails 2 of the wiring tests, reverting `record_architect_usage` fails 6, and reverting the derived `unmetered` fails the metered-architect test.
- `uv run mypy kstrl/ --strict`, `uv run ruff check kstrl/ tests/`, `pre-commit run --all-files` all green.
- Coverage ratchet: 88.86% combined against the 79.91% baseline.
- The terminal ordering claim in the `factory.py` comment was observed, not assumed: the coverage warning prints immediately before the "Factory: Execution" section.

## Round two: four review findings

1. **`ks factory`'s toml-notes sweep loaded the evolution config unguarded**, between the architect being paid for and `run_factory` being entered - the one window where the spend lives only in a local variable. Reproduced against the real CLI: `KSTRL_EVOLUTION_LOOKBACK_RUNS=many` left a raw ValueError traceback, because `_KstrlGroup.invoke` catches only `BudgetConfigError`. Fixed with `load_or_none`, in its own function because the guard has to sit between the two loads (`from_env` applies the same env overrides, so passing both as arguments would raise first).

   The function states honestly what it does *not* fix. Evolution is not the only loader here that can raise: measured on this tree, `KSTRL_MUTATION_THRESHOLD=many` and `KSTRL_SECURITY_TIMEOUT=many` still leak a traceback. What separates evolution is what a failure may cost - the journal is an optional audit trail, so degrading is honest, whereas silently substituting defaults for configured verify or security checks would be a semantic substitution. Those need a typed parse error at the `_KstrlGroup.invoke` seam, not a fallback; that is a change to six config modules and is out of scope here.

2. **The architect record claimed a guarantee two reachable paths broke.** `decompose_spec` only warns on DAG errors and returns the manifest anyway, so an LLM-produced cyclic manifest reached `_run_factory_locked`'s DAG return with the run directory on disk and no architect row - `serve` charged $0 for a launch that spent real money. The pipeline is now constructed above the DAG check, which is where it belongs: it owns the meter, so the meter's lifetime starts with the run directory's. Manifest stamping and saving stay below the check, so a rejected DAG still leaves nothing that reads as a run in flight. The refused-lock exit returns before a run id is minted, so it is accepted residue and now says so, with a test.

3. **`unmetered_phases` was read off a sum.** A launch is not simply a bigger run, so it gets its own type: `LaunchSpend` adds the dollar figures and unions the phases, has no `architect_calls` to sum, and makes the misuse unreachable rather than documented.

4. **The journal dropped the architect row.** `record_run` walks the manifest, so the key was dropped while `run_usage` fed the TSV's `total_cost_usd` and the rows stopped summing to the run total. Roles with no manifest component now get a `role_usage` entry - a distinct event type, because three readers in that module aggregate `component_result` as outcomes and the architect has none.

Each fix is mutation-checked: reverting it fails the matching tests and nothing else.

### Known and not fixed

`ARCHITECT_ROLE` is a bare `"architect"` in the same namespace as LLM-chosen component ids, and `validate_component_id` has no reserved-name check. A component genuinely named `architect` would merge the two meters. Pre-existing, but this change makes it consequential; fixing it would reject existing manifests, so it is reported rather than bundled.

The "nothing between the run directory's sinks and the meter returns early" invariant is checked by hand and stated at the record site. It holds today; only the case that was actually reachable is pinned by a test.

## Note

`docs/atlas/` is deliberately untouched, so the `atlas` check will fail. `test`, `spine`, `coverage` and `lint` are the gates here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHYpsJ8ecHLh5HdrswJtJK
