### PR TITLE
fix(prompt): step 9 defers to the injected verify block, and names lint

### DIFF
--- a/docs/control-loop-design.md
+++ b/docs/control-loop-design.md
@@ -594,7 +594,7 @@ stories (`review.py:547`). The second sensor exists and is simply not consulted.
 **A correction to the earlier draft.** That draft claimed this crosses the H3
 prompt-versioning boundary, because the engineer prompt's step 14 would become
 misleading. On re-reading, it does not. Step 14 says "set that story's `passes`
-to `true` (only after tests/typecheck pass AND the self-critique is written)".
+to `true` (only after step 9 is green AND the self-critique is written)".
 That instruction stays exactly correct. What changes is not what the agent is
 asked to do; it is that its claim stops being the sole authority. The flag was
 always a claim. The harness just started treating it as one.

--- a/examples/uv-python/scripts/kstrl/prompt.md
+++ b/examples/uv-python/scripts/kstrl/prompt.md
@@ -21,14 +21,16 @@ reviewer as already reading your diff while you write it.
    (verify only; do not switch)
 7. Pick the highest priority story where `passes` is `false` (lowest `priority` wins)
 8. Implement that ONE story (keep the change small and focused)
-9. Run feedback loops (Python + uv):
-   - Find the project's fastest typecheck and tests
-   - Use `uv run ...` to run them
-   - If the project has no typecheck/tests configured, add them (prefer `ruff` + `mypy`
-     or `pyright` + `pytest`)
-     and ensure they run fast and deterministically
-   - Do NOT mark the story as done unless typecheck AND tests pass. If they fail, fix and rerun;
-     only proceed when both are green.
+9. Run the verification commands:
+   - Run every command in the `Verification Commands (resolved by kstrl)` block
+     above, lint included, exactly as written. Do NOT derive your own or substitute
+     a narrower or broader variant (an added path, a `-k` filter, a dropped flag):
+     a command the gate will not run proves nothing.
+   - If that block is absent, no mechanical gate runs on this iteration. Verify in
+     proportion to what you changed.
+   - Do NOT mark the story as done until every command passes. If one fails because
+     the project has no such tooling configured, configure the tooling rather than
+     swapping the command.
 10. If you discover durable, reusable codebase facts, append a brief, evidence-based note to
    `$codebase_map_path` under **Iteration Notes** or update **Quick Facts**
    (skip if nothing new).
@@ -50,7 +52,7 @@ reviewer as already reading your diff while you write it.
     fail the mechanical check.
 13. Commit with message: `feat: [ID] - [Title]`
 14. Update `$prd_path`: set that story's `passes` to `true`
