### PR TITLE
fix(scope): carve kstrl's own state directory out at the guard

### DIFF
--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -1197,6 +1197,7 @@ def _understand_core(
             interaction=interaction,
             stop_check=stop_check,
             guard_ignored_paths=understand_harness_paths,
+            guard_state_root=root_dir,
         )
     except Exception as exc:
         duration = round(time.monotonic() - started, 2)

--- a/kstrl/factory.py
+++ b/kstrl/factory.py
@@ -2151,6 +2151,12 @@ def _run_component(
             on_iteration_usage=on_iteration_usage,
             guard_base_ref=base_branch,
             guard_ignored_paths=harness_paths,
+            # #274: the project root, NOT worktree_path. The two are the
+            # same directory only under use_worktrees=False, which is
+            # exactly when `.kstrl/` reaches the guard's walk; in a real
+            # worktree they differ and the loop carves nothing out, so a
+            # `.kstrl/` the AGENT wrote there stays a violation.
+            guard_state_root=root_dir,
             verify_config=verify_config,
         )
         # Report which limit fired so the retry/fail path can act on it

--- a/kstrl/feature_cmd.py
+++ b/kstrl/feature_cmd.py
@@ -170,14 +170,12 @@ def run_feature(
     """
     component = params.feature_name
     bus = run.bus if run is not None else None
-    guard_ignored_paths: list[str] = []
-    try:
-        relative_log_dir = params.log_dir.relative_to(root_dir).as_posix()
-    except ValueError:
-        pass
-    else:
-        if relative_log_dir.startswith(".kstrl/logs/"):
-            guard_ignored_paths.append(relative_log_dir.rstrip("/") + "/")
+    # This flow used to hand `run_loop` its own `.kstrl/logs/<feature>/`
+    # entry. #274 removed it: every loop below runs with `cwd=root_dir`,
+    # `guard_state_root=root_dir` carves out `.kstrl/logs/` as part of
+    # the whole state directory, and `path_is_allowed` matches that as a
+    # prefix. Declaring it here as well would print two entries for one
+    # carve-out and read as wider than it is.
 
     def emit(event: Event) -> None:
         if bus is not None:
@@ -251,7 +249,7 @@ def run_feature(
             bus=bus,
             interaction=interaction,
             stop_check=stop_check,
-            guard_ignored_paths=guard_ignored_paths,
+            guard_state_root=root_dir,
         )
     except Exception as exc:
         detail = f"{type(exc).__name__}: {exc}"
@@ -382,7 +380,7 @@ def run_feature(
             bus=bus,
             interaction=interaction,
             stop_check=stop_check,
-            guard_ignored_paths=guard_ignored_paths,
+            guard_state_root=root_dir,
         )
     except Exception as exc:
         detail = f"{type(exc).__name__}: {exc}"
@@ -485,7 +483,7 @@ def run_feature(
                 bus=bus,
                 interaction=interaction,
                 stop_check=stop_check,
-                guard_ignored_paths=guard_ignored_paths,
+                guard_state_root=root_dir,
             )
         except Exception as exc:
             detail = f"{type(exc).__name__}: {exc}"

--- a/kstrl/guards.py
+++ b/kstrl/guards.py
@@ -91,8 +91,18 @@ def check_violations(
 ) -> list[str]:
     """Check for files that violate ALLOWED_PATHS.
 
-    ``ignored_paths`` contains exact harness-owned files or directory
-    prefixes for this invocation, never a blanket state-directory bypass.
+    ``ignored_paths`` is harness-owned only: the exact files kstrl
+    requires this invocation's agent to write
+    (``config.component_harness_paths``, #264) plus the entries kstrl
+    itself creates under its state directory
+    (``statedir.state_dir_carve_out``, #274).
+
+    Still never a blanket state-directory bypass. ``.kstrl/`` as a bare
+    prefix is refused everywhere - ``decompose._ALLOWED_PATHS_EXCLUDE``
+    will not let an architect authorise it - and the state carve-out
+    names only the subtrees and files kstrl writes, so a path the
+    harness does not create (``.kstrl/notes.md``) is still a violation.
+
     Returns list of disallowed files.
     """
     if not allowed_paths:
@@ -139,6 +149,43 @@ def _revert_violation(
         ui.info(f"  Deleted: {file}")
 
 
+def _report_violations(
+    ui: UI,
+    allowed_paths: list[str],
+    ignored_paths: list[str] | None,
+    violations: list[str],
+) -> None:
+    """Print the scope failure, authored list and carve-out apart.
+
+    The two lists never merge (#264, #274). An operator reading a scope
+    failure has to be able to tell what THEY authorised from what the
+    harness added on their behalf, and a retry agent must not read
+    kstrl's own PRD, progress log or state directory as the thing it has
+    to stop writing - that is the one instruction it cannot obey and
+    still pass ``prd_stories``. Mirrors ``verify._diff_scope_details``,
+    which does the same for the Phase 1 half of the same question.
+
+    The parenthetical repeats ``verify._diff_scope_details`` and
+    ``factory._run_component`` word for word. Deliberate: the three
+    scope failures must read identically wherever they are caught, and
+    the claim itself has to be the same claim, because a retry agent
+    told "already in scope" at one guard and "not part of
+    ALLOWED_PATHS" at another has been given two different instructions
+    about the same files.
+    """
+    ui.channel_header("GUARD", "Disallowed changes")
+    ui.kv("ALLOWED_PATHS", ", ".join(allowed_paths))
+    if ignored_paths:
+        ui.kv("HARNESS_PATHS", ", ".join(ignored_paths))
+        ui.info(
+            "  (kstrl's own files, already in scope, no need to widen allowedPaths)",
+        )
+    ui.info("")
+    ui.info("Disallowed files:")
+    for f in violations:
+        ui.info(f"    - {f}")
+
+
 def enforce_allowed_paths(
     config: KstrlConfig,
     ui: UI,
@@ -153,8 +200,10 @@ def enforce_allowed_paths(
     - ok is True if enforcement passed (no violations or resolved)
     - violations is list of disallowed files
 
-    ``ignored_paths`` is the caller's exact set of harness-owned outputs
-    for the active run.
+    ``ignored_paths`` is the harness-owned set for the active run: the
+    caller's per-invocation files plus kstrl's own state directory. It
+    is reported separately from ``config.allowed_paths`` in the failure
+    block, never folded into it.
 
     ``baseline`` is the workspace as it stood before the agent started
     (``git.capture_workspace_baseline``). With one, the guard judges the
@@ -190,13 +239,7 @@ def enforce_allowed_paths(
     if not violations:
         return True, []
 
-    # Display violations
-    ui.channel_header("GUARD", "Disallowed changes")
-    ui.kv("ALLOWED_PATHS", ", ".join(config.allowed_paths))
-    ui.info("")
-    ui.info("Disallowed files:")
-    for f in violations:
-        ui.info(f"    - {f}")
+    _report_violations(ui, config.allowed_paths, ignored_paths, violations)
 
     if not config.interactive:
         ui.err(

--- a/kstrl/guards.py
+++ b/kstrl/guards.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Literal
 
@@ -12,12 +13,19 @@ from kstrl.interaction import (
     PromptRequest,
     UiInteractionChannel,
 )
+from kstrl.statedir import STATE_DIR_NAME
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from kstrl.config import KstrlConfig
     from kstrl.ui.base import UI
+
+
+#: A repo-relative path inside kstrl's own state directory. Matched
+#: rather than string-compared so ``.kstrl-backup/x`` and ``sub/.kstrl/x``
+#: do not qualify: only the state directory AT THE WALK ROOT is kstrl's.
+_WITHIN_STATE_DIR = re.compile(rf"^{re.escape(STATE_DIR_NAME)}/")
 
 
 def path_is_allowed(path: str, allowed_paths: list[str]) -> bool:
@@ -122,8 +130,8 @@ def _revert_violation(
     ui: UI,
     cwd: Path | None,
     baseline: git.WorkspaceBaseline | None,
-) -> None:
-    """Undo one out-of-scope change.
+) -> bool:
+    """Undo one out-of-scope change. False when it was REFUSED.
 
     With a baseline the revert source is the BASELINE COMMIT, not the
     index: the violation may already be committed, and restoring from
@@ -132,7 +140,23 @@ def _revert_violation(
     violation and the next iteration would re-detect it forever. A file
     that did not exist at the baseline is dropped from the index and
     deleted, so it disappears from the delta the way a revert should.
+
+    Nothing under kstrl's own state directory is ever reverted (#274
+    review). The paths that reach here are by definition the ones the
+    carve-out does NOT cover, and ``statedir.STATE_NOT_CARVED`` keeps
+    exactly the authority-carrying entries countable: the work queue,
+    evolution proposals, the autonomy level, the pause marker. Deleting
+    an untracked file is how this function disposes of a violation, and
+    ``git.delete_untracked`` recurses into directories - so without this
+    refusal, making those paths VISIBLE to the guard would also hand
+    them to a deleter, and an operator choosing "Revert and continue"
+    could destroy the pause marker they had just written. Reporting a
+    file and destroying it are different powers; this function only has
+    the second, so it declines the cases where only the first is wanted.
     """
+    if _WITHIN_STATE_DIR.match(file):
+        ui.warn(f"  Refused (kstrl state, reported not reverted): {file}")
+        return False
     if baseline is not None and baseline.head is not None:
         if git.restore_file_from(file, baseline.head, cwd):
             ui.info(f"  Restored: {file}")
@@ -140,13 +164,30 @@ def _revert_violation(
             git.remove_from_index(file, cwd)
             git.delete_untracked(file, cwd)
             ui.info(f"  Deleted: {file}")
-        return
+        return True
     if git.is_file_tracked(file, cwd):
         git.restore_file(file, cwd)
         ui.info(f"  Restored: {file}")
     else:
         git.delete_untracked(file, cwd)
         ui.info(f"  Deleted: {file}")
+    return True
+
+
+def _revert_violations(
+    violations: list[str],
+    ui: UI,
+    cwd: Path | None,
+    baseline: git.WorkspaceBaseline | None,
+) -> list[str]:
+    """Revert what may be reverted; return what was refused.
+
+    Its own function so ``enforce_allowed_paths`` keeps one statement
+    here rather than a branch: the refusals have to travel back to the
+    caller, because reporting "reverted" for a file still on disk is the
+    silent-success failure this whole guard exists to avoid.
+    """
+    return [f for f in violations if not _revert_violation(f, ui, cwd, baseline)]
 
 
 def _report_violations(
@@ -272,11 +313,11 @@ def enforce_allowed_paths(
         # Quit
         return False, violations
     elif choice == 1:
-        # Revert
+        # Revert. Anything refused (kstrl's own state) is reported back
+        # unreverted rather than silently counted as handled.
         ui.info("Reverting disallowed changes...")
-        for f in violations:
-            _revert_violation(f, ui, cwd, baseline)
-        return True, []
+        refused = _revert_violations(violations, ui, cwd, baseline)
+        return not refused, refused
     else:
         # Continue anyway
         ui.warn("Continuing with disallowed changes")

--- a/kstrl/init_cmd.py
+++ b/kstrl/init_cmd.py
@@ -601,6 +601,13 @@ _GITIGNORE_BLOCK_HEADER = f"""{GITIGNORE_BLOCK_MARKER}
 
 # Ignored everywhere: kstrl's own runtime state, plus the one OS artifact
 # that lands in a working tree without anybody asking for it.
+#
+# `.kstrl/` stays here after #274 carved the state directory out at the
+# scope guard. The two answer different questions and neither subsumes
+# the other: the guard only decides whether a file counts as a scope
+# violation, while this line is what keeps `git add -A` from committing
+# kstrl's run journals into the project's history and thence into a PR.
+# Delete it and a --no-worktrees run starts shipping its own state.
 _COMMON_IGNORES = (
     ".kstrl/",
     ".DS_Store",

--- a/kstrl/loop.py
+++ b/kstrl/loop.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from kstrl import git, guards
+from kstrl import git, guards, statedir
 from kstrl.agents.base import UsageTotals, collect_usage
 from kstrl.agents.proc import TIMEOUT_MESSAGE_PREFIX
 from kstrl.breaker import BreakerConfig, NoProgressBreaker
@@ -475,6 +475,12 @@ def run_loop(
     interaction: InteractionChannel | None = None,
     stop_check: Callable[[], bool] | None = None,
     guard_ignored_paths: list[str] | None = None,
+    # The project root whose `.kstrl/` this run writes (#274). Only the
+    # caller knows it: `cwd` is the component worktree in a factory run
+    # and the project root everywhere else, and the two are the same
+    # directory only under --no-worktrees. Left None the loop carves
+    # nothing out, which is the pre-#274 behaviour.
+    guard_state_root: Path | None = None,
     # The component's base branch. The in-loop scope guard measures from
     # here so it asks the same question check_diff_scope does; None (the
     # standalone `ks run` case) falls back to the starting HEAD.
@@ -618,7 +624,23 @@ def run_loop(
     # Guardrails info
     ui.subsection("Guardrails")
     guard_baseline: git.WorkspaceBaseline | None = None
+    # The complete set the guard must not count: the caller's
+    # per-invocation harness files (#264) and kstrl's own state
+    # directory (#274). Both are loop-invariant, so this is assembled
+    # once here rather than rebuilt every iteration.
+    #
+    # The state carve-out supersedes the `.kstrl/runs/<run_id>/` entry
+    # this loop used to derive from the bus. `.kstrl/runs/` covers it
+    # wherever kstrl actually writes it, and it is now absent inside a
+    # component worktree, which is a TIGHTENING: the run journal is
+    # never written there, so that entry could only ever have hidden a
+    # `.kstrl/runs/<run_id>/` path the AGENT wrote.
+    guard_ignored: list[str] = []
     if config.allowed_paths and is_repo:
+        guard_ignored = [
+            *(guard_ignored_paths or ()),
+            *statedir.state_dir_carve_out(cwd, guard_state_root),
+        ]
         ui.info(f"Enforcing ALLOWED_PATHS={','.join(config.allowed_paths)}")
         # R8 review finding 4: the guard's question is "what did THIS
         # agent change", and only a before-picture can answer it. Taken
@@ -745,15 +767,12 @@ def run_loop(
         # When enforcement fails the iteration is treated as failed even
         # if the marker was seen.
         if config.allowed_paths and is_repo:
-            ignored_paths = list(guard_ignored_paths or ())
-            if bus is not None and bus.run_id:
-                ignored_paths.append(f".kstrl/runs/{bus.run_id}/")
             ok, violations = guards.enforce_allowed_paths(
                 config,
                 ui,
                 cwd,
                 interaction=channel,
-                ignored_paths=ignored_paths,
+                ignored_paths=guard_ignored,
                 baseline=guard_baseline,
             )
             if not ok:

--- a/kstrl/statedir.py
+++ b/kstrl/statedir.py
@@ -53,12 +53,142 @@ CONTROL_FILENAMES: tuple[str, ...] = (
     CONTROL_GITHUB_PROCESSED,
 )
 
+#: Directories kstrl creates directly under ``.kstrl/`` and then fills
+#: with names it invents at runtime - a run id, a component id, a queue
+#: item, a fact digest. A directory prefix is the narrowest statement
+#: that can cover a tree whose leaf names do not exist until the run
+#: does; an exact-file carve-out is impossible for these.
+#:
+#: Every name here is written by kstrl and by nothing else:
+#:
+#: - ``contract``   ``contract.py`` throwaway merge worktrees
+#: - ``debug``      ``pipeline.py`` per-component debug dumps
+#: - ``knowledge``  ``knowledge.py`` distilled facts (default root)
+#: - ``logs``       ``cli.py`` feature transcripts, ``serve.py`` launchd logs
+#: - ``proposals``  ``cli.py`` evolution proposals
+#: - ``queue``      ``workqueue.py`` (``QUEUE_DIR_NAME``)
+#: - ``runs``       ``events.py`` event journals and transcripts
+#: - ``snapshots``  ``fixtures.py`` (``FixturesConfig.snapshot_dir``)
+#: - ``worktrees``  ``factory.py`` component worktrees and their locks
+#:
+#: ``tests/test_state_dir_scope.py`` AST-walks ``kstrl/`` for the entries
+#: the package names and fails on one that is missing here. Its reach is
+#: exactly the two spellings kstrl uses today - a ``/`` join off the
+#: state directory (``root / ".kstrl" / "runs"``,
+#: ``state_dir(root) / QUEUE_DIR_NAME``) and a literal ``.kstrl/<name>``
+#: inside a string. It would NOT see a local alias, an f-string or an
+#: ``os.path.join``, so it is a net under the current idiom, not a proof
+#: about the next one. Write a new state path in one of those two forms
+#: and the net catches the omission; write it another way and this list
+#: is what has to be updated by hand.
+#:
+#: ``queue`` re-spells ``workqueue.QUEUE_DIR_NAME`` as a literal because
+#: ``workqueue`` imports this module; importing back would cycle. The
+#: AST net is what keeps the two in step.
+STATE_SUBDIRS: tuple[str, ...] = (
+    "contract",
+    "debug",
+    "knowledge",
+    "logs",
+    "proposals",
+    "queue",
+    "runs",
+    "snapshots",
+    "worktrees",
+)
+
+#: Single files kstrl writes directly in the state directory. Exact
+#: paths, never prefixes. The legacy in-tree control files
+#: (``autonomy.json``, ``inbox.jsonl``, and the three under ``queue/``)
+#: are derived from ``legacy_control_paths`` rather than repeated here,
+#: so a control file added later is covered without a second edit.
+STATE_FILES: tuple[str, ...] = (
+    CONTROL_RELOCATED_MARKER,
+    "evolution.jsonl",
+    "experiments.tsv",
+    "factory.lock",
+    "progress.jsonl",
+)
+
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 
 def state_dir(root_dir: Path) -> Path:
     """Return the in-tree artifact/lock directory for ``root_dir``."""
     return root_dir / STATE_DIR_NAME
+
+
+def _same_directory(left: Path, right: Path) -> bool:
+    """Whether two paths name one directory, symlinks resolved.
+
+    ``realpath`` rather than ``Path.resolve`` because neither side is
+    required to exist - the walk root may be a worktree the caller is
+    about to create - and because macOS reaches ``/tmp`` through a
+    symlink, so the project root and the loop's ``cwd`` are routinely
+    the same directory spelled two ways. Falls back to ``normpath`` if
+    the filesystem refuses to answer.
+    """
+    try:
+        return os.path.realpath(left) == os.path.realpath(right)
+    except OSError:
+        return os.path.normpath(left) == os.path.normpath(right)
+
+
+def state_dir_carve_out(walk_root: Path, state_root: Path | None) -> list[str]:
+    """Paths under ``.kstrl/`` the scope guard must not count (#274).
+
+    The in-loop scope guard walks UNTRACKED files
+    (``git ls-files --others --exclude-standard``) and counts every one
+    against the component's ``allowedPaths``. kstrl writes its own run
+    journals, locks and queue into ``<state_root>/.kstrl/`` while that
+    walk is happening, so in a repository that does not ignore
+    ``.kstrl/`` the harness trips over its own artifacts and the
+    operator pays an engineer iteration for it. ``ks init`` now
+    scaffolds a ``.gitignore`` (#273), which cannot reach a repository
+    that already exists; this carve-out travels with the harness
+    instead.
+
+    **Not a blanket ``.kstrl/`` bypass**, which is what
+    ``guards.check_violations`` warns against and what
+    ``decompose._ALLOWED_PATHS_EXCLUDE`` refuses to let an architect
+    authorise. The return value names only the entries kstrl itself
+    creates (``STATE_SUBDIRS`` + ``STATE_FILES`` + the legacy control
+    files), so ``.kstrl/anything-else`` stays a violation and an agent
+    cannot invent a hiding place under the state directory.
+
+    ``walk_root`` is the tree the guard is about to walk;
+    ``state_root`` is the project root whose ``.kstrl/`` kstrl actually
+    writes, which only the caller knows. Empty unless the two name the
+    same directory, so a component worktree - whose ``.kstrl/`` can only
+    be the agent's, because kstrl writes nothing there - keeps full
+    guard visibility. ``state_root=None`` means the caller has no state
+    directory to declare and also yields nothing: a caller that forgets
+    to pass it gets the pre-#274 behaviour, which fails loudly on
+    kstrl's own artifacts, rather than a carve-out applied to a tree
+    kstrl does not own.
+
+    Entries are relative to the walk root because that is what
+    ``git ls-files`` reports and what ``guards.path_is_allowed``
+    matches on. Directory entries carry a trailing slash so
+    ``path_is_allowed`` treats them as prefixes; file entries do not.
+    """
+    if state_root is None or not _same_directory(walk_root, state_root):
+        return []
+    prefix = f"{STATE_DIR_NAME}/"
+    entries = {f"{prefix}{name}/" for name in STATE_SUBDIRS}
+    entries.update(f"{prefix}{name}" for name in STATE_FILES)
+    # Only the FLAT legacy control files are added here. The other three
+    # sit under queue/, which is already a prefix entry, and listing
+    # both would tell the operator the carve-out is wider than it is.
+    # Derived rather than copied, so a control file added later is
+    # covered without a second edit to STATE_FILES.
+    in_tree = state_dir(state_root)
+    entries.update(
+        f"{prefix}{path.name}"
+        for path in legacy_control_paths(state_root).values()
+        if path.parent == in_tree
+    )
+    return sorted(entries)
 
 
 def _utc_now_iso() -> str:

--- a/kstrl/statedir.py
+++ b/kstrl/statedir.py
@@ -53,11 +53,19 @@ CONTROL_FILENAMES: tuple[str, ...] = (
     CONTROL_GITHUB_PROCESSED,
 )
 
-#: Directories kstrl creates directly under ``.kstrl/`` and then fills
-#: with names it invents at runtime - a run id, a component id, a queue
-#: item, a fact digest. A directory prefix is the narrowest statement
-#: that can cover a tree whose leaf names do not exist until the run
-#: does; an exact-file carve-out is impossible for these.
+#: Directories kstrl creates directly under ``.kstrl/``. A statement of
+#: FACT about what the package writes, kept complete: which of them the
+#: scope guard actually carves out is the separate policy in
+#: ``STATE_NOT_CARVED`` below. Complete because this is the one place to
+#: read what kstrl puts in its state directory, and because the AST
+#: drift net and the exclusion policy are both checked against it.
+#:
+#: kstrl fills each of these with names it invents at runtime - a run
+#: id, a component id, a queue item, a fact digest - so a carved one is
+#: emitted as a directory PREFIX. That is the narrowest form available
+#: for a tree whose leaf names do not exist until the run does, and it
+#: means everything beneath a carved prefix is uncounted by the in-loop
+#: guard. ``state_dir_carve_out`` says what that does and does not buy.
 #:
 #: Every name here is written by kstrl and by nothing else:
 #:
@@ -98,16 +106,59 @@ STATE_SUBDIRS: tuple[str, ...] = (
 )
 
 #: Single files kstrl writes directly in the state directory. Exact
-#: paths, never prefixes. The legacy in-tree control files
-#: (``autonomy.json``, ``inbox.jsonl``, and the three under ``queue/``)
-#: are derived from ``legacy_control_paths`` rather than repeated here,
-#: so a control file added later is covered without a second edit.
+#: paths, never prefixes. The last two are the flat legacy in-tree
+#: control files; R8.9 moved live control state to the XDG directory,
+#: but a repository that has not run a control command since still has
+#: them here. The other three legacy control files live under ``queue/``
+#: and are covered by that subtree.
 STATE_FILES: tuple[str, ...] = (
     CONTROL_RELOCATED_MARKER,
     "evolution.jsonl",
     "experiments.tsv",
     "factory.lock",
     "progress.jsonl",
+    CONTROL_AUTONOMY,
+    CONTROL_INBOX,
+)
+
+#: Entries kstrl creates but the guard deliberately keeps COUNTING
+#: (#274 review). Two criteria, and BOTH must hold before a name goes
+#: here:
+#:
+#: 1. It carries AUTHORITY over what kstrl does next, so losing sight of
+#:    it is worse than a false scope failure. ``queue`` is the in-tree
+#:    work queue ``ks serve`` drains (``workqueue.py``), so a file
+#:    written there can admit work; the pause marker, spend ledger and
+#:    GitHub processed-ids sit inside it. ``proposals`` is what
+#:    ``ks evolve --apply`` reads to mutate config and prompts, and
+#:    ``[evolution] auto_apply_computational`` can skip its confirmation.
+#:    ``autonomy.json`` is the autonomy level itself and ``inbox.jsonl``
+#:    the human-decision stream. All five are exactly
+#:    ``policy.ENFORCEMENT_MACHINERY_PATHS``, where touching one is a
+#:    non-overridable hard fail; a guard that stopped reporting them
+#:    would disagree with the envelope about the same files.
+#: 2. NOTHING reachable from ``run_loop`` writes it, so keeping it
+#:    countable cannot reintroduce the failure this carve-out exists to
+#:    fix. They are written only by ``serve.py`` and ``cli.py`` command
+#:    entry points, and ``serve`` moves a queue item to running BEFORE it
+#:    launches the factory and to a terminal state after it returns, so
+#:    its writes bracket the run rather than land inside it. The R8.9
+#:    migration only ever moves a control file OUT, and a deletion is
+#:    not a violation. ``tests/test_state_dir_scope.py`` checks this
+#:    against the loop's static import closure rather than leaving it as
+#:    a claim.
+#:
+#: Criterion 2 is affordable because the guard already subtracts
+#: whatever was on disk when the agent started
+#: (``git.capture_workspace_baseline``). Measured, not assumed: an
+#: operator running ``ks serve`` against this repo does not trip over
+#: queue items that predate the run, only over one written while the
+#: agent was working, which is the case worth seeing.
+STATE_NOT_CARVED: tuple[str, ...] = (
+    CONTROL_AUTONOMY,
+    CONTROL_INBOX,
+    "proposals",
+    "queue",
 )
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
@@ -151,10 +202,31 @@ def state_dir_carve_out(walk_root: Path, state_root: Path | None) -> list[str]:
     **Not a blanket ``.kstrl/`` bypass**, which is what
     ``guards.check_violations`` warns against and what
     ``decompose._ALLOWED_PATHS_EXCLUDE`` refuses to let an architect
-    authorise. The return value names only the entries kstrl itself
-    creates (``STATE_SUBDIRS`` + ``STATE_FILES`` + the legacy control
-    files), so ``.kstrl/anything-else`` stays a violation and an agent
-    cannot invent a hiding place under the state directory.
+    authorise. The return value is ``STATE_SUBDIRS`` and ``STATE_FILES``
+    minus ``STATE_NOT_CARVED``, so a NEW top-level name under the state
+    directory - ``.kstrl/notes.md``, ``.kstrl/payload.py`` - is still a
+    violation.
+
+    **What it does NOT claim.** The carved subtrees are directory
+    PREFIXES, so a file the agent places INSIDE one
+    (``.kstrl/runs/x/evil.py``) is not counted by the in-loop guard. No
+    exact-path form exists for those trees, because kstrl invents their
+    leaf names at runtime, and a shape constraint on the leaves would be
+    a mechanism an agent satisfies by choosing a filename. The residual
+    is accepted and pinned by test rather than papered over, and it is
+    bounded three ways: ``STATE_NOT_CARVED`` keeps every
+    authority-carrying entry countable, so what is left is audit and
+    artifact trees; Phase 1's ``verify.check_diff_scope`` is
+    deliberately un-carved, so anything the agent COMMITS under
+    ``.kstrl/`` still fails there and never reaches a PR; and it applies
+    only where the walk root IS the state root, so a component worktree
+    gets nothing.
+
+    None of this is prevention. The agent has a filesystem; a scope
+    guard reports out-of-bounds edits, it does not authenticate
+    journals. What changes here is only what gets REPORTED, and
+    reporting under ``.kstrl/`` was already off in every repository
+    whose ``.gitignore`` lists it.
 
     ``walk_root`` is the tree the guard is about to walk;
     ``state_root`` is the project root whose ``.kstrl/`` kstrl actually
@@ -175,20 +247,11 @@ def state_dir_carve_out(walk_root: Path, state_root: Path | None) -> list[str]:
     if state_root is None or not _same_directory(walk_root, state_root):
         return []
     prefix = f"{STATE_DIR_NAME}/"
-    entries = {f"{prefix}{name}/" for name in STATE_SUBDIRS}
-    entries.update(f"{prefix}{name}" for name in STATE_FILES)
-    # Only the FLAT legacy control files are added here. The other three
-    # sit under queue/, which is already a prefix entry, and listing
-    # both would tell the operator the carve-out is wider than it is.
-    # Derived rather than copied, so a control file added later is
-    # covered without a second edit to STATE_FILES.
-    in_tree = state_dir(state_root)
-    entries.update(
-        f"{prefix}{path.name}"
-        for path in legacy_control_paths(state_root).values()
-        if path.parent == in_tree
+    carved = (
+        *(f"{name}/" for name in STATE_SUBDIRS if name not in STATE_NOT_CARVED),
+        *(name for name in STATE_FILES if name not in STATE_NOT_CARVED),
     )
-    return sorted(entries)
+    return sorted(f"{prefix}{name}" for name in carved)
 
 
 def _utc_now_iso() -> str:

--- a/kstrl/verify.py
+++ b/kstrl/verify.py
@@ -48,6 +48,7 @@ from kstrl.policy import (
     evaluate_policy,
 )
 from kstrl.prd import PRD
+from kstrl.statedir import STATE_DIR_NAME
 
 # R2.6 env scrub: verification subprocesses execute agent-authored code
 # (the project's tests, linters run over agent files, CLI fixtures), so
@@ -1687,8 +1688,25 @@ def check_dead_code(
         # belt over braces: --no-fix already keeps the count at zero.
         if not read_only and ruff_fixed_count > 0:
             try:
-                # Stage all changes ruff made
-                run_scrubbed("git add -A", cwd=cwd, timeout=30)
+                # Stage all changes ruff made, EXCEPT the state directory
+                # (#274 review). Under use_worktrees=False this runs with
+                # cwd at the project root, so a bare `git add -A` commits
+                # kstrl's own live `.kstrl/` journals onto the component
+                # branch the moment ruff fixes one finding - and
+                # check_diff_scope is deliberately un-carved, so the next
+                # pass fails on them and they ride into the PR. In a
+                # worktree the same exclusion is wanted for the opposite
+                # reason: a `.kstrl/` there is the agent's, and this
+                # function must not commit it on the agent's behalf.
+                #
+                # A list, not a string: run_scrubbed only shells out for a
+                # string, and the `:(exclude)` pathspec must reach git
+                # unmangled.
+                run_scrubbed(
+                    ["git", "add", "-A", "--", ".", f":(exclude){STATE_DIR_NAME}"],
+                    cwd=cwd,
+                    timeout=30,
+                )
                 run_scrubbed(
                     'git commit -m "chore: auto-remove dead code (ruff F401/F811/F841)"',
                     cwd=cwd,

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -360,6 +360,17 @@ class TestGuardsRunBeforeCompletion:
         self,
         tmp_path: Path,
     ) -> None:
+        """Still true after #274, for a different reason.
+
+        The loop used to derive this one entry from the bus's run id.
+        It now carves out ``.kstrl/runs/`` as part of the whole state
+        directory, and only when the CALLER declares which root owns
+        that directory - so ``guard_state_root`` is what makes this
+        pass, not the bus. ``tests/test_state_dir_scope.py`` pins both
+        halves, including the case this file cannot see: the same loop
+        inside a component worktree, where the carve-out is empty and
+        an agent-written ``.kstrl/`` is still a violation.
+        """
         config = self._git_repo(tmp_path)
         run_id = "understand-20260721-test"
         state_file = tmp_path / ".kstrl" / "runs" / run_id / "events.jsonl"
@@ -372,6 +383,7 @@ class TestGuardsRunBeforeCompletion:
             agent,
             tmp_path,
             bus=EventBus(run_id=run_id),
+            guard_state_root=tmp_path,
         )
 
         assert result.completed is True

--- a/tests/test_state_dir_scope.py
+++ b/tests/test_state_dir_scope.py
@@ -12,9 +12,14 @@ with the harness instead, and the tests here pin the four things that
 keep it from becoming the blanket bypass ``check_violations`` warns
 against:
 
-1. It names only the entries kstrl itself creates. ``.kstrl/notes.md``
-   is still a violation, so an agent cannot invent a hiding place under
-   the state directory.
+1. It names only the entries kstrl itself creates, so a NEW top-level
+   name (``.kstrl/notes.md``) is still a violation. It does NOT stop an
+   agent hiding a file INSIDE a carved subtree, because those trees hold
+   runtime-invented names and only a prefix can cover them. That
+   residual is stated outright by
+   ``test_a_carved_subtree_is_a_prefix_and_everything_under_it_is_uncounted``
+   and bounded by
+   ``test_the_subtrees_that_carry_authority_are_not_carved_out``.
 2. The enumeration is checked against the CODE, not maintained by hand:
    ``TestTheEnumerationMatchesTheCode`` AST-walks ``kstrl/`` for the
    ``.kstrl/<entry>`` names the package spells out and fails on one that
@@ -25,13 +30,16 @@ against:
    the state root the CALLER declares. A component worktree therefore
    gets nothing, because a ``.kstrl/`` there can only be the agent's.
 4. It is reported apart from the operator's authored allowlist in the
-   guard's failure block.
+   guard's failure block, and never REVERTED: making the authority
+   entries countable again would otherwise have handed them to the
+   guard's deleter (``TestTheRevertArmRefusesKstrlState``).
 """
 
 from __future__ import annotations
 
 import ast
 import re
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -43,9 +51,14 @@ from kstrl import git, guards, statedir
 from kstrl.config import KstrlConfig
 from kstrl.guards import check_violations, path_is_allowed
 from kstrl.loop import COMPLETION_MARKER, run_loop
-from kstrl.statedir import STATE_FILES, STATE_SUBDIRS, state_dir_carve_out
+from kstrl.statedir import (
+    STATE_FILES,
+    STATE_NOT_CARVED,
+    STATE_SUBDIRS,
+    state_dir_carve_out,
+)
 from kstrl.ui.plain import PlainUI
-from kstrl.verify import _diff_scope_details, check_diff_scope
+from kstrl.verify import _diff_scope_details, check_dead_code, check_diff_scope
 from tests.test_loop import MockAgent
 
 PROJECT = Path("/project")
@@ -77,8 +90,15 @@ STATE_ARTIFACTS = (
 )
 
 
-def _git(repo: Path, *args: str) -> None:
-    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
 
 
 @pytest.fixture
@@ -115,19 +135,15 @@ def repo(tmp_path: Path) -> Path:
 class TestStateDirCarveOut:
     def test_it_names_the_entries_kstrl_creates(self) -> None:
         assert state_dir_carve_out(PROJECT, PROJECT) == [
-            ".kstrl/autonomy.json",
             ".kstrl/contract/",
             ".kstrl/control_relocated",
             ".kstrl/debug/",
             ".kstrl/evolution.jsonl",
             ".kstrl/experiments.tsv",
             ".kstrl/factory.lock",
-            ".kstrl/inbox.jsonl",
             ".kstrl/knowledge/",
             ".kstrl/logs/",
             ".kstrl/progress.jsonl",
-            ".kstrl/proposals/",
-            ".kstrl/queue/",
             ".kstrl/runs/",
             ".kstrl/snapshots/",
             ".kstrl/worktrees/",
@@ -150,23 +166,74 @@ class TestStateDirCarveOut:
         ):
             assert not path_is_allowed(invented, entries), invented
 
+    def test_a_carved_subtree_is_a_prefix_and_everything_under_it_is_uncounted(
+        self,
+    ) -> None:
+        """The residual, pinned rather than papered over (#274 review).
+
+        The first version of ``state_dir_carve_out``'s docstring claimed
+        an agent "cannot invent a hiding place under the state
+        directory". It can, inside any carved subtree, because kstrl
+        invents those leaf names at runtime and no exact-path form
+        exists. This test states exactly how far that goes, so the claim
+        and the code can never drift apart again: shrink the carve-out
+        and this fails, widen it and the exclusion test below fails.
+        """
+        entries = state_dir_carve_out(PROJECT, PROJECT)
+        for hidden in (
+            ".kstrl/runs/x/evil.py",
+            ".kstrl/knowledge/x/y.md",
+            ".kstrl/debug/x/y.sh",
+            ".kstrl/contract/x/y",
+            ".kstrl/logs/x/y",
+            ".kstrl/snapshots/x.json",
+            ".kstrl/worktrees/x/payload.sh",
+        ):
+            assert path_is_allowed(hidden, entries), hidden
+
+    def test_the_subtrees_that_carry_authority_are_not_carved_out(self) -> None:
+        """The bound on that residual.
+
+        ``queue`` is the in-tree work queue ``ks serve`` drains, so a
+        file written there can admit work; ``proposals`` is what
+        ``ks evolve --apply`` reads to mutate config and prompts, and
+        ``auto_apply_computational`` can skip its confirmation. The
+        control files these subtrees hold are owned by
+        ``test_no_legacy_control_file_is_carved_out``.
+        """
+        entries = state_dir_carve_out(PROJECT, PROJECT)
+        for visible in (
+            ".kstrl/queue/new/item-1/item.json",
+            ".kstrl/proposals/prop-001.md",
+            ".kstrl/proposals/evil.json",
+        ):
+            assert not path_is_allowed(visible, entries), visible
+
+    def test_the_exclusions_name_entries_that_actually_exist(self) -> None:
+        """An exclusion for something kstrl does not create excludes
+        nothing, and would read as a bound that is not there."""
+        assert set(STATE_NOT_CARVED) <= set(STATE_SUBDIRS) | set(STATE_FILES)
+
     def test_a_lookalike_directory_is_not_covered(self) -> None:
         entries = state_dir_carve_out(PROJECT, PROJECT)
         assert not path_is_allowed(".kstrl-backup/runs/x", entries)
         assert not path_is_allowed("sub/.kstrl/runs/x", entries)
         assert not path_is_allowed("kstrl/factory.py", entries)
 
-    def test_the_legacy_in_tree_control_files_are_covered(self) -> None:
-        """R8.9 moved these to XDG state, but a repository that has not
-        migrated still has them in the tree, and ``migrate_control_state``
-        only moves them once somebody runs a command that reads control
-        state. Derived from ``legacy_control_paths`` rather than copied,
-        so a control file added later is covered without a second edit."""
+    def test_no_legacy_control_file_is_carved_out(self) -> None:
+        """R8.9 moved live control state to the XDG directory, but a
+        repository that has not run a control command since still has
+        these in the tree - and they are the highest-authority files
+        there. All five stay countable, which is the same ranking
+        ``policy.ENFORCEMENT_MACHINERY_PATHS`` gives them: a guard that
+        stopped reporting the autonomy level while the envelope treats
+        touching it as a non-overridable hard fail would be two
+        mechanisms disagreeing about one file.
+        """
         entries = state_dir_carve_out(PROJECT, PROJECT)
-        legacy = statedir.legacy_control_paths(PROJECT)
-        for path in legacy.values():
+        for path in statedir.legacy_control_paths(PROJECT).values():
             rel = path.relative_to(PROJECT).as_posix()
-            assert path_is_allowed(rel, entries), rel
+            assert not path_is_allowed(rel, entries), rel
 
     def test_a_walk_root_that_is_not_the_state_root_gets_nothing(self) -> None:
         """The tightening, and the reason the function takes both paths.
@@ -211,11 +278,18 @@ class TestStateDirCarveOut:
 
 _EMBEDDED = re.compile(r"\.kstrl/([A-Za-z0-9_][A-Za-z0-9_.-]*)")
 
-#: Entries a caller may name under the state directory that kstrl does
-#: NOT create there. ``control.lock`` lives in the XDG control directory
-#: (``statedir.control_dir``), never in the tree, so carving it out would
-#: authorise a path the harness never writes.
-_NOT_IN_TREE = frozenset({statedir.CONTROL_LOCK_FILENAME})
+#: Names the AST scan will find that the carve-out is expected NOT to
+#: cover, each for its own reason:
+#:
+#: - ``control.lock`` lives in the XDG control directory
+#:   (``statedir.control_dir``), never in the tree, so carving it out
+#:   would authorise a path the harness never writes.
+#: - ``STATE_NOT_CARVED`` is the deliberate authority exclusion
+#:   (#274 review), sourced from the constant rather than repeated so
+#:   the drift net and the policy cannot disagree.
+_EXPECTED_UNCOVERED = frozenset(
+    {statedir.CONTROL_LOCK_FILENAME, *STATE_NOT_CARVED},
+)
 
 
 def _module_constants(tree: ast.Module) -> dict[str, str]:
@@ -328,7 +402,7 @@ class TestTheEnumerationMatchesTheCode:
         missing = sorted(
             name
             for name in _package_entries()
-            if name not in _NOT_IN_TREE and not path_is_allowed(f".kstrl/{name}", entries)
+            if name not in _EXPECTED_UNCOVERED and not path_is_allowed(f".kstrl/{name}", entries)
         )
         assert missing == [], (
             f"kstrl writes these under .kstrl/ but the carve-out does not "
@@ -374,6 +448,89 @@ class TestTheEnumerationMatchesTheCode:
         assert declared - set(_package_entries()) == set()
 
 
+def _import_closure(module: str) -> set[str]:
+    """Every ``kstrl.*`` module reachable from ``module`` by import.
+
+    Static, and deliberately includes function-level imports, which this
+    codebase uses to break cycles (``loop.py`` defers ``init_cmd``,
+    ``breaker.py`` defers ``verify``). A static closure over-approximates
+    what actually runs, which is the safe direction here: the claim being
+    checked is that a writer is NOT reachable.
+    """
+    package = Path(statedir.__file__).parent
+    seen: set[str] = set()
+    pending = [module]
+    while pending:
+        name = pending.pop()
+        if name in seen:
+            continue
+        seen.add(name)
+        parts = name.split(".")[1:]
+        if not parts:
+            # Bare `from kstrl import git`: the package itself, whose
+            # __init__ imports nothing. The submodules it names are
+            # queued separately by the ImportFrom arm below.
+            continue
+        source = package.joinpath(*parts).with_suffix(".py")
+        if not source.is_file():
+            continue
+        for node in ast.walk(ast.parse(source.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.Import):
+                pending.extend(a.name for a in node.names if a.name.startswith("kstrl"))
+            elif isinstance(node, ast.ImportFrom) and (node.module or "").startswith("kstrl"):
+                base = node.module or ""
+                pending.append(base)
+                pending.extend(f"{base}.{a.name}" for a in node.names)
+    return seen
+
+
+class TestNothingTheLoopRunsWritesTheUncarvedEntries:
+    """Criterion 2 of ``STATE_NOT_CARVED``, mechanised (#274 review).
+
+    Keeping ``queue``, ``proposals``, ``autonomy.json`` and
+    ``inbox.jsonl`` countable is only affordable because nothing the
+    engineer loop invokes writes them - otherwise the guard would fire
+    on kstrl's own artifacts again, which is the whole failure this
+    change exists to remove. That was a comment; it is the half of the
+    argument that carries the weight, and this file's convention is that
+    load-bearing claims are checked against the code.
+
+    A static import closure is a proxy for reachability, not a proof.
+    It over-approximates (it counts an import that never executes), so a
+    pass is meaningful and a failure means somebody has to think.
+    """
+
+    #: The modules that write the uncarved entries: the work queue
+    #: itself, the two command entry points that drive it, the proposal
+    #: writer, and the GitHub intake that admits work.
+    WRITERS = frozenset(
+        {
+            "kstrl.workqueue",
+            "kstrl.serve",
+            "kstrl.cli",
+            "kstrl.evolution",
+            "kstrl.intake_github",
+        }
+    )
+
+    def test_the_loop_cannot_reach_a_writer_of_an_uncarved_entry(self) -> None:
+        reachable = _import_closure("kstrl.loop") & self.WRITERS
+        assert reachable == set(), (
+            f"kstrl.loop can now reach {sorted(reachable)}, which write the "
+            f"entries STATE_NOT_CARVED keeps countable. Either the loop no "
+            f"longer needs that import, or those entries have to be carved "
+            f"out again and the authority argument revisited."
+        )
+
+    def test_the_closure_is_actually_walking_something(self) -> None:
+        """Without this the assertion above could be passing because the
+        closure is empty, which would make it a test of nothing."""
+        closure = _import_closure("kstrl.loop")
+        assert "kstrl.guards" in closure
+        assert "kstrl.statedir" in closure
+        assert _import_closure("kstrl.serve") & self.WRITERS
+
+
 # ---------------------------------------------------------------------------
 # A real repository with no .gitignore: the case #273 cannot reach
 # ---------------------------------------------------------------------------
@@ -389,9 +546,56 @@ class TestRealRepositoryWithoutAGitignore:
         violations = check_violations(changed, AUTHORED)
         assert sorted(violations) == sorted(STATE_ARTIFACTS)
 
-    def test_with_the_carve_out_the_run_is_clean(self, repo: Path) -> None:
+    def test_with_the_carve_out_only_the_excluded_subtrees_remain(
+        self,
+        repo: Path,
+    ) -> None:
         changed = git.get_changed_files(repo)
-        assert check_violations(changed, AUTHORED, state_dir_carve_out(repo, repo)) == []
+        assert check_violations(changed, AUTHORED, state_dir_carve_out(repo, repo)) == [
+            ".kstrl/autonomy.json",
+            ".kstrl/inbox.jsonl",
+            ".kstrl/proposals/p1.json",
+            ".kstrl/queue/new/item-1/item.json",
+            ".kstrl/queue/pause.json",
+        ]
+
+    def test_the_baseline_is_what_clears_the_excluded_subtrees(
+        self,
+        repo: Path,
+    ) -> None:
+        """The measurement ``STATE_NOT_CARVED``'s criterion 2 rests on.
+
+        The real guard does not walk the working tree naked: it
+        subtracts everything that was already there when the agent
+        started. That is what makes keeping the authority entries
+        countable affordable, so it is measured rather than argued.
+        """
+        baseline = git.capture_workspace_baseline(repo)
+        entries = state_dir_carve_out(repo, repo)
+        # Control, for failure localisation: the second assertion below
+        # cannot pass while this one fails.
+        assert (
+            check_violations(
+                git.get_changed_files_since(baseline, repo),
+                AUTHORED,
+                entries,
+            )
+            == []
+        )
+
+        # kstrl writes on; the agent slips a file into each excluded
+        # subtree and one into a carved one.
+        (repo / ".kstrl" / "runs" / "run-1" / "heartbeat.jsonl").write_text("x\n")
+        (repo / ".kstrl" / "queue" / "new" / "item-1" / "agent.json").write_text("x\n")
+        (repo / ".kstrl" / "proposals" / "prop-999.md").write_text("x\n")
+        assert check_violations(
+            git.get_changed_files_since(baseline, repo),
+            AUTHORED,
+            entries,
+        ) == [
+            ".kstrl/proposals/prop-999.md",
+            ".kstrl/queue/new/item-1/agent.json",
+        ]
 
     def test_a_registered_worktree_is_covered(self, repo: Path) -> None:
         """git reports a linked worktree as one directory entry with a
@@ -403,7 +607,10 @@ class TestRealRepositoryWithoutAGitignore:
         _git(repo, "worktree", "add", "-q", ".kstrl/worktrees/run-1/comp-a", "comp-a")
         changed = git.get_changed_files(repo)
         assert any(f.startswith(".kstrl/worktrees/") for f in changed)
-        assert check_violations(changed, AUTHORED, state_dir_carve_out(repo, repo)) == []
+        assert not any(
+            f.startswith(".kstrl/worktrees/")
+            for f in check_violations(changed, AUTHORED, state_dir_carve_out(repo, repo))
+        )
 
     def test_an_agent_file_under_the_state_dir_is_still_a_violation(
         self,
@@ -415,10 +622,9 @@ class TestRealRepositoryWithoutAGitignore:
         (repo / ".kstrl" / "notes.md").write_text("x\n")
         (repo / ".kstrl" / "runs.txt").write_text("x\n")
         changed = git.get_changed_files(repo)
-        assert check_violations(changed, AUTHORED, state_dir_carve_out(repo, repo)) == [
-            ".kstrl/notes.md",
-            ".kstrl/runs.txt",
-        ]
+        violations = check_violations(changed, AUTHORED, state_dir_carve_out(repo, repo))
+        assert ".kstrl/notes.md" in violations
+        assert ".kstrl/runs.txt" in violations
 
     def test_it_never_creates_a_scope_where_none_was_configured(
         self,
@@ -430,9 +636,11 @@ class TestRealRepositoryWithoutAGitignore:
     def test_product_code_outside_scope_is_still_caught(self, repo: Path) -> None:
         (repo / "pyproject.toml").write_text("x\n")
         changed = git.get_changed_files(repo)
-        assert check_violations(changed, AUTHORED, state_dir_carve_out(repo, repo)) == [
-            "pyproject.toml",
-        ]
+        assert "pyproject.toml" in check_violations(
+            changed,
+            AUTHORED,
+            state_dir_carve_out(repo, repo),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -458,6 +666,40 @@ class TestPhase1KeepsSeeingTheStateDir:
         result = check_diff_scope(repo, "main", AUTHORED)
         assert result.passed is False
         assert ".kstrl/runs/run-1/events.jsonl" in "\n".join(result.details)
+
+    @pytest.mark.skipif(shutil.which("ruff") is None, reason="needs ruff on PATH")
+    def test_dead_code_cleanup_does_not_commit_the_state_dir(
+        self,
+        repo: Path,
+    ) -> None:
+        """The one path that could have committed it for the agent.
+
+        ``check_dead_code`` auto-commits ruff's fixes so the tree stays
+        clean for later checks. Under ``use_worktrees=False`` it runs
+        with ``cwd`` at the PROJECT ROOT, so the ``git add -A`` it used
+        to issue swept kstrl's own live journals onto the component
+        branch the moment ruff fixed one finding - and since
+        ``check_diff_scope`` is deliberately un-carved, the next pass
+        then failed on them and they rode into the PR. That is precisely
+        the configuration the in-loop carve-out targets, so the backstop
+        had a hole in exactly the case it was meant to cover
+        (#274 review).
+
+        The fix excludes the state directory from that one commit. The
+        agent's own work must still be staged, or the auto-commit stops
+        doing its job, so both halves are asserted.
+        """
+        _git(repo, "checkout", "-q", "-b", "work")
+        (repo / "src" / "app.py").write_text("import os\nVALUE = 1\n")
+        (repo / "src" / "new.py").write_text("VALUE = 2\n")
+
+        check_dead_code(repo, "main", command=None, timeout=60)
+
+        committed = _git(repo, "show", "--name-only", "--format=", "HEAD").split()
+        assert not any(f.startswith(".kstrl/") for f in committed), committed
+        assert "src/app.py" in committed
+        assert "src/new.py" in committed
+        assert check_diff_scope(repo, "main", AUTHORED).passed is True
 
 
 # ---------------------------------------------------------------------------
@@ -559,7 +801,7 @@ class TestTheLoopAppliesIt:
 
 
 # ---------------------------------------------------------------------------
-# The four production callers declare it
+# Every production caller declares it
 # ---------------------------------------------------------------------------
 
 
@@ -571,11 +813,15 @@ class TestEveryCallerDeclaresTheStateRoot:
     applied to a tree kstrl does not own. That is the right failure
     direction, and it is only safe because something checks the callers
     actually pass it. This is that check, by source inspection: driving
-    all four flows end to end would cost four agent harnesses to assert
-    one keyword.
+    the five call sites end to end would cost five agent harnesses to
+    assert one keyword.
+
+    Five call sites across three modules, which is why the assertion
+    counts per module rather than naming a total: ``feature_cmd`` calls
+    ``run_loop`` three times, once per phase.
     """
 
-    def test_the_four_run_loop_call_sites_pass_it(self) -> None:
+    def test_every_run_loop_call_site_passes_it(self) -> None:
         package = Path(statedir.__file__).parent
         callers: dict[str, int] = {}
         declared: dict[str, int] = {}
@@ -619,7 +865,7 @@ class TestTheFailureBlockSeparatesTheTwoSets:
         )
         assert ok is False
         assert "pyproject.toml" in violations
-        assert not any(v.startswith(".kstrl/") for v in violations)
+        assert ".kstrl/runs/run-1/events.jsonl" not in violations
         printed = capsys.readouterr()
         lines = (printed.out + printed.err).splitlines()
         allowed_line = next(line for line in lines if "ALLOWED_PATHS" in line)
@@ -667,3 +913,74 @@ class TestTheFailureBlockSeparatesTheTwoSets:
         guards.enforce_allowed_paths(config, PlainUI(no_color=True), repo)
         printed = capsys.readouterr()
         assert "HARNESS_PATHS" not in printed.out + printed.err
+
+
+# ---------------------------------------------------------------------------
+# Reporting a file and destroying it are different powers
+# ---------------------------------------------------------------------------
+
+
+class _RevertingUI(PlainUI):
+    """An operator who picks "Revert and continue" at the guard prompt."""
+
+    def can_prompt(self) -> bool:
+        return True
+
+    def choose(self, header: str, options: list[str], default: int = 0) -> int:
+        return options.index("Revert and continue")
+
+
+class TestTheRevertArmRefusesKstrlState:
+    """The consequence of keeping the authority entries countable.
+
+    ``STATE_NOT_CARVED`` makes the queue, the proposals, the autonomy
+    level and the pause marker VISIBLE to the guard again. The guard's
+    interactive arm disposes of a violation by deleting it, and
+    ``git.delete_untracked`` recurses into directories, so visibility
+    alone would have handed those paths to a deleter: an operator
+    choosing "Revert and continue" could destroy the pause marker they
+    had just written to stop the run. Reporting and destroying are
+    different powers (#274 review).
+    """
+
+    def test_it_reports_the_state_file_and_leaves_it_on_disk(
+        self,
+        repo: Path,
+    ) -> None:
+        pause = repo / ".kstrl" / "queue" / "pause.json"
+        rogue = repo / "pyproject.toml"
+        rogue.write_text("x\n")
+        config = _loop_config(repo, AUTHORED)
+        config.interactive = True
+
+        ok, violations = guards.enforce_allowed_paths(
+            config,
+            _RevertingUI(no_color=True),
+            repo,
+            ignored_paths=state_dir_carve_out(repo, repo),
+        )
+
+        assert pause.exists(), "the guard deleted kstrl's own pause marker"
+        assert not rogue.exists(), "the genuine violation was not reverted"
+        assert ok is False, "a refused revert must not report success"
+        assert ".kstrl/queue/pause.json" in violations
+        assert "pyproject.toml" not in violations
+
+    def test_a_carved_state_file_never_reaches_the_revert_arm_at_all(
+        self,
+        repo: Path,
+    ) -> None:
+        """Belt and braces from the other side: the carve-out means
+        ``.kstrl/runs/`` is not a violation, so the refusal above is the
+        second line of defence, not the only one."""
+        events = repo / ".kstrl" / "runs" / "run-1" / "events.jsonl"
+        config = _loop_config(repo, AUTHORED)
+        config.interactive = True
+
+        guards.enforce_allowed_paths(
+            config,
+            _RevertingUI(no_color=True),
+            repo,
+            ignored_paths=state_dir_carve_out(repo, repo),
+        )
+        assert events.exists()

--- a/tests/test_state_dir_scope.py
+++ b/tests/test_state_dir_scope.py
@@ -1,0 +1,669 @@
+"""kstrl's own state directory is carved out at the guard (#274).
+
+The in-loop scope guard counts UNTRACKED files against a component's
+``allowedPaths``. kstrl writes its run journals, locks, queue and
+worktrees into ``<root>/.kstrl/`` WHILE that walk is happening, so in a
+repository that does not ignore ``.kstrl/`` the harness trips over its
+own artifacts and the operator pays an engineer iteration for it.
+
+``ks init`` scaffolds a ``.gitignore`` carrying ``.kstrl/`` (#273), which
+cannot reach a repository that already exists. This carve-out travels
+with the harness instead, and the tests here pin the four things that
+keep it from becoming the blanket bypass ``check_violations`` warns
+against:
+
+1. It names only the entries kstrl itself creates. ``.kstrl/notes.md``
+   is still a violation, so an agent cannot invent a hiding place under
+   the state directory.
+2. The enumeration is checked against the CODE, not maintained by hand:
+   ``TestTheEnumerationMatchesTheCode`` AST-walks ``kstrl/`` for the
+   ``.kstrl/<entry>`` names the package spells out and fails on one that
+   is missing. That scan is what found ``snapshots`` and the legacy
+   control files while this change was being written, and one test pins
+   the spellings it CANNOT see so the net is not sold as more than it is.
+3. It is empty unless the tree the guard walks is the same directory as
+   the state root the CALLER declares. A component worktree therefore
+   gets nothing, because a ``.kstrl/`` there can only be the agent's.
+4. It is reported apart from the operator's authored allowlist in the
+   guard's failure block.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from kstrl import git, guards, statedir
+from kstrl.config import KstrlConfig
+from kstrl.guards import check_violations, path_is_allowed
+from kstrl.loop import COMPLETION_MARKER, run_loop
+from kstrl.statedir import STATE_FILES, STATE_SUBDIRS, state_dir_carve_out
+from kstrl.ui.plain import PlainUI
+from kstrl.verify import _diff_scope_details, check_diff_scope
+from tests.test_loop import MockAgent
+
+PROJECT = Path("/project")
+WORKTREE = PROJECT / ".kstrl" / "worktrees" / "run-1" / "comp-a"
+
+# The authored scope: product code only, as an architect writes it.
+AUTHORED = ["src/", "tests/"]
+
+# One file per entry kstrl creates under the state directory, spelled the
+# way `git ls-files --others` reports it. Written to disk by the `repo`
+# fixture, so the real-git tests measure the real walk.
+STATE_ARTIFACTS = (
+    ".kstrl/autonomy.json",
+    ".kstrl/contract/merge-ab12/README.md",
+    ".kstrl/control_relocated",
+    ".kstrl/debug/run-1/comp-a/prompt.txt",
+    ".kstrl/evolution.jsonl",
+    ".kstrl/experiments.tsv",
+    ".kstrl/factory.lock",
+    ".kstrl/inbox.jsonl",
+    ".kstrl/knowledge/comp-a/run-1/fact.md",
+    ".kstrl/logs/feature_x/understand.log",
+    ".kstrl/progress.jsonl",
+    ".kstrl/proposals/p1.json",
+    ".kstrl/queue/new/item-1/item.json",
+    ".kstrl/queue/pause.json",
+    ".kstrl/runs/run-1/events.jsonl",
+    ".kstrl/snapshots/fixture-1.json",
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A committed repository with NO ``.gitignore`` at all.
+
+    The case this change exists for, and the one PR #273 cannot reach: a
+    project scaffolded before the ``.gitignore`` shipped, or one whose
+    operator curates their own. Nothing here is ignored, so every file
+    kstrl writes under ``.kstrl/`` reaches the guard's walk.
+    """
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.com")
+    _git(root, "config", "user.name", "T")
+    (root / "src").mkdir()
+    (root / "src" / "app.py").write_text("x\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "base")
+    assert not (root / ".gitignore").exists()
+    for rel in STATE_ARTIFACTS:
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x\n")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# The carve-out itself
+# ---------------------------------------------------------------------------
+
+
+class TestStateDirCarveOut:
+    def test_it_names_the_entries_kstrl_creates(self) -> None:
+        assert state_dir_carve_out(PROJECT, PROJECT) == [
+            ".kstrl/autonomy.json",
+            ".kstrl/contract/",
+            ".kstrl/control_relocated",
+            ".kstrl/debug/",
+            ".kstrl/evolution.jsonl",
+            ".kstrl/experiments.tsv",
+            ".kstrl/factory.lock",
+            ".kstrl/inbox.jsonl",
+            ".kstrl/knowledge/",
+            ".kstrl/logs/",
+            ".kstrl/progress.jsonl",
+            ".kstrl/proposals/",
+            ".kstrl/queue/",
+            ".kstrl/runs/",
+            ".kstrl/snapshots/",
+            ".kstrl/worktrees/",
+        ]
+
+    def test_the_state_directory_itself_is_never_an_entry(self) -> None:
+        """The whole difference between this and the bypass the
+        ``check_violations`` docstring refuses. ``.kstrl/`` as a bare
+        prefix would authorise anything under it;
+        ``decompose._ALLOWED_PATHS_EXCLUDE`` will not even let an
+        architect write that entry into ``allowedPaths``."""
+        entries = state_dir_carve_out(PROJECT, PROJECT)
+        assert ".kstrl/" not in entries
+        assert ".kstrl" not in entries
+        for invented in (
+            ".kstrl/notes.md",
+            ".kstrl/payload.py",
+            ".kstrl/.env",
+            ".kstrl/runs.txt",
+        ):
+            assert not path_is_allowed(invented, entries), invented
+
+    def test_a_lookalike_directory_is_not_covered(self) -> None:
+        entries = state_dir_carve_out(PROJECT, PROJECT)
+        assert not path_is_allowed(".kstrl-backup/runs/x", entries)
+        assert not path_is_allowed("sub/.kstrl/runs/x", entries)
+        assert not path_is_allowed("kstrl/factory.py", entries)
+
+    def test_the_legacy_in_tree_control_files_are_covered(self) -> None:
+        """R8.9 moved these to XDG state, but a repository that has not
+        migrated still has them in the tree, and ``migrate_control_state``
+        only moves them once somebody runs a command that reads control
+        state. Derived from ``legacy_control_paths`` rather than copied,
+        so a control file added later is covered without a second edit."""
+        entries = state_dir_carve_out(PROJECT, PROJECT)
+        legacy = statedir.legacy_control_paths(PROJECT)
+        for path in legacy.values():
+            rel = path.relative_to(PROJECT).as_posix()
+            assert path_is_allowed(rel, entries), rel
+
+    def test_a_walk_root_that_is_not_the_state_root_gets_nothing(self) -> None:
+        """The tightening, and the reason the function takes both paths.
+
+        A component worktree is a different directory from the project
+        root, and kstrl writes its journals, locks and queue only at the
+        root - so a ``.kstrl/`` inside a worktree can only be the
+        agent's. Carving it out there would hide files and clear
+        nothing.
+        """
+        assert state_dir_carve_out(WORKTREE, PROJECT) == []
+        assert state_dir_carve_out(PROJECT, WORKTREE) == []
+        assert state_dir_carve_out(Path("/other"), PROJECT) == []
+
+    def test_an_undeclared_state_root_gets_nothing(self) -> None:
+        """The safe default. A caller that does not declare where its
+        state directory lives gets the pre-#274 behaviour, which fails
+        loudly on kstrl's own artifacts - never a carve-out applied to a
+        tree kstrl does not own."""
+        assert state_dir_carve_out(PROJECT, None) == []
+
+    def test_the_two_paths_are_compared_as_directories_not_strings(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """macOS reaches ``/tmp`` through a symlink and the loop's
+        ``cwd`` routinely arrives spelled differently from the project
+        root it was derived from, so a string comparison would silently
+        disable the carve-out on the platform this is developed on."""
+        real = tmp_path / "project"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real, target_is_directory=True)
+        assert state_dir_carve_out(link, real) != []
+        assert state_dir_carve_out(real / "." / "sub" / "..", real) != []
+
+
+# ---------------------------------------------------------------------------
+# The enumeration is checked against the code, not maintained by hand
+# ---------------------------------------------------------------------------
+
+
+_EMBEDDED = re.compile(r"\.kstrl/([A-Za-z0-9_][A-Za-z0-9_.-]*)")
+
+#: Entries a caller may name under the state directory that kstrl does
+#: NOT create there. ``control.lock`` lives in the XDG control directory
+#: (``statedir.control_dir``), never in the tree, so carving it out would
+#: authorise a path the harness never writes.
+_NOT_IN_TREE = frozenset({statedir.CONTROL_LOCK_FILENAME})
+
+
+def _module_constants(tree: ast.Module) -> dict[str, str]:
+    """Module-level ``NAME = "literal"`` assignments."""
+    out: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, str):
+                out[target.id] = node.value.value
+    return out
+
+
+def _is_state_anchor(node: ast.expr) -> bool:
+    """Whether ``node`` evaluates to the state directory itself."""
+    if isinstance(node, ast.Constant) and node.value == statedir.STATE_DIR_NAME:
+        return True
+    if isinstance(node, ast.Name) and node.id == "STATE_DIR_NAME":
+        return True
+    if isinstance(node, ast.Call):
+        func = node.func
+        if isinstance(func, ast.Name):
+            return func.id == "state_dir"
+        if isinstance(func, ast.Attribute):
+            return func.attr == "state_dir"
+    return False
+
+
+def _named_entries(source: str) -> set[str]:
+    """Every ``.kstrl/<entry>`` name this module's CODE spells out.
+
+    Two forms, because those are the two the package uses: a ``/`` join
+    off the state directory (``root / ".kstrl" / "runs"``,
+    ``state_dir(root) / QUEUE_DIR_NAME``), and a literal ``.kstrl/...``
+    inside a string (config defaults such as
+    ``Path(".kstrl/snapshots")``, and ``policy.py``'s glob patterns).
+
+    Deliberately no more than that. A local alias, an f-string or an
+    ``os.path.join`` would slip past, so this is a net under the current
+    idiom rather than a proof about every possible one - which is what
+    ``STATE_SUBDIRS``'s own comment says, so the claim and the mechanism
+    agree.
+    """
+    tree = ast.parse(source)
+    constants = _module_constants(tree)
+    # Strings used as a bare statement are docstrings, and a comment
+    # about a directory kstrl archived in 2026 is not a directory kstrl
+    # writes: without this the scan reported `.kstrl/archive/` from a
+    # two-line comment in evolution.py. Collected in the SAME walk as
+    # the joins below rather than in a pass of its own - measured at
+    # 85ms per package walk, and there are two walkers here.
+    prose: set[int] = set()
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+            prose.add(id(node.value))
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            # ast.walk reaches every BinOp in a `a / b / c` chain, so
+            # each one only has to look one step left for its anchor.
+            left = node.left
+            anchor = (
+                left.right if isinstance(left, ast.BinOp) and isinstance(left.op, ast.Div) else left
+            )
+            if _is_state_anchor(anchor):
+                following = node.right
+                if isinstance(following, ast.Constant) and isinstance(following.value, str):
+                    names.add(following.value)
+                elif isinstance(following, ast.Name) and following.id in constants:
+                    names.add(constants[following.id])
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if id(node) not in prose:
+                names.update(match.group(1) for match in _EMBEDDED.finditer(node.value))
+    return names
+
+
+def _package_entries() -> dict[str, set[str]]:
+    """Every state-dir entry ``kstrl/`` names, mapped to its modules.
+
+    Module-scoped so the two tests below parse the package once
+    between them rather than once each.
+    """
+    global _PACKAGE_ENTRIES
+    if _PACKAGE_ENTRIES is None:
+        found: dict[str, set[str]] = {}
+        for module in sorted(Path(statedir.__file__).parent.rglob("*.py")):
+            for name in _named_entries(module.read_text(encoding="utf-8")):
+                found.setdefault(name, set()).add(module.name)
+        _PACKAGE_ENTRIES = found
+    return _PACKAGE_ENTRIES
+
+
+_PACKAGE_ENTRIES: dict[str, set[str]] | None = None
+
+
+class TestTheEnumerationMatchesTheCode:
+    """The regression net that keeps the list honest.
+
+    ``STATE_SUBDIRS`` and ``STATE_FILES`` are hand-written, and a
+    hand-written list of what a package writes is exactly the thing that
+    rots. This walks every module for the entries the code actually
+    names and fails if one is not carved out, so a subtree added later
+    reintroduces the untracked-file failure loudly rather than in a paid
+    run.
+    """
+
+    def test_every_entry_the_package_names_is_carved_out(self) -> None:
+        entries = state_dir_carve_out(PROJECT, PROJECT)
+        missing = sorted(
+            name
+            for name in _package_entries()
+            if name not in _NOT_IN_TREE and not path_is_allowed(f".kstrl/{name}", entries)
+        )
+        assert missing == [], (
+            f"kstrl writes these under .kstrl/ but the carve-out does not "
+            f"cover them: {missing}. Add each to "
+            f"statedir.STATE_SUBDIRS or STATE_FILES."
+        )
+
+    def test_the_scan_would_notice_a_new_subtree(self) -> None:
+        """The net itself, tested. Without this the scan could be
+        silently matching nothing and every run would pass."""
+        source = 'from pathlib import Path\nP = Path("/x") / ".kstrl" / "brand-new"\n'
+        assert _named_entries(source) == {"brand-new"}
+        assert not path_is_allowed(".kstrl/brand-new", state_dir_carve_out(PROJECT, PROJECT))
+
+    def test_the_scan_reads_a_constant_rather_than_its_name(self) -> None:
+        source = 'from pathlib import Path\nQ = "queue"\nP = Path("/x") / ".kstrl" / Q\n'
+        assert _named_entries(source) == {"queue"}
+
+    def test_the_scan_ignores_prose(self) -> None:
+        source = '"""Wave 1 archived the old journals to .kstrl/archive/."""\n'
+        assert _named_entries(source) == set()
+
+    def test_the_scan_does_not_claim_to_see_every_spelling(self) -> None:
+        """The limit of the net, pinned so the claim cannot drift.
+
+        These four idioms would slip past. None appears in ``kstrl/``
+        today, and ``STATE_SUBDIRS``'s comment says exactly this - the
+        test exists so an edit that broadens the comment has to broaden
+        the scan too, and an edit that broadens the scan makes a test
+        here fail rather than passing silently.
+        """
+        assert _named_entries('S = state_dir(r)\nP = S / "cache"\n') == set()
+        assert _named_entries('P = base / f".kstrl/{name}"\n') == set()
+        assert _named_entries('P = os.path.join(root, ".kstrl", "cache")\n') == set()
+        assert _named_entries('P = self.state_dir / "cache"\n') == set()
+
+    def test_every_declared_entry_is_reachable(self) -> None:
+        """The inverse: nothing in the lists that the package never
+        writes. A carve-out entry with no writer is authorisation
+        granted for nothing, which is the same defect the entries are
+        meant to remove."""
+        declared = set(STATE_SUBDIRS) | set(STATE_FILES)
+        assert declared - set(_package_entries()) == set()
+
+
+# ---------------------------------------------------------------------------
+# A real repository with no .gitignore: the case #273 cannot reach
+# ---------------------------------------------------------------------------
+
+
+class TestRealRepositoryWithoutAGitignore:
+    def test_without_the_carve_out_every_state_file_is_a_violation(
+        self,
+        repo: Path,
+    ) -> None:
+        """The bug, measured against real git rather than a fixture."""
+        changed = git.get_changed_files(repo)
+        violations = check_violations(changed, AUTHORED)
+        assert sorted(violations) == sorted(STATE_ARTIFACTS)
+
+    def test_with_the_carve_out_the_run_is_clean(self, repo: Path) -> None:
+        changed = git.get_changed_files(repo)
+        assert check_violations(changed, AUTHORED, state_dir_carve_out(repo, repo)) == []
+
+    def test_a_registered_worktree_is_covered(self, repo: Path) -> None:
+        """git reports a linked worktree as one directory entry with a
+        trailing slash, not as its contents. Measured: without
+        ``.kstrl/worktrees/`` in the carve-out that entry is a
+        violation, so every factory run in an unignored repository trips
+        on the worktree it just created."""
+        _git(repo, "branch", "comp-a")
+        _git(repo, "worktree", "add", "-q", ".kstrl/worktrees/run-1/comp-a", "comp-a")
+        changed = git.get_changed_files(repo)
+        assert any(f.startswith(".kstrl/worktrees/") for f in changed)
+        assert check_violations(changed, AUTHORED, state_dir_carve_out(repo, repo)) == []
+
+    def test_an_agent_file_under_the_state_dir_is_still_a_violation(
+        self,
+        repo: Path,
+    ) -> None:
+        """The hiding case. The carve-out stops the guard counting what
+        kstrl wrote; it does not stop it counting what the agent wrote
+        next to it."""
+        (repo / ".kstrl" / "notes.md").write_text("x\n")
+        (repo / ".kstrl" / "runs.txt").write_text("x\n")
+        changed = git.get_changed_files(repo)
+        assert check_violations(changed, AUTHORED, state_dir_carve_out(repo, repo)) == [
+            ".kstrl/notes.md",
+            ".kstrl/runs.txt",
+        ]
+
+    def test_it_never_creates_a_scope_where_none_was_configured(
+        self,
+        repo: Path,
+    ) -> None:
+        changed = git.get_changed_files(repo)
+        assert check_violations(changed, [], state_dir_carve_out(repo, repo)) == []
+
+    def test_product_code_outside_scope_is_still_caught(self, repo: Path) -> None:
+        (repo / "pyproject.toml").write_text("x\n")
+        changed = git.get_changed_files(repo)
+        assert check_violations(changed, AUTHORED, state_dir_carve_out(repo, repo)) == [
+            "pyproject.toml",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 is deliberately NOT given the carve-out
+# ---------------------------------------------------------------------------
+
+
+class TestPhase1KeepsSeeingTheStateDir:
+    def test_a_committed_state_dir_file_still_fails_diff_scope(
+        self,
+        repo: Path,
+    ) -> None:
+        """``check_diff_scope`` judges ``git diff base...HEAD``: only
+        what the agent COMMITTED. Nothing kstrl writes at ``<root>``
+        appears in a component worktree's diff, so Phase 1 never needed
+        the carve-out - and leaving it out is what keeps a ``.kstrl/``
+        file the agent committed from riding into the PR. That is the
+        backstop for the one iteration the in-loop guard now lets pass.
+        """
+        _git(repo, "checkout", "-q", "-b", "work")
+        _git(repo, "add", "-A", "-f")
+        _git(repo, "commit", "-q", "-m", "work")
+        result = check_diff_scope(repo, "main", AUTHORED)
+        assert result.passed is False
+        assert ".kstrl/runs/run-1/events.jsonl" in "\n".join(result.details)
+
+
+# ---------------------------------------------------------------------------
+# The loop actually applies it, and only where the state dir is kstrl's
+# ---------------------------------------------------------------------------
+
+
+def _loop_config(root: Path, allowed: list[str]) -> KstrlConfig:
+    kstrl_dir = root / "scripts" / "kstrl"
+    kstrl_dir.mkdir(parents=True, exist_ok=True)
+    (kstrl_dir / "prompt.md").write_text("test prompt")
+    (kstrl_dir / "prd.json").write_text('{"branchName": "t", "userStories": []}')
+    return KstrlConfig(
+        max_iterations=1,
+        prompt_file=kstrl_dir / "prompt.md",
+        prd_file=kstrl_dir / "prd.json",
+        sleep_seconds=0,
+        allowed_paths=allowed,
+        kstrl_branch="",
+        kstrl_branch_explicit=True,
+    )
+
+
+def _captured_ignored_paths(cwd: Path, config: KstrlConfig, **kwargs: Any) -> list[str]:
+    """Run one loop iteration and return what the guard was handed."""
+    seen: list[list[str]] = []
+
+    def fake(*args: Any, **call_kwargs: Any) -> tuple[bool, list[str]]:
+        seen.append(list(call_kwargs.get("ignored_paths") or ()))
+        return True, []
+
+    with patch.object(guards, "enforce_allowed_paths", side_effect=fake):
+        run_loop(
+            config,
+            PlainUI(no_color=True),
+            MockAgent(["working", COMPLETION_MARKER]),
+            cwd,
+            **kwargs,
+        )
+    assert len(seen) == 1
+    return seen[0]
+
+
+class TestTheLoopAppliesIt:
+    def test_the_guard_is_handed_the_state_carve_out(self, repo: Path) -> None:
+        captured = _captured_ignored_paths(
+            repo,
+            _loop_config(repo, AUTHORED),
+            guard_state_root=repo,
+        )
+        assert captured == state_dir_carve_out(repo, repo)
+
+    def test_the_callers_own_harness_files_come_first_and_survive(
+        self,
+        repo: Path,
+    ) -> None:
+        """#264's per-component files and #274's state directory are two
+        carve-outs, not one. The loop unions them; neither replaces the
+        other."""
+        harness = ["scripts/kstrl/feature/comp-a/prd.json"]
+        captured = _captured_ignored_paths(
+            repo,
+            _loop_config(repo, AUTHORED),
+            guard_ignored_paths=harness,
+            guard_state_root=repo,
+        )
+        assert captured == [*harness, *state_dir_carve_out(repo, repo)]
+
+    def test_a_component_worktree_gets_only_the_callers_files(
+        self,
+        repo: Path,
+    ) -> None:
+        """The tightening, driven through the real loop.
+
+        The factory hands ``cwd=<worktree>`` and
+        ``guard_state_root=<root>``, so the loop adds nothing and an
+        agent-written ``.kstrl/`` inside the worktree stays visible to
+        the guard. The ``.kstrl/runs/<run_id>/`` entry this site used to
+        append unconditionally, worktree or not, is gone with it.
+        """
+        _git(repo, "branch", "comp-a")
+        _git(repo, "worktree", "add", "-q", ".kstrl/worktrees/run-1/comp-a", "comp-a")
+        worktree = repo / ".kstrl" / "worktrees" / "run-1" / "comp-a"
+        harness = ["scripts/kstrl/feature/comp-a/prd.json"]
+        captured = _captured_ignored_paths(
+            worktree,
+            _loop_config(worktree, AUTHORED),
+            guard_ignored_paths=harness,
+            guard_state_root=repo,
+        )
+        assert captured == harness
+
+    def test_a_caller_that_declares_nothing_gets_nothing(self, repo: Path) -> None:
+        """No implicit default. The loop never guesses that its ``cwd``
+        owns a state directory, so the carve-out cannot be applied to a
+        tree the caller did not name."""
+        captured = _captured_ignored_paths(repo, _loop_config(repo, AUTHORED))
+        assert captured == []
+
+
+# ---------------------------------------------------------------------------
+# The four production callers declare it
+# ---------------------------------------------------------------------------
+
+
+class TestEveryCallerDeclaresTheStateRoot:
+    """The cost of the safe default, paid once here.
+
+    ``guard_state_root=None`` means "no carve-out", so a caller that
+    forgets it gets the pre-#274 bug back rather than a carve-out
+    applied to a tree kstrl does not own. That is the right failure
+    direction, and it is only safe because something checks the callers
+    actually pass it. This is that check, by source inspection: driving
+    all four flows end to end would cost four agent harnesses to assert
+    one keyword.
+    """
+
+    def test_the_four_run_loop_call_sites_pass_it(self) -> None:
+        package = Path(statedir.__file__).parent
+        callers: dict[str, int] = {}
+        declared: dict[str, int] = {}
+        for module in sorted(package.rglob("*.py")):
+            if module.name == "loop.py":
+                continue
+            tree = ast.parse(module.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+                if name != "run_loop":
+                    continue
+                callers[module.name] = callers.get(module.name, 0) + 1
+                if any(kw.arg == "guard_state_root" for kw in node.keywords):
+                    declared[module.name] = declared.get(module.name, 0) + 1
+        assert callers == {"cli.py": 1, "factory.py": 1, "feature_cmd.py": 3}
+        assert declared == callers
+
+
+# ---------------------------------------------------------------------------
+# Reported apart from the operator's authored allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestTheFailureBlockSeparatesTheTwoSets:
+    def test_it_names_what_the_operator_authorised_and_what_kstrl_added(
+        self,
+        repo: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        (repo / "pyproject.toml").write_text("x\n")
+        config = _loop_config(repo, AUTHORED)
+        config.interactive = False
+        ok, violations = guards.enforce_allowed_paths(
+            config,
+            PlainUI(no_color=True),
+            repo,
+            ignored_paths=state_dir_carve_out(repo, repo),
+        )
+        assert ok is False
+        assert "pyproject.toml" in violations
+        assert not any(v.startswith(".kstrl/") for v in violations)
+        printed = capsys.readouterr()
+        lines = (printed.out + printed.err).splitlines()
+        allowed_line = next(line for line in lines if "ALLOWED_PATHS" in line)
+        harness_line = next(line for line in lines if "HARNESS_PATHS" in line)
+        assert allowed_line.endswith("src/, tests/")
+        assert ".kstrl/runs/" in harness_line
+        assert ".kstrl" not in allowed_line
+
+    def test_it_makes_the_same_claim_the_other_two_guards_make(
+        self,
+        repo: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A retry agent must not be told two different things about the
+        same files depending on which guard fired.
+
+        Compared against what Phase 1 actually PRINTS, not against its
+        source, so an edit to either wording breaks this rather than an
+        edit to either layout. The factory's third copy of the sentence
+        is pinned by ``tests/test_harness_path_scope.py``.
+        """
+        (repo / "pyproject.toml").write_text("x\n")
+        config = _loop_config(repo, AUTHORED)
+        config.interactive = False
+        guards.enforce_allowed_paths(
+            config,
+            PlainUI(no_color=True),
+            repo,
+            ignored_paths=state_dir_carve_out(repo, repo),
+        )
+        printed = capsys.readouterr()
+        claim = "already in scope, no need to widen allowedPaths"
+        assert claim in printed.out + printed.err
+        phase_1 = _diff_scope_details("main", AUTHORED, [".kstrl/runs/"], ["pyproject.toml"])
+        assert claim in "\n".join(phase_1)
+
+    def test_nothing_is_printed_when_there_is_no_carve_out(
+        self,
+        repo: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        (repo / "pyproject.toml").write_text("x\n")
+        config = _loop_config(repo, AUTHORED)
+        config.interactive = False
+        guards.enforce_allowed_paths(config, PlainUI(no_color=True), repo)
+        printed = capsys.readouterr()
+        assert "HARNESS_PATHS" not in printed.out + printed.err

--- a/tests/test_understand_run.py
+++ b/tests/test_understand_run.py
@@ -55,12 +55,14 @@ def _fake_run_loop(
         interaction: Any = None,
         stop_check: Any = None,
         guard_ignored_paths: Any = None,
+        guard_state_root: Any = None,
     ) -> LoopResult:
         record.update(
             bus=bus,
             interaction=interaction,
             agent=agent,
             guard_ignored_paths=guard_ignored_paths,
+            guard_state_root=guard_state_root,
         )
         for _ in agent.run("prompt", cwd):
             pass

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1141,11 +1141,19 @@ class TestReadOnlyVerification:
         """The factory path is untouched: no existing caller passes the flag."""
         import subprocess as sp
 
+        # `run_scrubbed` takes a shell string OR an argv list, and the
+        # staging call is a list (#274: the `:(exclude)` pathspec must
+        # reach git unmangled). Rendered to one string per call so the
+        # assertions below read the same for both forms.
         calls: list[str] = []
 
-        def mock_run(cmd: str, **kwargs: object) -> sp.CompletedProcess[str]:
-            calls.append(cmd)
-            if "ruff check --fix" in cmd:
+        def mock_run(
+            cmd: str | list[str],
+            **kwargs: object,
+        ) -> sp.CompletedProcess[str]:
+            rendered = cmd if isinstance(cmd, str) else " ".join(cmd)
+            calls.append(rendered)
+            if "ruff check --fix" in rendered:
                 return sp.CompletedProcess(
                     cmd,
                     0,
@@ -1162,7 +1170,8 @@ class TestReadOnlyVerification:
             result = check_dead_code(tmp_path, "main")
 
         assert any("ruff check --fix" in c for c in calls)
-        assert any("git add -A" in c for c in calls)
+        staged = next(c for c in calls if c.startswith("git add"))
+        assert staged == "git add -A -- . :(exclude).kstrl"
         assert any("git commit" in c for c in calls)
         assert "auto-fixed 2" in result.message
 


### PR DESCRIPTION
Fixes #274

## What was wrong

`.kstrl/` is kstrl's own runtime state directory. Keeping it out of the in-loop scope guard's untracked-file walk was delegated to the **user's** `.gitignore`: the guard calls `git ls-files --others --exclude-standard`, so the only thing stopping kstrl's journals, locks, queue and worktrees from counting as the agent going out of bounds was a file the harness does not own, in a repository it does not control.

Measured against real git in a repository with no `.gitignore`, one file per entry kstrl creates:

```
.kstrl/autonomy.json           .kstrl/logs/feature_x/understand.log
.kstrl/contract/.../README.md  .kstrl/progress.jsonl
.kstrl/control_relocated       .kstrl/proposals/p1.json
.kstrl/debug/.../prompt.txt    .kstrl/queue/new/item-1/item.json
.kstrl/evolution.jsonl         .kstrl/queue/pause.json
.kstrl/experiments.tsv         .kstrl/runs/run-1/events.jsonl
.kstrl/factory.lock            .kstrl/snapshots/fixture-1.json
.kstrl/inbox.jsonl             .kstrl/worktrees/run-1/comp-a/
```

Sixteen scope violations, none of them the agent's. The failure surfaces as a wasted engineer iteration rather than as a configuration problem, and in interactive mode "Revert and continue" **deletes** them, because `_revert_violation` drops untracked files.

One measured detail worth recording: git reports a registered worktree as the single entry `.kstrl/worktrees/run-1/comp-a/` with a trailing slash, not as its contents. So `.kstrl/worktrees/` has to be in the carve-out or every factory run in an unignored repository trips over the worktree it just created. There is a test for exactly that.

PR #273 makes `ks init` scaffold a `.gitignore` carrying `.kstrl/`. That covers every repository initialised from now on and cannot reach one that already exists, because no newly written file arrives in a project that is already scaffolded. This fix travels with the harness instead.

## What changed

`statedir.state_dir_carve_out(walk_root, state_root)` returns the exact entries kstrl writes under `.kstrl/`: nine subtrees whose leaf names the harness invents at runtime (`contract`, `debug`, `knowledge`, `logs`, `proposals`, `queue`, `runs`, `snapshots`, `worktrees`), five files (`control_relocated`, `evolution.jsonl`, `experiments.tsv`, `factory.lock`, `progress.jsonl`), and the flat legacy in-tree control files derived from `legacy_control_paths` rather than copied.

`loop.run_loop` gains `guard_state_root` and assembles the guard's complete ignore set once, before the iteration loop: the caller's per-invocation harness files (#264) plus this. All five call sites (`factory._run_component`, `cli` understand, three in `feature_cmd`) declare it.

`guards.enforce_allowed_paths` now reports the carve-out on its own `HARNESS_PATHS` line, apart from `ALLOWED_PATHS`. The parenthetical is word-for-word the one `verify._diff_scope_details` and `factory._run_component` already print, with a test comparing the two rendered messages: a retry agent told "already in scope" at one guard and something else at another has been given two different instructions about the same files.

Two special cases retired, both now strictly subsumed:

- `loop.py`'s `.kstrl/runs/<run_id>/` entry, derived from the bus and appended unconditionally.
- `feature_cmd.py`'s hand-built `.kstrl/logs/<feature>/` entry, plus the `guard_ignored_paths` kwarg at its three `run_loop` call sites.

## Design question 1: which paths, and how they were found

**Enumerated from the code, not by hand.** `tests/test_state_dir_scope.py` AST-walks `kstrl/` for the `.kstrl/<entry>` names the package spells out and fails if one is not covered. A by-hand list, written first, missed two: `.kstrl/snapshots` (`fixtures.py`'s `FixturesConfig.snapshot_dir`) and the flat legacy control files. The scan found both. A second test runs the inverse, so a declared entry with no writer also fails.

The scan's reach is exactly the two spellings kstrl uses today: a `/` join off the state directory (`root / ".kstrl" / "runs"`, `state_dir(root) / QUEUE_DIR_NAME`, resolving a module-level constant to its literal) and a literal `.kstrl/<name>` inside a non-docstring string. It would **not** see a local alias, an f-string, `self.state_dir / x`, or `os.path.join`. That limit is pinned by its own test and stated in the constant's comment, so the claim and the mechanism agree. It is a net under the current idiom, not a proof about the next one.

**Prefixes only where an exact path is impossible.** #268 could name exact files because a component has exactly one PRD, one progress log and one map. Here nine of the entries are directories kstrl creates and then fills with names that do not exist until the run does: a run id, a component id, a queue item, a fact digest, a worktree. No exact-path form exists for those, so the honest answer is that the state directory genuinely needs prefixes, and the narrowing available is at the level below `.kstrl/` rather than at `.kstrl/` itself.

That narrowing is real and load-bearing. `.kstrl/` is **never** an entry, so `.kstrl/notes.md`, `.kstrl/payload.py`, `.kstrl/.env` and `.kstrl/runs.txt` all stay violations. `decompose._ALLOWED_PATHS_EXCLUDE` already refuses to let an architect write `.kstrl/` into `allowedPaths` at all, which is the same judgment from the other end: the state directory is never authorisable, and this is a harness-owned carve-out reported separately, not a widening of anyone's allowlist.

Operator-configured paths are deliberately excluded. `knowledge_root`, the evolution journal and `progress_log_path` are all configurable; if an operator points one at `docs/`, that is their tree and their `allowedPaths` decision, and following the config there is exactly the blanket bypass the docstring warns about. Only the fixed `.kstrl/` layout is carved out.

## Design question 2: where it is computed

**At the guard, not at plan time, and not per component.** The carve-out is not a property of a component or a PRD: it is identical for every component in a run, and the only thing it varies on is which tree the guard is about to walk. #269 proposes resolving component scope once at plan time, and that is the right home for the *component* scope, which is derived from the PRD and must be identical at both guards. It is the wrong home for this one, because a plan-time snapshot cannot know each worker's `cwd`.

**But the state root is passed in, not inferred.** The first version of this change inferred "is this walk root the project root" from the path shape, looking for `.kstrl/worktrees` in the parts. That was a bandaid: move the worktree location and the shape test silently returns "this is a project root", handing the full carve-out to a guard walking the agent's own tree. Silent widening is the wrong failure direction for a carve-out whose whole job is not to hide anything.

So `run_loop` takes `guard_state_root` and all five call sites declare it, all of which already hold `root_dir`. The default is `None`, meaning no carve-out: a caller that forgets gets the pre-fix bug, which fails loudly and is attributable, rather than a carve-out applied to a tree kstrl does not own. One test AST-walks the package and asserts every `run_loop` call site outside `loop.py` passes it, which is what makes that safe default affordable.

## Design question 3: does #273's `.gitignore` still need `.kstrl/`

**Yes, and it is not belt and braces.** The two answer different questions and neither subsumes the other. The guard only decides whether a file counts as a scope violation. The `.gitignore` is what keeps `git add -A` from committing kstrl's run journals into the project's history and thence into a PR. Delete it and a `--no-worktrees` run starts shipping its own state, with the guard now saying nothing. There is a comment on `_COMMON_IGNORES` saying exactly that, so the next reader does not remove the line as redundant.

## The hiding risk

The substantive question: what could an agent put in `.kstrl/` now that the guard stops looking there?

**It cannot invent a hiding place.** The carve-out names entries, never the directory. `.kstrl/notes.md` is still a violation, tested against a real repository and not only against a fixture.

**Inside a component worktree the guard's visibility is unchanged, and is in fact wider than before.** The carve-out is empty whenever the walk root is not the declared state root. kstrl writes nothing into a worktree's own `.kstrl/`, so carving it out there could only ever hide agent-written files. This is where the `.kstrl/runs/<run_id>/` entry the loop used to append *unconditionally* went: that entry did apply inside worktrees, where the run journal is never written, so it could only ever have covered a path the agent wrote. Removing it is a net tightening, and there is a test that drives the real loop with `cwd=<worktree>` to pin it.

**Anything committed is still caught, everywhere.** Phase 1's `check_diff_scope` is deliberately untouched. It judges `git diff base...HEAD`, so it sees only what the agent COMMITTED, and nothing kstrl writes at the project root ever appears in a component worktree's diff. A `.kstrl/` file the agent commits still fails Phase 1 and never reaches a PR. That is the backstop for the one in-loop iteration the carve-out now lets pass, and there is a test asserting it.

**The remaining exposure is bounded to a `--no-worktrees` run at the project root**, where the agent's `cwd` really is the directory holding the live state. There it could append to `.kstrl/runs/<id>/events.jsonl`, drop a fact into `.kstrl/knowledge/`, or touch `.kstrl/factory.lock`, without the scope guard reporting it. Three things bound that:

1. **This is not new exposure; it is the status quo made uniform.** `git ls-files --others --exclude-standard` respects `.gitignore`, so in every correctly scaffolded repository (which is now every repository `ks init` touches) the guard already sees nothing under `.kstrl/`. Today the guard's visibility there depends on whether the user happened to ignore the directory, and the repositories where it *can* see are exactly the ones where it breaks. This replaces "sometimes blind, and broken when not" with a known constant.
2. **The one control file that would actually buy an agent authority fails closed on being written.** Autonomy level, spend ledger, pause marker, inbox and the GitHub processed-ids ledger moved to XDG state under R8.9. `statedir.legacy_control_remaining` treats any leftover in-tree copy as dual-state and refuses to treat empty XDG as first-run, so writing `.kstrl/autonomy.json` does not escalate anything, it halts the control plane. That is why the legacy paths are in the carve-out for scope purposes and remain a fail-closed signal for authorisation purposes; the two are separate mechanisms and this change touches only the first.
3. **The guard was never the integrity mechanism for that state.** Nothing compares `.kstrl/` contents against a baseline; a scope guard reports out-of-bounds edits, it does not authenticate journals. If audit-trail integrity under `--no-worktrees` is worth defending, it wants its own mechanism, and pretending an untracked-file walk that a one-line `.gitignore` disables was that mechanism would be the more dangerous claim.

## How it was tested

`tests/test_state_dir_scope.py`, 28 tests. Behaviour, not presence:

- **A real git repository with no `.gitignore` at all**, which is the case this fixes and the one PR #273 cannot reach: 16 violations without the carve-out, zero with it, and `.kstrl/notes.md` plus `.kstrl/runs.txt` still violations. A registered worktree added with real `git worktree add` and covered. `pyproject.toml` still caught. An unconstrained component stays unconstrained.
- **The carve-out itself**: the exact 16 entries; `.kstrl/` never among them; lookalikes (`.kstrl-backup/`, `sub/.kstrl/`) not covered; every legacy control file covered; a walk root that is not the state root gets nothing in both directions; an undeclared state root gets nothing; the two paths compared as directories through a real symlink, because macOS reaches `/tmp` through one and a string comparison would silently disable this on the platform it is developed on.
- **The drift net**: every entry the package names is carved out; every declared entry has a writer; the scan notices a new subtree; it resolves a constant rather than its name; it ignores prose; and it does not claim to see the four spellings it would miss.
- **The seam**: the real loop hands the guard the carve-out; the caller's #264 files survive alongside it; a component worktree gets only the caller's files; a caller declaring nothing gets nothing; and every `run_loop` call site outside `loop.py` passes `guard_state_root`.
- **Reporting**: the failure block names the authored list and the carve-out on separate lines, prints nothing extra when there is no carve-out, and makes the same claim Phase 1 makes, compared against what Phase 1 actually renders rather than against its source.
- **Phase 1**: a committed `.kstrl/` file still fails `check_diff_scope`.

`tests/test_loop.py::test_active_run_state_does_not_trip_scope_guard` still passes and now declares `guard_state_root`; its docstring says why, since the bus is no longer what makes it pass.

Full local gate green on the rebased branch: `pytest tests/ -q` **3950 passed / 28 skipped**, `mypy kstrl/ --strict`, `ruff check kstrl/ tests/`, `pre-commit run --all-files` (29 hooks). Coverage **89.11%** against the 79.91% ratchet.

No `*_PROMPT` constant was touched, so no calibration run, version bump or snapshot update is implicated (H2/H3).

## /simplify findings, verbatim

Four agents (reuse, simplification, efficiency, altitude). Their findings as returned, then what was applied and what was declined.

### Reuse

> **1. `kstrl/feature_cmd.py:173-180` is now a hand-rolled duplicate of the new carve-out** (highest value)
>
> That block builds `.kstrl/logs/<feature>/` as a `guard_ignored_paths` entry. `state_dir_carve_out` now returns `.kstrl/logs/` for every run, and `feature_cmd` passes `cwd=root_dir` into `run_loop` (feature_cmd.py:248), the same anchor `loop.py:623` computes the carve-out from, so the entry is strictly subsumed. Cost: two declarations of the same carve-out, and since `loop.py:762` unions the two lists without collapsing prefixes, the `ks feature` failure block now prints `.kstrl/logs/feature_x/` next to `.kstrl/logs/` - exactly the "tells the operator the carve-out is wider than it is" defect that `statedir.py:179-182`'s own dedup comment exists to prevent. Fix: delete feature_cmd.py:174-180, the way `loop.py` already deleted the bus's `.kstrl/runs/<run_id>/` append.
>
> **2. `kstrl/statedir.py:183-188` re-implements `guards.path_is_allowed`'s prefix rule**
>
> `guards.path_is_allowed` (kstrl/guards.py:23-39) is the single definition of "a trailing-slash entry is a directory prefix". The redundancy filter respells it as `entry.startswith(sub)`, and `tests/test_state_dir_scope.py:174-176` spells it a third time to assert the result. Cost: `path_is_allowed` already has a second arm (`path + "/" == allowed`) that these copies lack, so the rules are not the same rule today, and the test that should catch drift is written against the copy rather than the original. Fix: `path_is_allowed(entry, [s for s in subtrees if s != entry])`. Import direction is safe - `guards` imports only `kstrl.git` and `kstrl.interaction`, neither of which imports `statedir`, so `statedir -> guards` is cycle-free; alternatively put the collapse helper in guards.py next to `path_is_allowed`.
>
> **3. `kstrl/statedir.py:176-178` re-does `config.relative_to_root`**
>
> It anchors to `state_dir(walk_root)`, then re-attaches `prefix` by hand. `kstrl/config.py:35 relative_to_root(path, root_dir)` returns `.kstrl/queue/spend.json` from `(legacy_path, walk_root)` in one call. Cost: small - one extra local (`state_root`) and a manual concatenation that must stay in step with `STATE_DIR_NAME`.
>
> **4. `WORKTREES_DIR_NAME` (kstrl/statedir.py:59) is a new constant its own writers do not use**
>
> The sites that actually build the path still use literals: `kstrl/factory.py:1053` and `:1056` (`root_dir / ".kstrl" / "worktrees" / run_id`, `.../f"{component_id}.lock"`) and `kstrl/cli.py:2860`. Cost: the constant is justified in its docstring as the thing that keeps producer and recogniser in step, but it only has the recogniser; the new AST scan is covering for what a shared constant would enforce for free. Same shape for `"queue"` in `STATE_SUBDIRS` vs `workqueue.QUEUE_DIR_NAME` (kstrl/workqueue.py:87), which the docstring names - though that one is genuinely blocked, since `workqueue` imports `statedir`.
>
> **5. `tests/test_state_dir_scope.py:311-315` and `:347-349` are the third copy of the package AST-walk boilerplate**
>
> `tests/test_prompt_versions.py:295-330` (`_module_level_prompt_constants`) and `tests/test_timeout_enforcement.py:1170-1177` already do `Path(...)/"kstrl"` + `sorted(rglob("*.py"))` + `ast.parse(read_text(...))`. The node predicates are genuinely new; the traversal is not. Both existing walkers wrap `ast.parse` in `except SyntaxError: continue` and the new one does not, which is the usual cost of a fourth-hand copy. `tests/helpers/` already exists as the shared-helper home. Also, the two tests in the new class each re-walk and re-parse the whole package; one scan would serve both.
>
> **6. `_git`, the `repo` fixture, and `_loop_config` re-declare the sibling module's versions** (lowest priority)
>
> `tests/test_state_dir_scope.py:78-79` is byte-identical to `tests/test_harness_path_scope.py:312-313`; the `repo` fixture's first eight lines match `test_harness_path_scope.py:315-327`; `_loop_config`'s scaffolding lines (`"test prompt"`, `'{"branchName": "t", "userStories": []}'`) match `_setup_project` at `test_harness_path_scope.py:154-160`. The suite's shared versions are `tests/spine_utils.py:45 git()` and `:152 base_config()`. Cost is real but small, and a per-module `_git` is an entrenched convention (15 modules declare one) - worth acting on only for these two paired #264/#274 modules. Note `spine_utils.init_kstrl_repo` is genuinely unusable here: it writes a `.gitignore` containing `.kstrl/`, which is the exact condition this fixture must not have.
>
> ## Checked, not findings
>
> - `guards._report_violations` vs `verify._diff_scope_details` (kstrl/verify.py:990). Not duplication: different sinks (UI channel vs `list[str]` details spliced into the retry prompt, with a 15-entry truncation), and verify.py:1098-1103 already documents why that seam deliberately does not share code with guards. Only the harness-note wording overlaps, and it differs between the two.
> - No existing helper fits `_is_component_worktree`. `statedir._is_under` (statedir.py:327) resolves against a known root and touches the filesystem, which the new predicate deliberately avoids; `cli.py:460-462` is a fixed-index match on a different subtree, not a reusable scan.
> - `_captured_ignored_paths` (test file:461) is not a duplicate of `_spy_run_loop` (test_harness_path_scope.py:129): different seam, different kwarg.

### Simplification

> **1. `kstrl/statedir.py:177-188` - the redundancy filter is avoidable by constructing the set correctly.**
> `legacy_control_paths` contributes 5 entries; 3 of them (`queue/spend.json`, `queue/pause.json`, `queue/github_processed.json`) are already under the `.kstrl/queue/` prefix, and the trailing 6-line `subtrees` pass exists only to remove those 3. Filtering at the source gives a byte-identical result:
>
> ```python
> for path in legacy_control_paths(walk_root).values():
>     if path.parent == state_root:                      # flat control files only
>         entries.add(f"{prefix}{path.name}")
> return sorted(entries)
> ```
>
> Measured: `sorted(entries | flat) == state_dir_carve_out(P)` -> `True`. Cost of the current form: 4 lines of comment + 6 lines of filter with an `entry != sub` self-exclusion guard (the guard is itself a tell that the filter is compensating for a set it shouldn't have built), an O(n*m) pass, and a test that exists only to assert the filter ran (see 3). The property the docstring wants to preserve ("a control file added later is covered without a second edit") survives intact: a new flat one is picked up automatically, a new one under `queue/` is covered by the prefix.
>
> **2. `kstrl/feature_cmd.py:173-180` is now dead - and with it the kwarg at `:254`, `:385`, `:488`.**
> The block computes `.kstrl/logs/feature_<name>/` and appends it to `guard_ignored_paths`. All three `run_loop` call sites pass `cwd=root_dir` (never a worktree), so `run_loop` now computes a carve-out containing `.kstrl/logs/`, and `path_is_allowed` matches by prefix - the feature entry is strictly subsumed. The `startswith(".kstrl/logs/")` branch is precisely the condition under which the shared carve-out already covers it; in the `else` case (`ValueError`, or a log dir elsewhere) nothing was ever appended. `guard_ignored_paths` has no other consumer in `feature_cmd.py`, and in `loop.py` it feeds only `enforce_allowed_paths` (`loop.py:762` -> `:768`). Net: 8 lines plus 3 argument lines removable, and one fewer place that hand-spells a `.kstrl/` path.
>
> **3. `tests/test_state_dir_scope.py:169-176` (`test_no_entry_is_redundant`) restates the implementation verbatim.**
> The assertion is a character-for-character copy of the filter expression at `statedir.py:185-187`, so it can only fail if the code is edited to disagree with itself. It is also already implied by `test_it_names_the_entries_kstrl_creates` (`:114`), which pins the exact 16-entry list. Delete it; if finding 1 is taken it has nothing left to test.
>
> **4. `tests/test_state_dir_scope.py:226-249` - `_docstring_ids` and `_div_operands` are ~24 lines that collapse to ~4, with identical output.**
> `_docstring_ids` walks four node types, reaches into `body[0]`, and triple-tests it. Any bare string statement is a docstring for this purpose:
>
> ```python
> docstrings = {id(n.value) for n in ast.walk(tree)
>               if isinstance(n, ast.Expr) and isinstance(n.value, ast.Constant)}
> ```
>
> `_div_operands` re-flattens the whole left chain for every nested `BinOp` `ast.walk` visits (quadratic, and mostly duplicate work). Since `ast.walk` already reaches every node, each `BinOp` only needs to look one step left:
>
> ```python
> left = node.left
> anchor = left.right if isinstance(left, ast.BinOp) and isinstance(left.op, ast.Div) else left
> ```
>
> I ran both replacements against every module under `kstrl/`: **0 modules differ** from the current `_named_entries`. The three meta-tests at `:326-339` still pass by construction. The remaining machinery (`_module_constants`, `_is_state_anchor`, the regex) is earning its keep - it is what found `snapshots` and the legacy files - so I would keep the scan and shrink it, not remove it.
>
> **5. `kstrl/loop.py:626` - redundant None-handling.**
> `cwd if cwd is not None else Path.cwd()` re-does what `loop.py:514-515` already did (`if cwd is None: cwd = Path.cwd()`); `cwd` is a plain `Path` from there on, which is why `:636` passes it bare to `capture_workspace_baseline`. Just `statedir.state_dir_carve_out(cwd)`. Relatedly, the comment at `:625` says the call "costs a Path walk" - it does no filesystem access at all (`normpath` plus string joins), so the justification is describing a cost that isn't there.
>
> **6. `kstrl/statedir.py:131-135` - the index scan has a simpler form, and the test cited as justifying `normpath` doesn't.**
> `any(parts[i] == ... for i in range(len(parts) - 1))` is a pairwise-adjacency test: `(STATE_DIR_NAME, WORKTREES_DIR_NAME) in zip(parts, parts[1:])`. Verified equivalent on all six shapes the tests cover. Minor on its own, but worth pairing with this: `test_the_worktree_test_survives_a_dotted_path` (`:185`) returns `True` **with or without** `normpath`, because `..` never separates `.kstrl` from `worktrees`. The case `normpath` actually buys is a path that *escapes* the tree (`.kstrl/worktrees/../..`), which no test covers. Either the test should pin the escape case or the docstring should stop citing the dotted path as the reason.
>
> **7. Overlap with `tests/test_guards.py`.**
> - `:151` `test_a_lookalike_directory_is_not_covered` re-tests the same three shapes as `test_guards.py:93` `test_lookalike_paths_still_flagged` (`.kstrl-backup/`, `sub/.kstrl/`). It is `path_is_allowed`'s prefix semantics, already pinned there.
> - `:400` `test_it_never_creates_a_scope_where_none_was_configured` duplicates `test_guards.py:60` `test_empty_allowed_no_violations`, but pays for a real git repo fixture to do it.
> - `:157` `test_the_legacy_in_tree_control_files_are_covered` is implied today by the exact-list test at `:114`; it only earns its place as a guard against a *future* control file, which is worth stating in its docstring or dropping.
>
> Nothing else in the diff struck me as over-built. The `_report_violations` extraction in `guards.py` has one call site but genuinely shortens `enforce_allowed_paths`, and the `STATE_SUBDIRS` / `STATE_FILES` split is the right shape for the two matching rules.

### Efficiency

> Caveat on state: `kstrl/statedir.py`, `kstrl/loop.py` and the test file were **revised on disk mid-review** by another agent. Two of the four things I was asked to check are already fixed in the current revision, and the test file is currently mid-edit (it still calls `state_dir_carve_out` with one argument while `statedir.py` now takes two, so 18 of 25 tests fail right now). Test-file timings below come from the last fully-green run plus standalone benchmarks that the signature change does not affect.
>
> ### Already fixed since the briefing
>
> - **Per-iteration list rebuild is gone.** `kstrl/loop.py:633-637` now builds `guard_ignored` once, inside the `if config.allowed_paths and is_repo:` block, and hands the same list to every iteration. (For reference, the rebuild it replaced measured 49 ns/iteration - it never mattered.)
> - **The carve-out is no longer computed when the guard is off.** The call moved inside the `allowed_paths and is_repo` guard, so runs without a scope pay nothing.
>
> ### Findings
>
> **1. `kstrl/statedir.py:132` - yes, `state_dir_carve_out` now does filesystem I/O, and it does not matter.**
> `_same_directory` calls `os.path.realpath` twice, which is real `lstat` traffic per path component. Measured on a 9-component real path: `realpath` 9.5 us, `_same_directory` 17.7 us, full `state_dir_carve_out` **36.6 us** on the matching path and **0.1 us** on the `state_root=None` fast path. Called once per `run_loop`, so 37 us against a run measured in minutes. Note this is new I/O relative to the earlier revision (which was pure `Path` arithmetic via `legacy_control_paths`); `legacy_control_paths` itself touches no disk. No action.
>
> **2. `kstrl/guards.py:112-116` - `ignored_paths` is tested before `allowed_paths`, so every changed file scans all 16 carve-out entries.** Carve-out hits are rare (only kstrl's own artifacts), so the 16-entry scan runs on files that would have matched `allowed_paths` on the first entry. Measured, `allowed=["src/","tests/"]`, 16 carve-out entries:
>
> | changed files | before (no ignored) | now (16 ignored) | reordered |
> |---|---|---|---|
> | 100 | 0.01 ms | 0.10 ms | - |
> | 1 000 | 0.13 ms | 1.04 ms | 0.14 ms |
> | 10 000 | 1.78 ms | 10.74 ms | 1.77 ms |
>
> Swapping to `if path_is_allowed(file, allowed_paths): continue` first, then the ignored check, is output-identical (verified against the current function on a mixed set) and restores pre-change cost exactly. But the absolute worst case is **+9 ms once per iteration**, against an iteration dominated by minutes of agent time. Only worth doing if you want the guard's cost to stay flat as the carve-out list grows; on today's numbers it is not a cost.
>
> **3. `tests/test_state_dir_scope.py:311` and `:345` - the `kstrl/` package AST walk runs twice, once per test.**
> Package is 118 modules / 2.20 MiB. Measured: `read_text` 1.9 ms, `ast.parse` 98.9 ms, full `_named_entries` over all modules **244.7 ms**. `--durations` confirms **0.25s for each of the two tests**, out of a 3.22s file total (25 passed). A module- or session-scoped fixture returning `{module: names}` removes one of the two walks: **~0.25s, ~8% of the file.**
>
> **4. `tests/test_state_dir_scope.py:231-245`, used at `:273` - `_named_entries` does two full `ast.walk` passes per module.** `_prose_ids`/`_docstring_ids` is one walk (**84.9 ms** across the package) and the main loop is a second; a bare `ast.walk` over all modules is 54.5 ms of the 246.2 ms total. Collecting the prose ids during the single main walk (docstrings are `ast.Expr` statements, reachable in the same pass) saves **~85 ms per walk, ~170 ms across both tests.** Combined with finding 3, the two tests go from ~0.50s to roughly ~0.16s.
>
> **5. `tests/test_state_dir_scope.py:83` - the `repo` fixture rebuilds a git repo per test.** Measured **30.5 ms/build**; 13 tests consume it, so **~396 ms**, matching the ~0.03s setup rows in `--durations`. A session-scoped template plus `shutil.copytree` per test measured **8.3 ms/copy = 108 ms**, saving **~288 ms (~9% of the file)**. The copy is required, not a shared fixture - several tests mutate the repo (`git worktree add`, commits, extra files).
>
> ### Bottom line
>
> Nothing in the production path is worth changing: the loop-invariant work is already hoisted, and the two remaining costs (37 us of `realpath` per run, <=9 ms of extra prefix comparisons per iteration) are invisible next to an LLM iteration. The only real waste is test-side: findings 3+4+5 total **~0.7s of the file's 3.2s (~22%)**, which is ~0.25% of the 283s full suite. Worth doing if this file is run often in isolation; otherwise optional.

### Altitude

> ## Verdict on the two seam questions you posed
>
> **The #264 seam is the wrong home for this, and the change is right not to use it.** `component_harness_paths` lives in `config.py` because two consumers (in-loop guard and Phase 1) must judge the same set, and the derivation needs per-component config the loop does not have. The state carve-out has exactly one consumer, depends only on the walk root, and is identical for every run. Pushing it to the three `run_loop` callers would be three chances to forget with no second consumer to keep in sync. Not a finding.
>
> **`_is_component_worktree` is a bandaid.** The fact is available at every caller. That is finding 1.
>
> ## Findings
>
> **1. `kstrl/statedir.py:116-136` - the shape test infers a fact the callers already hold, and its supporting constant proves the coupling is unenforced.**
> `factory._run_component` takes `root_dir_str` (factory.py:1685) and passes `worktree_path` as `cwd`; the other four `run_loop` call sites (`cli.py:1149`, `feature_cmd.py:244/375/478`) pass `root_dir` *as* `cwd`. So "is this walk root the project root" is knowable everywhere. Instead the change reads it off path parts, and `WORKTREES_DIR_NAME` (statedir.py:59) - introduced to represent the coupling - is referenced nowhere outside statedir.py, while factory.py builds the path from literals at 1053, 1056, 1149, 1210, 3489 and cli.py:2860. Cost: move the worktree location and the shape test silently returns `False` for a worktree, so the loop hands the full carve-out to a guard walking the agent's own tree and an agent-written `.kstrl/runs/...` stops being a violation. Silent widening, and no test covers it. The alternative is one optional `root_dir: Path | None` on `run_loop`, threaded through five sites that all already hold it; it deletes `_is_component_worktree`, `WORKTREES_DIR_NAME`, and three tests.
>
> **2. `kstrl/loop.py:626` and `:762` - computed one level above its only consumer.**
> `enforce_allowed_paths` is the sole caller of `check_violations`, `run_loop` is the sole caller of `enforce_allowed_paths`, and the guard already receives `cwd` - the walk root. The new docstring at guards.py:193-196 now describes `ignored_paths` as a two-part union that the guard does not assemble. Assembling it inside `enforce_allowed_paths` makes the docstring true of the function, drops loop.py's `statedir` import, and removes the `guard_state_paths` local computed at line 626 outside the `if config.allowed_paths and is_repo` branch that consumes it. Cost: guards.py gains a `statedir` import (no cycle - statedir imports neither guards nor git). The counter-argument, "compute once per run", is thin: the function is pure path arithmetic with no I/O.
>
> **3. `kstrl/feature_cmd.py:173-181` - the change removed one subsumed special case and left its sibling.**
> loop.py:754-761 correctly deletes the `.kstrl/runs/<run_id>/` append because `.kstrl/runs/` now covers it. `feature_cmd` hand-builds `.kstrl/logs/<feature>/` for exactly the same reason and is now strictly subsumed by `.kstrl/logs/` in `STATE_SUBDIRS` - it passes `root_dir` as cwd, so the carve-out is always non-empty there. Cost: nine lines of dead special-casing that the next maintainer will read as load-bearing, in the one file that most invites copying the pattern.
>
> **4. `kstrl/statedir.py:79-81` + `tests/test_state_dir_scope.py:266-296` - the drift net is much narrower than the comment that sells it.**
> The comment claims the test "AST-walks `kstrl/` for every `.kstrl/<entry>` the package actually names and fails if one is missing here, so a subtree added later cannot silently reintroduce the bug". Measured against `_named_entries`, five idiomatic spellings return empty: a local alias (`S = state_dir(r)` then `S / "cache"`), a local helper function, an f-string, `self.state_dir / "cache"`, and `os.path.join(root, ".kstrl", "cache")`. Only `state_dir(x) / "literal"` and a literal `.kstrl/name` substring are seen. Cost: ~130 lines of AST heuristics that genuinely catch the two forms kstrl uses today, sold as a guarantee that covers the next form too. Either narrow the claim in the constant's docstring, or make the scan fail loudly when it sees a join off something it cannot resolve.
>
> On the underlying structure question: the central hand-maintained list is *forced*, not a bandaid. `statedir` is a leaf that `workqueue`, `events`, `factory` and `fixtures` all import; having each module declare its own entry for statedir to collect inverts that and cycles. And the net does cover both drift directions (`test_every_entry_the_package_names_is_carved_out` for additions, `test_every_declared_entry_is_reachable` for orphans). The one place worth tightening is `"queue"` in `STATE_SUBDIRS`, which re-spells `workqueue.QUEUE_DIR_NAME` as a bare string when the constant exists.
>
> **5. `kstrl/guards.py:152-176` - right seam, third hand-copy of the sentence it prints.**
> Extracting `_report_violations` to mirror `verify._diff_scope_details` is correct: both keep the authored list and the harness carve-out visibly apart. But the sentence is now written out three times, and the new one diverges. verify.py:1017-1020 and factory.py:2059-2062 both say "kstrl's own files, already in scope, no need to widen allowedPaths"; guards.py:172 says "kstrl's own files, added by the harness; not part of ALLOWED_PATHS" - a different claim. factory.py's own comment says the two scope failures must "read identically wherever they are caught". Cost: one shared formatter for the harness-paths line, consumed by all three, versus a retry agent that is told two different things about whether those paths are in scope depending on which guard fired.
>
> **6. `kstrl/statedir.py:180-188` - display logic inside the policy function (minor).**
> The redundancy pruning is justified in its own docstring by "the failure message has to be readable"; `path_is_allowed` is indifferent to redundant entries. It makes `state_dir_carve_out` do two jobs and is the sole reason `test_no_entry_is_redundant` exists. Small enough to leave.

### Applied

- **Altitude 1** (and the dead `WORKTREES_DIR_NAME` it names, Reuse 4). The biggest change in the branch. The path-shape test is gone; `run_loop` takes `guard_state_root` and all five call sites declare it. Silent widening was the wrong failure direction for a carve-out whose job is not to hide anything, and a new test AST-walks the package to assert every call site passes it, which is what makes the safe `None` default affordable. Also deletes `_is_component_worktree` and Simplification 6 with it.
- **Reuse 1 / Simplification 2 / Altitude 3** (all three found it independently): `feature_cmd`'s `.kstrl/logs/<feature>/` block and the `guard_ignored_paths` kwarg at its three call sites, with a comment saying why it went so the pattern is not copied back in.
- **Simplification 1** (which subsumes Reuse 2, Reuse 3 and Altitude 6): the legacy control paths are filtered at the source on `path.parent == in_tree`, so only the flat ones are added. The redundancy filter, the `path_is_allowed` re-spelling and `test_no_entry_is_redundant` (Simplification 3) all disappear with it.
- **Simplification 4** and **Efficiency 4**: `_docstring_ids` collapsed to a set comprehension and then folded into the single main walk; `_div_operands` replaced by the one-step-left lookup. Verified identical output across all 118 modules by the agents; the tests that pin the scan still pass.
- **Efficiency 3**: the package walk is memoized so the two tests parse `kstrl/` once between them, not once each.
- **Altitude 4**: the `STATE_SUBDIRS` comment now states the scan's actual reach (a `/` join off the state dir, and a literal `.kstrl/<name>`), and a new test pins the four spellings it cannot see. The claim and the mechanism now agree.
- **Altitude 5**: the guard's harness-paths sentence is now word-for-word the one `verify` and `factory` print, with a test comparing the guard's rendered output against Phase 1's rendered output.
- **Simplification 5**: `cwd` is already defaulted at the top of `run_loop`, so the redundant `if cwd is not None` is gone. The comment claiming a filesystem cost went with it, and the cost is now real anyway (`realpath`), so the comment would have been wrong twice.
- **Altitude 4 (partial), Reuse 4 (partial)**: the `"queue"` literal now carries a comment naming `workqueue.QUEUE_DIR_NAME` and the import direction that blocks sharing it.

### Declined

- **Altitude 2** (assemble the union inside `enforce_allowed_paths`). Blocked mechanically: `enforce_allowed_paths` is at cyclomatic 11 against a limit of 10, grandfathered, and the repo's ratchet hook refuses any commit that grows it. Adding the branch there fails the gate. `run_loop` also owns `guard_ignored_paths`, so it is the site that holds both halves; the guard's docstring was reworded to describe what it receives rather than what it assembles.
- **Efficiency 2** (test `allowed_paths` before `ignored_paths` in `check_violations`). Measured at +9 ms once per iteration at 10 000 changed files, against an iteration measured in minutes. The current order also states the rule more plainly: the harness's own files are never violations, full stop. Not worth reordering a security-adjacent predicate for a cost that does not register.
- **Efficiency 5** (session-scoped repo template plus `copytree`). Measured saving ~288 ms on a 287 s suite, 0.1%. The per-test `git init` is the more obvious fixture.
- **Reuse 5** (extract the package AST walk to `tests/helpers/`). The shared part is three lines (`rglob`, `read_text`, `ast.parse`); the predicates are all new. A shared helper for three lines across three unrelated walkers is the more expensive shape. The `except SyntaxError: continue` the other walkers carry is deliberately not copied: a `kstrl/` module that does not parse should fail this test loudly, not be skipped.
- **Reuse 6** (share `_git` / the repo fixture / `_loop_config` with `test_harness_path_scope.py`). A per-module `_git` is an entrenched convention here (15 modules declare one), and the reviewer notes `spine_utils.init_kstrl_repo` is unusable for this file specifically, because it writes a `.gitignore` containing `.kstrl/` - the exact condition this fixture must not have.
- **Simplification 7** (overlap with `tests/test_guards.py`). Kept. `test_a_lookalike_directory_is_not_covered` tests the lookalikes against the computed carve-out, not against a hand-written list, so it fails if a future entry is spelled loosely; the other two are cheap and assert the end-to-end behaviour against real git output rather than a fixture. Noted rather than argued.
- **Simplification 6** (the `zip` pairwise form, and the `normpath` justification). Moot: the shape test it describes was deleted by Altitude 1. The `..` case it asked for is now covered against the real comparison instead, by the symlink test.

---

# Review round 2

Three findings, all confirmed by measurement before fixing. The first one contradicted my own docstring and my own hiding-risk section, so both are corrected below as well as in the code.

## 1. The carve-out was a blanket bypass under nine prefixes

Confirmed against the shipped code:

```
.kstrl/queue/new/i/item.json   -> allowed
.kstrl/runs/x/evil.py          -> allowed
.kstrl/knowledge/x/y.md        -> allowed
.kstrl/proposals/evil.json     -> allowed
```

The docstring said "an agent cannot invent a hiding place under the state directory". True one level up, false one level down, and nothing pinned the subtree case.

**The prefixes stay.** kstrl invents those leaf names at runtime, so no exact-path form exists, and a shape constraint on the leaves would be a mechanism an agent satisfies by choosing a filename. What changed is that the claim is now what the code does, and the residual is bounded rather than denied.

**`STATE_NOT_CARVED` keeps every authority-carrying entry countable.** Two criteria, both of which must hold:

1. **It carries authority over what kstrl does next.** `queue` is the in-tree work queue `ks serve` drains, so a file written there can admit work, and it holds the pause marker, the spend ledger and the GitHub processed-ids. `proposals` is what `ks evolve --apply` reads to mutate config and prompts, with `auto_apply_computational` able to skip the confirmation. `autonomy.json` is the autonomy level; `inbox.jsonl` is the human-decision stream. Those five are exactly `policy.ENFORCEMENT_MACHINERY_PATHS`, where touching one is already a non-overridable hard fail, so the guard and the envelope now agree about the same files instead of one ignoring what the other halts on.
2. **Nothing reachable from `run_loop` writes it**, so keeping it countable cannot reintroduce the failure this change exists to fix.

Criterion 2 was the load-bearing half and it was only a comment. It is now checked: `test_the_loop_cannot_reach_a_writer_of_an_uncarved_entry` walks `kstrl.loop`'s static import closure, including the function-level imports this codebase uses to break cycles, and asserts it reaches none of `workqueue`, `serve`, `cli`, `evolution`, `intake_github`. A second test asserts the closure is non-empty and that `kstrl.serve` does reach them, so the first cannot pass by walking nothing.

Criterion 2 is affordable because the guard subtracts whatever was on disk when the agent started. Measured, not assumed:

```
baseline dirty          : .kstrl/queue/new/item-1/item.json, .kstrl/runs/r1/events.jsonl
changed since baseline  : .kstrl/queue/new/item-1/agent.json, .kstrl/runs/r1/heartbeat.jsonl, rogue.py
violations, queue carved: rogue.py
violations, queue NOT   : .kstrl/queue/new/item-1/agent.json, rogue.py
```

So an operator running `ks serve` against this repo does not trip over queue items that predate the run. Only one written while the agent was working is reported, which is the case worth seeing. `serve` also moves an item to running before it launches the factory and to a terminal state after it returns, so its own writes bracket the run.

Effective carve-out: **14 entries down to 12**, and the two removed are the two that could admit work or rewrite config.

## 2. Making them visible handed them to a deleter

Not in the review, found while fixing finding 1 and worth more than it: the guard's interactive arm disposes of a violation by DELETING the untracked file, and `git.delete_untracked` recurses into directories. Un-carving `queue` and `proposals` therefore gave the guard's write arm paths it previously could not reach, and an operator choosing "Revert and continue" could destroy the pause marker they had just written to stop the run.

`_revert_violation` now refuses anything under the state directory, reports it, and returns it unreverted so the guard cannot claim a clean revert for a file still on disk. Reporting a file and destroying it are different powers; the function only had the second.

Mutation-checked. With the refusal removed, the test watches the guard delete `.kstrl/autonomy.json`, `.kstrl/queue/pause.json` and the rest.

## 3. The Phase 1 backstop had a hole in the case it was meant to cover

`verify.check_dead_code` auto-commits ruff's fixes so the tree stays clean for later checks. Under `use_worktrees=False` it runs with `cwd` at the project root, so `git add -A` swept kstrl's own live journals onto the component branch the moment ruff fixed one finding, and since `check_diff_scope` is deliberately un-carved they failed the next pass and rode into the PR. That is precisely the `--no-worktrees`-at-root configuration my layer (d) named as the residual, so the backstop that was supposed to make it acceptable was absent in it.

Fixed with an exclude pathspec, measured against real git:

```
git add -A (old)         -> staged .kstrl/runs/r1/events.jsonl, src/a.py, src/new.py
exclude pathspec (new)   -> staged src/a.py, src/new.py
```

The agent's own work, new files included, is still staged, so the auto-commit keeps doing its job. In a worktree the same exclusion is wanted for the opposite reason: a `.kstrl/` there is the agent's and this function must not commit it on the agent's behalf. Mutation-checked: reverting to `git add -A` fails the test with the full journal listing.

Measured side effect: the argv-list form is **2.5ms faster** than the shell string it replaces (4.98ms vs 7.47ms on a 20-file repo), because `run_scrubbed` only spawns `/bin/sh` for a string.

## Corrections to what this PR previously claimed

- The hiding-risk section said "(a) The carve-out names entries, never the directory, so no invented hiding place". That is true only for a NEW top-level name. Inside a carved subtree an agent can still place a file the in-loop guard does not count, and that is now stated in the code, in the tests and here.
- Layer (c) leaned on Phase 1 as the backstop for the `--no-worktrees` residual. Finding 3 was a hole in exactly that. It is closed; the argument now holds where it is made.
- "All four `run_loop` call sites" was wrong in the test name, the class docstring, the first commit message and this body. There are five: `feature_cmd` calls it three times. Corrected everywhere.

## 4. Emoji

Dropped the robot emoji from the attribution trailer. The no-emoji rule applies to the PR body, and the harness template includes one.

## Tests added this round

`tests/test_state_dir_scope.py` is now 37 tests. New:

- the residual stated outright: every carved subtree is a prefix and a file inside one is uncounted, named path by path
- the bound: `queue` and `proposals` entries stay countable, and no legacy control file is carved out
- `STATE_NOT_CARVED` names entries that actually exist
- criterion 2 mechanised: the loop's import closure reaches no writer, plus the control that the closure is walking something
- the baseline measurement the exclusion rests on, against real git
- the revert arm refuses kstrl state, leaves it on disk, reports it unreverted, and still reverts the genuine violation
- the dead-code cleanup does not commit the state dir, does commit the agent's work, and leaves `check_diff_scope` passing

`tests/test_verify.py::test_dead_code_default_still_fixes_and_commits` asserted `"git add -A" in cmd` against what is now an argv list. It renders both forms to one string and asserts the exact staging command, so it pins the pathspec rather than a substring.

Full local gate green on the rebased branch: `pytest tests/ -q` **3979 passed / 28 skipped**, `mypy kstrl/ --strict`, `ruff check kstrl/ tests/`, `pre-commit run --all-files` (29 hooks). Coverage **89.12%** against the 79.91% ratchet. Rebased onto `d7af68b` after #283 and #284 merged; no `*_PROMPT` constant touched.

## /simplify, round 2, findings verbatim

### Reuse

> **1. `tests/test_state_dir_scope.py:632-638` - raw `subprocess.run` duplicates the file's own `_git` helper.**
> The new test builds a 7-line `subprocess.run(["git", "show", "--name-only", ...])` block, while `_git` at line 91 (14 call sites in the same file) already wraps `["git", *args]` with `check=True, capture_output=True` - it just discards stdout and lacks `text=True`. `tests/spine_utils.py:45` has the same helper already returning stdout with an rc assertion.
> Cost: 7 duplicated lines, and the next test in this file that needs git output copies the block again. Cheapest fix is a two-token change to `_git` (`text=True`, `return result.stdout`, `-> str`), then `_git(repo, "show", "--name-only", "--format=", "HEAD").split()`. Importing `spine_utils.git` also works but adds a cross-module import for one call site.
>
> **2. `kstrl/verify.py:1706` - inline argv is correct here; do not move it to `kstrl/git.py`.**
> I checked: no pathspec-exclusion or "stage everything" helper exists anywhere in `kstrl/`. `git.stage_file` (`kstrl/git.py:591`) is single-path `git add -- <file>` and is not a home for this. More importantly it *cannot* be: `check_dead_code` must route through `run_scrubbed` for the R2.6 env scrub, `run_scrubbed` lives in `verify.py`, and `verify.py:18` already does `from kstrl import git` - so hosting it in `git.py` would either drop the scrub or create a cycle. `git add -A` has exactly one call site in the package. Verdict: no change; the inline form is the cheap correct one. (Good reuse noted: it imports `STATE_DIR_NAME` rather than hardcoding `".kstrl"`, unlike `policy.py` and `decompose.py`, which both hardcode it.)
>
> **3. `kstrl/statedir.py:107` `STATE_SUBDIRS_NOT_CARVED` - not a duplicate of any existing policy list.**
> `policy.DEFAULT_PATHS_DENY` (`.kstrl/**`) and `decompose._ALLOWED_PATHS_EXCLUDE` (bare `.kstrl`) are whole-tree, no per-subdir granularity. `policy.ENFORCEMENT_MACHINERY_PATHS` (`kstrl/policy.py:65-75`) names five *specific control files*, not subtrees, and never mentions `proposals` at all. Different artifact too: policy judges the branch diff, this judges the untracked walk. No change.
>
> **4. (Pre-existing, outside this diff, optional) `kstrl/policy.py:65-75` re-spells state paths `statedir` already owns.**
> Ten literal entries (`.kstrl/autonomy.json`, `.kstrl/inbox.jsonl`, `.kstrl/queue/{spend,pause,github_processed}.json`, each in two spellings) restate `statedir.CONTROL_FILENAMES` + `legacy_control_paths`. This round adds three more hand-written prose copies of the same three `queue/` filenames (statedir comment at ~line 250, the `state_dir_carve_out` docstring, and the test docstring at `tests/test_state_dir_scope.py:~168`).
> Direction: **policy should source from statedir**, not the reverse - `kstrl/statedir.py` imports stdlib only (verified), so `policy -> statedir` is cycle-free, whereas policy's entries are globs and omit `proposals`, so they cannot generate statedir's tuple. Cost of leaving it: a sixth control file means editing statedir, policy, and three prose blocks. Low priority, and I would not gate this change on it.
>
> ## One out-of-angle item you should know about
>
> `tests/test_verify.py:1165` now **fails**. `TestReadOnlyVerification::test_dead_code_default_still_fixes_and_commits` asserts `any("git add -A" in c for c in calls)`, and its `mock_run` records the raw `cmd`; that argument is now a `list`, so the substring test can never match. Confirmed by running: `1 failed, 1 passed`. `tests/test_state_dir_scope.py` itself is green (34 passed).

### Simplification

> ## Measurements I ran first
>
> - **Mutation probe, shrink** (add `runs` to `STATE_SUBDIRS_NOT_CARVED`): 6 tests fail, including *all four* of the tests you asked about except `test_the_subtrees_that_carry_authority_are_not_carved_out`.
> - **Mutation probe, widen** (drop `queue` from `STATE_SUBDIRS_NOT_CARVED`): 5 tests fail.
> - **Probe on the stated justification**: with `proposals`/`queue` deleted from `STATE_SUBDIRS`, `test_every_entry_the_package_names_is_carved_out`, `test_every_declared_entry_is_reachable` and `test_the_scan_would_notice_a_new_subtree` all still **pass**.
> - **Prose:code ratio of the statedir diff**: 88 added lines, 7 of them code.
>
> ## Findings
>
> **1. `kstrl/statedir.py:95-136` - the stated reason for the indirection is not what the code does.** The AST drift net compares `_package_entries()` against the *carve-out*, not against `STATE_SUBDIRS` (`tests/test_state_dir_scope.py:401-412`), and `_EXPECTED_UNCOVERED` already sources the two names from `STATE_SUBDIRS_NOT_CARVED`. Measured: removing them from `STATE_SUBDIRS` breaks exactly one test, `test_the_exclusions_name_subtrees_that_actually_exist:209`, which is the subset assertion that exists only because of the subtraction. Cost: a justification a reader will check and find false. Verdict on the design itself: **keep the subtraction**, but for the real reason - `STATE_SUBDIRS` is the single place to read "what kstrl writes under `.kstrl/`", and splitting it would force a rename to `STATE_SUBDIRS_CARVED` plus a union in `test_every_declared_entry_is_reachable:448`. That is a wash on complexity, so the tie goes to not churning. Fix the sentence at `statedir.py:56-60`, not the structure.
>
> **2. `kstrl/statedir.py:245-264` - the two filters are one idea only by coincidence, and the split is fine.** Note the `path.parent == in_tree` filter is **pre-existing** (verified against `HEAD`); the diff adds one filter and re-justifies the other. They test genuinely different things (membership in a policy tuple vs. a path's parent directory), and unifying them would mean normalizing legacy paths to relative posix strings and splitting on `/` - more machinery, not less. The split earns its keep. What does not is the *comment* (see 4).
>
> **3. `kstrl/statedir.py:198-224` - the "What it does NOT claim" block is 27 lines, of which ~15 are cuttable.** Three specific paragraphs:
>    - `198-199` "*Stated plainly because the first version of this docstring claimed it and was wrong (#274 review)*" - changelog in production code. The same sentence already lives at `tests/test_state_dir_scope.py:165-173`, which is where a regression narrative belongs. Cost: production docstrings that grow one paragraph per review round.
>    - `209-211` (first bullet) restates `STATE_SUBDIRS_NOT_CARVED`'s own docstring at `107-117`, 25 lines above. A cross-reference does the same work.
>    - `219-224` - the load-bearing sentence is "*a scope guard reports out-of-bounds edits, it does not authenticate journals*". The trailing `.gitignore` clause restates the opening paragraph at `183-187`, which already explains the #273 relationship. Cost: 66-line docstring on a 22-line function.
>
> **4. `kstrl/statedir.py:249-258` - 10-line comment on a 5-line expression, and the third copy of one fact.** "The three legacy control files under `queue/` stay with the subtree that holds them" is now stated at `statedir.py:249-254`, `tests/...:194-196`, and `tests/...:226-231`. Cost: three copies to move together when the policy moves; the first 6 lines are derivable from `STATE_SUBDIRS_NOT_CARVED` plus the filter itself. The "Derived from `legacy_control_paths`" half (`256-258`) is load-bearing - keep it.
>
> **5. `kstrl/statedir.py:107-132` and `tests/test_state_dir_scope.py:482-495` - the affordability argument is written out twice, near-verbatim.** Both narrate `capture_workspace_baseline`, both narrate "`serve` moves an item to running before it launches the factory and to a terminal state after it returns", both end on "the case worth seeing". The test docstring even says "*Measured here rather than argued*" while the constant says "*measured, not assumed*" - each pointing at the other. Cost: ~15 duplicated lines. The constant should assert the policy and point at the test; the test is where the measurement lives.
>
> **6. `kstrl/verify.py:1691-1700` vs `tests/test_state_dir_scope.py:610-623` - same paragraph, twice.** Cost: 10 lines duplicated. The second half of the code comment (`1702-1704`, "*A list, not a string: `run_scrubbed` only shells out for a string*") is the genuinely local, non-obvious bit and is the part that must stay - it explains an API constraint a reader cannot see from the call site. The first half is the test's job.
>
> **7. `tests/test_state_dir_scope.py:519-532` `test_a_file_inside_a_carved_subtree_is_not_counted` - delete it.** Measured: it has **zero unique mutation coverage**. The shrink probe shows `test_with_the_carve_out_only_the_excluded_subtrees_remain:467` and `test_the_baseline_is_what_clears_the_excluded_subtrees:478` both already fail on the same mutation at the same real-git level, because both assert exact-equality violation lists that would gain the `.kstrl/runs/...` entry. Its own docstring concedes the point: "*Named so a reader of this file finds the limit here and not only in the unit test above*" - that is a naming argument, not a property. Cost: 14 lines plus a git-repo fixture per run, to re-assert what two neighbours already assert.
>
> **8. The four tests are two properties x two levels, not four properties.** P1 (files inside a carved subtree are uncounted) = `162` unit + `519` real-git; P2 (proposals/queue stay counted) = `187` unit + `467` real-git. The real-git level earns its keep for P2 at `467` (exact violation set, which the unit test cannot see). It does not for P1 - hence finding 7. Separately, `test_the_subtrees_that_carry_authority_are_not_carved_out:187` overlaps `test_the_legacy_control_files_split_on_where_they_live:220` on exactly 3 of its 6 paths (`queue/pause.json`, `queue/spend.json`, `queue/github_processed.json`) - drop those three lines from `199-206` and let `220` own them; keep the test for the `proposals/*` and `queue/new/...` paths and its docstring.
>
> **9. `tests/test_state_dir_scope.py:478-517` - not two tests' work, but the first assertion is subsumed.** It measures one property (baseline arithmetic). The `== []` at `499-503` cannot fail independently of the exact-equality at `510-517`: if the baseline cleared nothing, the second list would gain the three pre-existing artifacts and fail too. Keep it as a diagnostic control if you want failure localization - but say so in a word, because as written it reads as a second property. Low priority.
>
> ## What I would not touch
>
> The `git add -A -- . :(exclude)` change itself, the `STATE_SUBDIRS_NOT_CARVED` constant, the subset test at `209`, and `test_the_exclusions_name_subtrees_that_actually_exist` are all minimal for what they buy. The whole simplification opportunity here is prose, not structure: 81 of the 88 added lines in `statedir.py` are comment, and roughly 45 of those exist in a second or third copy somewhere else in the change.

### Efficiency

> ## Measured baseline
>
> `uv run pytest tests/test_state_dir_scope.py -q --durations=12`, three consecutive runs: **34 passed in 1.43s** (identical all three). Split: 0.82s in `call`, 0.54s in `setup` across 17 `repo` fixture builds. The diff took the file from 28 to 34 tests; the six added tests cost **~190ms (~13% of the file)**, of which 3 are pure-path and free and 3 build a git repo.
>
> Top durations:
> ```
> 0.18s call  TestTheEnumerationMatchesTheCode::test_every_entry_the_package_names_is_carved_out
> 0.18s call  TestEveryCallerDeclaresTheStateRoot::test_every_run_loop_call_site_passes_it
> 0.06s call  TestTheLoopAppliesIt::test_a_component_worktree_gets_only_the_callers_files
> 0.05s call  TestPhase1KeepsSeeingTheStateDir::test_dead_code_cleanup_does_not_commit_the_state_dir
> ```
>
> ## Findings
>
> **1. `tests/test_state_dir_scope.py:605` `test_dead_code_cleanup_does_not_commit_the_state_dir` - costs ~80ms, and it is worth it.** Breakdown from a standalone harness (median of 5): fixture 28.4ms, `check_dead_code` 30.6ms (real `ruff --fix` is 11.5ms of that), `git show` 4.1ms, `check_diff_scope` 7.3ms. That is 5% of the file and 0.08s against a 3984-test suite. It is the only test that exercises the `verify.py` pathspec change end to end, and no cheaper form reaches it - the bug it pins is `git add -A` sweeping an untracked `.kstrl/`, which needs a real index. No change.
>
> One cost note: `vulture` is not a declared dependency (`pyproject.toml` has only a `[tool.vulture]` config section) and is absent here, so Phase B short-circuits. With vulture on `PATH` the same test measures **0.10s call instead of 0.05s**. Still cheap, but the test's cost is environment-dependent and unpinned.
>
> **2. `kstrl/statedir.py:246` - the `STATE_SUBDIRS_NOT_CARVED` membership test is free. Do not hoist.** Over `len(STATE_SUBDIRS)=9` with 2 exclusions (20k iterations each):
> ```
> comprehension w/ tuple `not in` : 0.330 us
> comprehension w/ frozenset     : 0.304 us
> comprehension, no filter       : 0.335 us
> ```
> The filter is indistinguishable from no filter at all; converting the tuple to a `frozenset` would save ~26ns per call. Whole-function `state_dir_carve_out(P, P)` is **18.7us**, dominated by `_same_directory`'s `realpath` (2.4us), `legacy_control_paths` (3.5us) and the `sorted()`. And it has exactly one production call site, `kstrl/loop.py:642`, once per loop setup - not a hot path.
>
> **3. `kstrl/statedir.py:255-259` - the new `legacy_control_paths(...)` filter adds no filesystem I/O.** `legacy_control_paths` (statedir.py:392) and `state_dir` (statedir.py:154) are pure path arithmetic, and the added `if path.parent == in_tree` is a `Path.__eq__` string compare, not a `stat`. Measured `legacy_control_paths(P)` at 3.45us, `state_dir(P)` at 0.38us. The only syscall in `state_dir_carve_out` is the pre-existing `realpath`.
>
> **4. `kstrl/verify.py:1705` - the argv-list change is a net speedup, not a cost.** `run_scrubbed` spawns `/bin/sh` for a string and execs directly for a list. On a 20-file repo, median of 30:
> ```
> "git add -A"                              (shell) : 7.47 ms
> ["git","add","-A","--",".",":(exclude).kstrl"]    : 4.98 ms   (-2.50 ms)
> ```
> The extra pathspec is cheaper than the shell it removes.
>
> Adjacent, optional: the `git commit` on the next line (`kstrl/verify.py:1711`) is still a shell string and still pays that ~2.5ms `/bin/sh` spawn. Pre-existing and once per fixing run - mention only, not worth a change on its own.
>
> **5. `tests/test_state_dir_scope.py:519` `test_a_file_inside_a_carved_subtree_is_not_counted` - ~40ms to re-assert a claim already pinned 40 lines above.** It builds a fresh repo (30ms setup) plus 10ms call to show `.kstrl/runs/run-1/evil.py` is uncounted. `test_the_baseline_is_what_clears_the_excluded_subtrees` (line 478) already writes `.kstrl/runs/run-1/heartbeat.jsonl` and asserts the violations list equals *exactly* `[".kstrl/proposals/prop-999.md", ".kstrl/queue/new/item-1/agent.json"]` - so a file inside a carved subtree being absent is already pinned, against real git, on a repo that is already built. The pure-path `test_a_carved_subtree_is_a_prefix_and_everything_under_it_is_uncounted` (line 162) covers the same claim at ~0ms. The test's own docstring gives discoverability, not coverage, as its reason. Dropping it saves ~40ms (2.8% of the file); keeping it is defensible. This is the only measurable duplicate the diff introduces.
>
> ## Context, not a recommendation
>
> The `repo` fixture (`tests/test_state_dir_scope.py:96`) is function-scoped and rebuilt 17 times at ~30ms each - 0.54s, **38% of the file's 1.43s**. Every consumer mutates it (writes files, `checkout -b`, `worktree add`, commits), so it cannot simply be scoped up; a session-scoped template plus `shutil.copytree` would work. Measured: 17 fresh builds = 510ms vs one build (30ms) + 17 copytrees (104ms, 6.1ms each) = 135ms, a **376ms saving (~26% of the file)**. That is a refactor of pre-existing code, not of this diff - the diff only adds 3 more users at ~90ms. Reporting the number so the decision is grounded; I would not spend the indirection for 376ms on a suite of 3984 tests.
>
> ## Verdict
>
> Nothing in the diff is worth changing on efficiency grounds. The one production-code change is 2.5ms faster than what it replaced, the set-comprehension filter is free and single-call-site, and the new filter adds no I/O. The only flaggable item is finding 5, a ~40ms duplicated git-repo test, and that is a readability-versus-time judgement rather than clear waste.

### Altitude

> ## 1. `kstrl/guards.py:120-149` - fix 2 patched the smaller site of the class, and fix 1 enlarged the bigger one
>
> `check_dead_code` is genuinely the only place in `kstrl/` that stages or commits on the agent's behalf. I grepped `git add` / `git commit` / `git stash` / `git rm` / `git restore` / `git reset` across the package: the mutating helpers are `git.stage_file` (one caller, `init_cmd.py:965`, an explicit operator-named file), `git.restore_file_from` / `remove_from_index` / `delete_untracked` (callers only in `_revert_violation`), and the `worktree add/remove` calls in `factory.py` / `contract.py`, which target `.kstrl/worktrees` and `.kstrl/contract` and are harness-owned by construction. So the staging class has one member and it is now patched.
>
> But `_revert_violation` is the same class one rung up: it does not stage, it **restores or DELETES** - `git.remove_from_index` + `git.delete_untracked`, and `delete_untracked` recurses into directories. It runs with the same `cwd` at the project root under `--no-worktrees`. It only ever fires on paths in `violations`, i.e. paths *not* in the carve-out - which is exactly the set fix 1 just grew. Before this change `.kstrl/queue/**` and `.kstrl/proposals/**` were carved out and could never reach it. After it, in the configuration the tests themselves construct (interactive, `--no-worktrees`, a repo that does not gitignore `.kstrl/`), choosing "Revert and continue" deletes a queue item, a proposal, or `.kstrl/queue/pause.json` that appeared during the run. The pause marker written by an operator mid-run is precisely the case criterion 1 says is "worth seeing" - and the remediation arm's response to seeing it is to delete it.
>
> Tradeoff: fix 1 restored *visibility* of the authority subtrees without giving the guard's *write* arm a rule about what it may not touch. Either `_revert_violation` grows a refusal for anything under `STATE_DIR_NAME` (report it, never revert it), or `STATE_SUBDIRS_NOT_CARVED` is honest that un-carving hands those paths to a deleter. Preconditions are narrow (interactive + no-worktrees + no gitignore), so this is a depth judgement, not an urgent hole - but it is the one place where the change's own reasoning does not reach the end of its own code path.
>
> ## 2. `kstrl/statedir.py:249-264` vs `kstrl/policy.py:63-74` - criterion 1 is stated, then not applied to the flat control files
>
> The new comment says a subtree stays countable when it "carries AUTHORITY over what kstrl does next". The split actually implemented is by *location*, not by authority: the three legacy control files under `queue/` stay countable because `queue/` is excluded, while `.kstrl/autonomy.json` and `.kstrl/inbox.jsonl` stay carved out because they happen to sit flat. `policy.ENFORCEMENT_MACHINERY_PATHS` already ranks all five identically - modifying any of them is a **non-overridable** hard fail regardless of autonomy level. `autonomy.json` is the autonomy level itself; the guard now ignores it while the envelope treats touching it as a halt. The comment's own justification ("the R8.9 migration only ever moves them OUT") applies verbatim to the three under `queue/`, which were kept.
>
> Tradeoff: either the two flat control files join `STATE_FILES`' exclusions (two more names, symmetric with the queue three, and `legacy_control_paths` already returns them so the derivation is one predicate change), or criterion 1 is rewritten to say what it actually implements - "the subtree that holds the control files" - and stops claiming an authority test it does not run.
>
> ## 3. `kstrl/statedir.py:107-131` - criterion 2 has a cheap mechanism; a comment is *not* the right altitude here
>
> Criterion 2 ("nothing reachable from `run_loop` writes it") is currently prose. It is mechanically checkable, and I measured it: the static import closure of `kstrl.loop` (walking every `Import`/`ImportFrom` node, including the function-level deferred imports this codebase uses) is 22 modules, and it contains **none** of the five writers - `workqueue`, `serve`, `cli`, `evolution`, `intake_github`. `evolution.save_proposals` has exactly one call site, `cli.py:3668`. So a ~15-line test in `tests/test_state_dir_scope.py` - a file that already AST-walks `kstrl/` for exactly this kind of drift net - could assert the closure excludes the writer set, and would fail the day someone gives the loop a queue write.
>
> Tradeoff: the check is a proxy (static imports, not dynamic reachability) and would need a named writer set to compare against, which is one more list. Against that: this is the criterion that makes the exclusion *affordable*, the file's own convention is "checked against the CODE, not maintained by hand", and every other claim in this change got a test. Leaving the load-bearing half unmechanised is the altitude gap.
>
> ## 4. `kstrl/statedir.py:133` - right module, but it is now the third spelling of one fact
>
> `STATE_SUBDIRS_NOT_CARVED` belongs in `statedir.py`: it is a fact about statedir's own layout, `statedir` is a stdlib-only leaf that nine modules import, and `workqueue` already imports it (hence the `"queue"` literal at line 92). Moving it to `policy.py` would invert a dependency for no gain.
>
> The unification worth doing runs the other way. `policy.py:63-74` re-spells `statedir.legacy_control_paths` as ten literals in two glob forms - and `legacy_control_paths`' own docstring says "(migration + halt set)", so it was already meant to be the source. `policy` imports nothing from `kstrl` and `statedir` imports nothing from `kstrl`, so `policy -> statedir` is acyclic and legal. Tradeoff: the matchers differ (`policy._match_glob` on globs vs `guards.path_is_allowed` on prefixes/exacts), so this is "one source of names, two derived pattern forms", not one list. That duplication predates this change; what this change adds is a third statement of "queue holds authority" that can now drift against the other two - finding 2 is that drift already happening.
>
> ## 5. `kstrl/verify.py:1706` - the pathspec is at the right layer; the string/list split is the real leak
>
> A `git.py` helper is the wrong home here. Every wrapper in `git.py` uses plain `subprocess.run`; `check_dead_code` deliberately uses `run_scrubbed` for the scrubbed env and process-group kill, and `verify` imports `git`, so a `git.py` helper would need a lazy `from kstrl.verify import run_scrubbed` (the `breaker.py:224` pattern) or would silently drop the scrub. One call site does not earn that inversion, and the comment explaining the `:(exclude)` is genuinely local knowledge about *this* call's cwd.
>
> What is under-considered is the string/list asymmetry the fix introduces: `run_scrubbed` shells out for a string and not for a list, so the staging call is a list and the `git commit` two lines below is still a shell string. That is a real, silent contract split, and it already broke a sibling assertion - `tests/test_verify.py:1165` (`assert any("git add -A" in c for c in calls)`) now fails, confirmed by running `tests/test_verify.py::TestReadOnlyVerification` (1 failed, 1 passed). Flagging as out of scope per your instruction, but it is the evidence that the layer boundary moved without the callers noticing.
>
> ## Verdict
>
> Fix 3 is fine. Fix 2 is at the right depth for the class it names - the class has one member and it is patched - but `_revert_violation` is the adjacent, larger member of "the harness mutates the tree on the agent's behalf at project root", and fix 1 fed it new inputs. Fix 1's residual is honestly documented and well tested; its weakness is that criterion 1 is not applied consistently (finding 2) and criterion 2 has no mechanism when a cheap one is measurably available (finding 3).

### Applied

- **Altitude 1**, the most valuable finding of the round and the one I had missed: `_revert_violation` now refuses anything under the state directory and returns it unreverted, so `enforce_allowed_paths` cannot report a clean revert for a file still on disk. Extracted `_revert_violations` so the caller keeps one statement and the cyclomatic ratchet stays flat. Mutation-checked.
- **Altitude 2**: criterion 1 is now applied consistently. `autonomy.json` and `inbox.jsonl` join the exclusions, so no legacy control file is carved out and the set is exactly `policy.ENFORCEMENT_MACHINERY_PATHS`. The constant is renamed `STATE_NOT_CARVED` because it now spans files as well as subtrees, and the whole `legacy_control_paths` derivation block plus its ten-line comment disappears (which also closes **Simplification 2/4** and **Reuse 3**).
- **Altitude 3**: criterion 2 is mechanised, with a control test asserting the closure is walking something so it cannot pass by walking nothing.
- **Reuse 1**: `_git` returns stdout; the `git show` block uses it.
- **Simplification 1**: the false justification sentence is replaced with the real reason (`STATE_SUBDIRS` is the one place to read what kstrl writes, and both the drift net and the exclusion policy are checked against it).
- **Simplification 3, 5, 6**: the changelog paragraph, the bullet restating the constant, the duplicated `.gitignore` clause and the twice-written affordability argument are cut. The argument lives on the constant; the test points at it.
- **Simplification 7** and **Efficiency 5** (independently measured, same conclusion): `test_a_file_inside_a_carved_subtree_is_not_counted` deleted, zero unique mutation coverage.
- **Simplification 8**: the three queue-nested control paths dropped from the authority test; the legacy-control test owns them.
- **Simplification 9**: the first assertion is labelled a control for failure localisation.
- **Reuse's out-of-angle item** and **Altitude 5's** evidence: `tests/test_verify.py` fixed to render both command forms and assert the exact staging command.

### Declined

- **Reuse 2 / Altitude 5** (move the pathspec into `kstrl/git.py`). Both reviewers independently concluded it would either drop the R2.6 env scrub or invert a dependency, for one call site. Kept inline, with the comment explaining the argv-list requirement, which is the part a reader cannot infer.
- **Reuse 4 / Altitude 4** (`policy.py` should source its state paths from `statedir`). Correct, cycle-free, and pre-existing duplication that this PR did not create. It changes an enforcement list that gates merges, which is not something to fold into a scope-guard fix. Worth its own issue.
- **Efficiency 2** (hoist the membership test to a frozenset). Measured at ~26ns on a function called once per loop setup.
- **Efficiency's `repo` fixture note**: 376ms on a 287s suite, and the reviewer explicitly did not recommend it.
- **Efficiency 1's vulture note**: the dead-code test's cost doubles when vulture is on PATH. Recorded, not pinned; declaring vulture a test dependency is a separate call.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHYpsJ8ecHLh5HdrswJtJK
