### PR TITLE
fix(config): resolve kstrl.toml and the environment at command entry, before any agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,19 @@ stage, runtime feedback, and an earned-autonomy ladder). See
   that warns and continues, because the journal is an optional audit
   trail; every other section configures a gate, a budget, a boundary or
   a destination, where substituting a default would measure the run with
-  something other than what the operator configured. Four commands are
-  exempt from the entry seam and none from the check: `ks init` writes
-  the file, so refusing to run it would take away the recovery path;
-  `ks config show` prints its resolved rows and then reports the same
-  verdict, so it cannot disagree with the seam; and `ks sense` and
-  `ks serve` run the check themselves under their own documented exit
-  code 2, which for `ks sense --json` carries a JSON error document a
-  script can read (#272).
+  something other than what the operator configured. Bare `ks` on a
+  terminal is checked too, before the home shell opens, because the TUI
+  launches runs in-process.
+
+  One command is exempt from the check itself: `ks init`, which writes
+  the file, and would otherwise refuse to replace the very file it
+  cannot parse. Three more skip only the entry seam and run the same
+  check in their own bodies, under their own contracts: `ks config show`
+  prints every row it can resolve and then names each rejected section
+  with its key and value, `ks sense` reports through exit 2 and a JSON
+  error document, and `ks serve` through exit 2 before it can poison a
+  queue item. `ks config show` is the surface guaranteed to run and
+  explain whatever else refuses (#272).
 
 - Safe mode on the dashboard: six defects an independent review
   reproduced after the change merged. All three `dock: top` siblings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ stage, runtime feedback, and an earned-autonomy ladder). See
 
 ### Fixed
 
+- `kstrl.toml` and the `KSTRL_*` environment are now resolved once, at
+  command entry, before a command constructs anything. They used to be
+  parsed lazily, by whichever config dataclass first needed its section,
+  so a typo failed at the first loader that reached it: on the decompose
+  path that is `LinearConfig.load`, which runs after the architect has
+  been invoked and paid for (measured at 119 to 210 seconds against a
+  frontier model on a real spec), and `KSTRL_MUTATION_THRESHOLD=many` or
+  `KSTRL_SECURITY_TIMEOUT=many` left a raw `ValueError` traceback out of
+  `ks factory`. The blast radius of a typo therefore depended on which
+  section it was in and which command was run. Every section is now
+  checked up front and the error names the section, the offending key or
+  environment variable, and its value. `[evolution]` is the one section
+  that warns and continues, because the journal is an optional audit
+  trail; every other section configures a gate, a budget, a boundary or
+  a destination, where substituting a default would measure the run with
+  something other than what the operator configured. `ks init`,
+  `ks config show`, `ks sense` and `ks serve` are exempt from the entry
+  seam: the first two are how an operator repairs or reads a broken
+  config, and the last two already run the same check themselves under
+  their own documented exit code 2 (#272).
+
 - Safe mode on the dashboard: six defects an independent review
   reproduced after the change merged. All three `dock: top` siblings
   reserved row zero and painted over each other, so the checkpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,14 @@ stage, runtime feedback, and an earned-autonomy ladder). See
   that warns and continues, because the journal is an optional audit
   trail; every other section configures a gate, a budget, a boundary or
   a destination, where substituting a default would measure the run with
-  something other than what the operator configured. `ks init`,
-  `ks config show`, `ks sense` and `ks serve` are exempt from the entry
-  seam: the first two are how an operator repairs or reads a broken
-  config, and the last two already run the same check themselves under
-  their own documented exit code 2 (#272).
+  something other than what the operator configured. Four commands are
+  exempt from the entry seam and none from the check: `ks init` writes
+  the file, so refusing to run it would take away the recovery path;
+  `ks config show` prints its resolved rows and then reports the same
+  verdict, so it cannot disagree with the seam; and `ks sense` and
+  `ks serve` run the check themselves under their own documented exit
+  code 2, which for `ks sense --json` carries a JSON error document a
+  script can read (#272).
 
 - Safe mode on the dashboard: six defects an independent review
   reproduced after the change merged. All three `dock: top` siblings

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -15,10 +15,13 @@ or spends anything. Every section below is resolved once by
 command with an `error:` line naming the section, the key or environment
 variable, and the value (exit 1). `[evolution]` is the one section that
 warns and continues, because the journal is an optional audit trail;
-losing it costs the record and nothing else. `ks init`, `ks config show`,
-`ks sense` and `ks serve` do not go through that seam: the first two are
-how you repair or read a broken config, and the last two run the same
-check themselves and report it as exit 2.
+losing it costs the record and nothing else. `ks evolve` is the one
+command that section is fatal for, because there the journal is the work.
+
+Four commands skip the seam and none skip the check: `ks init` writes
+the file, `ks config show` prints its rows and then reports the same
+verdict, and `ks sense` and `ks serve` run the check themselves and
+report it as exit 2 (with a JSON error document for `ks sense --json`).
 
 ## Global / kstrlConfig (`[agent]`, `[run]`, `[paths]`, `[git]`, `[ui]`)
 

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -9,6 +9,17 @@ Every config dataclass has a `from_env()` classmethod that reads env vars, and a
 
 Precedence: **CLI flag > env var > `kstrl.toml` > dataclass default**.
 
+When is a bad value caught? At command entry, before the command builds
+or spends anything. Every section below is resolved once by
+`kstrl/config_preflight.py`, and a value that will not parse stops the
+command with an `error:` line naming the section, the key or environment
+variable, and the value (exit 1). `[evolution]` is the one section that
+warns and continues, because the journal is an optional audit trail;
+losing it costs the record and nothing else. `ks init`, `ks config show`,
+`ks sense` and `ks serve` do not go through that seam: the first two are
+how you repair or read a broken config, and the last two run the same
+check themselves and report it as exit 2.
+
 ## Global / kstrlConfig (`[agent]`, `[run]`, `[paths]`, `[git]`, `[ui]`)
 
 | Env var | Type | Default | Notes |

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -18,10 +18,16 @@ warns and continues, because the journal is an optional audit trail;
 losing it costs the record and nothing else. `ks evolve` is the one
 command that section is fatal for, because there the journal is the work.
 
-Four commands skip the seam and none skip the check: `ks init` writes
-the file, `ks config show` prints its rows and then reports the same
-verdict, and `ks sense` and `ks serve` run the check themselves and
-report it as exit 2 (with a JSON error document for `ks sense --json`).
+`ks init` skips the check: it writes the file, and refusing to replace a
+file it cannot parse would take away the recovery path. `ks config show`,
+`ks sense` and `ks serve` skip only the entry seam and run the same check
+themselves: `config show` prints every row it can resolve and then names
+each rejected section with its key and value, and the other two report
+through their documented exit 2 (with a JSON error document for
+`ks sense --json`).
+
+When everything else refuses, `ks config show` is the command guaranteed
+to run and tell you which section, key and value to fix.
 
 ## Global / kstrlConfig (`[agent]`, `[run]`, `[paths]`, `[git]`, `[ui]`)
 

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -515,20 +515,28 @@ def _timestamp() -> str:
 # - `ks init` WRITES a kstrl.toml, including over a broken one. Refusing
 #   to run it because the file it is about to replace does not parse
 #   takes away the tool the operator recovers with.
-# - `ks config show` exists to EXPLAIN a broken config: it prints the
-#   resolved rows first and reports the same verdict last, so it can
-#   neither be silenced by a broken section nor disagree with the seam.
+# - `ks config show` is the surface that must ALWAYS run and always
+#   explain, because every other command refuses on a rejected section.
+#   It prints every row it can resolve, then names each rejected section
+#   with its key and value. That guarantee is what makes universal
+#   fatality defensible without an escape flag: the way out of a bad
+#   config is a command, not a way to skip the check.
 # - `ks sense` reports a config failure through a documented MACHINE
 #   contract that the seam would destroy: exit 2 (not 1) and a JSON
 #   error document on stdout for `--json`. It calls the preflight
 #   itself, under that contract.
 # - `ks serve` has the same documented exit 2, and also calls the
-#   preflight itself.
+#   preflight itself, before `--print-plist` returns.
 #
 # The last three are exempt from the SEAM, never from the check: each
 # runs the same `preflight_config` in its own body, under its own
-# contract. An exemption that skipped the check would be the property
-# #272 removed, smuggled back in under a name.
+# contract. `init` is the one command exempt from the check itself, for
+# the reason above. An exemption that skipped the check for any other
+# reason would be the property #272 removed, smuggled back in under a
+# name.
+#
+# Bare `ks` is NOT on this list and is not a command: its callback
+# belongs to the group, so it preflights explicitly (see `cli`).
 #
 # Keyed by the TOP-LEVEL command name (see `_KstrlCommand._top_level_name`),
 # so `ks config show` is covered by "config" while a later `ks queue init`
@@ -555,34 +563,67 @@ def _preflight_warn(message: str) -> None:
     click.echo(f"warning: {message}", err=True)
 
 
+def _config_failure_detail(root_dir: Path, exc: ValueError) -> str:
+    """The seam's wording for a failure `config show` met on its own.
+
+    Falls back to the raw exception when the check disagrees (it found
+    nothing, or the document itself will not parse), so this can only
+    ever add information.
+    """
+    from kstrl.config_preflight import collect_config_problems
+
+    try:
+        problems = collect_config_problems(root_dir, warn=_preflight_warn)
+    except ValueError as document_exc:
+        return str(document_exc)
+    return "\n  ".join(problems) if problems else str(exc)
+
+
 def _preflight_root(ctx: click.Context) -> Path:
     """The root the command is about to use, derived before it runs.
 
-    Reuses ``_resolve_root`` - the same three inputs, in the same
-    precedence - so the file the preflight validates is the file the
-    command will load. A command with none of them gets the cwd, which
-    is what those commands do themselves.
+    Reuses ``_resolve_root`` - the same inputs, in the same precedence -
+    so the file the preflight validates is the file the command will
+    load. A command with none of them gets the cwd, which is what those
+    commands do themselves.
+
+    An input counts ONLY when the command DECLARES the matching option,
+    env vars included, and that is the whole correctness argument. Only
+    `run`, `understand` and `feature` derive a root from a prompt or PRD
+    path; the rest use ``root or Path.cwd()`` and never read
+    ``PROMPT_FILE``. Reading it for them broke this both ways with one
+    stale export: ``ks status`` refused on a broken kstrl.toml belonging
+    to an unrelated checkout, and - worse, because nothing shows it -
+    ``ks status`` in a project whose OWN config was broken PASSED, by
+    validating that other checkout instead.
 
     ``understand_prompt`` is read beside ``prompt`` because that is the
-    option the ``feature`` command feeds to ``_resolve_root``. Miss it
-    and the preflight validates the cwd while the command loads another
-    checkout's config, which fails SILENTLY, by passing. No command
-    declares both, so asking for both cannot be ambiguous.
+    option `ks feature` feeds to ``_resolve_root``. No command declares
+    both, so asking for both cannot be ambiguous.
     """
+
+    def _declared(name: str) -> bool:
+        return name in ctx.params
 
     def _param(name: str) -> str | None:
         value = ctx.params.get(name)
         return str(value) if value else None
 
-    def _path(name: str, env_var: str) -> Path | None:
-        value = _param(name) or os.environ.get(env_var)
-        return Path(value) if value else None
+    def _path(names: tuple[str, ...], env_var: str) -> Path | None:
+        if not any(_declared(name) for name in names):
+            return None
+        for name in names:
+            value = _param(name)
+            if value:
+                return Path(value)
+        from_env = os.environ.get(env_var)
+        return Path(from_env) if from_env else None
 
     root = _param("root")
     return _resolve_root(
         Path(root) if root else None,
-        _path("prompt", "PROMPT_FILE") or _path("understand_prompt", "PROMPT_FILE"),
-        _path("prd", "PRD_FILE"),
+        _path(("prompt", "understand_prompt"), "PROMPT_FILE"),
+        _path(("prd",), "PRD_FILE"),
     )
 
 
@@ -686,8 +727,18 @@ def cli(ctx: click.Context) -> None:
     # everywhere else stays byte-identical to click's no-args behavior
     # (help on stdout, exit 2) - the pipe/CI contract.
     if sys.stdout.isatty() and sys.stdin.isatty() and os.environ.get("KSTRL_NO_TUI") != "1":
+        from kstrl.config_preflight import preflight_config
         from kstrl.tui.home import run_home_shell
 
+        # The home shell is an ENTRY POINT, not a command: this callback
+        # belongs to the group, so `_KstrlCommand.invoke` never runs for
+        # it. Without this line it was a fifth exemption that nobody
+        # declared, and the most expensive one, because the shell
+        # launches runs IN-PROCESS (`tui/session.py` calls run_factory
+        # and decompose_spec directly). A bad [linear] value would have
+        # paid for the architect and then aborted: the original #272
+        # defect, on the path a user reaches by typing `ks`.
+        preflight_config(Path.cwd(), warn=_preflight_warn)
         ctx.exit(run_home_shell(Path.cwd()))
     click.echo(ctx.get_help())
     ctx.exit(2)
@@ -2834,7 +2885,11 @@ def config_show(
     try:
         report = build_config_report(root_dir, overlay=_overlay)
     except ValueError as exc:
-        click.echo(f"error: {exc}", err=True)
+        # No rows are possible: the base config itself was rejected, or
+        # the document will not parse. Say it the way every other command
+        # says it, with the section, the key and the offending value,
+        # rather than the bare coercion message this used to print.
+        click.echo(f"error: {_config_failure_detail(root_dir, exc)}", err=True)
         sys.exit(1)
 
     toml_path = report.toml_path
@@ -2852,18 +2907,22 @@ def config_show(
         click.echo(f"  {row.key} = {row.value}  ({row.source})")
     click.echo("")
 
-    # The rows above cover the sections `config_report` knows about; the
-    # entry seam (#272) resolves ELEVEN more, and refuses every other
-    # command when one of them is unusable. Reporting the verdict last
-    # means this command cannot say "all fine" about a config that stops
-    # `ks factory` - which would be the worst possible answer from the
-    # tool the seam exempts precisely so an operator can diagnose one.
-    from kstrl.config_preflight import preflight_config
+    # Every command refuses on an unusable section, so ONE command has to
+    # always run and always explain: this one. The rows above are printed
+    # first and cover what resolved (a rejected section is skipped, not
+    # fatal, and named in `report.unresolved`); the problems below cover
+    # every section, the eleven this report does not render included,
+    # with the section, the key and the offending value that the rest of
+    # the CLI reports.
+    from kstrl.config_preflight import collect_config_problems
 
-    try:
-        preflight_config(root_dir, warn=_preflight_warn)
-    except ValueError as exc:
-        click.echo(f"error: {exc}", err=True)
+    problems = collect_config_problems(root_dir, warn=_preflight_warn)
+    if problems:
+        click.echo("# Rejected sections (every other command refuses while these stand)")
+        for problem in problems:
+            click.echo(f"  {problem}")
+        click.echo("")
+        click.echo(f"error: {len(problems)} unusable config section(s)", err=True)
         sys.exit(1)
 
     sys.exit(0)
@@ -4978,6 +5037,22 @@ def serve(
     root_dir = (root or Path.cwd()).resolve()
     ui_impl = _autonomy_ui(ui, no_color)
 
+    # BEFORE the --print-plist branch, which returns without reaching the
+    # load below. That branch used to skip the check entirely and then
+    # exit 1 through the group's ConfigError handler, contradicting this
+    # command's documented exit 2 for a bad kstrl.toml. The check is also
+    # the WHOLE configuration, not just [serve]: this daemon spawns
+    # `ks factory` children and classifies their exit codes, so one typo
+    # in [verify] would poison queue items one after another until the
+    # breaker tripped, and the operator would be reading poison reports
+    # instead of a parse error. That is why `serve` is exempt from the
+    # entry seam and not from the check.
+    try:
+        preflight_config(root_dir, warn=_preflight_warn)
+    except ValueError as exc:
+        ui_impl.err(str(exc))
+        sys.exit(2)
+
     if print_plist:
         # Printed rather than installed: writing into ~/Library/LaunchAgents
         # and running launchctl are outward-facing acts an operator should
@@ -5010,16 +5085,6 @@ def serve(
         sys.exit(0)
 
     try:
-        # The WHOLE configuration, not just [serve]. This daemon spawns
-        # `ks factory` children, each of which would fail its own entry
-        # preflight and be classified from its exit code as a spec
-        # failure - so one typo in [verify] would poison queue items one
-        # after another until the breaker tripped, and the operator
-        # would be reading poison reports instead of a parse error.
-        # Exit 2 (this command's documented "cannot run" code) rather
-        # than the entry seam's exit 1, which is why `serve` is in
-        # _PREFLIGHT_EXEMPT: it does the same check, better.
-        preflight_config(root_dir, warn=ui_impl.warn)
         config = ServeConfig.load(root_dir)
     except (ServeError, ValueError) as exc:
         ui_impl.err(str(exc))

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -541,7 +541,7 @@ def _timestamp() -> str:
 # Keyed by the TOP-LEVEL command name (see `_KstrlCommand._top_level_name`),
 # so `ks config show` is covered by "config" while a later `ks queue init`
 # is not exempted by its leaf name.
-_PREFLIGHT_EXEMPT = frozenset({"init", "config", "sense", "serve"})
+_PREFLIGHT_EXEMPT = frozenset({"init", "config", "sense"})
 
 # Sections a command is ABOUT, promoted from degrading to fatal for that
 # command only. `[evolution]` degrades everywhere because the journal is
@@ -553,6 +553,22 @@ _PREFLIGHT_REQUIRED: dict[str, frozenset[str]] = {
     "evolve": frozenset({"evolution"}),
 }
 
+# Exit code for a rejected configuration, per command. 1 unless the
+# command documents otherwise. `ks serve` is the only entry here: it
+# promises exit 2 for "cannot run", and reading that from the seam is
+# what makes the ORDERING structural. Calling the check in its body
+# instead left `--print-plist` in front of it, returning before the
+# check ran and then exiting 1 through the group handler; the next early
+# return would have done the same.
+_PREFLIGHT_EXIT: dict[str, int] = {"serve": 2}
+
+# The commands that derive their root from a prompt or PRD path, and so
+# the only ones whose `--prompt` / `--prd` / `--understand-prompt` (and
+# PROMPT_FILE / PRD_FILE) the entry check may read. See `_preflight_root`
+# for why this is a list of commands and not "whichever command declares
+# the option".
+_ROOT_FROM_PROMPT = frozenset({"run", "understand", "feature"})
+
 
 def _preflight_warn(message: str) -> None:
     """A degrading section's warning, on STDERR.
@@ -563,20 +579,19 @@ def _preflight_warn(message: str) -> None:
     click.echo(f"warning: {message}", err=True)
 
 
-def _config_failure_detail(root_dir: Path, exc: ValueError) -> str:
-    """The seam's wording for a failure `config show` met on its own.
+def _echo_config_problems(problems: list[str]) -> None:
+    """`ks config show`'s rejected-section block, in ONE shape.
 
-    Falls back to the raw exception when the check disagrees (it found
-    nothing, or the document itself will not parse), so this can only
-    ever add information.
+    Both of that command's failure paths print it: the one where no row
+    could be built, and the one where the rows printed and some section
+    was still rejected. Two renderings 35 lines apart is how an operator
+    piping stderr gets a different answer for the same fault.
     """
-    from kstrl.config_preflight import collect_config_problems
-
-    try:
-        problems = collect_config_problems(root_dir, warn=_preflight_warn)
-    except ValueError as document_exc:
-        return str(document_exc)
-    return "\n  ".join(problems) if problems else str(exc)
+    click.echo("# Rejected sections (every other command refuses while these stand)")
+    for problem in problems:
+        click.echo(f"  {problem}")
+    click.echo("")
+    click.echo(f"error: {len(problems)} unusable config section(s)", err=True)
 
 
 def _preflight_root(ctx: click.Context) -> Path:
@@ -584,33 +599,31 @@ def _preflight_root(ctx: click.Context) -> Path:
 
     Reuses ``_resolve_root`` - the same inputs, in the same precedence -
     so the file the preflight validates is the file the command will
-    load. A command with none of them gets the cwd, which is what those
-    commands do themselves.
+    load. Every other command uses ``root or Path.cwd()``, which is what
+    this returns for them.
 
-    An input counts ONLY when the command DECLARES the matching option,
-    env vars included, and that is the whole correctness argument. Only
-    `run`, `understand` and `feature` derive a root from a prompt or PRD
-    path; the rest use ``root or Path.cwd()`` and never read
-    ``PROMPT_FILE``. Reading it for them broke this both ways with one
-    stale export: ``ks status`` refused on a broken kstrl.toml belonging
-    to an unrelated checkout, and - worse, because nothing shows it -
-    ``ks status`` in a project whose OWN config was broken PASSED, by
-    validating that other checkout instead.
+    The prompt and PRD inputs are read ONLY for the commands in
+    ``_ROOT_FROM_PROMPT``, and that is the whole correctness argument.
+    Reading them for every command broke this both ways with one stale
+    ``PROMPT_FILE`` export: ``ks status`` refused on a broken kstrl.toml
+    belonging to an unrelated checkout, and - worse, because nothing
+    shows it - ``ks status`` in a project whose OWN config was broken
+    PASSED, by validating that other checkout instead.
 
-    ``understand_prompt`` is read beside ``prompt`` because that is the
-    option `ks feature` feeds to ``_resolve_root``. No command declares
-    both, so asking for both cannot be ambiguous.
+    Keyed by command rather than by "declares the option", which reads
+    like the same rule and is not: `ks config show` declares ``--prompt``
+    and ``--prd`` as ``[paths]`` OVERRIDES and still roots itself at the
+    cwd, so the proxy already pointed that command at another checkout.
+    ``tests/test_config_preflight.py`` fails on any new command that
+    declares one of these options without a decision being recorded here.
     """
-
-    def _declared(name: str) -> bool:
-        return name in ctx.params
 
     def _param(name: str) -> str | None:
         value = ctx.params.get(name)
         return str(value) if value else None
 
-    def _path(names: tuple[str, ...], env_var: str) -> Path | None:
-        if not any(_declared(name) for name in names):
+    def _path(*names: str, env_var: str) -> Path | None:
+        if _KstrlCommand._top_level_name(ctx) not in _ROOT_FROM_PROMPT:
             return None
         for name in names:
             value = _param(name)
@@ -622,8 +635,10 @@ def _preflight_root(ctx: click.Context) -> Path:
     root = _param("root")
     return _resolve_root(
         Path(root) if root else None,
-        _path(("prompt", "understand_prompt"), "PROMPT_FILE"),
-        _path(("prd",), "PRD_FILE"),
+        # `ks feature` names its prompt option --understand-prompt and
+        # feeds THAT to _resolve_root. No command declares both.
+        _path("prompt", "understand_prompt", env_var="PROMPT_FILE"),
+        _path("prd", env_var="PRD_FILE"),
     )
 
 
@@ -707,7 +722,10 @@ class _KstrlGroup(click.Group):
     def invoke(self, ctx: click.Context) -> Any:
         try:
             return super().invoke(ctx)
-        except (BudgetConfigError, ConfigError) as exc:
+        except ConfigError as exc:
+            click.echo(f"error: {exc}", err=True)
+            sys.exit(_PREFLIGHT_EXIT.get(ctx.invoked_subcommand or "", 1))
+        except BudgetConfigError as exc:
             click.echo(f"error: {exc}", err=True)
             sys.exit(1)
 
@@ -738,8 +756,12 @@ def cli(ctx: click.Context) -> None:
         # and decompose_spec directly). A bad [linear] value would have
         # paid for the architect and then aborted: the original #272
         # defect, on the path a user reaches by typing `ks`.
-        preflight_config(Path.cwd(), warn=_preflight_warn)
-        ctx.exit(run_home_shell(Path.cwd()))
+        #
+        # Bound once: the point of the check is that the root it
+        # validates is the root the shell opens.
+        root_dir = Path.cwd()
+        preflight_config(root_dir, warn=_preflight_warn)
+        ctx.exit(run_home_shell(root_dir))
     click.echo(ctx.get_help())
     ctx.exit(2)
 
@@ -2882,14 +2904,25 @@ def config_show(
             prd_default=root_dir / "scripts/kstrl/prd.json",
         )
 
+    from kstrl.config_preflight import collect_config_problems
+
+    def _problems() -> list[str]:
+        try:
+            return collect_config_problems(root_dir, warn=_preflight_warn)
+        except ValueError as document_exc:
+            # The document will not parse, so no section resolved and
+            # the parse error IS the whole report.
+            return [str(document_exc)]
+
     try:
         report = build_config_report(root_dir, overlay=_overlay)
     except ValueError as exc:
         # No rows are possible: the base config itself was rejected, or
-        # the document will not parse. Say it the way every other command
-        # says it, with the section, the key and the offending value,
-        # rather than the bare coercion message this used to print.
-        click.echo(f"error: {_config_failure_detail(root_dir, exc)}", err=True)
+        # the document will not parse. Report it in the same shape as the
+        # success-with-problems path below, and in the seam's words -
+        # section, key, offending value - rather than the bare coercion
+        # message this used to print.
+        _echo_config_problems(_problems() or [str(exc)])
         sys.exit(1)
 
     toml_path = report.toml_path
@@ -2908,21 +2941,13 @@ def config_show(
     click.echo("")
 
     # Every command refuses on an unusable section, so ONE command has to
-    # always run and always explain: this one. The rows above are printed
-    # first and cover what resolved (a rejected section is skipped, not
-    # fatal, and named in `report.unresolved`); the problems below cover
-    # every section, the eleven this report does not render included,
-    # with the section, the key and the offending value that the rest of
-    # the CLI reports.
-    from kstrl.config_preflight import collect_config_problems
-
-    problems = collect_config_problems(root_dir, warn=_preflight_warn)
+    # always run and always explain: this one. The rows above cover what
+    # resolved (a rejected section costs its rows, not the report); the
+    # problems below cover every section, the eleven this report does not
+    # render included, in the words the rest of the CLI uses.
+    problems = _problems()
     if problems:
-        click.echo("# Rejected sections (every other command refuses while these stand)")
-        for problem in problems:
-            click.echo(f"  {problem}")
-        click.echo("")
-        click.echo(f"error: {len(problems)} unusable config section(s)", err=True)
+        _echo_config_problems(problems)
         sys.exit(1)
 
     sys.exit(0)
@@ -5017,7 +5042,6 @@ def serve(
     Only infrastructure failures are retried, and only with positive
     evidence. Spec-level failures go to poison/ and wait for a human.
     """
-    from kstrl.config_preflight import preflight_config
     from kstrl.serve import (
         REQUIRE_TIMEOUT_ENV,
         ServeConfig,
@@ -5036,22 +5060,6 @@ def serve(
 
     root_dir = (root or Path.cwd()).resolve()
     ui_impl = _autonomy_ui(ui, no_color)
-
-    # BEFORE the --print-plist branch, which returns without reaching the
-    # load below. That branch used to skip the check entirely and then
-    # exit 1 through the group's ConfigError handler, contradicting this
-    # command's documented exit 2 for a bad kstrl.toml. The check is also
-    # the WHOLE configuration, not just [serve]: this daemon spawns
-    # `ks factory` children and classifies their exit codes, so one typo
-    # in [verify] would poison queue items one after another until the
-    # breaker tripped, and the operator would be reading poison reports
-    # instead of a parse error. That is why `serve` is exempt from the
-    # entry seam and not from the check.
-    try:
-        preflight_config(root_dir, warn=_preflight_warn)
-    except ValueError as exc:
-        ui_impl.err(str(exc))
-        sys.exit(2)
 
     if print_plist:
         # Printed rather than installed: writing into ~/Library/LaunchAgents

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -35,6 +35,7 @@ from kstrl.agents.logging import LoggingAgent
 from kstrl.breaker import BreakerConfig
 from kstrl.commandrun import CommandRun, open_command_run
 from kstrl.config import (
+    ConfigError,
     KstrlConfig,
     _parse_paths,
     reconcile_progress_config,
@@ -508,9 +509,91 @@ def _timestamp() -> str:
     return datetime.now().strftime("%Y%m%d-%H%M%S")
 
 
+# The commands that must NOT be preflighted, and why each one is not a
+# hole in the guarantee:
+#
+# - `ks init` WRITES a kstrl.toml, including over a broken one. Refusing
+#   to run it because the file it is about to replace does not parse
+#   takes away the tool the operator recovers with.
+# - `ks config show` exists to EXPLAIN a broken config, and renders the
+#   failure itself with the row that caused it. Same reason.
+# - `ks sense` already does exactly what this preflight does, at its own
+#   entry, before any measurement - and does it BETTER, through a
+#   documented machine contract: exit 2 (not 1) and a JSON error
+#   document on stdout for `--json`. Preflighting it would replace a
+#   contract a script can read with one it cannot.
+# - `ks serve` has the same documented exit 2, and calls the preflight
+#   ITSELF (see the `serve` body) so the daemon still gets the whole
+#   check. Exempt from the seam, not from the guarantee.
+#
+# Matched on the command's name and on its parents', so `ks config show`
+# is covered by "config".
+_PREFLIGHT_EXEMPT = frozenset({"init", "config", "sense", "serve"})
+
+
+def _preflight_root(ctx: click.Context) -> Path:
+    """The root the command is about to use, derived before it runs.
+
+    Reuses ``_resolve_root`` - the same three inputs, in the same
+    precedence - so the file the preflight validates is the file the
+    command will load. A command with none of them gets the cwd, which
+    is what those commands do themselves.
+    """
+    params = ctx.params
+
+    def _as_path(name: str, env_var: str) -> Path | None:
+        value = params.get(name) or os.environ.get(env_var)
+        return Path(value) if value else None
+
+    root = params.get("root")
+    return _resolve_root(
+        Path(root) if root else None,
+        _as_path("prompt", "PROMPT_FILE"),
+        _as_path("prd", "PRD_FILE"),
+    )
+
+
+class _KstrlCommand(click.Command):
+    """Every command, with one guarantee: the configuration is resolved
+    before the command body constructs anything.
+
+    THIS seam and not ``_KstrlGroup.invoke``, which is where the error is
+    caught: at group level click has parsed the group's own arguments but
+    not the subcommand's, so ``--root`` is not known yet and the
+    preflight would validate the wrong file whenever an operator pointed
+    a command at another checkout. ``Command.invoke`` runs after the
+    subcommand's parameters are parsed and before its callback, which is
+    the first moment both facts are available - the root, and that
+    nothing has been built or paid for yet.
+
+    Installed through ``_KstrlGroup.command_class`` rather than on each
+    command, for the reason the group gives below: a guarantee that every
+    entry point has to remember is one a later entry point will forget.
+    """
+
+    def invoke(self, ctx: click.Context) -> Any:
+        from kstrl.config_preflight import preflight_config
+
+        if not self._exempt(ctx):
+            preflight_config(
+                _preflight_root(ctx),
+                warn=lambda message: click.echo(f"warning: {message}", err=True),
+            )
+        return super().invoke(ctx)
+
+    @staticmethod
+    def _exempt(ctx: click.Context) -> bool:
+        node: click.Context | None = ctx
+        while node is not None:
+            if node.command.name in _PREFLIGHT_EXEMPT:
+                return True
+            node = node.parent
+        return False
+
+
 class _KstrlGroup(click.Group):
-    """The CLI group, with one guarantee: a rejected budget ceiling is
-    reported, never raised.
+    """The CLI group, with two guarantees: a rejected budget ceiling and
+    unusable configuration are reported, never raised.
 
     ``BudgetConfigError`` is thrown deep inside config loading, which
     happens in `factory`, `run`, `retry`, the config report and the
@@ -521,14 +604,28 @@ class _KstrlGroup(click.Group):
     it HERE means no entry point can leak one, including entry points
     added later.
 
+    ``ConfigError`` is the same contract for the same reason (#272).
+    Before it, a typo's blast radius depended on which section it was in
+    and which command was run: ``KSTRL_MUTATION_THRESHOLD=many`` and
+    ``KSTRL_SECURITY_TIMEOUT=many`` both left a raw ``ValueError``
+    traceback out of `ks factory`, and a bad ``[linear]`` value aborted
+    `ks decompose` only after the architect had been paid for.
+    ``command_class`` puts the check that raises it in front of every
+    command body; this catches what it raises.
+
     Exit code 1 with an ``error:`` line, matching what `config show`
     already did for the same defect - one class of failure, one contract.
     """
 
+    command_class = _KstrlCommand
+    #: ``type`` is click's "same class as this group", so `ks config`,
+    #: `ks queue` and every later subgroup inherit ``command_class``.
+    group_class = type
+
     def invoke(self, ctx: click.Context) -> Any:
         try:
             return super().invoke(ctx)
-        except BudgetConfigError as exc:
+        except (BudgetConfigError, ConfigError) as exc:
             click.echo(f"error: {exc}", err=True)
             sys.exit(1)
 
@@ -3586,7 +3683,17 @@ def evolve(
     ui_impl = _console_ui(_normalize_ui_mode(ui), no_color, force_rich=force_rich)
 
     # R2.1: honor [evolution] in kstrl.toml + env, anchored to --root.
-    evo_config = EvolutionConfig.load(root_dir)
+    try:
+        evo_config = EvolutionConfig.load(root_dir)
+    except (ValueError, OSError) as exc:
+        # The entry preflight classifies [evolution] as DEGRADING and
+        # warns rather than stopping, because everywhere else the journal
+        # is an optional audit trail attached to work that is about
+        # something else. Here it is the work, so the same value is
+        # fatal - and this is the guard that keeps that from arriving as
+        # a traceback two lines after the preflight said "continuing".
+        ui_impl.err(f"[evolution] configuration is unusable: {exc}")
+        sys.exit(1)
 
     if not evo_config.enabled:
         ui_impl.err("Evolution is disabled in config")
@@ -4793,6 +4900,7 @@ def serve(
     Only infrastructure failures are retried, and only with positive
     evidence. Spec-level failures go to poison/ and wait for a human.
     """
+    from kstrl.config_preflight import preflight_config
     from kstrl.serve import (
         REQUIRE_TIMEOUT_ENV,
         ServeConfig,
@@ -4844,6 +4952,16 @@ def serve(
         sys.exit(0)
 
     try:
+        # The WHOLE configuration, not just [serve]. This daemon spawns
+        # `ks factory` children, each of which would fail its own entry
+        # preflight and be classified from its exit code as a spec
+        # failure - so one typo in [verify] would poison queue items one
+        # after another until the breaker tripped, and the operator
+        # would be reading poison reports instead of a parse error.
+        # Exit 2 (this command's documented "cannot run" code) rather
+        # than the entry seam's exit 1, which is why `serve` is in
+        # _PREFLIGHT_EXEMPT: it does the same check, better.
+        preflight_config(root_dir, warn=ui_impl.warn)
         config = ServeConfig.load(root_dir)
     except (ServeError, ValueError) as exc:
         ui_impl.err(str(exc))

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -530,8 +530,9 @@ def _timestamp() -> str:
 # contract. An exemption that skipped the check would be the property
 # #272 removed, smuggled back in under a name.
 #
-# Matched on the command's name and on its parents', so `ks config show`
-# is covered by "config".
+# Keyed by the TOP-LEVEL command name (see `_KstrlCommand._top_level_name`),
+# so `ks config show` is covered by "config" while a later `ks queue init`
+# is not exempted by its leaf name.
 _PREFLIGHT_EXEMPT = frozenset({"init", "config", "sense", "serve"})
 
 # Sections a command is ABOUT, promoted from degrading to fatal for that
@@ -563,10 +564,10 @@ def _preflight_root(ctx: click.Context) -> Path:
     is what those commands do themselves.
 
     ``understand_prompt`` is read beside ``prompt`` because that is the
-    option ``ks feature`` feeds to ``_resolve_root`` (cli.py:1498). Miss
-    it and the preflight validates the cwd while the command loads
-    another checkout's config, which fails SILENTLY, by passing. No
-    command declares both, so asking for both cannot be ambiguous.
+    option the ``feature`` command feeds to ``_resolve_root``. Miss it
+    and the preflight validates the cwd while the command loads another
+    checkout's config, which fails SILENTLY, by passing. No command
+    declares both, so asking for both cannot be ambiguous.
     """
 
     def _param(name: str) -> str | None:

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -515,20 +515,43 @@ def _timestamp() -> str:
 # - `ks init` WRITES a kstrl.toml, including over a broken one. Refusing
 #   to run it because the file it is about to replace does not parse
 #   takes away the tool the operator recovers with.
-# - `ks config show` exists to EXPLAIN a broken config, and renders the
-#   failure itself with the row that caused it. Same reason.
-# - `ks sense` already does exactly what this preflight does, at its own
-#   entry, before any measurement - and does it BETTER, through a
-#   documented machine contract: exit 2 (not 1) and a JSON error
-#   document on stdout for `--json`. Preflighting it would replace a
-#   contract a script can read with one it cannot.
-# - `ks serve` has the same documented exit 2, and calls the preflight
-#   ITSELF (see the `serve` body) so the daemon still gets the whole
-#   check. Exempt from the seam, not from the guarantee.
+# - `ks config show` exists to EXPLAIN a broken config: it prints the
+#   resolved rows first and reports the same verdict last, so it can
+#   neither be silenced by a broken section nor disagree with the seam.
+# - `ks sense` reports a config failure through a documented MACHINE
+#   contract that the seam would destroy: exit 2 (not 1) and a JSON
+#   error document on stdout for `--json`. It calls the preflight
+#   itself, under that contract.
+# - `ks serve` has the same documented exit 2, and also calls the
+#   preflight itself.
+#
+# The last three are exempt from the SEAM, never from the check: each
+# runs the same `preflight_config` in its own body, under its own
+# contract. An exemption that skipped the check would be the property
+# #272 removed, smuggled back in under a name.
 #
 # Matched on the command's name and on its parents', so `ks config show`
 # is covered by "config".
 _PREFLIGHT_EXEMPT = frozenset({"init", "config", "sense", "serve"})
+
+# Sections a command is ABOUT, promoted from degrading to fatal for that
+# command only. `[evolution]` degrades everywhere because the journal is
+# an audit trail attached to work about something else; `ks evolve` IS
+# the journal, so warning and continuing would be a promise the next two
+# lines break. Declared here, beside the exemptions, so a command does
+# not carry its own remembered guard for a policy the seam already owns.
+_PREFLIGHT_REQUIRED: dict[str, frozenset[str]] = {
+    "evolve": frozenset({"evolution"}),
+}
+
+
+def _preflight_warn(message: str) -> None:
+    """A degrading section's warning, on STDERR.
+
+    Stdout belongs to the command's output, and `ks sense --json` puts a
+    single JSON document there that a script parses.
+    """
+    click.echo(f"warning: {message}", err=True)
 
 
 def _preflight_root(ctx: click.Context) -> Path:
@@ -538,18 +561,27 @@ def _preflight_root(ctx: click.Context) -> Path:
     precedence - so the file the preflight validates is the file the
     command will load. A command with none of them gets the cwd, which
     is what those commands do themselves.
-    """
-    params = ctx.params
 
-    def _as_path(name: str, env_var: str) -> Path | None:
-        value = params.get(name) or os.environ.get(env_var)
+    ``understand_prompt`` is read beside ``prompt`` because that is the
+    option ``ks feature`` feeds to ``_resolve_root`` (cli.py:1498). Miss
+    it and the preflight validates the cwd while the command loads
+    another checkout's config, which fails SILENTLY, by passing. No
+    command declares both, so asking for both cannot be ambiguous.
+    """
+
+    def _param(name: str) -> str | None:
+        value = ctx.params.get(name)
+        return str(value) if value else None
+
+    def _path(name: str, env_var: str) -> Path | None:
+        value = _param(name) or os.environ.get(env_var)
         return Path(value) if value else None
 
-    root = params.get("root")
+    root = _param("root")
     return _resolve_root(
         Path(root) if root else None,
-        _as_path("prompt", "PROMPT_FILE"),
-        _as_path("prd", "PRD_FILE"),
+        _path("prompt", "PROMPT_FILE") or _path("understand_prompt", "PROMPT_FILE"),
+        _path("prd", "PRD_FILE"),
     )
 
 
@@ -574,21 +606,29 @@ class _KstrlCommand(click.Command):
     def invoke(self, ctx: click.Context) -> Any:
         from kstrl.config_preflight import preflight_config
 
-        if not self._exempt(ctx):
+        name = self._top_level_name(ctx)
+        if name not in _PREFLIGHT_EXEMPT:
             preflight_config(
                 _preflight_root(ctx),
-                warn=lambda message: click.echo(f"warning: {message}", err=True),
+                warn=_preflight_warn,
+                required=_PREFLIGHT_REQUIRED.get(name, frozenset()),
             )
         return super().invoke(ctx)
 
     @staticmethod
-    def _exempt(ctx: click.Context) -> bool:
-        node: click.Context | None = ctx
-        while node is not None:
-            if node.command.name in _PREFLIGHT_EXEMPT:
-                return True
+    def _top_level_name(ctx: click.Context) -> str:
+        """The command name directly under the root group.
+
+        Both tables key off THIS, not off any name in the chain: keying
+        off any would exempt a later ``ks queue init`` or ``ks inbox
+        serve`` purely because of its leaf name, which is a decision
+        nobody would have made. It is also what puts ``ks config show``
+        under ``config``.
+        """
+        node = ctx
+        while node.parent is not None and node.parent.parent is not None:
             node = node.parent
-        return False
+        return node.command.name or ""
 
 
 class _KstrlGroup(click.Group):
@@ -2811,6 +2851,20 @@ def config_show(
         click.echo(f"  {row.key} = {row.value}  ({row.source})")
     click.echo("")
 
+    # The rows above cover the sections `config_report` knows about; the
+    # entry seam (#272) resolves ELEVEN more, and refuses every other
+    # command when one of them is unusable. Reporting the verdict last
+    # means this command cannot say "all fine" about a config that stops
+    # `ks factory` - which would be the worst possible answer from the
+    # tool the seam exempts precisely so an operator can diagnose one.
+    from kstrl.config_preflight import preflight_config
+
+    try:
+        preflight_config(root_dir, warn=_preflight_warn)
+    except ValueError as exc:
+        click.echo(f"error: {exc}", err=True)
+        sys.exit(1)
+
     sys.exit(0)
 
 
@@ -3387,18 +3441,28 @@ def sense(
         _sense_error(f"path is not a directory: {path}", as_json)
 
     from kstrl.adequacy import AdequacyConfig
+    from kstrl.config_preflight import preflight_config
     from kstrl.fixtures import FixturesConfig
     from kstrl.policy import PolicyConfig
     from kstrl.verify import VerifyConfig, run_mechanical_verification
 
     try:
+        # The WHOLE configuration, not only the four sections this
+        # command reads. `sense` is exempt from the entry seam because
+        # its contract is exit 2 plus a JSON error document rather than
+        # the seam's exit 1, and an exemption is only honest if the
+        # command does the same check: checking four of twenty-two
+        # would keep exactly the "depends which section you typo'd"
+        # property #272 removed, inside the exemption.
+        preflight_config(root_dir, warn=_preflight_warn)
         verify_cfg = VerifyConfig.load(root_dir)
         policy_cfg = PolicyConfig.load(root_dir)
         adequacy_cfg = AdequacyConfig.load(root_dir)
         fixtures_cfg = FixturesConfig.load(root_dir) if prd_path is not None else None
     except (OSError, ValueError) as exc:
-        # ValueError covers malformed TOML (load_toml_section) and the
-        # loaders' own validation errors (PolicyConfigError is one).
+        # ValueError covers malformed TOML (load_toml_section), the
+        # preflight's ConfigError, and the loaders' own validation
+        # errors (PolicyConfigError is one).
         _sense_error(f"could not load kstrl.toml from {root_dir}: {exc}", as_json)
 
     base = resolve_base_branch(base_branch, path)
@@ -3683,17 +3747,10 @@ def evolve(
     ui_impl = _console_ui(_normalize_ui_mode(ui), no_color, force_rich=force_rich)
 
     # R2.1: honor [evolution] in kstrl.toml + env, anchored to --root.
-    try:
-        evo_config = EvolutionConfig.load(root_dir)
-    except (ValueError, OSError) as exc:
-        # The entry preflight classifies [evolution] as DEGRADING and
-        # warns rather than stopping, because everywhere else the journal
-        # is an optional audit trail attached to work that is about
-        # something else. Here it is the work, so the same value is
-        # fatal - and this is the guard that keeps that from arriving as
-        # a traceback two lines after the preflight said "continuing".
-        ui_impl.err(f"[evolution] configuration is unusable: {exc}")
-        sys.exit(1)
+    # Unguarded on purpose: `_PREFLIGHT_REQUIRED` lists this command as
+    # one that [evolution] is FATAL for, so the entry seam has already
+    # rejected a config this would raise on.
+    evo_config = EvolutionConfig.load(root_dir)
 
     if not evo_config.enabled:
         ui_impl.err("Evolution is disabled in config")

--- a/kstrl/config.py
+++ b/kstrl/config.py
@@ -447,13 +447,28 @@ def resolve_config_file(root_dir: Path) -> Path:
     return root_dir / CONFIG_FILE_NAME
 
 
+class ConfigError(ValueError):
+    """Configuration the operator has to fix before anything can run.
+
+    A ``ValueError`` SUBCLASS, deliberately: every loader in this package
+    has always raised ``ValueError`` for a rejected value, and several
+    callers catch exactly that on purpose (``ks config show``,
+    ``EvolutionConfig.load_or_none``, the TUI config screen). Narrowing
+    the type would silently step outside those guards. What the subclass
+    adds is a name the CLI can catch at its entry seam and render as an
+    ``error:`` line, the way ``BudgetConfigError`` (also a ValueError)
+    already is - so a typo in kstrl.toml stops being an unhandled
+    traceback from wherever the run happened to reach first (#272).
+    """
+
+
 def _load_toml(path: Path) -> dict[str, Any]:
-    """Load and parse a TOML file. Raises ValueError on malformed input."""
+    """Load and parse a TOML file. Raises ConfigError on malformed input."""
     try:
         with open(path, "rb") as f:
             return tomllib.load(f)
     except tomllib.TOMLDecodeError as exc:
-        raise ValueError(f"Invalid TOML in {path}: {exc}") from exc
+        raise ConfigError(f"Invalid TOML in {path}: {exc}") from exc
 
 
 def load_toml_section(toml_path: Path, section: str) -> dict[str, Any]:
@@ -461,9 +476,10 @@ def load_toml_section(toml_path: Path, section: str) -> dict[str, Any]:
 
     Shared by every config dataclass that has a corresponding
     ``[section]`` in the canonical kstrl.toml. Returns ``{}`` when the
-    file or the section is absent; raises ``ValueError`` with a clear
-    message when the file is malformed so every loader behaves
-    consistently. Sub-section keys that are not dicts (e.g. someone
+    file or the section is absent; raises :class:`ConfigError` (a
+    ``ValueError``) with a clear message when the file is malformed so
+    every loader behaves consistently. Sub-section keys that are not
+    dicts (e.g. someone
     wrote ``factory = "hi"`` instead of ``[factory]``) return ``{}``
     rather than crashing later in the per-key cast.
     """

--- a/kstrl/config.py
+++ b/kstrl/config.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import os
 import re
 import tomllib
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
@@ -462,13 +465,62 @@ class ConfigError(ValueError):
     """
 
 
-def _load_toml(path: Path) -> dict[str, Any]:
-    """Load and parse a TOML file. Raises ConfigError on malformed input."""
+#: Documents parsed inside the innermost :func:`toml_parse_scope`, or
+#: None outside one. A ContextVar rather than a module global so a
+#: scope cannot leak into another thread or task.
+_PARSE_SCOPE: ContextVar[dict[Path, dict[str, Any]] | None] = ContextVar(
+    "kstrl_toml_parse_scope",
+    default=None,
+)
+
+
+@contextmanager
+def toml_parse_scope() -> Iterator[None]:
+    """Parse each kstrl.toml at most once for the duration of the block.
+
+    Every config dataclass reads its own section, and each read reparses
+    the whole file: resolving all 22 sections at command entry lexed the
+    same bytes 23 times. Measured on the shipped 21 KB
+    kstrl.toml.example, the entry check cost 9.4 ms without this scope
+    and 0.6 ms with it, which took `ks status` from 159.9 ms to
+    157.7 ms against the same file.
+
+    SCOPED, not process-wide, and the distinction is the whole design.
+    A process-wide snapshot would freeze the file for the life of the
+    process, which two surfaces would be wrong about: the TUI config
+    screen has a refresh action whose job is to re-read the file on
+    demand (``tui/screens/config.py``), and ``ks serve`` is a long-lived
+    daemon that re-reads config per queue item. Inside a block that runs
+    for under a millisecond there is no window for either, and no
+    caller outside one sees any change at all.
+
+    Nothing in this package mutates what ``load_toml_section`` returns,
+    which is what makes handing out the same sub-dict twice safe.
+    """
+    token = _PARSE_SCOPE.set({})
+    try:
+        yield
+    finally:
+        _PARSE_SCOPE.reset(token)
+
+
+def load_toml_document(path: Path) -> dict[str, Any]:
+    """Load and parse a TOML file. Raises ConfigError on malformed input.
+
+    Inside a :func:`toml_parse_scope` the parsed document is reused
+    rather than re-read.
+    """
+    scope = _PARSE_SCOPE.get()
+    if scope is not None and path in scope:
+        return scope[path]
     try:
         with open(path, "rb") as f:
-            return tomllib.load(f)
+            data: dict[str, Any] = tomllib.load(f)
     except tomllib.TOMLDecodeError as exc:
         raise ConfigError(f"Invalid TOML in {path}: {exc}") from exc
+    if scope is not None:
+        scope[path] = data
+    return data
 
 
 def load_toml_section(toml_path: Path, section: str) -> dict[str, Any]:
@@ -485,7 +537,7 @@ def load_toml_section(toml_path: Path, section: str) -> dict[str, Any]:
     """
     if not toml_path.exists():
         return {}
-    data = _load_toml(toml_path)
+    data = load_toml_document(toml_path)
     section_data = data.get(section, {})
     if not isinstance(section_data, dict):
         return {}
@@ -502,7 +554,7 @@ def _apply_toml_overrides(
     Maps the documented section structure (agent, run, paths, git, ui) onto
     the flat KstrlConfig dataclass. Unknown keys are silently ignored.
     """
-    data = _load_toml(toml_path)
+    data = load_toml_document(toml_path)
 
     agent = data.get("agent")
     if isinstance(agent, dict):

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -87,7 +87,7 @@ from kstrl.config_report import scrubbed_environ
 #: the domain errors that derive from IT: ``ServeError`` rejects
 #: ``[serve] max_consecutive_poison = 0`` that way, and ``QueueError``,
 #: ``InboxError`` and ``IntakeError`` are its siblings.
-_REJECTIONS = (ValueError, TypeError, RuntimeError)
+REJECTIONS = (ValueError, TypeError, RuntimeError)
 
 
 @dataclass(frozen=True)
@@ -238,7 +238,7 @@ def collect_config_problems(
         for section in config_sections():
             try:
                 section.loader(root_dir)
-            except _REJECTIONS as exc:
+            except REJECTIONS as exc:
                 detail = _detail(section, toml_path, root_dir, exc)
                 if section.fatal or not required.isdisjoint(section.sections):
                     problems.append(detail)
@@ -290,9 +290,18 @@ def _blamed_env_var(
 
     An EMPTY environment is tried first, and a loader that still fails
     there ends the search: the file is at fault, and no variable can be.
-    That gate is what keeps a file fault at one extra load rather than
-    one per variable (measured with 83 variables set: 34.3 ms of
-    fruitless sweep before the gate, 0.5 ms after).
+    That gate keeps a file fault at one extra load rather than one per
+    variable. Measured on a file fault with the 21 KB example config,
+    INSIDE the parse scope: 0.54 ms with the gate against 0.84 ms
+    without at 83 variables, and 0.95 against 2.09 at 303. The saving is
+    small and linear in the size of the environment, which is the honest
+    reason to keep it: CI environments are the big ones.
+
+    An earlier version of this docstring claimed 34.3 ms for the
+    ungated sweep. That was measured before ``toml_parse_scope`` covered
+    the blame helpers, when every one of those loads reparsed the file.
+    It is off by 40x now, which is why it is written down here re-taken
+    rather than carried forward.
 
     Runs whenever a section is REJECTED, which includes a degrading
     section on an otherwise successful command. Both are before the
@@ -307,7 +316,7 @@ def _blamed_env_var(
         except Exception:
             return None
 
-    culprits: list[str] = []
+    blamed: str | None = None
     for name in sorted(os.environ):
         saved = os.environ.pop(name)
         try:
@@ -317,15 +326,18 @@ def _blamed_env_var(
             # this variable is not the one thing to change.
             continue
         else:
+            if blamed is not None:
+                # A second variable that fixes it on its own. Neither is
+                # "the one to change", so the sweep stops here rather
+                # than finishing to discard the answer.
+                return None
             # The value is echoed only where the loader's own message
             # already quotes it. Nothing has decided that an arbitrary
             # environment value may be printed, so nothing prints one.
-            culprits.append(
-                f"set by {name}={saved}" if repr(saved) in message else f"set by {name}"
-            )
+            blamed = f"set by {name}={saved}" if repr(saved) in message else f"set by {name}"
         finally:
             os.environ[name] = saved
-    return culprits[0] if len(culprits) == 1 else None
+    return blamed
 
 
 def _blamed_toml_value(
@@ -343,7 +355,7 @@ def _blamed_toml_value(
     """
     hits = []
     for name in sections:
-        with suppress(*_REJECTIONS, OSError):
+        with suppress(*REJECTIONS, OSError):
             for key, value in load_toml_section(toml_path, name).items():
                 if repr(value) in message:
                     hits.append(f"kstrl.toml has [{name}] {key} = {value!r}")

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -76,6 +76,12 @@ from kstrl.config_report import scrubbed_environ
 #:
 #: ``ValueError`` is the house type (``ConfigError``,
 #: ``PolicyConfigError`` and ``BudgetConfigError`` all derive from it).
+#: ``BudgetConfigError`` is deliberately collected like any other and
+#: not re-raised: re-raising it abandoned the traversal at ``[factory]``,
+#: which is second in the list, so one bad ceiling hid every later
+#: section and the operator fixed the ceiling only to meet ``[verify]``
+#: on the next run. ``_KstrlGroup.invoke`` still renders it for the
+#: paths that raise it outside this check, such as ``--max-cost-usd``.
 #: ``TypeError`` joins it because ``float(["600"])`` - a toml array where
 #: a number belongs - raises that instead. ``RuntimeError`` is there for
 #: the domain errors that derive from IT: ``ServeError`` rejects
@@ -187,13 +193,33 @@ def preflight_config(
     by the traceback the warning promised would not come. A command
     that is ABOUT a section declares that here rather than remembering
     its own guard.
-
-    Deliberately NOT swallowed here: ``BudgetConfigError``, which
-    ``_KstrlGroup.invoke`` already renders with its own message, and
-    which is about a value that parses fine and cannot bound anything.
     """
-    from kstrl.factory import BudgetConfigError
+    problems = collect_config_problems(root_dir, warn, required=required)
+    if problems:
+        raise ConfigError(
+            "configuration rejected before anything was started; "
+            "fix it and run again:\n  " + "\n  ".join(problems)
+        )
 
+
+def collect_config_problems(
+    root_dir: Path,
+    warn: Callable[[str], None],
+    *,
+    required: frozenset[str] = frozenset(),
+) -> list[str]:
+    """:func:`preflight_config`, but returning the problems instead of
+    raising on them.
+
+    Split out for ``ks config show``, which has to REPORT every rejected
+    section next to the rows it could resolve rather than stop at the
+    first one. A raising check and a reporting one reading different
+    section lists is exactly the drift this module exists to prevent, so
+    there is one traversal and the raise sits on top of it.
+
+    A malformed document still raises: no section can be resolved when
+    the file will not parse, so there is nothing to report beside.
+    """
     toml_path = resolve_config_file(root_dir)
     problems: list[str] = []
     # One parse of the file for the whole check, blame helpers included.
@@ -212,20 +238,13 @@ def preflight_config(
         for section in config_sections():
             try:
                 section.loader(root_dir)
-            except BudgetConfigError:
-                raise
             except _REJECTIONS as exc:
                 detail = _detail(section, toml_path, root_dir, exc)
                 if section.fatal or not required.isdisjoint(section.sections):
                     problems.append(detail)
                 else:
                     warn(f"{detail} - continuing without it")
-
-    if problems:
-        raise ConfigError(
-            "configuration rejected before anything was started; "
-            "fix it and run again:\n  " + "\n  ".join(problems)
-        )
+    return problems
 
 
 def _detail(
@@ -257,21 +276,29 @@ def _blamed_env_var(
     message: str,
 ) -> str | None:
     """The environment variable whose REMOVAL makes this loader accept
-    the configuration, if exactly one does.
+    the configuration, if EXACTLY ONE does.
 
     Measured, not guessed: a variable is named only when taking it out
-    of the environment demonstrably fixes the load. Nothing is reported
-    when the fault is in the file, or when two inputs are wrong at once.
+    of the environment demonstrably fixes the load. The sweep runs to
+    the end and reports nothing when two variables each fix it on their
+    own, because then neither is "the one to change" and naming the
+    alphabetically first contradicts the message beside it. Reproduced
+    on ``[linear]`` with ``KSTRL_LINEAR_ENABLED=1`` and an empty
+    ``KSTRL_LINEAR_TEAM_ID``: removing either satisfies the loader, and
+    the earlier code blamed ENABLED while the message told the operator
+    to set TEAM_ID.
 
     An EMPTY environment is tried first, and a loader that still fails
-    there ends the search: the file is at fault, and no single variable
-    can be. That gate is what keeps the common case at one extra load
-    rather than one per variable (measured with 83 variables set: 34.3
-    ms of fruitless sweep for a file fault, against 0.5 ms with it).
+    there ends the search: the file is at fault, and no variable can be.
+    That gate is what keeps a file fault at one extra load rather than
+    one per variable (measured with 83 variables set: 34.3 ms of
+    fruitless sweep before the gate, 0.5 ms after).
 
-    Mutating ``os.environ`` is PROCESS-WIDE, which is why this runs only
-    on the error path at command entry, where the command body has not
-    started and no other thread of ours is alive. That is the constraint
+    Runs whenever a section is REJECTED, which includes a degrading
+    section on an otherwise successful command. Both are before the
+    command body, which is the property that matters: mutating
+    ``os.environ`` is PROCESS-WIDE, and here nothing has been built and
+    no other thread of ours is alive. That is the constraint
     ``config_report.scrubbed_environ``, reused here, already documents.
     """
     with scrubbed_environ():
@@ -280,6 +307,7 @@ def _blamed_env_var(
         except Exception:
             return None
 
+    culprits: list[str] = []
     for name in sorted(os.environ):
         saved = os.environ.pop(name)
         try:
@@ -292,10 +320,12 @@ def _blamed_env_var(
             # The value is echoed only where the loader's own message
             # already quotes it. Nothing has decided that an arbitrary
             # environment value may be printed, so nothing prints one.
-            return f"set by {name}={saved}" if repr(saved) in message else f"set by {name}"
+            culprits.append(
+                f"set by {name}={saved}" if repr(saved) in message else f"set by {name}"
+            )
         finally:
             os.environ[name] = saved
-    return None
+    return culprits[0] if len(culprits) == 1 else None
 
 
 def _blamed_toml_value(

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -1,0 +1,265 @@
+"""One configuration check, at command entry, before anything is spent.
+
+kstrl.toml used to be parsed lazily, by whichever config dataclass first
+needed its section, at whatever point in the run that class happened to
+be constructed. A typo therefore did not fail at startup: it failed at
+the first loader that reached the bad section. On the decompose path one
+of those loaders is ``LinearConfig.load``, which runs AFTER the
+architect agent has been invoked and paid for - measured at 119 to 210
+seconds against a frontier model on a real spec - so a syntax error in
+kstrl.toml, or a bad value in a section the architect never needed,
+spent the architect and then aborted (#272).
+
+The blast radius of a typo therefore depended on which section it was in
+and which command was run. Nobody chose that property. This module
+replaces it with one: EVERY section is resolved once, at command entry,
+before the command body constructs anything.
+
+FATAL VERSUS DEGRADING
+----------------------
+Not every section can honestly be degraded past, and the difference is
+not about how likely the failure is - it is about what continuing would
+mean.
+
+- ``[evolution]`` configures an optional AUDIT TRAIL. Losing the journal
+  degrades the record and nothing else, so continuing without it is
+  honest, and four mid-run call sites already do exactly that through
+  ``EvolutionConfig.load_or_none``. This preflight makes the same call
+  earlier and louder: the warning arrives at startup instead of in the
+  middle of paid work.
+- Every other section configures a GATE, a BUDGET, a BOUNDARY or a
+  DESTINATION. Substituting defaults for a verify command, a security
+  threshold, a policy envelope or a cost ceiling the operator
+  configured is a semantic substitution: the run proceeds, reports
+  success, and was measured by something other than what was asked for.
+  CLAUDE.md names that failure directly ("No silent semantic
+  substitution. Retry identically or surface the failure"), so these
+  fail the command instead.
+
+WHY THE LOADERS THEMSELVES, NOT A SCHEMA
+----------------------------------------
+The check calls each dataclass's own ``load(root_dir)``. That is the
+same code the run will use later, so the preflight cannot drift from
+what is actually enforced - the drift failure this codebase has already
+recorded twice (see ``config.reconcile_progress_config``). It also means
+ENV coercion is covered for free: ``load`` overlays env on top of toml,
+so ``KSTRL_SECURITY_TIMEOUT=many`` is rejected here by the same
+``float()`` that would have rejected it mid-run. A toml-only preflight
+would have missed both of the failures measured on #272.
+
+The per-section ``from_env()`` / ``load(root_dir)`` convention is
+untouched: this module is a caller of it, not a replacement for it.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from kstrl.config import ConfigError, _load_toml, load_toml_section, resolve_config_file
+
+#: Exceptions a loader raises for input the operator has to fix, and the
+#: complete set of them: these loaders read a file and coerce values, so
+#: anything outside this tuple is a defect in kstrl and keeps its
+#: traceback rather than being reported as the operator's fault.
+#:
+#: ``ValueError`` is the house type (``ConfigError``,
+#: ``PolicyConfigError`` and ``BudgetConfigError`` all derive from it).
+#: ``TypeError`` joins it because ``float(["600"])`` - a toml array where
+#: a number belongs - raises that instead. ``RuntimeError`` is there for
+#: the domain errors that derive from IT: ``ServeError`` rejects
+#: ``[serve] max_consecutive_poison = 0`` that way, and ``QueueError``,
+#: ``InboxError`` and ``IntakeError`` are its siblings.
+_REJECTIONS = (ValueError, TypeError, RuntimeError)
+
+
+@dataclass(frozen=True)
+class ConfigSection:
+    """One kstrl.toml section (or group of them) and how it is loaded.
+
+    ``sections`` is a tuple because ``KstrlConfig`` fans out over five
+    toml tables; every other entry names exactly one. ``fatal`` records
+    the classification argued in the module docstring.
+    """
+
+    sections: tuple[str, ...]
+    loader: Callable[[Path], Any]
+    fatal: bool
+
+    @property
+    def label(self) -> str:
+        return "/".join(f"[{name}]" for name in self.sections)
+
+
+def config_sections() -> list[ConfigSection]:
+    """Every configuration section kstrl reads, with its loader.
+
+    Imports are deferred the way ``config_report._phase_sections`` defers
+    them. Measured on this tree, importing the twenty modules not already
+    pulled in by ``kstrl.cli`` costs under 5ms warm, so the reason is
+    ordering (this module is imported by ``kstrl.cli``, which several of
+    these import from) rather than latency.
+
+    ``tests/test_config_preflight.py`` walks ``kstrl/`` for config
+    dataclasses and fails if one is missing from this list, so a section
+    added later cannot quietly go unchecked.
+    """
+    from kstrl.adequacy import AdequacyConfig
+    from kstrl.autonomy import AutonomyConfig
+    from kstrl.breaker import BreakerConfig
+    from kstrl.config import KstrlConfig
+    from kstrl.contract import ContractConfig
+    from kstrl.divergence import DivergenceConfig
+    from kstrl.evolution import EvolutionConfig
+    from kstrl.factory import FactoryConfig
+    from kstrl.feedforward import FeedforwardConfig
+    from kstrl.fixtures import FixturesConfig
+    from kstrl.inbox import InboxConfig
+    from kstrl.intake_github import GitHubIntakeConfig
+    from kstrl.knowledge import KnowledgeConfig
+    from kstrl.linear import LinearConfig
+    from kstrl.observability import NotifyConfig
+    from kstrl.policy import PolicyConfig
+    from kstrl.sandbox import SandboxConfig
+    from kstrl.security import SecurityConfig
+    from kstrl.serve import ServeConfig
+    from kstrl.timeout import TimeoutConfig
+    from kstrl.verify import VerifyConfig
+    from kstrl.workqueue import QueueConfig
+
+    fatal: list[tuple[tuple[str, ...], Callable[[Path], Any]]] = [
+        (("agent", "run", "paths", "git", "ui"), KstrlConfig.load),
+        (("factory",), FactoryConfig.load),
+        (("verify",), VerifyConfig.load),
+        (("security",), SecurityConfig.load),
+        (("contract",), ContractConfig.load),
+        (("adequacy",), AdequacyConfig.load),
+        (("policy",), PolicyConfig.load),
+        (("autonomy",), AutonomyConfig.load),
+        (("divergence",), DivergenceConfig.load),
+        (("breaker",), BreakerConfig.load),
+        (("sandbox",), SandboxConfig.load),
+        (("timeout",), TimeoutConfig.load),
+        (("feedforward",), FeedforwardConfig.load),
+        (("knowledge",), KnowledgeConfig.load),
+        (("fixtures",), FixturesConfig.load),
+        (("queue",), QueueConfig.load),
+        (("inbox",), InboxConfig.load),
+        (("intake_github",), GitHubIntakeConfig.load),
+        (("serve",), ServeConfig.load),
+        (("notify",), NotifyConfig.load),
+        (("linear",), LinearConfig.load),
+    ]
+    entries = [ConfigSection(names, loader, fatal=True) for names, loader in fatal]
+    entries.append(ConfigSection(("evolution",), EvolutionConfig.load, fatal=False))
+    return entries
+
+
+def preflight_config(root_dir: Path, warn: Callable[[str], None]) -> None:
+    """Resolve every configuration section, or say exactly what to fix.
+
+    Raises :class:`ConfigError` naming the section, the offending input
+    and the loader's own message. Degrading sections (see the module
+    docstring) go to ``warn`` instead and the command continues.
+
+    Deliberately NOT swallowed here: ``BudgetConfigError``, which
+    ``_KstrlGroup.invoke`` already renders with its own message, and
+    which is about a value that parses fine and cannot bound anything.
+    """
+    from kstrl.factory import BudgetConfigError
+
+    toml_path = resolve_config_file(root_dir)
+    if toml_path.exists():
+        # The document first: a syntax error breaks every section, and
+        # one line naming the line and column beats twenty-two saying so.
+        try:
+            _load_toml(toml_path)
+        except OSError as exc:
+            raise ConfigError(f"{toml_path} could not be read: {exc}") from exc
+
+    problems: list[str] = []
+    for section in config_sections():
+        try:
+            section.loader(root_dir)
+        except BudgetConfigError:
+            raise
+        except _REJECTIONS as exc:
+            detail = _detail(section, root_dir, exc)
+            if section.fatal:
+                problems.append(detail)
+            else:
+                warn(f"{detail} - continuing without it")
+
+    if problems:
+        raise ConfigError(
+            "configuration rejected before anything was started; "
+            "fix it and run again:\n  " + "\n  ".join(problems)
+        )
+
+
+def _detail(section: ConfigSection, root_dir: Path, exc: Exception) -> str:
+    """One line: which section, what the loader said, and which input."""
+    message = str(exc)
+    blamed = _blamed_env_var(section.loader, root_dir) or _blamed_toml_value(
+        section.sections,
+        resolve_config_file(root_dir),
+        message,
+    )
+    line = f"{section.label} {message}"
+    return f"{line} ({blamed})" if blamed else line
+
+
+def _blamed_env_var(loader: Callable[[Path], Any], root_dir: Path) -> str | None:
+    """The environment variable whose REMOVAL makes this loader accept
+    the configuration, if exactly one does.
+
+    Measured, not guessed: the variable is named only when taking it out
+    of the environment demonstrably fixes the load. Nothing is reported
+    when the fault is in the file, or when two inputs are wrong at once.
+
+    Mutating ``os.environ`` is PROCESS-WIDE, so this runs only on the
+    error path at command entry, where the command body has not started
+    and no other thread of ours is alive - the same constraint
+    ``config_report.scrubbed_environ`` documents.
+    """
+    for name in sorted(os.environ):
+        saved = os.environ.pop(name)
+        try:
+            loader(root_dir)
+        except Exception:
+            # Still broken without it, or broken differently: either way
+            # this variable is not the one thing to change.
+            continue
+        else:
+            return f"set by {name}={saved}"
+        finally:
+            os.environ[name] = saved
+    return None
+
+
+def _blamed_toml_value(
+    sections: tuple[str, ...],
+    toml_path: Path,
+    message: str,
+) -> str | None:
+    """The kstrl.toml key holding the value the loader complained about.
+
+    Python's coercion errors quote the offending value verbatim ("could
+    not convert string to float: 'many'"), so a key in these sections
+    whose value reprs into that message is the one to look at. Reported
+    only when exactly one key matches, and phrased as what the file
+    says rather than as a diagnosis.
+    """
+    hits = []
+    for name in sections:
+        with suppress(*_REJECTIONS, OSError):
+            for key, value in load_toml_section(toml_path, name).items():
+                if repr(value) in message:
+                    hits.append(f"kstrl.toml has [{name}] {key} = {value!r}")
+    if len(hits) == 1:
+        return hits[0]
+    return None

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -60,7 +60,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from kstrl.config import ConfigError, _load_toml, load_toml_section, resolve_config_file
+from kstrl.config import (
+    ConfigError,
+    load_toml_document,
+    load_toml_section,
+    resolve_config_file,
+    toml_parse_scope,
+)
+from kstrl.config_report import scrubbed_environ
 
 #: Exceptions a loader raises for input the operator has to fix, and the
 #: complete set of them: these loaders read a file and coerce values, so
@@ -88,7 +95,9 @@ class ConfigSection:
 
     sections: tuple[str, ...]
     loader: Callable[[Path], Any]
-    fatal: bool
+    #: False for a section whose failure degrades rather than stops the
+    #: command. Exactly one entry sets it; see the module docstring.
+    fatal: bool = True
 
     @property
     def label(self) -> str:
@@ -99,10 +108,11 @@ def config_sections() -> list[ConfigSection]:
     """Every configuration section kstrl reads, with its loader.
 
     Imports are deferred the way ``config_report._phase_sections`` defers
-    them. Measured on this tree, importing the twenty modules not already
-    pulled in by ``kstrl.cli`` costs under 5ms warm, so the reason is
-    ordering (this module is imported by ``kstrl.cli``, which several of
-    these import from) rather than latency.
+    them, and the reason is ordering, not latency: this module is
+    imported by ``kstrl.cli``, which several of these import from.
+    Measured on this tree, only four of the twenty-two are new work
+    (evolution, intake_github with workqueue, and serve; the rest arrive
+    with ``kstrl.cli``), costing about 7 ms warm on a 151 ms process.
 
     ``tests/test_config_preflight.py`` walks ``kstrl/`` for config
     dataclasses and fails if one is missing from this list, so a section
@@ -131,40 +141,52 @@ def config_sections() -> list[ConfigSection]:
     from kstrl.verify import VerifyConfig
     from kstrl.workqueue import QueueConfig
 
-    fatal: list[tuple[tuple[str, ...], Callable[[Path], Any]]] = [
-        (("agent", "run", "paths", "git", "ui"), KstrlConfig.load),
-        (("factory",), FactoryConfig.load),
-        (("verify",), VerifyConfig.load),
-        (("security",), SecurityConfig.load),
-        (("contract",), ContractConfig.load),
-        (("adequacy",), AdequacyConfig.load),
-        (("policy",), PolicyConfig.load),
-        (("autonomy",), AutonomyConfig.load),
-        (("divergence",), DivergenceConfig.load),
-        (("breaker",), BreakerConfig.load),
-        (("sandbox",), SandboxConfig.load),
-        (("timeout",), TimeoutConfig.load),
-        (("feedforward",), FeedforwardConfig.load),
-        (("knowledge",), KnowledgeConfig.load),
-        (("fixtures",), FixturesConfig.load),
-        (("queue",), QueueConfig.load),
-        (("inbox",), InboxConfig.load),
-        (("intake_github",), GitHubIntakeConfig.load),
-        (("serve",), ServeConfig.load),
-        (("notify",), NotifyConfig.load),
-        (("linear",), LinearConfig.load),
+    return [
+        ConfigSection(("agent", "run", "paths", "git", "ui"), KstrlConfig.load),
+        ConfigSection(("factory",), FactoryConfig.load),
+        ConfigSection(("verify",), VerifyConfig.load),
+        ConfigSection(("security",), SecurityConfig.load),
+        ConfigSection(("contract",), ContractConfig.load),
+        ConfigSection(("adequacy",), AdequacyConfig.load),
+        ConfigSection(("policy",), PolicyConfig.load),
+        ConfigSection(("autonomy",), AutonomyConfig.load),
+        ConfigSection(("divergence",), DivergenceConfig.load),
+        ConfigSection(("breaker",), BreakerConfig.load),
+        ConfigSection(("sandbox",), SandboxConfig.load),
+        ConfigSection(("timeout",), TimeoutConfig.load),
+        ConfigSection(("feedforward",), FeedforwardConfig.load),
+        ConfigSection(("knowledge",), KnowledgeConfig.load),
+        ConfigSection(("fixtures",), FixturesConfig.load),
+        ConfigSection(("queue",), QueueConfig.load),
+        ConfigSection(("inbox",), InboxConfig.load),
+        ConfigSection(("intake_github",), GitHubIntakeConfig.load),
+        ConfigSection(("serve",), ServeConfig.load),
+        ConfigSection(("notify",), NotifyConfig.load),
+        ConfigSection(("linear",), LinearConfig.load),
+        ConfigSection(("evolution",), EvolutionConfig.load, fatal=False),
     ]
-    entries = [ConfigSection(names, loader, fatal=True) for names, loader in fatal]
-    entries.append(ConfigSection(("evolution",), EvolutionConfig.load, fatal=False))
-    return entries
 
 
-def preflight_config(root_dir: Path, warn: Callable[[str], None]) -> None:
+def preflight_config(
+    root_dir: Path,
+    warn: Callable[[str], None],
+    *,
+    required: frozenset[str] = frozenset(),
+) -> None:
     """Resolve every configuration section, or say exactly what to fix.
 
     Raises :class:`ConfigError` naming the section, the offending input
     and the loader's own message. Degrading sections (see the module
     docstring) go to ``warn`` instead and the command continues.
+
+    ``required`` promotes named sections to fatal for THIS caller. It
+    exists because "degrading" means "an audit trail attached to work
+    that is about something else": ``ks evolve`` IS the journal, so it
+    passes ``{"evolution"}`` and gets the error line, with the key and
+    the offending value, instead of a warning followed two lines later
+    by the traceback the warning promised would not come. A command
+    that is ABOUT a section declares that here rather than remembering
+    its own guard.
 
     Deliberately NOT swallowed here: ``BudgetConfigError``, which
     ``_KstrlGroup.invoke`` already renders with its own message, and
@@ -173,26 +195,31 @@ def preflight_config(root_dir: Path, warn: Callable[[str], None]) -> None:
     from kstrl.factory import BudgetConfigError
 
     toml_path = resolve_config_file(root_dir)
-    if toml_path.exists():
-        # The document first: a syntax error breaks every section, and
-        # one line naming the line and column beats twenty-two saying so.
-        try:
-            _load_toml(toml_path)
-        except OSError as exc:
-            raise ConfigError(f"{toml_path} could not be read: {exc}") from exc
-
     problems: list[str] = []
-    for section in config_sections():
-        try:
-            section.loader(root_dir)
-        except BudgetConfigError:
-            raise
-        except _REJECTIONS as exc:
-            detail = _detail(section, root_dir, exc)
-            if section.fatal:
-                problems.append(detail)
-            else:
-                warn(f"{detail} - continuing without it")
+    # One parse of the file for the whole check, blame helpers included.
+    # Without the scope the 22 loaders lex the same bytes 22 times:
+    # measured on the shipped 21 KB kstrl.toml.example, this check costs
+    # 9.4 ms without it and 0.6 ms with it.
+    with toml_parse_scope():
+        if toml_path.exists():
+            # The document first: a syntax error breaks every section,
+            # and one line naming the line and column beats 22 saying so.
+            try:
+                load_toml_document(toml_path)
+            except OSError as exc:
+                raise ConfigError(f"{toml_path} could not be read: {exc}") from exc
+
+        for section in config_sections():
+            try:
+                section.loader(root_dir)
+            except BudgetConfigError:
+                raise
+            except _REJECTIONS as exc:
+                detail = _detail(section, toml_path, root_dir, exc)
+                if section.fatal or not required.isdisjoint(section.sections):
+                    problems.append(detail)
+                else:
+                    warn(f"{detail} - continuing without it")
 
     if problems:
         raise ConfigError(
@@ -201,31 +228,58 @@ def preflight_config(root_dir: Path, warn: Callable[[str], None]) -> None:
         )
 
 
-def _detail(section: ConfigSection, root_dir: Path, exc: Exception) -> str:
-    """One line: which section, what the loader said, and which input."""
+def _detail(
+    section: ConfigSection,
+    toml_path: Path,
+    root_dir: Path,
+    exc: Exception,
+) -> str:
+    """One line: which section, what the loader said, and which input.
+
+    The environment is asked FIRST because the environment wins: with
+    the same bad value in both places, the variable is the one taking
+    effect, so naming the file's key would send the operator to a line
+    that changing does not help.
+    """
     message = str(exc)
-    blamed = _blamed_env_var(section.loader, root_dir) or _blamed_toml_value(
+    blamed = _blamed_env_var(section.loader, root_dir, message) or _blamed_toml_value(
         section.sections,
-        resolve_config_file(root_dir),
+        toml_path,
         message,
     )
     line = f"{section.label} {message}"
     return f"{line} ({blamed})" if blamed else line
 
 
-def _blamed_env_var(loader: Callable[[Path], Any], root_dir: Path) -> str | None:
+def _blamed_env_var(
+    loader: Callable[[Path], Any],
+    root_dir: Path,
+    message: str,
+) -> str | None:
     """The environment variable whose REMOVAL makes this loader accept
     the configuration, if exactly one does.
 
-    Measured, not guessed: the variable is named only when taking it out
+    Measured, not guessed: a variable is named only when taking it out
     of the environment demonstrably fixes the load. Nothing is reported
     when the fault is in the file, or when two inputs are wrong at once.
 
-    Mutating ``os.environ`` is PROCESS-WIDE, so this runs only on the
-    error path at command entry, where the command body has not started
-    and no other thread of ours is alive - the same constraint
-    ``config_report.scrubbed_environ`` documents.
+    An EMPTY environment is tried first, and a loader that still fails
+    there ends the search: the file is at fault, and no single variable
+    can be. That gate is what keeps the common case at one extra load
+    rather than one per variable (measured with 83 variables set: 34.3
+    ms of fruitless sweep for a file fault, against 0.5 ms with it).
+
+    Mutating ``os.environ`` is PROCESS-WIDE, which is why this runs only
+    on the error path at command entry, where the command body has not
+    started and no other thread of ours is alive. That is the constraint
+    ``config_report.scrubbed_environ``, reused here, already documents.
     """
+    with scrubbed_environ():
+        try:
+            loader(root_dir)
+        except Exception:
+            return None
+
     for name in sorted(os.environ):
         saved = os.environ.pop(name)
         try:
@@ -235,7 +289,10 @@ def _blamed_env_var(loader: Callable[[Path], Any], root_dir: Path) -> str | None
             # this variable is not the one thing to change.
             continue
         else:
-            return f"set by {name}={saved}"
+            # The value is echoed only where the loader's own message
+            # already quotes it. Nothing has decided that an arbitrary
+            # environment value may be printed, so nothing prints one.
+            return f"set by {name}={saved}" if repr(saved) in message else f"set by {name}"
         finally:
             os.environ[name] = saved
     return None

--- a/kstrl/config_report.py
+++ b/kstrl/config_report.py
@@ -40,6 +40,10 @@ class ConfigReport:
     toml_path: Path
     toml_exists: bool
     rows: tuple[ConfigRow, ...]
+    #: Sections whose loader rejected the configuration, so no row could
+    #: be built for them. The report is still returned: see
+    #: :func:`build_config_report`.
+    unresolved: tuple[str, ...] = ()
 
 
 # (toml section, [(toml key, KstrlConfig field)]) - the documented
@@ -345,17 +349,39 @@ def build_config_report(
 
     ``overlay`` is the CLI's flag layer: it mutates the resolved
     KstrlConfig and returns the field names it overrode (tagged
-    ``flag``). Raises ValueError when a loader rejects the config -
-    presentation of that error is the caller's job.
+    ``flag``).
+
+    A PHASE section whose loader rejects the config costs that section's
+    rows and is named in ``unresolved``; it does not cost the report.
+    One typo used to abort the whole thing before a single row printed,
+    which made ``ks config show`` the LEAST informative surface in the
+    CLI at the exact moment it is the one an operator opens: every other
+    command named the section, the key and the value, and this one said
+    ``error: could not convert string to float: 'many'``.
+
+    The base config still raises, because a malformed document or a bad
+    ``[run]`` value leaves nothing to render beside the failure.
     """
     toml_path = resolve_config_file(root_dir)
     phase_sections = _phase_sections()
+    unresolved: list[str] = []
+
+    def _resolve(name: str, loader: Any) -> Any:
+        try:
+            return loader(root_dir)
+        except (ValueError, TypeError, RuntimeError):
+            # The same rejection set config_preflight._REJECTIONS states.
+            # WHY it was rejected is that module's job to report; this
+            # one records only that the rows cannot be built.
+            if name not in unresolved:
+                unresolved.append(name)
+            return None
 
     resolved_base = KstrlConfig.load(root_dir)
-    phase_resolved = {name: loader(root_dir) for name, loader, _ in phase_sections}
+    phase_resolved = {name: _resolve(name, loader) for name, loader, _ in phase_sections}
     with scrubbed_environ():
         noenv_base = KstrlConfig.load(root_dir)
-        phase_noenv = {name: loader(root_dir) for name, loader, _ in phase_sections}
+        phase_noenv = {name: _resolve(name, loader) for name, loader, _ in phase_sections}
     phase_toml_keys = {
         name: set(load_toml_section(toml_path, name).keys()) for name, _, _ in phase_sections
     }
@@ -370,6 +396,8 @@ def build_config_report(
 
     rows = _base_rows(resolved_base, base_sources)
     for section, _, knob_fields in phase_sections:
+        if section in unresolved:
+            continue
         rows.extend(
             _phase_rows(
                 section,
@@ -385,4 +413,5 @@ def build_config_report(
         toml_path=toml_path,
         toml_exists=toml_path.exists(),
         rows=tuple(rows),
+        unresolved=tuple(unresolved),
     )

--- a/kstrl/config_report.py
+++ b/kstrl/config_report.py
@@ -362,29 +362,51 @@ def build_config_report(
     The base config still raises, because a malformed document or a bad
     ``[run]`` value leaves nothing to render beside the failure.
     """
+    from kstrl.config import toml_parse_scope
+    from kstrl.config_preflight import REJECTIONS
+
     toml_path = resolve_config_file(root_dir)
     phase_sections = _phase_sections()
-    unresolved: list[str] = []
 
-    def _resolve(name: str, loader: Any) -> Any:
+    def _resolve(loader: Any) -> Any:
+        """The section, or None when it rejects the configuration.
+
+        The rejection set is IMPORTED, not restated: it has already
+        widened twice, and a local copy that missed the third widening
+        would let the new exception escape and kill the whole report
+        before a single row printed, which is the defect this tolerance
+        was added to remove. WHY a section was rejected is
+        ``config_preflight``'s job to report; None here means only "no
+        row can be built from this".
+        """
         try:
             return loader(root_dir)
-        except (ValueError, TypeError, RuntimeError):
-            # The same rejection set config_preflight._REJECTIONS states.
-            # WHY it was rejected is that module's job to report; this
-            # one records only that the rows cannot be built.
-            if name not in unresolved:
-                unresolved.append(name)
+        except REJECTIONS:
             return None
 
-    resolved_base = KstrlConfig.load(root_dir)
-    phase_resolved = {name: _resolve(name, loader) for name, loader, _ in phase_sections}
-    with scrubbed_environ():
-        noenv_base = KstrlConfig.load(root_dir)
-        phase_noenv = {name: _resolve(name, loader) for name, loader, _ in phase_sections}
-    phase_toml_keys = {
-        name: set(load_toml_section(toml_path, name).keys()) for name, _, _ in phase_sections
-    }
+    # One parse of kstrl.toml for the whole report. Without this the
+    # loader calls and section reads below lex the same bytes 32 times:
+    # counted, and measured on the shipped 21 KB kstrl.toml.example at
+    # 13.34 ms against 0.82 ms with it. The TUI config screen pays that
+    # again on every refresh. Per call, so that screen's
+    # re-read-on-demand keeps seeing the file as it is now.
+    with toml_parse_scope():
+        resolved_base = KstrlConfig.load(root_dir)
+        phase_resolved = {name: _resolve(loader) for name, loader, _ in phase_sections}
+        with scrubbed_environ():
+            noenv_base = KstrlConfig.load(root_dir)
+            phase_noenv = {name: _resolve(loader) for name, loader, _ in phase_sections}
+        # Derived rather than accumulated: a loader never returns None, so
+        # the two passes ARE the record of which sections failed, and the
+        # skip below cannot drift from the reason for it.
+        unresolved = tuple(
+            name
+            for name, _, _ in phase_sections
+            if phase_resolved[name] is None or phase_noenv[name] is None
+        )
+        phase_toml_keys = {
+            name: set(load_toml_section(toml_path, name).keys()) for name, _, _ in phase_sections
+        }
 
     defaults_base = kstrl_config_defaults(root_dir)
 
@@ -413,5 +435,5 @@ def build_config_report(
         toml_path=toml_path,
         toml_exists=toml_path.exists(),
         rows=tuple(rows),
-        unresolved=tuple(unresolved),
+        unresolved=unresolved,
     )

--- a/kstrl/config_report.py
+++ b/kstrl/config_report.py
@@ -154,22 +154,25 @@ def kstrl_config_defaults(root_dir: Path) -> KstrlConfig:
 def _phase_sections() -> list[tuple[str, Any, list[str]]]:
     """(section, loader, knob fields) - the documented kstrl.toml
     surface for the factory-phase configs. Loaders import lazily; the
-    report is not on any hot path."""
-    from kstrl.contract import ContractConfig
-    from kstrl.evolution import EvolutionConfig
-    from kstrl.factory import FactoryConfig
-    from kstrl.feedforward import FeedforwardConfig
-    from kstrl.knowledge import KnowledgeConfig
-    from kstrl.linear import LinearConfig
-    from kstrl.observability import NotifyConfig
-    from kstrl.security import SecurityConfig
+    report is not on any hot path.
+
+    The LOADER for each section comes from
+    ``config_preflight.config_sections()``, which is the one registry of
+    section to loader and is kept complete by an AST test. Only the knob
+    lists are local, because they are about what this report RENDERS
+    rather than about what a section is loaded by. A second copy of the
+    loader table is what the comment on ``verify`` below is already an
+    account of, one level down.
+    """
+    from kstrl.config_preflight import config_sections
     from kstrl.timeout import TimeoutConfig
     from kstrl.verify import VerifyConfig
 
-    return [
+    loaders = {name: entry.loader for entry in config_sections() for name in entry.sections}
+
+    knobs: list[tuple[str, list[str]]] = [
         (
             "factory",
-            FactoryConfig.load,
             [
                 "max_parallel",
                 "max_retries",
@@ -196,10 +199,9 @@ def _phase_sections() -> list[tuple[str, Any, list[str]]]:
         # VerifyConfig IS a documented kstrl.toml key, which gen_docs
         # already enforces, so the field list is the key list and a
         # second copy of it can only ever be wrong.
-        ("verify", VerifyConfig.load, [f.name for f in dataclass_fields(VerifyConfig)]),
+        ("verify", [f.name for f in dataclass_fields(VerifyConfig)]),
         (
             "security",
-            SecurityConfig.load,
             [
                 "mode",
                 "fail_threshold",
@@ -209,10 +211,9 @@ def _phase_sections() -> list[tuple[str, Any, list[str]]]:
                 "model",
             ],
         ),
-        ("contract", ContractConfig.load, ["mode", "test_command", "timeout"]),
+        ("contract", ["mode", "test_command", "timeout"]),
         (
             "feedforward",
-            FeedforwardConfig.load,
             [
                 "enabled",
                 "module_map",
@@ -224,7 +225,6 @@ def _phase_sections() -> list[tuple[str, Any, list[str]]]:
         ),
         (
             "knowledge",
-            KnowledgeConfig.load,
             [
                 "enabled",
                 "max_core_tokens",
@@ -238,7 +238,6 @@ def _phase_sections() -> list[tuple[str, Any, list[str]]]:
         ),
         (
             "evolution",
-            EvolutionConfig.load,
             [
                 "enabled",
                 "journal_path",
@@ -249,10 +248,9 @@ def _phase_sections() -> list[tuple[str, Any, list[str]]]:
                 "auto_apply_computational",
             ],
         ),
-        ("timeout", TimeoutConfig.load, [f.name for f in dataclass_fields(TimeoutConfig)]),
+        ("timeout", [f.name for f in dataclass_fields(TimeoutConfig)]),
         (
             "notify",
-            NotifyConfig.load,
             [
                 "on_complete",
                 "on_first_failure",
@@ -262,7 +260,6 @@ def _phase_sections() -> list[tuple[str, Any, list[str]]]:
         ),
         (
             "linear",
-            LinearConfig.load,
             [
                 "enabled",
                 "team_id",
@@ -275,6 +272,7 @@ def _phase_sections() -> list[tuple[str, Any, list[str]]]:
             ],
         ),
     ]
+    return [(name, loaders[name], fields) for name, fields in knobs]
 
 
 def _base_sources(

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -136,7 +136,7 @@ class EvolutionConfig:
         guard somebody wrote around a call.
 
         ``TypeError`` was added when #272 gave the same section an entry
-        check: ``config_preflight._REJECTIONS`` treats it as operator
+        check: ``config_preflight.REJECTIONS`` treats it as operator
         input, and two lists that disagree would degrade the same value
         at startup and then raise on it mid-run.
 

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -129,16 +129,22 @@ class EvolutionConfig:
         Which exceptions that means is stated here rather than at a call
         site, because it is a fact about :meth:`load`: ``ValueError``
         from malformed TOML or a non-integer ``lookback_runs`` (from the
-        file or from ``KSTRL_EVOLUTION_LOOKBACK_RUNS``), and ``OSError``
-        from an unreadable ``kstrl.toml``. A future coercion added to
+        file or from ``KSTRL_EVOLUTION_LOOKBACK_RUNS``), ``TypeError``
+        from a toml array where a number belongs, and ``OSError`` from
+        an unreadable ``kstrl.toml``. A future coercion added to
         ``load`` is then covered here instead of silently escaping a
         guard somebody wrote around a call.
+
+        ``TypeError`` was added when #272 gave the same section an entry
+        check: ``config_preflight._REJECTIONS`` treats it as operator
+        input, and two lists that disagree would degrade the same value
+        at startup and then raise on it mid-run.
 
         Degrades loudly: ``warn`` is called with the parse failure.
         """
         try:
             return cls.load(root_dir)
-        except (ValueError, OSError) as exc:
+        except (ValueError, TypeError, OSError) as exc:
             warn(f"Evolution config unreadable, skipping journal: {exc}")
             return None
 

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -140,6 +140,16 @@ class EvolutionConfig:
         input, and two lists that disagree would degrade the same value
         at startup and then raise on it mid-run.
 
+        The cost of that widening, stated because it is real: a
+        ``TypeError`` from a DEFECT inside :meth:`load` - a None where a
+        path belongs, a signature that stopped matching - now reads as
+        "config unreadable, skipping journal" rather than surfacing. It
+        cannot be narrowed to the toml-array case without inspecting the
+        message, which would be guessing. The journal going quiet is the
+        signal that a defect is hiding here, so treat a "skipping
+        journal" warning on a config that looks correct as a bug report
+        about this method rather than about the operator's file.
+
         Degrades loudly: ``warn`` is called with the parse failure.
         """
         try:

--- a/kstrl/knowledge.py
+++ b/kstrl/knowledge.py
@@ -85,11 +85,12 @@ class KnowledgeConfig:
 
         Reads the [knowledge] section from ``<root_dir>/kstrl.toml`` if
         present, then applies any matching environment variable overrides.
-        Raises ValueError on malformed TOML, matching the error policy of
-        :meth:`KstrlConfig.load` so the two loaders treat the same file
-        consistently.
+        Raises ``ConfigError`` on malformed TOML through the shared
+        ``load_toml_section``, which is where every other loader reads
+        its section: a second copy of the open-and-decode was a second
+        place for the file's error policy to drift (#272).
         """
-        import tomllib
+        from kstrl.config import load_toml_section, resolve_config_file
 
         if root_dir is None:
             root_dir = Path.cwd()
@@ -97,35 +98,23 @@ class KnowledgeConfig:
         config = cls()
         config.knowledge_root = root_dir / ".kstrl" / "knowledge"
 
-        from kstrl.config import resolve_config_file
-
-        toml_path = resolve_config_file(root_dir)
-        data: dict[str, Any] = {}
-        if toml_path.exists():
-            try:
-                with open(toml_path, "rb") as f:
-                    data = tomllib.load(f)
-            except tomllib.TOMLDecodeError as exc:
-                raise ValueError(f"Invalid TOML in {toml_path}: {exc}") from exc
-
-        section = data.get("knowledge")
-        if isinstance(section, dict):
-            if "enabled" in section:
-                config.enabled = bool(section["enabled"])
-            if "max_core_tokens" in section:
-                config.max_core_tokens = int(section["max_core_tokens"])
-            if "max_dependency_tokens" in section:
-                config.max_dependency_tokens = int(section["max_dependency_tokens"])
-            if "max_sibling_tokens" in section:
-                config.max_sibling_tokens = int(section["max_sibling_tokens"])
-            if "distill_timeout_seconds" in section:
-                config.distill_timeout_seconds = float(section["distill_timeout_seconds"])
-            if "distill_model" in section:
-                config.distill_model = str(section["distill_model"])
-            if "max_facts_per_distill" in section:
-                config.max_facts_per_distill = int(section["max_facts_per_distill"])
-            if "dependency_scope" in section:
-                config.dependency_scope = str(section["dependency_scope"])
+        section = load_toml_section(resolve_config_file(root_dir), "knowledge")
+        if "enabled" in section:
+            config.enabled = bool(section["enabled"])
+        if "max_core_tokens" in section:
+            config.max_core_tokens = int(section["max_core_tokens"])
+        if "max_dependency_tokens" in section:
+            config.max_dependency_tokens = int(section["max_dependency_tokens"])
+        if "max_sibling_tokens" in section:
+            config.max_sibling_tokens = int(section["max_sibling_tokens"])
+        if "distill_timeout_seconds" in section:
+            config.distill_timeout_seconds = float(section["distill_timeout_seconds"])
+        if "distill_model" in section:
+            config.distill_model = str(section["distill_model"])
+        if "max_facts_per_distill" in section:
+            config.max_facts_per_distill = int(section["max_facts_per_distill"])
+        if "dependency_scope" in section:
+            config.dependency_scope = str(section["dependency_scope"])
 
         _apply_knowledge_env_overrides(config)
         return config

--- a/kstrl/tui/screens/config.py
+++ b/kstrl/tui/screens/config.py
@@ -221,10 +221,17 @@ class ConfigScreen(Screen[None]):
         if root_dir is None:
             return
         try:
-            self.app.config_report = (  # type: ignore[attr-defined]
-                build_config_report(root_dir)
-            )
+            report = build_config_report(root_dir)
         except ValueError as exc:
             self.app.notify(f"config failed to resolve: {exc}", severity="error")
             return
+        self.app.config_report = report  # type: ignore[attr-defined]
+        if report.unresolved:
+            # A rejected section costs its rows rather than the whole
+            # report (#272). Saying so is the difference between "this
+            # section has no rows" and "this section is silently absent".
+            self.app.notify(
+                "unusable, so not shown: " + ", ".join(f"[{s}]" for s in report.unresolved),
+                severity="error",
+            )
         self._render_report(self.query_one(Input).value)

--- a/kstrl/tui/screens/config.py
+++ b/kstrl/tui/screens/config.py
@@ -230,8 +230,13 @@ class ConfigScreen(Screen[None]):
             # A rejected section costs its rows rather than the whole
             # report (#272). Saying so is the difference between "this
             # section has no rows" and "this section is silently absent".
+            # The REASON lives in `ks config show`, which names the key
+            # and the value; this report carries only section names, and
+            # only for the sections it renders.
             self.app.notify(
-                "unusable, so not shown: " + ", ".join(f"[{s}]" for s in report.unresolved),
+                "unusable, so not shown: "
+                + ", ".join(f"[{s}]" for s in report.unresolved)
+                + " - run `ks config show` for the key and value",
                 severity="error",
             )
         self._render_report(self.query_one(Input).value)

--- a/tests/test_config_preflight.py
+++ b/tests/test_config_preflight.py
@@ -16,7 +16,9 @@ classified as degrading still degrades.
 from __future__ import annotations
 
 import ast
+import io
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -272,6 +274,59 @@ class TestWhatItNames:
         assert "max_core_tokens" not in message
         assert "max_sibling_tokens" not in message
 
+    def test_two_variables_that_each_fix_it_blame_neither(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Removing either variable satisfies the loader, so neither is
+        "the one to change". Naming the alphabetically first one made
+        the tool blame KSTRL_LINEAR_ENABLED while the message beside it
+        told the operator to set KSTRL_LINEAR_TEAM_ID."""
+        (tmp_path / "kstrl.toml").write_text('[linear]\nteam_id = "abc"\n')
+        monkeypatch.setenv("KSTRL_LINEAR_ENABLED", "1")
+        monkeypatch.setenv("KSTRL_LINEAR_TEAM_ID", "")
+
+        with pytest.raises(ConfigError) as caught:
+            preflight_config(tmp_path, warn=lambda _message: None)
+
+        message = str(caught.value)
+        assert "[linear]" in message
+        assert "set by KSTRL_LINEAR_ENABLED" not in message
+        assert "set by KSTRL_LINEAR_TEAM_ID" not in message
+
+    def test_one_variable_that_fixes_it_is_still_named(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The uniqueness rule must not cost the attribution it guards."""
+        monkeypatch.setenv("KSTRL_SECURITY_TIMEOUT", "many")
+
+        with pytest.raises(ConfigError) as caught:
+            preflight_config(tmp_path, warn=lambda _message: None)
+
+        assert "set by KSTRL_SECURITY_TIMEOUT=many" in str(caught.value)
+
+    def test_a_rejected_ceiling_does_not_hide_a_later_section(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`[factory]` is second in the traversal, so re-raising its
+        BudgetConfigError abandoned every section after it: the operator
+        fixed the ceiling, re-ran, and met `[verify]` for the first
+        time."""
+        (tmp_path / "kstrl.toml").write_text(
+            "[factory]\nmax_cost_usd = nan\n\n[verify]\nmutation_threshold = 'many'\n"
+        )
+
+        with pytest.raises(ConfigError) as caught:
+            preflight_config(tmp_path, warn=lambda _message: None)
+
+        message = str(caught.value)
+        assert "max_cost_usd" in message
+        assert "[verify]" in message
+
     def test_a_clean_config_raises_nothing(self, tmp_path: Path) -> None:
         """The example config ships as documentation; it has to pass."""
         example = REPO_ROOT / "kstrl.toml.example"
@@ -288,6 +343,67 @@ class TestTheRootIsTheOneTheCommandWillUse:
     level click has not parsed ``--root`` yet, so a preflight there would
     read the config of whatever directory the operator happened to be
     standing in."""
+
+    @staticmethod
+    def _other_checkout(tmp_path: Path, toml: str) -> Path:
+        """A second project, with a prompt file at the layout
+        ``_resolve_root`` recognises."""
+        other = tmp_path / "other"
+        (other / "scripts" / "kstrl").mkdir(parents=True)
+        (other / "kstrl.toml").write_text(toml)
+        (other / "scripts" / "kstrl" / "prompt.md").write_text("# prompt\n")
+        return other
+
+    def test_a_stale_prompt_file_does_not_redirect_a_command_that_ignores_it(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Only `run`, `understand` and `feature` derive a root from a
+        prompt path; `status` and the rest use ``root or cwd`` and never
+        read PROMPT_FILE. Reading it for them made one stale export in a
+        shell profile refuse `ks status` on an unrelated checkout's
+        broken file."""
+        other = self._other_checkout(tmp_path, MALFORMED_TOML)
+        monkeypatch.setenv("PROMPT_FILE", str(other / "scripts" / "kstrl" / "prompt.md"))
+
+        result = _invoke(["status"], toml="[factory]\nmax_parallel = 2\n")
+
+        assert "Invalid TOML" not in result.output
+        assert "configuration rejected" not in result.output
+
+    def test_a_stale_prompt_file_does_not_hide_the_commands_own_config(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The same bug's other half, and the dangerous one: the
+        redirect made the check validate the OTHER checkout, so a
+        command whose own config was broken PASSED. A preflight that
+        passes is invisible."""
+        other = self._other_checkout(tmp_path, "[factory]\nmax_parallel = 2\n")
+        monkeypatch.setenv("PROMPT_FILE", str(other / "scripts" / "kstrl" / "prompt.md"))
+
+        result = _invoke(["status"], toml='[verify]\nmutation_threshold = "many"\n')
+
+        assert result.exit_code == 1
+        assert "[verify] could not convert string to float: 'many'" in result.output
+
+    def test_a_command_that_declares_prompt_still_reads_the_env_var(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The fix narrows the inputs to what a command declares; it
+        does not drop env support for the three commands that resolve
+        their root that way."""
+        other = self._other_checkout(tmp_path, MALFORMED_TOML)
+        monkeypatch.setenv("PROMPT_FILE", str(other / "scripts" / "kstrl" / "prompt.md"))
+
+        result = _invoke(["run", "--agent-cmd", "true"])
+
+        assert result.exit_code == 1
+        assert "Invalid TOML" in result.output
 
     def test_the_prompt_option_feature_actually_uses_derives_the_root(
         self,
@@ -425,6 +541,17 @@ class TestTheCommandsThatMustSurviveABrokenConfig:
         assert result.exit_code == 0
         assert "Usage:" in result.output
 
+    def test_serve_print_plist_keeps_the_documented_exit_2(self) -> None:
+        """`--print-plist` returns before the config load, so it used to
+        skip the check and then exit 1 through the group's ConfigError
+        handler - contradicting this command's own documented exit 2 for
+        a bad kstrl.toml, on the one path an operator uses while setting
+        up an unattended daemon."""
+        result = _invoke(["serve", "--print-plist", "--no-color"], toml=MALFORMED_TOML)
+
+        assert result.exit_code == 2
+        assert "Invalid TOML" in result.output
+
     def test_serve_checks_the_whole_config_under_its_own_exit_2(self) -> None:
         """Exempt from the seam, not from the guarantee: the daemon calls
         the preflight itself, so a section it never reads still stops it
@@ -437,6 +564,132 @@ class TestTheCommandsThatMustSurviveABrokenConfig:
 
         assert result.exit_code == 2
         assert "[verify]" in result.output
+
+
+class _Tty(io.StringIO):
+    """A stream that claims to be a terminal, so the bare-`ks` branch
+    takes the home-shell path instead of printing help."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+class TestTheHomeShellIsNotAFifthExemption:
+    """Bare `ks` on a TTY runs the GROUP callback, so
+    ``_KstrlCommand.invoke`` never fires for it. That made the home shell
+    an undocumented fifth exemption, and the most expensive one: the TUI
+    launches runs IN-PROCESS (``tui/session.py`` calls ``run_factory``
+    and ``decompose_spec`` directly), so a bad ``[linear]`` value paid
+    for the architect and then aborted. The original #272 defect, on the
+    path a user reaches by typing `ks`.
+    """
+
+    @staticmethod
+    def _bare_ks(
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        toml: str,
+    ) -> tuple[int, list[Path]]:
+        import kstrl.tui.home as home_mod
+
+        (tmp_path / "kstrl.toml").write_text(toml)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("KSTRL_NO_TUI", raising=False)
+        opened: list[Path] = []
+        monkeypatch.setattr(
+            home_mod,
+            "run_home_shell",
+            lambda root: (opened.append(root), 0)[1],
+        )
+        monkeypatch.setattr(sys, "stdout", _Tty())
+        monkeypatch.setattr(sys, "stdin", _Tty())
+
+        try:
+            cli.main([], standalone_mode=False)
+        except SystemExit as exc:
+            return int(exc.code or 0), opened
+        return 0, opened
+
+    def test_a_rejected_section_stops_the_shell_before_it_opens(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        code, opened = self._bare_ks(
+            tmp_path,
+            monkeypatch,
+            '[linear]\ntimeout_seconds = "soon"\n',
+        )
+
+        assert opened == []
+        assert code == 1
+
+    def test_a_usable_config_still_opens_the_shell(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The guard must not cost the entry point it protects."""
+        code, opened = self._bare_ks(tmp_path, monkeypatch, "[factory]\nmax_parallel = 2\n")
+
+        assert opened == [Path.cwd()]
+        assert code == 0
+
+
+class TestConfigShowIsTheSurfaceThatAlwaysWorks:
+    """Every command refuses on an unusable section, so one command has
+    to always run and always explain. Before this it was the LEAST
+    informative surface in the CLI: ``build_config_report`` raised before
+    a single row printed, and `ks config show` said
+    ``error: could not convert string to float: 'many'`` while every
+    other command named the section, the key and the value.
+    """
+
+    def test_a_rejected_rendered_section_costs_its_rows_not_the_report(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`[verify]` is one of the 15 sections this report RENDERS, so
+        it is the case the earlier covering test missed by using
+        `[queue]`, which is one of the 11 it does not."""
+        result = _invoke(["config", "show"], toml='[verify]\nmutation_threshold = "many"\n')
+
+        assert result.exit_code == 1
+        # Rows first, for everything that resolved.
+        assert "[agent]" in result.output
+        assert "  type = " in result.output
+        # Then the verdict, in the words every other command uses.
+        assert "[verify] could not convert string to float: 'many'" in result.output
+        assert "mutation_threshold = 'many'" in result.output
+
+    def test_it_still_explains_when_every_other_command_refuses(self) -> None:
+        """The escape hatch is a command, not a flag: universal fatality
+        is only defensible while one surface always answers."""
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setenv("KSTRL_LINEAR_ENABLED", "1")
+            refused = _invoke(["status"])
+            explained = _invoke(["config", "show"])
+
+        assert refused.exit_code == 1
+        assert explained.exit_code == 1
+        assert "[agent]" in explained.output
+        assert "[linear]" in explained.output
+        assert "KSTRL_LINEAR_TEAM_ID" in explained.output
+
+    def test_a_base_section_failure_is_reported_in_the_seam_s_words(self) -> None:
+        """No rows are possible when the base config is rejected, but the
+        message still names the section, the key and the value rather
+        than the bare coercion error."""
+        result = _invoke(["config", "show"], toml='[run]\nmax_iterations = "many"\n')
+
+        assert result.exit_code == 1
+        assert "[run] max_iterations = 'many'" in result.output
+
+    def test_a_clean_config_still_exits_zero(self) -> None:
+        result = _invoke(["config", "show"], toml="[factory]\nmax_parallel = 2\n")
+
+        assert result.exit_code == 0, result.output
+        assert "Rejected sections" not in result.output
 
 
 class TestTheExemptionKeysOffTheTopLevelName:

--- a/tests/test_config_preflight.py
+++ b/tests/test_config_preflight.py
@@ -358,6 +358,15 @@ class TestTheCommandsThatMustSurviveABrokenConfig:
         assert result.exit_code == 2
         assert "error" in json.loads(result.stdout)
 
+    def test_help_still_renders_for_a_command_that_is_not_exempt(self) -> None:
+        """Reading the help is part of fixing the file. click handles
+        ``--help`` while parsing, before ``Command.invoke``, so this is a
+        property of where the check sits rather than of the exemptions."""
+        result = _invoke(["factory", "--help"], toml=MALFORMED_TOML)
+
+        assert result.exit_code == 0
+        assert "Usage:" in result.output
+
     def test_serve_checks_the_whole_config_under_its_own_exit_2(self) -> None:
         """Exempt from the seam, not from the guarantee: the daemon calls
         the preflight itself, so a section it never reads still stops it

--- a/tests/test_config_preflight.py
+++ b/tests/test_config_preflight.py
@@ -16,7 +16,6 @@ classified as degrading still degrades.
 from __future__ import annotations
 
 import ast
-import io
 import json
 import sys
 from pathlib import Path
@@ -566,14 +565,6 @@ class TestTheCommandsThatMustSurviveABrokenConfig:
         assert "[verify]" in result.output
 
 
-class _Tty(io.StringIO):
-    """A stream that claims to be a terminal, so the bare-`ks` branch
-    takes the home-shell path instead of printing help."""
-
-    def isatty(self) -> bool:
-        return True
-
-
 class TestTheHomeShellIsNotAFifthExemption:
     """Bare `ks` on a TTY runs the GROUP callback, so
     ``_KstrlCommand.invoke`` never fires for it. That made the home shell
@@ -596,13 +587,17 @@ class TestTheHomeShellIsNotAFifthExemption:
         monkeypatch.chdir(tmp_path)
         monkeypatch.delenv("KSTRL_NO_TUI", raising=False)
         opened: list[Path] = []
-        monkeypatch.setattr(
-            home_mod,
-            "run_home_shell",
-            lambda root: (opened.append(root), 0)[1],
-        )
-        monkeypatch.setattr(sys, "stdout", _Tty())
-        monkeypatch.setattr(sys, "stdin", _Tty())
+
+        def _fake_home_shell(root: Path) -> int:
+            opened.append(root)
+            return 0
+
+        monkeypatch.setattr(home_mod, "run_home_shell", _fake_home_shell)
+        # The live streams, so the refusal is still visible to capsys.
+        # Replacing them wholesale would swallow the message this branch
+        # exists to print.
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
 
         try:
             cli.main([], standalone_mode=False)
@@ -614,6 +609,7 @@ class TestTheHomeShellIsNotAFifthExemption:
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
         code, opened = self._bare_ks(
             tmp_path,
@@ -623,6 +619,8 @@ class TestTheHomeShellIsNotAFifthExemption:
 
         assert opened == []
         assert code == 1
+        # And the operator is told which section, not just refused.
+        assert "[linear]" in capsys.readouterr().err
 
     def test_a_usable_config_still_opens_the_shell(
         self,
@@ -690,6 +688,65 @@ class TestConfigShowIsTheSurfaceThatAlwaysWorks:
 
         assert result.exit_code == 0, result.output
         assert "Rejected sections" not in result.output
+
+
+class TestTheSeamCannotBeBypassedByDeclaration:
+    """Two drift guards, both for the same failure: a command that gets
+    no check, or gets one against the wrong root, and says nothing.
+
+    Mirrors ``tests/test_prompt_versions.py``, which fails on a prompt
+    constant that was added without being enrolled.
+    """
+
+    @staticmethod
+    def _walk(group: click.Group, path: tuple[str, ...] = ()) -> list[tuple[tuple[str, ...], Any]]:
+        found: list[tuple[tuple[str, ...], Any]] = []
+        for name, command in group.commands.items():
+            here = (*path, name)
+            if isinstance(command, click.Group):
+                found.append((here, command))
+                found.extend(TestTheSeamCannotBeBypassedByDeclaration._walk(command, here))
+            else:
+                found.append((here, command))
+        return found
+
+    def test_every_command_goes_through_the_seam(self) -> None:
+        """A command that is not a ``_KstrlCommand`` never reaches the
+        check, which is how the home shell became a fifth exemption."""
+        leaves = {
+            path: type(command).__name__
+            for path, command in self._walk(cli)
+            if not isinstance(command, click.Group)
+        }
+
+        assert {p: n for p, n in leaves.items() if n != "_KstrlCommand"} == {}
+
+    def test_only_the_root_group_runs_without_a_subcommand(self) -> None:
+        """``invoke_without_command`` means the GROUP callback does work,
+        and a group callback is not a ``_KstrlCommand``. The root one is
+        the home shell, which preflights explicitly; a second such group
+        would silently reintroduce #272."""
+        groups = [path for path, command in self._walk(cli) if isinstance(command, click.Group)]
+
+        assert [p for p in groups if cli.commands[p[0]].invoke_without_command] == []
+        assert cli.invoke_without_command is True
+
+    def test_a_command_declaring_a_root_option_records_a_decision(self) -> None:
+        """`_preflight_root` reads --prompt / --prd / --understand-prompt
+        only for the commands that DERIVE their root from them. A command
+        that declares one without being listed either way would be
+        checked against a root it does not use, and pass."""
+        declaring = {
+            path[0]
+            for path, command in self._walk(cli)
+            if not isinstance(command, click.Group)
+            and {p.name for p in command.params} & {"prompt", "prd", "understand_prompt"}
+        }
+
+        # `ks config show` declares --prompt and --prd as [paths]
+        # OVERRIDES and still roots itself at the cwd, which is why the
+        # rule is keyed by command rather than by "declares the option".
+        assert declaring - cli_mod._ROOT_FROM_PROMPT == {"config"}
 
 
 class TestTheExemptionKeysOffTheTopLevelName:

--- a/tests/test_config_preflight.py
+++ b/tests/test_config_preflight.py
@@ -1,0 +1,416 @@
+"""#272: the whole configuration is resolved at command entry.
+
+kstrl.toml used to be parsed by whichever loader reached its section
+first, so a typo's blast radius depended on which section it was in and
+which command was run. On the decompose path one of those loaders is
+``LinearConfig.load``, which runs after the architect has been invoked
+and paid for - 119 to 210 seconds against a frontier model, measured on
+a real spec.
+
+Every test here asserts a property of that entry check: that it fires
+before anything is constructed, that it covers the environment as well
+as the file, that it names what to change, and that the one section
+classified as degrading still degrades.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner, Result
+
+import kstrl.cli as cli_mod
+from kstrl.cli import cli
+from kstrl.config import ConfigError
+from kstrl.config_preflight import config_sections, preflight_config
+from kstrl.factory import FactoryResult
+from kstrl.manifest import Component, Manifest
+
+MALFORMED_TOML = "[verify\ntest_command = 'pytest'\n"
+
+DECOMPOSE_ARGS = [
+    "decompose",
+    "--spec",
+    "s.md",
+    "--project-name",
+    "p",
+    # --agent-cmd keeps the case independent of what is on PATH: without
+    # it the run can stop on agent detection and pass for the wrong
+    # reason.
+    "--agent-cmd",
+    "true",
+]
+
+
+def _write_manifest(path: Path) -> None:
+    Manifest(
+        version="1",
+        spec_file="s.md",
+        project_name="test",
+        base_branch="main",
+        single_pr=False,
+        components=[
+            Component(
+                "comp-a",
+                "Comp A",
+                "Desc",
+                [],
+                "scripts/kstrl/feature/comp-a/prd.json",
+                "kstrl/factory/comp-a",
+            )
+        ],
+    ).save(path)
+
+
+def _invoke(args: list[str], *, toml: str | None = None) -> Result:
+    """Run a command in an isolated checkout holding a spec and manifest."""
+    runner = CliRunner()
+    with runner.isolated_filesystem() as fs:
+        root = Path(fs)
+        (root / "s.md").write_text("# spec\n")
+        _write_manifest(root / "m.json")
+        if toml is not None:
+            (root / "kstrl.toml").write_text(toml)
+        return runner.invoke(cli, args, catch_exceptions=True)
+
+
+def _no_agents(monkeypatch: pytest.MonkeyPatch) -> list[tuple[Any, ...]]:
+    """Record every agent construction and every architect call."""
+    built: list[tuple[Any, ...]] = []
+
+    def fake_get_agent(*args: Any, **kwargs: Any) -> Any:
+        built.append(("get_agent", args))
+        raise AssertionError("an agent was constructed after a rejected config")
+
+    def fake_decompose_spec(*args: Any, **kwargs: Any) -> Any:
+        built.append(("decompose_spec", args))
+        raise AssertionError("the architect was invoked after a rejected config")
+
+    monkeypatch.setattr(cli_mod, "get_agent", fake_get_agent)
+    monkeypatch.setattr(cli_mod, "decompose_spec", fake_decompose_spec)
+    return built
+
+
+class TestTheDecomposePathFailsBeforeTheArchitect:
+    """The failure #272 was filed about, at the command it was filed
+    about, asserted as "nothing was built" rather than as an exit code
+    that a later abort would also produce."""
+
+    def test_malformed_toml_stops_before_any_agent_is_constructed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        built = _no_agents(monkeypatch)
+
+        result = _invoke(DECOMPOSE_ARGS, toml=MALFORMED_TOML)
+
+        assert built == []
+        assert result.exit_code == 1
+        assert "error:" in result.output
+        assert "Invalid TOML" in result.output
+        # The line and the column, so the operator can go straight there.
+        assert "line 1" in result.output
+
+    def test_a_bad_linear_value_stops_before_any_agent_is_constructed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``LinearConfig.load`` is the loader that used to run AFTER the
+        architect on this path, which is what made a typo in a section
+        the architect never needed cost an architect call."""
+        built = _no_agents(monkeypatch)
+
+        result = _invoke(
+            DECOMPOSE_ARGS,
+            toml='[linear]\ntimeout_seconds = "soon"\n',
+        )
+
+        assert built == []
+        assert result.exit_code == 1
+        assert "[linear]" in result.output
+        assert "timeout_seconds" in result.output
+        assert "'soon'" in result.output
+
+
+class TestTheEnvironmentIsCheckedInTheSamePass:
+    """Both failures measured on main for #272 are env vars, not toml.
+
+    A file-only preflight would have caught neither, which is the reason
+    the check calls each dataclass's own ``load`` - env is overlaid on
+    toml in there, by the same coercion that would have raised mid-run.
+    """
+
+    @pytest.mark.parametrize(
+        ("var", "section"),
+        [
+            ("KSTRL_MUTATION_THRESHOLD", "[verify]"),
+            ("KSTRL_SECURITY_TIMEOUT", "[security]"),
+        ],
+    )
+    def test_a_bad_env_value_is_an_error_line_not_a_traceback(
+        self,
+        var: str,
+        section: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Reproduced against main before the fix: exit 1 with a raw
+        ValueError traceback and no error line."""
+        monkeypatch.setenv(var, "many")
+        monkeypatch.setattr(cli_mod, "run_factory", lambda *a, **k: FactoryResult())
+
+        result = _invoke(["factory", "--manifest", "m.json", "--agent-cmd", "true", "--yes"])
+
+        assert not isinstance(result.exception, ValueError), result.exception
+        assert result.exit_code == 1
+        assert "error:" in result.output
+        assert section in result.output
+        # Named by REMOVAL: the variable whose absence makes the load
+        # succeed, not a variable that happens to look related.
+        assert f"set by {var}=many" in result.output
+
+
+class TestFatalVersusDegrading:
+    """The distinction the fix turns on. ``[evolution]`` configures an
+    optional audit trail, so continuing without it is honest; ``[verify]``
+    configures a GATE, and substituting a default for a check the
+    operator configured would report success for a run measured by
+    something else.
+    """
+
+    ARGS = ["factory", "--manifest", "m.json", "--agent-cmd", "true", "--yes"]
+
+    def test_a_bad_evolution_knob_warns_and_the_run_still_happens(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ran: list[bool] = []
+        monkeypatch.setattr(
+            cli_mod,
+            "run_factory",
+            lambda *a, **k: (ran.append(True), FactoryResult())[1],
+        )
+
+        result = _invoke(self.ARGS, toml='[evolution]\nlookback_runs = "many"\n')
+
+        assert result.exit_code == 0, result.output
+        assert ran == [True]
+        assert "[evolution]" in result.output
+        assert "continuing without it" in result.output
+
+    def test_evolve_treats_the_same_evolution_knob_as_fatal(self) -> None:
+        """Degrading means "the audit trail is dropped from work that is
+        about something else". `ks evolve` IS the journal, so the value
+        the preflight warns about has to stop THAT command - with an
+        error line, not the traceback the warning would otherwise be
+        followed by two lines later."""
+        result = _invoke(["evolve", "--status"], toml='[evolution]\nlookback_runs = "many"\n')
+
+        assert result.exit_code == 1
+        assert "[evolution] configuration is unusable" in result.output
+        assert not isinstance(result.exception, ValueError), result.exception
+
+    def test_a_bad_verify_knob_stops_the_run(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ran: list[bool] = []
+        monkeypatch.setattr(
+            cli_mod,
+            "run_factory",
+            lambda *a, **k: (ran.append(True), FactoryResult())[1],
+        )
+
+        result = _invoke(self.ARGS, toml='[verify]\nmutation_threshold = "many"\n')
+
+        assert result.exit_code == 1
+        assert ran == []
+        assert "[verify]" in result.output
+        assert "mutation_threshold" in result.output
+
+
+class TestWhatItNames:
+    """A rejection the operator cannot act on is only half a fix."""
+
+    def test_the_toml_key_and_value_are_quoted_from_the_file(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text('[security]\ntimeout_seconds = "many"\n')
+
+        with pytest.raises(ConfigError) as caught:
+            preflight_config(tmp_path, warn=lambda _message: None)
+
+        assert "[security] timeout_seconds = 'many'" in str(caught.value)
+
+    def test_two_wrong_inputs_name_the_section_without_guessing_a_key(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Attribution is by measurement, so it stays silent when the
+        measurement is ambiguous - two keys holding the same bad value
+        cannot be told apart, and neither is named."""
+        (tmp_path / "kstrl.toml").write_text(
+            '[knowledge]\nmax_core_tokens = "many"\nmax_sibling_tokens = "many"\n'
+        )
+
+        with pytest.raises(ConfigError) as caught:
+            preflight_config(tmp_path, warn=lambda _message: None)
+
+        message = str(caught.value)
+        assert "[knowledge]" in message
+        assert "max_core_tokens" not in message
+        assert "max_sibling_tokens" not in message
+
+    def test_a_clean_config_raises_nothing(self, tmp_path: Path) -> None:
+        """The example config ships as documentation; it has to pass."""
+        example = Path(__file__).resolve().parents[1] / "kstrl.toml.example"
+        (tmp_path / "kstrl.toml").write_text(example.read_text())
+
+        warnings: list[str] = []
+        preflight_config(tmp_path, warn=warnings.append)
+
+        assert warnings == []
+
+
+class TestTheRootIsTheOneTheCommandWillUse:
+    """Why the check sits on the COMMAND and not on the group: at group
+    level click has not parsed ``--root`` yet, so a preflight there would
+    read the config of whatever directory the operator happened to be
+    standing in."""
+
+    def test_a_broken_config_under_root_is_found_from_a_clean_cwd(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        elsewhere = tmp_path / "project"
+        elsewhere.mkdir()
+        (elsewhere / "kstrl.toml").write_text(MALFORMED_TOML)
+        built = _no_agents(monkeypatch)
+
+        result = _invoke([*DECOMPOSE_ARGS, "--root", str(elsewhere)])
+
+        assert built == []
+        assert result.exit_code == 1
+        assert "Invalid TOML" in result.output
+
+    def test_a_broken_config_in_the_cwd_does_not_fail_another_root(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The other half of the same property: the file that is NOT the
+        command's config must not stop it."""
+        clean = tmp_path / "project"
+        clean.mkdir()
+        monkeypatch.setattr(cli_mod, "run_factory", lambda *a, **k: FactoryResult())
+
+        runner = CliRunner()
+        with runner.isolated_filesystem() as fs:
+            root = Path(fs)
+            (root / "kstrl.toml").write_text(MALFORMED_TOML)
+            _write_manifest(clean / "m.json")
+            result = runner.invoke(
+                cli,
+                [
+                    "factory",
+                    "--manifest",
+                    str(clean / "m.json"),
+                    "--root",
+                    str(clean),
+                    "--agent-cmd",
+                    "true",
+                    "--yes",
+                ],
+                catch_exceptions=True,
+            )
+
+        assert result.exit_code == 0, result.output
+
+
+class TestTheCommandsThatMustSurviveABrokenConfig:
+    """Three exemptions, each of which would otherwise take away the tool
+    the operator recovers with, or replace a machine contract with a
+    weaker one."""
+
+    def test_config_show_still_explains_the_file_it_cannot_load(self) -> None:
+        result = _invoke(["config", "show"], toml=MALFORMED_TOML)
+
+        assert "Invalid TOML" in result.output
+        assert result.exit_code == 1
+
+    def test_init_still_scaffolds_next_to_a_broken_file(self) -> None:
+        result = _invoke(["init", "--ui", "plain", "--no-color"], toml=MALFORMED_TOML)
+
+        # Whatever init decides about an existing project, it is not
+        # allowed to be "cannot parse the file I am here to write".
+        assert result.exit_code == 0, result.output
+        assert "Invalid TOML" not in result.output
+        assert "Created prompt.md" in result.output
+
+    def test_sense_keeps_its_exit_2_and_its_json_envelope(self) -> None:
+        result = _invoke(["sense", "--json"], toml=MALFORMED_TOML)
+
+        assert result.exit_code == 2
+        assert "error" in json.loads(result.stdout)
+
+    def test_serve_checks_the_whole_config_under_its_own_exit_2(self) -> None:
+        """Exempt from the seam, not from the guarantee: the daemon calls
+        the preflight itself, so a section it never reads still stops it
+        before it spawns children that would each be classified as
+        poison for the same reason."""
+        result = _invoke(
+            ["serve", "--once", "--no-color"],
+            toml='[verify]\nmutation_threshold = "many"\n',
+        )
+
+        assert result.exit_code == 2
+        assert "[verify]" in result.output
+
+
+class TestEverySectionIsEnrolled:
+    """The registry is only a guarantee while it is complete.
+
+    Mirrors ``tests/test_prompt_versions.py``, which AST-walks for
+    ``*_PROMPT`` constants and fails on one that is not enrolled: a
+    config dataclass added later must not be able to reintroduce the
+    lazily-parsed section this issue removed.
+    """
+
+    @staticmethod
+    def _config_classes_with_a_loader() -> set[str]:
+        found: set[str] = set()
+        for path in sorted((Path(__file__).resolve().parents[1] / "kstrl").rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ClassDef) or not node.name.endswith("Config"):
+                    continue
+                loaders = {
+                    child.name
+                    for child in node.body
+                    if isinstance(child, ast.FunctionDef) and child.name == "load"
+                }
+                if loaders:
+                    found.add(node.name)
+        return found
+
+    def test_no_config_dataclass_is_missing_from_the_registry(self) -> None:
+        registered = {
+            getattr(section.loader, "__self__", type(None)).__name__
+            for section in config_sections()
+        }
+
+        assert self._config_classes_with_a_loader() - registered == set()
+
+    def test_the_registry_names_a_real_toml_section_for_each_loader(self) -> None:
+        """A section name is what the error line points the operator at,
+        so a typo in the registry would name a table that does not
+        exist. Every name here appears in the shipped example."""
+        example = (Path(__file__).resolve().parents[1] / "kstrl.toml.example").read_text()
+        names = {name for section in config_sections() for name in section.sections}
+
+        assert {name for name in names if f"[{name}]" not in example} == set()

--- a/tests/test_config_preflight.py
+++ b/tests/test_config_preflight.py
@@ -20,15 +20,17 @@ import json
 from pathlib import Path
 from typing import Any
 
+import click
 import pytest
 from click.testing import CliRunner, Result
 
 import kstrl.cli as cli_mod
 from kstrl.cli import cli
-from kstrl.config import ConfigError
+from kstrl.config import ConfigError, load_toml_document, toml_parse_scope
 from kstrl.config_preflight import config_sections, preflight_config
 from kstrl.factory import FactoryResult
-from kstrl.manifest import Component, Manifest
+from tests.conftest import REPO_ROOT
+from tests.spine_utils import component, make_manifest
 
 MALFORMED_TOML = "[verify\ntest_command = 'pytest'\n"
 
@@ -45,25 +47,7 @@ DECOMPOSE_ARGS = [
     "true",
 ]
 
-
-def _write_manifest(path: Path) -> None:
-    Manifest(
-        version="1",
-        spec_file="s.md",
-        project_name="test",
-        base_branch="main",
-        single_pr=False,
-        components=[
-            Component(
-                "comp-a",
-                "Comp A",
-                "Desc",
-                [],
-                "scripts/kstrl/feature/comp-a/prd.json",
-                "kstrl/factory/comp-a",
-            )
-        ],
-    ).save(path)
+FACTORY_ARGS = ["factory", "--manifest", "m.json", "--agent-cmd", "true", "--yes"]
 
 
 def _invoke(args: list[str], *, toml: str | None = None) -> Result:
@@ -72,27 +56,57 @@ def _invoke(args: list[str], *, toml: str | None = None) -> Result:
     with runner.isolated_filesystem() as fs:
         root = Path(fs)
         (root / "s.md").write_text("# spec\n")
-        _write_manifest(root / "m.json")
+        make_manifest([component("comp-a")]).save(root / "m.json")
         if toml is not None:
             (root / "kstrl.toml").write_text(toml)
         return runner.invoke(cli, args, catch_exceptions=True)
 
 
-def _no_agents(monkeypatch: pytest.MonkeyPatch) -> list[tuple[Any, ...]]:
+def _no_agents(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     """Record every agent construction and every architect call."""
-    built: list[tuple[Any, ...]] = []
+    built: list[str] = []
 
     def fake_get_agent(*args: Any, **kwargs: Any) -> Any:
-        built.append(("get_agent", args))
+        built.append("get_agent")
         raise AssertionError("an agent was constructed after a rejected config")
 
     def fake_decompose_spec(*args: Any, **kwargs: Any) -> Any:
-        built.append(("decompose_spec", args))
+        built.append("decompose_spec")
         raise AssertionError("the architect was invoked after a rejected config")
 
     monkeypatch.setattr(cli_mod, "get_agent", fake_get_agent)
     monkeypatch.setattr(cli_mod, "decompose_spec", fake_decompose_spec)
     return built
+
+
+def _class_defs(path: Path) -> list[ast.ClassDef]:
+    """Every class defined in one file.
+
+    A file that will not parse yields none: that is a defect for mypy
+    and ruff to report, not a reason for this test to fail obscurely.
+    ``tests/test_prompt_versions.py``'s walk tolerates it the same way.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+    return [node for node in ast.walk(tree) if isinstance(node, ast.ClassDef)]
+
+
+def _defines_load(node: ast.ClassDef) -> bool:
+    return any(isinstance(child, ast.FunctionDef) and child.name == "load" for child in node.body)
+
+
+def _stub_run_factory(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Stop at the factory boundary, recording whether we got there."""
+    ran: list[str] = []
+
+    def fake_run_factory(*args: Any, **kwargs: Any) -> FactoryResult:
+        ran.append("run_factory")
+        return FactoryResult()
+
+    monkeypatch.setattr(cli_mod, "run_factory", fake_run_factory)
+    return ran
 
 
 class TestTheDecomposePathFailsBeforeTheArchitect:
@@ -160,9 +174,9 @@ class TestTheEnvironmentIsCheckedInTheSamePass:
         """Reproduced against main before the fix: exit 1 with a raw
         ValueError traceback and no error line."""
         monkeypatch.setenv(var, "many")
-        monkeypatch.setattr(cli_mod, "run_factory", lambda *a, **k: FactoryResult())
+        _stub_run_factory(monkeypatch)
 
-        result = _invoke(["factory", "--manifest", "m.json", "--agent-cmd", "true", "--yes"])
+        result = _invoke(FACTORY_ARGS)
 
         assert not isinstance(result.exception, ValueError), result.exception
         assert result.exit_code == 1
@@ -181,50 +195,43 @@ class TestFatalVersusDegrading:
     something else.
     """
 
-    ARGS = ["factory", "--manifest", "m.json", "--agent-cmd", "true", "--yes"]
-
     def test_a_bad_evolution_knob_warns_and_the_run_still_happens(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        ran: list[bool] = []
-        monkeypatch.setattr(
-            cli_mod,
-            "run_factory",
-            lambda *a, **k: (ran.append(True), FactoryResult())[1],
-        )
+        ran = _stub_run_factory(monkeypatch)
 
-        result = _invoke(self.ARGS, toml='[evolution]\nlookback_runs = "many"\n')
+        result = _invoke(FACTORY_ARGS, toml='[evolution]\nlookback_runs = "many"\n')
 
         assert result.exit_code == 0, result.output
-        assert ran == [True]
+        assert ran == ["run_factory"]
         assert "[evolution]" in result.output
         assert "continuing without it" in result.output
 
     def test_evolve_treats_the_same_evolution_knob_as_fatal(self) -> None:
         """Degrading means "the audit trail is dropped from work that is
         about something else". `ks evolve` IS the journal, so the value
-        the preflight warns about has to stop THAT command - with an
-        error line, not the traceback the warning would otherwise be
-        followed by two lines later."""
+        the preflight warns about elsewhere has to stop THAT command -
+        with the same error line, key and value, rather than a warning
+        followed two lines later by the traceback it promised was not
+        coming."""
         result = _invoke(["evolve", "--status"], toml='[evolution]\nlookback_runs = "many"\n')
 
         assert result.exit_code == 1
-        assert "[evolution] configuration is unusable" in result.output
+        assert "error:" in result.output
+        assert "[evolution] lookback_runs = 'many'" in result.output
+        # Promoted at the seam, so the warning it would otherwise have
+        # printed never happens: one report, not two.
+        assert "continuing without it" not in result.output
         assert not isinstance(result.exception, ValueError), result.exception
 
     def test_a_bad_verify_knob_stops_the_run(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        ran: list[bool] = []
-        monkeypatch.setattr(
-            cli_mod,
-            "run_factory",
-            lambda *a, **k: (ran.append(True), FactoryResult())[1],
-        )
+        ran = _stub_run_factory(monkeypatch)
 
-        result = _invoke(self.ARGS, toml='[verify]\nmutation_threshold = "many"\n')
+        result = _invoke(FACTORY_ARGS, toml='[verify]\nmutation_threshold = "many"\n')
 
         assert result.exit_code == 1
         assert ran == []
@@ -267,7 +274,7 @@ class TestWhatItNames:
 
     def test_a_clean_config_raises_nothing(self, tmp_path: Path) -> None:
         """The example config ships as documentation; it has to pass."""
-        example = Path(__file__).resolve().parents[1] / "kstrl.toml.example"
+        example = REPO_ROOT / "kstrl.toml.example"
         (tmp_path / "kstrl.toml").write_text(example.read_text())
 
         warnings: list[str] = []
@@ -281,6 +288,35 @@ class TestTheRootIsTheOneTheCommandWillUse:
     level click has not parsed ``--root`` yet, so a preflight there would
     read the config of whatever directory the operator happened to be
     standing in."""
+
+    def test_the_prompt_option_feature_actually_uses_derives_the_root(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`ks feature` names its prompt option ``--understand-prompt``
+        and feeds THAT to ``_resolve_root``. Reading only ``prompt``
+        made the check validate the cwd while the command loaded another
+        checkout's config, and the failure mode was the worst kind: a
+        preflight that PASSES, which no other test here can catch.
+        """
+        project = tmp_path / "project"
+        (project / "scripts" / "kstrl").mkdir(parents=True)
+        # A section the command body does NOT load early. Malformed TOML
+        # would not distinguish anything: `KstrlConfig.load` is the
+        # command's second statement, so the operator gets a clean error
+        # either way. [linear] is the section #272 was filed about
+        # precisely because nothing reads it until after the agent.
+        (project / "kstrl.toml").write_text('[linear]\ntimeout_seconds = "soon"\n')
+        prompt = project / "scripts" / "kstrl" / "understand_prompt.md"
+        prompt.write_text("# understand\n")
+        built = _no_agents(monkeypatch)
+
+        result = _invoke(["feature", "--understand-prompt", str(prompt), "--agent-cmd", "true"])
+
+        assert built == []
+        assert result.exit_code == 1
+        assert "[linear]" in result.output
 
     def test_a_broken_config_under_root_is_found_from_a_clean_cwd(
         self,
@@ -307,13 +343,13 @@ class TestTheRootIsTheOneTheCommandWillUse:
         command's config must not stop it."""
         clean = tmp_path / "project"
         clean.mkdir()
-        monkeypatch.setattr(cli_mod, "run_factory", lambda *a, **k: FactoryResult())
+        _stub_run_factory(monkeypatch)
 
         runner = CliRunner()
         with runner.isolated_filesystem() as fs:
             root = Path(fs)
             (root / "kstrl.toml").write_text(MALFORMED_TOML)
-            _write_manifest(clean / "m.json")
+            make_manifest([component("comp-a")]).save(clean / "m.json")
             result = runner.invoke(
                 cli,
                 [
@@ -358,6 +394,28 @@ class TestTheCommandsThatMustSurviveABrokenConfig:
         assert result.exit_code == 2
         assert "error" in json.loads(result.stdout)
 
+    def test_sense_checks_sections_it_does_not_itself_read(self) -> None:
+        """`sense` loads four sections of its own. An exemption that
+        checked only those would keep the "depends which section you
+        typo'd" property inside itself, so it runs the whole preflight
+        under its own contract."""
+        result = _invoke(["sense", "--json"], toml='[linear]\ntimeout_seconds = "soon"\n')
+
+        assert result.exit_code == 2
+        assert "[linear]" in json.loads(result.stdout)["error"]
+
+    def test_config_show_reports_a_section_its_own_rows_do_not_cover(self) -> None:
+        """`config_report` renders 15 of the 26 sections. Without this,
+        the tool the seam exempts so an operator can DIAGNOSE a refusal
+        would print rows and exit 0 for the very config that refuses
+        every other command."""
+        result = _invoke(["config", "show"], toml='[queue]\nmax_attempts = "many"\n')
+
+        assert result.exit_code == 1
+        assert "[queue]" in result.output
+        # It still renders what it can before saying so.
+        assert "[agent]" in result.output
+
     def test_help_still_renders_for_a_command_that_is_not_exempt(self) -> None:
         """Reading the help is part of fixing the file. click handles
         ``--help`` while parsing, before ``Command.invoke``, so this is a
@@ -381,6 +439,64 @@ class TestTheCommandsThatMustSurviveABrokenConfig:
         assert "[verify]" in result.output
 
 
+class TestTheExemptionKeysOffTheTopLevelName:
+    """Both seam tables are keyed by the command directly under the root
+    group. Keyed by any name in the chain instead, a later ``ks queue
+    init`` or ``ks inbox serve`` would be exempted purely because of its
+    leaf name, which is not a decision anybody would have made.
+    """
+
+    @staticmethod
+    def _name_for(args: list[str]) -> str:
+        seen: list[str] = []
+
+        def record(self: Any, ctx: click.Context) -> Any:
+            seen.append(cli_mod._KstrlCommand._top_level_name(ctx))
+            return None
+
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(cli_mod._KstrlCommand, "invoke", record)
+            CliRunner().invoke(cli, args, catch_exceptions=True)
+        return seen[0]
+
+    def test_a_top_level_command_names_itself(self) -> None:
+        assert self._name_for(["status"]) == "status"
+
+    def test_a_subcommand_names_its_group(self) -> None:
+        assert self._name_for(["config", "show"]) == "config"
+        assert self._name_for(["queue", "ls"]) == "queue"
+
+
+class TestTheParseScope:
+    """The check resolves 22 sections, and each loader reparses the file.
+    ``toml_parse_scope`` makes that one parse. The property that matters
+    is how far the reuse reaches: inside the block, not beyond it.
+    """
+
+    def test_a_document_is_parsed_once_inside_the_scope(self, tmp_path: Path) -> None:
+        toml_path = tmp_path / "kstrl.toml"
+        toml_path.write_text("[factory]\nmax_parallel = 2\n")
+
+        with toml_parse_scope():
+            first = load_toml_document(toml_path)
+            toml_path.write_text("[factory]\nmax_parallel = 9\n")
+            assert load_toml_document(toml_path) is first
+
+    def test_the_scope_does_not_outlive_its_block(self, tmp_path: Path) -> None:
+        """The half that keeps this honest. A process-wide snapshot
+        would freeze the file for surfaces built to re-read it: the TUI
+        config screen's refresh action, and `ks serve` re-reading per
+        queue item."""
+        toml_path = tmp_path / "kstrl.toml"
+        toml_path.write_text("[factory]\nmax_parallel = 2\n")
+
+        with toml_parse_scope():
+            load_toml_document(toml_path)
+        toml_path.write_text("[factory]\nmax_parallel = 9\n")
+
+        assert load_toml_document(toml_path)["factory"]["max_parallel"] == 9
+
+
 class TestEverySectionIsEnrolled:
     """The registry is only a guarantee while it is complete.
 
@@ -392,20 +508,12 @@ class TestEverySectionIsEnrolled:
 
     @staticmethod
     def _config_classes_with_a_loader() -> set[str]:
-        found: set[str] = set()
-        for path in sorted((Path(__file__).resolve().parents[1] / "kstrl").rglob("*.py")):
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.ClassDef) or not node.name.endswith("Config"):
-                    continue
-                loaders = {
-                    child.name
-                    for child in node.body
-                    if isinstance(child, ast.FunctionDef) and child.name == "load"
-                }
-                if loaders:
-                    found.add(node.name)
-        return found
+        return {
+            node.name
+            for path in sorted((REPO_ROOT / "kstrl").rglob("*.py"))
+            for node in _class_defs(path)
+            if node.name.endswith("Config") and _defines_load(node)
+        }
 
     def test_no_config_dataclass_is_missing_from_the_registry(self) -> None:
         registered = {
@@ -419,7 +527,7 @@ class TestEverySectionIsEnrolled:
         """A section name is what the error line points the operator at,
         so a typo in the registry would name a table that does not
         exist. Every name here appears in the shipped example."""
-        example = (Path(__file__).resolve().parents[1] / "kstrl.toml.example").read_text()
+        example = (REPO_ROOT / "kstrl.toml.example").read_text()
         names = {name for section in config_sections() for name in section.sections}
 
         assert {name for name in names if f"[{name}]" not in example} == set()

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -1299,11 +1299,15 @@ class TestSpecConvergenceThroughDecompose:
     ) -> None:
         """The other ValueError path into EvolutionConfig.load.
 
-        Scoped to the halt path on purpose: a malformed kstrl.toml also
-        fails LinearConfig.load further down decompose, which is
-        pre-existing behaviour this change does not touch. The halt
-        raises before that point, and the halt is the case where the
-        artifact is the only record the operator gets.
+        Scoped to the halt path on purpose, and the reason narrowed when
+        #272 landed. It used to be that a malformed kstrl.toml ALSO
+        failed LinearConfig.load further down decompose, after the
+        architect had been paid for; ``ks decompose`` now rejects the
+        file at command entry and never reaches this function, which
+        ``tests/test_config_preflight.py`` pins. What this still covers
+        is the direct call: ``decompose_spec`` invoked in-process, where
+        the halt raises before the Linear load and the artifact is the
+        only record the operator gets.
         """
         (tmp_path / "kstrl.toml").write_text("[evolution\nenabled = true\n")
 


### PR DESCRIPTION
Fixes #272. The verdict on #192 is at the bottom.

## What was wrong

`kstrl.toml` was parsed lazily, by whichever config dataclass first needed its section, at whatever point in the run that class happened to be constructed. A typo did not fail at startup: it failed at the first loader that reached the bad section. On the decompose path one of those loaders is `LinearConfig.load`, which runs after the architect has been invoked and paid for (119 to 210 seconds against a frontier model, measured on a real spec). Measured on `a8cbe43`, `KSTRL_MUTATION_THRESHOLD=many` and `KSTRL_SECURITY_TIMEOUT=many` both left a raw `ValueError` traceback out of `ks factory`, because `_KstrlGroup.invoke` caught only `BudgetConfigError`.

So the blast radius of a typo depended on which section it was in and which command you ran. This replaces that with one property: every section is resolved once, at command entry, before the command body constructs anything.

## What it looks like now

```
$ KSTRL_SECURITY_TIMEOUT=many ks factory --manifest m.json
error: configuration rejected before anything was started; fix it and run again:
  [security] could not convert string to float: 'many' (set by KSTRL_SECURITY_TIMEOUT=many)

$ ks status          # kstrl.toml has [security] timeout_seconds = "many"
error: configuration rejected before anything was started; fix it and run again:
  [security] could not convert string to float: 'many' (kstrl.toml has [security] timeout_seconds = 'many')

$ ks status          # kstrl.toml has a syntax error
error: Invalid TOML in /path/kstrl.toml: Expected ']' at the end of a table declaration (at line 1, column 8)
```

All three exit 1.

## The four design questions

### 1. Where exactly is "entry"?

`_KstrlCommand.invoke`, a `click.Command` subclass installed on every command through `_KstrlGroup.command_class` (and `group_class = type`, so subgroups inherit it). `_KstrlGroup.invoke` catches the error it raises, next to `BudgetConfigError`.

**Rejected: running the check in `_KstrlGroup.invoke`.** At group level click has parsed the group's own arguments but not the subcommand's, so `--root` is not known yet. A preflight there would validate the config of whatever directory the operator happened to be standing in, which is wrong for every `ks <cmd> --root elsewhere`. `Command.invoke` runs after the subcommand's parameters are parsed and before its callback: the first moment both facts hold, the right root and "nothing has been built or paid for yet". Three tests pin that, including the one that caught a real defect in my own first version (see the review section).

**Rejected: adding the call to each command body.** That is the guarantee `_KstrlGroup` was created to stop relying on. Its own docstring records what happened last time: `BudgetConfigError` was caught per command, `factory` forgot, and it exited 1 with an empty stdout and a raw traceback.

**Rejected: validating only the sections a command uses.** That preserves the property the issue objects to, that the blast radius depends on the command. A factory run reaches most sections anyway, so the uniform rule costs almost nothing and is one sentence instead of a table.

Four commands are exempt from the **seam**, and none from the **check**:

| Command | Why exempt | What it does instead |
|---|---|---|
| `ks init` | Writes a `kstrl.toml`, including over a broken one. Refusing to run it removes the tool the operator recovers with. | Nothing. It is the recovery path. |
| `ks config show` | Exists to explain a broken config. | Prints its resolved rows, then reports the preflight verdict and exits 1. |
| `ks sense` | A documented machine contract the seam would destroy: exit **2** and a JSON error document on stdout for `--json`. | Calls `preflight_config` itself, inside its existing try. |
| `ks serve` | The same documented exit 2. | Calls `preflight_config` itself. |

`ks serve` is where the exemption would have cost the most. It spawns `ks factory` children and classifies each child's exit code; every child would fail its own preflight, so one typo in `[verify]` would have poisoned queue items one after another until the breaker tripped, and the operator would be reading poison reports instead of a parse error.

Both seam tables (`_PREFLIGHT_EXEMPT`, and `_PREFLIGHT_REQUIRED` from question 3) key off the **top-level** command name rather than any name in the chain, so a later `ks queue init` or `ks inbox serve` cannot be exempted by accident. Tested.

Also not covered, and stated rather than hidden: the bare `ks` home shell (a TUI, which has its own config screen) and any in-process library use of `run_factory`.

### 2. What do the per-section loaders become?

They stay exactly as they are. That is a deliberate departure from the implementation the issue sketched ("the per-section loaders then read from the already-parsed document"): the mandated `from_env()` plus `load(root_dir)` convention is untouched, and `kstrl/config_preflight.py` is a **caller** of it, not a replacement.

That is the load-bearing choice, not a shortcut. The preflight calls each dataclass's own `load(root_dir)`, which is the same code the run uses later, so the check cannot drift from what is actually enforced. A separate schema would be a second description of the same knobs, and this codebase has already recorded that failure twice: `config.reconcile_progress_config` exists because two independently loaded config domains drifted, and its docstring records the second-order bug where the strings compared equal while the runtime paths did not.

The registry naming the 22 sections and their loaders lives in `config_sections()`, and it is now the only one: `config_report._phase_sections()` takes its loaders from it instead of keeping a second copy of the table. `tests/test_config_preflight.py` AST-walks `kstrl/` for classes ending in `Config` that define a `load` and fails if one is not enrolled, mirroring how `tests/test_prompt_versions.py` stops a new `*_PROMPT` going unversioned. A section added later cannot quietly reintroduce the lazy parse.

Two loaders did change. `KnowledgeConfig.load` had a private copy of open-and-decode-TOML with its own error message, and now reads through the shared `load_toml_section`. `EvolutionConfig.load_or_none` now also catches `TypeError`, because its exception list and the preflight's would otherwise degrade past the same value at startup and raise on it mid-run.

### 3. Which failures are fatal and which degrade?

| Section | Verdict |
|---|---|
| `[evolution]` | **Degrades.** Warns and continues. |
| `[agent]` `[run]` `[paths]` `[git]` `[ui]` `[factory]` `[verify]` `[security]` `[contract]` `[adequacy]` `[policy]` `[autonomy]` `[divergence]` `[breaker]` `[sandbox]` `[timeout]` `[feedforward]` `[knowledge]` `[fixtures]` `[queue]` `[inbox]` `[intake_github]` `[serve]` `[notify]` `[linear]` | **Fatal.** |

The line is not about likelihood, it is about what continuing would mean. The evolution journal is an optional audit trail: losing it degrades the record and nothing else, which is why four mid-run call sites already degrade through `EvolutionConfig.load_or_none`. This makes the same call earlier and louder, so the warning arrives at startup instead of in the middle of paid work.

Every other section configures a gate, a budget, a boundary or a destination. Substituting a default for a verify command, a security threshold, a policy envelope or a cost ceiling the operator configured is a semantic substitution: the run proceeds, reports success, and was measured by something other than what was asked for. CLAUDE.md names that failure directly.

The one I will defend hardest is `[notify]`, which looks optional and is not: degrading it means notifications the operator configured are silently off, and the whole point of a notification is that its absence is indistinguishable from "nothing happened".

The classification also has an edge, and it needed a mechanism rather than a special case. `ks evolve` **is** the journal command, so the section that degrades everywhere else is that command's subject, and warning-then-continuing there is a promise the next two lines break. `_PREFLIGHT_REQUIRED` lets a command declare the sections it is about, and the seam promotes those to fatal for it: one report carrying the key and the value, instead of a warning followed by a traceback, and no remembered `try/except` in the command body.

### 4. Does env-var coercion belong in the same pass?

Yes, and it is the reason for the design in question 2. Both failures measured on main are env vars, not TOML, so a file-only preflight would have caught neither. Because the check calls `load(root_dir)`, which overlays env on top of TOML, the same `float()` that would have raised mid-run raises here instead. There is no separate env pass to keep in sync.

Naming which input to change is done by measurement, not by pattern matching:

- **Env**: `_blamed_env_var` reports a variable only when removing it demonstrably makes the load succeed. An empty environment is tried once first, so a fault in the file ends the search immediately instead of sweeping every variable. Two wrong inputs at once name nothing, and a value is echoed only where the loader's own message already quotes it.
- **TOML**: Python's coercion errors quote the offending value (`could not convert string to float: 'many'`), so a key in that section whose value reprs into the message is reported, and only when exactly one key matches. A test pins the ambiguous case staying silent rather than guessing.

Mutating `os.environ` is process-wide, so this runs only on the error path at command entry, where the command body has not started and no thread of ours is alive. That is the constraint `config_report.scrubbed_environ`, reused here, already documents.

## Measured cost

The check runs on every command, so I measured it rather than assuming it is free (best of 30 in-process; median of 9 subprocess runs for `ks status`):

| Situation | Preflight | `ks status`, end to end |
|---|---|---|
| No `kstrl.toml` | 0.13 ms | 157.7 ms |
| The shipped 21 KB `kstrl.toml.example` | 0.60 ms | 159.9 ms |

The first version of this cost 9.4 ms on the 21 KB file, because 22 loaders each reparsed it. `config.toml_parse_scope` reuses the parsed document for the duration of the check. It is scoped to that block and never process-wide, because two surfaces exist to see the file change: the TUI config screen's refresh action, and `ks serve` re-reading per queue item. Both halves of the scoping are tested.

Importing the config modules `kstrl.cli` does not already pull in (evolution, intake_github with workqueue, serve) costs about 7 ms warm.

## Verdict on #192

**It leaves #192 open.** Checked rather than assumed, against that issue's own acceptance list:

| #192 acceptance | Status after this PR |
|---|---|
| One parse of `kstrl.toml` per process | **No.** One parse per *check* (that is what `toml_parse_scope` buys), but the command body then loads what it needs again. |
| A mid-run edit has no effect on the running factory | **No.** `pipeline.py:1973-1976` still re-loads `PolicyConfig`, `AdequacyConfig` and `AutonomyConfig` per component, from disk. |
| The policy hash provably matches the enforced envelope for the whole run | **No.** Unchanged by this PR. |

"One parse at entry" answers #272 but not #192, because the two want different things: #272 wants the whole surface *validated* before anything is spent, and #192 wants it *frozen* for the duration of a run. Validation can be done by calling the loaders; freezing cannot.

What this PR does contribute is the enumeration #192 was missing. `config_sections()` is the single list of every section and its loader, which is what an `AppConfig` would be composed from, and it is kept complete by a test rather than by memory. `config.toml_parse_scope` is also the mechanism that freeze needs, already written and already tested, waiting only for someone to decide its scope.

And one measured warning for whoever takes #192, because the obvious move is the wrong one. The cheap way to get "one parse per process" is a process-wide snapshot of the parsed document. I rejected it: `kstrl/tui/screens/config.py:205` has a refresh action that exists to re-read the config on demand, and `ks serve` is a long-lived daemon that re-loads config per queue item (`serve.py:1236`, `:1684`, `:1893`). A process-wide freeze breaks both. The snapshot #192 needs is scoped to one factory run, and that scoping decision has not been made yet.

## Definition of done

- `uv run pytest tests/ -q`: 3948 passed, 28 skipped. (One flake seen once and diagnosed, not mine: `test_pool_worker_sigterm_kills_agent_group` greps machine-wide for `sleep 60` and found one belonging to a sibling agent's pytest run in another worktree. It passes on its own.)
- `uv run mypy kstrl/ --strict`: clean, 120 source files.
- `uv run ruff check kstrl/ tests/`: clean.
- `pre-commit run --all-files`: every hook passed, tree unchanged.
- Coverage: local combined total 89.16%, `kstrl/config_preflight.py` at 97.87%, against the 79.91% ratchet.
- `uv run python scripts/gen_docs.py --check`: README generated sections current.
- No `*_PROMPT` constant is touched, so no H2/H3 calibration is implicated.

### Tests

`tests/test_config_preflight.py`, 26 cases:

- Malformed TOML and a bad `[linear]` value each stop `ks decompose` with **no agent constructed and no architect call** (`get_agent` and `decompose_spec` are both replaced with recorders that fail loudly if reached).
- Each of the two measured env-var cases produces an `error:` line rather than a `ValueError`, and names the variable.
- Both sides of the classification: a bad `[evolution]` knob warns and the run still happens; a bad `[verify]` knob stops it and `run_factory` is never called. Plus the edge, `ks evolve` treating that same `[evolution]` value as fatal, with one report rather than two.
- The `--root` seam in both directions, and the `--understand-prompt` case that a defect in my first version failed silently.
- The four exempt commands keep their own contracts: `sense`'s exit 2 with its JSON envelope (including for a section `sense` does not itself read), `serve` rejecting a broken `[verify]` under its own exit 2, `config show` reporting a `[queue]` fault its own rows cannot render, and `init` still scaffolding next to a file it cannot parse.
- `--help` still renders for a non-exempt command with a broken config, which is a property of where the check sits: click handles eager options while parsing, before `Command.invoke`.
- The parse scope reuses inside the block and does not outlive it.
- The registry is complete (AST walk) and every section it names is a real table in the shipped example, which itself passes the preflight with no warnings.
- The seam tables key off the top-level command name.

The issue's test note is also settled. `tests/test_decompose.py::test_malformed_toml_does_not_cost_the_audit_artifact_either` was deliberately scoped to the halt path because a malformed `kstrl.toml` also failed `LinearConfig.load` further down decompose. Its docstring now records that `ks decompose` rejects the file at entry and never reaches that function, and that what the test still covers is the direct in-process call.

## The `/simplify` pass

Four cleanup agents (reuse, simplification, efficiency, altitude) over the first two commits. Their findings are pasted verbatim below, in collapsed blocks. What I did with them, first:

| Finding | Applied? |
|---|---|
| `_preflight_root` misses `understand_prompt`, so `ks feature --understand-prompt <other checkout>` validates the cwd and passes silently (altitude 2, simplification 4) | **Applied.** This was a real defect in my change, and the worst kind: a preflight that passes. Fixed, with a test that fails without the fix. |
| The `sense` exemption is justified by a check `sense` does not perform: 4 of 22 sections (reuse 4, simplification 5, altitude 3) | **Applied.** `sense` now calls `preflight_config` inside its existing try, so it keeps exit 2 and the JSON envelope and the claim becomes true. |
| `ks config show` reports "all fine" for a config that stops every other command, for the 11 sections `config_report` does not cover (altitude 1, reuse 2) | **Applied**, as far as it goes without a feature change: `config show` renders its rows and then reports the preflight verdict, so it can no longer disagree with the seam. Rendering rows for the other 11 sections is a separate change (see declined). |
| The `evolve` guard is a fourth expression of the evolution policy and renders worse than the preflight (altitude 5, reuse 3) | **Applied.** The guard is gone. `_PREFLIGHT_REQUIRED` lets a command declare the sections it is about, and the seam promotes them: one report, with the key and the value. |
| 23 parses of one file per check; a call-scoped cache measured at 9.40 ms to 0.578 ms (efficiency 1) | **Applied.** `config.toml_parse_scope`, scoped to the check and never process-wide. Re-measured here: 9.4 ms to 0.6 ms, `ks status` 159.9 ms to 157.7 ms. |
| `_blamed_env_var` re-runs a loader once per environment variable: 34.3 ms per failing section for a file fault (efficiency 2) | **Applied.** The empty environment is tried once first, and a loader that still fails there ends the search. |
| The import-cost measurement in my docstring was wrong: 4 modules and about 7 ms, not 20 modules and under 5 ms (efficiency 3) | **Applied.** My probe imported `serve` on a separate line and then excluded it. Docstring and this PR body corrected. |
| Two section registries: `config_sections()` and `config_report._phase_sections()` (reuse 1 and 2, simplification 1, altitude 1) | **Applied for the in-package pair.** `_phase_sections()` now takes its loaders from `config_sections()` and keeps only its knob lists. |
| `EvolutionConfig.load_or_none` catches `(ValueError, OSError)` while the preflight catches `(ValueError, TypeError, RuntimeError)`, so they disagree (reuse 3, altitude 4) | **Applied.** `load_or_none` now catches `TypeError` too, with the reason recorded next to it. |
| The exemption matches a name anywhere in the chain, so a later `ks queue init` would be exempt by accident (simplification 5, altitude 3) | **Applied.** Both seam tables key off the top-level command name. Tested. |
| The registry's intermediate `fatal` list is a second representation of the same table (simplification 2) | **Applied.** `fatal: bool = True` on the dataclass and one literal list. |
| `_detail` recomputes `resolve_config_file` per failing section (simplification 8) | **Applied.** Passed down. |
| Import the private `config._load_toml` across a module boundary (reuse 10) | **Applied.** Renamed to a public `load_toml_document`. |
| Test hygiene: `spine_utils.make_manifest`/`component`, `conftest.REPO_ROOT`, the `(ran.append(True), ...)[1]` lambda trick, `FACTORY_ARGS` written twice, the `{"load"}` set comprehension, unused payloads in `_no_agents`, no `SyntaxError` tolerance in the AST walk (reuse 6 and 8, simplification 9 to 13) | **Applied,** all of them. |
| `f"set by {name}={saved}"` prints an environment value with nothing deciding it may (altitude 6, minor) | **Applied.** The value is echoed only where the loader's message already quotes it. |
| Fold `scripts/gen_docs.py::_section_specs()` into the same registry (reuse 1) | **Declined, for this PR.** It is a third consumer with its own `keys`/`defaults`/`title` per section and its own `--check` gate in CI. The in-package duplication is the one that made `ks config show` wrong; this one is a script whose own test already asserts a stronger bidirectional match against `kstrl.toml.example`. Worth a follow-up, not worth widening this diff. |
| Render `ks config show` rows for all 26 sections (reuse 2, altitude 1) | **Declined.** That is a feature change to a reporting surface with snapshot tests, not a fix for #272. What #272 required was that the tool cannot contradict the seam, and it no longer can. |
| Replace the blame helpers with a typed error raised at each coercion, carrying `(section, key, value, source)` (altitude 6) | **Declined, deliberately.** This is the right end state and it is the 20-module sweep I sized out before starting: coercion is scattered across `workqueue`, `policy`, `observability`, `autonomy_replay`, `knowledge`, `security`, `linear` and inline `int()`/`float()` in the loaders. The parent's brief said to stop rather than sprawl past roughly six modules. The interim is documented in the helpers themselves. |
| Drop the `BudgetConfigError` re-raise (simplification 7) | **Declined.** It changes the preamble, and "configuration rejected before anything was started" is wrong for a budget value that parses fine and cannot bound anything. That error has its own message for that reason. |
| `ConfigSection.label` is a property with one caller (simplification 6) | **Declined.** One line, named, and it keeps the rendering rule next to the `sections` tuple it derives from. |
| `kstrl/tui/screens/evolve.py:178` calls `EvolutionConfig.load` unguarded, reachable from the home shell (altitude 5) | **Declined as out of scope,** and recorded here instead. It is pre-existing, unchanged by this PR, and on the one path that never reaches the seam (the bare `ks` TUI). Worth its own issue. |
| Thread the preflight's already-built config objects through to the command body (reuse 9, efficiency, "checked and clean") | **Declined,** and the efficiency agent agreed after measuring: with the parse cached the second build is sub-0.05 ms of coercion, so it buys coupling rather than time. |

### One correction to the reviews

Reuse finding 9 and efficiency's "checked and clean" both say `serve` loads `ServeConfig` twice and that `preflight_config` runs once per process. Both are true of the version they read; `serve` still loads it twice, deliberately, because the preflight discards what it builds and returning 22 objects to every caller is the coupling the efficiency agent measured as not worth buying (sub-0.05 ms with the parse cached).

The four agents' full reports are pasted verbatim in a comment on this PR (together with the rest of this write-up they exceed the body size limit). Em dashes in them are normalized to hyphens per this repo's house style; nothing else is edited.


---

# Round 2: nine review findings

An independent review of this PR found nine issues, every one reproduced against the built CLI. Findings 1 and 2 together meant the original #272 defect was still reachable. All nine are fixed; I pushed back on none, because all nine reproduced.

## What was wrong, and what it is now

**1. The root resolver failed both ways (MEDIUM/HIGH).** `_preflight_root` read `PROMPT_FILE` and `PRD_FILE` for every command, while only `run`, `understand` and `feature` derive a root that way. With one stale export:

```
$ PROMPT_FILE=../other/scripts/kstrl/prompt.md ks status     # other/ has a broken kstrl.toml
error: Invalid TOML in .../other/kstrl.toml ...              # refused on an unrelated checkout

$ PROMPT_FILE=../other/scripts/kstrl/prompt.md ks status     # THIS project's [verify] is broken
ERROR: No manifest found ...                                 # passed. Nothing shows it.
```

The second is the mode my own docstring called "worse, because nothing shows it", and it also reached `ks evolve`, whose guard this seam had replaced, so the raw `ValueError` traceback #272 exists to remove was back. Both now behave, and `ks evolve` reports both problems at once.

The rule is now keyed by command (`_ROOT_FROM_PROMPT`), not by "declares the option". The cleanup pass showed those are not the same rule: `ks config show` declares `--prompt` and `--prd` as `[paths]` overrides and still roots itself at the cwd, so the proxy already pointed one command at another checkout, harmless only because `config` happens to be exempt. A test now fails on any new command that declares one of those options without a decision being recorded.

**2. The home shell was a fifth exemption (MEDIUM).** Bare `ks` on a TTY runs the group callback, and a group callback is not a `_KstrlCommand`, so the seam never fired. The TUI launches runs in-process (`tui/session.py` calls `run_factory` and `decompose_spec` directly), so a bad `[linear]` value paid for the architect and then aborted: the original defect, on the path a user reaches by typing `ks`. The callback now preflights before the shell opens, and two new drift guards stop the class recurring: every leaf command must be a `_KstrlCommand`, and no group but the root may run without a subcommand.

**3. The diagnosis tool was the least informative surface (MEDIUM).** `build_config_report` raised before a single row printed, so `ks config show` said `error: could not convert string to float: 'many'` while every other command named the section, the key and the value. A rejected section now costs its rows, not the report; the command prints every row it can resolve and then names each rejected section in the seam's words. The covering test now uses `[verify]`, one of the 15 sections the report renders, which is the case the earlier `[queue]` test missed.

**4. Universal fatality (MEDIUM, design).** Kept, with the escape hatch made real rather than added. Finding 3's fix is what makes it defensible: one command always runs and always explains.

```
$ KSTRL_LINEAR_ENABLED=1 ks status
error: configuration rejected before anything was started; fix it and run again:
  [linear] LinearConfig.enabled requires team_id ... (set by KSTRL_LINEAR_ENABLED)

$ KSTRL_LINEAR_ENABLED=1 ks config show
[agent]
  type = None  (default)
  ... every row that resolved ...
# Rejected sections (every other command refuses while these stand)
  [linear] LinearConfig.enabled requires team_id (the Linear team UUID); set [linear] team_id or KSTRL_LINEAR_TEAM_ID (set by KSTRL_LINEAR_ENABLED)
```

The two alternatives the reviewer offered are rejected on the record. **Scoping fatality per command** needs a second description of which command reads which section; it drifts, and it drifts invisibly, because the failure is a check that passes. It also gets the tense wrong: a command that only reads state today spends money tomorrow. **A skip flag** is reachable from a shell alias and from CI, so the property would be off exactly where nobody is watching, and it does not help the operator who does not know it exists. The way out of a bad config should be a command that explains it, not a way to run unchecked.

I will name the limit rather than leave it implied: `ks config show` always runs and always explains, and it prints rows whenever the base config resolves. When `[run]` itself is bad, or the document will not parse, there are no rows to print, and it says so in the same words:

```
error: [agent]/[run]/[paths]/[git]/[ui] invalid literal for int() with base 10: 'many' (kstrl.toml has [run] max_iterations = 'many')
```

**5. The blame was not unique (LOW/MEDIUM).** With `[linear] team_id = "abc"` plus `KSTRL_LINEAR_ENABLED=1` and an empty `KSTRL_LINEAR_TEAM_ID`, removing either fixed the load, so the tool blamed ENABLED while the message beside it said to set TEAM_ID. The sweep now reports only a unique culprit, and stops at the second one rather than finishing to discard the answer.

**6. One bad ceiling hid every other problem (LOW).** `except BudgetConfigError: raise` abandoned the traversal at `[factory]`, which is second. Collected like any other problem now, so a bad ceiling and a bad `[verify]` are reported together. `_KstrlGroup.invoke` still renders `BudgetConfigError` for the paths that raise it outside the check, such as `--max-cost-usd`.

**7. A documented exit code was wrong on one path (LOW).** `serve --print-plist` returned before the check and exited 1 rather than the documented 2. Fixed at a better depth than the report asked for: `_PREFLIGHT_EXIT` gives `serve` its exit 2 from the seam, so the ordering is structural and the next early return cannot get in front of it. `serve`'s exemption and its body call are both gone.

**8. The environment sweep ran on the success path (LOW).** True: `_detail` is called for degrading sections too. The docstring said "only on the error path" and now says what it does. The property that matters is unchanged: it runs before the command body, where nothing has been built and no thread of ours is alive.

**9. A widened guard that can hide defects (LOW).** `load_or_none`'s `TypeError` catch now records what it costs: a `TypeError` from a defect inside `load` reads as "config unreadable, skipping journal" rather than surfacing. It cannot be narrowed without inspecting the message, which would be guessing, so the docstring says to treat a "skipping journal" warning on a config that looks correct as a bug report about that method.

**The false claim in my own docs.** Finding 7 also noted that "none skip the check" was plainly false for `ks init`. Corrected in the CHANGELOG, `docs/env-vars.md` and the seam comment: `ks init` skips the check (it writes the file); `config show`, `sense` and `serve` skip only the seam.

## Tests

`tests/test_config_preflight.py` is now 42 cases. New in this round: both halves of finding 1 plus the positive case that `run` still reads `PROMPT_FILE`; the home shell refusing before it opens and still opening on a good config; `config show` rendering rows and naming a rejected rendered section, explaining when every other command refuses, and reporting a base-section failure in the seam's words; two variables that each fix it blaming neither, and one that does still being named; a rejected ceiling not hiding a later section; `serve --print-plist` keeping exit 2; and the three drift guards.

## Measured after the round

| | Before this round | After |
|---|---|---|
| `build_config_report`, 21 KB config | 13.34 ms, 32 parses | 0.82 ms, 1 parse |
| Empty-environment gate saving, 83 vars | claimed 34.3 ms | 0.54 ms against 0.84 |
| Empty-environment gate saving, 303 vars | not measured | 0.95 ms against 2.09 |

The 34.3 ms was my own number and it was stale by 40x: it predated `toml_parse_scope` covering the blame helpers. I caught the correction only because I re-measured rather than trusting the review, and my first re-measurement was itself wrong (it appended a second `[verify]` table, so the document was malformed and nothing could be cached). The gate stays because the saving is linear in the size of the environment, and CI environments are the big ones.

## The round-2 `/simplify` pass

Four agents again, over the nine fixes. Applied: the parse scope on `build_config_report` (efficiency 1); the command-keyed root rule and the three drift guards (altitude 1 to 3); `_PREFLIGHT_EXIT` replacing `serve`'s body call (altitude 6); importing `REJECTIONS` instead of restating it (reuse 2, altitude 4); the corrected 34.3 ms claim (efficiency 4); the early-return uniqueness sweep, the derived `unresolved`, the single rejected-section renderer, the flatter `_preflight_root`, the TTY patch replacing a stream subclass, and the TUI notification pointing at the command that has the reasons (simplification 1 to 5, reuse 4).

Declined: threading the preflight's built configs through to command bodies (measured at under 0.05 ms of coercion, so it buys coupling); putting the problem strings on `ConfigReport` so the TUI renders them (it moves a deliberately click-free module onto the preflight's warn contract, for 0.6 ms and a nicer notification); folding `scripts/gen_docs.py`'s registry in (a third consumer with its own `--check` gate, and its own test already asserts a stronger bidirectional match); dropping `test_one_variable_that_fixes_it_is_still_named` as redundant (it pins the positive half of the uniqueness rule beside the negative half, at a different level from the CLI test); and rewriting the exemption prose in three places to one (the CLI comment is authoritative and the docs now state the observable contract).

### What I did not take, and why

- **Reuse 1 and simplification 2 disagreed about `_config_failure_detail`.** Reuse wanted it deleted in favour of letting the seam raise; simplification wanted one shared renderer. I took simplification's, because `config show` must print its rows before it reports, and letting the seam raise would abandon the rows. The helper is gone either way.
- **Reuse 3 (serve should warn through `ui_impl`)** is moot: altitude 6's fix removes serve's body call entirely, so the warning now comes from the seam like every other command's.
- **Altitude 1's full fix (one `_command_root` read by every body)** is a 19-site refactor. I took the half that closes the hazard: the rule is keyed by command, and a test fails when a new command declares one of those options. The remaining divergence (bodies gate on `ParameterSource.COMMANDLINE`, the seam on truthiness) is inert while none of those options has a default, and is recorded here rather than fixed.
- **Altitude 3's full fix (an AST walk over `cli.py` callbacks)** became two structural tests over the live command tree instead, which is stronger: it inspects what click actually built rather than what the source looks like.
- **Altitude 5 (`problems` on `ConfigReport`)** is declined for this round. It moves a deliberately click-free reporting module onto the preflight's `warn` contract to save 0.6 ms and improve one TUI notification; the notification now points at the command that has the reasons instead.