-    (only after tests/typecheck pass AND the self-critique is written)
+    (only after step 9's commands pass AND the self-critique is written)
 15. Append learnings to `$progress_path`
 
 ## PRD ambiguity

--- a/examples/uv-python/scripts/kstrl/prompt.md
+++ b/examples/uv-python/scripts/kstrl/prompt.md
@@ -26,11 +26,14 @@ reviewer as already reading your diff while you write it.
      above, lint included, exactly as written. Do NOT derive your own or substitute
      a narrower or broader variant (an added path, a `-k` filter, a dropped flag):
      a command the gate will not run proves nothing.
-   - If that block is absent, no mechanical gate runs on this iteration. Verify in
-     proportion to what you changed.
-   - Do NOT mark the story as done until every command passes. If one fails because
-     the project has no such tooling configured, configure the tooling rather than
-     swapping the command.
+   - If a command fails for a reason other than your work, fix the cause and never
+     substitute a different command. Missing tooling is yours to configure. A
+     command that is wrong for this project's language is not: name the `[verify]`
+     section of `kstrl.toml` in your progress entry rather than editing it, because
+     kstrl's policy envelope can treat that edit as tampering.
+   - Do NOT mark the story as done until every command passes. If that block is
+     absent, nothing will check this work mechanically: run the project's own
+     typecheck and tests yourself first.
 10. If you discover durable, reusable codebase facts, append a brief, evidence-based note to
    `$codebase_map_path` under **Iteration Notes** or update **Quick Facts**
    (skip if nothing new).
@@ -52,7 +55,7 @@ reviewer as already reading your diff while you write it.
     fail the mechanical check.
 13. Commit with message: `feat: [ID] - [Title]`
 14. Update `$prd_path`: set that story's `passes` to `true`
-    (only after step 9's commands pass AND the self-critique is written)
+    (only after step 9 is green AND the self-critique is written)
 15. Append learnings to `$progress_path`
 
 ## PRD ambiguity

--- a/kstrl/contract.py
+++ b/kstrl/contract.py
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING
 
 from kstrl import git
 from kstrl.manifest import Manifest
-from kstrl.verify import run_scrubbed
+from kstrl.verify import DEFAULT_TEST_COMMAND, run_scrubbed
 
 if TYPE_CHECKING:
     from kstrl.ui.base import UI
@@ -76,7 +76,13 @@ class ContractConfig:
     """Configuration for contract testing."""
 
     mode: str = ContractMode.TIER.value
-    test_command: str = "uv run pytest"
+    #: #276: Phase 3 runs the merged tiers through the same suite Phase 1
+    #: ran per component, so the default is the Phase 1 constant rather
+    #: than a second literal that happens to agree with it today. Note
+    #: this only shares the DEFAULT: a project that sets
+    #: ``[verify] test_command`` does not move Phase 3 with it, because
+    #: ``load`` reads only ``[contract]``.
+    test_command: str = DEFAULT_TEST_COMMAND
     timeout: float = 600.0
 
     def __post_init__(self) -> None:
@@ -93,7 +99,7 @@ class ContractConfig:
         """Load contract config from environment variables."""
         return cls(
             mode=os.environ.get("KSTRL_CONTRACT_MODE", ContractMode.TIER.value),
-            test_command=os.environ.get("KSTRL_CONTRACT_TEST_CMD", "uv run pytest"),
+            test_command=os.environ.get("KSTRL_CONTRACT_TEST_CMD", DEFAULT_TEST_COMMAND),
             timeout=float(os.environ.get("KSTRL_TIMEOUT_CONTRACT", "600")),
         )
 

--- a/kstrl/init_cmd.py
+++ b/kstrl/init_cmd.py
@@ -19,8 +19,20 @@ DEFAULT_PRD = {
     "userStories": [],
 }
 
-DEFAULT_PROMPT_VERSION = "1.1.1"
+DEFAULT_PROMPT_VERSION = "1.2.0"
 
+# v1.2.0 (#276): step 9 defers to the verification block the harness
+# injects (verify.VERIFY_COMMANDS_PROMPT) instead of telling the agent to
+# find its own typecheck and test commands. #261 made
+# verify.resolve_verify_commands the only answer to "what does Phase 1
+# run" and injected it above this body every iteration, but step 9 still
+# told the agent to derive two of the three and never mentioned lint at
+# all - so a blocking `ruff check` failure was discovered by the gate
+# rather than by the agent, which costs a whole engineer iteration.
+# Step 14 carried a second copy of the same done-rule ("only after
+# tests/typecheck pass"), with the same lint omission, at the moment the
+# agent flips passes to true; it now refers to step 9 instead.
+#
 # The $prd_path / $progress_path / $codebase_map_path placeholders are
 # substituted by loop.run_loop (string.Template.safe_substitute) with the
 # per-component paths, so a decomposed component's agent reads the SAME
@@ -51,14 +63,16 @@ reviewer as already reading your diff while you write it.
    (verify only; do not switch)
 7. Pick the highest priority story where `passes` is `false` (lowest `priority` wins)
 8. Implement that ONE story (keep the change small and focused)
-9. Run feedback loops (Python + uv):
-   - Find the project's fastest typecheck and tests
-   - Use `uv run ...` to run them
-   - If the project has no typecheck/tests configured, add them (prefer `ruff` + `mypy`
-     or `pyright` + `pytest`)
-     and ensure they run fast and deterministically
-   - Do NOT mark the story as done unless typecheck AND tests pass. If they fail, fix and rerun;
-     only proceed when both are green.
+9. Run the verification commands:
+   - Run every command in the `Verification Commands (resolved by kstrl)` block
+     above, lint included, exactly as written. Do NOT derive your own or substitute
+     a narrower or broader variant (an added path, a `-k` filter, a dropped flag):
+     a command the gate will not run proves nothing.
+   - If that block is absent, no mechanical gate runs on this iteration. Verify in
+     proportion to what you changed.
+   - Do NOT mark the story as done until every command passes. If one fails because
+     the project has no such tooling configured, configure the tooling rather than
+     swapping the command.
 10. If you discover durable, reusable codebase facts, append a brief, evidence-based note to
    `$codebase_map_path` under **Iteration Notes** or update **Quick Facts**
    (skip if nothing new).
@@ -80,7 +94,7 @@ reviewer as already reading your diff while you write it.
     fail the mechanical check.
 13. Commit with message: `feat: [ID] - [Title]`
 14. Update `$prd_path`: set that story's `passes` to `true`
-    (only after tests/typecheck pass AND the self-critique is written)
+    (only after step 9's commands pass AND the self-critique is written)
 15. Append learnings to `$progress_path`
 
 ## PRD ambiguity

--- a/kstrl/init_cmd.py
+++ b/kstrl/init_cmd.py
@@ -19,9 +19,9 @@ DEFAULT_PRD = {
     "userStories": [],
 }
 
-DEFAULT_PROMPT_VERSION = "1.2.0"
+DEFAULT_PROMPT_VERSION = "1.3.0"
 
-# v1.2.0 (#276): step 9 defers to the verification block the harness
+# v1.3.0 (#276): step 9 defers to the verification block the harness
 # injects (verify.VERIFY_COMMANDS_PROMPT) instead of telling the agent to
 # find its own typecheck and test commands. #261 made
 # verify.resolve_verify_commands the only answer to "what does Phase 1
@@ -32,6 +32,22 @@ DEFAULT_PROMPT_VERSION = "1.2.0"
 # Step 14 carried a second copy of the same done-rule ("only after
 # tests/typecheck pass"), with the same lint omission, at the moment the
 # agent flips passes to true; it now refers to step 9 instead.
+#
+# The no-block branch states a FLOOR, not a proportionality hint, and it
+# is scoped to marking a story done rather than to every iteration:
+# `ks feature`'s implement and repair loops reach it while writing
+# production code with no Phase 1 at all (feature_cmd has no
+# verification), while an `ks understand` iteration that reaches it -
+# only un-init'd, since `ks init` scaffolds a separate
+# understand_prompt.md - marks no story and so owes nothing.
+#
+# INTERIM, tracked as #288. A text floor is not a mechanism: nothing on
+# that path samples whether the agent ran anything, and it asks the agent
+# to find commands that resolve_verify_commands could have named, which
+# is the derive-your-own shape #261 exists to remove. The harness stays
+# silent there because VERIFY_COMMANDS_PROMPT claims the gate runs the
+# commands, which would be false, and because #261 decided that
+# verify_config=None states nothing. Revisiting that is #288's job.
 #
 # The $prd_path / $progress_path / $codebase_map_path placeholders are
 # substituted by loop.run_loop (string.Template.safe_substitute) with the
@@ -68,11 +84,14 @@ reviewer as already reading your diff while you write it.
      above, lint included, exactly as written. Do NOT derive your own or substitute
      a narrower or broader variant (an added path, a `-k` filter, a dropped flag):
      a command the gate will not run proves nothing.
-   - If that block is absent, no mechanical gate runs on this iteration. Verify in
-     proportion to what you changed.
-   - Do NOT mark the story as done until every command passes. If one fails because
-     the project has no such tooling configured, configure the tooling rather than
-     swapping the command.
+   - If a command fails for a reason other than your work, fix the cause and never
+     substitute a different command. Missing tooling is yours to configure. A
+     command that is wrong for this project's language is not: name the `[verify]`
+     section of `kstrl.toml` in your progress entry rather than editing it, because
+     kstrl's policy envelope can treat that edit as tampering.
+   - Do NOT mark the story as done until every command passes. If that block is
+     absent, nothing will check this work mechanically: run the project's own
+     typecheck and tests yourself first.
 10. If you discover durable, reusable codebase facts, append a brief, evidence-based note to
    `$codebase_map_path` under **Iteration Notes** or update **Quick Facts**
    (skip if nothing new).
@@ -94,7 +113,7 @@ reviewer as already reading your diff while you write it.
     fail the mechanical check.
 13. Commit with message: `feat: [ID] - [Title]`
 14. Update `$prd_path`: set that story's `passes` to `true`
-    (only after step 9's commands pass AND the self-critique is written)
+    (only after step 9 is green AND the self-critique is written)
 15. Append learnings to `$progress_path`
 
 ## PRD ambiguity

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -8,6 +8,7 @@ from kstrl.contract import (
     compute_tiers,
 )
 from kstrl.manifest import Component, Manifest
+from kstrl.verify import DEFAULT_TEST_COMMAND
 
 
 def _make_manifest(components: list[Component]) -> Manifest:
@@ -83,7 +84,10 @@ class TestContractConfig:
     def test_defaults(self) -> None:
         config = ContractConfig()
         assert config.mode == ContractMode.TIER.value
-        assert config.test_command == "uv run pytest"
+        # #276: the Phase 1 constant, not a copy of the string. The
+        # "these are one fact" assertion lives in
+        # tests/test_engineer_verify_instructions.py.
+        assert config.test_command == DEFAULT_TEST_COMMAND
         assert config.timeout == 600.0
 
     def test_from_env(self, monkeypatch) -> None:

--- a/tests/test_engineer_verify_instructions.py
+++ b/tests/test_engineer_verify_instructions.py
@@ -1,0 +1,153 @@
+"""#276: what the engineer prompt says about the injected verify block.
+
+``tests/test_verify_command_contract.py`` covers the harness side of
+#261: one resolver, the gate shelling out to exactly what it returns,
+and the resolved block reaching the engineer. This module covers the
+other side of the same seam - what ``DEFAULT_PROMPT`` tells the engineer
+to do with that block, and what it tells the engineer when no block was
+injected at all.
+
+Before #276 the answer was "derive your own": the harness handed the
+agent an authoritative block naming the three commands the gate would
+run, and step 9, one line below it, told the agent to work two of them
+out for itself and never mentioned lint. `ruff check` blocks Phase 1, so
+a lint error was found by the gate rather than by the agent. Measured
+cost: one wasted engineer iteration.
+
+Split from the contract module rather than appended: the two are
+different jobs, and that file was at the 800-line ratchet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kstrl.contract import ContractConfig
+from kstrl.init_cmd import DEFAULT_KSTRL_TOML, DEFAULT_PROMPT
+from kstrl.verify import (
+    DEFAULT_TEST_COMMAND,
+    VERIFY_COMMANDS_PROMPT,
+    VerifyConfig,
+)
+from tests.test_verify_command_contract import (
+    _block_is_injected,
+    _engineer_prompt,
+    _prompt_from_cli,
+)
+
+
+def _step_nine(prompt_body: str) -> str:
+    """The text of DEFAULT_PROMPT's step 9, up to step 10."""
+    start = prompt_body.index("\n9. ")
+    return prompt_body[start : prompt_body.index("\n10. ", start)]
+
+
+class TestStepNineDefersToTheInjectedBlock:
+    #: The literal DEFAULT_PROMPT points the engineer at.
+    HEADING = "Verification Commands (resolved by kstrl)"
+
+    def test_it_points_at_the_block(self) -> None:
+        assert self.HEADING in _step_nine(DEFAULT_PROMPT)
+
+    def test_the_heading_it_names_is_the_block_s_own(self) -> None:
+        """The pointer is a literal, so a retitled block would leave the
+        engineer looking for a section that does not exist. This
+        assertion is the only thing holding the two strings together."""
+        assert self.HEADING in VERIFY_COMMANDS_PROMPT
+
+    def test_it_no_longer_tells_the_agent_to_derive_commands(self) -> None:
+        assert "Find the project's fastest typecheck and tests" not in DEFAULT_PROMPT
+        assert "derive your own" in _step_nine(DEFAULT_PROMPT)
+
+    def test_lint_is_named(self) -> None:
+        """The omission that cost the iteration."""
+        assert "lint" in _step_nine(DEFAULT_PROMPT).lower()
+
+    def test_it_forbids_substituting_a_variant(self) -> None:
+        step_nine = _step_nine(DEFAULT_PROMPT)
+        assert "narrower or broader" in step_nine
+        assert "exactly as written" in step_nine
+
+    def test_the_done_rule_is_stated_once(self) -> None:
+        """Step 14 carried its own copy reading "only after
+        tests/typecheck pass" - the two-of-three formulation whose lint
+        omission is the premise of this change, sitting at the moment the
+        agent flips ``passes`` to true. It now refers to step 9."""
+        assert "tests/typecheck pass" not in DEFAULT_PROMPT
+        assert "Do NOT mark the story as done until every command passes" in DEFAULT_PROMPT
+        assert "only after step 9's commands pass" in DEFAULT_PROMPT
+
+    def test_the_body_names_no_command_of_its_own(self) -> None:
+        """It defers or it says nothing. DEFAULT_PROMPT is a static
+        template scaffolded to disk, so any command literal in it is a
+        second source of truth that cannot know what the gate resolved -
+        which is the whole of #261 restated one layer up."""
+        for tool in ("uv run", "pytest", "mypy", "ruff", "pyright"):
+            assert tool not in DEFAULT_PROMPT
+
+    def test_the_block_and_the_deferral_arrive_together(self, tmp_path: Path) -> None:
+        """End to end: the fallback body and the injected block compose,
+        so the pointer resolves in the prompt the agent is handed."""
+        prompt = _engineer_prompt(tmp_path, VerifyConfig(), scaffold_prompt=False)
+        assert _block_is_injected(prompt)
+        assert self.HEADING in _step_nine(prompt)
+
+
+class TestStepNineWhenNoBlockIsInjected:
+    """``verify_config=None`` means no mechanical gate runs (#261), which
+    is what `ks understand` and `ks feature` produce. Step 9 must not
+    then send the agent after commands it was never given: an understand
+    iteration whose allowed paths permit only the codebase map has
+    nothing to gain from a suite run, and the old step 9 told it to go
+    and find one anyway.
+    """
+
+    def test_the_fallback_clause_is_stated(self) -> None:
+        step_nine = _step_nine(DEFAULT_PROMPT)
+        assert "If that block is absent" in step_nine
+        assert "no mechanical gate runs on this iteration" in step_nine
+
+    def test_it_does_not_name_the_project_context_as_a_command_source(self) -> None:
+        """On the no-gate path ``build_project_context`` injects CLAUDE.md
+        UNSCRUBBED - it only drops stale verification bullets when it has
+        resolved commands to compare them against - so a pre-#261
+        project's `## Verification Commands` section is still in the
+        prompt, and the block's own "ignore any other verification
+        command list" sentence is not. The fallback must not point the
+        agent at that list."""
+        assert "project context" not in _step_nine(DEFAULT_PROMPT)
+
+    def test_the_engineer_gets_the_fallback_and_no_block(self, tmp_path: Path) -> None:
+        prompt = _engineer_prompt(tmp_path, scaffold_prompt=False)
+        assert not _block_is_injected(prompt)
+        assert "no mechanical gate runs on this iteration" in prompt
+
+    def test_ks_understand_renders_this_body_and_gets_no_block(self, tmp_path: Path) -> None:
+        """The path that actually reaches DEFAULT_PROMPT: no
+        understand_prompt.md was scaffolded, so run_loop falls back to
+        it. Asserted here rather than in the contract module because what
+        is at stake is which step 9 that command ends up running."""
+        prompt = _prompt_from_cli(["understand", "--root", str(tmp_path)])
+        assert _step_nine(DEFAULT_PROMPT) in prompt
+        assert not _block_is_injected(prompt)
+
+
+class TestContractDefaultIsNotACopy:
+    """#276 sweep: Phase 3 carried its own literal copy of the Phase 1
+    default. Not a prompt edit, so no calibration policy attaches, but it
+    is the duplicated-literal shape #261 removed from Phase 1.
+
+    ``tests/test_contract.py::TestContractConfig`` covers the values.
+    What it cannot see is whether they are one fact or two copies that
+    happen to agree today, which is what these two pin.
+    """
+
+    def test_the_dataclass_default_is_the_phase_1_default(self) -> None:
+        assert ContractConfig().test_command == DEFAULT_TEST_COMMAND
+
+    def test_the_scaffolded_kstrl_toml_documents_that_same_default(self) -> None:
+        """`ks init` writes the [contract] default into every user's
+        kstrl.toml as a commented line. Nothing else pins it, so moving
+        DEFAULT_TEST_COMMAND would leave every scaffolded file
+        documenting the old value with a green suite."""
+        assert f'# test_command = "{ContractConfig().test_command}"' in DEFAULT_KSTRL_TOML

--- a/tests/test_engineer_verify_instructions.py
+++ b/tests/test_engineer_verify_instructions.py
@@ -21,9 +21,13 @@ different jobs, and that file was at the 800-line ratchet.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+from unittest.mock import patch
 
 from kstrl.contract import ContractConfig
 from kstrl.init_cmd import DEFAULT_KSTRL_TOML, DEFAULT_PROMPT
+from kstrl.loop import LoopResult
+from kstrl.policy import ENFORCEMENT_MACHINERY_PATHS
 from kstrl.verify import (
     DEFAULT_TEST_COMMAND,
     VERIFY_COMMANDS_PROMPT,
@@ -32,7 +36,11 @@ from kstrl.verify import (
 from tests.test_verify_command_contract import (
     _block_is_injected,
     _engineer_prompt,
+    _feature_cli_args,
     _prompt_from_cli,
+    _prompts_from_cli,
+    _run_cli,
+    _write_feature_prd,
 )
 
 
@@ -40,6 +48,17 @@ def _step_nine(prompt_body: str) -> str:
     """The text of DEFAULT_PROMPT's step 9, up to step 10."""
     start = prompt_body.index("\n9. ")
     return prompt_body[start : prompt_body.index("\n10. ", start)]
+
+
+def _unwrapped(text: str) -> str:
+    """``text`` with every run of whitespace collapsed to one space.
+
+    The prompt body is hard-wrapped, so a sentence the agent reads as one
+    phrase is not a contiguous substring of the source. Asserting against
+    the wrapped form would make these tests fail on a reflow that changes
+    nothing the agent sees.
+    """
+    return " ".join(text.split())
 
 
 class TestStepNineDefersToTheInjectedBlock:
@@ -56,16 +75,16 @@ class TestStepNineDefersToTheInjectedBlock:
         assert self.HEADING in VERIFY_COMMANDS_PROMPT
 
     def test_it_no_longer_tells_the_agent_to_derive_commands(self) -> None:
-        assert "Find the project's fastest typecheck and tests" not in DEFAULT_PROMPT
-        assert "derive your own" in _step_nine(DEFAULT_PROMPT)
+        assert "Find the project's fastest typecheck and tests" not in _unwrapped(DEFAULT_PROMPT)
+        assert "Do NOT derive your own" in _unwrapped(_step_nine(DEFAULT_PROMPT))
 
     def test_lint_is_named(self) -> None:
         """The omission that cost the iteration."""
         assert "lint" in _step_nine(DEFAULT_PROMPT).lower()
 
     def test_it_forbids_substituting_a_variant(self) -> None:
-        step_nine = _step_nine(DEFAULT_PROMPT)
-        assert "narrower or broader" in step_nine
+        step_nine = _unwrapped(_step_nine(DEFAULT_PROMPT))
+        assert "substitute a narrower or broader variant" in step_nine
         assert "exactly as written" in step_nine
 
     def test_the_done_rule_is_stated_once(self) -> None:
@@ -74,8 +93,9 @@ class TestStepNineDefersToTheInjectedBlock:
         omission is the premise of this change, sitting at the moment the
         agent flips ``passes`` to true. It now refers to step 9."""
         assert "tests/typecheck pass" not in DEFAULT_PROMPT
-        assert "Do NOT mark the story as done until every command passes" in DEFAULT_PROMPT
-        assert "only after step 9's commands pass" in DEFAULT_PROMPT
+        unwrapped = _unwrapped(DEFAULT_PROMPT)
+        assert "Do NOT mark the story as done until every command passes" in unwrapped
+        assert "only after step 9 is green" in unwrapped
 
     def test_the_body_names_no_command_of_its_own(self) -> None:
         """It defers or it says nothing. DEFAULT_PROMPT is a static
@@ -94,18 +114,37 @@ class TestStepNineDefersToTheInjectedBlock:
 
 
 class TestStepNineWhenNoBlockIsInjected:
-    """``verify_config=None`` means no mechanical gate runs (#261), which
-    is what `ks understand` and `ks feature` produce. Step 9 must not
-    then send the agent after commands it was never given: an understand
-    iteration whose allowed paths permit only the codebase map has
-    nothing to gain from a suite run, and the old step 9 told it to go
-    and find one anyway.
+    """``verify_config=None`` means no mechanical gate runs (#261).
+
+    Who reaches this branch decides how strong the instruction has to be.
+    `ks init` scaffolds a separate ``understand_prompt.md``, so
+    `ks understand` only lands here on a project that was never init'd.
+    The path that reaches it in normal use is `ks feature`'s implement
+    and repair loops, which run ``scripts/kstrl/prompt.md`` - this body -
+    and run NO verification phase at all (#288).
+
+    So this is the one path that writes production code with nothing
+    checking it, and a proportionality hint is not enough there: the
+    other guards are vacuous over an empty command list, and the v1.1.1
+    body carried an unconditional "do NOT mark the story as done unless
+    typecheck AND tests pass". The floor restates that, scoped to marking
+    a story done so a map-only understand iteration still owes nothing.
     """
 
-    def test_the_fallback_clause_is_stated(self) -> None:
-        step_nine = _step_nine(DEFAULT_PROMPT)
-        assert "If that block is absent" in step_nine
-        assert "no mechanical gate runs on this iteration" in step_nine
+    def test_the_fallback_states_a_floor_and_not_a_proportionality_hint(self) -> None:
+        assert (
+            "If that block is absent, nothing will check this work mechanically: "
+            "run the project's own typecheck and tests yourself first"
+            in _unwrapped(_step_nine(DEFAULT_PROMPT))
+        )
+
+    def test_the_floor_is_scoped_to_marking_a_story_done(self) -> None:
+        """Not to every iteration. An `ks understand` fallback edits only
+        the codebase map and marks no story, so it must not be told to
+        run a suite; `ks feature` implement does mark stories, and is."""
+        assert "Do NOT mark the story as done until every command passes." in _unwrapped(
+            _step_nine(DEFAULT_PROMPT)
+        )
 
     def test_it_does_not_name_the_project_context_as_a_command_source(self) -> None:
         """On the no-gate path ``build_project_context`` injects CLAUDE.md
@@ -115,21 +154,101 @@ class TestStepNineWhenNoBlockIsInjected:
         prompt, and the block's own "ignore any other verification
         command list" sentence is not. The fallback must not point the
         agent at that list."""
-        assert "project context" not in _step_nine(DEFAULT_PROMPT)
+        assert "project context" not in _unwrapped(_step_nine(DEFAULT_PROMPT))
 
-    def test_the_engineer_gets_the_fallback_and_no_block(self, tmp_path: Path) -> None:
+    def test_the_engineer_gets_the_floor_and_no_block(self, tmp_path: Path) -> None:
         prompt = _engineer_prompt(tmp_path, scaffold_prompt=False)
         assert not _block_is_injected(prompt)
-        assert "no mechanical gate runs on this iteration" in prompt
+        assert "nothing will check this work mechanically" in _unwrapped(prompt)
+
+    def test_ks_feature_passes_no_verify_config_to_any_phase(self, tmp_path: Path) -> None:
+        """The structural fact that makes the floor necessary, asserted at
+        the seam rather than through the prompt text.
+
+        Pinned here and not on a phase count: this is what would have to
+        change for #288 to be fixed, and a new phase in feature_cmd
+        should not break a prompt-wording test."""
+        _write_feature_prd(tmp_path)
+        seen: list[Any] = []
+
+        def fake_run_loop(*args: Any, **kwargs: Any) -> LoopResult:
+            # feature_cmd omits the argument entirely rather than passing
+            # None, so run_loop's own default supplies it. Either way the
+            # effective answer is "no gate", and this fails the moment a
+            # phase starts naming one.
+            seen.append(kwargs.get("verify_config"))
+            return LoopResult(completed=True, iterations=1, exit_code=0)
+
+        # feature_cmd binds the name at import (from kstrl.loop import
+        # run_loop), so patching kstrl.loop.run_loop would miss it.
+        with patch("kstrl.feature_cmd.run_loop", side_effect=fake_run_loop):
+            _run_cli(_feature_cli_args(tmp_path, auto_run=True))
+        assert len(seen) >= 2, f"expected understand + implement, got {len(seen)}"
+        assert all(config is None for config in seen), seen
+
+    def test_ks_feature_renders_this_body_with_no_block_and_the_floor(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """End to end through the real CLI, including the implement phase
+        that writes production code.
+
+        ``--implementation-auto-run`` is load-bearing: without it the
+        command halts at the interactive review checkpoint and only the
+        understand prompt is ever built. Every prompt the command
+        produces is checked rather than a chosen index, because on this
+        fixture the phases render byte-identically and picking one would
+        assert nothing the other does not.
+        """
+        _write_feature_prd(tmp_path)
+        prompts = _prompts_from_cli(_feature_cli_args(tmp_path, auto_run=True))
+        for prompt in prompts:
+            assert _step_nine(DEFAULT_PROMPT) in prompt
+            assert not _block_is_injected(prompt)
+            assert "run the project's own typecheck and tests yourself" in _unwrapped(prompt)
 
     def test_ks_understand_renders_this_body_and_gets_no_block(self, tmp_path: Path) -> None:
-        """The path that actually reaches DEFAULT_PROMPT: no
-        understand_prompt.md was scaffolded, so run_loop falls back to
-        it. Asserted here rather than in the contract module because what
-        is at stake is which step 9 that command ends up running."""
+        """The other, narrower way in: no understand_prompt.md was
+        scaffolded, so run_loop falls back to this body."""
         prompt = _prompt_from_cli(["understand", "--root", str(tmp_path)])
         assert _step_nine(DEFAULT_PROMPT) in prompt
         assert not _block_is_injected(prompt)
+
+
+class TestStepNineNamesTheRightRepair:
+    """#284 review: "configure the tooling" was the wrong default advice.
+
+    With ``[verify]`` unset, ``resolve_verify_commands`` yields the Python
+    defaults whatever the project is written in, so in a Node or Go repo
+    the commands fail because they are the wrong commands, not because
+    tooling is missing. Telling the agent to configure the tooling there
+    means installing pytest and mypy into a repo that is not Python,
+    while step 9 forbids the substitution that would be its only way out.
+
+    The repair names `[verify]` but routes the agent to REPORT it rather
+    than edit it, because `kstrl.toml` is in
+    ``policy.ENFORCEMENT_MACHINERY_PATHS``.
+    """
+
+    def test_it_names_the_config_that_owns_the_command(self) -> None:
+        step_nine = _unwrapped(_step_nine(DEFAULT_PROMPT))
+        assert "wrong for this project's language" in step_nine
+        assert "`[verify]` section of `kstrl.toml`" in step_nine
+
+    def test_it_routes_the_agent_to_report_that_file_not_edit_it(self) -> None:
+        """`kstrl.toml` is enforcement machinery: editing it is a
+        non-overridable hard fail whenever the envelope is enabled,
+        independent of paths_deny and of the autonomy level, precisely so
+        an agent cannot widen its own permissions. An earlier draft of
+        this clause told the agent to correct the file, which is an
+        instruction to trip that halt."""
+        assert "kstrl.toml" in ENFORCEMENT_MACHINERY_PATHS
+        assert "in your progress entry rather than editing it" in _unwrapped(
+            _step_nine(DEFAULT_PROMPT)
+        )
+
+    def test_it_no_longer_tells_the_agent_to_install_a_toolchain(self) -> None:
+        assert "configure the tooling rather than swapping" not in _unwrapped(DEFAULT_PROMPT)
 
 
 class TestContractDefaultIsNotACopy:

--- a/tests/test_prompt_versions.py
+++ b/tests/test_prompt_versions.py
@@ -106,9 +106,14 @@ _EXPECTED_SNAPSHOTS: dict[str, tuple[str, str]] = {
         "8040021a09d97598434d08c766495a4185df70b632e3ff4e5e1086b2e56ab30c",
         "1.1.0",
     ),
+    # 1.2.0 (#276): step 9 now defers to the VERIFY_COMMANDS_PROMPT block
+    # rather than telling the engineer to derive its own typecheck and
+    # test commands, and it names lint - a blocking Phase 1 gate the
+    # previous body never mentioned. Step 14's duplicate done-rule, which
+    # carried the same lint omission, now refers to step 9.
     "DEFAULT_PROMPT": (
-        "4f7370f5f4efb2d9b89ce6ae09fcbf7e5c3c8fb3db22cdeb07a9221ccbc638dc",
-        "1.1.1",
+        "9bde9b20785f3740396906d1d199c2228c553c11ae956dc2f85d8aa2439fb49b",
+        "1.2.0",
     ),
     # 1.0.0 (#261): harness-authored instruction text prepended to the
     # engineer prompt every iteration, naming the commands Phase 1 will

--- a/tests/test_prompt_versions.py
+++ b/tests/test_prompt_versions.py
@@ -106,14 +106,17 @@ _EXPECTED_SNAPSHOTS: dict[str, tuple[str, str]] = {
         "8040021a09d97598434d08c766495a4185df70b632e3ff4e5e1086b2e56ab30c",
         "1.1.0",
     ),
-    # 1.2.0 (#276): step 9 now defers to the VERIFY_COMMANDS_PROMPT block
+    # 1.3.0 (#276): step 9 now defers to the VERIFY_COMMANDS_PROMPT block
     # rather than telling the engineer to derive its own typecheck and
     # test commands, and it names lint - a blocking Phase 1 gate the
     # previous body never mentioned. Step 14's duplicate done-rule, which
-    # carried the same lint omission, now refers to step 9.
+    # carried the same lint omission, now refers to step 9. 1.2.0 was an
+    # unreleased draft of the same change, revised in review and never
+    # pinned here; the version moved with the body rather than being
+    # reused, so each round carries its own audit trail.
     "DEFAULT_PROMPT": (
-        "9bde9b20785f3740396906d1d199c2228c553c11ae956dc2f85d8aa2439fb49b",
-        "1.2.0",
+        "392eb698daf71d486a9d4573698df3bb2b3ca4be87c178657accc8a66c54f384",
+        "1.3.0",
     ),
     # 1.0.0 (#261): harness-authored instruction text prepended to the
     # engineer prompt every iteration, naming the commands Phase 1 will

--- a/tests/test_verify_command_contract.py
+++ b/tests/test_verify_command_contract.py
@@ -37,6 +37,7 @@ from kstrl.verify import (
     DEFAULT_TEST_COMMAND,
     DEFAULT_TYPECHECK_COMMAND,
     SCOPED_TYPECHECK_COMMAND,
+    VERIFY_COMMANDS_PROMPT,
     ResolvedVerifyCommands,
     VerifyConfig,
     check_linter,
@@ -77,10 +78,11 @@ class _PromptCapturingAgent:
         yield COMPLETION_MARKER
 
 
-def _project(root: Path) -> KstrlConfig:
+def _project(root: Path, *, scaffold_prompt: bool = True) -> KstrlConfig:
     kstrl_dir = root / "scripts" / "kstrl"
     kstrl_dir.mkdir(parents=True, exist_ok=True)
-    (kstrl_dir / "prompt.md").write_text("STORY-PROMPT-BODY")
+    if scaffold_prompt:
+        (kstrl_dir / "prompt.md").write_text("STORY-PROMPT-BODY")
     (kstrl_dir / "prd.json").write_text('{"branchName": "t", "userStories": []}')
     return KstrlConfig(
         max_iterations=1,
@@ -135,13 +137,24 @@ def _write_feature_prd(root: Path) -> None:
     )
 
 
-def _engineer_prompt(root: Path, verify_config: VerifyConfig | None = None) -> str:
+def _engineer_prompt(
+    root: Path,
+    verify_config: VerifyConfig | None = None,
+    *,
+    scaffold_prompt: bool = True,
+) -> str:
     """The prompt the engineer was handed.
 
     ``verify_config=None`` is run_loop's own default and means "no gate
     runs", so it is what the no-verification entry points produce.
+
+    ``scaffold_prompt=False`` leaves no prompt.md, so run_loop falls back
+    to the harness DEFAULT_PROMPT. The stub body is right for the
+    assembly tests here; the fallback is what an un-customised project
+    actually runs, and is what tests/test_engineer_verify_instructions.py
+    asserts against.
     """
-    config = _project(root)
+    config = _project(root, scaffold_prompt=scaffold_prompt)
     agent = _PromptCapturingAgent()
     result = run_loop(
         config,
@@ -153,6 +166,17 @@ def _engineer_prompt(root: Path, verify_config: VerifyConfig | None = None) -> s
     assert result.completed is True
     assert agent.prompts
     return agent.prompts[0]
+
+
+def _block_is_injected(prompt: str) -> bool:
+    """Whether the resolved verification block itself reached the agent.
+
+    Searching for the bare heading text no longer answers that: since
+    #276 DEFAULT_PROMPT names the same string to point the engineer at
+    the block. As a markdown heading - line-initial, with its ``# `` -
+    it is only ever the block.
+    """
+    return f"\n{VERIFY_COMMANDS_PROMPT.splitlines()[0]}\n" in f"\n{prompt}"
 
 
 # ---------------------------------------------------------------------------
@@ -585,7 +609,7 @@ class TestNoVerificationEntryPoints:
         prompt = _prompt_from_cli(["understand", "--root", str(tmp_path)])
         assert DEFAULT_TEST_COMMAND not in prompt
         assert DEFAULT_LINT_COMMAND not in prompt
-        assert "Verification Commands (resolved by kstrl)" not in prompt
+        assert not _block_is_injected(prompt)
 
     def test_ks_feature_states_no_commands(self, tmp_path: Path) -> None:
         _write_feature_prd(tmp_path)
@@ -603,7 +627,7 @@ class TestNoVerificationEntryPoints:
             ]
         )
         assert DEFAULT_TEST_COMMAND not in prompt
-        assert "Verification Commands (resolved by kstrl)" not in prompt
+        assert not _block_is_injected(prompt)
 
 
 class TestParentReportsDivergence:

--- a/tests/test_verify_command_contract.py
+++ b/tests/test_verify_command_contract.py
@@ -94,12 +94,12 @@ def _project(root: Path, *, scaffold_prompt: bool = True) -> KstrlConfig:
     )
 
 
-def _prompt_from_cli(args: list[str]) -> str:
-    """The prompt a real CLI entry point hands the engineer.
+def _run_cli(args: list[str]) -> _PromptCapturingAgent:
+    """Invoke a real CLI entry point with the agent replaced.
 
-    ``run_loop`` runs unpatched, because that is where the block is
-    built. Only the agent is replaced, and it is handed the finished
-    prompt, so what is asserted is what the command actually produces.
+    Returns the agent rather than its prompts, because a caller that
+    stubs ``run_loop`` is asserting on the call and gets no prompt at
+    all.
     """
     agent = _PromptCapturingAgent()
     runner = CliRunner()
@@ -109,8 +109,52 @@ def _prompt_from_cli(args: list[str]) -> str:
         patch("kstrl.cli._check_agent_preflight"),
     ):
         runner.invoke(cli, args, catch_exceptions=False)
-    assert agent.prompts, "no engineer prompt was built"
-    return agent.prompts[0]
+    return agent
+
+
+def _prompts_from_cli(args: list[str]) -> list[str]:
+    """Every prompt a real CLI entry point hands an agent, in order.
+
+    ``run_loop`` runs unpatched, because that is where the block is
+    built. Only the agent is replaced, and it is handed the finished
+    prompt, so what is asserted is what the command actually produces.
+
+    A multi-phase command (`ks feature` runs understand, then implement,
+    then repair) yields one entry per agent.run call, so a caller that
+    cares about a specific phase has to pick it rather than assume the
+    first.
+    """
+    prompts = _run_cli(args).prompts
+    assert prompts, "no engineer prompt was built"
+    return prompts
+
+
+def _prompt_from_cli(args: list[str]) -> str:
+    """The FIRST prompt a real CLI entry point hands an agent."""
+    return _prompts_from_cli(args)[0]
+
+
+def _feature_cli_args(root: Path, *, auto_run: bool = False) -> list[str]:
+    """argv for `ks feature` against the tree ``_write_feature_prd`` built.
+
+    ``auto_run`` adds ``--implementation-auto-run``, without which the
+    command halts at the interactive review checkpoint after the
+    understand phase and never builds an implement prompt.
+    """
+    args = [
+        "feature",
+        "--root",
+        str(root),
+        "--prd",
+        "scripts/kstrl/feature/demo/prd.json",
+        "--understand-iterations",
+        "1",
+        "--branch",
+        "",
+    ]
+    if auto_run:
+        args.append("--implementation-auto-run")
+    return args
 
 
 def _write_feature_prd(root: Path) -> None:
@@ -613,19 +657,7 @@ class TestNoVerificationEntryPoints:
 
     def test_ks_feature_states_no_commands(self, tmp_path: Path) -> None:
         _write_feature_prd(tmp_path)
-        prompt = _prompt_from_cli(
-            [
-                "feature",
-                "--root",
-                str(tmp_path),
-                "--prd",
-                "scripts/kstrl/feature/demo/prd.json",
-                "--understand-iterations",
-                "1",
-                "--branch",
-                "",
-            ]
-        )
+        prompt = _prompt_from_cli(_feature_cli_args(tmp_path))
         assert DEFAULT_TEST_COMMAND not in prompt
         assert not _block_is_injected(prompt)
 


### PR DESCRIPTION
Fixes #276

## The gap

#261 / PR #275 established a single source of truth for what Phase 1 runs: `resolve_verify_commands` is the only answer, the gate shells out to exactly what it returns, and an authoritative block naming those three commands is injected above the engineer prompt on every iteration.

`DEFAULT_PROMPT` step 9 still told the engineer to go and find its own typecheck and test commands, and never mentioned lint at all. So the harness handed the agent a contract and, one line below it, told the agent to work two of them out for itself and said nothing about the third. `ruff check` is a blocking Phase 1 gate, so a lint error was discovered by the gate rather than by the agent, which is the expensive order. Measured cost: one wasted engineer iteration, roughly $4.

## What changed

**Step 9 now defers.** Run every command in the `Verification Commands (resolved by kstrl)` block above, lint included, exactly as written; do not derive your own or substitute a narrower or broader variant. The wording agrees with the block, which already declares itself authoritative, rather than inventing a second contract.

**Step 14 stopped carrying a second copy of the done-rule.** It read `(only after tests/typecheck pass AND the self-critique is written)` - the same two-of-three formulation whose lint omission is the premise of this change, sitting at the moment the agent flips `passes` to `true`. It now refers to step 9, so the rule is stated once. Found by the `/simplify` pass, not by me.

**The no-block case is handled.** `verify_config=None` means no gate runs (`ks understand`, `ks feature`), and on that path no block is injected. Step 9 says so and asks for verification in proportion to what changed. It deliberately does **not** point at the project context as a command source: on that path `build_project_context` injects CLAUDE.md **unscrubbed** (it only drops stale verification bullets when it has resolved commands to compare against), so a pre-#261 project's `## Verification Commands` bullets are still in the prompt while the block's own "ignore any other verification command list" sentence is not.

**Phase 3 sweep.** `ContractConfig.test_command` carried a literal copy of the Phase 1 default in two places; both now reference `verify.DEFAULT_TEST_COMMAND`. Behaviour-neutral - the two literals already agreed. `tests/test_contract.py` was still pinning the raw string and now pins the constant.

## H3

- `DEFAULT_PROMPT_VERSION` 1.1.1 -> 1.2.0
- `_EXPECTED_SNAPSHOTS["DEFAULT_PROMPT"]` moved to `9bde9b20...` / `1.2.0` in the same commit
- `examples/uv-python/scripts/kstrl/prompt.md` ships the same body (`tests/test_gen_docs.py` pins it byte-for-byte) and is resynced

## H2 is waived, by the owner, explicitly

**No calibration run was performed for this change, on the owner's explicit instruction.** The reasoning, recorded here so the waiver is on the audit trail:

Calibration measures the detection rates of the **adversarial** roles - architect (`DECOMPOSE_PROMPT`), code reviewer (`REVIEWER_PROMPT`), security reviewer (`SECURITY_PROMPT`). None of them read `DEFAULT_PROMPT`. This edit changes what the **engineer** is told about which verification commands to run, which the engineer was already being told, only wrongly. There is no detection rate for calibration to move.

## Tests

New `tests/test_engineer_verify_instructions.py` (split out because `tests/test_verify_command_contract.py` was at the 800-line ratchet):

- step 9 points at the block, and the heading literal it names is the block's own (the only thing tying the two constants together)
- it no longer tells the agent to derive commands, and it names lint
- it forbids substituting a variant
- the done-rule is stated once, and `tests/typecheck pass` is gone from the body
- the body names no command literal of its own (`uv run`, `pytest`, `mypy`, `ruff`, `pyright` all absent)
- the block and the deferral compose end to end through `run_loop`
- **no-block case:** the fallback clause is stated, it does not name the project context as a command source, `run_loop` with `verify_config=None` injects no block and the agent gets the fallback, and `ks understand` through the real CLI renders this step 9 verbatim with no block
- the Phase 3 default is the Phase 1 constant, and the commented `[contract] test_command` line `ks init` scaffolds into every user's `kstrl.toml` is pinned to it

Local gate green: `uv run pytest tests/ -q`, `uv run mypy kstrl/ --strict`, `uv run ruff check kstrl/ tests/`, `pre-commit run --all-files`, `scripts/gen_docs.py --check`.

One flake seen: `tests/test_shutdown.py::TestWorkerSigterm::test_pool_worker_sigterm_kills_agent_group` failed once under full-suite load and passes in isolation (60s SIGTERM timing test). It passed in the full run before these edits and touches nothing in this diff.

---

# `/simplify` findings, verbatim

Four agents ran over the diff and the surrounding code. Their reports are reproduced below; what I applied and what I declined follows each.

The only edit to the quoted text is that em dashes were replaced with a hyphen, because this repo forbids the character in every artefact. No wording, claim or line reference was changed.

## Reuse

> Read the diff and the surrounding modules. Findings, reuse angle only:
>
> **1. `tests/test_engineer_verify_instructions.py:41-65` - `_default_prompt_engineer_prompt` re-implements `_engineer_prompt`.**
> The body is line-for-line the existing helper at `tests/test_verify_command_contract.py:139-157` (`_project(root)` → `_PromptCapturingAgent()` → `run_loop(config, PlainUI(no_color=True), agent, root, verify_config=verify_config)` → the two asserts → `return agent.prompts[0]`), with exactly one line inserted (`config.prompt_file.unlink()` at :54). The new module already imports `_project`, `_prompt_from_cli` and `_PromptCapturingAgent` from that file, so the helper is one import away. Cost: two copies of the same `run_loop` call site, including the `# type: ignore[arg-type]`, both of which have to track `run_loop`'s 20-parameter signature (`kstrl/loop.py:465-485`). A keyword on the existing helper (`_engineer_prompt(root, verify_config, *, scaffold_prompt=True)`) removes the copy.
>
> **2. `tests/test_engineer_verify_instructions.py:178-198` - `TestContractTestCommandDefault` duplicates `TestContractConfig` in `tests/test_contract.py:82-94`.**
> `test_the_dataclass_default_is_the_phase_1_default` (:187-188) is `tests/test_contract.py:83-87` again; `test_an_explicit_command_still_wins` (:193-198) is `tests/test_contract.py:89-94` again (same env var, different literal). Concrete cost: the de-duplication the production change makes is left half done. `kstrl/contract.py:83` now says `DEFAULT_TEST_COMMAND`, but `tests/test_contract.py:86` still asserts the raw literal `"uv run pytest"` - so the repo now has two tests in two files pinning the same field's default, one through the constant and one through a copy of the string the change was removing. Importing `DEFAULT_TEST_COMMAND` at `tests/test_contract.py:86` (and dropping the two duplicated new tests) is the cheaper shape.
>
> **3. `kstrl/init_cmd.py:64` - the block heading is a bare literal with no named constant, now in four files.**
> `"Verification Commands (resolved by kstrl)"` lives at `kstrl/verify.py:626` (first line of `VERIFY_COMMANDS_PROMPT`), and the change adds copies at `kstrl/init_cmd.py:64`, `examples/uv-python/scripts/kstrl/prompt.md:25`, and `tests/test_engineer_verify_instructions.py:89`; `tests/test_verify_command_contract.py:477` still carries a fifth literal even though the new `_block_is_injected` helper (`tests/test_verify_command_contract.py:159-167`) converted the other two call sites. The module already follows the constant convention for exactly this class of string (`DEFAULT_TEST_COMMAND` / `DEFAULT_LINT_COMMAND` / `DEFAULT_TYPECHECK_COMMAND` / `SCOPED_TYPECHECK_COMMAND`, `kstrl/verify.py:604-616`). Cost: renaming the heading means finding four hand-written copies, and the only thing binding them is one assertion (`tests/test_engineer_verify_instructions.py:98`), which the diff's own docstring admits ("This is the only thing holding the two strings together"). A `VERIFY_COMMANDS_HEADING` in `verify.py`, interpolated into both prompt bodies, makes the coupling structural instead of asserted.
>
> **4. `kstrl/init_cmd.py:63-73` - the new step 9 restates instructions `VERIFY_COMMANDS_PROMPT` already carries, in the prompt with the weaker reach.**
> `kstrl/verify.py:628-639` already tells the engineer "Run them yourself before you report a story complete. They are authoritative: ignore any other verification command list", and "A command may chain several toolchains. Run all of it." The new step 9 says the same thing again in different words ("Run every one of them, lint included, exactly as written", "do NOT substitute a narrower or broader variant"). The two constants do not reach the same projects: `VERIFY_COMMANDS_PROMPT` is injected by the harness on every iteration, so an upgrade updates every project, while `DEFAULT_PROMPT` is copied to disk once at scaffold time (`kstrl/init_cmd.py:733`, `_create_if_missing`) and afterwards is only the missing-file fallback (`kstrl/loop.py:555-576`). So the strengthened wording, and the lint mention that the issue was about, does not reach any project that already ran `ks init` - its `scripts/kstrl/prompt.md` keeps step 9 v1.1.1 forever. Putting the "run every one, lint included, exactly as written / do not substitute" clauses in `VERIFY_COMMANDS_PROMPT` (which owns this topic and is version-snapshotted the same way) and leaving step 9 as a pure pointer would land them on existing projects and keep one source for the rule.
>
> **5. Minor - `tests/test_engineer_verify_instructions.py:170-175`** re-runs the identical `_prompt_from_cli(["understand", "--root", str(tmp_path)])` invocation as `tests/test_verify_command_contract.py:593-600`, with different assertions. The setup (a full Click CLI invocation through `run_loop`) is the most expensive shape in this suite and is now paid twice for one code path.
>
> Not a finding, for the record: the new module importing private names across test modules (`from tests.test_verify_command_contract import ...`) is the established convention here (`tests/test_setpoint_agreement.py:40`, `tests/test_harness_path_scope.py:61`, `tests/test_prd_tamper.py:33`, `tests/test_feature_run.py:25`), and reusing `POLYGLOT_TEST` / `_prompt_from_cli` / `_project` / `_PromptCapturingAgent` is the right call. The `ContractConfig.test_command` de-duplication itself (`kstrl/contract.py:83,100`) is correct reuse of `verify.DEFAULT_TEST_COMMAND`.

**Applied:** 1 (added `scaffold_prompt` to `_project` / `_engineer_prompt`, deleted the 25-line copy), 2 (dropped both duplicated tests, pointed `tests/test_contract.py` at `DEFAULT_TEST_COMMAND`), 5 (the remaining CLI test now asserts a fact the contract module's copy does not: that `ks understand` renders *this* step 9 verbatim).

**Declined, 3** (`VERIFY_COMMANDS_HEADING` constant interpolated into both bodies): `DEFAULT_PROMPT` is a plain literal that `ks init` copies to disk for the user to edit. Interpolating a constant into a 4 KB prompt body means either an f-string over text full of backticks and `$`-placeholders, or a `$verify_block_heading` placeholder that `safe_substitute` would render literally into any scaffolded copy whose name later drifts. The in-repo drift is caught loudly by the assertion added here, and a heading rename is a versioned event, not a silent one.

**Declined, 4** (move the clauses into `VERIFY_COMMANDS_PROMPT`): this is the strongest finding in the whole pass and it is real - see "Reported, not fixed" below. Not done here because it is a second adversarial-prompt edit on a change whose H2 was waived for a narrow, specific reason, and because the block already carries the substantive instruction ("Run them yourself before you report a story complete", "They are authoritative", and a `Lint:` line) for every installed harness. What #276 fixes is `DEFAULT_PROMPT` contradicting it.

## Simplification

> Read the diff and verified every claim against the files.
>
> **1. `tests/test_engineer_verify_instructions.py:136-141` - `test_the_block_and_the_deferral_arrive_together` proves nothing new.** Injection with `VerifyConfig()` through `run_loop` is already asserted by `TestEngineerPromptCarriesTheGateCommands.test_the_block_is_injected_without_a_claude_md` (`tests/test_verify_command_contract.py:377-381`), including `DEFAULT_LINT_COMMAND in prompt`; swapping the stub body for `DEFAULT_PROMPT` cannot change whether the block is prepended. The remaining assert, `HEADING in _step_nine(prompt)`, is the same static fact as line 92. Cost: one extra `run_loop` + tmp_path per test run, and a third caller of the loop machinery to update when `run_loop`'s signature moves.
>
> **2. `tests/test_engineer_verify_instructions.py:161-168` - `test_no_command_reaches_the_agent` spins a full `run_loop` to assert a static string fact.** The same three asserts against `DEFAULT_PROMPT` directly need no fixture and no loop; the "verify_config=None injects nothing" half is already `tests/test_verify_command_contract.py:587-591`.
>
> **3. `tests/test_engineer_verify_instructions.py:170-175` - duplicate CLI invocation.** `_prompt_from_cli(["understand", "--root", str(tmp_path)])` is the identical call already made at `tests/test_verify_command_contract.py:597`, and both of this test's asserts are static `DEFAULT_PROMPT` facts already asserted at line 154 ("If that block is absent") and line 101 ("Find the project's fastest typecheck and tests" not in `DEFAULT_PROMPT`). Cost: a second `CliRunner` end-to-end run for zero new fact.
>
> **4. `tests/test_engineer_verify_instructions.py:123-134` - four of the nine loop entries are dead.** `DEFAULT_TEST_COMMAND` = `"uv run pytest"`, `DEFAULT_TYPECHECK_COMMAND` = `"uv run mypy ."`, `DEFAULT_LINT_COMMAND` = `"uv run ruff check ."`, `SCOPED_TYPECHECK_COMMAND` = `"uv run mypy"` (`kstrl/verify.py:604-616`) all begin `"uv run"` and contain `pytest`/`mypy`/`ruff`, so the bare substrings that follow subsume them. Dropping the four leaves the test's meaning identical and makes the `SCOPED_TYPECHECK_COMMAND` import at line 28 unused.
>
> **5. `tests/test_engineer_verify_instructions.py:154, 159, 174` - one sentence of the prompt asserted three times.** "If that block is absent" and "no mechanical gate runs on this iteration" are two halves of the same step-9 bullet; the static check at 154 is enough, leaving 159's `assert not _block_is_injected(prompt)` as the only load-bearing part of that test.
>
> **6. `kstrl/init_cmd.py:63-74` (byte-identical copy at `examples/uv-python/scripts/kstrl/prompt.md:24-35`) - step 9 states the "use the command as given" rule three times, and its first bullet restates the injected block.** Bullet 1 "exactly as written", bullet 2 "do NOT derive your own command and do NOT substitute a narrower or broader variant", bullet 4 "rather than swapping the command" are one rule said three ways. Bullet 1's other two clauses are `VERIFY_COMMANDS_PROMPT` (`kstrl/verify.py:628-632`) restated: "names the exact commands the mechanical gate will run on your work" ≡ "These are the exact commands kstrl's mechanical verification gate runs on your work"; "Run every one of them" ≡ "Run them yourself before you report a story complete"; and "lint included" is already carried by the block's `- Lint: {lint}` line plus "every one of them". The simpler step 9, keeping every distinct instruction: run every command in the `Verification Commands (resolved by kstrl)` block above exactly as written (bullet 1, one line); no narrower or broader variant, a command the gate will not run proves nothing (bullet 2); the absent-block fallback (bullet 3, unchanged); do not mark done until every command passes, fix or configure missing tooling (bullet 4, tail dropped). Twelve lines to about seven. Cost: this is prompt text an LLM reads every iteration, so the duplication is paid in tokens and in diluted emphasis on each pass. Note the shrink drags `tests/test_engineer_verify_instructions.py:102,110-111` plus the version/hash bump with it.
>
> **7. `kstrl/init_cmd.py:96` (and `examples/uv-python/scripts/kstrl/prompt.md:57`) - step 14's "(only after tests/typecheck pass AND the self-critique is written)" is a second copy of step 9's done-gate, and it is the copy that was not updated.** It still enumerates two of the three gates, which is the exact lint omission the change removed from step 9 one step earlier. Simpler: "(only after the step 9 commands pass AND the self-critique is written)" - one statement of the rule, no enumeration to drift.
>
> **8. The same rationale paragraph is now written out in three places.** `kstrl/init_cmd.py:24-31` (8 lines), `tests/test_prompt_versions.py:109-112` (4 lines), `tests/test_engineer_verify_instructions.py:75-86` (12 lines, plus the module docstring at 1-11 covering the same ground). The snapshot-table comment matches an existing convention (`REVIEWER_PROMPT` has one) and the source comment matches the v1.1.0 precedent above it, so the class docstring is the added copy: it can shrink to the one fact its tests actually pin, since the history already lives next to the constant. Cost: three prose sites to edit for any future correction of the same story.
>
> **9. `tests/test_engineer_verify_instructions.py:41-65` - `_default_prompt_engineer_prompt` is `_engineer_prompt` (`tests/test_verify_command_contract.py:139-156`) copied with one line added (`config.prompt_file.unlink()`).** Twenty-five duplicated lines including the `# type: ignore[arg-type]` and the two asserts. Simpler: give the shared helper a `use_default_prompt: bool = False` parameter and import it, as the module already imports `_project`, `_prompt_from_cli`, `_PromptCapturingAgent` and `_block_is_injected` from there.
>
> **10. `kstrl/contract.py:79` - minor.** The first comment line, "#276: the Phase 1 default, not a second copy of the same string", restates the assignment on line 83 (`test_command: str = DEFAULT_TEST_COMMAND`); the three lines below it carry the actual reason and are worth keeping. Cost is one line, listed only for completeness.
>
> Nothing else in the diff struck me as over-built: `_block_is_injected` (`tests/test_verify_command_contract.py:159-167`) is a genuine de-duplication of the two call sites it replaces, and the `ContractConfig` change removes a literal rather than adding state.

**Applied:** 2 (now a static whole-body check, strictly stronger and no `run_loop`), 4 (five bare substrings, no dead entries), 5 (the two halves are asserted once, in one test), 6 (step 9 went from 4 bullets / 12 lines to 3 bullets / 10 lines; 131 words to 104), 7 (step 14 now refers to step 9 - this one is the best find in the pass and is called out in the change summary above), 8 (class docstring cut to the fact its tests pin; the history stays next to the constant), 9 (same fix as Reuse 1), 10 (line dropped, and the surviving comment now names the divergence that is still reachable rather than the one this edit closed).

**Declined, 1:** kept, narrowed. It is the only test that exercises the `DEFAULT_PROMPT` fallback body composing with an injected block, which is the assembly the fix depends on. The redundant `DEFAULT_LINT_COMMAND` assert was dropped.

**Declined, 3:** kept, but rewritten so it earns the CLI run - it now asserts that `ks understand` renders step 9 *verbatim* and gets no block, which is a fact about which body that command ends up running, and is not asserted anywhere else.

## Efficiency

> **1. `kstrl/init_cmd.py:64-66** - Step 9's first bullet restates the injected block's own opening paragraph, which sits a few hundred characters above it in the same prompt.
>
> `VERIFY_COMMANDS_PROMPT` (kstrl/verify.py:625) already says "These are the exact commands kstrl's mechanical verification gate runs on your work" and "Run them yourself before you report a story complete" and "They are authoritative: ignore any other verification command list." Bullet 1 says "the block above names the exact commands the mechanical gate will run on your work. Run every one of them, lint included, exactly as written." Of its 30 words, roughly 22 are a paraphrase of text already in context; only "lint included" and "exactly as written" are new information. Bullet 4's closing clause ("configure the tooling rather than swapping the command", 9 words) similarly re-states bullet 2's substitution prohibition from a second angle.
>
> Cost, measured: step 9 went 73 → 131 words (429 → 807 chars). `DEFAULT_PROMPT` went 3954 → 4332 chars, +9.6%. `loop.py:566-588` assembles the prompt once per `run_loop` but `agent.run(prompt)` is invoked per iteration (kstrl/agents/claude_code.py:111 pipes it to a fresh `claude --print`), so the full +378 chars are re-sent on every engineer iteration. No tokenizer is installed here, so I am not converting that to a token figure.
>
> **2. `kstrl/init_cmd.py:63-74** - one static step 9 serves both the gated and un-gated paths, so every iteration pays for the branch it is not on.
>
> `loop.py:443` sets `commands = ... if verify_config is not None else None` and `461` appends the block only when it resolved. When the block is absent (`ks understand`, `ks feature`), bullets 1 and 2 (63 words) point the agent at a section that is not in its prompt. When the block is present, bullet 3 (26 words) is inapplicable. So 26-63 words per iteration are text about the other path. The harness already branches at that exact point, so a conditional step 9 is mechanically available; the offsetting cost is a second H3-enrolled prompt constant, which is not free. Flagging the number, not prescribing the fix.
>
> ## Checked and clear
>
> - **kstrl/contract.py:40** - `from kstrl.verify import DEFAULT_TEST_COMMAND, run_scrubbed` adds nothing. `contract.py` already imported `run_scrubbed` from the same module, so the edge and its import-time cost were already paid; adding a name to an existing `from` costs one extra binding. No cycle risk: `kstrl/verify.py` has no import of `kstrl.contract`.
> - **kstrl/contract.py:79 and :100** - the default is a reference to a module-level constant, not a computed value; `os.environ.get(..., DEFAULT_TEST_COMMAND)` swaps a literal for a global lookup. No per-instance work added.
> - **tests/test_verify_command_contract.py:159-166** - `_block_is_injected` does recompute `VERIFY_COMMANDS_PROMPT.splitlines()[0]` and build two whole-string copies on each call, as you suspected. Measured: 4.94 µs per call against a 13 KB prompt, and it has 4 call sites in the entire suite, so ~20 µs total. Test-only, no hot path. Hoisting it to a module constant would not pay for the line.
> - **tests/test_engineer_verify_instructions.py** - 15 tests, 0.13 s total, slowest case 0.01 s. `test_the_engineer_is_told_no_gate_runs` (:156) and `test_no_command_reaches_the_agent` (:161) do rebuild the same project and run `run_loop` with identical arguments, so a shared fixture would drop one duplicate run, but the duplicate costs 0.01 s. Below anything worth changing.
> - No closures, no long-lived objects capturing a large scope, no blocking work added at import time, nothing new made sequential.

**Applied, 1:** step 9 is now 104 words (was 131 in the reviewed draft, 73 before the change). The paraphrase of the block's opening was cut; "lint included" and "exactly as written" - the two clauses the agent identified as carrying new information - were kept.

**Declined, 2** (a conditional step 9, injected per path): this trades ~26-63 words per iteration for a second H3-enrolled prompt constant and a caller decision about which to inject. It adds a mechanism to save tokens, and the residual is small. Reported below.

## Altitude

> **1. `kstrl/init_cmd.py:64` - the new instruction was put in the one artifact the harness can never update again.**
> `DEFAULT_PROMPT` is copied to `scripts/kstrl/prompt.md` by `_create_if_missing` (init_cmd.py:733), which by name never overwrites. `DEFAULT_PROMPT_VERSION` is not written to disk, not stamped into the scaffolded file, and not compared against anything anywhere in `kstrl/` (only `tests/test_prompt_versions.py` reads it). So every project already `ks init`'d keeps a v1.1.1 prompt.md forever: still told to derive its own typecheck and test commands, still never told about lint, with no warning and no upgrade path. Cost: the measured failure this change exists to fix (one wasted engineer iteration on an unmentioned blocking `ruff check`) keeps being paid by every existing project, and the fix only reaches greenfield inits. Deeper alternative: the same sentences belong in `verify.VERIFY_COMMANDS_PROMPT` (verify.py:625), which is harness-owned, re-rendered every iteration by the installed harness, already H3-version-enrolled, already asserts "They are authoritative", and is present exactly when those instructions apply. Bump it to 1.1.0, and step 9 shrinks to a version-independent pointer that reaches every project on the next `pip install -U`, with no re-init.
>
> **2. `kstrl/init_cmd.py:64` - the heading literal is held in-repo but not on the disks that matter.**
> In-repo the coupling is adequately tested: `tests/test_engineer_verify_instructions.py:98` ties `DEFAULT_PROMPT`'s literal to `VERIFY_COMMANDS_PROMPT`, and `tests/test_gen_docs.py:141` pins `examples/uv-python/scripts/kstrl/prompt.md` byte-for-byte against `DEFAULT_PROMPT`. What no test can reach is the scaffolded copy in every user project: rename the block heading in verify.py and those copies point the engineer at a section that does not exist, with a green suite. The guard is "nobody renames it", not a mechanism. Cost is bounded (a rename is a versioned event) but it is the same class as the #261 bug: a copy that goes wrong the moment the owner moves. Deeper alternative, if the pointer must stay in the body: `run_loop` already `safe_substitute`s the body with three placeholders (loop.py:582), so a `$verify_block_heading` placeholder makes the harness compose the pointer for the shipped and the scaffolded copies alike. That is precisely the mechanism `$prd_path` used to solve this class in v1.1.0.
>
> **3. `kstrl/init_cmd.py:70` - the "if that block is absent" branch asks the agent for negative evidence the harness holds structurally.**
> `build_project_context` simply appends nothing when `verify_config is None` (loop.py:443, 460-462), so the agent must prove a section absent. Two concrete costs. (a) In that same None path, CLAUDE.md is injected **unscrubbed** (the `scrub_project_claude_md` call is inside `if commands is not None`, loop.py:452-459), so a pre-#261 project's `## Verification Commands` section survives with its three stale bullets, and the new fallback then says to verify "using only checks the project context documents" - pointing the agent straight at that stale list, while the "ignore any other verification command list" sentence lives only inside the block that is not there. The test suite needed a structural discriminator for exactly this ambiguity (`_block_is_injected`, tests/test_verify_command_contract.py:159-167, which matches a line-initial `# ` heading because a substring search no longer answers the question); the agent is given no such precision. (b) `verify_config=None` conflates two different situations: `ks understand` (read-only mapping) and `ks feature`'s implement phase, which writes real code and runs no gate at all (feature_cmd.py:375 passes no verify_config, and `grep -n "verif" kstrl/feature_cmd.py` finds no verification anywhere). One clause must serve both, and the implement case is where the done-rule got weaker: the old body said "do not mark done unless typecheck AND tests pass", the new one gates on "every command passes" over an empty command list. Deeper alternative: have the harness inject a positive, H3-enrolled no-gate block beside `VERIFY_COMMANDS_PROMPT` so the prompt body stays unconditional and the fact is stated by the component that knows it; which of the two blocks to inject is then a caller decision, and the caller already knows whether it is mapping or implementing.
>
> **4. `kstrl/init_cmd.py:96` - the done-rule is stated twice and only one copy was updated.**
> Step 14 still reads `(only after tests/typecheck pass AND the self-critique is written)` - the two-of-three formulation whose lint omission is the entire premise of this change - and it sits at the exact moment the agent flips `passes: true`. Cost: the change's own named failure mode survives one screen below the fix, in the sentence most proximate to the action it governs. Deeper alternative: let step 9 own the rule and have step 14 refer to it ("only after step 9's commands pass AND the self-critique is written"), so the next verification change has one place to touch instead of two.
>
> **5. `kstrl/contract.py:83` - the dedupe removes the literal but not the divergence its own comment names.**
> The comment says "a project that changes one and not the other has two gates disagreeing about what 'the tests' are". That case is exactly the one still unhandled: both literals were already the same string, so this edit is behaviour-neutral, while a project that sets `[verify] test_command` in kstrl.toml (or `KSTRL_VERIFY_TEST_CMD`) still gets Phase 3 running `uv run pytest`, because `ContractConfig.load` (contract.py:102-122) reads only `[contract]`. Only the CLI flag bridges them (cli.py:2419, `contract_test_cmd or test_command`). Cost: the divergence the change is justified by remains reachable through the config file, which is the documented control plane. Deeper alternative, and the shape #261 established: make `test_command: str | None = None` and resolve at use against the verify config, so "unset" means "whatever Phase 1 actually runs" rather than "the harness default that happens to match today".
>
> **6. `kstrl/init_cmd.py:519` - the sweep stopped one copy short, at the copy `ks init` writes into user projects.**
> `DEFAULT_KSTRL_TOML`'s `[contract]` block still hardcodes `# test_command = "uv run pytest"`. Nothing pins it: `tests/test_config_control_plane.py:772-800` uncomments the scaffold and checks the keys are real and that every loader accepts them, but never compares a commented value against its dataclass default. Cost: change `DEFAULT_TEST_COMMAND` and every scaffolded kstrl.toml documents the old default with a fully green suite - a hardcoded copy of a fact another module owns, written into a user's repo by init, which is the literal #261 shape. (`docs/env-vars.md:401` is a fourth copy; lower stakes, docs restate defaults throughout.) Deeper alternative: interpolate the constant into the template (`kstrl_toml_for` already does a `.replace` pass at init_cmd.py:830-837), or add one test asserting every commented scaffold value equals its loader's default, which covers the whole file rather than this key.
>
> **Test seam: no finding.** The split is forced by a real mechanism, not taste: `tests/test_verify_command_contract.py` is 655 lines, the new module is 198, and `scripts/precommit/file_length_ratchet.py` (`MAX_LINES = 800`) fails a file crossing from under to over - 853 would have failed the hook. Cross-module import of private test helpers is well-established convention here: `tests/test_prd_tamper.py:41` imports `_pipeline` from `test_progress_scope`, `tests/test_harness_path_scope.py:61` imports `_base_config, _pipeline`, and `test_calibration_matchers.py:32`, `test_decompose_run.py:18`, `test_feature_run.py:25` do the same. Two small caveats not worth a finding: `_block_is_injected` (test_verify_command_contract.py:159) is new in this change and authored for two consumers, and the repo has `tests/helpers/` plus `tests/spine_utils.py` as the designated home for exactly that case - importing a module's pre-existing privates is what precedent covers, authoring a shared one inside a test module is the case that pulls toward `helpers/`. And `_default_prompt_engineer_prompt` (test_engineer_verify_instructions.py:54) derives its fixture by unlinking the prompt.md that `_project` just created; a `_project(root, with_prompt=False)` parameter would state the intent directly.
>
> **One process note, outside my angle:** H3 is satisfied (version constant, body, and snapshot tuple all move together). Whether H2 was satisfied - a calibration re-run for a `DEFAULT_PROMPT` edit - is not visible in the diff.

**Applied, 3(a):** the fallback no longer says "using only checks the project context documents". It now says "Verify in proportion to what you changed" and stops, so it does not aim the agent at a stale, unscrubbed CLAUDE.md list. A test pins that the phrase stays out.

**Applied, 4:** step 14 now refers to step 9.

**Applied, 6:** as a test rather than an interpolation. `tests/test_engineer_verify_instructions.py::test_the_scaffolded_kstrl_toml_documents_that_same_default` pins the commented `[contract] test_command` line in `DEFAULT_KSTRL_TOML` to `ContractConfig().test_command`, so moving the constant fails loudly instead of silently shipping a stale comment to every new project. Interpolating into the template was declined as the riskier half of the same fix for a commented documentation line.

**Applied, test-seam caveat:** `_default_prompt_engineer_prompt` is gone; `_project` / `_engineer_prompt` take `scaffold_prompt=False`.

**Declined, 1** (move the sentences into `VERIFY_COMMANDS_PROMPT`): see Reuse 4 above and "Reported, not fixed" below. Real, and out of scope for a change whose H2 waiver is scoped to "this touches only the engineer's verification instructions".

**Declined, 2** (`$verify_block_heading` placeholder): `safe_substitute` renders an unknown placeholder *literally*, so a scaffolded copy carrying `$verify_block_heading` after a rename would show the agent the raw placeholder rather than a heading. That is a worse failure than a stale-but-readable heading, and it adds a fourth entry to the placeholder contract that `tests/test_run_honesty.py` pins.

**Declined, 3(b)** (inject a positive no-gate block): adds an H3-enrolled prompt constant plus a caller decision in `feature_cmd` and `cli`, to state a fact the one-line fallback already states. Adding a mechanism where the existing one suffices.

**Declined, 5** (`ContractConfig.test_command: str | None` resolving against the verify config): this is a behaviour change to Phase 3 - a project that sets `[verify] test_command` would silently start running a different Phase 3 command - and it needs its own decision about whether Phase 3 *should* follow Phase 1 or stay independently configurable. The issue asked to sweep the duplicated default "if genuinely small"; this is the point where it stops being small. The surviving comment on `ContractConfig.test_command` now names the divergence explicitly so the next reader is not misled. Reported below.

---

## Reported, not fixed

Three things this pass surfaced that are real and out of scope. Recorded here rather than expanded into the diff:

1. **A scaffolded `scripts/kstrl/prompt.md` is never upgraded.** `_create_if_missing` does not overwrite, `DEFAULT_PROMPT_VERSION` is not stamped into the file or compared against anything at run time, and `loop.run_loop` prefers the file. So every project that has already run `ks init` keeps its v1.1.1 step 9 - deriving its own commands, never told about lint - and this fix reaches only greenfield inits and the missing-file fallback. That is general to every future `DEFAULT_PROMPT` change, not specific to #276, and it wants its own issue: either stamp the version and warn on drift, or move engineer instructions that must reach installed projects into the harness-injected blocks.

2. **Phase 3 does not follow a project's `[verify] test_command`.** `ContractConfig.load` reads only `[contract]`, so a project that configures Phase 1's test command still gets the harness default in Phase 3 unless it also sets `[contract] test_command` or passes the CLI flag. This PR removes the duplicated *literal*; it does not connect the two settings, which is a design decision rather than a sweep.

3. **On the no-gate path, CLAUDE.md is injected unscrubbed.** `build_project_context` only drops stale verification bullets when it has resolved commands to compare against, so `ks understand` and `ks feature` still show the agent a pre-#261 project's stale `## Verification Commands` section. This PR stops step 9 pointing at it; it does not remove it.

---

# Round 2: code review findings

A code review raised four findings on the first round. All four are addressed. The prompt body changed again, so **`DEFAULT_PROMPT_VERSION` moved 1.2.0 -> 1.3.0** with the snapshot tuple, in the same commit as the body. 1.2.0 was the unreleased round-1 draft and is pinned nowhere; the version moves with the body rather than being reused, so each round carries its own audit trail.

## 1. MEDIUM/HIGH, the no-block branch dissolved the done-rule where it matters most. Fixed.

The reviewer is right and I verified every step of it. The v1.1.1 text was unconditional: "Do NOT mark the story as done unless typecheck AND tests pass." Round 1 replaced it with a proportionality hint.

Who reaches that branch: `ks init` scaffolds a separate `understand_prompt.md`, so `ks understand` only lands there un-init'd. The path that reaches it in normal use is **`ks feature`'s implement and repair loops**, and `ks feature` runs no verification at all. Verified three ways: `grep -n "verif" kstrl/feature_cmd.py` returns only a local `verification: list[str]` built from PRD acceptance criteria; all three `run_loop` calls (`:244`, `:375`, `:478`) omit `verify_config`; and `run_mechanical_verification` is reachable only from `pipeline.py` (factory Phase 1) and `cli.py` (`ks verify`).

So on the one path that writes production code with nothing checking it, both remaining guards were vacuous over an empty command list.

The fallback now states a floor: `nothing will check this work mechanically: run the project's own typecheck and tests yourself first`. It is scoped to marking a story done rather than to every iteration, which also resolves the tension the altitude reviewer raised, that a map-only `ks understand` iteration should not be told to run a suite.

**Labelled as an interim, and tracked.** A text floor is not a mechanism: nothing on that path samples whether the agent ran anything, and the engineer prompt has no calibration coverage either. Rather than let the shallow fix become the permanent answer by default, I filed **#288** and referenced it from the source comment. #288 also records the deeper option the altitude reviewer identified: `resolve_verify_commands` is a pure function of `(VerifyConfig, cwd)` and needs no gate, so the harness *could* name the commands here. It does not, because `VERIFY_COMMANDS_PROMPT` opens by claiming the mechanical gate runs them (false on this path) and because #261 deliberately decided `verify_config=None` states nothing. Revisiting that is an owner decision, not this PR's.

## 2. LOW/MEDIUM, "configure the tooling" aimed at the wrong fix. Fixed, and the fix goes further than asked.

Correct as stated: with `[verify]` unset the resolver yields the Python defaults whatever the project is written in, so in a Node or Go repo the commands fail because they are the wrong commands. The repair now names the `[verify]` section of `kstrl.toml`.

But the `/simplify` altitude pass found the escape hatch is sharper than the review described. `kstrl.toml` is not merely in the scaffolded `[policy] paths_deny` - it is in `policy.ENFORCEMENT_MACHINERY_PATHS`, where modification is "a non-overridable hard fail whenever the envelope is enabled, independent of `paths_deny` and of the autonomy level", explicitly so "an agent editing `kstrl.toml` cannot widen its own permissions". Telling the agent to *correct* that file is telling it to trip a non-overridable halt.

So the clause names `[verify]` as where the fix belongs and routes the agent to **report it rather than edit it**:

> A command that is wrong for this project's language is not: name the `[verify]` section of `kstrl.toml` in your progress entry rather than editing it, because kstrl's policy envelope can treat that edit as tampering.

A test pins `"kstrl.toml" in ENFORCEMENT_MACHINERY_PATHS` alongside the prompt clause, so the two cannot drift apart.

## 3. On the review record. Agreed, and thank you for filing it.

Nothing to do here. Recorded in the "Reported, not fixed" section below as well, and I have not touched it.

## 4. LOW, the doc quotes prompt text that no longer exists. Fixed.

`docs/control-loop-design.md:597` now quotes the current step 14.

**One I did not fix, deliberately.** `docs/lessons/pr-221.html:939` carries the same stale quote. It is a dated lesson page about PR #221 whose adjacent line reference (`kstrl/init_cmd.py:81`) was already stale before this change, and `docs/lessons/` is covered by the atlas workflow's lessons-register step, which I was told to leave alone. If lesson pages are frozen artefacts that is worth writing down, because right now it is indistinguishable from an oversight. Flagging rather than deciding.

## Round 2 tests

- The floor and the repair clause are each pinned by name, and both were **mutation checked**: reverting the floor sentence fails 3 tests, reverting the repair clause to the halt-inducing wording fails 1. Neither is a test that passes on the broken code.
- `ks feature` is covered twice. End to end through the real CLI to the implement phase (`--implementation-auto-run` is load-bearing; without it the command halts at the interactive checkpoint and only the understand prompt is ever built), and **at the seam**: `test_ks_feature_passes_no_verify_config_to_any_phase` asserts no phase names a gate. The seam test is the one that matters, because it pins the structural fact rather than a phase count, and it is what would have to change for #288 to be fixed.
- `_unwrapped` normalises whitespace before substring assertions, because the prompt is hard-wrapped and a sentence the agent reads as one phrase is not a contiguous substring of the source. Without it these tests would fail on a reflow that changes nothing the agent sees.

Full local gate green again: `uv run pytest tests/ -q` (3942 passed), `uv run mypy kstrl/ --strict`, `uv run ruff check kstrl/ tests/`, `pre-commit run --all-files`, `scripts/gen_docs.py --check`.

---

# `/simplify` round 2, findings verbatim

Four agents ran again over the round-2 diff. Reproduced below; what I applied and what I declined follows each. As in round 1, the only edit to the quoted text is that em dashes were replaced with a hyphen for house style. No wording, claim or line reference was changed.

## Reuse

> ## Reuse review, round 2 of #276/#284
>
> Three findings, all in the new test code. The two helpers the brief asked about (`_unwrapped`, `_prompts_from_cli`) are **not** duplicates - I verified that below the findings.
>
> ### 1. `understand.md` pre-write duplicates what the CLI under test already does
>
> **`tests/test_engineer_verify_instructions.py:173`**
>
> ```python
> (tmp_path / "scripts/kstrl/feature/demo/understand.md").write_text("# understand\n")
> ```
>
> `kstrl/cli.py:1504-1506` already scaffolds that exact file, unconditionally, before it builds `FeatureParams` (line 1536) and calls `run_feature`:
>
> ```python
> feature_understand = feature_dir / "understand.md"
> if not feature_understand.exists():
>     feature_understand.write_text(DEFAULT_FEATURE_UNDERSTAND)
> ```
>
> Cost: the test hand-rolls a file the command creates for itself, with a stub body in place of `init_cmd.DEFAULT_FEATURE_UNDERSTAND` (`kstrl/init_cmd.py:207`). The existing sibling test `test_ks_feature_states_no_commands` (`tests/test_verify_command_contract.py:624`) drives the same command with no pre-write and works. Related: the docstring justifies the line as getting "past that gate's own file check" - I read `kstrl/feature_cmd.py:295-330` and the review gate has no file-existence check; `implementation_auto_run` alone skips it. If the line is kept for determinism its home is `_write_feature_prd` (`tests/test_verify_command_contract.py:126`), which already builds that same directory and already writes the other start-up precondition file (`codebase_map.md`).
>
> ### 2. The `ks feature` CLI argv is copied verbatim across two test modules
>
> **`tests/test_engineer_verify_instructions.py:175-187`**
>
> The argv list is a character-for-character copy of `tests/test_verify_command_contract.py:626-637` plus one trailing `--implementation-auto-run`: same `feature`, `--root str(tmp_path)`, `--prd "scripts/kstrl/feature/demo/prd.json"`, `--understand-iterations 1`, `--branch ""`.
>
> Cost: the PRD path literal `scripts/kstrl/feature/demo/prd.json` now appears in two modules while the directory it points at is constructed in a third place (`_write_feature_prd`, `tests/test_verify_command_contract.py:127`). The shared module already owns the setup half of this fixture; a `_feature_cli_args(root, *, auto_run=False)` beside `_write_feature_prd` would collapse both copies and keep the path literal in one place.
>
> ### 3. `"kstrl.toml"` asserted as a substring when a named constant holds the same fact
>
> **`tests/test_engineer_verify_instructions.py:232`**
>
> ```python
> assert '"kstrl.toml"' in DEFAULT_KSTRL_TOML
> ```
>
> The docstring's claim is about the scaffolded `[policy] paths_deny`, which exists as `kstrl/policy.py:79 DEFAULT_PATHS_DENY` (a tuple that contains `"kstrl.toml"`, and is the default for `PolicyConfig.paths_deny` at `kstrl/policy.py:539`). The filename itself is `kstrl/config.py:437 CONFIG_FILE_NAME`. What the assertion actually pins is the *commented-out example line* at `kstrl/init_cmd.py:474`, which is itself a hand-maintained copy of `DEFAULT_PATHS_DENY` - pre-existing duplication the new test now anchors to instead of to the constant. `tests/test_policy_envelope.py:252` shows the reuse pattern already in the suite (`assert list(cfg.paths_deny) == list(DEFAULT_PATHS_DENY)`). Low severity, but it is a new literal where a constant exists.
>
> ---
>
> ### Verified non-findings (checked because the brief asked)
>
> - **`_unwrapped`** (`tests/test_engineer_verify_instructions.py:47`) is not re-implementing anything importable. Repo-wide, `" ".join(x.split())` occurs at only two other sites, both inline inside functions with a different job: `kstrl/decompose.py:980` (`_issue_identity`, folds case too) and `kstrl/agents/liveness.py:320` (`_truncate`, then clips to `_DETAIL_MAX_CHARS`). No named normaliser exists in `kstrl/`, `tests/conftest.py`, `tests/helpers/`, or `tests/spine_utils.py`. Keep it.
> - **`_prompts_from_cli`** is a clean generalization, not a copy: `_prompt_from_cli` now delegates to it (`tests/test_verify_command_contract.py:120-124`), so there is one implementation. Nothing else in `tests/` enumerates prompts per phase - `tests/test_feature_run.py`, `tests/test_understand_run.py`, and `tests/test_feature_cmd.py` all stub `run_loop`, so they never build a prompt at all.
> - **The `examples/uv-python/scripts/kstrl/prompt.md` edit** is sanctioned duplication with an enforcing mechanism: `tests/test_gen_docs.py:132-140` asserts `example == DEFAULT_PROMPT`. Editing both files is required, not redundant.

**Applied, all three.** 1: the pre-write is gone, and I verified the agent's correction myself - the command still reaches the implement phase without it (2 prompts), and the review gate has no file check, so my docstring claim was simply false. That was the most useful finding of the round: a false justification in a docstring is worse than the redundant line it justified. 2: `_feature_cli_args(root, *, auto_run=False)` now lives beside `_write_feature_prd` and both call sites use it. 3: the test now asserts against `policy.ENFORCEMENT_MACHINERY_PATHS`, which is stronger than the agent's suggestion of `DEFAULT_PATHS_DENY` - `paths_deny` is an overridable default, while enforcement machinery is the non-overridable set, and that is the fact the prompt clause depends on.

## Simplification

> ## Prompt wording (read by the engineer every iteration)
>
> **1. `kstrl/init_cmd.py:79-85` - the done-rule is now stated twice inside step 9, and five times in the prompt as a whole.**
> Bullet 2 ends "...before you mark anything done"; bullet 4 is "Do NOT mark the story as done until every command passes." Round 1 stated it once (in the last bullet); round 2 adds the second. Counting outward, the same rule also appears in the injected block (`kstrl/verify.py:629-630`, "Run them yourself before you report a story complete") and at step 14 (`init_cmd.py:107`, "only after step 9 is green"). Cost: 11 words per iteration for a rule already stated, and the test at `tests/test_engineer_verify_instructions.py:84` is now named `test_the_done_rule_is_stated_once` while the body states it twice. Bullets 2 and 4 merge cleanly: `- Do NOT mark the story as done until every command passes. If that block is absent, nothing will check this work mechanically: run the project's own typecheck and tests yourself instead.`
>
> **2. `kstrl/init_cmd.py:75-78` - bullet 1 (47 words) restates three of the injected block's four sentences, and the block sits directly above it in the same prompt** (`loop.build_project_context` appends it as the last context section, `kstrl/loop.py:459-461`). Pairs: "Run every command ... exactly as written" vs `verify.py:629-630` "Run them yourself before you report a story complete" and `verify.py:638` "A command may chain several toolchains. Run all of it."; "Do NOT derive your own" vs `verify.py:630-632` "They are authoritative: ignore any other verification command list". The non-duplicated content is only "lint included", the variant taxonomy, and "a command the gate will not run proves nothing" - the three clauses that earned the change. Cost: 71-word block plus a 47-word paraphrase of it, and two versioned prompts (`VERIFY_COMMANDS_PROMPT_VERSION`, `DEFAULT_PROMPT_VERSION`) that both have to move if either wording is revised.
>
> **3. `kstrl/init_cmd.py:74-85` - the four bullets alternate between two worlds, so the reader has to track which one each bullet is in.** Bullets 1, 3, 4 assume the block is present; bullet 2 assumes it is absent; bullet 3 ("correct the `[verify]` section of `kstrl.toml`") is meaningless in the no-block world it immediately follows, because on that path no `[verify]` was consulted. Cost: no words, but the ordering is the reason bullet 2 had to carry its own done-clause (finding 1). Grouping present-case bullets first and the fallback last removes both problems at once. A 3-bullet step 9 covering every distinct fact runs ~100 words against the current 141.
>
> **4. `kstrl/init_cmd.py:83-84` - "If policy denies you that file, say so in your progress entry" spends 2 of step 9's 12 lines on a case the default scaffold does not enable.** `DEFAULT_KSTRL_TOML`'s entire `[policy]` block is commented out (`kstrl/init_cmd.py:472-486`), the `paths_deny` line naming `kstrl.toml` included. The test that justifies the clause (`tests/test_engineer_verify_instructions.py:227-233`) asserts `'"kstrl.toml"' in DEFAULT_KSTRL_TOML`, which matches inside that commented line, so it does not distinguish "denied by default" from "shown as an example". The clause is defensible for policy-enabled runs; it is not defensible as unconditional text at the same altitude as "run the commands".
>
> ## Comments and docstrings
>
> **5. The "why a floor, and who reaches the no-block branch" story is told four times.** `kstrl/init_cmd.py:36-43` (8 lines, new in this round), `tests/test_engineer_verify_instructions.py:111-129` (19-line class docstring), `tests/test_engineer_verify_instructions.py:137-139` (method docstring restating it again), `tests/test_prompt_versions.py:115-122` (9 lines). The `[verify]`-repair rationale is told twice more: `tests/test_engineer_verify_instructions.py:207-216` and the same `test_prompt_versions.py` paragraph. Cost: six places to keep consistent; a future revision that updates one leaves five contradicting it. The version-snapshot comment is the one with a policy reason to exist (H3 audit trail) and it is also the shortest-lived - 1.2.0 never shipped, so `tests/test_prompt_versions.py:115-122` is nine lines documenting a version no user will ever see. One sentence there ("1.2.0 was an unreleased draft; review found its no-block branch stated only a hint and its repair advice assumed Python") carries the whole audit fact.
>
> ## Tests
>
> **6. `tests/test_engineer_verify_instructions.py:194-196` - assertion derivable from two facts already asserted.** Line 192 asserts `_step_nine(DEFAULT_PROMPT) in implement`; the test at 136-142 asserts the floor sentence is in `_step_nine(DEFAULT_PROMPT)`. Given both, 194-196 cannot fail independently. Cost: one wording change to that sentence breaks three tests instead of one. The genuinely new fact in this test is that `ks feature`'s *implement* phase (not just understand) renders this body with no block - lines 190-193 already establish it.
>
> **7. `tests/test_engineer_verify_instructions.py:206-236` - four test methods and five assertions pinning fragments of a single four-line sentence.** Lines 220, 224, 225 and 233 all match inside bullet 3's one sentence; 236 is the negative for the text it replaced. Cost: rewording that one bullet fails four named tests, none of which tells you anything the other three don't. One test asserting the sentence (plus the existing negative) is the same coverage.
>
> **8. `tests/test_engineer_verify_instructions.py:133-134` and `:141-142` - assert pairs that split one sentence in half.** "If that block is absent" / "nothing will check this work mechanically" is one sentence; "Run the project's own typecheck and tests yourself" / "before you mark anything done" is one sentence. Since `_unwrapped` already removes the hard-wrap that was the reason to split, each pair can be one assertion on the whole sentence.
>
> **9. `tests/test_engineer_verify_instructions.py:198-203` and `:159-196` largely re-drive CLI paths already driven in `tests/test_verify_command_contract.py:615-621` and `:624-639`.** Both existing tests already invoke `ks understand` / `ks feature` and assert `not _block_is_injected(prompt)`. The new module adds `_step_nine(DEFAULT_PROMPT) in prompt` and, for feature, the implement phase. That delta is real; the `not _block_is_injected` half is a third and fourth copy. Cost: four CLI invocations (each a full `run_loop`) where two plus two cheap assertions would do.
>
> **10. `tests/test_engineer_verify_instructions.py:47-55` - `_unwrapped` is applied at 9 of 14 substring sites.** Not applied at 89, 100, 152. Line 152 (`assert "project context" not in _step_nine(DEFAULT_PROMPT)`) is the one that matters: it is a negative assertion on a two-word phrase, exactly the case the helper's own docstring says the wrap defeats. Minor, but if the helper is worth adding it is worth applying uniformly.
>
> ## Not added by this diff, noted for context
>
> `examples/uv-python/scripts/kstrl/prompt.md` is byte-identical to `DEFAULT_PROMPT` and is edited by hand in the same diff. It is pinned by `tests/test_gen_docs.py:132-141`, so it cannot drift silently - this is a maintained copy, not a defect, and pre-dates the change.
>
> ## Trade-off the caller should weigh
>
> Findings 1-4 are prompt-body edits, so acting on them costs `DEFAULT_PROMPT_VERSION` 1.4.0, a new snapshot hash in `tests/test_prompt_versions.py`, the mirrored edit in `examples/`, and a calibration re-run under H2 - the third version bump on one change. Findings 5-10 cost nothing but a test-file edit. If the appetite is for one more round, findings 1 and 3 together are the highest-value pair: they remove a bullet, remove a duplicated rule, and fix the branch interleave in a single rewrite.

**Applied: 1, 3, 5, 6, 7, 8, 10.** Findings 1 and 3 together, as recommended: the fallback merged into the done-rule bullet and the present-case bullets group first, taking step 9 from four bullets to three and stating the done-rule once. That also removed the incoherence the agent spotted between the body and a test literally named `test_the_done_rule_is_stated_once`. The version-bump cost it warned about did not apply: round 2 was still uncommitted, so all of it landed as one 1.2.0 -> 1.3.0 move, and H2 is waived. 5: the snapshot comment is now one sentence and the duplicated class/method docstrings are cut. 6, 7, 8, 10: the derivable assertion is gone, the four repair tests are three with no fragment-splitting, the split assert pairs are single whole-sentence assertions, and `_unwrapped` is applied uniformly.

**Declined, 2** (bullet 1 paraphrases the injected block): the overlap is real, but removing it would leave step 9 pointing at a block whose instructions it does not restate at all, and the failure this issue is about was precisely an agent following step 9 instead of the block. The three clauses the agent identifies as non-duplicated ("lint included", the variant taxonomy, "a command the gate will not run proves nothing") are the load-bearing ones and they need a sentence to sit in. Cost is ~30 tokens per iteration against a 2858-token preamble.

**Declined, 4** (drop the policy clause): overtaken by the altitude finding. The clause is not about the commented-out `[policy]` scaffold at all - `kstrl.toml` is in `ENFORCEMENT_MACHINERY_PATHS`, a non-overridable hard fail. The agent was right that my test did not distinguish "denied by default" from "shown as an example", and that is now fixed by asserting against the enforcement constant rather than the scaffold text.

**Declined, 9** (the CLI paths are re-driven): the contract module's copies assert "no command reached the agent"; these assert "*this body* rendered, with no block". Different facts about different constants, and the whole module runs in 0.13s.

## Efficiency

> ## Direct answers to the two questions asked
>
> **The `ks feature` CLI test is cheap and worth it.** Whole file: 20 tests, **0.12s**. The new test is the slowest at **0.02s** (`--durations`), confirmed at **17.9ms** in an isolated probe. It does no git init, no subprocess, no network. At ~15% of a 120ms file it pays for itself.
>
> **`_unwrapped(_step_nine(DEFAULT_PROMPT))` recomputation is real but costs nothing.** Measured **3.7us per call**, 7 identical occurrences of that exact expression (plus 15 `_step_nine(` and 13 `_unwrapped(` calls overall). Hoisting to a module constant saves ~**62us** across the file, or **0.05%** of the run. Measured and dismissed - not worth a change.
>
> ## Findings
>
> **1. `tests/test_engineer_verify_instructions.py:190` - the second run_loop phase the test's setup exists to reach produces a byte-identical prompt to the first.**
> Measured: `prompts[0]` (understand) and `prompts[1]` (implement) are both 5142 chars and compare `==` True. All three assertions on `prompts[-1]` (lines 192-196) hold unchanged on `prompts[0]`. The `--implementation-auto-run` flag plus the pre-written `understand.md` roughly double the invocation (~9ms of the 17.9ms; `ks understand` alone measures 9.3ms). The only thing the second phase uniquely establishes is the `len(prompts) == 2` assert - that implement ran at all and fell back to this body - which is a genuine fact, so this is not pure waste. Cost of the redundancy: ~9ms and the setup complexity the docstring spends 8 lines defending.
>
> **2. `tests/test_engineer_verify_instructions.py:154` - `test_the_engineer_gets_the_floor_and_no_block` is now an assertion-subset of the new CLI test, one layer down.**
> It asserts `{not _block_is_injected, floor sentence present}`; the CLI test asserts both plus step 9 identity, through the real command. Measured cost of keeping it: **7.6ms** (`_engineer_prompt` isolated), ~6% of the file. Defensible as layer coverage, but it is the same fact paid twice.
>
> **3. `kstrl/init_cmd.py:79,81` - step 9 now carries 105 of its 200 tokens that are dead on any given invocation.**
> Token measurements (cl100k_base proxy, no Anthropic tokenizer available offline, treat as +/-10%):
>
> | | step 9 chars | words | tokens | body tokens |
> |---|---|---|---|---|
> | v1.1.1 pre-#276 | 429 | 73 | 113 | 982 |
> | v1.2.0 round 1 | 648 | 104 | 144 | 1015 |
> | v1.3.0 round 2 | 867 | 141 | 200 | 1070 |
>
> Round 2 adds **+219 chars / +37 words / +56 tokens** to step 9 (**+38.9%**) and **+55 tokens** to the body (+5.4%). Bullet breakdown: B1 run-the-block 67 tok (inert when no block), B2 floor 31 tok (inert when the block IS present - i.e. every gated `ks run`/factory iteration), B3 repair 74 tok (inert when the block is ABSENT - there are no commands to fail, which is exactly the `ks feature` path round 2 set out to protect), B4 done-rule 12 tok (vacuous with an empty command list). Before round 2 the branch-dead text was 45 of 144 tokens; now it is 105 of 200.
>
> **4. `kstrl/init_cmd.py:83` - the policy-denial clause is 14 tokens for a triply-conditional case.**
> "If policy denies you that file, say so in your progress entry" fires only when a command fails for a non-work reason AND the command is wrong for the project's language AND policy denies `kstrl.toml`. Thinnest 14 tokens in the change.
>
> **5. `kstrl/init_cmd.py:81` - "fix the cause and not the command" (20 tok with lead-in) restates B1's substitution ban.**
> B1 already says "Do NOT derive your own or substitute a narrower or broader variant... a command the gate will not run proves nothing" (67 tok). Emphasis differs, semantics overlap.
>
> **6. `kstrl/init_cmd.py:79,85,107` - the done-rule is now stated three times (~45 tokens across the body).**
> B2's "before you mark anything done" (in 31 tok), B4 "Do NOT mark the story as done until every command passes" (12 tok), step 14's "only after step 9 is green" (17 tok). Round 1's stated premise was collapsing exactly this duplication out of step 14; round 2 reintroduces a second instance in step 9. B2/B4 are branch-exclusive so this is defensible, but the guarding test at line 84 is still named `test_the_done_rule_is_stated_once`, which the body no longer honours literally.
>
> ## Verdict on the token cost
>
> Worth it. Measured against this repo, the static preamble the engineer actually receives is **7509 chars / 1788 tokens** of project context plus **1070 tokens** of body = **2858 tokens**. Round 2's +55 tokens is **+1.9%** of that, to close the hole on the one path that writes production code with no Phase 1 at all. The identifiable trimmable slack is ~34 tokens (findings 4 and 5), i.e. **1.2%** of the preamble - below the tokenizer proxy's own error bar. Not worth a round 3 on cost grounds.
>
> Nothing blocking added at import time: the new imports (`_prompts_from_cli`, `_write_feature_prd`) come from a module this file already imported, and the `_prompt_from_cli` to `_prompts_from_cli(args)[0]` refactor adds one function call and a list index, no extra CLI invocation.

**Applied: 1 and 6.** 1 was the sharpest measurement of the round: the two phases render byte-identically, so asserting on `prompts[-1]` proved nothing that `prompts[0]` did not. The test now checks *every* prompt the command produces and says why, and the phase-count assert is replaced by a seam test that pins the structural fact instead. 6 is the same finding as Simplification 1, applied.

**Declined, 2:** kept as layer coverage at 7.6ms. The unit test fails on a `build_project_context` regression that the CLI test would also catch but would attribute less precisely.

**Declined, 4 and 5:** the agent measured the trimmable slack at ~34 tokens, 1.2% of the preamble, below its own tokenizer proxy's error bar. Finding 4's clause survived on correctness grounds anyway (see Simplification 4), though its wording changed. Declining on the agent's own numbers rather than despite them.

**Noted, 3:** the branch-dead-text figure is the real cost of one static prompt serving two callers, and it is the strongest quantitative argument for #288's option 1 (two templates sharing the resolver). Recorded in the issue.

## Altitude

> Verified ground truth first, since several findings rest on it:
> - `grep -n "verif" kstrl/feature_cmd.py` returns only lines 108/117/126, a local `verification: list[str]` built from PRD acceptance criteria. There is no Phase 1 anywhere in the file. All three `run_loop` calls (`:244`, `:375`, `:478`) omit `verify_config`, so it defaults to `None`.
> - `run_mechanical_verification` is called from exactly two places: `kstrl/pipeline.py:2572` (factory Phase 1) and `kstrl/cli.py:3341` (`ks verify`). `ks feature` reaches neither.
> - `resolve_verify_commands` (`kstrl/verify.py:725`) is a pure function of `(VerifyConfig, cwd)`. It needs no gate to produce an answer.
>
> **1. `kstrl/init_cmd.py:79-80` - the branch is keyed on the wrong fact, so one sentence has to serve two callers with opposite needs.**
> The discriminator is "was a block injected", i.e. `verify_config is None`. That value conflates two situations: `ks feature` implement/repair, which writes production code with nothing checking it, and `ks understand`, whose `allowed_paths` default is `["scripts/kstrl/codebase_map.md"]` (`kstrl/cli.py:1024`) and whose feature-phase equivalent is `[rel_feature_understand]` (`kstrl/feature_cmd.py:236`). Round 1 wrote the sentence for the second caller; round 2 rewrote it for the first. Neither can be right, because the prompt cannot see which caller it is under. Round 2 also deleted the reasoning that justified the old wording (the round-1 docstring's "an understand iteration whose allowed paths permit only the codebase map has nothing to gain from a suite run") without noting that it inverted the instruction for that path.
> Cost: a map-only iteration is now told to run the project's typecheck and tests before marking anything done. On the un-init'd project that is the only way understand reaches this body, the cost is a wasted suite run per iteration rather than a false claim, so it is small, but the change traded one wrong caller for another rather than removing the ambiguity.
> Deeper alternative: put the discriminator at the call site, where it is known. Either `run_loop` gains an explicit signal ("no gate runs and this agent writes code"), or `build_project_context` gains a no-gate variant of the block that `feature_cmd` opts into. Then step 9 states one rule per branch and each is true for its caller.
>
> **2. `kstrl/init_cmd.py:79-80` - the floor asks the agent to rediscover a fact the harness has already resolved, which is the anti-pattern #261 was created to remove.**
> "Run the project's own typecheck and tests yourself" is a derive-your-own instruction wearing a stronger modal verb. `VerifyConfig.load(root_dir)` plus `resolve_verify_commands(cfg, root_dir)` would name the three exact commands with no gate involved. The reason they are not injected is real and worth stating: `VERIFY_COMMANDS_PROMPT` (`kstrl/verify.py:625`) opens with "These are the exact commands kstrl's mechanical verification gate runs on your work", which would be a false claim on the `ks feature` path.
> Cost: on the one path this change exists to protect, the agent is back to guessing what "the project's own typecheck" means, which is precisely the failure that cost the iteration in #276.
> Deeper alternative, still inside #276's prompt scope: split `VERIFY_COMMANDS_PROMPT` into two templates that share the resolver, "the gate will run these" and "these are this project's checks, nothing will run them for you". Cost is one template plus one branch in `build_project_context`, which already receives `cwd`.
>
> **3. `kstrl/init_cmd.py:79-80` and `tests/test_engineer_verify_instructions.py:136-142` - the floor has no mechanism, and by construction cannot acquire one on this path.**
> Every test on the new sentence is a substring assertion that the sentence exists. Nothing samples whether the agent ran anything: `run_mechanical_verification` never executes on the `ks feature` path, `check_prd_stories` (`kstrl/verify.py:556`) only runs inside it, and `DEFAULT_PROMPT` has no calibration coverage (no hits in `tests/test_calibration.py`), so H2's measurement lever does not exist for the engineer prompt either. Against the project's own "if there is no mechanism, there is no plan", the floor is a claim about the agent, verified by a claim about the string.
> Cost: the change's stated value in `kstrl/init_cmd.py:39-41` ("the only thing standing between that path and a story flipped to passing on unchecked code") is unfalsifiable by anything in the repo.
> Deeper alternative, and cheaper than a full gate: run the resolved commands advisory-only after `ks feature`'s implement phase and record the result as a finding. That makes compliance measurable without adopting Phase 1's worktree/PRD/policy assumptions. The full gate is genuinely expensive: `run_mechanical_verification` was built for a worktree the factory owns and disposes of, and `docs/control-loop-design.md:560-570` already documents that it edits and commits (`check_dead_code` runs `ruff --fix`, `git add -A`, `git commit`), so pointing it at an operator's live checkout needs a read-only mode first. That is a real project, not a line change, and correctly out of scope here.
>
> **4. `kstrl/init_cmd.py:36-42` - the interim is not labelled as an interim, and has no successor.**
> The comment states the gap accurately but in the register of a design fact. There is no "this is a stopgap", no issue reference, and I checked the open issue list: nothing tracks "`ks feature` runs no verification phase". #276 is the prompt-wording issue itself.
> Cost: a future reader finds the gap documented and accepted, with no thread to pull. The prompt floor becomes the permanent answer by default rather than by decision.
> Deeper alternative: one sentence naming a filed follow-up issue. That is what converts "we chose the shallow fix because the deep one is out of scope" into a record instead of a rationalisation.
>
> **5. `kstrl/init_cmd.py:83-84` versus `kstrl/policy.py:46-75` - the escape clause papers over a genuine disagreement about who owns verification config, and understates it.**
> `kstrl.toml` is not merely in the scaffolded `[policy] paths_deny` (`kstrl/init_cmd.py:474`, and note it ships commented out with `enabled = false`). It is in `ENFORCEMENT_MACHINERY_PATHS`, whose own comment says modifying it is "a non-overridable hard fail whenever the envelope is enabled, independent of `paths_deny` and of the autonomy level", explicitly so "an agent editing `kstrl.toml` cannot widen its own permissions". So the prompt now routes the agent at a file the envelope treats as tampering. Two further facts sharpen it: nothing in the prompt or in `build_project_context` (`kstrl/loop.py:418-462`, CLAUDE.md plus commands, nothing else) tells the agent whether the envelope is on, so "if policy denies you that file" asks it to know something it was never told; and on the `ks feature` path this round is about, policy never runs and `[verify]` is never read, so the repair is inert there in both directions.
> Cost: the advice is correct only on the factory path with policy off, is a halt-inducing suggestion on the factory path with policy on, and is a no-op on the path round 2 was written for. Low blast radius today because policy ships disabled, but the conflict is now written into the prompt.
> Deeper alternative: your framing is right. The disagreement is that policy says verification config belongs to the operator and the prompt now says it belongs to the agent. Resolve it in one place. Either the harness states the posture (surface policy-enabled plus writability alongside the commands, so the prompt stops guessing), or the prompt's only sanctioned repair route on a wrong command is the finding/progress channel and the operator fixes `[verify]`.
>
> **6. `kstrl/init_cmd.py:744` and `kstrl/init_wizard.py:53-62` - the fix ships in a template that no existing project will ever receive.**
> `_create_if_missing` (`kstrl/init_cmd.py:851-857`) never overwrites, the wizard reports an existing `prompt.md` as "keep", and `DEFAULT_PROMPT_VERSION` is never written to disk, so drift is not merely unfixed, it is undetectable. `ks feature`'s implement and repair phases read `scripts/kstrl/prompt.md` (`feature_cmd.py:363`, `:453`), which on any already-init'd project is a v1.1.1-era copy. There is no doctor or upgrade command.
> Cost: the population the review finding is about, people already running `ks feature`, gets nothing from this change. They keep the old unconditional done-rule, so it is not a regression, but the floor does not reach them. Only newly-init'd projects and un-init'd fallbacks get it.
> Deeper alternative: stamp the version into the scaffolded `prompt.md` and report drift at init or in a doctor command. Larger than #276 and rightly its own issue, but the PR body should say plainly that the fix does not reach existing checkouts.
>
> **7. `tests/test_engineer_verify_instructions.py:159-196` - the new CLI test is coupled to `ks feature`'s flow shape, and its fixture is the un-init'd case rather than the normal-use case it is cited to support.**
> Two specifics. First, `_write_feature_prd` writes no `scripts/kstrl/prompt.md`, so `assert _step_nine(DEFAULT_PROMPT) in implement` (line 192) holds only because `run_loop` fell back to the constant. On the init'd project the class docstring calls "normal use", the implement phase reads a scaffolded copy, which this test cannot see. Second, `assert len(prompts) == 2` (line 190) pins `ks feature`'s phase count inside a prompt-wording module: adding a pre-implement phase breaks it with no prompt change. The docstring is honest that `--implementation-auto-run` and the pre-written `understand.md` are load-bearing, which is exactly the admission that the test is coupled to the checkpoint gate and its file check. Runtime is not the cost here, the whole module runs in half a second; coupling is.
> Deeper alternative: assert the structural fact at the seam, that `feature_cmd`'s implement `run_loop` call receives `verify_config=None`, and keep the wording assertions on `DEFAULT_PROMPT`. Add separately the fact the CLI test is really standing in for, that `ks init` scaffolds `prompt.md` byte-identical to `DEFAULT_PROMPT`. If the seam assertion is kept, label it as characterising the gap and point at the follow-up from finding 4, so it does not read as blessing `None`.
>
> **8. `tests/test_prompt_versions.py:106-125` - the 1.2.0 to 1.3.0 bump is defensible, but the audit trail it buys lives in prose, not in the mechanism.**
> `origin/main` is at 1.1.1, so main will move 1.1.1 to 1.3.0 and 1.2.0 will exist in no artifact. `_EXPECTED_SNAPSHOTS` holds one tuple per prompt, not a history, so the record of the abandoned draft is a nine-line comment in an enforcement file describing a version that file will never pin. H3 as CLAUDE.md states it ("the PR diff with prompt body + version constant + snapshot tuple all moving") is satisfied either way, because the PR diff shows both rounds whichever number the constant lands on.
> Cost: a permanent explanatory paragraph in the file whose job is pinning the current value, plus a gap in the released sequence that every future reader has to be told about.
> Deeper alternative: amend 1.2.0 in place and let the PR's commit history carry the round-1/round-2 record, keeping the snapshot comment about the shipped change only. If the project does want unshipped drafts numbered, state that once in CLAUDE.md's H3 section rather than arguing it per PR. Low severity, and I would not block on it.
>
> **9. `docs/control-loop-design.md:597` - updating one inline quote of the prompt body is the right edit at the wrong level, and this diff proves it.**
> The doc quotes step 14 verbatim with no version pin, so every prompt edit silently obliges a doc edit that nothing enforces. `docs/lessons/pr-221.html:939` still carries the old "only after tests/typecheck pass AND the self-critique is written". One prose copy moved, the other did not, and there is no stated rule for which should.
> Cost: H3 pins the prompt's hash while its prose copies drift on memory alone.
> Deeper alternative: a test that asserts quoted prompt lines in `docs/` appear in `DEFAULT_PROMPT`, or stop quoting and cite `init_cmd.py` step 14 by reference. If `docs/lessons/*.html` are deliberately frozen artifacts of a past PR, that exemption should be written down, because right now it is indistinguishable from an oversight.
>
> Overall judgment on the central question: the prompt floor is a reasonable interim for an issue about prompt wording, and the round-2 body is a better sentence than round 1's on the path that matters. But it is a text floor with no mechanism on a path that has no mechanism, and it is not labelled as interim, has no tracked successor, does not reach existing projects, and reintroduces derive-your-own on the very path it protects when the harness could have named the commands. Findings 1 through 4 are the ones I would want answered before merge; 5 is a latent conflict worth a sentence in the PR body; 6 through 9 are level observations with small immediate cost.

**Applied, 1** (partially, by wording): the floor is now scoped to marking a story done rather than to every iteration, which is the discriminator the prompt *can* see. A map-only `ks understand` fallback marks no story and so owes nothing; `ks feature` implement does mark stories and does owe. That removes the wasted-suite-run cost without needing a call-site signal. The deeper fix (a call-site discriminator) is recorded in #288.

**Applied, 4:** filed **#288** and referenced it from the source comment, which now says INTERIM in as many words and states why the harness stays silent there.

**Applied, 5:** this changed the fix materially. See "Round 2 finding 2" above: the clause now routes the agent to report `[verify]` rather than edit it, and a test pins `"kstrl.toml" in ENFORCEMENT_MACHINERY_PATHS`.

**Applied, 7:** the phase-count assert is gone, replaced by a seam test asserting no `ks feature` phase names a gate, labelled as characterising the gap and pointing at #288. The CLI test now asserts over every prompt rather than a chosen index (which Efficiency 1 showed proved nothing extra), and the unnecessary `understand.md` pre-write and its false justification are gone.

**Applied, 8** (partially): the snapshot comment is one sentence, not nine lines. The version still moves to 1.3.0, because the reviewer explicitly required it and because a body edit landing on a pinned version is the "silent version pin" failure mode `tests/test_prompt_versions.py` exists to catch. Whether unshipped drafts should be numbered is a CLAUDE.md question, not a per-PR one, and I agree it should be settled there.

**Declined, 2** (split `VERIFY_COMMANDS_PROMPT` into two templates): this is the best idea in the pass and I want to be clear it is declined on scope, not on merit. It reverses #261's deliberate decision that `verify_config=None` states nothing, which is pinned by `test_no_gate_means_no_commands_are_stated` and was an owner call about not claiming a gate exists. Recorded as option 1 in #288 with the token measurements from the efficiency pass, which are the strongest argument for it.

**Declined, 3** (advisory verification on the `ks feature` path): agreed that the floor has no mechanism, and the PR now says so in those words rather than implying otherwise. The fix is #288 option 2, correctly out of scope for a prompt-wording issue.

**Noted, 6:** already reported in round 1 and now confirmed with the extra detail that the wizard reports an existing `prompt.md` as "keep". Stated plainly below: **this fix does not reach existing checkouts.** The reviewer is filing that separately.

**Noted, 9:** `docs/lessons/pr-221.html` deliberately left alone. See Round 2 finding 4 above.

---

## Reported, not fixed, after both rounds

1. **A scaffolded `scripts/kstrl/prompt.md` is never upgraded, so this fix does not reach existing checkouts.** `_create_if_missing` never overwrites, the init wizard reports an existing copy as "keep", and `DEFAULT_PROMPT_VERSION` is never written to disk, so the drift is undetectable as well as unfixed. Any project already running `ks feature` keeps its v1.1.1 body. It is not a regression for them (they keep the old unconditional done-rule) but they gain nothing. The reviewer is filing this separately.
2. **`ks feature` runs no verification phase at all.** Now tracked as **#288**, with the three options and their costs.
3. **Phase 3 does not follow a project's `[verify] test_command`.** `ContractConfig.load` reads only `[contract]`. This PR removes the duplicated literal; it does not connect the two settings.
4. **On the no-gate path, CLAUDE.md is injected unscrubbed.** `build_project_context` only drops stale verification bullets when it has resolved commands to compare against. This PR stops step 9 pointing at that list; it does not remove it.
5. **Policy and the prompt disagree about who owns verification config, and the agent is never told which posture is in force.** Nothing in the prompt or in `build_project_context` tells the agent whether the envelope is enabled. This PR resolves the disagreement in the safe direction (report, do not edit), but the underlying question - should the harness surface policy state alongside the commands - is open.
