### PR TITLE
fix(verify): dispatch each gate's parser instead of assuming the Python toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,9 @@ allow_network = false  # re-open outbound network inside the sandbox (off = deny
 test_command = ""              # empty = the harness default (uv run pytest)
 typecheck_command = ""         # empty = uv run mypy when [tool.mypy] scopes it, else uv run mypy .
 lint_command = ""              # empty = the harness default (uv run ruff check .)
+test_tool = ""                 # parser for the test gate's output; empty = every parser (pytest, vitest), unioned
+typecheck_tool = ""            # parser for the typecheck gate's output; empty = every parser (mypy, tsc), unioned
+lint_tool = ""                 # parser for the lint gate's output; empty = every parser (ruff, eslint), unioned
 check_diff_scope = true        # fail on changes outside allowed paths
 check_bad_patterns = true      # scan the diff for secret-like patterns
 dead_code_cleanup = false      # optional dead-code check

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -259,6 +259,9 @@ agent's worktree by construction on both CLIs.
 | `KSTRL_VERIFY_TEST_CMD` | str | unset (uses `uv run pytest`) |
 | `KSTRL_VERIFY_TYPECHECK_CMD` | str | unset (uses `uv run mypy .`) |
 | `KSTRL_VERIFY_LINT_CMD` | str | unset (uses `uv run ruff check .`) |
+| `KSTRL_VERIFY_TEST_TOOL` | `pytest` \| `vitest` | unset = run both parsers and union the failures |
+| `KSTRL_VERIFY_TYPECHECK_TOOL` | `mypy` \| `tsc` | unset = run both parsers and union the failures |
+| `KSTRL_VERIFY_LINT_TOOL` | `ruff` \| `eslint` | unset = run both parsers and union the failures |
 | `KSTRL_DEAD_CODE_CLEANUP` | bool (`1`) | false |
 | `KSTRL_DEAD_CODE_CMD` | str | unset |
 | `KSTRL_MUTATION_TESTING` | bool (`1`) | false |

--- a/kstrl/config_report.py
+++ b/kstrl/config_report.py
@@ -187,26 +187,16 @@ def _phase_sections() -> list[tuple[str, Any, list[str]]]:
                 "keep_worktrees_on_failure",
             ],
         ),
-        (
-            "verify",
-            VerifyConfig.load,
-            [
-                "test_command",
-                "typecheck_command",
-                "lint_command",
-                "check_diff_scope",
-                "check_bad_patterns",
-                "dead_code_cleanup",
-                "dead_code_command",
-                "mutation_testing",
-                "mutation_threshold",
-                "mutation_timeout",
-                "subprocess_timeout",
-                "require_self_critique",
-                "self_critique_min_bullets",
-                "progress_file_path",
-            ],
-        ),
+        # Derived, not hand-listed. The hand-written copy of this list
+        # went stale the moment #258 added the three `*_tool` keys: they
+        # reached VerifyConfig, gen_docs, the README and env-vars.md and
+        # not this list, so `ks config` and the config screen showed no
+        # row for the one setting an operator reaches for when a gate is
+        # parsed by the wrong toolchain. Every scalar field of
+        # VerifyConfig IS a documented kstrl.toml key, which gen_docs
+        # already enforces, so the field list is the key list and a
+        # second copy of it can only ever be wrong.
+        ("verify", VerifyConfig.load, [f.name for f in dataclass_fields(VerifyConfig)]),
         (
             "security",
             SecurityConfig.load,
@@ -287,6 +277,67 @@ def _phase_sections() -> list[tuple[str, Any, list[str]]]:
     ]
 
 
+def _base_sources(
+    resolved: KstrlConfig, noenv: KstrlConfig, defaults: KstrlConfig
+) -> dict[str, str]:
+    """Per-field source for KstrlConfig, computed BEFORE the flag overlay.
+
+    A flag replaces whatever source the value had, so it has to be
+    applied after this, not folded into it.
+    """
+    sources: dict[str, str] = {}
+    for f in dataclass_fields(KstrlConfig):
+        if getattr(resolved, f.name) != getattr(noenv, f.name):
+            sources[f.name] = "env"
+        elif getattr(noenv, f.name) != getattr(defaults, f.name):
+            sources[f.name] = "toml"
+        else:
+            sources[f.name] = "default"
+    return sources
+
+
+def _base_rows(resolved: KstrlConfig, sources: dict[str, str]) -> list[ConfigRow]:
+    """Rows for the sections KstrlConfig fans out over."""
+    return [
+        ConfigRow(
+            section=section,
+            key=toml_key,
+            value=format_row_value(section, toml_key, getattr(resolved, field_name)),
+            source=sources[field_name],
+        )
+        for section, keys in SHOW_SECTIONS
+        for toml_key, field_name in keys
+    ]
+
+
+def _phase_rows(
+    section: str,
+    knob_fields: list[str],
+    resolved: Any,
+    noenv: Any,
+    toml_keys: set[str],
+) -> list[ConfigRow]:
+    """Rows for one phase config, each tagged with where its value came from."""
+    rows: list[ConfigRow] = []
+    for field_name in knob_fields:
+        value = getattr(resolved, field_name)
+        if value != getattr(noenv, field_name):
+            source = "env"
+        elif field_name in toml_keys:
+            source = "toml"
+        else:
+            source = "default"
+        rows.append(
+            ConfigRow(
+                section=section,
+                key=field_name,
+                value=format_config_value(value),
+                source=source,
+            )
+        )
+    return rows
+
+
 def build_config_report(
     root_dir: Path,
     *,
@@ -313,57 +364,23 @@ def build_config_report(
 
     defaults_base = kstrl_config_defaults(root_dir)
 
-    # Per-field sources for KstrlConfig, computed BEFORE the flag
-    # overlay (a flag replaces whatever source the value had).
-    base_sources: dict[str, str] = {}
-    for f in dataclass_fields(KstrlConfig):
-        if getattr(resolved_base, f.name) != getattr(noenv_base, f.name):
-            base_sources[f.name] = "env"
-        elif getattr(noenv_base, f.name) != getattr(defaults_base, f.name):
-            base_sources[f.name] = "toml"
-        else:
-            base_sources[f.name] = "default"
-
+    base_sources = _base_sources(resolved_base, noenv_base, defaults_base)
     if overlay is not None:
         for name in overlay(resolved_base):
             base_sources[name] = "flag"
     resolved_base.ui_mode = normalize_ui_mode(resolved_base.ui_mode)
 
-    rows: list[ConfigRow] = []
-    for section, keys in SHOW_SECTIONS:
-        for toml_key, field_name in keys:
-            rows.append(
-                ConfigRow(
-                    section=section,
-                    key=toml_key,
-                    value=format_row_value(
-                        section,
-                        toml_key,
-                        getattr(resolved_base, field_name),
-                    ),
-                    source=base_sources[field_name],
-                )
-            )
+    rows = _base_rows(resolved_base, base_sources)
     for section, _, knob_fields in phase_sections:
-        resolved = phase_resolved[section]
-        noenv = phase_noenv[section]
-        toml_keys = phase_toml_keys[section]
-        for field_name in knob_fields:
-            value = getattr(resolved, field_name)
-            if value != getattr(noenv, field_name):
-                source = "env"
-            elif field_name in toml_keys:
-                source = "toml"
-            else:
-                source = "default"
-            rows.append(
-                ConfigRow(
-                    section=section,
-                    key=field_name,
-                    value=format_config_value(value),
-                    source=source,
-                )
+        rows.extend(
+            _phase_rows(
+                section,
+                knob_fields,
+                phase_resolved[section],
+                phase_noenv[section],
+                phase_toml_keys[section],
             )
+        )
 
     return ConfigReport(
         root_dir=root_dir,

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -193,7 +193,7 @@ class HarnessProposal:
     title: str
     description: str
     proposal_type: str  # "computational" or "inferential"
-    target: str  # what to change: "claude_md", "pyproject", "feedforward_config"
+    target: str  # what to change: "claude_md", "typecheck_config", "feedforward_config"
     suggested_change: str  # the actual proposed content/config change
     source_patterns: list[str]  # pattern descriptions that led to this proposal
 
@@ -824,7 +824,12 @@ class EvolutionJournal:
                             f"expected typing style."
                         ),
                         proposal_type="computational",
-                        target="pyproject",
+                        # Not "pyproject": save_proposals writes this
+                        # verbatim as "**Target**: ..." into the
+                        # proposal file, so a TypeScript project got a
+                        # proposal naming a file it does not have,
+                        # directly above prose that carefully did not.
+                        target="typecheck_config",
                         # Toolchain-neutral prose on purpose. The gate
                         # dispatches per project (#258), so this code can
                         # be a tsc TS-number as easily as a mypy code,

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -289,11 +289,6 @@ def _classify_check(error: str) -> tuple[str, str]:
 # difference is the number.
 _DIGIT_RUN_RE = re.compile(r"\d+")
 
-# Leading Python exception name in a pytest failure message.
-_EXC_NAME_RE = re.compile(
-    r"^([A-Z][A-Za-z0-9]*(?:Error|Exception|Failure|Warning|Exit|Interrupt))\b"
-)
-
 _CATEGORY_BY_CHECK = {
     "linter": "verification",
     "typecheck": "verification",
@@ -355,23 +350,24 @@ def category_for_check(check_name: str) -> str:
 def signatures_from_verification(checks: Iterable[CheckResult]) -> list[str]:
     """Derive structured signatures from failed mechanical checks.
 
-    Prefers the parser's structured codes (ruff rule, mypy error code,
-    pytest exception type); falls back to a slug of the check message
-    when no parse is available."""
+    Prefers the parser's structured codes (linter rule, checker error
+    code, the exception a test died on); falls back to a slug of the
+    check message when no parse is available.
+
+    #258: this used to ask ``ParsedOutput.tool`` which of those it was,
+    against the exact strings "ruff", "mypy" and "pytest". That is a name
+    check standing in for a capability check, and it broke twice over as
+    soon as a gate could dispatch: a newly supported tool fell silently
+    through to the prose slug, and the unioned label a chained command
+    produces ("pytest+vitest") matched nothing at all. The parser now
+    names its own signature in ``ParsedFailure.code``, so this reads a
+    capability instead of guessing from a label."""
     signatures: list[str] = []
     for check in checks:
         if check.passed:
             continue
-        codes: list[str] = []
         parsed = check.parsed
-        if parsed is not None and parsed.failures:
-            if parsed.tool in ("ruff", "mypy"):
-                codes = [f.rule_or_test for f in parsed.failures if f.rule_or_test]
-            elif parsed.tool == "pytest":
-                for failure in parsed.failures:
-                    m = _EXC_NAME_RE.match(failure.message or "")
-                    if m:
-                        codes.append(re.sub(r"(?<!^)(?=[A-Z])", "-", m.group(1)).lower())
+        codes = [f.code for f in parsed.failures if f.code] if parsed is not None else []
         if codes:
             distinct = list(dict.fromkeys(codes))[:_MAX_SIGNATURES_PER_CHECK]
             signatures.extend(f"{check.name}:{code}" for code in distinct)
@@ -809,7 +805,8 @@ class EvolutionJournal:
                         suggested_change=(
                             f"Add to CLAUDE.md:\n"
                             f"> Avoid triggering linter rule {pattern.error_signature}. "
-                            f"Check ruff/flake8 docs for the correct pattern."
+                            f"Check the rule in your linter's documentation for the "
+                            f"correct pattern."
                         ),
                         source_patterns=[pattern.description],
                     )
@@ -822,15 +819,23 @@ class EvolutionJournal:
                         title=f"Adjust type-checking config for '{pattern.error_signature}'",
                         description=(
                             f"Type error pattern '{pattern.error_signature}' recurred in "
-                            f"{pattern.frequency} components. Consider adjusting pyproject.toml "
-                            f"or adding a CLAUDE.md note about the expected typing style."
+                            f"{pattern.frequency} components. Consider adjusting the type "
+                            f"checker's config or adding a CLAUDE.md note about the "
+                            f"expected typing style."
                         ),
                         proposal_type="computational",
                         target="pyproject",
+                        # Toolchain-neutral prose on purpose. The gate
+                        # dispatches per project (#258), so this code can
+                        # be a tsc TS-number as easily as a mypy code,
+                        # and `check_name` is the GATE, which carries no
+                        # toolchain. Naming [tool.mypy] here sent a
+                        # TypeScript project to edit a pyproject.toml it
+                        # does not have.
                         suggested_change=(
-                            f"Review [tool.mypy] or [tool.pyright] settings in pyproject.toml. "
-                            f"If this is a known false positive, add to ignore list. "
-                            f"Otherwise add to CLAUDE.md:\n"
+                            f"Review the type checker's configuration. If this is a known "
+                            f"false positive, add it to the ignore list. Otherwise add to "
+                            f"CLAUDE.md:\n"
                             f"> Ensure all functions have return type annotations to avoid "
                             f"'{pattern.error_signature}'."
                         ),

--- a/kstrl/gateparse.py
+++ b/kstrl/gateparse.py
@@ -1,0 +1,119 @@
+"""Which parser a verify gate's output goes through (#258).
+
+Each Phase 1 gate runs ONE operator-configured command, and that command
+is not required to be a single tool: ``run_scrubbed`` shells out, so
+``test_command = "uv run pytest && (cd web && npm run test)"`` is a
+supported and common way to gate a polyglot repo. The gate therefore
+cannot assume a toolchain, and until this module existed it assumed one
+anyway - pytest for tests, mypy for typecheck, ruff for lint, whatever
+had actually run.
+
+The dispatch is a per-gate ``tool`` config key (``[verify] test_tool`` /
+``typecheck_tool`` / ``lint_tool``). Unset means auto, and auto runs
+EVERY parser registered for the gate and unions what they find.
+
+Three designs were considered and two rejected:
+
+- **Sniff the command string.** Rejected by the case that motivated the
+  issue: ``"uv run pytest -q && cd web && npm run test"`` contains both
+  ``pytest`` and ``npm``, so a substring rule must pick one and is wrong
+  half the time. It also fails the most common invocations of all -
+  ``npm run test``, ``make test``, ``just test`` - where no tool name
+  appears anywhere. A command string is not evidence of the tool.
+- **Try every parser and pick a winner.** A wrong guess is a silent
+  semantic substitution, and no tie-break can serve the chain case,
+  where one command legitimately emits two formats and both are real.
+- **Union what every parser found.** No tie-break to get wrong, the
+  chain case works by construction, and a parser that understood
+  nothing contributes nothing. This is what auto does.
+
+The floor from the labelling half of #258 is unchanged: when no parser
+finds a failure, the primary parser's result is returned, tail fallback
+and all, and ``ParsedOutput.prompt_label`` names the COMMAND rather than
+claiming a tool parsed output it never saw.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from kstrl.parsers import (
+    ParsedOutput,
+    parse_mypy_output,
+    parse_pytest_output,
+    parse_ruff_output,
+    strip_ansi,
+)
+from kstrl.parsers_web import parse_eslint_output, parse_tsc_output, parse_vitest_output
+
+#: Gate names, matching the ``CheckResult.name`` each gate reports under.
+GATE_TEST = "test_suite"
+GATE_TYPECHECK = "typecheck"
+GATE_LINT = "linter"
+
+#: Every parser kstrl can dispatch to, by the name the config key takes.
+TOOL_PARSERS: dict[str, Callable[[str], ParsedOutput]] = {
+    "pytest": parse_pytest_output,
+    "vitest": parse_vitest_output,
+    "mypy": parse_mypy_output,
+    "tsc": parse_tsc_output,
+    "ruff": parse_ruff_output,
+    "eslint": parse_eslint_output,
+}
+
+#: Which parsers each gate tries on the auto path. The first entry is the
+#: gate's PRIMARY: its result is what a caller gets when no parser found
+#: anything, so it is the one whose raw-tail fallback the engineer sees.
+GATE_TOOLS: dict[str, tuple[str, ...]] = {
+    GATE_TEST: ("pytest", "vitest"),
+    GATE_TYPECHECK: ("mypy", "tsc"),
+    GATE_LINT: ("ruff", "eslint"),
+}
+
+
+def validate_tool(gate: str, tool: str | None) -> str | None:
+    """``tool`` if the gate can dispatch to it, None when unset (auto).
+
+    Raises ``ValueError`` naming the accepted values otherwise. An
+    unknown name must not quietly become auto: the operator wrote it to
+    stop kstrl guessing, and silently guessing anyway is the failure the
+    key exists to prevent.
+    """
+    if not tool:
+        return None
+    if tool not in GATE_TOOLS[gate]:
+        accepted = ", ".join(GATE_TOOLS[gate])
+        raise ValueError(f"unknown tool {tool!r} for the {gate} gate; expected one of: {accepted}")
+    return tool
+
+
+def _union(results: list[ParsedOutput]) -> ParsedOutput:
+    """Merge the parsers that each found something into one result.
+
+    Correct for one result as well as several, which is why there is no
+    separate single-parser path: joining one name yields that name, and
+    summing one count yields that count.
+    """
+    merged = ParsedOutput(tool="+".join(r.tool for r in results))
+    for result in results:
+        merged.failures.extend(result.failures)
+    merged.total_errors = sum(r.total_errors for r in results)
+    merged.raw_summary = "\n".join(r.raw_summary for r in results if r.raw_summary)
+    return merged
+
+
+def parse_gate_output(raw: str, gate: str, tool: str | None = None) -> ParsedOutput:
+    """Parse one gate's raw output, dispatching per this gate's config."""
+    text = strip_ansi(raw)
+
+    chosen = validate_tool(gate, tool)
+    if chosen is not None:
+        return TOOL_PARSERS[chosen](text)
+
+    results = [TOOL_PARSERS[name](text) for name in GATE_TOOLS[gate]]
+    found = [result for result in results if result.failures]
+    if not found:
+        # Nobody understood it. The primary's result carries the raw
+        # tail, which is the only honest thing left to show.
+        return results[0]
+    return _union(found)

--- a/kstrl/parsers.py
+++ b/kstrl/parsers.py
@@ -2,6 +2,11 @@
 
 Transforms raw CLI output into structured failure objects that can generate
 LLM-optimized context for retry prompts.
+
+This module owns the shared types and the Python toolchain (pytest, mypy,
+ruff). The other toolchains a gate can be pointed at live in
+``kstrl.parsers_web``, and ``kstrl.gateparse`` is the dispatcher that
+decides which of them a gate's output goes through (#258).
 """
 
 from __future__ import annotations
@@ -9,6 +14,17 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+
+# CSI and OSC escape sequences. Tools colour their output whenever they
+# think a human is watching, and `tsc --pretty` does it even through a
+# pipe if the operator asked for it. Stripped once at the dispatcher so
+# no parser has to carry `\x1b\[[0-9;]*m` in its own pattern (#258).
+_ANSI_RE = re.compile(r"\x1b\[[0-9;:?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+
+
+def strip_ansi(raw: str) -> str:
+    """``raw`` with terminal colour and cursor escapes removed."""
+    return _ANSI_RE.sub("", raw)
 
 
 @dataclass
@@ -21,13 +37,32 @@ class ParsedFailure:
     message: str = ""
     source_context: str = ""  # relevant source lines if available
     fix_hint: str = ""  # generated fix suggestion
+    # Stable signature code for this failure, when the tool emits one:
+    # a linter rule (`E501`, `no-unused-vars`), a checker error code
+    # (`arg-type`, `TS2322`), or the exception class a test died on
+    # (`assertion-error`). Empty when the tool gave nothing durable.
+    #
+    # `rule_or_test` cannot serve: for a test runner it holds the TEST
+    # NAME, which is unique per test and useless as a signature.
+    # evolution.signatures_from_verification used to recover the
+    # difference by switching on `ParsedOutput.tool` against the exact
+    # strings "ruff", "mypy" and "pytest" - so every tool added here fell
+    # through to a prose slug, and a unioned label like "pytest+vitest"
+    # broke the switch outright (#258). The parser knows its own format,
+    # so the parser answers the question once, here.
+    code: str = ""
 
 
 @dataclass
 class ParsedOutput:
     """Structured parse result from a tool's raw output."""
 
-    tool: str  # "pytest", "mypy", "ruff"
+    # Which parser produced this. One registered name ("pytest", "vitest",
+    # "mypy", "tsc", "ruff", "eslint"), or several joined with "+" when a
+    # chained command emitted more than one format and the auto path
+    # unioned them (#258). Read it as a label, never as a switch: the
+    # capability consumers need is on ParsedFailure.code.
+    tool: str
     total_errors: int = 0
     failures: list[ParsedFailure] = field(default_factory=list)
     raw_summary: str = ""  # last line(s) summary from the tool
@@ -105,21 +140,74 @@ _PYTEST_ERROR_RE = re.compile(
 # Matches: === 3 failed, 10 passed, 1 error in 4.52s ===
 _PYTEST_SUMMARY_RE = re.compile(r"=+\s+(?P<summary>.+?)\s+=+\s*$")
 
-# Extract failure count from summary like "3 failed"
-_PYTEST_FAILED_COUNT_RE = re.compile(r"(\d+)\s+failed")
+# Extract failure count from a summary line like "3 failed". Not
+# pytest-specific: vitest's footer says "2 failed | 3 passed (5)", so
+# parsers_web reads the same count with the same pattern.
+FAILED_COUNT_RE = re.compile(r"(\d+)\s+failed")
+
 _PYTEST_ERROR_COUNT_RE = re.compile(r"(\d+)\s+error")
+
+
+# Leading exception class in a test-runner failure message, e.g.
+# "AssertionError: assert 1 == 2" or vitest's "AssertionError: expected
+# false to be true". Python and JavaScript agree on the shape, so both
+# test parsers share it.
+_EXC_NAME_RE = re.compile(
+    r"^([A-Z][A-Za-z0-9]*(?:Error|Exception|Failure|Warning|Exit|Interrupt))\b"
+)
+
+# Split points for CamelCase -> kebab-case, i.e. before each capital
+# that is not the first character.
+_CAMEL_BOUNDARY_RE = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def exception_code(message: str) -> str:
+    """Signature code for a test failure: "assertion-error", or "".
+
+    Lifted out of ``evolution.signatures_from_verification`` so the
+    parser that recognised the message shape also names it (#258).
+    """
+    m = _EXC_NAME_RE.match(message or "")
+    if not m:
+        return ""
+    return _CAMEL_BOUNDARY_RE.sub("-", m.group(1)).lower()
 
 
 def _pytest_failure_count(summary: str) -> int:
     """Failures plus errors reported by a pytest-shaped summary line."""
     count = 0
-    failed_m = _PYTEST_FAILED_COUNT_RE.search(summary)
+    failed_m = FAILED_COUNT_RE.search(summary)
     if failed_m:
         count += int(failed_m.group(1))
     error_m = _PYTEST_ERROR_COUNT_RE.search(summary)
     if error_m:
         count += int(error_m.group(1))
     return count
+
+
+def _pytest_failure_from_line(stripped: str) -> ParsedFailure | None:
+    """One FAILED or ERROR line as a failure, or None if it is neither."""
+    m = _PYTEST_FAILED_RE.match(stripped)
+    if m:
+        message = m.group("message") or ""
+        return ParsedFailure(
+            file=m.group("file"),
+            rule_or_test=m.group("test"),
+            message=message,
+            code=exception_code(message),
+        )
+
+    m = _PYTEST_ERROR_RE.match(stripped)
+    if m:
+        message = m.group("message") or ""
+        return ParsedFailure(
+            file=m.group("file"),
+            rule_or_test=m.group("test") or "collection",
+            message=message,
+            code=exception_code(message),
+        )
+
+    return None
 
 
 def parse_pytest_output(raw: str) -> ParsedOutput:
@@ -131,47 +219,22 @@ def parse_pytest_output(raw: str) -> ParsedOutput:
     result = ParsedOutput(tool="pytest")
 
     if not raw or not raw.strip():
-        result.raw_summary = raw.strip() if raw else ""
         return result
 
     lines = raw.splitlines()
-    in_short_summary = False
 
     for line in lines:
         stripped = line.strip()
 
-        # Detect short test summary section
+        # The short-summary banner is "=" padded like the footer, so
+        # without this it would match _PYTEST_SUMMARY_RE and stand as
+        # raw_summary for any run whose footer never arrived.
         if "short test summary info" in stripped.lower():
-            in_short_summary = True
             continue
 
-        # End of short summary section (next separator line)
-        if in_short_summary and stripped.startswith("=") and stripped.endswith("="):
-            in_short_summary = False
-            # This is likely the final summary line - fall through to summary match
-
-        # Parse FAILED lines (appear in short summary or standalone)
-        m = _PYTEST_FAILED_RE.match(stripped)
-        if m:
-            result.failures.append(
-                ParsedFailure(
-                    file=m.group("file"),
-                    rule_or_test=m.group("test"),
-                    message=m.group("message") or "",
-                )
-            )
-            continue
-
-        # Parse ERROR lines
-        m = _PYTEST_ERROR_RE.match(stripped)
-        if m:
-            result.failures.append(
-                ParsedFailure(
-                    file=m.group("file"),
-                    rule_or_test=m.group("test") or "collection",
-                    message=m.group("message") or "",
-                )
-            )
+        failure = _pytest_failure_from_line(stripped)
+        if failure is not None:
+            result.failures.append(failure)
             continue
 
         # Parse summary line
@@ -232,7 +295,6 @@ def parse_mypy_output(raw: str) -> ParsedOutput:
     result = ParsedOutput(tool="mypy")
 
     if not raw or not raw.strip():
-        result.raw_summary = raw.strip() if raw else ""
         return result
 
     lines = raw.splitlines()
@@ -243,12 +305,14 @@ def parse_mypy_output(raw: str) -> ParsedOutput:
         # Parse error lines
         m = _MYPY_ERROR_RE.match(stripped)
         if m:
+            code = m.group("code") or ""
             result.failures.append(
                 ParsedFailure(
                     file=m.group("file"),
                     line=int(m.group("line")),
-                    rule_or_test=m.group("code") or "",
+                    rule_or_test=code,
                     message=m.group("message"),
+                    code=code,
                 )
             )
             continue
@@ -276,8 +340,19 @@ def parse_mypy_output(raw: str) -> ParsedOutput:
 # ---------------------------------------------------------------------------
 
 # Matches: file.py:10:5: E501 Line too long (82 > 79)
+#
+# The rule slot is a RUFF-SHAPED code (letters then digits: E501, F401,
+# PLR0913, RUF001), with the optional trailing colon pylint writes. It
+# used to be a bare `\S+`, which matched any `file:line:col: message`
+# line and put that message's first word in the rule slot. Measured on
+# real `eslint --format unix` output, all three findings parsed with the
+# rule recorded as `'cache'`, `Expected` and `'missingHelper'` - the real
+# rule id sits at the END of an eslint line, and those slugs were fed
+# to evolution.py as failure signatures. Requiring the shape both fixes
+# that and keeps this parser out of the eslint parser's way when the
+# auto path runs both over the same output (#258).
 _RUFF_ERROR_RE = re.compile(
-    r"^(?P<file>[^:]+):(?P<line>\d+):(?P<col>\d+):\s+(?P<rule>\S+)\s+(?P<message>.+)$"
+    r"^(?P<file>[^:]+):(?P<line>\d+):(?P<col>\d+):\s+(?P<rule>[A-Z]{1,6}\d{1,5}):?\s+(?P<message>.+)$"
 )
 
 # Matches: Found 12 errors.  /  Found 12 errors (8 fixed, 4 remaining).
@@ -293,7 +368,6 @@ def parse_ruff_output(raw: str) -> ParsedOutput:
     result = ParsedOutput(tool="ruff")
 
     if not raw or not raw.strip():
-        result.raw_summary = raw.strip() if raw else ""
         return result
 
     lines = raw.splitlines()
@@ -310,6 +384,7 @@ def parse_ruff_output(raw: str) -> ParsedOutput:
                     line=int(m.group("line")),
                     rule_or_test=m.group("rule"),
                     message=m.group("message"),
+                    code=m.group("rule"),
                 )
             )
             continue

--- a/kstrl/parsers.py
+++ b/kstrl/parsers.py
@@ -126,16 +126,37 @@ class ParsedOutput:
 # ---------------------------------------------------------------------------
 
 # Matches: FAILED tests/test_foo.py::test_bar - AssertionError: some message
+#
+# The test id is `.+?`, not `[^\s]+`. A parametrized id can contain
+# spaces, and measured against pytest 9.1.1 the old pattern did not
+# match `FAILED test_drafts.py::test_x[a draft] - ...` at all, so every
+# such failure was dropped from the parse in silence.
 _PYTEST_FAILED_RE = re.compile(
-    r"^FAILED\s+(?P<file>[^\s:]+)::(?P<test>[^\s]+)"
+    r"^FAILED\s+(?P<file>[^\s:]+)::(?P<test>.+?)"
     r"(?:\s+-\s+(?P<message>.+))?$"
 )
 
 # Matches: ERROR tests/test_foo.py - CollectionError
 _PYTEST_ERROR_RE = re.compile(
-    r"^ERROR\s+(?P<file>[^\s:]+)(?:::(?P<test>[^\s]+))?"
+    r"^ERROR\s+(?P<file>[^\s:]+)(?:::(?P<test>.+?))?"
     r"(?:\s+-\s+(?P<message>.+))?$"
 )
+
+# The header of one block in the FAILURES / ERRORS sections:
+#   _____ test_counts_the_words[a draft] _____
+#   ___ ERROR at setup of test_uses_a_fixture ___
+# A class-based test is spelled `TestClass.test_method` here, against
+# `TestClass::test_method` in the short summary, which is the whole of
+# the translation between the two.
+_PYTEST_BLOCK_HEAD_RE = re.compile(r"^_{3,}\s+(?P<name>.+?)\s+_{3,}$")
+_PYTEST_BLOCK_ERROR_PREFIX_RE = re.compile(r"^ERROR at (?:setup|teardown) of\s+")
+
+# The last line of a traceback block: "test_drafts.py:20: AssertionError".
+_PYTEST_TRACEBACK_RE = re.compile(r"^(?P<file>\S+):(?P<line>\d+):\s+(?P<exc>[A-Za-z_][\w.]*)$")
+
+# The first `E   ` line of a block carries the untruncated exception
+# message: "E       AssertionError: assert 3 == 4".
+_PYTEST_EXC_LINE_RE = re.compile(r"^E\s{2,}(?P<message>\S.*)$")
 
 # Matches: === 3 failed, 10 passed, 1 error in 4.52s ===
 _PYTEST_SUMMARY_RE = re.compile(r"=+\s+(?P<summary>.+?)\s+=+\s*$")
@@ -152,13 +173,25 @@ _PYTEST_ERROR_COUNT_RE = re.compile(r"(\d+)\s+error")
 # "AssertionError: assert 1 == 2" or vitest's "AssertionError: expected
 # false to be true". Python and JavaScript agree on the shape, so both
 # test parsers share it.
+# The class-name prefix is OPTIONAL. It used to be mandatory, which
+# meant a bare `Error:` could not match: the pattern needed at least one
+# character before the suffix, and `Error` is the suffix. Measured, that
+# silently dropped the code for EVERY vitest suite-load failure
+# ("Error: Failed to load url ...") and for every plain
+# `throw new Error(...)` in JavaScript, so those signatures fell through
+# to a prose slug.
 _EXC_NAME_RE = re.compile(
-    r"^([A-Z][A-Za-z0-9]*(?:Error|Exception|Failure|Warning|Exit|Interrupt))\b"
+    r"^((?:[A-Z][A-Za-z0-9]*)?(?:Error|Exception|Failure|Warning|Exit|Interrupt))\b"
 )
 
 # Split points for CamelCase -> kebab-case, i.e. before each capital
 # that is not the first character.
 _CAMEL_BOUNDARY_RE = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def _kebab(name: str) -> str:
+    """CamelCase class name to the kebab-case a signature is spelled in."""
+    return _CAMEL_BOUNDARY_RE.sub("-", name).lower()
 
 
 def exception_code(message: str) -> str:
@@ -168,9 +201,7 @@ def exception_code(message: str) -> str:
     parser that recognised the message shape also names it (#258).
     """
     m = _EXC_NAME_RE.match(message or "")
-    if not m:
-        return ""
-    return _CAMEL_BOUNDARY_RE.sub("-", m.group(1)).lower()
+    return _kebab(m.group(1)) if m else ""
 
 
 def _pytest_failure_count(summary: str) -> int:
@@ -183,6 +214,84 @@ def _pytest_failure_count(summary: str) -> int:
     if error_m:
         count += int(error_m.group(1))
     return count
+
+
+@dataclass(frozen=True)
+class _PytestBlock:
+    """What one FAILURES / ERRORS block knows that the summary does not."""
+
+    file: str
+    line: int
+    exception: str
+    message: str
+
+
+def _pytest_blocks(lines: list[str]) -> dict[str, _PytestBlock]:
+    """Traceback detail from the FAILURES / ERRORS sections, by test id.
+
+    The short summary alone is not enough, measured against pytest
+    9.1.1 with realistic test names. pytest truncates those lines to the
+    terminal width, which under a pipe is 80 columns, and it truncates
+    the MESSAGE first: of four failures in one run, two carried no
+    message at all, one carried `AssertionErro...` and one carried
+    `AssertionError:...`. So the exception a failure died on, and with it
+    the evolution signature, depended on how long somebody had made the
+    test name.
+
+    The traceback block has all of it untruncated, and it has the LINE,
+    which the summary never carries. Nothing here fabricates: a failure
+    whose block is missing keeps exactly what the summary gave it.
+    """
+    blocks: dict[str, _PytestBlock] = {}
+    name = ""
+    message = ""
+
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        head = _PYTEST_BLOCK_HEAD_RE.match(stripped)
+        if head:
+            name = _PYTEST_BLOCK_ERROR_PREFIX_RE.sub("", head.group("name").strip())
+            message = ""
+            continue
+        if not name:
+            continue
+        exc_line = _PYTEST_EXC_LINE_RE.match(stripped)
+        if exc_line and not message:
+            message = exc_line.group("message")
+            continue
+        # Written as soon as a frame names an exception, and overwritten
+        # by any later one in the same block, so the LAST frame wins
+        # without a flush step. An intermediate frame writes "file:line:"
+        # with nothing after it and does not match at all; only the frame
+        # that names the class the test died on does.
+        tail = _PYTEST_TRACEBACK_RE.match(stripped)
+        if tail:
+            blocks[name] = _PytestBlock(
+                tail.group("file"), int(tail.group("line")), tail.group("exc"), message
+            )
+    return blocks
+
+
+def _enrich_from_block(failure: ParsedFailure, blocks: dict[str, _PytestBlock]) -> None:
+    """Fill in what the width-truncated summary line could not carry."""
+    block = blocks.get(failure.rule_or_test.replace("::", "."))
+    if block is None:
+        return
+    # File AND line together, never the line alone. The summary names the
+    # file the TEST lives in; the traceback names the file the exception
+    # was RAISED in, and they differ whenever a test calls a helper.
+    # Measured: a test in a 7-line test_cross.py failing at loader.py:17
+    # yielded `test_cross.py:17`, a location that does not exist, and
+    # add_source_context would happily print whatever sat at line 17 of
+    # some longer test file. The raising frame is also the better
+    # instruction: it is where the defect is.
+    failure.file = block.file
+    failure.line = block.line
+    # The summary's copy is the same sentence with the tail cut off, so
+    # the block's is never worse.
+    if block.message:
+        failure.message = block.message
+    failure.code = exception_code(failure.message) or _kebab(block.exception)
 
 
 def _pytest_failure_from_line(stripped: str) -> ParsedFailure | None:
@@ -210,6 +319,27 @@ def _pytest_failure_from_line(stripped: str) -> ParsedFailure | None:
     return None
 
 
+def _pytest_scan(lines: list[str]) -> tuple[list[ParsedFailure], str]:
+    """Walk the short summary once, returning its failures and its footer."""
+    failures: list[ParsedFailure] = []
+    summary = ""
+    for line in lines:
+        stripped = line.strip()
+        # The short-summary banner is "=" padded like the footer, so
+        # without this it would match _PYTEST_SUMMARY_RE and stand as
+        # raw_summary for any run whose footer never arrived.
+        if "short test summary info" in stripped.lower():
+            continue
+        failure = _pytest_failure_from_line(stripped)
+        if failure is not None:
+            failures.append(failure)
+            continue
+        m = _PYTEST_SUMMARY_RE.match(stripped)
+        if m:
+            summary = m.group("summary").strip()
+    return failures, summary
+
+
 def parse_pytest_output(raw: str) -> ParsedOutput:
     """Parse pytest output into structured failures.
 
@@ -222,25 +352,12 @@ def parse_pytest_output(raw: str) -> ParsedOutput:
         return result
 
     lines = raw.splitlines()
+    result.failures, result.raw_summary = _pytest_scan(lines)
 
-    for line in lines:
-        stripped = line.strip()
-
-        # The short-summary banner is "=" padded like the footer, so
-        # without this it would match _PYTEST_SUMMARY_RE and stand as
-        # raw_summary for any run whose footer never arrived.
-        if "short test summary info" in stripped.lower():
-            continue
-
-        failure = _pytest_failure_from_line(stripped)
-        if failure is not None:
-            result.failures.append(failure)
-            continue
-
-        # Parse summary line
-        m = _PYTEST_SUMMARY_RE.match(stripped)
-        if m:
-            result.raw_summary = m.group("summary").strip()
+    if result.failures:
+        blocks = _pytest_blocks(lines)
+        for failure in result.failures:
+            _enrich_from_block(failure, blocks)
 
     # Nothing structured parsed AND no summary reporting a failure: what
     # we matched, if anything, is not describing whatever failed this
@@ -283,7 +400,15 @@ _MYPY_ERROR_RE = re.compile(
 )
 
 # Matches: Found 5 errors in 3 files (checked 12 source files)
-_MYPY_SUMMARY_RE = re.compile(r"Found\s+(?P<count>\d+)\s+error[s]?\s+in\s+(?P<files>\d+)\s+file")
+# The `(checked N source files)` tail is REQUIRED, and it is the half
+# that identifies the tool. `Found 3 errors in 2 files` alone is also
+# tsc's footer, word for word, and the two share the typecheck gate: on
+# a chained `mypy && tsc` run the loose pattern had each parser claim
+# the other's summary. Measured across mypy's flag shapes (default,
+# --strict, --hide-error-context, --pretty), the tail is always there
+# when a footer is printed at all; --no-error-summary prints none, and
+# that already falls through to the raw tail.
+_MYPY_SUMMARY_RE = re.compile(r"Found\s+(?P<count>\d+)\s+errors?\s+in\s+\d+\s+files?\s+\(checked\s")
 
 
 def parse_mypy_output(raw: str) -> ParsedOutput:
@@ -339,30 +464,113 @@ def parse_mypy_output(raw: str) -> ParsedOutput:
 # Ruff parser
 # ---------------------------------------------------------------------------
 
-# Matches: file.py:10:5: E501 Line too long (82 > 79)
+# What ruff puts in the rule slot, measured against ruff 0.16.1 rather
+# than assumed. Two shapes, and the second one is why a bare
+# `[A-Z]{1,6}\d{1,5}` is wrong:
 #
-# The rule slot is a RUFF-SHAPED code (letters then digits: E501, F401,
-# PLR0913, RUF001), with the optional trailing colon pylint writes. It
-# used to be a bare `\S+`, which matched any `file:line:col: message`
-# line and put that message's first word in the rule slot. Measured on
-# real `eslint --format unix` output, all three findings parsed with the
-# rule recorded as `'cache'`, `Expected` and `'missingHelper'` - the real
-# rule id sits at the END of an eslint line, and those slugs were fed
-# to evolution.py as failure signatures. Requiring the shape both fixes
-# that and keeps this parser out of the eslint parser's way when the
-# auto path runs both over the same output (#258).
-_RUFF_ERROR_RE = re.compile(
-    r"^(?P<file>[^:]+):(?P<line>\d+):(?P<col>\d+):\s+(?P<rule>[A-Z]{1,6}\d{1,5}):?\s+(?P<message>.+)$"
+# - a rule code, letters then digits: E501, F401, PLR0913, RUF001.
+# - a lowercase kebab name with NO code, which is how ruff reports a
+#   file it could not parse: `invalid-syntax: Expected `)`, found
+#   newline`. Dropping those is the worst possible trade, because a
+#   syntax error is the one failure class whose file and line an agent
+#   cannot guess from the message.
+#
+# The kebab branch requires a hyphen and a trailing colon. That is what
+# keeps this parser off `eslint --format unix`, whose messages sit in
+# the same slot and begin `'cache'`, `Expected`, `'missingHelper'`. A
+# bare `\S+` here matched all three and fed those slugs to evolution.py
+# as failure signatures (#258).
+_RUFF_RULE = r"(?:[A-Z]{1,6}\d{1,5}:?|[a-z][a-z0-9]*(?:-[a-z0-9]+)+:)"
+
+# --output-format=concise: file.py:10:5: E501 Line too long (82 > 79)
+_RUFF_CONCISE_RE = re.compile(
+    rf"^(?P<file>[^:]+):(?P<line>\d+):\d+:\s+(?P<rule>{_RUFF_RULE})\s+(?P<message>.+)$"
 )
+
+# The DEFAULT format since ruff 0.9, and therefore what kstrl's own
+# DEFAULT_LINT_COMMAND (`uv run ruff check .`) actually produces. It is
+# two lines, not one:
+#
+#   F401 [*] `os` imported but unused
+#    --> kstrl/x.py:1:8
+#
+# Measured: the concise-only parser returned ZERO failures on it, so the
+# lint gate's primary parser could not read its own tool's default
+# output and the entire retry detail was `Found 1 error.` Every fixture
+# in the suite was concise, which is how it went unnoticed.
+_RUFF_FULL_HEAD_RE = re.compile(rf"^(?P<rule>{_RUFF_RULE})\s+(?P<message>.+)$")
+_RUFF_FULL_LOC_RE = re.compile(r"^-->\s+(?P<file>[^:]+):(?P<line>\d+):\d+$")
+
+# Ruff marks an auto-fixable diagnostic with `[*]` between the rule and
+# the message, in both formats. It describes the fix, not the defect.
+_RUFF_FIXABLE_RE = re.compile(r"^\[\*\]\s+")
 
 # Matches: Found 12 errors.  /  Found 12 errors (8 fixed, 4 remaining).
 _RUFF_SUMMARY_RE = re.compile(r"Found\s+(?P<count>\d+)\s+error")
 
 
+def _ruff_failure(rule: str, message: str, file: str, line: int) -> ParsedFailure:
+    """One ruff diagnostic, however the two formats spelled it."""
+    code = rule.rstrip(":")
+    return ParsedFailure(
+        file=file,
+        line=line,
+        rule_or_test=code,
+        message=_RUFF_FIXABLE_RE.sub("", message).strip(),
+        code=code,
+    )
+
+
+def _ruff_concise_failures(lines: list[str]) -> list[ParsedFailure]:
+    """Diagnostics written one-per-line by --output-format=concise."""
+    found: list[ParsedFailure] = []
+    for line in lines:
+        m = _RUFF_CONCISE_RE.match(line.strip())
+        if m:
+            found.append(
+                _ruff_failure(
+                    m.group("rule"), m.group("message"), m.group("file"), int(m.group("line"))
+                )
+            )
+    return found
+
+
+def _ruff_full_failures(lines: list[str]) -> list[ParsedFailure]:
+    """Diagnostics written as a head line plus a `-->` location line.
+
+    A separate pass from the concise one rather than a combined state
+    machine, because the two formats cannot both describe the same
+    diagnostic: concise emits no `-->` line and full emits no
+    `file:line:col:` head, so neither pass can see the other's output.
+    """
+    found: list[ParsedFailure] = []
+    # The rule is adjacency, so it is written as adjacency: a head and
+    # the `-->` on the very next line. Carrying the head forward in a
+    # `pending` slot said the same thing but left open the question of
+    # what happens when the two are not adjacent; over a pair window
+    # that case cannot be expressed. The head must also be UNINDENTED,
+    # which is what stops a line of the code frame opening a diagnostic.
+    for head_line, loc_line in zip(lines, lines[1:], strict=False):
+        if not head_line[:1].strip():
+            continue
+        head = _RUFF_FULL_HEAD_RE.match(head_line.strip())
+        loc = _RUFF_FULL_LOC_RE.match(loc_line.strip())
+        if head and loc:
+            found.append(
+                _ruff_failure(
+                    head.group("rule"),
+                    head.group("message"),
+                    loc.group("file"),
+                    int(loc.group("line")),
+                )
+            )
+    return found
+
+
 def parse_ruff_output(raw: str) -> ParsedOutput:
     """Parse ruff output into structured failures.
 
-    Handles per-line diagnostics and the summary footer.
+    Reads both the default `full` format and `--output-format=concise`.
     Falls through gracefully on unparseable input.
     """
     result = ParsedOutput(tool="ruff")
@@ -371,28 +579,12 @@ def parse_ruff_output(raw: str) -> ParsedOutput:
         return result
 
     lines = raw.splitlines()
+    result.failures = _ruff_concise_failures(lines) + _ruff_full_failures(lines)
 
     for line in lines:
-        stripped = line.strip()
-
-        # Parse error lines
-        m = _RUFF_ERROR_RE.match(stripped)
+        m = _RUFF_SUMMARY_RE.search(line.strip())
         if m:
-            result.failures.append(
-                ParsedFailure(
-                    file=m.group("file"),
-                    line=int(m.group("line")),
-                    rule_or_test=m.group("rule"),
-                    message=m.group("message"),
-                    code=m.group("rule"),
-                )
-            )
-            continue
-
-        # Parse summary line
-        m = _RUFF_SUMMARY_RE.search(stripped)
-        if m:
-            result.raw_summary = stripped
+            result.raw_summary = line.strip()
             result.total_errors = int(m.group("count"))
 
     # Fallback total from parsed failures

--- a/kstrl/parsers_web.py
+++ b/kstrl/parsers_web.py
@@ -172,7 +172,22 @@ _TSC_PRETTY_RE = re.compile(
 )
 
 # --pretty only; the piped form prints no footer at all.
-_TSC_SUMMARY_RE = re.compile(r"^Found\s+\d+\s+error")
+#
+# Matched POSITIVELY against tsc's three measured tails rather than by
+# the leading `Found N error`, because mypy's footer opens with the same
+# five words and the two share the typecheck gate:
+#
+#   tsc   Found 3 errors in 2 files.
+#   tsc   Found 2 errors in the same file, starting at: src/only.ts:6
+#   tsc   Found 1 error in src/only.ts:2
+#   mypy  Found 1 error in 1 file (checked 1 source file)
+#
+# Measured on a chained `mypy && tsc` gate, the loose pattern had the
+# tsc parser claim mypy's footer, so the unioned raw_summary carried it
+# TWICE and tsc's own count not at all.
+_TSC_SUMMARY_RE = re.compile(
+    r"^Found\s+\d+\s+errors?\s+in\s+(?:\d+\s+files?\.$|the\s+same\s+file,|\S+:\d+$)"
+)
 
 
 def parse_tsc_output(raw: str) -> ParsedOutput:

--- a/kstrl/parsers_web.py
+++ b/kstrl/parsers_web.py
@@ -1,0 +1,317 @@
+"""Output parsers for the JavaScript and TypeScript toolchains (#258).
+
+kstrl's verify gates run whatever command the operator configured, and a
+polyglot repo configures a chain: ``uv run pytest && (cd web && npm run
+test)``. Before this module the three gates parsed every command's output
+as pytest, mypy or ruff, so a real failing vitest run yielded ZERO parsed
+failures - file, line, test name, assertion message and the
+expected-versus-received diff were all present in the raw text and all
+dropped.
+
+Every regex here was written against output captured from the real tool
+and checked in under ``tests/tool_output/``, never from documentation or
+memory. Two of the shapes the issue predicted turned out to be wrong when
+measured, and the fixtures are what caught it:
+
+- ``tsc`` was expected to emit ``file:line:col: message`` like mypy. It
+  emits ``src/broken.ts(5,7): error TS2322: ...`` with PARENTHESES
+  through a pipe, and ``src/broken.ts:5:7 - error TS2322: ...`` under
+  ``--pretty``. Neither matches the mypy or the ruff pattern; measured,
+  all three existing parsers returned 0 failures on real tsc output.
+- ``eslint --format unix`` DID match the old ruff pattern, three of three
+  with the right file and line, but the rule slot took the message's
+  first word (``'cache'``) and left the real rule id buried at the end of
+  the line. ``--format compact`` did not parse at all. Both are moot for
+  most repos anyway: eslint 9 removed the two formatters from core, and
+  the default ``stylish`` output is what ``npm run lint`` actually
+  prints, so all three shapes are handled here.
+
+Adding another toolchain is one parse function, one entry in
+``kstrl.gateparse.TOOL_PARSERS`` and ``GATE_TOOLS``, and one captured
+fixture. A JavaScript or TypeScript tool (jest, biome, oxlint) belongs
+here; a tool from another ecosystem (cargo, go test) belongs in its own
+``kstrl/parsers_<ecosystem>.py`` importing the same shared types from
+``kstrl.parsers``. The split is by ecosystem rather than by gate because
+``kstrl.parsers`` is over half the 800-line ceiling the repo's
+file-length ratchet enforces, and because a toolchain's formats change
+together.
+
+Two invariants a new parser owes the dispatcher, both enforced by tests
+in ``tests/test_gateparse.py`` rather than by convention:
+
+- Output it does not recognise must still leave ``raw_summary``
+  populated, because ``gateparse`` returns the gate's PRIMARY parser
+  when nothing matched and that summary is then the whole retry detail.
+- It must not match another parser on the same gate. Auto unions without
+  deduplicating, so an overlap doubles the failures the engineer sees.
+"""
+
+from __future__ import annotations
+
+import re
+
+from kstrl.parsers import FAILED_COUNT_RE, ParsedFailure, ParsedOutput, exception_code
+
+# ---------------------------------------------------------------------------
+# Vitest
+# ---------------------------------------------------------------------------
+
+# The header of one failure block under "Failed Tests" / "Failed Suites":
+#
+#   FAIL  tests/failing.test.ts > word counter > counts the words
+#   FAIL  tests/broken-import.test.ts [ tests/broken-import.test.ts ]
+#
+# The tail is captured whole rather than alternated over, because the two
+# shapes mean different things: "> ..." is the suite-and-test chain, and
+# "[ ... ]" is a suite that never loaded, which HAS no test name.
+_VITEST_FAIL_RE = re.compile(r"^FAIL\s+(?P<file>\S+)(?P<rest>.*)$")
+
+# The location line inside a block: "❯ tests/failing.test.ts:5:41", or
+# "❯ loadAndTransform node_modules/vite/dist/...js:51969:17" when the
+# frame is somebody else's code. Only "❯" is accepted as the marker
+# because that is the character measured in vitest 2.1.9's output.
+_VITEST_LOC_RE = re.compile(r"^❯\s+.*?(?P<file>[^\s:]+):(?P<line>\d+):\d+\s*$")
+
+# The footer rows: "Test Files  2 failed (2)" and
+# "Tests  2 failed | 3 passed (5)". Two or more spaces after the label is
+# the column separator vitest pads with.
+_VITEST_SUMMARY_RE = re.compile(r"^(?:Test Files|Tests)\s{2,}\S")
+
+# Lines that open their own section rather than describing the failure
+# above them. Used to find a block's message line.
+_VITEST_MARKERS = ("FAIL", "❯", "⎯")
+
+
+def _vitest_message(block: list[str]) -> str:
+    """The assertion or load error line of one FAIL block.
+
+    Measured, it is always the line directly under the FAIL header
+    ("AssertionError: expected 3 to be 4", "Error: Failed to load url
+    ..."), but blank lines and section rules are skipped so a version
+    that spaces its blocks out does not lose the message silently.
+    """
+    for line in block[1:]:
+        stripped = line.strip()
+        if stripped and not stripped.startswith(_VITEST_MARKERS):
+            return stripped
+    return ""
+
+
+def _vitest_line_number(block: list[str], file: str) -> int:
+    """Line number from the first frame pointing at the FAIL block's own file.
+
+    The file is compared rather than the first frame taken: a suite that
+    failed to load reports its top frame inside ``node_modules/vite``,
+    and sending the engineer to a line in vite's bundle is worse than
+    sending it no line at all.
+    """
+    for line in block:
+        m = _VITEST_LOC_RE.match(line.strip())
+        if m and m.group("file") == file:
+            return int(m.group("line"))
+    return 0
+
+
+def _vitest_failure(block: list[str]) -> ParsedFailure:
+    """One FAIL block as a structured failure."""
+    head = _VITEST_FAIL_RE.match(block[0].strip())
+    assert head is not None  # only called on lines that already matched
+    file = head.group("file")
+    rest = head.group("rest").strip()
+    message = _vitest_message(block)
+    return ParsedFailure(
+        file=file,
+        line=_vitest_line_number(block, file),
+        rule_or_test=rest[1:].strip() if rest.startswith(">") else "",
+        message=message,
+        code=exception_code(message),
+    )
+
+
+def parse_vitest_output(raw: str) -> ParsedOutput:
+    """Parse vitest output into structured failures."""
+    result = ParsedOutput(tool="vitest")
+
+    if not raw or not raw.strip():
+        return result
+
+    lines = raw.splitlines()
+    # A failure's detail runs from its FAIL header to the next one, so
+    # the blocks are the gaps between the headers.
+    starts = [i for i, line in enumerate(lines) if _VITEST_FAIL_RE.match(line.strip())]
+    for n, start in enumerate(starts):
+        end = starts[n + 1] if n + 1 < len(starts) else len(lines)
+        result.failures.append(_vitest_failure(lines[start:end]))
+
+    summary = [line.strip() for line in lines if _VITEST_SUMMARY_RE.match(line.strip())]
+    result.raw_summary = "\n".join(summary)
+    if not result.failures and not result.raw_summary:
+        result.raw_summary = "\n".join(lines[-5:])
+
+    count_m = FAILED_COUNT_RE.search(result.raw_summary)
+    result.total_errors = len(result.failures) or (int(count_m.group(1)) if count_m else 0)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# TypeScript compiler
+# ---------------------------------------------------------------------------
+
+# Through a pipe, which is how the gate always runs it:
+#   src/broken.ts(7,9): error TS2322: Type 'string' is not assignable ...
+_TSC_PLAIN_RE = re.compile(
+    r"^(?P<file>[^\s(]+)\((?P<line>\d+),\d+\):\s+"
+    r"error\s+(?P<code>TS\d+):\s+(?P<message>.+)$"
+)
+
+# Under --pretty, which an npm script may well pass:
+#   src/broken.ts:7:9 - error TS2322: Type 'string' is not assignable ...
+_TSC_PRETTY_RE = re.compile(
+    r"^(?P<file>[^\s:]+):(?P<line>\d+):\d+\s+-\s+"
+    r"error\s+(?P<code>TS\d+):\s+(?P<message>.+)$"
+)
+
+# --pretty only; the piped form prints no footer at all.
+_TSC_SUMMARY_RE = re.compile(r"^Found\s+\d+\s+error")
+
+
+def parse_tsc_output(raw: str) -> ParsedOutput:
+    """Parse TypeScript compiler diagnostics into structured failures."""
+    result = ParsedOutput(tool="tsc")
+
+    if not raw or not raw.strip():
+        return result
+
+    lines = raw.splitlines()
+    for line in lines:
+        stripped = line.strip()
+        m = _TSC_PLAIN_RE.match(stripped) or _TSC_PRETTY_RE.match(stripped)
+        if m:
+            result.failures.append(
+                ParsedFailure(
+                    file=m.group("file"),
+                    line=int(m.group("line")),
+                    rule_or_test=m.group("code"),
+                    message=m.group("message"),
+                    code=m.group("code"),
+                )
+            )
+            continue
+        if _TSC_SUMMARY_RE.match(stripped):
+            result.raw_summary = stripped
+
+    if not result.failures and not result.raw_summary:
+        result.raw_summary = "\n".join(lines[-3:])
+
+    result.total_errors = len(result.failures)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# ESLint
+# ---------------------------------------------------------------------------
+
+# stylish (the default, and unchanged between eslint 8 and 9): a bare
+# file path, then indented diagnostics padded into columns.
+#
+#   /repo/lint/draft.js
+#     4:7   error    'cache' is assigned a value but never used  no-unused-vars
+#
+# The rule is optional because a fatal parse error has no rule id.
+_ESLINT_STYLISH_RE = re.compile(
+    r"^(?P<line>\d+):\d+\s+(?:error|warning)\s+"
+    r"(?P<message>.+?)(?:\s{2,}(?P<rule>[\w@/-]+))?$"
+)
+
+# --format unix: /repo/lint/draft.js:4:7: 'cache' is ... [Error/no-unused-vars]
+#
+# The file group is `[^:]+`, not `.+?`. Lazy-prefix versions of these two
+# patterns retry at every offset where `:digits:digits:` follows and then
+# rescan the rest of the line, which is quadratic in line length:
+# measured on one synthetic line of repeated `x:1:1: `, 23 ms at 7 KB,
+# 368 ms at 28 KB, 1475 ms at 56 KB. Gate output is whatever the
+# operator's command wrote, uncapped, and the lint gate now runs this
+# parser on every failure whether eslint was involved or not. `[^:]+`
+# is linear (0.37 ms on the same 56 KB line) and costs one POSIX
+# assumption: no colon in the path.
+_ESLINT_UNIX_RE = re.compile(
+    r"^(?P<file>[^:]+):(?P<line>\d+):\d+:\s+(?P<message>.+?)"
+    r"\s+\[(?:Error|Warning)/(?P<rule>[^\]]*)\]$"
+)
+
+# --format compact: /repo/lint/draft.js: line 4, col 7, Error - msg (rule)
+_ESLINT_COMPACT_RE = re.compile(
+    r"^(?P<file>[^:]+):\s+line\s+(?P<line>\d+),\s+col\s+\d+,\s+"
+    r"(?:Error|Warning)\s+-\s+(?P<message>.+?)(?:\s+\((?P<rule>[^)]*)\))?$"
+)
+
+# stylish's footer: "✖ 5 problems (4 errors, 1 warning)". unix and
+# compact print a bare "5 problems".
+_ESLINT_SUMMARY_RE = re.compile(r"^.?\s*\d+\s+problems?\b")
+
+
+def _eslint_failure(stripped: str, current_file: str) -> ParsedFailure | None:
+    """One eslint diagnostic in any of the three formats, or None.
+
+    ``current_file`` carries the stylish file header down to the indented
+    rows beneath it; the other two formats name the file on every line
+    and ignore it.
+    """
+    for pattern in (_ESLINT_UNIX_RE, _ESLINT_COMPACT_RE, _ESLINT_STYLISH_RE):
+        m = pattern.match(stripped)
+        if not m:
+            continue
+        rule = (m.group("rule") or "").strip()
+        return ParsedFailure(
+            file=m.groupdict().get("file") or current_file,
+            line=int(m.group("line")),
+            rule_or_test=rule,
+            message=m.group("message").strip(),
+            code=rule,
+        )
+    return None
+
+
+def _eslint_scan(lines: list[str]) -> tuple[list[ParsedFailure], str]:
+    """Walk eslint output once, returning its failures and its footer."""
+    failures: list[ParsedFailure] = []
+    summary = ""
+    current_file = ""
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _ESLINT_SUMMARY_RE.match(stripped):
+            summary = stripped
+            continue
+        failure = _eslint_failure(stripped, current_file)
+        if failure is not None:
+            failures.append(failure)
+            continue
+        # An unindented, undiagnosed line is stylish's file header. Any
+        # other stray line simply becomes a header nothing attaches to.
+        if line[:1].strip():
+            current_file = stripped
+    return failures, summary
+
+
+def parse_eslint_output(raw: str) -> ParsedOutput:
+    """Parse eslint output into structured failures.
+
+    Warnings are kept alongside errors. eslint's exit code is what failed
+    the gate and ``--max-warnings 0`` makes a warning do exactly that, so
+    dropping them would hand the engineer an empty parse for a gate that
+    genuinely failed.
+    """
+    result = ParsedOutput(tool="eslint")
+
+    if not raw or not raw.strip():
+        return result
+
+    lines = raw.splitlines()
+    result.failures, result.raw_summary = _eslint_scan(lines)
+    if not result.failures and not result.raw_summary:
+        result.raw_summary = "\n".join(lines[-3:])
+
+    result.total_errors = len(result.failures)
+    return result

--- a/kstrl/verify.py
+++ b/kstrl/verify.py
@@ -9,9 +9,11 @@ import signal
 import subprocess
 import tempfile
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from kstrl import git, licensing
 
@@ -23,16 +25,20 @@ from kstrl.adequacy import (
     is_test_path,
     layer0_blocks,
 )
-from kstrl.config import component_progress_path
+from kstrl.config import component_progress_path, relative_to_root
 from kstrl.findings import Finding
+from kstrl.gateparse import (
+    GATE_LINT,
+    GATE_TEST,
+    GATE_TYPECHECK,
+    parse_gate_output,
+    validate_tool,
+)
 from kstrl.guards import path_is_allowed
 from kstrl.parsers import (
     ParsedOutput,
     add_source_context,
     generate_fix_hint,
-    parse_mypy_output,
-    parse_pytest_output,
-    parse_ruff_output,
 )
 from kstrl.policy import (
     PolicyConfig,
@@ -212,6 +218,41 @@ class VerificationResult:
         return "\n".join(lines)
 
 
+def _optional_str(value: object) -> str | None:
+    """A toml scalar as a string, with the empty string meaning unset."""
+    return str(value) or None
+
+
+#: Every live ``[verify]`` toml key and how its value is coerced onto the
+#: dataclass. A table rather than a per-key ``if``: the chain it replaced
+#: was fourteen near-identical branches, and its cyclomatic complexity
+#: was already twice the repo's ratchet limit before #258 added three
+#: more keys to it. Order is the dataclass's, so a reader can diff the
+#: two lists by eye. Anything absent from this table is not a toml key.
+_VERIFY_TOML_FIELDS: tuple[tuple[str, Callable[[Any], object]], ...] = (
+    ("test_command", _optional_str),
+    ("typecheck_command", _optional_str),
+    ("lint_command", _optional_str),
+    # validate_tool already maps the empty string to None (auto) and
+    # raises on anything it does not recognise, so it needs no coercion
+    # in front of it.
+    ("test_tool", partial(validate_tool, GATE_TEST)),
+    ("typecheck_tool", partial(validate_tool, GATE_TYPECHECK)),
+    ("lint_tool", partial(validate_tool, GATE_LINT)),
+    ("check_diff_scope", bool),
+    ("check_bad_patterns", bool),
+    ("dead_code_cleanup", bool),
+    ("dead_code_command", _optional_str),
+    ("mutation_testing", bool),
+    ("mutation_threshold", float),
+    ("mutation_timeout", float),
+    ("subprocess_timeout", float),
+    ("require_self_critique", bool),
+    ("self_critique_min_bullets", int),
+    ("progress_file_path", _optional_str),
+)
+
+
 @dataclass
 class VerifyConfig:
     """Configuration for mechanical verification."""
@@ -219,6 +260,15 @@ class VerifyConfig:
     test_command: str | None = None
     typecheck_command: str | None = None
     lint_command: str | None = None
+    # Which parser reads each gate's output (#258). None is auto: every
+    # parser registered for the gate runs and their findings are unioned,
+    # which is what makes a chained command
+    # (`uv run pytest && npm run test`) yield BOTH toolchains' failures.
+    # Set one to pin the gate to a single parser. Accepted values are
+    # kstrl.gateparse.GATE_TOOLS[<gate>]; anything else raises on load.
+    test_tool: str | None = None
+    typecheck_tool: str | None = None
+    lint_tool: str | None = None
     check_diff_scope: bool = True
     check_bad_patterns: bool = True
     dead_code_cleanup: bool = False
@@ -250,6 +300,11 @@ class VerifyConfig:
             test_command=os.environ.get("KSTRL_VERIFY_TEST_CMD"),
             typecheck_command=os.environ.get("KSTRL_VERIFY_TYPECHECK_CMD"),
             lint_command=os.environ.get("KSTRL_VERIFY_LINT_CMD"),
+            test_tool=validate_tool(GATE_TEST, os.environ.get("KSTRL_VERIFY_TEST_TOOL")),
+            typecheck_tool=validate_tool(
+                GATE_TYPECHECK, os.environ.get("KSTRL_VERIFY_TYPECHECK_TOOL")
+            ),
+            lint_tool=validate_tool(GATE_LINT, os.environ.get("KSTRL_VERIFY_LINT_TOOL")),
             dead_code_cleanup=os.environ.get("KSTRL_DEAD_CODE_CLEANUP", "") == "1",
             dead_code_command=os.environ.get("KSTRL_DEAD_CODE_CMD"),
             mutation_testing=os.environ.get("KSTRL_MUTATION_TESTING", "") == "1",
@@ -272,34 +327,9 @@ class VerifyConfig:
             root_dir = Path.cwd()
         config = cls()
         section = load_toml_section(resolve_config_file(root_dir), "verify")
-        if "test_command" in section:
-            config.test_command = str(section["test_command"]) or None
-        if "typecheck_command" in section:
-            config.typecheck_command = str(section["typecheck_command"]) or None
-        if "lint_command" in section:
-            config.lint_command = str(section["lint_command"]) or None
-        if "check_diff_scope" in section:
-            config.check_diff_scope = bool(section["check_diff_scope"])
-        if "check_bad_patterns" in section:
-            config.check_bad_patterns = bool(section["check_bad_patterns"])
-        if "dead_code_cleanup" in section:
-            config.dead_code_cleanup = bool(section["dead_code_cleanup"])
-        if "dead_code_command" in section:
-            config.dead_code_command = str(section["dead_code_command"]) or None
-        if "mutation_testing" in section:
-            config.mutation_testing = bool(section["mutation_testing"])
-        if "mutation_threshold" in section:
-            config.mutation_threshold = float(section["mutation_threshold"])
-        if "mutation_timeout" in section:
-            config.mutation_timeout = float(section["mutation_timeout"])
-        if "subprocess_timeout" in section:
-            config.subprocess_timeout = float(section["subprocess_timeout"])
-        if "require_self_critique" in section:
-            config.require_self_critique = bool(section["require_self_critique"])
-        if "self_critique_min_bullets" in section:
-            config.self_critique_min_bullets = int(section["self_critique_min_bullets"])
-        if "progress_file_path" in section:
-            config.progress_file_path = str(section["progress_file_path"]) or None
+        for key, coerce in _VERIFY_TOML_FIELDS:
+            if key in section:
+                setattr(config, key, coerce(section[key]))
         # Env overrides. Each var is applied only when it is explicitly
         # set in the environment: the previous compare-against-default
         # heuristic silently dropped an env value that happened to equal
@@ -311,6 +341,9 @@ class VerifyConfig:
             "KSTRL_VERIFY_TEST_CMD": "test_command",
             "KSTRL_VERIFY_TYPECHECK_CMD": "typecheck_command",
             "KSTRL_VERIFY_LINT_CMD": "lint_command",
+            "KSTRL_VERIFY_TEST_TOOL": "test_tool",
+            "KSTRL_VERIFY_TYPECHECK_TOOL": "typecheck_tool",
+            "KSTRL_VERIFY_LINT_TOOL": "lint_tool",
             "KSTRL_DEAD_CODE_CLEANUP": "dead_code_cleanup",
             "KSTRL_DEAD_CODE_CMD": "dead_code_command",
             "KSTRL_MUTATION_TESTING": "mutation_testing",
@@ -809,6 +842,17 @@ def _failed_gate_result(
     """
     parsed.command = cmd
     for failure in parsed.failures:
+        # eslint's default formatter prints ABSOLUTE paths, so without
+        # this the engineer is handed a path rooted in kstrl's throwaway
+        # worktree: correct on disk, useless as an instruction, and not
+        # the path its own tools use. Deliberately the FILE only. The
+        # message is prose the tool wrote and may quote a path too
+        # (measured: vitest's load errors do); rewriting a tool's own
+        # sentences by string substitution is a different and less safe
+        # mechanism than resolving a path, and the file is the field the
+        # engineer acts on and add_source_context resolves.
+        if failure.file:
+            failure.file = relative_to_root(Path(failure.file), cwd)
         add_source_context(failure, cwd)
         if not failure.fix_hint:
             failure.fix_hint = generate_fix_hint(failure)
@@ -826,8 +870,13 @@ def check_test_suite(
     cwd: Path,
     command: str | None = None,
     timeout: float = 300.0,
+    tool: str | None = None,
 ) -> CheckResult:
-    """Run the project's test suite independently."""
+    """Run the project's test suite independently.
+
+    ``tool`` pins which parser reads the output; None runs every parser
+    registered for the gate and unions what they find (#258).
+    """
     start = time.monotonic()
     cmd = resolve_test_command(command)
 
@@ -835,7 +884,7 @@ def check_test_suite(
         result = run_scrubbed(cmd, cwd=cwd, timeout=timeout)
     except subprocess.TimeoutExpired:
         return CheckResult(
-            name="test_suite",
+            name=GATE_TEST,
             passed=False,
             message=f"Test suite timed out after {timeout}s",
             duration_seconds=time.monotonic() - start,
@@ -843,21 +892,17 @@ def check_test_suite(
 
     if result.returncode != 0:
         output = (result.stdout + result.stderr).strip()
-        # Whatever `cmd` is, it is parsed as pytest: there is no
-        # dispatch. Recording the command lets an unparsed passthrough
-        # be labelled with what actually ran instead of claiming pytest
-        # produced output pytest never saw (#258).
         return _failed_gate_result(
-            "test_suite",
+            GATE_TEST,
             f"Tests failed (exit code {result.returncode})",
-            parse_pytest_output(output),
+            parse_gate_output(output, GATE_TEST, tool),
             cmd,
             cwd,
             start,
         )
 
     return CheckResult(
-        name="test_suite",
+        name=GATE_TEST,
         passed=True,
         message="Tests passed",
         duration_seconds=time.monotonic() - start,
@@ -868,8 +913,9 @@ def check_typecheck(
     cwd: Path,
     command: str | None = None,
     timeout: float = 300.0,
+    tool: str | None = None,
 ) -> CheckResult:
-    """Run typecheck independently."""
+    """Run typecheck independently. See ``check_test_suite`` for ``tool``."""
     start = time.monotonic()
     cmd = resolve_typecheck_command(command, cwd)
 
@@ -877,7 +923,7 @@ def check_typecheck(
         result = run_scrubbed(cmd, cwd=cwd, timeout=timeout)
     except subprocess.TimeoutExpired:
         return CheckResult(
-            name="typecheck",
+            name=GATE_TYPECHECK,
             passed=False,
             message=f"Typecheck timed out after {timeout}s",
             duration_seconds=time.monotonic() - start,
@@ -886,16 +932,16 @@ def check_typecheck(
     if result.returncode != 0:
         output = (result.stdout + result.stderr).strip()
         return _failed_gate_result(
-            "typecheck",
+            GATE_TYPECHECK,
             f"Typecheck failed (exit code {result.returncode})",
-            parse_mypy_output(output),
+            parse_gate_output(output, GATE_TYPECHECK, tool),
             cmd,
             cwd,
             start,
         )
 
     return CheckResult(
-        name="typecheck",
+        name=GATE_TYPECHECK,
         passed=True,
         message="Typecheck passed",
         duration_seconds=time.monotonic() - start,
@@ -906,8 +952,9 @@ def check_linter(
     cwd: Path,
     command: str | None = None,
     timeout: float = 300.0,
+    tool: str | None = None,
 ) -> CheckResult:
-    """Run linter independently."""
+    """Run linter independently. See ``check_test_suite`` for ``tool``."""
     start = time.monotonic()
     cmd = resolve_lint_command(command)
 
@@ -915,7 +962,7 @@ def check_linter(
         result = run_scrubbed(cmd, cwd=cwd, timeout=timeout)
     except subprocess.TimeoutExpired:
         return CheckResult(
-            name="linter",
+            name=GATE_LINT,
             passed=False,
             message=f"Linter timed out after {timeout}s",
             duration_seconds=time.monotonic() - start,
@@ -924,16 +971,16 @@ def check_linter(
     if result.returncode != 0:
         output = (result.stdout + result.stderr).strip()
         return _failed_gate_result(
-            "linter",
+            GATE_LINT,
             f"Linter failed (exit code {result.returncode})",
-            parse_ruff_output(output),
+            parse_gate_output(output, GATE_LINT, tool),
             cmd,
             cwd,
             start,
         )
 
     return CheckResult(
-        name="linter",
+        name=GATE_LINT,
         passed=True,
         message="Linter passed",
         duration_seconds=time.monotonic() - start,
@@ -1788,6 +1835,7 @@ def run_mechanical_verification(
             worktree_path,
             config.test_command,
             config.subprocess_timeout,
+            config.test_tool,
         )
     )
 
@@ -1796,6 +1844,7 @@ def run_mechanical_verification(
             worktree_path,
             config.typecheck_command,
             config.subprocess_timeout,
+            config.typecheck_tool,
         )
     )
 
@@ -1804,6 +1853,7 @@ def run_mechanical_verification(
             worktree_path,
             config.lint_command,
             config.subprocess_timeout,
+            config.lint_tool,
         )
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,4 +166,8 @@ ignore_names = ["cancel_futures"]
 # env value in a test asserting ValueError. Excetra is a project name.
 # unparseable and pre-empt are accepted spellings codespell dislikes.
 ignore-words-list = "crasher,critcial,excetra,missable,nd,pre-empt,unparseable"
-skip = "uv.lock,*/package-lock.json,.git"
+# tests/tool_output/ is captured tool output kept as evidence (#258).
+# pytest truncates its short-summary lines to the terminal width, which
+# cuts the exception name off mid-word - the very behaviour those
+# fixtures exist to pin. Spell-correcting a capture would falsify it.
+skip = "uv.lock,*/package-lock.json,.git,tests/tool_output/*"

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -45,6 +45,7 @@ import click
 # them keeps this reference from drifting the way it had: it claimed
 # "uv run ruff check" without the path argument the gate actually
 # passes, and named only the scoped branch of the typecheck default.
+from kstrl.gateparse import GATE_LINT, GATE_TEST, GATE_TOOLS, GATE_TYPECHECK
 from kstrl.verify import (
     DEFAULT_LINT_COMMAND,
     DEFAULT_TEST_COMMAND,
@@ -529,6 +530,12 @@ KEY_DESCRIPTIONS: dict[tuple[str, str], str] = {
         f"else {DEFAULT_TYPECHECK_COMMAND}"
     ),
     ("verify", "lint_command"): f"empty = the harness default ({DEFAULT_LINT_COMMAND})",
+    ("verify", "test_tool"): "parser for the test gate's output; empty = every parser "
+    f"({', '.join(GATE_TOOLS[GATE_TEST])}), unioned",
+    ("verify", "typecheck_tool"): "parser for the typecheck gate's output; empty = every "
+    f"parser ({', '.join(GATE_TOOLS[GATE_TYPECHECK])}), unioned",
+    ("verify", "lint_tool"): "parser for the lint gate's output; empty = every parser "
+    f"({', '.join(GATE_TOOLS[GATE_LINT])}), unioned",
     ("verify", "check_diff_scope"): "fail on changes outside allowed paths",
     ("verify", "check_bad_patterns"): "scan the diff for secret-like patterns",
     ("verify", "dead_code_cleanup"): "optional dead-code check",
@@ -678,6 +685,14 @@ ENUM_SENTINELS: dict[tuple[str, str], str | float] = {
     # intake_github.repo is validated as owner/name, so the generic
     # string sentinel is rejected by the loader.
     ("intake_github", "repo"): "sentinel-owner/sentinel-repo",
+    # The three verify tool keys are validated against their gate's
+    # registered parsers, so the probe has to use a real one. The SECOND
+    # entry, never the first: the probe asserts the loaded value differs
+    # from the default, and picking the primary would still differ from
+    # None but reads as if the primary were special.
+    ("verify", "test_tool"): GATE_TOOLS[GATE_TEST][1],
+    ("verify", "typecheck_tool"): GATE_TOOLS[GATE_TYPECHECK][1],
+    ("verify", "lint_tool"): GATE_TOOLS[GATE_LINT][1],
 }
 
 

--- a/tests/helpers/tool_output.py
+++ b/tests/helpers/tool_output.py
@@ -1,0 +1,44 @@
+"""Access to the real tool output checked in under ``tests/tool_output`` (#258).
+
+Every file there was produced by running the named tool at the named
+version against a deliberately broken toy project and capturing what came
+out of the pipe. None of it is written from documentation or from memory,
+because the shapes this suite has to parse are exactly the shapes that
+were guessed wrong: the issue predicted tsc would emit ``file:line:col:``
+like mypy, and it emits ``src/broken.ts(5,7):`` instead. A hand-written
+fixture would have encoded the guess and passed.
+
+The captures are through a PIPE, not a terminal, because that is how
+``verify.run_scrubbed`` invokes every gate. That is not cosmetic: vitest
+drops its ANSI colour when stdout is not a tty, eslint does the same, and
+pytest truncates its short-summary lines to 80 columns, which is why the
+pytest fixture's messages end in "...".
+
+Two normalizations are applied, both recorded here because a fixture that
+claims to be verbatim has to say where it is not:
+
+1. The capture machine's absolute paths are replaced with ``/repo``.
+   Nothing in the suite may depend on one developer's directory layout.
+2. Trailing whitespace is stripped and the file ends in exactly one
+   newline, so four of these lost the blank line their tool printed
+   last. The repo's ``trailing-whitespace`` and ``end-of-file-fixer``
+   hooks impose both on the first commit, so the alternative was not
+   verbatim files, it was files whose checked-in bytes differ from what
+   the tests were written against. What was removed is a blank line and
+   some padding inside vitest's code frames; no parser reads either.
+
+The escape characters in ``tsc-5.6.3-pretty.txt`` are deliberate: that
+file is real ``--pretty`` output with its ANSI sequences intact, and it
+is what proves ``parsers.strip_ansi`` earns its place.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+TOOL_OUTPUT_DIR = Path(__file__).resolve().parent.parent / "tool_output"
+
+
+def tool_output(name: str) -> str:
+    """Captured output of one tool run, by file name."""
+    return (TOOL_OUTPUT_DIR / name).read_text(encoding="utf-8")

--- a/tests/test_config_report.py
+++ b/tests/test_config_report.py
@@ -76,6 +76,31 @@ class TestBuildConfigReport:
             "env",
         )
 
+    def test_verify_tool_keys_are_reported(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """#258: the per-gate parser keys reach `ks config`.
+
+        They were added to VerifyConfig, gen_docs, the README and
+        docs/env-vars.md but not to this report, so the one setting an
+        operator reaches for when a gate is parsed by the wrong
+        toolchain had no row, no value and no source anywhere in the
+        resolved-config surface.
+        """
+        monkeypatch.setenv("KSTRL_VERIFY_TYPECHECK_TOOL", "tsc")
+        (tmp_path / "kstrl.toml").write_text('[verify]\ntest_tool = "vitest"\n', encoding="utf-8")
+        report = build_config_report(tmp_path)
+
+        assert _row(report.rows, "verify", "test_tool") == ConfigRow(
+            "verify", "test_tool", "'vitest'", "toml"
+        )
+        assert _row(report.rows, "verify", "typecheck_tool") == ConfigRow(
+            "verify", "typecheck_tool", "'tsc'", "env"
+        )
+        assert _row(report.rows, "verify", "lint_tool").source == "default"
+
     def test_absent_toml(self, tmp_path: Path) -> None:
         report = build_config_report(tmp_path)
         assert not report.toml_exists

--- a/tests/test_config_toml_full.py
+++ b/tests/test_config_toml_full.py
@@ -98,6 +98,74 @@ self_critique_min_bullets = 5
         assert config.require_self_critique is True
         assert config.self_critique_min_bullets == 5
 
+    def test_tool_keys_default_to_auto(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # #258: None is "run every parser for the gate and union the
+        # failures", which is what makes a chained command work.
+        _clear_env(monkeypatch, "KSTRL_VERIFY_TEST_TOOL", "KSTRL_VERIFY_LINT_TOOL")
+        _write(tmp_path / "kstrl.toml", '[verify]\ntest_command = "pytest"\n')
+        config = VerifyConfig.load(tmp_path)
+        assert (config.test_tool, config.typecheck_tool, config.lint_tool) == (None, None, None)
+
+    def test_reads_the_tool_keys(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _clear_env(
+            monkeypatch,
+            "KSTRL_VERIFY_TEST_TOOL",
+            "KSTRL_VERIFY_TYPECHECK_TOOL",
+            "KSTRL_VERIFY_LINT_TOOL",
+        )
+        _write(
+            tmp_path / "kstrl.toml",
+            """
+[verify]
+test_tool = "vitest"
+typecheck_tool = "tsc"
+lint_tool = "eslint"
+""",
+        )
+        config = VerifyConfig.load(tmp_path)
+        assert (config.test_tool, config.typecheck_tool, config.lint_tool) == (
+            "vitest",
+            "tsc",
+            "eslint",
+        )
+
+    def test_env_overrides_the_toml_tool(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _write(tmp_path / "kstrl.toml", '[verify]\ntest_tool = "vitest"\n')
+        monkeypatch.setenv("KSTRL_VERIFY_TEST_TOOL", "pytest")
+        assert VerifyConfig.load(tmp_path).test_tool == "pytest"
+
+    def test_an_unknown_tool_raises_rather_than_falling_back_to_auto(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Silently reverting to auto would be the failure the key exists
+        # to prevent: the operator wrote it to stop kstrl guessing.
+        _clear_env(monkeypatch, "KSTRL_VERIFY_TEST_TOOL")
+        _write(tmp_path / "kstrl.toml", '[verify]\ntest_tool = "jest"\n')
+        with pytest.raises(ValueError, match="unknown tool 'jest'"):
+            VerifyConfig.load(tmp_path)
+
+    def test_an_unknown_tool_in_the_environment_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("KSTRL_VERIFY_LINT_TOOL", "prettier")
+        with pytest.raises(ValueError, match="unknown tool 'prettier'"):
+            VerifyConfig.from_env()
+
 
 # ---------------------------------------------------------------------------
 # ContractConfig

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -441,33 +441,33 @@ class TestSaveProposals:
 
 class TestSignatureHelpers:
     def test_signatures_from_verification_uses_parser_codes(self) -> None:
-        from kstrl.parsers import ParsedFailure, ParsedOutput
+        from kstrl.gateparse import GATE_LINT, GATE_TEST, GATE_TYPECHECK, parse_gate_output
         from kstrl.verify import CheckResult
 
-        ruff = ParsedOutput(
-            tool="ruff",
-            failures=[
-                ParsedFailure(file="a.py", line=1, rule_or_test="E501", message="x"),
-                ParsedFailure(file="b.py", line=2, rule_or_test="S608", message="y"),
-                ParsedFailure(file="c.py", line=3, rule_or_test="E501", message="z"),
-            ],
+        # Real tool output through the real dispatcher rather than
+        # hand-built ParsedOutputs: the signature is only worth anything
+        # if the parser actually puts a code where this reads one, and a
+        # synthetic ParsedFailure can be given a code the parser never
+        # emits (#258).
+        ruff = parse_gate_output(
+            "a.py:1:1: E501 Line too long (120 > 100)\n"
+            "b.py:2:5: S608 Possible SQL injection vector\n"
+            "c.py:3:9: E501 Line too long (110 > 100)\n"
+            "Found 3 errors.\n",
+            GATE_LINT,
         )
-        mypy = ParsedOutput(
-            tool="mypy",
-            failures=[
-                ParsedFailure(file="a.py", line=4, rule_or_test="arg-type", message="m"),
-            ],
+        mypy = parse_gate_output(
+            'a.py:4: error: Argument 1 has incompatible type "str" [arg-type]\n'
+            "Found 1 error in 1 file (checked 2 source files)\n",
+            GATE_TYPECHECK,
         )
-        pytest_out = ParsedOutput(
-            tool="pytest",
-            failures=[
-                ParsedFailure(
-                    file="tests/test_a.py",
-                    rule_or_test="test_x",
-                    message="AssertionError: assert 1 == 2",
-                ),
-            ],
+        pytest_out = parse_gate_output(
+            "=========================== short test summary info ===========================\n"
+            "FAILED tests/test_a.py::test_x - AssertionError: assert 1 == 2\n"
+            "=============================== 1 failed in 0.10s ===============================\n",
+            GATE_TEST,
         )
+        assert (ruff.tool, mypy.tool, pytest_out.tool) == ("ruff", "mypy", "pytest")
         checks = [
             CheckResult(name="linter", passed=False, message="Linter failed", parsed=ruff),
             CheckResult(name="typecheck", passed=False, message="Typecheck failed", parsed=mypy),

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from kstrl.evolution import (
     JOURNAL_SCHEMA_VERSION,
     EvolutionConfig,
@@ -393,6 +395,56 @@ class TestProposeImprovements:
         assert "S608" in proposals[0].title
         assert proposals[0].target == "claude_md"
         assert proposals[1].target == "feedforward_config"
+
+    # Every branch of propose_improvements, not just the two that named
+    # a toolchain. `check_name` is the GATE, which carries no toolchain
+    # at all now that each gate dispatches per project (#258), so a code
+    # in any of these can be a tsc TS-number or an eslint rule as easily
+    # as a mypy or ruff one.
+    @pytest.mark.parametrize(
+        ("check_name", "signature", "expected_target"),
+        [
+            ("linter", "no-unused-vars", "claude_md"),
+            ("typecheck", "TS2322", "typecheck_config"),
+            ("test_suite", "assertion-error", "feedforward_config"),
+            ("review", "scope_creep", "claude_md"),
+            ("security", "injection", "claude_md"),
+        ],
+    )
+    def test_proposals_name_no_toolchain(
+        self, check_name: str, signature: str, expected_target: str
+    ) -> None:
+        """#258 review: a TypeScript project was sent to edit a pyproject.toml.
+
+        save_proposals writes the target verbatim into the proposal file
+        as `**Target**: ...`, one line above the prose, so the field is
+        as visible to the reader as the sentences are and has to be as
+        neutral. The whole proposal is searched, not just the suggested
+        change, because a name in the description or the target ships
+        just as far.
+        """
+        config = EvolutionConfig()
+        journal = EvolutionJournal(config)
+        patterns = [
+            FailurePattern(
+                description=f"{check_name} failure '{signature}' in 3/5 components",
+                frequency=3,
+                total_components=5,
+                affected_components=["a", "b", "c"],
+                check_name=check_name,
+                error_signature=signature,
+                category="verification",
+            )
+        ]
+
+        proposal = journal.propose_improvements(patterns)[0]
+        written = " ".join(
+            [proposal.target, proposal.title, proposal.description, proposal.suggested_change]
+        )
+
+        assert proposal.target == expected_target
+        for toolchain in ("pyproject", "mypy", "pyright", "ruff", "flake8"):
+            assert toolchain not in written, f"{check_name} proposal names {toolchain}"
 
     def test_propose_improvements_empty(self) -> None:
         config = EvolutionConfig()

--- a/tests/test_gateparse.py
+++ b/tests/test_gateparse.py
@@ -1,0 +1,364 @@
+"""Per-gate parser dispatch and the non-Python parsers (#258).
+
+Every assertion here runs against output captured from the real tool at
+a named version (``tests/tool_output``, provenance in
+``tests/helpers/tool_output.py``). That is deliberate and it is the
+point of the exercise: the issue reasoned from the code that tsc and
+eslint would be "close to free" because they emit ``file:line:col``, and
+measurement said otherwise for tsc and half-otherwise for eslint. A
+hand-written fixture would have encoded the reasoning and passed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kstrl.evolution import signatures_from_verification
+from kstrl.gateparse import (
+    GATE_LINT,
+    GATE_TEST,
+    GATE_TOOLS,
+    GATE_TYPECHECK,
+    TOOL_PARSERS,
+    parse_gate_output,
+    validate_tool,
+)
+from kstrl.parsers import parse_mypy_output, parse_pytest_output, parse_ruff_output, strip_ansi
+from kstrl.verify import CheckResult
+from tests.helpers.tool_output import tool_output
+
+PYTEST_FAILURES = tool_output("pytest-9.1.1-two-failures.txt")
+PYTEST_PASSING = tool_output("pytest-9.1.1-passing.txt")
+VITEST_FAILURES = tool_output("vitest-2.1.9-two-failures.txt")
+VITEST_SUITE_ERROR = tool_output("vitest-2.1.9-suite-load-error.txt")
+TSC_PLAIN = tool_output("tsc-5.6.3-plain.txt")
+TSC_PRETTY = tool_output("tsc-5.6.3-pretty.txt")
+ESLINT_STYLISH = tool_output("eslint-8.57.1-stylish.txt")
+ESLINT_UNIX = tool_output("eslint-8.57.1-unix.txt")
+ESLINT_COMPACT = tool_output("eslint-8.57.1-compact.txt")
+ESLINT_9_STYLISH = tool_output("eslint-9.39.5-stylish.txt")
+
+
+class TestVitest:
+    """The failure the issue was filed about: 0 parsed, everything dropped."""
+
+    def test_the_old_behaviour_is_the_bug(self) -> None:
+        # The baseline this PR moves. Fed to the pytest parser, which is
+        # what the gate did unconditionally, real vitest output yields
+        # nothing: no file, no line, no test name, no assertion.
+        assert parse_pytest_output(VITEST_FAILURES).failures == []
+
+    def test_both_failures_parse_with_file_line_test_and_message(self) -> None:
+        parsed = parse_gate_output(VITEST_FAILURES, GATE_TEST)
+
+        assert parsed.tool == "vitest"
+        assert [(f.file, f.line) for f in parsed.failures] == [
+            ("tests/failing.test.ts", 5),
+            ("tests/summary.test.ts", 5),
+        ]
+        assert parsed.failures[0].rule_or_test == (
+            "word counter > counts the words in a draft title"
+        )
+        assert parsed.failures[0].message == (
+            "AssertionError: expected 3 to be 4 // Object.is equality"
+        )
+        assert parsed.total_errors == 2
+
+    def test_summary_reports_the_failing_half_only(self) -> None:
+        parsed = parse_gate_output(VITEST_FAILURES, GATE_TEST)
+        assert "2 failed" in parsed.raw_summary
+        # Timing noise is not a failure summary; #258 measured a retry
+        # prompt whose entire content was vitest's Duration line.
+        assert "Duration" not in parsed.raw_summary
+
+    def test_a_suite_that_never_loaded_keeps_the_error_and_refuses_a_wrong_line(self) -> None:
+        # Measured: vitest's only stack frame for a failed import points
+        # into node_modules/vite. Sending the engineer to a line inside
+        # vite's bundle is worse than sending it no line, so the parser
+        # takes a location only from a frame in the failing file itself.
+        parsed = parse_gate_output(VITEST_SUITE_ERROR, GATE_TEST)
+
+        assert len(parsed.failures) == 1
+        failure = parsed.failures[0]
+        assert failure.file == "tests/broken-import.test.ts"
+        assert failure.line == 0
+        assert failure.message.startswith("Error: Failed to load url ../src/render-draft")
+        assert "node_modules" not in failure.file
+
+
+class TestTsc:
+    """The issue's own prediction about tsc, disproven by measurement."""
+
+    def test_no_existing_parser_reads_real_tsc_output(self) -> None:
+        # The issue expected tsc to emit `file:line:col: message` and so
+        # to be nearly free through the mypy or ruff parser. It emits
+        # `src/broken.ts(7,9): error TS2322:` through a pipe. All three
+        # of the Python parsers find nothing in it.
+        assert parse_mypy_output(TSC_PLAIN).failures == []
+        assert parse_ruff_output(TSC_PLAIN).failures == []
+        assert parse_pytest_output(TSC_PLAIN).failures == []
+
+    @pytest.mark.parametrize("raw", [TSC_PLAIN, TSC_PRETTY], ids=["plain", "pretty"])
+    def test_both_output_modes_parse_identically(self, raw: str) -> None:
+        # Piped and --pretty are different formats, not different data.
+        # An npm script may pass --pretty, so the gate has to read both.
+        parsed = parse_gate_output(raw, GATE_TYPECHECK)
+
+        assert parsed.tool == "tsc"
+        assert [(f.file, f.line, f.code) for f in parsed.failures] == [
+            ("src/broken.ts", 7, "TS2322"),
+            ("src/broken.ts", 12, "TS2339"),
+            ("src/index.ts", 4, "TS2353"),
+        ]
+        assert parsed.failures[0].message == "Type 'string' is not assignable to type 'number'."
+
+    def test_pretty_output_still_carries_its_ansi_escapes(self) -> None:
+        # Guards the fixture rather than the parser: if a hook ever
+        # strips the escapes from that file, the test above stops
+        # exercising strip_ansi and silently proves nothing.
+        assert "\x1b[" in TSC_PRETTY
+        assert "\x1b[" not in strip_ansi(TSC_PRETTY)
+
+
+class TestEslint:
+    """The rule slot, which the ruff parser filled with the wrong token."""
+
+    def test_the_old_ruff_regex_no_longer_claims_eslint_output(self) -> None:
+        # Measured before the fix: `--format unix` DID match the ruff
+        # pattern, three of three with the right file and line, and put
+        # the message's first word in the rule slot - `'cache'`,
+        # `Expected`, `'missingHelper'`. Those slugs were then harvested
+        # by evolution.py as failure signatures. Requiring a ruff-shaped
+        # code (letters then digits) is what stops it, and it is also
+        # what keeps the two parsers from double-reporting on the auto
+        # path below.
+        assert parse_ruff_output(ESLINT_UNIX).failures == []
+
+    @pytest.mark.parametrize(
+        "raw",
+        [ESLINT_STYLISH, ESLINT_UNIX, ESLINT_COMPACT],
+        ids=["stylish", "unix", "compact"],
+    )
+    def test_every_format_yields_the_real_rule_ids(self, raw: str) -> None:
+        parsed = parse_gate_output(raw, GATE_LINT)
+
+        assert parsed.tool == "eslint"
+        assert [f.code for f in parsed.failures] == [
+            "no-unused-vars",
+            "prefer-const",
+            "eqeqeq",
+            "no-undef",
+            "no-unused-vars",
+        ]
+        assert [f.line for f in parsed.failures] == [4, 4, 5, 6, 3]
+
+    def test_stylish_attaches_diagnostics_to_the_file_header_above_them(self) -> None:
+        # stylish is the DEFAULT, which is what `npm run lint` prints and
+        # what the issue's suggested `--format compact` is not. It names
+        # the file once and indents the rows beneath it.
+        parsed = parse_gate_output(ESLINT_STYLISH, GATE_LINT)
+        assert [f.file for f in parsed.failures] == [
+            "/repo/lint/draft.js",
+            "/repo/lint/draft.js",
+            "/repo/lint/draft.js",
+            "/repo/lint/draft.js",
+            "/repo/lint/render.js",
+        ]
+
+    def test_eslint_9_stylish_parses_the_same_way(self) -> None:
+        # eslint 9 removed the unix and compact formatters from core, so
+        # stylish is the only one a current install is guaranteed to
+        # have. Measured against 9.39.5: byte-for-byte the same shape.
+        parsed = parse_gate_output(ESLINT_9_STYLISH, GATE_LINT)
+        assert [f.code for f in parsed.failures] == [
+            f.code for f in parse_gate_output(ESLINT_STYLISH, GATE_LINT).failures
+        ]
+
+    def test_warnings_are_kept(self) -> None:
+        # `--max-warnings 0` makes a warning fail the gate, and dropping
+        # warnings would then hand the engineer an empty parse for a
+        # gate that genuinely failed.
+        codes = [f.code for f in parse_gate_output(ESLINT_STYLISH, GATE_LINT).failures]
+        assert "prefer-const" in codes
+
+
+class TestAutoDispatch:
+    """Unset `tool` means: run every parser for the gate, union the result."""
+
+    def test_a_chained_command_yields_both_toolchains_failures(self) -> None:
+        # The case that kills command-string sniffing. One command,
+        # `uv run pytest && (cd web && npm run test)`, two formats, both
+        # real. A dispatcher that picks ONE parser is wrong half the
+        # time; the union is right by construction.
+        parsed = parse_gate_output(PYTEST_FAILURES + VITEST_FAILURES, GATE_TEST)
+
+        assert parsed.tool == "pytest+vitest"
+        assert [f.file for f in parsed.failures] == [
+            "test_drafts.py",
+            "test_drafts.py",
+            "tests/failing.test.ts",
+            "tests/summary.test.ts",
+        ]
+        assert parsed.total_errors == 4
+
+    def test_the_passing_half_does_not_stand_in_for_the_failing_one(self) -> None:
+        # pytest passes, vitest fails. Before #258's labelling half the
+        # engineer was told "5 passed" by a gate that had just failed;
+        # now the pytest parser contributes nothing and only the failing
+        # toolchain is reported.
+        parsed = parse_gate_output(PYTEST_PASSING + VITEST_FAILURES, GATE_TEST)
+
+        assert parsed.tool == "vitest"
+        assert len(parsed.failures) == 2
+        assert "5 passed" not in "".join(parsed.format_for_prompt())
+
+    def test_a_single_toolchain_is_not_labelled_as_a_union(self) -> None:
+        assert parse_gate_output(PYTEST_FAILURES, GATE_TEST).tool == "pytest"
+        assert parse_gate_output(TSC_PLAIN, GATE_TYPECHECK).tool == "tsc"
+
+    def test_output_nobody_understands_falls_back_to_the_primary(self) -> None:
+        # The floor the labelling half of #258 put in, unchanged: the
+        # primary parser's result, tail and all, and prompt_label names
+        # the COMMAND rather than claiming a tool parsed it.
+        raw = "cargo test\nerror: could not compile `draft` due to 2 previous errors\n"
+        parsed = parse_gate_output(raw, GATE_TEST)
+
+        assert parsed.tool == "pytest"
+        assert parsed.failures == []
+        parsed.command = "cargo test"
+        assert parsed.format_for_prompt()[0].startswith("[cargo test]")
+
+    def test_ansi_coloured_output_is_parsed(self) -> None:
+        # Whichever parser gets it, it gets it clean: the strip happens
+        # once at the dispatcher rather than in six regexes.
+        assert len(parse_gate_output(TSC_PRETTY, GATE_TYPECHECK).failures) == 3
+
+    @pytest.mark.parametrize("gate", [GATE_TEST, GATE_TYPECHECK, GATE_LINT])
+    def test_every_gate_tool_has_a_registered_parser(self, gate: str) -> None:
+        # A name in GATE_TOOLS with no parser behind it is a KeyError at
+        # gate time, on the failure path, in a paid run.
+        for name in GATE_TOOLS[gate]:
+            assert name in TOOL_PARSERS
+
+
+class TestParserContract:
+    """The two rules auto dispatch depends on, enforced rather than assumed."""
+
+    @pytest.mark.parametrize("tool", sorted(TOOL_PARSERS))
+    def test_unrecognised_output_still_leaves_a_summary(self, tool: str) -> None:
+        # `parse_gate_output` returns the gate's PRIMARY parser when
+        # nothing matched, so that parser's raw tail becomes the entire
+        # retry detail. A parser that returns an empty summary makes the
+        # gate report a failure with nothing in it, silently. Every
+        # parser is checked because any of them may be promoted to
+        # primary by a reordering of GATE_TOOLS.
+        parsed = TOOL_PARSERS[tool]("gradle build FAILED\nsee the report for details\n")
+
+        assert parsed.failures == []
+        assert parsed.raw_summary != ""
+
+    @pytest.mark.parametrize(
+        ("gate", "owner", "raw"),
+        [
+            (GATE_TEST, "pytest", PYTEST_FAILURES),
+            (GATE_TEST, "vitest", VITEST_FAILURES),
+            (GATE_TEST, "vitest", VITEST_SUITE_ERROR),
+            (GATE_TYPECHECK, "tsc", TSC_PLAIN),
+            (GATE_TYPECHECK, "tsc", TSC_PRETTY),
+            (GATE_LINT, "eslint", ESLINT_STYLISH),
+            (GATE_LINT, "eslint", ESLINT_UNIX),
+            (GATE_LINT, "eslint", ESLINT_COMPACT),
+            (GATE_LINT, "eslint", ESLINT_9_STYLISH),
+        ],
+    )
+    def test_only_the_owning_parser_claims_a_fixture(self, gate: str, owner: str, raw: str) -> None:
+        # `_union` concatenates without deduplicating, so two parsers
+        # matching the same line double the failures the engineer sees
+        # and double total_errors, on the DEFAULT path. That invariant
+        # is currently held by one hand-tightened regex (ruff's rule
+        # slot); this is what says so out loud, for every pair.
+        for name in GATE_TOOLS[gate]:
+            found = TOOL_PARSERS[name](strip_ansi(raw)).failures
+            assert (found != []) is (name == owner), (
+                f"{name} should {'' if name == owner else 'not '}claim this fixture"
+            )
+
+
+class TestExplicitTool:
+    """`tool` set pins the gate to one parser, and a bad name halts."""
+
+    def test_an_override_suppresses_the_other_parser(self) -> None:
+        parsed = parse_gate_output(PYTEST_FAILURES + VITEST_FAILURES, GATE_TEST, tool="vitest")
+
+        assert parsed.tool == "vitest"
+        assert [f.file for f in parsed.failures] == [
+            "tests/failing.test.ts",
+            "tests/summary.test.ts",
+        ]
+
+    def test_an_override_that_cannot_read_the_output_reports_nothing_rather_than_guessing(
+        self,
+    ) -> None:
+        # Pinning to the wrong tool is the operator's error, and the
+        # result is an honest empty parse plus the raw tail, not a
+        # silent fallback to a parser they told kstrl not to use.
+        parsed = parse_gate_output(VITEST_FAILURES, GATE_TEST, tool="pytest")
+        assert parsed.tool == "pytest"
+        assert parsed.failures == []
+
+    @pytest.mark.parametrize("absent", [None, ""])
+    def test_absent_means_auto(self, absent: str | None) -> None:
+        assert validate_tool(GATE_TEST, absent) is None
+
+    def test_an_unknown_name_raises_and_names_the_accepted_values(self) -> None:
+        # It must not quietly become auto: the operator wrote the key to
+        # stop kstrl guessing, so guessing anyway is the failure the key
+        # exists to prevent.
+        with pytest.raises(ValueError, match="unknown tool 'jest'.*pytest, vitest"):
+            validate_tool(GATE_TEST, "jest")
+
+    def test_a_name_from_another_gate_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unknown tool 'eslint'"):
+            validate_tool(GATE_TYPECHECK, "eslint")
+
+
+class TestEvolutionSignatures:
+    """evolution.py reads a capability now, not a tool name (#258)."""
+
+    @staticmethod
+    def _signatures(raw: str, gate: str, check: str) -> list[str]:
+        parsed = parse_gate_output(raw, gate)
+        return signatures_from_verification(
+            [CheckResult(name=check, passed=False, message=f"{check} failed", parsed=parsed)]
+        )
+
+    def test_every_supported_tool_resolves_to_its_own_codes(self) -> None:
+        assert self._signatures(TSC_PLAIN, GATE_TYPECHECK, "typecheck") == [
+            "typecheck:TS2322",
+            "typecheck:TS2339",
+            "typecheck:TS2353",
+        ]
+        assert self._signatures(ESLINT_STYLISH, GATE_LINT, "linter") == [
+            "linter:no-unused-vars",
+            "linter:prefer-const",
+            "linter:eqeqeq",
+            "linter:no-undef",
+        ]
+        assert self._signatures(VITEST_FAILURES, GATE_TEST, "test_suite") == [
+            "test_suite:assertion-error"
+        ]
+
+    def test_a_unioned_label_still_resolves(self) -> None:
+        # The exact-string switch this replaced compared `parsed.tool`
+        # against "pytest", so the joined "pytest+vitest" matched nothing
+        # and every signature fell through to a prose slug of the check
+        # message. Both halves contribute now.
+        sigs = self._signatures(PYTEST_FAILURES + VITEST_FAILURES, GATE_TEST, "test_suite")
+        assert sigs == ["test_suite:assertion-error"]
+        assert not any("failed" in s.split(":", 1)[1] for s in sigs)
+
+    def test_a_gate_no_parser_read_still_produces_a_signature(self) -> None:
+        # No codes means the message slug, which is the pre-existing
+        # fallback and the only thing left when nothing parsed.
+        sigs = self._signatures("cargo test: 2 failed\n", GATE_TEST, "test_suite")
+        assert sigs == ["test_suite:test-suite-failed"]

--- a/tests/test_gateparse.py
+++ b/tests/test_gateparse.py
@@ -23,7 +23,13 @@ from kstrl.gateparse import (
     parse_gate_output,
     validate_tool,
 )
-from kstrl.parsers import parse_mypy_output, parse_pytest_output, parse_ruff_output, strip_ansi
+from kstrl.parsers import (
+    exception_code,
+    parse_mypy_output,
+    parse_pytest_output,
+    parse_ruff_output,
+    strip_ansi,
+)
 from kstrl.verify import CheckResult
 from tests.helpers.tool_output import tool_output
 
@@ -37,6 +43,19 @@ ESLINT_STYLISH = tool_output("eslint-8.57.1-stylish.txt")
 ESLINT_UNIX = tool_output("eslint-8.57.1-unix.txt")
 ESLINT_COMPACT = tool_output("eslint-8.57.1-compact.txt")
 ESLINT_9_STYLISH = tool_output("eslint-9.39.5-stylish.txt")
+RUFF_FULL = tool_output("ruff-0.16.1-full.txt")
+RUFF_CONCISE = tool_output("ruff-0.16.1-concise.txt")
+PYTEST_LONG_NAMES = tool_output("pytest-9.1.1-long-names.txt")
+PYTEST_CROSS_FILE = tool_output("pytest-9.1.1-raised-in-another-file.txt")
+
+# mypy needs no capture of its own: two lines is the whole format, and
+# the footer is the half that matters here, because tsc opens its own
+# with the same five words.
+MYPY_FAILURE = (
+    'a.py:2: error: Incompatible return value type (got "int", expected "str")'
+    "  [return-value]\n"
+    "Found 1 error in 1 file (checked 1 source file)\n"
+)
 
 
 class TestVitest:
@@ -182,6 +201,145 @@ class TestEslint:
         assert "prefer-const" in codes
 
 
+class TestRuff:
+    """The lint gate's PRIMARY parser, measured against ruff 0.16.1."""
+
+    @pytest.mark.parametrize("raw", [RUFF_CONCISE, RUFF_FULL], ids=["concise", "full"])
+    def test_both_output_formats_parse_identically(self, raw: str) -> None:
+        # `full` is ruff's DEFAULT since 0.9, so it is what kstrl's own
+        # DEFAULT_LINT_COMMAND (`uv run ruff check .`) produces, and it
+        # is two lines per diagnostic rather than one. Measured before
+        # the fix: 0 failures parsed, and the whole retry detail was
+        # `[uv run ruff check .] Found 4 errors.` The gate's primary
+        # parser could not read its own tool's default output.
+        parsed = parse_gate_output(raw, GATE_LINT)
+
+        # Messages are compared too, which is what pins that ruff's
+        # `[*]` autofix marker never reaches the engineer: it describes
+        # the fix, not the defect, and it sits between the rule and the
+        # message in both formats.
+        assert parsed.tool == "ruff"
+        assert [(f.file, f.line, f.code, f.message) for f in parsed.failures] == [
+            ("draft.py", 1, "F401", "`os` imported but unused"),
+            ("draft.py", 2, "F401", "`sys` imported but unused"),
+            ("draft.py", 6, "F841", "Local variable `cache` is assigned to but never used"),
+            ("loader.py", 1, "invalid-syntax", "Expected `)`, found newline"),
+        ]
+
+    @pytest.mark.parametrize("raw", [RUFF_CONCISE, RUFF_FULL], ids=["concise", "full"])
+    def test_a_syntax_error_keeps_its_file_and_line(self, raw: str) -> None:
+        # Ruff reports a file it cannot parse as `invalid-syntax`, with
+        # no rule code. Requiring a code-shaped rule slot dropped these
+        # entirely, which is the worst class to drop: a syntax error's
+        # file and line are the two things an agent cannot guess from
+        # the message.
+        syntax = [f for f in parse_gate_output(raw, GATE_LINT).failures if f.file == "loader.py"]
+
+        assert len(syntax) == 1
+        assert (syntax[0].line, syntax[0].code) == (1, "invalid-syntax")
+        assert syntax[0].message == "Expected `)`, found newline"
+
+    def test_the_two_formats_do_not_double_count_each_other(self) -> None:
+        # The parser runs a concise pass and a full pass over the same
+        # text. Neither format contains the other's shape, so a repo
+        # that somehow emitted both would still count each once.
+        assert len(parse_gate_output(RUFF_CONCISE + RUFF_FULL, GATE_LINT).failures) == 8
+
+
+class TestPytestTracebacks:
+    """The summary line alone cannot carry the failure (#258 review)."""
+
+    def test_long_test_names_still_yield_a_code_and_a_line(self) -> None:
+        # pytest truncates the short summary to the terminal width, 80
+        # columns under a pipe, and truncates the MESSAGE first. In this
+        # captured run two of five failures carry no message at all and
+        # one carries `AssertionErro...`, so reading the summary alone
+        # made the evolution signature depend on how long somebody had
+        # made the test name. The traceback block has it untruncated.
+        parsed = parse_gate_output(PYTEST_LONG_NAMES, GATE_TEST)
+
+        assert parsed.tool == "pytest"
+        assert [(f.line, f.code) for f in parsed.failures] == [
+            (20, "assertion-error"),
+            (11, "file-not-found-error"),
+            (30, "assertion-error"),
+            (30, "assertion-error"),
+            (16, "runtime-error"),
+        ]
+
+    def test_a_parametrized_id_with_spaces_parses(self) -> None:
+        # `FAILED f.py::test_x[a draft] - ...` did not match at all: the
+        # test id was `[^\s]+`. Every parametrized failure whose id
+        # contained a space was dropped from the parse in silence.
+        tests = [f.rule_or_test for f in parse_gate_output(PYTEST_LONG_NAMES, GATE_TEST).failures]
+        assert "test_every_title_has_exactly_one_word[a draft]" in tests
+
+    def test_a_class_based_test_is_matched_to_its_block(self) -> None:
+        # The short summary spells it `TestClass::test_method` and the
+        # traceback header spells it `TestClass.test_method`.
+        failure = next(
+            f
+            for f in parse_gate_output(PYTEST_LONG_NAMES, GATE_TEST).failures
+            if f.rule_or_test.startswith("TestDraftLoading")
+        )
+        assert (failure.line, failure.message) == (11, "FileNotFoundError: index.md")
+
+    def test_a_setup_error_is_matched_to_its_block(self) -> None:
+        # Its block header reads `ERROR at setup of <name>`.
+        failure = next(
+            f
+            for f in parse_gate_output(PYTEST_LONG_NAMES, GATE_TEST).failures
+            if f.rule_or_test == "test_uses_a_fixture_that_cannot_build"
+        )
+        assert failure.code == "runtime-error"
+
+    def test_file_and_line_come_from_the_same_frame(self) -> None:
+        # The summary names the file the TEST lives in; the traceback
+        # names the file the exception was RAISED in. Taking the line
+        # from one and the file from the other produced `test_cross.py:17`
+        # for a 7-line test file, and add_source_context would have
+        # printed whatever sat at line 17 of some longer file. The
+        # raising frame is also the better instruction.
+        parsed = parse_gate_output(PYTEST_CROSS_FILE, GATE_TEST)
+
+        assert len(parsed.failures) == 1
+        failure = parsed.failures[0]
+        assert (failure.file, failure.line) == ("loader.py", 17)
+        assert failure.rule_or_test == "test_loads_a_draft_from_a_helper_module_in_another_file"
+        assert failure.code == "file-not-found-error"
+
+    def test_a_summary_with_no_traceback_keeps_what_it_had(self) -> None:
+        # Nothing is fabricated when the block is absent: `--tb=no` and
+        # `-q` runs still parse, with line 0 as before.
+        raw = (
+            "=========================== short test summary info ============================\n"
+            "FAILED tests/test_a.py::test_x - AssertionError: nope\n"
+            "========================= 1 failed in 0.10s ==========================\n"
+        )
+        parsed = parse_gate_output(raw, GATE_TEST)
+
+        assert len(parsed.failures) == 1
+        assert parsed.failures[0].line == 0
+        assert parsed.failures[0].code == "assertion-error"
+
+
+class TestExceptionCode:
+    """A bare `Error:` is the commonest shape in JavaScript."""
+
+    def test_a_bare_error_yields_a_code(self) -> None:
+        # The class-name prefix used to be mandatory, so `Error` itself
+        # could not match. That is every vitest suite-load failure and
+        # every plain `throw new Error(...)`.
+        assert exception_code("Error: Failed to load url ../src/x") == "error"
+
+    def test_the_vitest_suite_load_fixture_carries_a_code(self) -> None:
+        parsed = parse_gate_output(VITEST_SUITE_ERROR, GATE_TEST)
+        assert [f.code for f in parsed.failures] == ["error"]
+
+    def test_a_word_merely_starting_with_error_is_not_a_code(self) -> None:
+        assert exception_code("Errors were found in the config") == ""
+
+
 class TestAutoDispatch:
     """Unset `tool` means: run every parser for the gate, union the result."""
 
@@ -257,30 +415,57 @@ class TestParserContract:
         assert parsed.failures == []
         assert parsed.raw_summary != ""
 
-    @pytest.mark.parametrize(
-        ("gate", "owner", "raw"),
-        [
-            (GATE_TEST, "pytest", PYTEST_FAILURES),
-            (GATE_TEST, "vitest", VITEST_FAILURES),
-            (GATE_TEST, "vitest", VITEST_SUITE_ERROR),
-            (GATE_TYPECHECK, "tsc", TSC_PLAIN),
-            (GATE_TYPECHECK, "tsc", TSC_PRETTY),
-            (GATE_LINT, "eslint", ESLINT_STYLISH),
-            (GATE_LINT, "eslint", ESLINT_UNIX),
-            (GATE_LINT, "eslint", ESLINT_COMPACT),
-            (GATE_LINT, "eslint", ESLINT_9_STYLISH),
-        ],
-    )
+    # Every parser of every gate appears as an owner, so the loop below
+    # also asserts the negative for each of its gate-mates. The earlier
+    # version listed only pytest, vitest, tsc and eslint, which left
+    # "eslint does not claim ruff output" and "tsc does not claim mypy
+    # output" asserted nowhere. The second of those was in fact broken.
+    _OWNED = [
+        (GATE_TEST, "pytest", PYTEST_FAILURES),
+        (GATE_TEST, "pytest", PYTEST_LONG_NAMES),
+        (GATE_TEST, "vitest", VITEST_FAILURES),
+        (GATE_TEST, "vitest", VITEST_SUITE_ERROR),
+        (GATE_TYPECHECK, "mypy", MYPY_FAILURE),
+        (GATE_TYPECHECK, "tsc", TSC_PLAIN),
+        (GATE_TYPECHECK, "tsc", TSC_PRETTY),
+        (GATE_LINT, "ruff", RUFF_CONCISE),
+        (GATE_LINT, "ruff", RUFF_FULL),
+        (GATE_LINT, "eslint", ESLINT_STYLISH),
+        (GATE_LINT, "eslint", ESLINT_UNIX),
+        (GATE_LINT, "eslint", ESLINT_COMPACT),
+        (GATE_LINT, "eslint", ESLINT_9_STYLISH),
+    ]
+
+    @pytest.mark.parametrize(("gate", "owner", "raw"), _OWNED)
     def test_only_the_owning_parser_claims_a_fixture(self, gate: str, owner: str, raw: str) -> None:
         # `_union` concatenates without deduplicating, so two parsers
         # matching the same line double the failures the engineer sees
-        # and double total_errors, on the DEFAULT path. That invariant
-        # is currently held by one hand-tightened regex (ruff's rule
-        # slot); this is what says so out loud, for every pair.
+        # and double total_errors, on the DEFAULT path.
         for name in GATE_TOOLS[gate]:
             found = TOOL_PARSERS[name](strip_ansi(raw)).failures
             assert (found != []) is (name == owner), (
                 f"{name} should {'' if name == owner else 'not '}claim this fixture"
+            )
+
+    @pytest.mark.parametrize(("gate", "owner", "raw"), _OWNED)
+    def test_a_foreign_parser_claims_no_summary_either(
+        self, gate: str, owner: str, raw: str
+    ) -> None:
+        # The failures check above does not cover this, and it is not
+        # harmless: `_union` joins every non-empty summary, so a footer
+        # two parsers both claim reaches the engineer TWICE. Measured on
+        # a chained `mypy && tsc` gate, where tsc's `^Found \d+ error`
+        # also matched mypy's footer, and tsc's own count went missing.
+        #
+        # A parser that understood nothing is still allowed its raw tail
+        # fallback, which is several lines; what it may not do is single
+        # out one line of another tool's output and call it a summary.
+        for name in GATE_TOOLS[gate]:
+            if name == owner:
+                continue
+            summary = TOOL_PARSERS[name](strip_ansi(raw)).raw_summary
+            assert "\n" in summary or summary == "", (
+                f"{name} claimed a single line of {owner} output as its summary: {summary!r}"
             )
 
 
@@ -356,6 +541,22 @@ class TestEvolutionSignatures:
         sigs = self._signatures(PYTEST_FAILURES + VITEST_FAILURES, GATE_TEST, "test_suite")
         assert sigs == ["test_suite:assertion-error"]
         assert not any("failed" in s.split(":", 1)[1] for s in sigs)
+
+    def test_a_syntax_error_signs_as_itself(self) -> None:
+        # `invalid-syntax` reaching the journal at all depends on the
+        # ruff rule slot accepting a non-code diagnostic.
+        assert "linter:invalid-syntax" in self._signatures(RUFF_FULL, GATE_LINT, "linter")
+
+    def test_long_test_names_do_not_change_the_signature(self) -> None:
+        # The whole point of reading the traceback: two runs of the same
+        # suite must sign the same way whatever the tests are called.
+        # Before, a name long enough to truncate the summary line left
+        # the code empty and the signature fell back to a prose slug.
+        assert self._signatures(PYTEST_LONG_NAMES, GATE_TEST, "test_suite") == [
+            "test_suite:assertion-error",
+            "test_suite:file-not-found-error",
+            "test_suite:runtime-error",
+        ]
 
     def test_a_gate_no_parser_read_still_produces_a_signature(self) -> None:
         # No codes means the message slug, which is the pre-existing

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -13,6 +13,7 @@ from kstrl.parsers import (
     parse_pytest_output,
     parse_ruff_output,
 )
+from tests.helpers.tool_output import tool_output
 
 # ---------------------------------------------------------------------------
 # parse_pytest_output
@@ -290,74 +291,34 @@ class TestFormatForPrompt:
 # Non-Python tool output (#258)
 # ---------------------------------------------------------------------------
 
-# Captured verbatim from a real `vitest run` (vitest 2.1.9) with one
-# deliberately failing test, ANSI escapes stripped. Every fixture in this
-# suite was Python tool output before this one, which is why the pytest
-# parser was never measured against anything it could not read.
-VITEST_FAILURE_OUTPUT = """\
- RUN  v2.1.9 /tmp/writers-room/web
- ❯ tests/failing.test.ts (2 tests | 1 failed) 3ms
-   × deliberate failure > shows what a real vitest failure looks like 2ms
-     → expected false to be true // Object.is equality
-
-⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
-
- FAIL  tests/failing.test.ts > deliberate failure > shows what a real vitest failure looks like
-AssertionError: expected false to be true // Object.is equality
-
-- Expected
-+ Received
-
-- true
-+ false
-
- ❯ tests/failing.test.ts:5:19
-      3| describe("deliberate failure", () => {
-      4|   it("shows what a real vitest failure looks like", () => {
-      5|     expect(false).toBe(true);
-       |                   ^
-      6|   });
-      7|   it("passes", () => {
-
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
-
- Test Files  1 failed (1)
-      Tests  1 failed | 1 passed (2)
-   Start at  18:13:20
-   Duration  181ms (transform 16ms, setup 0ms, collect 11ms, tests 3ms, environment 0ms, prepare 31ms)
-"""
-
-
-# Captured verbatim from a real `pytest` run where every test PASSED.
-# The polyglot gate chains toolchains (`uv run pytest && npm test`), so
-# the half that passes can be the half the parser understands.
-PYTEST_PASSING_OUTPUT = """\
-============================= test session starts ==============================
-platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0
-rootdir: /tmp/writers-room
-collected 5 items
-
-tests/test_ok.py .....                                                   [100%]
-
-============================== 5 passed in 0.00s ===============================
-"""
+# Both captured from real runs; provenance and the two normalizations
+# applied live in tests/helpers/tool_output.py. The vitest one is the
+# reporter's own writers-room repo, one deliberately failing test. The
+# pytest one is a run where every test PASSED: the polyglot gate chains
+# toolchains (`uv run pytest && npm test`), so the half that passes can
+# be the half the parser understands.
+VITEST_FAILURE_OUTPUT = tool_output("vitest-2.1.9-writers-room.txt")
+PYTEST_PASSING_OUTPUT = tool_output("pytest-9.1.1-passing.txt")
 
 
 class TestNonPythonToolOutput:
-    """The pytest parser is applied to whatever `test_command` ran.
+    """What the pytest parser ALONE does with output pytest never wrote.
 
-    `check_test_suite` has no dispatch, so a polyglot repo's
-    `uv run pytest && (cd web && npm run test)` sends vitest output
-    through `parse_pytest_output`. These tests pin what that actually
-    does, measured rather than reasoned.
+    These pin the behaviour of one parser, not of the gate. The gate no
+    longer sends vitest output here unaccompanied: `check_test_suite`
+    dispatches through `gateparse.parse_gate_output`, which also runs the
+    vitest parser and unions the result (tests/test_gateparse.py). The
+    pytest parser is still exercised on foreign text because it remains
+    the test gate's PRIMARY, so its behaviour when it understands nothing
+    is what an unrecognised toolchain still falls back to.
     """
 
     def test_vitest_output_parses_no_structured_failures(self) -> None:
-        # The known gap, recorded rather than asserted as desirable: the
+        # Unchanged and still correct: this parser knows pytest. The
         # failing file, line, test name, assertion message and the
         # expected-versus-received diff are all in the raw output and
-        # none of them survive. Closing that needs a parser that knows
-        # vitest, which is the other half of #258.
+        # none of them survive HERE. Recovering them is the vitest
+        # parser's job, and the dispatcher's job to call it.
         parsed = parse_pytest_output(VITEST_FAILURE_OUTPUT)
         assert parsed.failures == []
 
@@ -379,9 +340,10 @@ class TestNonPythonToolOutput:
         assert "[pytest]" not in "".join(lines)
 
     def test_tool_identity_is_unchanged(self) -> None:
-        # evolution.signatures_from_verification switches on
-        # `parsed.tool` by exact string, so the label change must not
-        # move it. Only the prompt label is command-derived.
+        # `tool` names the PARSER; only the prompt label is derived from
+        # the command. Nothing switches on `tool` any more (#258 moved
+        # evolution onto ParsedFailure.code), but the two fields still
+        # have to stay distinct or the label fix collapses back.
         parsed = parse_pytest_output(VITEST_FAILURE_OUTPUT)
         parsed.command = "npm run test"
         assert parsed.tool == "pytest"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -8,6 +8,8 @@ from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from kstrl.fixtures import FixturesConfig
 from kstrl.verify import (
     CheckResult,
@@ -16,6 +18,7 @@ from kstrl.verify import (
     check_bad_patterns,
     check_dead_code,
     check_diff_scope,
+    check_linter,
     check_mutation_score,
     check_prd_stories,
     check_self_critique,
@@ -162,6 +165,38 @@ class TestCheckTestSuite:
 
         assert result.passed is False
         assert result.details[0].startswith("[pytest]")
+
+
+class TestLinterGateReadsRuffDefaults:
+    """#258 review: the lint gate could not read its own default command.
+
+    `DEFAULT_LINT_COMMAND` is `uv run ruff check .`, and ruff's default
+    output format has been `full` since 0.9. The parser read only
+    `--output-format=concise`, so the gate's primary parser returned
+    zero failures on the harness's own default invocation and the whole
+    retry detail was the `Found N errors.` footer.
+    """
+
+    def _run(self, tmp_path: Path, fixture: str) -> CheckResult:
+        raw = tool_output(fixture)
+        script = tmp_path / "fake_ruff.py"
+        script.write_text(f"import sys\nsys.stdout.write({raw!r})\nsys.exit(1)\n")
+        return check_linter(tmp_path, command=f"{sys.executable} {script}", timeout=30.0)
+
+    @pytest.mark.parametrize(
+        "fixture",
+        ["ruff-0.16.1-full.txt", "ruff-0.16.1-concise.txt"],
+        ids=["default-full", "concise"],
+    )
+    def test_the_gate_carries_file_line_and_rule(self, tmp_path: Path, fixture: str) -> None:
+        result = self._run(tmp_path, fixture)
+
+        assert result.passed is False
+        assert result.parsed is not None
+        assert result.parsed.tool == "ruff"
+        detail = "".join(result.details)
+        assert "draft.py:1 [F401]" in detail
+        assert "loader.py:1 [invalid-syntax]" in detail
 
 
 class TestCheckTypecheck:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -23,7 +23,9 @@ from kstrl.verify import (
     check_typecheck,
     run_mechanical_verification,
 )
-from tests.test_parsers import VITEST_FAILURE_OUTPUT
+from tests.helpers.tool_output import tool_output
+
+VITEST_FAILURE_OUTPUT = tool_output("vitest-2.1.9-writers-room.txt")
 
 
 class TestCheckPrdStories:
@@ -107,13 +109,14 @@ class TestCheckTestSuite:
         assert result.passed is False
         assert "timed out" in result.message
 
-    def test_unparsed_output_is_labelled_with_the_command(self, tmp_path: Path) -> None:
-        """#258: a vitest failure reached the engineer tagged [pytest].
+    def test_vitest_output_reaches_the_gate_parsed(self, tmp_path: Path) -> None:
+        """#258: a vitest failure reached the engineer tagged [pytest]
+        with every actionable line stripped out.
 
-        `check_test_suite` parses every gate as pytest whatever the
-        configured command was, so the label pointed the implementing
-        agent at the wrong toolchain and the wrong half of the repo.
-        The command is the one name that cannot be wrong.
+        The label was the first half of the fix and this is the second:
+        the gate dispatches, so the retry detail now carries the failing
+        file, its line, the test name and the assertion message that were
+        all in the raw output and all dropped.
         """
         script = tmp_path / "fake_vitest.py"
         script.write_text(f"import sys\nsys.stdout.write({VITEST_FAILURE_OUTPUT!r})\nsys.exit(1)\n")
@@ -122,12 +125,28 @@ class TestCheckTestSuite:
         result = check_test_suite(tmp_path, command=command, timeout=30.0)
 
         assert result.passed is False
+        assert result.parsed is not None
+        assert result.parsed.tool == "vitest"
+        assert "[pytest]" not in "".join(result.details)
+        detail = "".join(result.details)
+        assert "tests/failing.test.ts:5" in detail
+        assert "shows what a real vitest failure looks like" in detail
+        assert "expected false to be true" in detail
+
+    def test_output_no_parser_reads_is_still_labelled_with_the_command(
+        self, tmp_path: Path
+    ) -> None:
+        """The #258 labelling floor, kept for a toolchain kstrl has no
+        parser for. The command is the one name that cannot be wrong."""
+        script = tmp_path / "fake_cargo.py"
+        script.write_text("import sys\nprint('error: could not compile `draft`')\nsys.exit(101)\n")
+        command = f"{sys.executable} {script}"
+
+        result = check_test_suite(tmp_path, command=command, timeout=30.0)
+
+        assert result.passed is False
         assert result.details[0].startswith(f"[{command}]")
         assert "[pytest]" not in "".join(result.details)
-        # The parser identity is untouched, so evolution's exact-string
-        # switch on parsed.tool still resolves.
-        assert result.parsed is not None
-        assert result.parsed.tool == "pytest"
 
     def test_parsed_pytest_output_keeps_the_tool_label(self, tmp_path: Path) -> None:
         script = tmp_path / "fake_pytest.py"
@@ -154,15 +173,32 @@ class TestCheckTypecheck:
         result = check_typecheck(tmp_path, command="false", timeout=5.0)
         assert result.passed is False
 
-    def test_unparsed_output_is_labelled_with_the_command(self, tmp_path: Path) -> None:
-        """The typecheck gate runs whatever `typecheck_command` is and
-        parses it as mypy, so a `tsc` failure had the same #258
-        mislabel. All three gates go through one builder now; this pins
-        that the second one is not left behind."""
+    def test_tsc_output_reaches_the_gate_parsed(self, tmp_path: Path) -> None:
+        """#258: the typecheck gate parsed everything as mypy, so a real
+        `tsc` failure arrived with 0 findings under a `[mypy]` label. The
+        gate dispatches now, and the assertion is on the DETAIL rather
+        than the label: file, line, error code and message all present."""
+        raw = tool_output("tsc-5.6.3-plain.txt")
         script = tmp_path / "fake_tsc.py"
-        script.write_text(
-            "import sys\nprint('src/a.ts(5,3): error TS2322: not assignable')\nsys.exit(2)\n"
-        )
+        script.write_text(f"import sys\nsys.stdout.write({raw!r})\nsys.exit(2)\n")
+        command = f"{sys.executable} {script}"
+
+        result = check_typecheck(tmp_path, command=command, timeout=30.0)
+
+        assert result.passed is False
+        assert result.parsed is not None
+        assert result.parsed.tool == "tsc"
+        assert "  src/broken.ts:7 [TS2322] Type 'string' is not assignable" in result.details[0]
+        assert "[mypy]" not in "".join(result.details)
+
+    def test_output_no_parser_reads_is_still_labelled_with_the_command(
+        self, tmp_path: Path
+    ) -> None:
+        """The #258 labelling floor, kept: an unrecognised toolchain
+        falls back to the raw tail named by the command that ran, never
+        by a parser that did not read it."""
+        script = tmp_path / "fake_checker.py"
+        script.write_text("import sys\nprint('go: cannot find package')\nsys.exit(2)\n")
         command = f"{sys.executable} {script}"
 
         result = check_typecheck(tmp_path, command=command, timeout=30.0)

--- a/tests/tool_output/eslint-8.57.1-compact.txt
+++ b/tests/tool_output/eslint-8.57.1-compact.txt
@@ -1,0 +1,7 @@
+/repo/lint/draft.js: line 4, col 7, Error - 'cache' is assigned a value but never used. (no-unused-vars)
+/repo/lint/draft.js: line 4, col 7, Warning - 'cache' is never reassigned. Use 'const' instead. (prefer-const)
+/repo/lint/draft.js: line 5, col 12, Error - Expected '===' and instead saw '=='. (eqeqeq)
+/repo/lint/draft.js: line 6, col 12, Error - 'missingHelper' is not defined. (no-undef)
+/repo/lint/render.js: line 3, col 30, Error - 'unusedOption' is defined but never used. (no-unused-vars)
+
+5 problems

--- a/tests/tool_output/eslint-8.57.1-stylish.txt
+++ b/tests/tool_output/eslint-8.57.1-stylish.txt
@@ -1,0 +1,11 @@
+/repo/lint/draft.js
+  4:7   error    'cache' is assigned a value but never used        no-unused-vars
+  4:7   warning  'cache' is never reassigned. Use 'const' instead  prefer-const
+  5:12  error    Expected '===' and instead saw '=='               eqeqeq
+  6:12  error    'missingHelper' is not defined                    no-undef
+
+/repo/lint/render.js
+  3:30  error  'unusedOption' is defined but never used  no-unused-vars
+
+✖ 5 problems (4 errors, 1 warning)
+  0 errors and 1 warning potentially fixable with the `--fix` option.

--- a/tests/tool_output/eslint-8.57.1-unix.txt
+++ b/tests/tool_output/eslint-8.57.1-unix.txt
@@ -1,0 +1,7 @@
+/repo/lint/draft.js:4:7: 'cache' is assigned a value but never used. [Error/no-unused-vars]
+/repo/lint/draft.js:4:7: 'cache' is never reassigned. Use 'const' instead. [Warning/prefer-const]
+/repo/lint/draft.js:5:12: Expected '===' and instead saw '=='. [Error/eqeqeq]
+/repo/lint/draft.js:6:12: 'missingHelper' is not defined. [Error/no-undef]
+/repo/lint/render.js:3:30: 'unusedOption' is defined but never used. [Error/no-unused-vars]
+
+5 problems

--- a/tests/tool_output/eslint-9.39.5-stylish.txt
+++ b/tests/tool_output/eslint-9.39.5-stylish.txt
@@ -1,0 +1,11 @@
+/repo/lint/draft.js
+  2:7   error    'cache' is assigned a value but never used        no-unused-vars
+  2:7   warning  'cache' is never reassigned. Use 'const' instead  prefer-const
+  3:12  error    Expected '===' and instead saw '=='               eqeqeq
+  4:12  error    'missingHelper' is not defined                    no-undef
+
+/repo/lint/render.js
+  3:30  error  'unusedOption' is defined but never used  no-unused-vars
+
+✖ 5 problems (4 errors, 1 warning)
+  0 errors and 1 warning potentially fixable with the `--fix` option.

--- a/tests/tool_output/pytest-9.1.1-long-names.txt
+++ b/tests/tool_output/pytest-9.1.1-long-names.txt
@@ -1,0 +1,72 @@
+============================= test session starts ==============================
+platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0
+rootdir: /repo
+collected 5 items
+
+test_drafts.py FFFFE                                                     [100%]
+
+==================================== ERRORS ====================================
+___________ ERROR at setup of test_uses_a_fixture_that_cannot_build ____________
+
+    @pytest.fixture
+    def broken_fixture() -> str:
+>       raise RuntimeError("the fixture could not build a draft")
+E       RuntimeError: the fixture could not build a draft
+
+test_drafts.py:16: RuntimeError
+=================================== FAILURES ===================================
+_____ test_counts_the_words_in_a_draft_title_and_keeps_the_original_casing _____
+
+    def test_counts_the_words_in_a_draft_title_and_keeps_the_original_casing() -> None:
+>       assert count_words("a short title") == 4
+E       AssertionError: assert 3 == 4
+E        +  where 3 = count_words('a short title')
+
+test_drafts.py:20: AssertionError
+______ TestDraftLoading.test_loads_a_draft_from_disk_when_the_path_exists ______
+
+self = <test_drafts.TestDraftLoading object at 0x1044b8e30>
+
+    def test_loads_a_draft_from_disk_when_the_path_exists(self) -> None:
+>       assert load_draft("index.md") == "# Index"
+               ^^^^^^^^^^^^^^^^^^^^^^
+
+test_drafts.py:25:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+path = 'index.md'
+
+    def load_draft(path: str) -> str:
+>       raise FileNotFoundError(path)
+E       FileNotFoundError: index.md
+
+test_drafts.py:11: FileNotFoundError
+________________ test_every_title_has_exactly_one_word[a draft] ________________
+
+title = 'a draft'
+
+    @pytest.mark.parametrize("title", ["a draft", "another draft"])
+    def test_every_title_has_exactly_one_word(title: str) -> None:
+>       assert count_words(title) == 1
+E       AssertionError: assert 2 == 1
+E        +  where 2 = count_words('a draft')
+
+test_drafts.py:30: AssertionError
+_____________ test_every_title_has_exactly_one_word[another draft] _____________
+
+title = 'another draft'
+
+    @pytest.mark.parametrize("title", ["a draft", "another draft"])
+    def test_every_title_has_exactly_one_word(title: str) -> None:
+>       assert count_words(title) == 1
+E       AssertionError: assert 2 == 1
+E        +  where 2 = count_words('another draft')
+
+test_drafts.py:30: AssertionError
+=========================== short test summary info ============================
+FAILED test_drafts.py::test_counts_the_words_in_a_draft_title_and_keeps_the_original_casing
+FAILED test_drafts.py::TestDraftLoading::test_loads_a_draft_from_disk_when_the_path_exists
+FAILED test_drafts.py::test_every_title_has_exactly_one_word[a draft] - Asser...
+FAILED test_drafts.py::test_every_title_has_exactly_one_word[another draft]
+ERROR test_drafts.py::test_uses_a_fixture_that_cannot_build - RuntimeError: t...
+========================== 4 failed, 1 error in 0.01s ==========================

--- a/tests/tool_output/pytest-9.1.1-passing.txt
+++ b/tests/tool_output/pytest-9.1.1-passing.txt
@@ -1,0 +1,8 @@
+============================= test session starts ==============================
+platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0
+rootdir: /tmp/writers-room
+collected 5 items
+
+tests/test_ok.py .....                                                   [100%]
+
+============================== 5 passed in 0.00s ===============================

--- a/tests/tool_output/pytest-9.1.1-raised-in-another-file.txt
+++ b/tests/tool_output/pytest-9.1.1-raised-in-another-file.txt
@@ -1,0 +1,27 @@
+============================= test session starts ==============================
+platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0
+rootdir: /repo
+collected 1 item
+
+test_cross.py F                                                          [100%]
+
+=================================== FAILURES ===================================
+___________ test_loads_a_draft_from_a_helper_module_in_another_file ____________
+
+    def test_loads_a_draft_from_a_helper_module_in_another_file() -> None:
+>       assert load_draft("index.md") == "# Index"
+               ^^^^^^^^^^^^^^^^^^^^^^
+
+test_cross.py:7:
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+path = 'index.md'
+
+    def load_draft(path: str) -> str:
+>       raise FileNotFoundError(path)
+E       FileNotFoundError: index.md
+
+loader.py:17: FileNotFoundError
+=========================== short test summary info ============================
+FAILED test_cross.py::test_loads_a_draft_from_a_helper_module_in_another_file
+============================== 1 failed in 0.01s ===============================

--- a/tests/tool_output/pytest-9.1.1-two-failures.txt
+++ b/tests/tool_output/pytest-9.1.1-two-failures.txt
@@ -1,0 +1,32 @@
+============================= test session starts ==============================
+platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0
+rootdir: /repo
+collected 4 items
+
+test_drafts.py F.F.                                                      [100%]
+
+=================================== FAILURES ===================================
+____________________ test_counts_the_words_in_a_draft_title ____________________
+
+    def test_counts_the_words_in_a_draft_title() -> None:
+>       assert count_words("a short title") == 4
+E       AssertionError: assert 3 == 4
+E        +  where 3 = count_words('a short title')
+
+test_drafts.py:13: AssertionError
+_____________________ test_renders_the_title_and_the_count _____________________
+
+    def test_renders_the_title_and_the_count() -> None:
+>       assert summarize("a draft") == {"title": "a draft", "words": 3}
+E       AssertionError: assert {'title': 'a ...', 'words': 2} == {'title': 'a ...', 'words': 3}
+E
+E         Omitting 1 identical items, use -vv to show
+E         Differing items:
+E         {'words': 2} != {'words': 3}
+E         Use -v to get more diff
+
+test_drafts.py:21: AssertionError
+=========================== short test summary info ============================
+FAILED test_drafts.py::test_counts_the_words_in_a_draft_title - AssertionErro...
+FAILED test_drafts.py::test_renders_the_title_and_the_count - AssertionError:...
+========================= 2 failed, 2 passed in 0.01s ==========================

--- a/tests/tool_output/ruff-0.16.1-concise.txt
+++ b/tests/tool_output/ruff-0.16.1-concise.txt
@@ -1,0 +1,6 @@
+draft.py:1:8: F401 [*] `os` imported but unused
+draft.py:2:8: F401 [*] `sys` imported but unused
+draft.py:6:5: F841 Local variable `cache` is assigned to but never used
+loader.py:1:20: invalid-syntax: Expected `)`, found newline
+Found 4 errors.
+[*] 2 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).

--- a/tests/tool_output/ruff-0.16.1-full.txt
+++ b/tests/tool_output/ruff-0.16.1-full.txt
@@ -1,0 +1,46 @@
+F401 [*] `os` imported but unused
+ --> draft.py:1:8
+  |
+1 | import os
+  |        ^^
+2 | import sys
+  |
+help: Remove unused import: `os`
+  |
+  - import os
+1 | import sys
+  |
+
+F401 [*] `sys` imported but unused
+ --> draft.py:2:8
+  |
+1 | import os
+2 | import sys
+  |        ^^^
+help: Remove unused import: `sys`
+  |
+1 | import os
+  - import sys
+2 |
+  |
+
+F841 Local variable `cache` is assigned to but never used
+ --> draft.py:6:5
+  |
+5 | def render(title, unused_arg):
+6 |     cache = 1
+  |     ^^^^^
+7 |     return f"<article>{title}</article>"
+  |
+help: Remove assignment to unused variable `cache`
+
+invalid-syntax: Expected `)`, found newline
+ --> loader.py:1:20
+  |
+1 | def load_draft(path
+  |                    ^
+2 |     return path
+  |
+
+Found 4 errors.
+[*] 2 fixable with the `--fix` option (1 hidden fix can be enabled with the `--unsafe-fixes` option).

--- a/tests/tool_output/tsc-5.6.3-plain.txt
+++ b/tests/tool_output/tsc-5.6.3-plain.txt
@@ -1,0 +1,3 @@
+src/broken.ts(7,9): error TS2322: Type 'string' is not assignable to type 'number'.
+src/broken.ts(12,16): error TS2339: Property 'words' does not exist on type 'Draft'.
+src/index.ts(4,49): error TS2353: Object literal may only specify known properties, and 'extra' does not exist in type 'Draft'.

--- a/tests/tool_output/tsc-5.6.3-pretty.txt
+++ b/tests/tool_output/tsc-5.6.3-pretty.txt
@@ -1,0 +1,21 @@
+[96msrc/broken.ts[0m:[93m7[0m:[93m9[0m - [91merror[0m[90m TS2322: [0mType 'string' is not assignable to type 'number'.
+
+[7m7[0m   const words: number = draft.title;
+[7m [0m [91m        ~~~~~[0m
+
+[96msrc/broken.ts[0m:[93m12[0m:[93m16[0m - [91merror[0m[90m TS2339: [0mProperty 'words' does not exist on type 'Draft'.
+
+[7m12[0m   return draft.words;
+[7m  [0m [91m               ~~~~~[0m
+
+[96msrc/index.ts[0m:[93m4[0m:[93m49[0m - [91merror[0m[90m TS2353: [0mObject literal may only specify known properties, and 'extra' does not exist in type 'Draft'.
+
+[7m4[0m   return summarize({ title: name, wordCount: 1, extra: true });
+[7m [0m [91m                                                ~~~~~[0m
+
+
+Found 3 errors in 2 files.
+
+Errors  Files
+     2  src/broken.ts[90m:7[0m
+     1  src/index.ts[90m:4[0m

--- a/tests/tool_output/vitest-2.1.9-suite-load-error.txt
+++ b/tests/tool_output/vitest-2.1.9-suite-load-error.txt
@@ -1,0 +1,16 @@
+ RUN  v2.1.9 /repo
+
+ ❯ tests/broken-import.test.ts (0 test)
+
+⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  tests/broken-import.test.ts [ tests/broken-import.test.ts ]
+Error: Failed to load url ../src/render-draft (resolved id: ../src/render-draft) in /repo/tests/broken-import.test.ts. Does the file exist?
+ ❯ loadAndTransform node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:51969:17
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+ Test Files  1 failed (1)
+      Tests  no tests
+   Start at  20:48:13
+   Duration  183ms (transform 14ms, setup 0ms, collect 0ms, tests 0ms, environment 0ms, prepare 24ms)

--- a/tests/tool_output/vitest-2.1.9-two-failures.txt
+++ b/tests/tool_output/vitest-2.1.9-two-failures.txt
@@ -1,0 +1,56 @@
+ RUN  v2.1.9 /repo
+
+ ❯ tests/failing.test.ts (3 tests | 1 failed) 3ms
+   × word counter > counts the words in a draft title 3ms
+     → expected 3 to be 4 // Object.is equality
+ ❯ tests/summary.test.ts (2 tests | 1 failed) 4ms
+   × draft summary > renders the title and the count 3ms
+     → expected { title: 'a draft', words: 2 } to deeply equal { title: 'a draft', words: 3 }
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  tests/failing.test.ts > word counter > counts the words in a draft title
+AssertionError: expected 3 to be 4 // Object.is equality
+
+- Expected
++ Received
+
+- 4
++ 3
+
+ ❯ tests/failing.test.ts:5:41
+      3| describe("word counter", () => {
+      4|   it("counts the words in a draft title", () => {
+      5|     expect(countWords("a short title")).toBe(4);
+       |                                         ^
+      6|   });
+      7|
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯
+
+ FAIL  tests/summary.test.ts > draft summary > renders the title and the count
+AssertionError: expected { title: 'a draft', words: 2 } to deeply equal { title: 'a draft', words: 3 }
+
+- Expected
++ Received
+
+  Object {
+    "title": "a draft",
+-   "words": 3,
++   "words": 2,
+  }
+
+ ❯ tests/summary.test.ts:5:34
+      3| describe("draft summary", () => {
+      4|   it("renders the title and the count", () => {
+      5|     expect(summarize("a draft")).toEqual({ title: "a draft", words: 3 …
+       |                                  ^
+      6|   });
+      7|
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯
+
+ Test Files  2 failed (2)
+      Tests  2 failed | 3 passed (5)
+   Start at  20:44:28
+   Duration  186ms (transform 24ms, setup 0ms, collect 22ms, tests 7ms, environment 0ms, prepare 50ms)

--- a/tests/tool_output/vitest-2.1.9-writers-room.txt
+++ b/tests/tool_output/vitest-2.1.9-writers-room.txt
@@ -1,0 +1,30 @@
+ RUN  v2.1.9 /tmp/writers-room/web
+ ❯ tests/failing.test.ts (2 tests | 1 failed) 3ms
+   × deliberate failure > shows what a real vitest failure looks like 2ms
+     → expected false to be true // Object.is equality
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  tests/failing.test.ts > deliberate failure > shows what a real vitest failure looks like
+AssertionError: expected false to be true // Object.is equality
+
+- Expected
++ Received
+
+- true
++ false
+
+ ❯ tests/failing.test.ts:5:19
+      3| describe("deliberate failure", () => {
+      4|   it("shows what a real vitest failure looks like", () => {
+      5|     expect(false).toBe(true);
+       |                   ^
+      6|   });
+      7|   it("passes", () => {
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
+
+ Test Files  1 failed (1)
+      Tests  1 failed | 1 passed (2)
+   Start at  18:13:20
+   Duration  181ms (transform 16ms, setup 0ms, collect 11ms, tests 3ms, environment 0ms, prepare 31ms)


### PR DESCRIPTION
Fixes #258.

PR #278 fixed the **misdirection** half: a foreign tool's output is no longer labelled `[pytest]`. This is the **content** half. Measured on real output, not reasoned from the code:

| input | before | after |
|---|---|---|
| real failing vitest run | 0 failures parsed | 2, with file, line, test name and assertion |
| real failing `tsc` run | 0 | 3, with file, line, `TS####` and message |
| real failing `eslint` run (stylish, the default) | 0 | 5, with file, line and the real rule id |
| `eslint --format unix` | 3, rule recorded as `'cache'` / `Expected` / `'missingHelper'` | 3, correct rule ids |

## The dispatch design

A per-gate `tool` key: `[verify] test_tool` / `typecheck_tool` / `lint_tool`, plus `KSTRL_VERIFY_*_TOOL`, default unset. Unset means **auto**: run every parser registered for the gate and **union** the failures. The neutral raw passthrough from #278 stays as the floor when no parser matches anything.

Why union rather than the alternatives:

- **Command-string sniffing, rejected.** The chain that motivated the issue, `uv run pytest -q && cd web && npm run test`, contains both `pytest` and `npm`, so a substring rule must pick one and is wrong half the time. It also fails the most common invocations of all, `npm run test` / `make test` / `just test`, where no tool name appears anywhere. A command string is not evidence of the tool.
- **Try every parser and pick a winner, rejected.** A wrong pick is a silent semantic substitution, and no tie-break can serve the chain case where one command legitimately emits two formats and both are real.
- **Union.** No tie-break to get wrong, the chain case works by construction, and a parser that understood nothing contributes nothing. The tie-break question disappears rather than being answered.

An unknown `tool` value raises on config load naming the accepted values. It must not quietly become auto: the operator wrote the key to stop kstrl guessing.

## Tools supported, and skipped

**Supported:** pytest, mypy, ruff (existing), plus **vitest**, **tsc** and **eslint**. eslint reads all three formats, stylish included, because stylish is the default that `npm run lint` actually prints and is the only one eslint 9 still ships in core.

**Deliberately skipped:** jest, cargo, `go test`, biome. Adding one is a parse function, one entry in `TOOL_PARSERS` and `GATE_TOOLS`, and one captured fixture; `kstrl/parsers_web.py`'s module docstring says where the function goes and states the two invariants a new parser owes the dispatcher, both of which are enforced by tests rather than by convention.

## Two of the issue's own predictions, disproven by measurement

- **tsc.** The issue expected `file:line:col: message`, matching the mypy pattern "close to free". Through a pipe it emits `src/broken.ts(7,9): error TS2322: ...` with **parentheses**, and under `--pretty` it emits `src/broken.ts:7:9 - error TS2322: ...`. All three existing parsers returned 0 failures on real tsc output. It needed its own regexes, one per mode.
- **eslint.** `--format unix` did parse through `parse_ruff_output`, three of three with the right file and line, but the rule slot took the message's first word and left the real rule id at the end of the line. Those slugs were fed to `evolution.py` as failure signatures. `--format compact`, which the issue names, did not parse at all. `_RUFF_ERROR_RE`'s rule slot is now a ruff-shaped code (`[A-Z]{1,6}\d{1,5}`), which fixes the garbage and keeps the two parsers off each other's lines on the auto path.

## The consumer that would have broken

`evolution.signatures_from_verification` switched on `ParsedOutput.tool` against the exact strings `"ruff"`, `"mypy"` and `"pytest"`. That is a name check standing in for a capability check, and it broke twice over as soon as a gate could dispatch: a newly supported tool fell silently through to a prose slug, and the unioned `"pytest+vitest"` label matched nothing at all.

The parser now names its own signature in `ParsedFailure.code` (a linter rule, a checker error code, or the exception class a test died on), and the switch is gone. `ParsedOutput.tool` is documented as a label, never a switch. `propose_improvements` went with it: it was writing "check ruff/flake8 docs" for an eslint rule and "review `[tool.mypy]` in pyproject.toml" for a `TS2322`, in files `ks evolve` writes to disk.

## Fixtures

Eleven captures under `tests/tool_output/`, every one produced by running the named tool at the named version against a deliberately broken toy project. Provenance and the two normalizations applied (machine paths replaced with `/repo`; trailing whitespace and blank last lines removed, because the repo's hygiene hooks impose both) are documented in `tests/helpers/tool_output.py`. `tsc-5.6.3-pretty.txt` keeps its real ANSI escapes, and a test asserts it still does, so `strip_ansi` is exercised against real escapes rather than a hand-typed `\x1b[31m`.

The two inline captures #278 added move into that directory unchanged, so there is one home for real tool output rather than two.

## Also in the diff

- `strip_ansi` at the dispatcher, once, rather than in six regexes. `tsc --pretty` colours its output through a pipe.
- Absolute paths in a parsed failure's `file` are made worktree-relative via the existing `config.relative_to_root`. eslint's default formatter prints absolute paths, and a path rooted in kstrl's throwaway worktree is correct on disk and useless as an instruction.
- `VerifyConfig.load`'s fourteen-branch `if "key" in section` chain became a table. Its cyclomatic complexity was already twice the repo's ratchet limit before this change added three keys to it.
- `check_test_suite`'s dead `in_short_summary` flag removed; it only ever gated skipping one line, which a plain `continue` does.

## Verification

`uv run pytest tests/ -q` (3811 passed, 28 skipped), `uv run mypy kstrl/ --strict`, `uv run ruff check kstrl/ tests/`, `pre-commit run --all-files`, all green locally. Coverage 88.94% total against the 79.91% ratchet; `kstrl/parsers.py` 98.9%, `kstrl/parsers_web.py` 97.2%. No `*_PROMPT` constant was touched and `tests/test_prompt_versions.py` passes.

`/simplify` ran over the change. Applied: the redundant single-parser branch in `parse_gate_output`, the duplicate ANSI and "N failed" regexes, an unused-named-group cleanup, a `groupdict().get` that could not fail, a `partial` hop in the config table, six dead `raw_summary` assignments, and a measured quadratic-backtracking cliff in the eslint patterns (`.+?` to `[^:]+`: 1475 ms to 0.37 ms on a 56 KB line). It also added the two contract tests named above. Skipped, with reasons: collapsing the three near-identical `check_*` gate functions into one (restructures three public functions beyond this change), normalizing paths inside tool-written prose as well as `failure.file` (string-substituting a tool's own sentences is a different and less safe mechanism), and splitting `kstrl/parsers.py` into a package (the 800-line ratchet is what forced the current seam).

Note: the `atlas` check will fail. `docs/atlas/` is deliberately byte-identical to main.
