### PR TITLE
fix(meter): namespace role rows out of the LLM-chosen component keyspace

### DIFF
--- a/kstrl/agents/base.py
+++ b/kstrl/agents/base.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, Protocol
 
+from kstrl.names import role_component_key
+
 if TYPE_CHECKING:
     from kstrl.ui.base import UI
 
@@ -421,14 +423,34 @@ def usage_coverage(
     )
 
 
-#: The architect's role name, which is also its pseudo-component id
-#: (``decompose.ARCHITECT_COMPONENT`` aliases this). Stated HERE because
-#: the ordering tuple below has to agree with it and cannot import
-#: ``decompose`` - the dependency runs the other way. The same reasoning
-#: as ``CEILING_AXES`` above: a name re-derived locally is a name two
-#: surfaces can disagree about, and here the disagreement would be
-#: silent, dropping the architect to the tail of the rollup.
+#: The architect's role name: its PHASE key in the meter, the word the
+#: coverage footer prints, and the label ``RunSpend.unmetered_phases``
+#: hands the operator. Stated HERE because the ordering tuple below has
+#: to agree with it and cannot import ``decompose`` - the dependency runs
+#: the other way. The same reasoning as ``CEILING_AXES`` above: a name
+#: re-derived locally is a name two surfaces can disagree about, and here
+#: the disagreement would be silent, dropping the architect to the tail
+#: of the rollup.
+#:
+#: Phase keys are kstrl's own vocabulary on both sides of the mapping, so
+#: this one is deliberately left bare. The COMPONENT axis is the one an
+#: LLM also writes to, and that is what ``ARCHITECT_COMPONENT`` below
+#: namespaces (#281).
 ARCHITECT_ROLE: Final = "architect"
+
+#: The architect's pseudo-component id: the key it occupies in the usage
+#: meter, in ``ComponentUsage`` events, in the reducer's component table,
+#: in the evolution journal and in ``serve.read_run_spend``.
+#:
+#: It is NOT ``ARCHITECT_ROLE``. It was, until #281: the architect is a
+#: one-role pseudo-component, so using one word for both read as an
+#: economy. It was in fact a collision, because component ids are chosen
+#: by the architect LLM and a component genuinely named `architect` is
+#: an ordinary thing to ask for. ``role_component_key`` puts kstrl's own
+#: rows in a namespace no component id can reach, which fixes every
+#: role row that exists and every one added later, rather than this one
+#: name.
+ARCHITECT_COMPONENT: Final = role_component_key(ARCHITECT_ROLE)
 
 # Rollup row order for the R3.1 usage table, in the order the roles run:
 # the architect decomposes the spec before any component's engineer loop

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -29,7 +29,13 @@ from kstrl.agents import (
     CodexAgent,
     get_agent,
 )
-from kstrl.agents.base import Agent, UsageTotals, collect_usage, usage_cursor
+from kstrl.agents.base import (
+    ARCHITECT_COMPONENT,
+    Agent,
+    UsageTotals,
+    collect_usage,
+    usage_cursor,
+)
 from kstrl.agents.liveness import CLAUDE_FAMILY, PROBE_ENV_VAR, probe_family
 from kstrl.agents.logging import LoggingAgent
 from kstrl.breaker import BreakerConfig
@@ -2056,7 +2062,7 @@ def decompose(
                 ui=core_ui,
                 root_dir=root_dir,
                 bus=command_run.bus,
-                transcript=command_run.transcript_writer("architect"),
+                transcript=command_run.transcript_writer(ARCHITECT_COMPONENT),
             )
             core_ui.ok(f"Decomposed into {len(manifest.components)} components")
             return 0
@@ -2098,7 +2104,7 @@ def decompose(
                 embed_ctx.ui,
                 root_dir,
                 "decompose",
-                component="architect",
+                component=ARCHITECT_COMPONENT,
                 run_id=embed_ctx.run_id,
             )
             try:
@@ -2122,7 +2128,7 @@ def decompose(
         ui_impl,
         root_dir,
         "decompose",
-        component="architect",
+        component=ARCHITECT_COMPONENT,
     )
     try:
         code = _decompose_core(ui_impl, command_run)

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from kstrl.agents.base import (
+    ARCHITECT_COMPONENT,
     ARCHITECT_ROLE,
     Agent,
     collect_usage,
@@ -1168,13 +1169,6 @@ def _generate_component_prd(
     return prd_path
 
 
-#: The architect is a one-role pseudo-component, so its component id and
-#: its role name are deliberately the same string. Aliased rather than
-#: restated so a rename cannot move one without the other and silently
-#: drop the architect to the tail of the usage rollup.
-ARCHITECT_COMPONENT = ARCHITECT_ROLE
-
-
 def _report_architect_usage(
     agent: Agent,
     ui: UI,
@@ -1195,11 +1189,16 @@ def _report_architect_usage(
 
     The component id is the pseudo-component ``_decompose_spec_impl``
     already announced in the plan, so the event lands on an existing row
-    rather than conjuring one. The PHASE key is that same word because a
-    meter's phase key is the ROLE name - it is what the coverage footer
-    prints - and the taxonomy's fifth role is the architect. It is
-    deliberately not ``decompose``/``audit``, the lifecycle phases this
-    component reports elsewhere, which name steps rather than roles.
+    rather than conjuring one. The PHASE key is the bare role name
+    because a meter's phase key is the ROLE - it is what the coverage
+    footer prints - and the taxonomy's fifth role is the architect. It
+    is deliberately not ``decompose``/``audit``, the lifecycle phases
+    this component reports elsewhere, which name steps rather than roles.
+
+    The two keys are no longer the same string (#281): the phase axis is
+    kstrl's vocabulary on both sides, but the component axis is one the
+    architect LLM also writes to, so ``ARCHITECT_COMPONENT`` carries the
+    role namespace and ``ARCHITECT_ROLE`` stays bare.
 
     Called from a ``finally``, so it must not raise: ``collect_usage``
     already swallows a malformed record set, and zero calls (an agent

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -455,6 +455,15 @@ def _role_usage_entries(
     pseudo-component that spends before any component exists and never
     appears in a manifest.
 
+    "Never" became structural in #281. This split is a set difference
+    against the manifest's ids, so while role keys were bare words a
+    component genuinely named `architect` swallowed the role row: the
+    difference was empty, the spend was attributed to the component's
+    ``usage`` field, and no ``role_usage`` row was written at all.
+    ``names.role_component_key`` puts role keys where no component id can
+    be spelled, so the two sets are now disjoint by construction rather
+    than by what the architect happened to name things.
+
     A distinct ``event_type`` rather than a synthetic
     ``component_result``, because every field that row carries - status,
     retries, findings, failed_phase - is meaningless for something that

--- a/kstrl/names.py
+++ b/kstrl/names.py
@@ -15,6 +15,7 @@ typecheck is ``mypy --strict``, which implies ``--no-implicit-reexport``, so
 from __future__ import annotations
 
 import re
+from typing import Final
 
 # R0.6 input hygiene: component ids and branch names are LLM-emitted
 # (architect output) and flow into filesystem paths
@@ -24,6 +25,56 @@ import re
 # deliberate - silent sanitizing would hide architect drift.
 COMPONENT_ID_PATTERN = r"^[a-z0-9][a-z0-9._-]{0,63}$"
 _COMPONENT_ID_RE = re.compile(COMPONENT_ID_PATTERN)
+
+# #281: kstrl's own ROLE rows are written into surfaces that are
+# otherwise keyed by an LLM-emitted component id - the usage meter, the
+# run's event stream, the reducer's component table, the evolution
+# journal, and serve's spend ledger. While a role key was a bare word
+# ("architect") it shared that keyspace, so a spec that led the
+# architect to emit a component genuinely called `architect` merged the
+# two rows: the component's engineer/review/security/distill spend
+# folded into the role's, and - worse - `RunSpend.architect_calls` went
+# non-zero for a run whose architect may never have reported, clearing
+# `unmetered_phases` and letting the daemon call a day's total exact on
+# no evidence.
+#
+# The prefix removes the CLASS rather than one name: it namespaces every
+# role row, including ones added later. It lives beside
+# COMPONENT_ID_PATTERN because that is what makes it safe - the pattern
+# anchors the first character to [a-z0-9], and '@' is outside the
+# charset besides, so no valid component id can ever be spelled this
+# way. That is a property of two constants in one file, and
+# tests/test_input_hygiene.py pins them together, so loosening the
+# pattern fails a test instead of silently re-merging the meter.
+#
+# '@' rather than a punctuation mark that reads more like prose,
+# because a role key is not only a dict key: `ks decompose` opens the
+# architect's transcript at
+# .kstrl/runs/<run>/components/<key>/engineer.log, so the prefix becomes
+# a PATH SEGMENT. '@' is unremarkable in a path on every filesystem
+# kstrl targets and needs no quoting in a shell; ':' is neither.
+# validate_branch_name rejects '@' too, so a role key that ever reached
+# a git ref would be a loud rejection rather than a silent bad ref.
+ROLE_KEY_PREFIX: Final = "@"
+
+
+def role_component_key(role: str) -> str:
+    """The component-table key for a kstrl ROLE rather than a component.
+
+    Roles are kstrl's own vocabulary; component ids are the architect
+    LLM's. Both are written to the same keyed surfaces, so the role side
+    is namespaced and the component side is left exactly as the operator
+    and the architect wrote it (#281). No compatibility break falls on
+    manifests: nothing a manifest carries changes.
+
+    ``role`` is the bare role name and stays bare wherever it is a PHASE
+    key or an operator-facing label - phase keys are kstrl's vocabulary
+    on both sides, so they never collided in the first place, and
+    prefixing a label would only make the honesty warnings harder to
+    read.
+    """
+    return f"{ROLE_KEY_PREFIX}{role}"
+
 
 # ASCII allowlist for branch names. Anything outside it (whitespace,
 # ':', control characters, unicode dash confusables like U+2011) is

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -41,6 +41,7 @@ from kstrl import events as ev
 from kstrl import git
 from kstrl.adequacy import AdequacyConfig
 from kstrl.agents.base import (
+    ARCHITECT_COMPONENT,
     ARCHITECT_ROLE,
     CEILING_AXES,
     CeilingCoverage,
@@ -591,10 +592,17 @@ class ComponentPipeline:
         metered call rather than leaving it invisible to the coverage
         accounting.
 
-        Component id and phase are both ``ARCHITECT_ROLE``, which is the
-        key `ks decompose` already writes (``ARCHITECT_COMPONENT``) and
-        the one ``serve.read_run_spend`` reads. Pairing them HERE is why
-        the constant exists rather than a literal per surface.
+        The component id is ``ARCHITECT_COMPONENT``, the namespaced key
+        `ks decompose` already writes and the one
+        ``serve.read_run_spend`` reads; the phase is the bare
+        ``ARCHITECT_ROLE``. Pairing them HERE is why the constants exist
+        rather than a literal per surface.
+
+        They stopped being the same string in #281. A bare component key
+        shared a keyspace with LLM-emitted component ids, so a component
+        genuinely named `architect` merged with this row - folding its
+        spend into the architect's, and clearing the honesty flag on
+        ``serve.RunSpend`` for a run whose architect never reported.
 
         ``None`` or zero calls records nothing: a run resumed from a
         manifest never ran an architect, and an agent that reported no
@@ -602,7 +610,7 @@ class ComponentPipeline:
         """
         if totals is None:
             return
-        self._record_usage(ARCHITECT_ROLE, ARCHITECT_ROLE, totals)
+        self._record_usage(ARCHITECT_COMPONENT, ARCHITECT_ROLE, totals)
 
     def record_injected_knowledge(
         self,

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -68,7 +68,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any, Final, Protocol
 
-from kstrl.agents.base import ARCHITECT_ROLE
+from kstrl.agents.base import ARCHITECT_COMPONENT, ARCHITECT_ROLE
 from kstrl.runid import run_kind
 from kstrl.statedir import (
     CONTROL_SPEND,
@@ -727,6 +727,23 @@ def read_run_spend(root_dir: Path, run_id: str) -> RunSpend:
     previous run's spend and could be classified from a stale manifest.
     An empty id now returns zeros instead of silently reading someone
     else's run.
+
+    #281: the architect's row moved to ``ARCHITECT_COMPONENT``, so a run
+    recorded before that change - whose stream says ``"architect"`` -
+    reads here as having no architect row, and the day's total is
+    reported as a FLOOR rather than exact. That is the pessimistic
+    direction, and it is the same answer this function already gives for
+    a resume, a blocker halt and an adapter that reports nothing.
+
+    There is deliberately no fallback to the old bare key. It would be
+    unsafe rather than merely redundant: on a NEW run whose architect did
+    not report and which happens to contain a component named
+    `architect`, the fallback would read that component's calls as the
+    architect's and clear the honesty flag - which is exactly the bug
+    #281 removes. The narrower thing is not worth building either,
+    because ``owned_run_spend`` only ever reads run dirs created inside
+    the launch window it is charging, so the daemon never reads a
+    pre-#281 run at all.
     """
     if not run_id:
         return RunSpend()
@@ -736,7 +753,7 @@ def read_run_spend(root_dir: Path, run_id: str) -> RunSpend:
         state, _source = load_run_state(root_dir, run_id)
     except OSError:
         return RunSpend()
-    architect = state.components.get(ARCHITECT_ROLE)
+    architect = state.components.get(ARCHITECT_COMPONENT)
     return RunSpend(
         cost_usd=state.cost_usd,
         cost_calls=state.cost_calls,

--- a/kstrl/tui/screens/decompose.py
+++ b/kstrl/tui/screens/decompose.py
@@ -25,6 +25,7 @@ from textual.widgets import DataTable, Footer, Static
 from kstrl.agents.base import ARCHITECT_COMPONENT
 from kstrl.tui import theme
 from kstrl.tui.messages import StateChanged
+from kstrl.tui.state import architect_component_id, planned_component_ids
 from kstrl.tui.widgets.context_bar import ContextBar
 from kstrl.tui.widgets.cost_meter import CostMeter
 from kstrl.tui.widgets.dag_table import DagTable
@@ -46,7 +47,7 @@ _SEVERITY_STYLES = {
 def _issue_strip(state: RunState) -> Text:
     text = Text()
     counts = state.spec_issue_counts
-    architect = state.components.get(ARCHITECT_COMPONENT)
+    architect = state.components.get(architect_component_id(state))
     audit_ran = architect is not None and any(
         p.get("phase") == "audit" for p in architect.phase_history
     )
@@ -81,7 +82,7 @@ def _issue_strip(state: RunState) -> Text:
 
 def _attempt_strip(state: RunState) -> Text:
     text = Text()
-    architect = state.components.get(ARCHITECT_COMPONENT)
+    architect = state.components.get(architect_component_id(state))
     if architect is None:
         text.append("waiting for the architect...", style=theme.MUTED)
         return text
@@ -105,11 +106,11 @@ def _summary(state: RunState) -> Text | None:
     if not state.finished:
         return None
     text = Text()
-    architect = state.components.get(ARCHITECT_COMPONENT)
+    architect = state.components.get(architect_component_id(state))
     if architect is None or architect.status != "completed":
         text.append("✗ decompose did not complete", style=f"bold {theme.ERROR}")
         return text
-    planned = [c for c in state.plan_order if c != ARCHITECT_COMPONENT]
+    planned = planned_component_ids(state)
     prds = [a for a in state.artifacts if a.get("label") == "prd"]
     manifest = next(
         (a for a in state.artifacts if a.get("label") == "manifest"),
@@ -134,6 +135,11 @@ class DecomposeScreen(Screen[None]):
         super().__init__()
         # The app's duck-typed poll contract (A3): refresh_state +
         # the architect's bounded transcript tail.
+        #
+        # Seeded with the current key and re-resolved in refresh_state,
+        # because the run's own format is not knowable until its first
+        # events have folded (#281). A pre-#281 dir keeps its transcript
+        # under the bare word, so tailing the new key found nothing.
         self.transcript_component = ARCHITECT_COMPONENT
         self._following = True
 
@@ -168,6 +174,10 @@ class DecomposeScreen(Screen[None]):
         manifest: Manifest | None,
     ) -> None:
         del manifest  # the folded plan is the source; no manifest join
+        # Before the ready guard: the tail key must track the run's
+        # format even on a poll whose widgets are not up yet, and it is
+        # a plain assignment that cannot raise.
+        self.transcript_component = architect_component_id(state)
         if not self.ready:
             return
         try:
@@ -261,7 +271,7 @@ class SpecTriageScreen(Screen[None]):
             key=lambda i: _SEVERITY_ORDER.get(i.get("severity", ""), 9),
         )
         banner = self.query_one("#triage-banner", Static)
-        architect = state.components.get(ARCHITECT_COMPONENT)
+        architect = state.components.get(architect_component_id(state))
         halted = (
             bool(state.spec_issue_counts.get("blocker"))
             and architect is not None

--- a/kstrl/tui/screens/decompose.py
+++ b/kstrl/tui/screens/decompose.py
@@ -22,11 +22,12 @@ from textual.css.query import NoMatches
 from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Static
 
+from kstrl.agents.base import ARCHITECT_COMPONENT
 from kstrl.tui import theme
 from kstrl.tui.messages import StateChanged
 from kstrl.tui.widgets.context_bar import ContextBar
 from kstrl.tui.widgets.cost_meter import CostMeter
-from kstrl.tui.widgets.dag_table import ARCHITECT_ID, DagTable
+from kstrl.tui.widgets.dag_table import DagTable
 from kstrl.tui.widgets.header import RunHeader
 from kstrl.tui.widgets.transcript import TranscriptTail
 
@@ -45,7 +46,7 @@ _SEVERITY_STYLES = {
 def _issue_strip(state: RunState) -> Text:
     text = Text()
     counts = state.spec_issue_counts
-    architect = state.components.get(ARCHITECT_ID)
+    architect = state.components.get(ARCHITECT_COMPONENT)
     audit_ran = architect is not None and any(
         p.get("phase") == "audit" for p in architect.phase_history
     )
@@ -80,7 +81,7 @@ def _issue_strip(state: RunState) -> Text:
 
 def _attempt_strip(state: RunState) -> Text:
     text = Text()
-    architect = state.components.get(ARCHITECT_ID)
+    architect = state.components.get(ARCHITECT_COMPONENT)
     if architect is None:
         text.append("waiting for the architect...", style=theme.MUTED)
         return text
@@ -104,11 +105,11 @@ def _summary(state: RunState) -> Text | None:
     if not state.finished:
         return None
     text = Text()
-    architect = state.components.get(ARCHITECT_ID)
+    architect = state.components.get(ARCHITECT_COMPONENT)
     if architect is None or architect.status != "completed":
         text.append("✗ decompose did not complete", style=f"bold {theme.ERROR}")
         return text
-    planned = [c for c in state.plan_order if c != ARCHITECT_ID]
+    planned = [c for c in state.plan_order if c != ARCHITECT_COMPONENT]
     prds = [a for a in state.artifacts if a.get("label") == "prd"]
     manifest = next(
         (a for a in state.artifacts if a.get("label") == "manifest"),
@@ -133,7 +134,7 @@ class DecomposeScreen(Screen[None]):
         super().__init__()
         # The app's duck-typed poll contract (A3): refresh_state +
         # the architect's bounded transcript tail.
-        self.transcript_component = ARCHITECT_ID
+        self.transcript_component = ARCHITECT_COMPONENT
         self._following = True
 
     def compose(self) -> ComposeResult:
@@ -260,7 +261,7 @@ class SpecTriageScreen(Screen[None]):
             key=lambda i: _SEVERITY_ORDER.get(i.get("severity", ""), 9),
         )
         banner = self.query_one("#triage-banner", Static)
-        architect = state.components.get(ARCHITECT_ID)
+        architect = state.components.get(ARCHITECT_COMPONENT)
         halted = (
             bool(state.spec_issue_counts.get("blocker"))
             and architect is not None

--- a/kstrl/tui/session.py
+++ b/kstrl/tui/session.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from kstrl.agents.base import ARCHITECT_COMPONENT
 from kstrl.commandrun import open_command_run
 from kstrl.config import KstrlConfig
 from kstrl.events import CallbackSink, EventBus, RunPaths
@@ -267,7 +268,7 @@ def _prepare_decompose(
                 ui,
                 root_dir,
                 "decompose",
-                component="architect",
+                component=ARCHITECT_COMPONENT,
                 run_id=run_id,
             )
             try:
@@ -281,7 +282,7 @@ def _prepare_decompose(
                         ui=ui,
                         root_dir=root_dir,
                         bus=command_run.bus,
-                        transcript=command_run.transcript_writer("architect"),
+                        transcript=command_run.transcript_writer(ARCHITECT_COMPONENT),
                     )
                     ui.ok(f"Decomposed into {len(manifest.components)} components")
                     return 0

--- a/kstrl/tui/state.py
+++ b/kstrl/tui/state.py
@@ -1,7 +1,12 @@
 """StateStore: the dashboard's single state source (stage 3 PR D).
 
-The ONLY module in kstrl/tui/ that imports the reducer - any
-reducer-contract drift has a one-module blast radius (plan decision).
+The module that owns the reducer contract for the live-run screens, so
+reducer drift has a small blast radius (plan decision). Stated as
+"small" rather than "one module": ``home_data.py`` folds run dirs for
+the home board and imports the reducer directly, so the original
+"ONLY module" claim has not been true since that board landed, and a
+decision leaning on it would be leaning on nothing.
+
 The manifest join is lazy and mtime-cached: authoritative snapshot
 data (DAG, PR URLs, evidence pointers) without a read per frame.
 """
@@ -10,9 +15,83 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from kstrl.agents.base import ARCHITECT_COMPONENT, ARCHITECT_ROLE
 from kstrl.events import Event
 from kstrl.manifest import Manifest
 from kstrl.reducer import RunState, apply
+
+
+def architect_component_id(state: RunState) -> str:
+    """The key THIS run dir uses for the architect's pseudo-component.
+
+    #281 moved the role's key off the bare word so it could not collide
+    with an LLM-chosen component id. Run directories are the durable
+    record, so every decompose dir written before that still says
+    ``architect``, and reading only the new key rendered a COMPLETED
+    historical run as failed, left the transcript tailing a path that
+    does not exist, and let the stale pseudo-row through as a graph
+    node. That is not a conservative degradation, it is a wrong one,
+    which is why this seam gets a fallback and ``serve`` does not.
+
+    The fallback cannot resurrect the bug, for two independent reasons:
+
+    - It is reachable only on ``decompose`` runs. A factory run keeps
+      the pessimistic read, so a manifest component named `architect`
+      is never mistaken for the role.
+    - Within a decompose run it is unreachable after #281 anyway.
+      ``_decompose_spec_impl`` emits the architect's ``RunPlan`` entry
+      and ``ComponentStarted`` unconditionally as its first component
+      events, before the spec is ever handed to an LLM, and the reducer
+      creates a row from ``RunPlan``. So any post-#281 dir answers on
+      the first branch, and the LLM's own components - which arrive at
+      the SECOND ``RunPlan``, strictly later - are never consulted.
+
+    ``serve.read_run_spend`` gets no such fallback, and the reason is
+    about ITS seam rather than about this one's placement. It reads
+    factory runs, where an old role row and a component genuinely named
+    `architect` are the same shape and no probe can separate them, so it
+    stays pessimistic and reports the day as a floor. See
+    ``RunSpend.unmetered_phases``.
+
+    Living in ``kstrl/tui/`` is a LAYERING choice, not a safety
+    mechanism, and it is worth being exact about that because the
+    tempting claim is wrong: a gate on ``decompose`` would be a no-op for
+    ``serve`` wherever this function lived, since ``owned_run_spend`` is
+    ``read_run_spend``'s only caller and already narrows to
+    ``SPAWNED_RUN_KIND``. What the placement actually buys is that an
+    era shim for RENDERING sits with the renderer, so a future
+    money-reading caller has to reach into the TUI package on purpose
+    rather than find this beside the fold.
+
+    Not normalised inside ``StateStore.apply_events`` either, which
+    would otherwise be the tidier shape: ``transcript_component`` has to
+    stay the key the dir actually wrote, because it becomes the path
+    segment in ``components/<key>/engineer.log``. Rewriting the key on
+    fold would re-break the transcript tail it is here to fix.
+
+    On a pre-#281 dir whose architect ALSO named a component
+    `architect`, the two were already merged into one row when the dir
+    was written and no reader can separate them now. Returning that row
+    is the best available reading, and it is what the dashboard showed
+    at the time.
+    """
+    if ARCHITECT_COMPONENT in state.components:
+        return ARCHITECT_COMPONENT
+    if state.kind == "decompose" and ARCHITECT_ROLE in state.components:
+        return ARCHITECT_ROLE
+    return ARCHITECT_COMPONENT
+
+
+def planned_component_ids(state: RunState) -> list[str]:
+    """The run's REAL components, in plan order, without the architect.
+
+    One definition because it has now moved twice: the decompose
+    summary's count and the DAG table's row set are the same rule, and
+    #281 and this change each had to edit both. Spelling it once is what
+    stops the third edit reaching only one of them.
+    """
+    pseudo = architect_component_id(state)
+    return [cid for cid in state.plan_order if cid != pseudo]
 
 
 class StateStore:

--- a/kstrl/tui/widgets/dag_table.py
+++ b/kstrl/tui/widgets/dag_table.py
@@ -13,17 +13,23 @@ clear()+rebuild per poll (spike finding 3).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 from rich.text import Text
 from textual.widgets import DataTable
 
+from kstrl.agents.base import ARCHITECT_COMPONENT
 from kstrl.tui import theme
 
 if TYPE_CHECKING:
     from kstrl.reducer import ComponentState, RunState
 
-ARCHITECT_ID = "architect"
+#: Re-exported from ``agents.base`` rather than restated (#281). It WAS
+#: a second declaration of the literal "architect", and this table
+#: filters the plan by it: a component the architect genuinely named
+#: `architect` was dropped from the DAG view entirely, on the strength
+#: of a string two modules happened to agree on.
+ARCHITECT_ID: Final = ARCHITECT_COMPONENT
 COLUMNS = ("component", "tier", "deps", "prd")
 _CYCLE_TIER = -1
 

--- a/kstrl/tui/widgets/dag_table.py
+++ b/kstrl/tui/widgets/dag_table.py
@@ -18,8 +18,8 @@ from typing import TYPE_CHECKING
 from rich.text import Text
 from textual.widgets import DataTable
 
-from kstrl.agents.base import ARCHITECT_COMPONENT
 from kstrl.tui import theme
+from kstrl.tui.state import planned_component_ids
 
 if TYPE_CHECKING:
     from kstrl.reducer import ComponentState, RunState
@@ -84,7 +84,10 @@ class DagTable(DataTable[Text | str]):
         # architect named `architect` is not. Those were one string until
         # #281, and this table had its own declaration of it, so a real
         # component with that name vanished from the DAG entirely.
-        order = [cid for cid in state.plan_order if cid != ARCHITECT_COMPONENT]
+        #
+        # Resolved per run rather than pinned to the constant, or a
+        # pre-#281 dir's stale pseudo-row renders as a graph node.
+        order = planned_component_ids(state)
         deps_map = {cid: state.components[cid].deps for cid in order if cid in state.components}
         tiers = compute_tiers(deps_map)
         prds = {a["component"] for a in state.artifacts if a.get("label") == "prd"}

--- a/kstrl/tui/widgets/dag_table.py
+++ b/kstrl/tui/widgets/dag_table.py
@@ -13,7 +13,7 @@ clear()+rebuild per poll (spike finding 3).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING
 
 from rich.text import Text
 from textual.widgets import DataTable
@@ -24,12 +24,6 @@ from kstrl.tui import theme
 if TYPE_CHECKING:
     from kstrl.reducer import ComponentState, RunState
 
-#: Re-exported from ``agents.base`` rather than restated (#281). It WAS
-#: a second declaration of the literal "architect", and this table
-#: filters the plan by it: a component the architect genuinely named
-#: `architect` was dropped from the DAG view entirely, on the strength
-#: of a string two modules happened to agree on.
-ARCHITECT_ID: Final = ARCHITECT_COMPONENT
 COLUMNS = ("component", "tier", "deps", "prd")
 _CYCLE_TIER = -1
 
@@ -86,7 +80,11 @@ class DagTable(DataTable[Text | str]):
             self.add_column(column, key=column)
 
     def update_state(self, state: RunState) -> None:
-        order = [cid for cid in state.plan_order if cid != ARCHITECT_ID]
+        # The architect's own pseudo-row is filtered out; a COMPONENT the
+        # architect named `architect` is not. Those were one string until
+        # #281, and this table had its own declaration of it, so a real
+        # component with that name vanished from the DAG entirely.
+        order = [cid for cid in state.plan_order if cid != ARCHITECT_COMPONENT]
         deps_map = {cid: state.components[cid].deps for cid in order if cid in state.components}
         tiers = compute_tiers(deps_map)
         prds = {a["component"] for a in state.artifacts if a.get("label") == "prd"}

--- a/tests/helpers/fake_run.py
+++ b/tests/helpers/fake_run.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from kstrl import events as ev
+from kstrl.agents.base import ARCHITECT_COMPONENT
 
 DEFAULT_RUN_ID = "factory-20260720-120000.000000-fake"
 
@@ -360,31 +361,33 @@ def write_fake_decompose_run(
     bus = ev.EventBus(
         ev.JsonlSink(paths.events_file),
         run_id=run_id,
-        component="architect",
+        component=ARCHITECT_COMPONENT,
     )
     bus.emit(ev.RunStarted(project="fake-project", components=0))
     bus.emit(
         ev.RunPlan(
-            components=({"id": "architect", "title": "Architect / PRD red-team", "deps": []},)
+            components=(
+                {"id": ARCHITECT_COMPONENT, "title": "Architect / PRD red-team", "deps": []},
+            )
         )
     )
-    bus.emit(ev.ComponentStarted(component="architect"))
-    log_path = paths.engineer_log("architect")
+    bus.emit(ev.ComponentStarted(component=ARCHITECT_COMPONENT))
+    log_path = paths.engineer_log(ARCHITECT_COMPONENT)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     for attempt in range(1, attempts + 1):
-        bus.emit(ev.PhaseStarted(component="architect", phase="decompose", attempt=attempt))
+        bus.emit(ev.PhaseStarted(component=ARCHITECT_COMPONENT, phase="decompose", attempt=attempt))
         with open(log_path, "a", encoding="utf-8") as log:
             log.write(f'{{"components": [... attempt {attempt} ...]}}\n')
         bus.emit(
             ev.PhaseCompleted(
-                component="architect",
+                component=ARCHITECT_COMPONENT,
                 phase="decompose",
                 passed=attempt == attempts,
                 duration_seconds=30.0,
                 detail="" if attempt == attempts else "JSON extraction failed",
             )
         )
-    bus.emit(ev.PhaseStarted(component="architect", phase="audit", attempt=1))
+    bus.emit(ev.PhaseStarted(component=ARCHITECT_COMPONENT, phase="audit", attempt=1))
     for n in range(blockers):
         bus.emit(
             ev.SpecIssueRecorded(
@@ -406,7 +409,7 @@ def write_fake_decompose_run(
     bus.emit(ev.ArtifactWritten(label="spec_issues", path="scripts/kstrl/spec-issues.json"))
     bus.emit(
         ev.PhaseCompleted(
-            component="architect",
+            component=ARCHITECT_COMPONENT,
             phase="audit",
             passed=blockers == 0,
             detail=f"{blockers} blocker(s)" if blockers else "",
@@ -416,7 +419,7 @@ def write_fake_decompose_run(
     if blockers:
         bus.emit(
             ev.ComponentFailed(
-                component="architect",
+                component=ARCHITECT_COMPONENT,
                 error=f"spec halted: {blockers} blocker-severity issue(s)",
             )
         )
@@ -426,7 +429,7 @@ def write_fake_decompose_run(
     bus.emit(
         ev.RunPlan(
             components=(
-                {"id": "architect", "title": "Architect / PRD red-team", "deps": []},
+                {"id": ARCHITECT_COMPONENT, "title": "Architect / PRD red-team", "deps": []},
                 *(
                     {"id": cid, "title": cid.title(), "deps": [components[i - 1]] if i else []}
                     for i, cid in enumerate(components)
@@ -444,7 +447,9 @@ def write_fake_decompose_run(
         )
     bus.emit(ev.ArtifactWritten(label="manifest", path="scripts/kstrl/manifest.json"))
     bus.emit(
-        ev.ComponentCompleted(component="architect", duration_seconds=35.0, iterations=attempts)
+        ev.ComponentCompleted(
+            component=ARCHITECT_COMPONENT, duration_seconds=35.0, iterations=attempts
+        )
     )
     bus.emit(ev.RunCompleted(completed=1, failed=0, skipped=0, duration_seconds=35.0))
     bus.close()

--- a/tests/helpers/fake_run.py
+++ b/tests/helpers/fake_run.py
@@ -353,41 +353,47 @@ def write_fake_decompose_run(
     minors: int = 1,
     attempts: int = 1,
     components: tuple[str, ...] = ("database", "api"),
+    architect_key: str = ARCHITECT_COMPONENT,
 ) -> Path:
     """A decompose-kind run: architect attempts, spec issues, the
     forming DAG, per-component PRD artifacts (TUI surface C4).
-    ``blockers`` > 0 makes it a halted run (no plan, no PRDs)."""
+    ``blockers`` > 0 makes it a halted run (no plan, no PRDs).
+
+    ``architect_key`` is what the dir calls the architect's
+    pseudo-component. It is a parameter so a test can write a run the
+    PRE-#281 way ("architect"), which is what every dir already on disk
+    says: run directories are the durable record, and a reader that only
+    knows the new key rendered a completed historical run as failed.
+    """
     paths = ev.RunPaths.for_run(root, run_id)
     bus = ev.EventBus(
         ev.JsonlSink(paths.events_file),
         run_id=run_id,
-        component=ARCHITECT_COMPONENT,
+        component=architect_key,
     )
     bus.emit(ev.RunStarted(project="fake-project", components=0))
     bus.emit(
         ev.RunPlan(
-            components=(
-                {"id": ARCHITECT_COMPONENT, "title": "Architect / PRD red-team", "deps": []},
-            )
+            components=({"id": architect_key, "title": "Architect / PRD red-team", "deps": []},)
         )
     )
-    bus.emit(ev.ComponentStarted(component=ARCHITECT_COMPONENT))
-    log_path = paths.engineer_log(ARCHITECT_COMPONENT)
+    bus.emit(ev.ComponentStarted(component=architect_key))
+    log_path = paths.engineer_log(architect_key)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     for attempt in range(1, attempts + 1):
-        bus.emit(ev.PhaseStarted(component=ARCHITECT_COMPONENT, phase="decompose", attempt=attempt))
+        bus.emit(ev.PhaseStarted(component=architect_key, phase="decompose", attempt=attempt))
         with open(log_path, "a", encoding="utf-8") as log:
             log.write(f'{{"components": [... attempt {attempt} ...]}}\n')
         bus.emit(
             ev.PhaseCompleted(
-                component=ARCHITECT_COMPONENT,
+                component=architect_key,
                 phase="decompose",
                 passed=attempt == attempts,
                 duration_seconds=30.0,
                 detail="" if attempt == attempts else "JSON extraction failed",
             )
         )
-    bus.emit(ev.PhaseStarted(component=ARCHITECT_COMPONENT, phase="audit", attempt=1))
+    bus.emit(ev.PhaseStarted(component=architect_key, phase="audit", attempt=1))
     for n in range(blockers):
         bus.emit(
             ev.SpecIssueRecorded(
@@ -409,7 +415,7 @@ def write_fake_decompose_run(
     bus.emit(ev.ArtifactWritten(label="spec_issues", path="scripts/kstrl/spec-issues.json"))
     bus.emit(
         ev.PhaseCompleted(
-            component=ARCHITECT_COMPONENT,
+            component=architect_key,
             phase="audit",
             passed=blockers == 0,
             detail=f"{blockers} blocker(s)" if blockers else "",
@@ -419,7 +425,7 @@ def write_fake_decompose_run(
     if blockers:
         bus.emit(
             ev.ComponentFailed(
-                component=ARCHITECT_COMPONENT,
+                component=architect_key,
                 error=f"spec halted: {blockers} blocker-severity issue(s)",
             )
         )
@@ -429,7 +435,7 @@ def write_fake_decompose_run(
     bus.emit(
         ev.RunPlan(
             components=(
-                {"id": ARCHITECT_COMPONENT, "title": "Architect / PRD red-team", "deps": []},
+                {"id": architect_key, "title": "Architect / PRD red-team", "deps": []},
                 *(
                     {"id": cid, "title": cid.title(), "deps": [components[i - 1]] if i else []}
                     for i, cid in enumerate(components)
@@ -447,9 +453,7 @@ def write_fake_decompose_run(
         )
     bus.emit(ev.ArtifactWritten(label="manifest", path="scripts/kstrl/manifest.json"))
     bus.emit(
-        ev.ComponentCompleted(
-            component=ARCHITECT_COMPONENT, duration_seconds=35.0, iterations=attempts
-        )
+        ev.ComponentCompleted(component=architect_key, duration_seconds=35.0, iterations=attempts)
     )
     bus.emit(ev.RunCompleted(completed=1, failed=0, skipped=0, duration_seconds=35.0))
     bus.close()

--- a/tests/test_decompose_run.py
+++ b/tests/test_decompose_run.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from kstrl.agents.base import UsageRecord
+from kstrl.agents.base import ARCHITECT_COMPONENT, ARCHITECT_ROLE, UsageRecord
 from kstrl.commandrun import open_command_run
 from kstrl.decompose import SpecBlockerError, decompose_spec
 from kstrl.reducer import load_run_state
@@ -98,7 +98,7 @@ def _decompose(
         ui,
         tmp_path,
         "decompose",
-        component="architect",
+        component=ARCHITECT_COMPONENT,
         enabled=True,
         heartbeat=False,
     )
@@ -112,7 +112,7 @@ def _decompose(
             ui=ui,
             root_dir=tmp_path,
             bus=run.bus,
-            transcript=run.transcript_writer("architect"),
+            transcript=run.transcript_writer(ARCHITECT_COMPONENT),
         )
     finally:
         run.close()
@@ -133,10 +133,10 @@ class TestDecomposeRun:
         assert state.finished
         # The forming DAG: architect first, then the manifest order.
         assert state.plan_order == [
-            "architect",
+            ARCHITECT_COMPONENT,
             *[c.id for c in manifest.components],  # type: ignore[attr-defined]
         ]
-        architect = state.components["architect"]
+        architect = state.components[ARCHITECT_COMPONENT]
         assert architect.status == "completed"
         assert [p["phase"] for p in architect.phase_history] == [
             "decompose",
@@ -180,7 +180,7 @@ class TestDecomposeRun:
     ) -> None:
         _decompose(tmp_path, TwoShotAgent(VALID_DECOMPOSE_OUTPUT))
         state, _ = load_run_state(tmp_path)
-        architect = state.components["architect"]
+        architect = state.components[ARCHITECT_COMPONENT]
         decompose_phases = [p for p in architect.phase_history if p["phase"] == "decompose"]
         assert [p["passed"] for p in decompose_phases] == [False, True]
         assert architect.attempt == 2
@@ -195,14 +195,14 @@ class TestDecomposeRun:
 
         state, _ = load_run_state(tmp_path)
         assert state.finished  # not dead - the architect judged and halted
-        architect = state.components["architect"]
+        architect = state.components[ARCHITECT_COMPONENT]
         assert architect.status == "failed"
         audit = [p for p in architect.phase_history if p["phase"] == "audit"]
         assert audit and audit[0]["passed"] is False
         assert state.spec_issue_counts == {"blocker": 1}
         assert [a["label"] for a in state.artifacts] == ["spec_issues"]
         # No plan beyond the architect: nothing was decomposed.
-        assert state.plan_order == ["architect"]
+        assert state.plan_order == [ARCHITECT_COMPONENT]
 
     def test_transcript_captures_the_architect_stream(
         self,
@@ -211,7 +211,7 @@ class TestDecomposeRun:
         _decompose(tmp_path, MockDecomposeAgent(MINOR_ISSUE_OUTPUT))
         runs_root = tmp_path / ".kstrl" / "runs"
         run_dir = next(iter(runs_root.iterdir()))
-        transcript = run_dir / "components" / "architect" / "engineer.log"
+        transcript = run_dir / "components" / ARCHITECT_COMPONENT / "engineer.log"
         assert "spec_issues" in transcript.read_text()
 
     def test_agent_exception_finishes_the_run(self, tmp_path: Path) -> None:
@@ -219,7 +219,7 @@ class TestDecomposeRun:
             _decompose(tmp_path, ExplodingAgent())
         state, _ = load_run_state(tmp_path)
         assert state.finished
-        architect = state.components["architect"]
+        architect = state.components[ARCHITECT_COMPONENT]
         assert architect.status == "failed"
         assert architect.error == "RuntimeError: architect exploded"
         assert architect.phase_history[-1]["phase"] == "decompose"
@@ -240,7 +240,7 @@ class TestDecomposeRun:
 
         state, _ = load_run_state(tmp_path)
         assert state.finished
-        architect = state.components["architect"]
+        architect = state.components[ARCHITECT_COMPONENT]
         assert architect.status == "failed"
         assert architect.error == "OSError: manifest disk full"
         assert [a["label"] for a in state.artifacts] == ["spec_issues"]
@@ -341,7 +341,7 @@ class TestArchitectUsageIsRecorded:
         assert state.cost_calls == 1
         assert state.cost_usd == pytest.approx(0.5)
         assert state.total_tokens == 120
-        architect = state.components["architect"]
+        architect = state.components[ARCHITECT_COMPONENT]
         assert architect.usage_calls == 1
         assert architect.cost_usd == pytest.approx(0.5)
 
@@ -377,14 +377,21 @@ class TestArchitectUsageIsRecorded:
         """The meter's phase key is the ROLE name, which is what the
         coverage footer prints. It must be the fifth role's name, not the
         ``decompose``/``audit`` lifecycle phases this component reports
-        elsewhere."""
+        elsewhere.
+
+        #281: the two axes are asserted against DIFFERENT constants, and
+        that is the property. The phase axis is kstrl's vocabulary on
+        both sides, so it stays the bare role name; the component axis is
+        one the architect LLM also writes to, so the role's key is
+        namespaced out of reach of any component id.
+        """
         _decompose(tmp_path, MeteringAgent(MINOR_ISSUE_OUTPUT))
         run_dir = next(iter((tmp_path / ".kstrl" / "runs").iterdir()))
         events = [json.loads(line) for line in (run_dir / "events.jsonl").read_text().splitlines()]
         usage = [e for e in events if e.get("event") == "component_usage"]
         assert len(usage) == 1
-        assert usage[0]["component"] == "architect"
-        assert usage[0]["data"]["phase"] == "architect"
+        assert usage[0]["component"] == ARCHITECT_COMPONENT
+        assert usage[0]["data"]["phase"] == ARCHITECT_ROLE
 
     def test_an_agent_that_reports_nothing_adds_no_phantom_row(
         self,

--- a/tests/test_decompose_screens.py
+++ b/tests/test_decompose_screens.py
@@ -11,6 +11,7 @@ from rich.text import Text
 from textual.coordinate import Coordinate
 from textual.widgets import DataTable
 
+from kstrl.agents.base import ARCHITECT_COMPONENT
 from kstrl.cli import cli
 from kstrl.tui.app import KstrlTuiApp, Mode
 from kstrl.tui.dispatch import initial_screens_for_kind
@@ -108,10 +109,32 @@ class TestDecomposeScreen:
 
             # A replaced event stream may contain a smaller plan; rows
             # from the old fold must not survive the rebuild.
-            app.store.state.plan_order = ["architect", "database"]
+            app.store.state.plan_order = [ARCHITECT_COMPONENT, "database"]
             app.store.state.components.pop("api")
             table.update_state(app.store.state)
             assert {key.value for key in table.rows} == {"database"}
+
+    async def test_a_component_named_architect_is_not_filtered_out_of_the_dag(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """#281 in the TUI. ``DagTable`` hides the architect's pseudo
+        row by comparing plan ids against the role's key, so while that
+        key was the bare word a component the architect genuinely NAMED
+        `architect` was excluded from the DAG view - present in the plan,
+        holding real dependencies, and invisible.
+
+        Asserted as membership rather than against the constant: with the
+        namespace collapsed both spellings are the same word, and any
+        assertion phrased in constants would be satisfied by the row
+        being absent.
+        """
+        run_dir = write_fake_decompose_run(tmp_path, components=("architect", "api"))
+        app = _decompose_app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            table = app.screen.query_one(DagTable)
+            assert {key.value for key in table.rows} == {"architect", "api"}
 
     async def test_state_update_after_header_removed_is_safe(
         self,

--- a/tests/test_decompose_screens.py
+++ b/tests/test_decompose_screens.py
@@ -13,11 +13,13 @@ from textual.widgets import DataTable
 
 from kstrl.agents.base import ARCHITECT_COMPONENT
 from kstrl.cli import cli
+from kstrl.reducer import ComponentState, RunState
 from kstrl.tui.app import KstrlTuiApp, Mode
 from kstrl.tui.dispatch import initial_screens_for_kind
 from kstrl.tui.screens.component import ComponentScreen
 from kstrl.tui.screens.decompose import DecomposeScreen, SpecTriageScreen
 from kstrl.tui.screens.overview import OverviewScreen
+from kstrl.tui.state import architect_component_id
 from kstrl.tui.widgets.dag_table import DagTable, compute_tiers
 from kstrl.tui.widgets.header import RunHeader
 from tests.helpers.fake_run import (
@@ -50,6 +52,55 @@ class TestComputeTiers:
 
     def test_self_dependency_is_a_cycle(self) -> None:
         assert compute_tiers({"a": ("a",)}) == {"a": -1}
+
+
+class TestArchitectComponentId:
+    """#296 review: the read side of #281, for run dirs already on disk.
+
+    The fallback exists because this seam's failure was WRONG rather than
+    conservative. These pin the two conditions that stop it becoming the
+    collision it was built to remove.
+    """
+
+    @staticmethod
+    def _state(run_id: str, *component_ids: str) -> RunState:
+        state = RunState(run_id=run_id)
+        for cid in component_ids:
+            state.components[cid] = ComponentState(component_id=cid)
+        return state
+
+    def test_a_pre_281_decompose_dir_resolves_to_the_bare_key(self) -> None:
+        state = self._state("decompose-20260101-120000.000000-old", "architect", "api")
+        assert architect_component_id(state) == "architect"
+
+    def test_a_post_281_decompose_dir_resolves_to_the_namespaced_key(self) -> None:
+        state = self._state("decompose-20260901-120000.000000-new", ARCHITECT_COMPONENT, "api")
+        assert architect_component_id(state) == ARCHITECT_COMPONENT
+
+    def test_a_new_dir_with_a_component_named_architect_never_falls_back(self) -> None:
+        """Condition one. `ks decompose` writes the architect's RunPlan
+        entry before the spec reaches an LLM, and the reducer creates a
+        row from RunPlan - so a post-#281 dir always answers on the first
+        branch, and the LLM's own `architect` is never consulted."""
+        state = self._state(
+            "decompose-20260901-120000.000000-new",
+            ARCHITECT_COMPONENT,
+            "architect",
+        )
+        assert architect_component_id(state) == ARCHITECT_COMPONENT
+
+    def test_a_factory_run_never_falls_back(self) -> None:
+        """Condition two, and the one that does not depend on emit order.
+
+        A factory run's architect row is absent whenever the architect
+        never reported - a resume, or an adapter that reports nothing -
+        and its manifest may hold a component named `architect`. That is
+        exactly the ambiguity `serve.read_run_spend` refuses to guess at,
+        so the fallback is restricted to decompose runs and this stays
+        pessimistic.
+        """
+        state = self._state("factory-20260101-120000.000000-run", "architect", "api")
+        assert architect_component_id(state) == ARCHITECT_COMPONENT
 
 
 class TestDispatch:
@@ -135,6 +186,78 @@ class TestDecomposeScreen:
             await pilot.pause(0.2)
             table = app.screen.query_one(DagTable)
             assert {key.value for key in table.rows} == {"architect", "api"}
+
+    async def test_a_pre_281_run_dir_still_renders_as_the_run_it_was(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """#296 review, MEDIUM. Run directories are the durable record.
+
+        Every decompose dir written before #281 keys the architect by the
+        bare word, and reading only the new key made this screen report a
+        COMPLETED run as failed - a wrong answer, not a conservative one,
+        which is why this seam takes a fallback where
+        ``serve.read_run_spend`` refuses one.
+
+        Asserts all four symptoms the review named, off one old dir: the
+        summary, the attempt strip, the audit-ran branch of the issue
+        strip, and the stale pseudo-row leaking into the graph.
+        """
+        run_dir = write_fake_decompose_run(
+            tmp_path,
+            minors=0,
+            components=("database", "api"),
+            architect_key="architect",
+        )
+        app = _decompose_app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            screen = app.screen
+            assert isinstance(screen, DecomposeScreen)
+
+            summary = str(screen.query_one("#decompose-summary").content)
+            assert "did not complete" not in summary
+            assert "2 component(s)" in summary
+
+            attempt = str(screen.query_one("#attempt-strip").content)
+            assert "waiting for the architect" not in attempt
+            assert "completed" in attempt
+
+            # audit_ran, which only the architect's phase_history shows.
+            assert "clean audit" in str(screen.query_one("#issues-strip").content)
+
+            # The pseudo-row is still filtered, under the key THIS dir
+            # used rather than the one the constant now names.
+            table = screen.query_one(DagTable)
+            assert {key.value for key in table.rows} == {"database", "api"}
+
+            # The transcript tails the key the dir actually wrote.
+            assert screen.transcript_component == "architect"
+
+    async def test_a_pre_281_halted_run_still_shows_its_blocker_banner(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``SpecTriageScreen._refresh`` computes ``halted`` from the
+        architect's status, so on an old dir it read False for a run that
+        did halt and hid the banner pointing at the spec-issues
+        artifact."""
+        run_dir = write_fake_decompose_run(
+            tmp_path,
+            blockers=1,
+            minors=1,
+            architect_key="architect",
+        )
+        app = _decompose_app(tmp_path, run_dir)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(0.2)
+            await pilot.press("i")
+            await pilot.pause(0.1)
+            triage = app.screen
+            assert isinstance(triage, SpecTriageScreen)
+            banner = triage.query_one("#triage-banner")
+            assert banner.display, "an old halted run must still say it halted"
+            assert "halted" in str(banner.content)
 
     async def test_state_update_after_header_removed_is_safe(
         self,

--- a/tests/test_input_hygiene.py
+++ b/tests/test_input_hygiene.py
@@ -31,7 +31,6 @@ from kstrl.manifest import (
     Manifest,
 )
 from kstrl.names import (
-    ROLE_KEY_PREFIX,
     role_component_key,
     validate_branch_name,
     validate_component_id,
@@ -160,34 +159,25 @@ class TestRoleKeysCannotBeComponentIds:
     re-merging the usage meter and the spend ledger.
     """
 
-    #: Every role kstrl meters today plus the shapes a future one could
-    #: take. The point of the fix is that it is a property of the
+    #: The role that has a row today, plus the two shapes a future one
+    #: could take that the prefix has to survive: the shortest legal id,
+    #: and one long enough that the prefix pushes it over the 64-char
+    #: limit. The point of the fix is that rejection is a property of the
     #: namespace rather than of the word `architect`, so the guard is
-    #: parametrized rather than pinned to the one role that has a row.
-    ROLES = [
-        "architect",
-        "engineer",
-        "review",
-        "security",
-        "distill",
-        "understand",
-        "a",
-        "some-future-role",
-        "role.with.dots",
-        "x" * 64,
-    ]
+    #: parametrized rather than pinned to the one role.
+    ROLES = ["architect", "a", "x" * 64]
 
     @pytest.mark.parametrize("role", ROLES)
     def test_a_role_key_is_never_a_valid_component_id(self, role: str) -> None:
         assert validate_component_id(role_component_key(role)) is not None
 
-    @pytest.mark.parametrize("role", ROLES)
-    def test_the_bare_role_name_stays_a_valid_component_id(self, role: str) -> None:
-        """The compatibility half, and the reason option 1 was taken
-        over reserving the name: an operator or an architect may still
-        call a component `architect`, and a manifest that already does
-        keeps loading."""
-        assert validate_component_id(role) is None
+    def test_the_bare_role_name_stays_a_valid_component_id(self) -> None:
+        """The compatibility half, and the reason option 1 was taken over
+        reserving the name: an operator or an architect may still call a
+        component `architect`, and a manifest that already does keeps
+        loading. Only the real role is asserted - the generic id shapes
+        are ``ACCEPTED_COMPONENT_IDS``' job, not this class's."""
+        assert validate_component_id("architect") is None
 
     def test_a_role_key_is_never_a_valid_branch_name(self) -> None:
         """A role key is not only a dict key - it reaches disk as a run
@@ -202,7 +192,6 @@ class TestRoleKeysCannotBeComponentIds:
         names, and the collision is back with the tests still green.
         Measured - an earlier draft of the #281 meter tests passed in
         exactly that state."""
-        assert ROLE_KEY_PREFIX != ""
         assert role_component_key("architect") != "architect"
 
 

--- a/tests/test_input_hygiene.py
+++ b/tests/test_input_hygiene.py
@@ -30,7 +30,12 @@ from kstrl.manifest import (
     Component,
     Manifest,
 )
-from kstrl.names import validate_branch_name, validate_component_id
+from kstrl.names import (
+    ROLE_KEY_PREFIX,
+    role_component_key,
+    validate_branch_name,
+    validate_component_id,
+)
 from kstrl.pr import push_branch
 from kstrl.ui.plain import PlainUI
 
@@ -141,6 +146,64 @@ class TestValidateComponentId:
         assert error is not None
         assert "../../repo" in error
         assert "must match" in error
+
+
+class TestRoleKeysCannotBeComponentIds:
+    """#281: kstrl's own role rows share keyed surfaces with LLM-emitted
+    component ids, and are namespaced so the two cannot collide.
+
+    That namespacing is safe only because ``ROLE_KEY_PREFIX`` is
+    unreachable by ``COMPONENT_ID_PATTERN``. Both constants live in
+    ``names.py``, and this is the mechanism that keeps them agreeing: a
+    later relaxation of the pattern - or a prefix changed to something
+    an architect could emit - fails HERE, loudly, instead of silently
+    re-merging the usage meter and the spend ledger.
+    """
+
+    #: Every role kstrl meters today plus the shapes a future one could
+    #: take. The point of the fix is that it is a property of the
+    #: namespace rather than of the word `architect`, so the guard is
+    #: parametrized rather than pinned to the one role that has a row.
+    ROLES = [
+        "architect",
+        "engineer",
+        "review",
+        "security",
+        "distill",
+        "understand",
+        "a",
+        "some-future-role",
+        "role.with.dots",
+        "x" * 64,
+    ]
+
+    @pytest.mark.parametrize("role", ROLES)
+    def test_a_role_key_is_never_a_valid_component_id(self, role: str) -> None:
+        assert validate_component_id(role_component_key(role)) is not None
+
+    @pytest.mark.parametrize("role", ROLES)
+    def test_the_bare_role_name_stays_a_valid_component_id(self, role: str) -> None:
+        """The compatibility half, and the reason option 1 was taken
+        over reserving the name: an operator or an architect may still
+        call a component `architect`, and a manifest that already does
+        keeps loading."""
+        assert validate_component_id(role) is None
+
+    def test_a_role_key_is_never_a_valid_branch_name(self) -> None:
+        """A role key is not only a dict key - it reaches disk as a run
+        directory segment. Being rejected as a ref too means a leak into
+        git argv is a loud failure rather than a silent bad ref."""
+        assert validate_branch_name(role_component_key("architect")) is not None
+
+    def test_the_prefix_is_not_empty(self) -> None:
+        """The degenerate case the guards above cannot see: with an
+        empty prefix ``role_component_key`` is the identity, every
+        assertion about role keys becomes an assertion about bare role
+        names, and the collision is back with the tests still green.
+        Measured - an earlier draft of the #281 meter tests passed in
+        exactly that state."""
+        assert ROLE_KEY_PREFIX != ""
+        assert role_component_key("architect") != "architect"
 
 
 class TestValidateBranchName:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from kstrl.agents.base import ARCHITECT_COMPONENT, ARCHITECT_ROLE
 from kstrl.findings import Finding
 from kstrl.inbox import Inbox, InboxConfig, ItemKind
 from kstrl.manifest import Component, ComponentStatus, Manifest
@@ -2159,10 +2160,16 @@ class TestRunOwnership:
     ) -> None:
         """The seat #257 piece B writes to and the one serve reads from
         are the same key, which is the only reason the check above can
-        distinguish a metered architect from a silent one."""
+        distinguish a metered architect from a silent one.
+
+        #281 moved that key into the role namespace. Both sides are
+        spelled from the one constant here, so a future move keeps them
+        together rather than leaving this test passing on a literal the
+        writer no longer uses.
+        """
         state = RunState(cost_usd=2.0, cost_calls=1, usage_calls=1)
-        state.components["architect"] = ComponentState(
-            component_id="architect",
+        state.components[ARCHITECT_COMPONENT] = ComponentState(
+            component_id=ARCHITECT_COMPONENT,
             usage_calls=1,
             cost_calls=1,
             cost_usd=2.0,
@@ -2171,6 +2178,61 @@ class TestRunOwnership:
             load.return_value = (state, None)
             spend = REAL_READ_RUN_SPEND(tmp_path, "factory-abc")
         assert spend.architect_calls == 1
+
+    def test_a_bare_architect_key_never_clears_the_honesty_flag(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """#281, and the consequence that is not cosmetic.
+
+        ONE state, because two readings of it are indistinguishable here
+        and that is the whole argument:
+
+        - a NEW run whose architect never reported (a resume, or an
+          adapter that reports no usage) which also carries a component
+          the architect genuinely NAMED `architect` - a legal id, and an
+          ordinary one for a spec about design tooling; or
+        - an OLD run, recorded before the role key moved, whose stream
+          still says ``"architect"`` for the role itself.
+
+        Both put ``usage_calls`` on a component row spelled
+        ``architect``. While the role's own row was keyed by that same
+        bare word, the first case answered "did the architect report?"
+        with a different role's calls, cleared ``unmetered_phases``, and
+        let the daemon announce a day's total as exact on no evidence -
+        the honesty property #257 piece B exists to establish.
+
+        Both now read as unmetered. For the first that is correct; for
+        the second it is a lost decimal place - the money is still
+        counted, only the exactness claim degrades - and it is the same
+        answer already given for a resume, a blocker halt and a silent
+        adapter. Never a false exact.
+
+        This is also why there is no fallback to the old key: nothing at
+        this seam can tell the two readings apart, so a fallback would
+        reintroduce case one in order to prettify case two.
+        ``read_run_spend`` states why nothing narrower is worth building.
+        """
+        state = RunState(cost_usd=2.0, cost_calls=1, usage_calls=1)
+        state.components[ARCHITECT_ROLE] = ComponentState(
+            component_id=ARCHITECT_ROLE,
+            usage_calls=1,
+            cost_calls=1,
+            cost_usd=2.0,
+        )
+        with patch("kstrl.reducer.load_run_state") as load:
+            load.return_value = (state, None)
+            spend = REAL_READ_RUN_SPEND(tmp_path, "factory-abc")
+
+        assert spend.architect_calls == 0, "a component's calls are not the architect's"
+        assert spend.unmetered_phases == (ARCHITECT_ROLE,)
+        assert spend.cost_usd == 2.0, "the money is still read; only the claim degrades"
+        # ``RunSpend.lower_bound`` is the per-axis coverage question
+        # (usage_calls vs cost_calls) and is deliberately NOT asserted
+        # here: it is ``DailySpend.lower_bound`` that reads
+        # ``unmetered_phases`` and brands the day a floor, which
+        # ``test_an_architect_that_reached_no_run_dir_is_named_unmetered``
+        # already covers end to end.
 
     def test_a_decompose_run_dir_never_supplies_the_architect_row(
         self,

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -158,6 +158,30 @@ def _spec_finding() -> Finding:
     )
 
 
+def _spend_with_component_keyed(tmp_path: Path, key: str) -> RunSpend:
+    """``read_run_spend`` over a run whose ONE component row is ``key``.
+
+    The double is a REAL ``RunState``: a hand-rolled object carrying only
+    the fields this function read at the time silently became wrong the
+    moment it read another (#257 piece B).
+
+    Shared because #281's two cases differ only in that key - the role's
+    namespaced row, versus the bare word that is now only ever a
+    component (or a pre-#281 role row, which reads the same way and is
+    the reason no compat fallback is safe).
+    """
+    state = RunState(cost_usd=2.0, cost_calls=1, usage_calls=1)
+    state.components[key] = ComponentState(
+        component_id=key,
+        usage_calls=1,
+        cost_calls=1,
+        cost_usd=2.0,
+    )
+    with patch("kstrl.reducer.load_run_state") as load:
+        load.return_value = (state, None)
+        return REAL_READ_RUN_SPEND(tmp_path, "factory-abc")
+
+
 def _stub_runner(
     outcome: RunOutcome,
     calls: list[dict[str, object]] | None = None,
@@ -2162,21 +2186,13 @@ class TestRunOwnership:
         are the same key, which is the only reason the check above can
         distinguish a metered architect from a silent one.
 
-        #281 moved that key into the role namespace. Both sides are
-        spelled from the one constant here, so a future move keeps them
-        together rather than leaving this test passing on a literal the
-        writer no longer uses.
+        #281 moved that key into the role namespace. It is spelled from
+        the constant, so a future move keeps writer and reader together
+        rather than leaving this passing on a literal the writer no
+        longer uses.
         """
-        state = RunState(cost_usd=2.0, cost_calls=1, usage_calls=1)
-        state.components[ARCHITECT_COMPONENT] = ComponentState(
-            component_id=ARCHITECT_COMPONENT,
-            usage_calls=1,
-            cost_calls=1,
-            cost_usd=2.0,
-        )
-        with patch("kstrl.reducer.load_run_state") as load:
-            load.return_value = (state, None)
-            spend = REAL_READ_RUN_SPEND(tmp_path, "factory-abc")
+        spend = _spend_with_component_keyed(tmp_path, ARCHITECT_COMPONENT)
+
         assert spend.architect_calls == 1
 
     def test_a_bare_architect_key_never_clears_the_honesty_flag(
@@ -2213,16 +2229,7 @@ class TestRunOwnership:
         reintroduce case one in order to prettify case two.
         ``read_run_spend`` states why nothing narrower is worth building.
         """
-        state = RunState(cost_usd=2.0, cost_calls=1, usage_calls=1)
-        state.components[ARCHITECT_ROLE] = ComponentState(
-            component_id=ARCHITECT_ROLE,
-            usage_calls=1,
-            cost_calls=1,
-            cost_usd=2.0,
-        )
-        with patch("kstrl.reducer.load_run_state") as load:
-            load.return_value = (state, None)
-            spend = REAL_READ_RUN_SPEND(tmp_path, "factory-abc")
+        spend = _spend_with_component_keyed(tmp_path, ARCHITECT_ROLE)
 
         assert spend.architect_calls == 0, "a component's calls are not the architect's"
         assert spend.unmetered_phases == (ARCHITECT_ROLE,)

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -32,6 +32,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from kstrl.agents.base import (
+    ARCHITECT_COMPONENT,
+    ARCHITECT_ROLE,
     UsageRecord,
     UsageTotals,
     collect_usage,
@@ -58,6 +60,7 @@ from kstrl.factory import (
 from kstrl.inbox import Inbox, InboxConfig
 from kstrl.loop import COMPLETION_MARKER, LoopBudget, run_loop
 from kstrl.manifest import Component, ComponentStatus, Manifest
+from kstrl.names import validate_component_id
 from kstrl.observability import ProgressLog
 from kstrl.shutdown import StopController
 from kstrl.ui.plain import PlainUI
@@ -5187,6 +5190,8 @@ class _SeededRun:
 def _run_with_architect_spend(
     tmp_path: Path,
     architect_usage: UsageTotals | None,
+    *,
+    component_id: str = "comp-a",
     **config: Any,
 ) -> _SeededRun:
     """A one-component run whose engineer is cheap and whose architect
@@ -5194,9 +5199,13 @@ def _run_with_architect_spend(
 
     The scaffolding lives here rather than at each call site because only
     the architect's spend and the ceiling ever vary between them.
+
+    ``component_id`` exists for one caller: #281 needs a run whose single
+    component is genuinely NAMED `architect`, which is a legal id an
+    architect asked for a spec about design tooling may well emit.
     """
-    root = _setup_project(tmp_path, ["comp-a"])
-    manifest = _make_manifest([_component("comp-a")])
+    root = _setup_project(tmp_path, [component_id])
+    manifest = _make_manifest([_component(component_id)])
     launched: list[str] = []
     console = io.StringIO()
 
@@ -5291,7 +5300,14 @@ class TestArchitectSpendCountsAgainstTheCeiling:
     ) -> None:
         """One ``component_usage`` event, under the role name, on the
         pseudo-component `ks decompose` already reports under - so both
-        commands write the architect to the same key."""
+        commands write the architect to the same key.
+
+        #281: that key is namespaced, and the assertion spells it from
+        the constant rather than restating it. A literal here would keep
+        passing against a writer that had moved on, which is exactly how
+        the role row and the component keyspace drifted together in the
+        first place.
+        """
         run = _run_with_architect_spend(
             tmp_path,
             _architect_usage(1.5),
@@ -5300,7 +5316,7 @@ class TestArchitectSpendCountsAgainstTheCeiling:
 
         events = run.usage_events("architect")
         assert len(events) == 1
-        assert events[0]["component"] == "architect"
+        assert events[0]["component"] == ARCHITECT_COMPONENT
         assert events[0]["data"]["cost_usd"] == pytest.approx(1.5)
 
     def test_a_run_with_no_architect_records_no_phantom_row(
@@ -5645,8 +5661,8 @@ class TestTheJournalKeepsTheArchitectRow:
 
         roles = [e for e in _read_journal(run.root) if e.get("event_type") == "role_usage"]
         assert len(roles) == 1
-        assert roles[0]["component_id"] == "architect"
-        assert roles[0]["usage"]["architect"]["cost_usd"] == pytest.approx(1.5)
+        assert roles[0]["component_id"] == ARCHITECT_COMPONENT
+        assert roles[0]["usage"][ARCHITECT_ROLE]["cost_usd"] == pytest.approx(1.5)
 
     def test_the_journal_rows_sum_to_the_run_total(self, tmp_path: Path) -> None:
         """The property that was broken, asserted as arithmetic rather
@@ -5684,6 +5700,137 @@ class TestTheJournalKeepsTheArchitectRow:
 
         results = [e for e in _read_journal(run.root) if e.get("event_type") == "component_result"]
         assert [e["component_id"] for e in results] == ["comp-a"]
+
+
+class TestAComponentNamedArchitectDoesNotMergeWithTheRoleRow:
+    """#281: `architect` is a legal component id.
+
+    ``validate_component_id`` enforces a charset and a length and has no
+    reserved-name list, and the id is chosen by the architect LLM - so a
+    spec about design tooling, which is an ordinary thing to point kstrl
+    at, can produce a component genuinely called `architect`. While the
+    role's own row was keyed by the bare word, the two merged in every
+    surface that keys by component id.
+
+    The whole class is asserted against ONE run: a real component named
+    `architect`, plus a metered architect role, in the same run. That is
+    the run that used to be wrong, and each test below reads a different
+    surface off it.
+    """
+
+    @staticmethod
+    def _collided_run(tmp_path: Path) -> _SeededRun:
+        return _run_with_architect_spend(
+            tmp_path,
+            _architect_usage(1.5),
+            component_id=ARCHITECT_ROLE,
+        )
+
+    def test_the_two_rows_are_separate_in_the_meter(self, tmp_path: Path) -> None:
+        """The property the issue names first. The component's engineer
+        spend and the architect's spend are two rows, not one.
+
+        Read off the event stream rather than off the in-memory meter
+        because the stream is what every later surface is rebuilt from -
+        the reducer, the dashboard, ``serve``'s ledger. A meter that
+        separated them and a stream that did not would be the same bug
+        one layer down.
+        """
+        run = self._collided_run(tmp_path)
+
+        architect = run.usage_events(ARCHITECT_ROLE)
+        engineer = run.usage_events("engineer")
+        assert len(architect) == len(engineer) == 1
+
+        # Stated as a DIFFERENCE, not as equality against
+        # ARCHITECT_COMPONENT. Measured: an earlier draft of this test
+        # asserted each key equals its constant and passed with the
+        # namespace collapsed to "" - because both constants collapse to
+        # the same word alongside a component that carries it. An
+        # assertion that survives the bug it names is not evidence.
+        assert architect[0]["component"] != engineer[0]["component"], (
+            "the role row and a component named for the role must not share a key"
+        )
+        assert engineer[0]["component"] == ARCHITECT_ROLE, "the component keeps its own name"
+        assert architect[0]["data"]["cost_usd"] == pytest.approx(1.5)
+        assert engineer[0]["data"]["cost_usd"] == pytest.approx(0.01)
+
+    def test_the_component_keeps_the_name_the_architect_gave_it(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The compatibility half of the fix, stated as a test.
+
+        #281 lists rejecting the name at validation as option 2. This is
+        the assertion that says option 1 was taken instead: the operator
+        and the LLM keep the keyspace they already had, and kstrl moved
+        its own rows out of it. Nothing a manifest carries changed.
+        """
+        run = self._collided_run(tmp_path)
+
+        assert [c.id for c in run.manifest.components] == [ARCHITECT_ROLE]
+        assert validate_component_id(ARCHITECT_ROLE) is None
+        results = [e for e in _read_journal(run.root) if e.get("event_type") == "component_result"]
+        assert [e["component_id"] for e in results] == [ARCHITECT_ROLE]
+
+    def test_the_journal_still_writes_the_role_row(self, tmp_path: Path) -> None:
+        """``_role_usage_entries`` splits usage keys from manifest ids by
+        SET DIFFERENCE. A component named `architect` used to empty that
+        difference: no ``role_usage`` row was written at all, and the
+        architect's money was reattributed to the component's own
+        ``usage`` field, where three readers that aggregate over
+        ``component_result`` would then count it.
+        """
+        run = self._collided_run(tmp_path)
+        journal = _read_journal(run.root)
+
+        roles = [e for e in journal if e.get("event_type") == "role_usage"]
+        assert [e["component_id"] for e in roles] == [ARCHITECT_COMPONENT]
+        assert roles[0]["usage"][ARCHITECT_ROLE]["cost_usd"] == pytest.approx(1.5)
+
+        component = [e for e in journal if e.get("event_type") == "component_result"][0]
+        assert set(component["usage"]) == {"engineer"}, "the role's money is not the component's"
+
+    def test_the_journal_rows_still_sum_to_the_run_total(self, tmp_path: Path) -> None:
+        """The arithmetic the #257 review pinned, re-asserted on the
+        colliding run. Splitting a key is the kind of change that can
+        drop a row instead of moving it, and the sum is what notices.
+        """
+        run = self._collided_run(tmp_path)
+
+        rows = sum(
+            phase["cost_usd"]
+            for e in _read_journal(run.root)
+            if e.get("event_type") in ("component_result", "role_usage")
+            for phase in e.get("usage", {}).values()
+        )
+        tsv = (run.root / ".kstrl" / "experiments.tsv").read_text().splitlines()
+        totals = dict(zip(tsv[0].split("\t"), tsv[-1].split("\t"), strict=True))
+        assert rows == pytest.approx(1.51)
+        assert rows == pytest.approx(float(totals["total_cost_usd"]))
+
+    def test_the_rollup_prints_the_two_rows_under_different_labels(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """What the operator actually reads.
+
+        Counted as DISTINCT labels rather than matched against the
+        constants, for the reason given above: with the namespace
+        collapsed both constants are the same word, and an assertion
+        that each is present would be satisfied by the single merged row
+        that is the bug.
+        """
+        run = self._collided_run(tmp_path)
+
+        # The rollup's component column is fixed-width and left-aligned,
+        # so the first token of a row is its key.
+        labels = {
+            line.split()[0]
+            for line in run.printed.splitlines()
+            if line.split() and ARCHITECT_ROLE in line.split()[0]
+        }
+        assert len(labels) == 2, f"expected a role row and a component row, got {labels}"
 
 
 class TestNoConfigLoadStandsBetweenTheMoneyAndTheRun:

--- a/tests/test_usage_meter.py
+++ b/tests/test_usage_meter.py
@@ -60,7 +60,6 @@ from kstrl.factory import (
 from kstrl.inbox import Inbox, InboxConfig
 from kstrl.loop import COMPLETION_MARKER, LoopBudget, run_loop
 from kstrl.manifest import Component, ComponentStatus, Manifest
-from kstrl.names import validate_component_id
 from kstrl.observability import ProgressLog
 from kstrl.shutdown import StopController
 from kstrl.ui.plain import PlainUI
@@ -816,6 +815,30 @@ def _engineer_usage_events(root: Path) -> list[int]:
     are the same number of tokens but a different number of events.
     """
     return [int(e["data"]["total_tokens"]) for e in _usage_events(root, "engineer")]
+
+
+def _assert_journal_rows_sum_to_tsv(run: _SeededRun, *, expected: float) -> None:
+    """Every journal usage row adds up to the TSV's run total.
+
+    The #257 review's property: ``record_run`` builds rows by walking the
+    manifest, so a usage key belonging to no component was dropped while
+    ``run_usage`` - which includes it - fed ``total_cost_usd``. Shared
+    because #281 re-asserts it on a run whose component is NAMED for the
+    role: splitting a key is exactly the kind of change that drops a row
+    instead of moving it, and this arithmetic is what notices.
+    """
+    rows = sum(
+        phase["cost_usd"]
+        for e in _read_journal(run.root)
+        if e.get("event_type") in ("component_result", "role_usage")
+        for phase in e.get("usage", {}).values()
+    )
+    tsv = (run.root / ".kstrl" / "experiments.tsv").read_text().splitlines()
+    # Keyed by header, not by index: a column appended to the TSV
+    # must not silently move what this reads.
+    totals = dict(zip(tsv[0].split("\t"), tsv[-1].split("\t"), strict=True))
+    assert rows == pytest.approx(expected)
+    assert rows == pytest.approx(float(totals["total_cost_usd"]))
 
 
 def _read_journal(tmp_path: Path) -> list[dict[str, Any]]:
@@ -5281,7 +5304,7 @@ class TestArchitectSpendCountsAgainstTheCeiling:
         assert run.launched == ["comp-a"]
         assert run.result.failed == []
         # It is in the total the ceiling reads all the same.
-        assert run.usage_events("architect")
+        assert run.usage_events(ARCHITECT_ROLE)
 
     def test_an_unbounded_run_is_not_given_a_bound(
         self,
@@ -5314,7 +5337,7 @@ class TestArchitectSpendCountsAgainstTheCeiling:
             max_cost_usd=50.0,
         )
 
-        events = run.usage_events("architect")
+        events = run.usage_events(ARCHITECT_ROLE)
         assert len(events) == 1
         assert events[0]["component"] == ARCHITECT_COMPONENT
         assert events[0]["data"]["cost_usd"] == pytest.approx(1.5)
@@ -5329,7 +5352,7 @@ class TestArchitectSpendCountsAgainstTheCeiling:
         run = _run_with_architect_spend(tmp_path, None)
 
         assert run.launched == ["comp-a"]
-        assert run.usage_events("architect") == []
+        assert run.usage_events(ARCHITECT_ROLE) == []
 
     def test_an_architect_that_reported_nothing_records_no_row(
         self,
@@ -5341,7 +5364,7 @@ class TestArchitectSpendCountsAgainstTheCeiling:
         that reads as "the architect was free"."""
         run = _run_with_architect_spend(tmp_path, UsageTotals())
 
-        assert run.usage_events("architect") == []
+        assert run.usage_events(ARCHITECT_ROLE) == []
 
 
 class TestCoverageCountsTheArchitect:
@@ -5607,7 +5630,7 @@ class TestNothingBetweenTheRunDirAndTheMeterCanLoseTheSpend:
         result = self._run(root, self._cyclic_manifest())
 
         assert result.exit_code == 1, "the cyclic DAG must still fail the run"
-        events = _usage_events(root, "architect")
+        events = _usage_events(root, ARCHITECT_ROLE)
         assert len(events) == 1, "the spend must reach the run directory"
         assert events[0]["data"]["cost_usd"] == pytest.approx(4.0)
 
@@ -5669,18 +5692,7 @@ class TestTheJournalKeepsTheArchitectRow:
         than as the presence of a key."""
         run = _run_with_architect_spend(tmp_path, _architect_usage(1.5))
 
-        rows = sum(
-            phase["cost_usd"]
-            for e in _read_journal(run.root)
-            if e.get("event_type") in ("component_result", "role_usage")
-            for phase in e.get("usage", {}).values()
-        )
-        tsv = (run.root / ".kstrl" / "experiments.tsv").read_text().splitlines()
-        # Keyed by header, not by index: a column appended to the TSV
-        # must not silently move what this reads.
-        totals = dict(zip(tsv[0].split("\t"), tsv[-1].split("\t"), strict=True))
-        assert rows == pytest.approx(1.51)
-        assert rows == pytest.approx(float(totals["total_cost_usd"]))
+        _assert_journal_rows_sum_to_tsv(run, expected=1.51)
 
     def test_a_run_with_no_extra_role_adds_no_row(self, tmp_path: Path) -> None:
         """A resume has no architect, and every other usage key IS a
@@ -5712,10 +5724,12 @@ class TestAComponentNamedArchitectDoesNotMergeWithTheRoleRow:
     role's own row was keyed by the bare word, the two merged in every
     surface that keys by component id.
 
-    The whole class is asserted against ONE run: a real component named
-    `architect`, plus a metered architect role, in the same run. That is
-    the run that used to be wrong, and each test below reads a different
-    surface off it.
+    Every test below builds the SAME run shape - a real component named
+    `architect`, plus a metered architect role - and reads a different
+    surface off it. That is the run that used to be wrong. The run is
+    rebuilt per test rather than shared: `_run_component` and the diff
+    read are patched, so it costs ~20 ms, which measured at 0.19 s for
+    the class against the file's 2.8 s.
     """
 
     @staticmethod
@@ -5755,24 +5769,6 @@ class TestAComponentNamedArchitectDoesNotMergeWithTheRoleRow:
         assert architect[0]["data"]["cost_usd"] == pytest.approx(1.5)
         assert engineer[0]["data"]["cost_usd"] == pytest.approx(0.01)
 
-    def test_the_component_keeps_the_name_the_architect_gave_it(
-        self,
-        tmp_path: Path,
-    ) -> None:
-        """The compatibility half of the fix, stated as a test.
-
-        #281 lists rejecting the name at validation as option 2. This is
-        the assertion that says option 1 was taken instead: the operator
-        and the LLM keep the keyspace they already had, and kstrl moved
-        its own rows out of it. Nothing a manifest carries changed.
-        """
-        run = self._collided_run(tmp_path)
-
-        assert [c.id for c in run.manifest.components] == [ARCHITECT_ROLE]
-        assert validate_component_id(ARCHITECT_ROLE) is None
-        results = [e for e in _read_journal(run.root) if e.get("event_type") == "component_result"]
-        assert [e["component_id"] for e in results] == [ARCHITECT_ROLE]
-
     def test_the_journal_still_writes_the_role_row(self, tmp_path: Path) -> None:
         """``_role_usage_entries`` splits usage keys from manifest ids by
         SET DIFFERENCE. A component named `architect` used to empty that
@@ -5780,6 +5776,11 @@ class TestAComponentNamedArchitectDoesNotMergeWithTheRoleRow:
         architect's money was reattributed to the component's own
         ``usage`` field, where three readers that aggregate over
         ``component_result`` would then count it.
+
+        The component's own row is asserted too, and that is the
+        compatibility half: #281 lists rejecting the name at validation
+        as option 2, and this says option 1 was taken instead. The
+        operator and the LLM keep the keyspace they already had.
         """
         run = self._collided_run(tmp_path)
         journal = _read_journal(run.root)
@@ -5788,26 +5789,14 @@ class TestAComponentNamedArchitectDoesNotMergeWithTheRoleRow:
         assert [e["component_id"] for e in roles] == [ARCHITECT_COMPONENT]
         assert roles[0]["usage"][ARCHITECT_ROLE]["cost_usd"] == pytest.approx(1.5)
 
-        component = [e for e in journal if e.get("event_type") == "component_result"][0]
-        assert set(component["usage"]) == {"engineer"}, "the role's money is not the component's"
+        results = [e for e in journal if e.get("event_type") == "component_result"]
+        assert [e["component_id"] for e in results] == [ARCHITECT_ROLE]
+        assert set(results[0]["usage"]) == {"engineer"}, "the role's money is not the component's"
 
     def test_the_journal_rows_still_sum_to_the_run_total(self, tmp_path: Path) -> None:
         """The arithmetic the #257 review pinned, re-asserted on the
-        colliding run. Splitting a key is the kind of change that can
-        drop a row instead of moving it, and the sum is what notices.
-        """
-        run = self._collided_run(tmp_path)
-
-        rows = sum(
-            phase["cost_usd"]
-            for e in _read_journal(run.root)
-            if e.get("event_type") in ("component_result", "role_usage")
-            for phase in e.get("usage", {}).values()
-        )
-        tsv = (run.root / ".kstrl" / "experiments.tsv").read_text().splitlines()
-        totals = dict(zip(tsv[0].split("\t"), tsv[-1].split("\t"), strict=True))
-        assert rows == pytest.approx(1.51)
-        assert rows == pytest.approx(float(totals["total_cost_usd"]))
+        colliding run."""
+        _assert_journal_rows_sum_to_tsv(self._collided_run(tmp_path), expected=1.51)
 
     def test_the_rollup_prints_the_two_rows_under_different_labels(
         self,
@@ -5826,9 +5815,9 @@ class TestAComponentNamedArchitectDoesNotMergeWithTheRoleRow:
         # The rollup's component column is fixed-width and left-aligned,
         # so the first token of a row is its key.
         labels = {
-            line.split()[0]
+            tokens[0]
             for line in run.printed.splitlines()
-            if line.split() and ARCHITECT_ROLE in line.split()[0]
+            if (tokens := line.split()) and ARCHITECT_ROLE in tokens[0]
         }
         assert len(labels) == 2, f"expected a role row and a component row, got {labels}"
 


### PR DESCRIPTION
Fixes #281

## The collision

`ARCHITECT_ROLE` was the bare string `"architect"`, and since #279 it names a row in the usage meter, the run's event stream and the journal's role usage. Component ids live in the same namespace and are chosen by the architect LLM; `validate_component_id` enforces a charset and a length and has no reserved-name check. So a component genuinely named `architect` merged with the role row.

Not cosmetic: that component's engineer, review, security and distill spend folded into the architect's row and the architect's into the component's; and `RunSpend.architect_calls` went non-zero for a run whose architect may never have reported, clearing `unmetered_phases` and letting the daemon announce an exact daily total it had no evidence for. That is the honesty property #279 was built to establish.

## The decision: option 1

Namespace the role rows. `names.role_component_key` puts kstrl's own rows behind a prefix that `COMPONENT_ID_PATTERN` cannot produce, because the pattern anchors the first character to `[a-z0-9]`.

Option 2 (reserve the name) was rejected for the reason the issue gives: it is a policy about what operators may call things, imposed to work around an internal key choice, and it breaks manifests that already use the name. Option 1 breaks nothing a manifest carries and removes the class rather than one instance.

`ROLE_KEY_PREFIX` lives beside `COMPONENT_ID_PATTERN` in `names.py` because co-location is what makes the disjointness checkable, and `tests/test_input_hygiene.py::TestRoleKeysCannotBeComponentIds` pins the two together: loosen the pattern and a test fails, rather than the meter silently re-merging.

`@` rather than something that reads more like prose, because the key is not only a dict key. `ks decompose` opens the architect's transcript at `components/<key>/engineer.log`, so the prefix becomes a path segment. `@` is unremarkable in a path and needs no shell quoting; `validate_branch_name` rejects it too, so a leak into a git ref is a loud failure.

The **phase** axis stays bare. Phase keys are kstrl's own vocabulary on both sides of the mapping, so they never collided. Only the component axis is one an LLM also writes to.

## Design question 1: how many keyed surfaces are there really?

Enumerated from the code, not from the issue. Nine, of which #279's report named three:

| Surface | Site |
|---|---|
| Pipeline usage meter | `pipeline.py` `_record_usage`, `usage_meter.setdefault(comp_id, ...)` |
| `ComponentUsage` events -> `events.jsonl` | `pipeline.py`, `decompose.py` |
| Reducer component table (lazy create from any id) | `reducer.py` `_component` |
| v1 twin of the reducer | `observability.py` `activity.components.setdefault` |
| Evolution journal role/component split | `evolution.py` `_role_usage_entries` |
| `serve`'s spend ledger | `serve.py` `read_run_spend` |
| Rollup renderer + `_USAGE_PHASE_ORDER` | `agents/base.py` |
| Run-dir transcript path `components/<id>/` | `events.py` `RunPaths.component_dir` |
| **TUI DAG table** | `tui/widgets/dag_table.py` |

The last one was not in the issue and is a **second live defect**, found during this work. `dag_table.py` held its own `ARCHITECT_ID = "architect"` declaration and filtered the plan by it, so a component genuinely named `architect` was dropped from the DAG view entirely: present in the plan, holding real dependencies, invisible. It is now covered by `test_a_component_named_architect_is_not_filtered_out_of_the_dag`.

Also confirmed and left alone: the `decompose.py` `RunPlan` at the plan-merge site emitted the architect entry followed by the LLM's components in one payload, so a component named `architect` produced two entries with the same id and `plan_order` carried a duplicate. Namespacing removes that case too.

## Design question 2: does the fix need to be visible in the audit trail?

**Old records still read, with one claim degraded, in the pessimistic direction.**

A run recorded before this change says `"architect"` in its events and journal. `read_run_spend` now looks for the namespaced key, finds nothing, and reports the run as having no architect row, so the day reads as a **floor** rather than exact. The money is still counted; only the exactness claim degrades. That is the same answer the function already gives for a resume, a blocker halt and an adapter that reports nothing. Never a false exact.

**There is deliberately no fallback to the old key.** It would be unsafe rather than merely redundant: on a new run whose architect did not report and which contains a component named `architect`, a fallback would read that component's calls as the architect's and clear the honesty flag, which is exactly the bug being removed. Nothing at that seam can tell the two apart, so a fallback would reintroduce the bug in order to prettify history. Nothing narrower is worth building either, because `owned_run_spend` only reads run dirs created inside the launch window it is charging, so the daemon never reads a pre-change run at all.

That reasoning is pinned by `test_a_bare_architect_key_never_clears_the_honesty_flag`, which asserts both readings of the one ambiguous state.

## Design question 3: is `architect` the only role at risk?

The **helper** generalises: `role_component_key` namespaces any role, and the hygiene guard is parametrized over role shapes rather than pinned to the word.

The **defect** is currently unique to the architect, and I checked rather than assumed. The bug needs two writers into one run's component keyspace, one of them LLM-chosen. `ks understand` (`component="understand"`, `phase="understand"`) and `ks feature` (feature name as pseudo-component id) have the same id-equals-role shape but not the defect:

- neither loads a manifest or emits `ComponentUsage`; the only two emitters are in `pipeline.py` and `decompose.py`, neither of which runs there;
- the keyspace is per-run (`load_run_state(root_dir, run_id)`, `RunPaths.for_run`), so a component named `understand` in a factory run cannot reach an understand run's row;
- `owned_run_spend` charges only `factory`-kind runs, so those runs never reach the architect probe.

Namespacing them would be cost with no defect behind it, so they are left alone.

Honest limit: a future role row is namespaced only if its author calls `role_component_key`. Nothing at the write seam enforces it. An assertion in `_record_usage` was considered and rejected because `agents/base` states that accounting must never gate a run, and an assert there would. The constant, the docstrings at both write sites, and the hygiene test are the mechanism.

## Tests

- `test_the_two_rows_are_separate_in_the_meter` - the two rows do not share a key.
- `test_the_journal_still_writes_the_role_row` - the journal's set difference no longer swallows the role row, and the component keeps its own name.
- `test_the_rollup_prints_the_two_rows_under_different_labels`.
- `test_a_bare_architect_key_never_clears_the_honesty_flag` - the honesty flag, plus the audit-trail answer.
- `test_a_component_named_architect_is_not_filtered_out_of_the_dag`.
- `TestRoleKeysCannotBeComponentIds` - the lockstep guard between prefix and pattern.

**Each was verified to fail without the fix**, by collapsing `ROLE_KEY_PREFIX` to `""` and re-running: 10 failures. This caught a real problem. An earlier draft asserted each key equals its constant and **passed** in the collapsed state, because both constants collapse to the same word alongside a component that carries it. Those assertions were restated as differences and counts. The two tests that still pass under collapse are documented as guarding something else (that option 2 was not taken, and that no row was dropped).

## Gate

| Check | Result |
|---|---|
| `uv run pytest tests/ -q` | 4117 passed, 28 skipped |
| `uv run mypy kstrl/ --strict` | no issues, 121 files |
| `uv run ruff check kstrl/ tests/` | passed |
| `pre-commit run --all-files` | all hooks passed |

One pre-existing flake: `tests/test_shutdown.py::TestWorkerSigterm::test_pool_worker_sigterm_kills_agent_group`. Measured on unchanged code in isolation: **1 failed, 2 passed** over three runs, and it passed in one full-suite run of this branch and failed in another. It is a timing-dependent SIGTERM test; this diff touches no signal or process code.

## `/simplify` findings, verbatim

Four cleanup agents over the branch diff. Reproduced as returned.

<details>
<summary><b>Reuse</b></summary>

**1. `kstrl/tui/widgets/dag_table.py:32` - `ARCHITECT_ID` is now a pure alias, a second name for one constant.**
`ARCHITECT_ID: Final = ARCHITECT_COMPONENT` no longer holds any value of its own; it only re-exports. Its consumers are `dag_table.py:89` plus six sites in `kstrl/tui/screens/decompose.py` (lines 29, 48, 83, 107, 111, 136, 263), which import it *through* `dag_table` rather than from the defining module. `kstrl/names.py`'s own module docstring states the opposite convention for exactly this situation ("Import them from HERE, not from `kstrl.manifest`... that is not a re-export"). Cost: two greppable names for one key, so the next person adding a role row must find both, and `screens/decompose.py` depends on a *widget* module for a domain constant it could get from `agents.base` directly. Fix: delete `ARCHITECT_ID` and import `ARCHITECT_COMPONENT` in the two files (9 line edits, no behaviour change).

**2. `tests/test_usage_meter.py:5794-5810` - verbatim copy of `tests/test_usage_meter.py:5667-5683`.**
`TestAComponentNamedArchitectDoesNotMergeWithTheRoleRow.test_the_journal_rows_still_sum_to_the_run_total` reproduces `TestTheJournalKeepsTheArchitectRow.test_the_journal_rows_sum_to_the_run_total` line for line: the same four-line `sum(...)` comprehension over `("component_result", "role_usage")`, the same `experiments.tsv` header-zip, the same `pytest.approx(1.51)` magic total. Only the run differs (`self._collided_run(tmp_path)` vs `_run_with_architect_spend(tmp_path, _architect_usage(1.5))`). The copy even drops the original's "Keyed by header, not by index" comment, so the second copy loses the reason it was written that way. Cost: a TSV column rename or a change to the journal event types means editing the same comprehension twice. Fix: a module-level `_journal_cost_total(run) -> float` next to the existing `_read_journal` helper (line 821), called from both.

**3. `tests/test_serve.py:2216-2222` - duplicated setup of `tests/test_serve.py:2170-2176`.**
`test_a_bare_architect_key_never_clears_the_honesty_flag` repeats the `RunState(cost_usd=2.0, cost_calls=1, usage_calls=1)` + `ComponentState(usage_calls=1, cost_calls=1, cost_usd=2.0)` + `patch("kstrl.reducer.load_run_state")` + `REAL_READ_RUN_SPEND(tmp_path, "factory-abc")` scaffold of the test immediately above it; the only variable is the dict key (`ARCHITECT_COMPONENT` vs `ARCHITECT_ROLE`). Cost: a `ComponentState` signature change or a move of `load_run_state` touches two identical blocks. Fix: one `_spend_for_component_key(tmp_path, key) -> RunSpend` helper, or `@pytest.mark.parametrize` over `(key, expected_architect_calls, expected_unmetered)`.

**4. Bare role literals left in files that now import the constant.**
`tests/test_serve.py` imports `ARCHITECT_ROLE` (line 24) and uses it at 2217/2218/2228, but still spells the same role as a literal at lines 397, 617, 622, 675, 2120, 2269, 2306, 2321 (`unmetered_phases=("architect",)`, `assert "architect" in spend.unmetered_phases`). `tests/test_usage_meter.py` imports `ARCHITECT_ROLE` (line 36) and uses it in the new class, but keeps `run.usage_events("architect")` / `_usage_events(root, "architect")` at 5284, 5317, 5332, 5344, 5610. These are role/phase-position uses, so they are *correct* today - but the diff's own stated rationale ("a literal here would keep passing against a writer that had moved on", `test_usage_meter.py:5305-5307`) applies verbatim to them. Cost: the file now teaches both conventions, so the next role-key move has to be audited literal by literal rather than by import graph.

**5. `tests/test_input_hygiene.py:167-186` - the `ROLES` table re-runs cases the file's existing tables already cover.**
The file is table-driven: `ACCEPTED_COMPONENT_IDS` (line 72) and `REJECTED_COMPONENT_IDS` (line 48) feed `TestValidateComponentId.test_accepted` / `test_rejected`. `test_the_bare_role_name_stays_a_valid_component_id` is `test_accepted` again over a different word list, and three of its ten rows (`"a"`, `"role.with.dots"`, `"x" * 64`) are already covered by `ACCEPTED_COMPONENT_IDS`'s `"a"`, `"api.v2"`, `"a" * 64`. The genuinely new facts are one row each: `"architect"` belongs in `ACCEPTED_COMPONENT_IDS`, and `role_component_key("architect")` in `REJECTED_COMPONENT_IDS`. The two tests that carry real new properties - `test_a_role_key_is_never_a_valid_component_id` as a class property and `test_the_prefix_is_not_empty` - do not fit the tables and should stay.

**6. `tests/test_commandrun.py:88, 94, 102` - the last bare literal in *component* position anywhere in the tree.**
`open_command_run(ui, tmp_path, "decompose", component="architect", ...)` mirrors the `kstrl/cli.py:2107` call the diff changed to `ARCHITECT_COMPONENT`, and asserts on the stamped value at 94 and 102. Low priority (the test is about bus stamping, not about the architect), but it is now the only place a test writes the architect's old component key.

## Clean on this angle

- `role_component_key` duplicates nothing. `kstrl/names.py` had no key-namespacing helper, and the other `*_PREFIX` constants in the tree (`findings.POLICY_CATEGORY_PREFIX`, `git._ORIGIN_REF_PREFIX`, `knowledge._CORE_SECTION_PREFIX`) are unrelated domains with no shared abstraction to reach for.
- `ARCHITECT_COMPONENT` has exactly one definition (`kstrl/agents/base.py:453`); the old `decompose.ARCHITECT_COMPONENT` alias was correctly deleted and nothing imported it from there. Finding 1 is an alias, not a second definition.
- Production `kstrl/` has zero remaining bare `"architect"` literals in component position - the only survivors are docstrings, comments, and `calibration.py:76`'s `MIN_ROLE_DETECTION_RATE` key, which is a separate calibration-role vocabulary (it sits beside `"architect_allowed_paths"`) and correctly stays bare.
- The new tests reuse the existing fixtures rather than reinventing them: `write_fake_decompose_run`, `_decompose_app`, `_read_journal`, `_run_with_architect_spend` (extended with one keyword-only `component_id` rather than forked).

</details>

<details>
<summary><b>Simplification</b></summary>

**1. `kstrl/tui/widgets/dag_table.py:32` - `ARCHITECT_ID` is now a pure alias and should go**

`ARCHITECT_ID: Final = ARCHITECT_COMPONENT` leaves three names for one string, and the alias hides the TUI from the very grep the rest of the diff relies on: `grep -rn ARCHITECT_COMPONENT kstrl/` returns nothing under `kstrl/tui/screens/`, yet `screens/decompose.py` uses the value at lines 48, 83, 107, 111, 136, 263. It also makes a screen import a domain constant from a widget module. Cost: 7 use sites invisible to the constant's own name, plus a reader hop to learn the alias is not its own concept. Simpler: delete the alias, `from kstrl.agents.base import ARCHITECT_COMPONENT` in both `dag_table.py` (1 use, line 89) and `screens/decompose.py` (6 uses). The `Final` import this diff adds to `dag_table.py` then goes away too.

**2. `tests/test_usage_meter.py:5794` - `test_the_journal_rows_still_sum_to_the_run_total` is a verbatim copy**

Its 12-line body is character-identical to `test_the_journal_rows_sum_to_the_run_total` at line 5667 (sum over `component_result`+`role_usage`, TSV header zip, same `1.51`); only the fixture line differs. Cost: two copies of the TSV-header parse to keep in step. Simpler: extract `_assert_journal_sums_to_tsv(run, expected)`, or parametrize the existing `TestTheJournalKeepsTheArchitectRow` over `component_id` in `("comp-a", ARCHITECT_ROLE)` - that also subsumes finding 3, collapsing three new methods into the existing bodies.

**3. `tests/test_usage_meter.py:5758` - `test_the_component_keeps_the_name_the_architect_gave_it`: 2 of its 3 assertions carry nothing**

- `[c.id for c in run.manifest.components] == [ARCHITECT_ROLE]` restates what `_run_with_architect_spend(component_id=...)` was just told to build (`_make_manifest([_component(component_id)])`) - it can only fail if the helper is broken.
- `validate_component_id(ARCHITECT_ROLE) is None` duplicates `tests/test_input_hygiene.py:185` with the `"architect"` param, and the id shape is already in `ACCEPTED_COMPONENT_IDS`.
- The event-stream form of the same claim is already asserted at line 5754 (`engineer[0]["component"] == ARCHITECT_ROLE`).

Only the journal line is load-bearing. Cost: a whole extra factory run for one assertion. Simpler: move `[e["component_id"] for e in results] == [ARCHITECT_ROLE]` into `test_the_journal_still_writes_the_role_row` (which already reads `component_result` at line 5791) and delete the method - about 17 lines and one run.

Related: the class docstring says "asserted against ONE run", but `_collided_run` is a staticmethod called per test, so it is five full `run_factory` executions. A class-scoped fixture (`tmp_path_factory`) would make the code match the claim.

**4. `tests/test_usage_meter.py:5827-5832` - `line.split()` evaluated three times per line**

```python
if line.split() and ARCHITECT_ROLE in line.split()[0]
```
Cost: two redundant splits per console line, and the guard reads as a puzzle. Simpler: `if (tokens := line.split()) and ARCHITECT_ROLE in tokens[0]`, taking `tokens[0]`.

The `len(labels) == 2` shape itself is correct and I would not change it - the docstring's argument holds under check: with the prefix collapsed, `labels == {ARCHITECT_COMPONENT, ARCHITECT_ROLE}` would compare `{"architect"}` to `{"architect"}` and pass, while the count fails. That is the one place the roundabout form earns itself.

**5. `tests/test_input_hygiene.py:167-190` - the 10-name `ROLES` fanout is 20 cases over a property independent of the parameter**

`validate_component_id("@" + role)` is rejected at character 0 by the anchor for every entry, so nine of the ten params exercise the identical branch. The bare-name half is worse: every shape in the list (`"a"`, `"x"*64`, dotted, hyphenated) is already covered by `ACCEPTED_COMPONENT_IDS`, so it re-tests `TestValidateComponentId.test_accepted`. Cost: a fictional role list to maintain (`"understand"`, `"distill"` have no rows) and 20 test ids for roughly two distinct paths. Simpler: keep the rejection test parametrized over ~3 shapes, and reduce `test_the_bare_role_name_stays_a_valid_component_id` to the single `"architect"` case, which is the actual compatibility claim.

**6. `tests/test_input_hygiene.py:205` - `assert ROLE_KEY_PREFIX != ""` is implied by line 206**

If the prefix is empty, `role_component_key("architect") == "architect"` and the next line already fails. Drop the first assert. Trivial, but it is a second assertion that cannot independently fail.

**7. `kstrl/names.py:61` - `role_component_key()` has exactly one production caller**

`kstrl/agents/base.py:453` is the only non-test call. The generalisation is real but currently exercised only by the hygiene tests. The plain form is `ARCHITECT_COMPONENT: Final = ROLE_KEY_PREFIX + ARCHITECT_ROLE`, with the hygiene test asserting against the prefix directly. **I would keep the function**: it is one line, it is the thing `TestRoleKeysCannotBeComponentIds` puts under test, and a second role row makes it general at zero further cost. Flagging it so the single-caller status is a known choice rather than an assumption. Note the new `kstrl.agents.base -> kstrl.names` runtime import edge is unavoidable either way (the constant form still needs `ROLE_KEY_PREFIX`), and `names.py` is a leaf so there is no cycle risk.

**8. Nit, `tests/test_usage_meter.py:5314`** - `run.usage_events("architect")` keeps a phase-axis literal two lines above an assertion whose docstring argues that literals are exactly how the two axes drifted. `ARCHITECT_ROLE` is used for the same argument at line 5741. Inconsistent, cheap to fix.

## Clean on this angle

No dead code left behind: `decompose.ARCHITECT_COMPONENT` was removed and nothing imports it from there; no bare `"architect"` key literal survives in `kstrl/` (the remaining hits are prose, `ARCHITECT_ROLE`'s own definition, and `calibration.py`'s unrelated role-rate table). No new nesting, no derivable state stored twice on the production side, and `_run_with_architect_spend`'s `component_id` parameter is the minimal way to reuse that fixture.

</details>

<details>
<summary><b>Efficiency</b></summary>

Measured everything against a `git archive main` snapshot in the scratchpad, same interpreter, 9 runs per module, medians.

## Efficiency findings

**No efficiency regression worth fixing.** Details, all measured:

**1. `kstrl/agents/base.py:11` - `from kstrl.names import role_component_key`. Clean, no cost, no cycle risk.**
`kstrl/names.py` imports only `re` and `typing` and nothing from `kstrl`, so it is a leaf - a cycle is structurally impossible, and `re` is already loaded by the interpreter. Measured `import kstrl.agents.base`: branch 27.6 ms median vs main 27.5 ms (+0.1 ms, noise). `role_component_key` is called exactly once, at import, to build the `Final` constant at `base.py:453`; there is no per-row or per-event call site (grep over `kstrl/` returns only the one call plus comments).

**2. `kstrl/tui/widgets/dag_table.py:21` - new `from kstrl.agents.base import ARCHITECT_COMPONENT` in a presentation widget. Layering nit; zero cost on every real path.**
The import does pull `kstrl/agents/__init__.py` (claude_code, claude_sdk, codex, custom, sandbox, proc) into the widget: `-X importtime` attributes 3715 us cumulative to `kstrl.agents`, and importing the widget *alone* goes 77.8 -> 81.8 ms median (+4.0 ms). That +4 ms never materializes, because `kstrl/reducer.py:31` already does `from kstrl.agents.base import CEILING_AXES` at module level **on main too**, and the widget's only importer is `kstrl/tui/screens/decompose.py`, which sits behind the reducer/store. Measured on the real startup paths:

| module | branch | main |
|---|---|---|
| `kstrl.tui.app` | 142.0 ms | 152.8 ms |
| `kstrl.tui.session` | 150.4 ms | 150.9 ms |
| `kstrl.cli` | 96.5 ms | 94.2 ms |

No regression (the app number came out *lower* on the branch - run-to-run variance). Same verdict for `kstrl/tui/session.py:22`.

**3. `tests/test_usage_meter.py:938` (`_collided_run`) - five `run_factory` invocations where a shared fixture would do one. Real in shape, negligible in cost: 0.10 s.**
Measured with `-k ComponentNamedArchitect -q --durations=10`: **5 passed in 0.19 s**, each test's `call` phase 0.02 s. `run_factory` here is fully mocked (`kstrl.factory._run_component` and `kstrl.git.get_diff_content` patched), so a "full run" is ~20 ms of tmpdir writes and meter arithmetic, not an agent call. Context: the whole file is 239 tests in 2.80 s, so the new class is 3.6% of it. A class-scoped fixture saves ~0.08 s and would cost per-test tmpdir isolation (`tmp_path` is function-scoped; sharing needs `tmp_path_factory`). The sibling `TestArchitectSpendCountsAgainstTheCeiling` already uses the identical per-test pattern. **Not worth changing.** One wording nit: the class docstring says "asserted against ONE run" - it is one run *shape*, executed five times.

**4. `tests/test_decompose_screens.py:648` - `await pilot.pause(0.2)` is the largest single cost the diff adds: 0.26 s for that one test, ~0.2 s of it pure sleep.** It is a fixed sleep, not a condition wait, but the file already contains 8 `pilot.pause` calls following the same idiom, so this is the local convention rather than something the diff regresses.

**5. No closures, captured environments, or long-lived objects introduced.** `ARCHITECT_ID: Final = ARCHITECT_COMPONENT` in `dag_table.py:31` is a plain `str` alias. No blocking work added to a hot path, no repeated I/O in production code, no independent operations serialized.

Total measured suite delta from the diff: ~0.36 s (0.10 s meter class + 0.26 s TUI test).

</details>

<details>
<summary><b>Altitude</b></summary>

## Verdict: the altitude is right

The fix is at the keyspace, not at any reader or display. Both writers moved (`pipeline.py:613`, `decompose.py:1213/1220` and the plan/lifecycle emits at `decompose.py:1282-1767`), and the readers moved with them (`serve.py:756`, `dag_table.py:89`). No compat fallback was added on the read side, and `read_run_spend`'s docstring argues correctly why one would be unsafe rather than merely redundant. I found no reader-only patch and no display-layer filter standing in for a keyspace fix.

The home is right too. `ROLE_KEY_PREFIX` (`kstrl/names.py:58`) sits beside `COMPONENT_ID_PATTERN` (`names.py:26`) because co-location is what makes the disjointness checkable, and `tests/test_input_hygiene.py:150-206` pins the two constants together - loosening the pattern fails there instead of silently re-merging the meter. `ARCHITECT_COMPONENT` belongs in `agents/base.py:453` rather than `names.py`: `names.py` is charset hygiene and should not know the role taxonomy, while `base.py` already owns `ARCHITECT_ROLE` for `_USAGE_PHASE_ORDER`, so one file now owns both axes and the phase/component split is visible in one place. The new `agents/base.py:11 -> kstrl.names` import introduces no cycle (`names.py` imports only `re`).

I verified the fix breaks nothing downstream: the only `validate_component_id` call sites are `decompose.py:611` (LLM output) and `manifest.py:54` (manifest load), neither of which ever sees a role key; `RunPaths.component_dir` (`events.py:1114`) does no sanitisation, so `@architect` is a legal path segment. `tests/test_input_hygiene.py` and `tests/test_decompose_screens.py` pass (140 tests).

## Findings

**1. `kstrl/cli.py:1366,1398,1432` (`ks understand`) and `kstrl/feature_cmd.py:177` (`ks feature`) - NOT the same defect. Out of scope, firmly.**
The bug needs two writers into one run's component keyspace, one of them LLM-chosen. Evidence that neither command has that:
- `_understand_core` (`cli.py:1413-1533`) emits every component-keyed event under the single id `"understand"`; no manifest is loaded, and `run_loop` emits no `ComponentUsage` - the only two emitters are `pipeline.py:519` and `decompose.py:1212`, neither of which runs in an understand run.
- `run_feature` (`feature_cmd.py:177` onward) keys every emit off `params.feature_name`, operator-supplied, one component, no second writer and no architect.
- The keyspace is per-run: `load_run_state(root_dir, run_id)` and `RunPaths.for_run` scope both the component table and the transcript dirs to one run dir, so a component named `understand` in a factory run cannot reach an understand run's row.
- `serve.owned_run_spend` charges only `SPAWNED_RUN_KIND = "factory"` runs (`serve.py:768`), so understand/feature runs never reach the architect probe at all.
No change warranted. Namespacing them would be cost with no defect behind it.

**2. `kstrl/evolution.py:485` - the role row is still identified by ABSENCE, not by the marker the fix just created.**
`for role in sorted(set(usage_by_component) - component_ids)` infers "this is a role" from "not in the manifest". The fix makes role keys positively identifiable (`startswith(ROLE_KEY_PREFIX)`), and this is the one site that could have consumed that and did not. Cost: any usage key that is neither a manifest component nor a role - a future emitter's typo, a component dropped from a mutated manifest - is silently journalled as `event_type: "role_usage"`, inventing a role. The set difference is now *correct* for the architect (that is the diff's claim, and it holds), but it is still a heuristic where a test is now available. Deeper fix: partition on the prefix and warn on the residue. Low severity, genuinely optional - but it is the one place the new mechanism was built and not used.

**3. `kstrl/tui/widgets/dag_table.py:32` - the second declaration became a re-export hop rather than being deleted.**
`ARCHITECT_ID: Final = ARCHITECT_COMPONENT` fixes the duplicate *value*, which was the bug. But `kstrl/tui/screens/decompose.py:29` still imports `ARCHITECT_ID` from a widget module and uses it at lines 48, 83, 107, 111, 136, 263 - six sites where a reader sees a TUI-local name for what is actually the shared meter key. Per the project's own "removing a mechanism wins over adding a check", the deeper move is to delete `ARCHITECT_ID` and have both files import `ARCHITECT_COMPONENT` from `agents.base` directly (7 call sites, mechanical, no test imports it - `tests/test_decompose_screens.py:21` imports only `DagTable, compute_tiers`). Cost of leaving it: one extra name to keep pointed at the right thing, and a widget module that is now an import waypoint for a non-TUI constant.

**4. `kstrl/pipeline.py:504` / `kstrl/agents/base.py:453` - generalisation to future roles is by convention, not by mechanism.**
The prefix removes the class of bug, and the parametrized guard in `tests/test_input_hygiene.py:169-182` exercises hypothetical future roles - but it tests `role_component_key` in isolation, not that any future role row *calls* it. Nothing at the write seam (`_record_usage(comp_id, phase, totals)`) distinguishes a role key from a component key, so a second pre-run role added later can be written bare and every test stays green. The project's own rule is "if there is no mechanism, there is no plan". The cheap mechanism, if wanted, is an assertion at `_record_usage` that `comp_id` is either role-prefixed or a valid component id. I would not block on this - one role row exists, and the docstrings at `base.py:441-452` and `pipeline.py:595-601` name the discipline clearly - but the diff's claim that the fix "fixes every role row added later" is true of the *helper*, not yet of the *codebase*.

No other independent role-name literals remain in the component keyspace: the only surviving `"architect"` strings in `kstrl/` are `ARCHITECT_ROLE` itself (`base.py:439`), prose in comments, and `calibration.py:76`, which is a role dimension in the calibration report - a different keyspace with no component ids in it.

</details>

### What was applied and what was skipped

Applied: delete `ARCHITECT_ID` (all four agents); extract `_assert_journal_rows_sum_to_tsv`; fold the redundant test into the journal test; extract `_spend_with_component_keyed`; walrus in the label filter; trim `ROLES` to three shapes; drop the subsumed assert; spell the phase axis from `ARCHITECT_ROLE` in the files that already import it.

Skipped, with reasons:

- **`evolution._role_usage_entries` by absence rather than by prefix** (Altitude 2). The set difference is total: every usage key with no component becomes a row, which is exactly what makes the journal sum to its own total, a property with a test. A prefix test would need a third bucket for the residue to preserve that. Scope beyond this fix, and the finding calls it optional.
- **A runtime assertion at `_record_usage`** (Altitude 4). `agents/base` states that accounting must never gate a run, and an assert there would. Recorded as an honest limit above instead.
- **Per-test factory run in the new class** (Efficiency 3, Simplification 3). Measured at 0.19 s for the class against the file's 2.8 s; sharing costs `tmp_path` isolation for no gain. The docstring's inaccurate "ONE run" claim was corrected to name the measurement.
- **Bare literals in `test_serve.py` at lines outside this diff, and `test_commandrun.py`** (Reuse 4, Reuse 6). Correct today, and touching them would widen the diff past the fix.
- **Moving `"architect"` into `ACCEPTED_COMPONENT_IDS`** (Reuse 5). The compatibility claim keeps its reasoning in `TestRoleKeysCannotBeComponentIds`; duplicating the row into the generic shape table would split it from its argument.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHYpsJ8ecHLh5HdrswJtJK

---

# Follow-up: the same seam in the TUI (review MEDIUM)

Review found that #281's key move broke the TUI's reading of run directories written before it. Confirmed by reproduction before changing anything: a **completed** old-format decompose run rendered

```
summary: X decompose did not complete
attempt: waiting for the architect...
```

with three further symptoms on the same dir - `audit_ran` never true, `SpecTriageScreen` computing `halted=False` for a run that halted, the transcript tailing `components/@architect/engineer.log` which does not exist, and the stale pseudo-row rendering as a graph node.

## Why this seam takes a fallback and `serve` still does not

The review's distinction is right and I had not carried my own reasoning across.

| | `serve.read_run_spend` | `DecomposeScreen` |
|---|---|---|
| Failure mode on an old dir | reads the day as a **floor** - understates, honest | reports a successful run as **failed** - simply wrong |
| Are the two candidate rows distinguishable? | **No.** An old role row and a component named `architect` are the same shape | **Yes.** A post-#281 dir always contains the namespaced key |

So `serve` stays pessimistic and the TUI gets `architect_component_id(state)`, which returns the key that run dir actually wrote.

## Why the fallback cannot resurrect the collision

Two independent conditions, each verified by deleting it and watching a test fail:

1. **Gated on `decompose` runs.** A factory run whose architect never reported and whose manifest holds a component named `architect` keeps the pessimistic read. Removing the gate fails `test_a_factory_run_never_falls_back`.
2. **Unreachable within a decompose run anyway.** `_decompose_spec_impl` emits the architect's `RunPlan` entry and `ComponentStarted` unconditionally before the spec reaches an LLM, and the reducer creates a row from `RunPlan`. So a post-#281 dir always answers on the first branch, and the LLM's own components (second `RunPlan`, strictly later) are never consulted.

Removing the fallback entirely fails 3 tests including both end-to-end screen tests.

## Two of my own claims were wrong, and are corrected

The altitude reviewer checked the justifications in my docstring and both failed. I verified each against the code rather than taking them on trust:

- **"`kstrl/tui/state.py` is the ONLY module in `kstrl/tui/` that imports the reducer."** False since the home board landed - `kstrl/tui/home_data.py:17` imports it at runtime. My placement argument was leaning on a property that does not hold. The module docstring now says what is actually true.
- **"Putting the resolver in `reducer.py` would make the fallback reachable from `serve.py`, where it is unsafe."** Wrong. `owned_run_spend` is `read_run_spend`'s only caller and already narrows to `SPAWNED_RUN_KIND == "factory"`, so a `decompose`-gated fallback would be a **no-op** there wherever it lived. Unreachable, not unsafe. The placement is a layering choice - an era shim for rendering sits with the renderer - and the docstring now says that instead of claiming a safety property it does not have.

A third design note, from the reuse reviewer, is now recorded in the code: this must **not** be "simplified" into normalising the key during the fold, because `transcript_component` has to stay the on-disk key - it becomes the path segment in `components/<key>/engineer.log`.

## Tests

- `test_a_pre_281_run_dir_still_renders_as_the_run_it_was` - all four symptoms off one old dir.
- `test_a_pre_281_halted_run_still_shows_its_blocker_banner`.
- `TestArchitectComponentId` - 4 unit tests, including the two "never falls back" guards.
- `write_fake_decompose_run` gained an `architect_key` parameter so a test can write a dir the pre-#281 way.

## Gate

| Check | Result |
|---|---|
| `uv run pytest tests/ -q` | 4106 passed, 28 skipped |
| `uv run mypy kstrl/ --strict` | no issues, 121 files |
| `uv run ruff check kstrl/ tests/` | passed |
| `pre-commit run --all-files` | all hooks passed |

## `/simplify` round 2, verbatim

<details>
<summary><b>Reuse</b></summary>

## 1. `architect_component_id` does not duplicate anything - confirmed new

Searched every #281-aware site: `kstrl/names.py:61` `role_component_key` (write side only), `kstrl/serve.py:721-756` `read_run_spend` (documents refusing exactly this fallback), `kstrl/evolution.py:443` `_role_usage_entries` (set difference, no fallback), `kstrl/agents/base.py:439-453`. No run-format probe or legacy-key resolver exists anywhere in `kstrl/`. Nothing to reuse; the helper is correctly new, and correctly placed in `kstrl/tui/state.py` (the only module in `kstrl/tui/` that imports the reducer, and `StateStore` has exactly one construction site, `kstrl/tui/runcontext.py:52`, so the seam is TUI-only).

The one alias-on-read precedent in the codebase is `kstrl/knowledge.py:197` `_CONFIDENCE_ALIASES`, which normalizes the legacy token once at parse so no downstream caller has to remember it. The equivalent shape here (rewrite the folded key inside `StateStore.apply_events`) is **not** applicable and should not be suggested: `transcript_component` must stay the on-disk key because it becomes the path segment in `components/<key>/engineer.log`, so normalizing the key would re-break the transcript tail on old dirs. A resolver returning the dir's own key is the right shape. Worth noting only so nobody "simplifies" it into the reducer.

## 2. MEDIUM - the "plan minus the architect pseudo-row" rule is spelled twice

- `kstrl/tui/screens/decompose.py:113` - `planned = [c for c in state.plan_order if c != architect_component_id(state)]`
- `kstrl/tui/widgets/dag_table.py:90-91` - `pseudo = architect_component_id(state)` / `order = [cid for cid in state.plan_order if cid != pseudo]`

Cost: this diff is itself the evidence - both sites had to be edited identically, and the previous #281 change edited both too. Two definitions of one rule that have now moved together twice. Concrete fix: one helper beside `architect_component_id` in `kstrl/tui/state.py`, e.g. `planned_component_ids(state) -> list[str]`, called from both. It also gives the two unfiltered readers a correct thing to call: `kstrl/tui/home_data.py:46` (`total = len(state.plan_order) or ...`) and `kstrl/tui/widgets/component_table.py:121` both count the architect pseudo-row as a component on decompose runs. Those are pre-existing and outside this diff, but today there is no single place from which to fix them.

## 3. LOW - the resolved key is already held on the screen; the render helpers re-derive it

`kstrl/tui/screens/decompose.py:180` stores the resolved key in `self.transcript_component`, which is exactly the convention `ComponentScreen` uses (`kstrl/tui/screens/component.py:41-44`: `self.component_id` held once, read by the render code). Then lines 50, 85, 109 and 113 re-resolve it from `state`.

Cost, measured rather than asserted: `architect_component_id` is 0.030 us/call on the post-#281 fast path and 0.143 us/call on the fallback path (200k iterations each). Five calls is under 1 us per poll frame against a 0.05 s poll. **There is no performance cost.** The cost is that the same value has two derivations in one refresh. Fix, if taken: give `_attempt_strip`/`_issue_strip`/`_summary` the resolved key as a parameter and pass `self.transcript_component`. `SpecTriageScreen._refresh` (line 274) has no such attribute, so the module-level helper stays either way.

**Explicit answer to the caching question: do not add a cache.** There is no per-refresh caching idiom in the TUI screens to follow - `kstrl/tui/home_data.py:72` `SummaryCache` is a stream-signature cache over many run dirs for the home board, not a per-frame derived-value cache, and `kstrl/tui/screens/safemode.py:102` is an app-attribute read. Caching here would invent a mechanism to save under a microsecond.

## 4. Tests - no material duplication; the new parameter matches the existing convention

- `tests/helpers/fake_run.py:356` `architect_key: str = ARCHITECT_COMPONENT`: there is no pre-existing legacy-format convention in this file to match (no schema-version or legacy flag anywhere in it), but keyword-variation params are exactly how the other writers vary (`blockers`, `minors`, `attempts`, `components`, `repaired` at lines 274-283). It fits, and defaulting to the constant keeps all existing callers byte-identical.
- `tests/test_decompose_screens.py:65-70` `_state`: no shared in-memory `RunState` builder exists to reuse (only 9 direct `RunState(...)` constructions across all of `tests/`, each shaped for its module). `tests/test_serve.py:161` `_spend_with_component_keyed` is the parallel #281 helper in its own module and is deliberately not shared - same precedent, so the local static method is consistent.
- Partial overlap, not worth merging: `test_a_pre_281_halted_run_still_shows_its_blocker_banner` (line 237) repeats the two banner assertions of `test_triage_shows_blocker_banner_and_detail` (line 280) with only `architect_key` differing, and `test_a_pre_281_run_dir_still_renders_as_the_run_it_was` (line 190) overlaps `test_success_run_renders_dag_and_summary` (line 140). A `@pytest.mark.parametrize("architect_key", ...)` merge would save roughly 24 lines but re-run the existing test's markup-safety half and escape-pop half a second time (measured: that test is the file's slowest at 0.52 s; the new halted test is 0.47 s, so the merge costs about as much time as the duplicate it removes), and it would couple two different intents. Recommend leaving both as-is.

Whole file runs 19 passed in 2.65 s; the two new Pilot tests account for 0.72 s of that.

</details>

<details>
<summary><b>Simplification</b></summary>

**1. `kstrl/tui/screens/decompose.py:113` - loop-invariant `architect_component_id(state)` inside a comprehension filter (LOW, worth fixing)**

`_summary` resolves the key twice: once at line 109 for the row lookup, then again at line 113 *inside* the filter, so it runs once per plan entry, not once. `dag_table.py:90` already establishes the right shape (`pseudo = architect_component_id(state)` hoisted to a local, then used in the comprehension) - the diff applies that pattern in one file and not the other. Concrete cost: readability inconsistency across two files in the same change, plus O(len(plan_order)) redundant calls. Fix is one local:

```python
architect_id = architect_component_id(state)
architect = state.components.get(architect_id)
...
planned = [c for c in state.plan_order if c != architect_id]
```

Perf is *not* the cost here: measured 0.030 us/call post-#281 (short-circuits on the first branch) and 0.142 us/call pre-#281, against a 0.2 s poll interval (`app.py:48`) - at most ~0.0004% of one poll's budget even with a 20-component plan. Do not sell this as an efficiency fix.

**2. The 5 call sites - resolving per-helper is correct, do not thread the key (NO CHANGE)**

`_issue_strip`, `_attempt_strip`, `_summary` and `SpecTriageScreen._refresh` are four independent entry points, each already taking `state: RunState` and deriving everything else from it. Threading a resolved key would add a parameter to four signatures and push the resolution into `refresh_state`, which is the caller that knows least about why the key matters. After fix 1 it is one call per helper, which is the same shape as every other `state.*` derivation in the module. Keep as is.

Adjacent, pre-existing, out of scope for this diff: `state.components.get(architect_component_id(state))` now appears verbatim at 4 sites (`decompose.py:50, 85, 109, 274`). The repetition predates the diff (it was `state.components.get(ARCHITECT_COMPONENT)` before); if it ever gets collapsed, an `architect_row(state) -> ComponentState | None` next to `architect_component_id` is the natural home. Not a diff finding.

**3. `transcript_component` seeded in `__init__` and reassigned in `refresh_state` - justified (NO CHANGE)**

The seed is load-bearing, not redundant. `app.py:286` does `component_id = str(getattr(screen, "transcript_component", ""))` and uses truthiness to decide the screen is a detail screen at all; an empty seed would route the screen down the `post_message(StateChanged)` branch, so `refresh_state` would never be called and the key would never resolve - a bootstrap deadlock. And no `RunState` exists at `__init__` time, so nothing better than the current constant can be seeded.

I checked the property alternative and it is not simpler: `self.app` raises `NoActiveAppError` on an unmounted screen, so the property needs a try/except plus a `store is None` guard (~5 lines replacing 2 assignments), and it would diverge from `ComponentScreen:45`, which sets the same duck-typed attribute plainly.

One residual the property *would* fix, noted for completeness rather than as a simplification: `_poll` reads `component_id` at line 286 *before* calling `refresh_state`, then reuses that same value for `run.transcript_tailer(component_id).poll()` at the end of the poll - so on a pre-#281 dir the very first transcript poll tails the seed key. It self-corrects on the next tick (0.2 s) and the test at `tests/test_decompose_screens.py:235` pins the settled value.

**4. Three-branch `architect_component_id` - keep the third `return ARCHITECT_COMPONENT` (NO CHANGE)**

The two-branch collapse is available and I rejected it:

```python
if state.kind == "decompose" and ARCHITECT_COMPONENT not in state.components and ARCHITECT_ROLE in state.components:
    return ARCHITECT_ROLE
return ARCHITECT_COMPONENT
```

It saves two lines and buries the precedence rule in a three-term conjunction with a negated membership test. The current first branch is not dead code - it short-circuits the `kind` check and is the executable statement of the docstring's "any post-#281 dir answers on the first branch" invariant, which `TestArchitectComponentId.test_a_new_dir_with_a_component_named_architect_never_falls_back` asserts directly. Three branches, one per case, is the clearer form.

**5. `tests/test_decompose_screens.py:237` - `test_a_pre_281_halted_run_still_shows_its_blocker_banner` near-duplicates an existing test (LOW, judgement call)**

Measured with `--durations`: the two new e2e tests cost 0.25 s + 0.47 s of the file's 2.67 s; the four `TestArchitectComponentId` unit tests are all under the 0.005 s reporting floor.

The unit/e2e split is *not* redundant - the unit tests pin the function's semantics (including two invariants unreachable through the UI), the e2e tests pin that the call sites are actually wired. Keep both layers. `test_a_pre_281_run_dir_still_renders_as_the_run_it_was` is dense: 5 assertions covering 4 call sites off one boot at 0.25 s. Keep it as written.

The second e2e test is the weak one: 26 lines and a second full Textual boot (0.47 s) to cover a single call site, and its body is `test_triage_shows_blocker_banner_and_detail` (line 280, 0.51 s) with `architect_key="architect"` added and the markup-injection half deleted - same fixture args, same boot, same `press("i")`, same two banner assertions. `@pytest.mark.parametrize("architect_key", (ARCHITECT_COMPONENT, "architect"))` on the existing test would delete all 26 lines. The trade is honest and close to neutral on runtime: the parametrized case re-runs the markup assertions, so 0.51 s replaces 0.47 s. Worth it for -26 duplicated lines, but it is a preference call, not a defect.

No dead code, no added nesting, and no complexity to flag in `tests/helpers/fake_run.py` - threading one `architect_key` parameter through the existing emit sites is the minimal change there. Per instructions I did not flag comment or docstring volume, and I modified nothing.

</details>

<details>
<summary><b>Efficiency</b></summary>

All numbers measured on this machine, `timeit` best-of-5, not estimated.

### Measurements

`architect_component_id`, 100k calls each:

| path | ns/call |
|---|---|
| post-#281 (first branch hits, `.kind` never read) | **27.9** |
| pre-#281 decompose (fallback: 2 dict tests + `.kind`) | **138.3** |
| factory run (both miss) | 132.9 |
| `RunState.kind` alone | 110.7 |
| `run_kind()` alone, module-level import | 52.8 |
| bare dict membership (floor) | 15.1 |

Local-import overhead in `RunState.kind`, isolated: **40.5 ns/call** (93.3 with the local import vs 52.8 without).

Real call count per refresh, measured by monkeypatching a counter into both call sites and driving the actual Textual app: **8 calls per `refresh_state`, not 6** - 5 fixed sites plus one per `plan_order` element (3-component fixture). Whole `refresh_state` measured at **143.6-159.0 us** over 200 reps.

### 1. Hot-path cost: not real. No action.

Worst case is 8 x 138.3 ns = **1.11 us per refresh**, which is **0.77 % of `refresh_state`** and **0.0006 % of the 200 ms poll** (`DEFAULT_POLL_INTERVAL = 0.2`, `kstrl/tui/app.py:48`; 0.05 s is test-harness only, still 0.002 %). Live runs take the 27.9 ns branch, where `.kind` is never read at all - 0.22 us per refresh. `refresh_state` also only runs when `changed` is true (`app.py` `_poll`). The function does no I/O and captures no scope. Nothing to fix here.

### 2. `kstrl/tui/screens/decompose.py:113` - loop-invariant call inside a comprehension. LOW.

```python
planned = [c for c in state.plan_order if c != architect_component_id(state)]
```

Called once per element. `dag_table.py:90` already does the right thing (`pseudo = architect_component_id(state)` hoisted out of the identical comprehension one line later); this is the same pattern left unhoisted. Measured `_summary` as-written vs a hoisted copy:

| plan_order | as-written | hoisted | saved |
|---|---|---|---|
| 3 | 2.62 us | 2.09 us | 0.53 us |
| 31 | 6.67 us | 2.35 us | 4.32 us |
| 101 | 16.44 us | 3.05 us | 13.39 us |

Cost is trivial in absolute terms (`_summary` only runs when `state.finished`), so this is a consistency fix, not a performance one. One line, and it makes the two comprehensions match.

### 3. `kstrl/reducer.py:170` - local import in `kind`, now newly hot. INFO, pre-existing.

`from kstrl.runid import run_kind` inside the property costs 40.5 ns per read. Hoisting to module level is safe: `kstrl/runid.py` imports only `typing`, so there is no cycle and near-zero added import time. Caching is *not* available - `reducer.py:255` reassigns `state.run_id` mid-fold on the first event that carries one, so `cached_property` would be wrong. At the measured rate this is under 0.5 us per poll; mention it, don't gate on it.

### 4. Import graph: no cycle, marginal cost zero in practice.

`dag_table.py:22` pulls `kstrl.tui.state` -> `reducer` + `manifest` + `events`. Marginal cost in a cold interpreter: **28.67 ms**. In every real import path it is **0 ms**:

- `kstrl/tui/app.py:37` imports `runcontext` (-> `StateStore`) before any screen at line 38.
- Both of `dag_table`'s only two importers load `kstrl.tui.state` on an *earlier* line: `screens/decompose.py:28` before `:31`, `tests/test_decompose_screens.py:22` before `:23`.

No cycle - `reducer`, `manifest`, `events`, `agents.base` import nothing from `kstrl.tui` (grep-verified).

**Invariant preserved.** `dag_table` imports `kstrl.tui.state`, not the reducer; its `ComponentState/RunState` import stays `TYPE_CHECKING`-only. Worth knowing though: the docstring claim at `kstrl/tui/state.py:2-3` ("the ONLY module in `kstrl/tui/` that imports the reducer") was **already false before this diff** - `kstrl/tui/home_data.py:17` does `from kstrl.reducer import RunState, fold, read_run_dir` at runtime. Every other `kstrl/tui` reference is `TYPE_CHECKING`-guarded. Stale docstring, not this diff's doing.

### 5. Test suite cost: +0.74 s, 0.24 % of the suite. Acceptable.

`uv run pytest tests/test_decompose_screens.py -q --durations=12`:
- `test_a_pre_281_halted_run_still_shows_its_blocker_banner` **0.48 s**
- `test_a_pre_281_run_dir_still_renders_as_the_run_it_was` **0.26 s**
- the 4 `TestArchitectComponentId` unit tests: all under 0.005 s

Cross-checked by deselection under identical conditions: 19 tests 2.61 s vs 13 tests 1.87 s = **0.74 s delta**, matching the per-test sum. Full suite: **304.44 s** (4105 passed), so the two e2e tests are **0.24 %**. The 0.48 s one is dominated by its `pilot.pause(0.2)` + `pause(0.1)` and app teardown - the same shape as the pre-existing `test_triage_shows_blocker_banner_and_detail` at 0.58 s. Not an outlier, and the 4 cheap unit tests carry the branch logic. No change warranted.

### Verified clean (no finding)

The seed-then-re-resolve of `transcript_component` does **not** leak a dead `TextTailer`. On a pre-#281 dir the key flips `@architect` -> `architect`, and because the assignment sits *before* the `ready` guard (`decompose.py:180`), the first poll's `ready=False` means no tailer is built from the stale seed. Measured `run_context.transcript_tailers` keys after startup: `['architect']`, pointing at a path that exists. The comment at `decompose.py:177-179` is load-bearing for this.

### Unrelated

The full-suite run had one failure, `tests/test_shutdown.py::TestWorkerSigterm::test_pool_worker_sigterm_kills_agent_group` - a process-group SIGTERM test, unrelated to this diff and run under load from my concurrent pytest sessions. Flagging it only so it is not mistaken for a regression here.

</details>

<details>
<summary><b>Altitude</b></summary>

## Verdict: the altitude is right. Ship it, with one docstring correction.

The change is 4 lines of resolver + 6 call sites + tests. It adds no state, no file format, no clock comparison, no version marker. That is the right size for "the durable record uses an older key".

---

### 1. Read-side fallback is the correct altitude (vs migration, vs nothing)

**Migration is the wrong altitude, decisively.** It would have to rewrite the `component` field of every event in each historical `events.jsonl` and rename `components/architect/` -> `components/@architect/`, in dirs that can be live-tailed, behind a trigger and a version marker. Worse, it has to resolve the one genuinely ambiguous case (a pre-#281 dir whose architect also named a component `architect`, already merged into one row at write time) by *guessing*, and a migration bakes that guess into the append-only evidence record permanently. A read-side guess is revisable; a migrated run dir is not. For a factory whose thesis is that the run dir is the measurement, rewriting it to please a renderer is the deeper mistake, not the deeper fix.

**"Nothing" is wrong** because the failure is a wrong answer, not a degraded one: `screens/decompose.py:110` printed `X decompose did not complete` over a completed run. That is the exact thing `serve.py:677` (`unmetered_phases`) exists to avoid on the money axis.

### 2. Placement in `kstrl/tui/state.py` is right - but both stated reasons are wrong

`kstrl/tui/state.py:1-7` - the module's charter line ("the ONLY module in `kstrl/tui/` that imports the reducer") **is already false**: `kstrl/tui/home_data.py:17` does `from kstrl.reducer import RunState, fold, read_run_dir` at runtime. So the "one-module blast radius" property the placement leans on does not hold today. (No cycle introduced: `dag_table.py:22` now imports `kstrl.tui.state` at runtime, and `state.py` imports nothing from widgets.)

`kstrl/tui/state.py:44-46` - the reducer-placement rejection ("it would make the fallback reachable from `serve.py`, where it is unsafe") does not survive checking. `read_run_spend` (`serve.py:721`) has exactly one caller, `owned_run_spend` (`serve.py:806`), which filters to `SPAWNED_RUN_KIND = "factory"` dirs. The helper's own `state.kind == "decompose"` gate would be a **no-op** on every dir serve reads. The fallback is *unreachable* there, not unsafe.

The placement is still correct, on a better argument: this is a presentation-layer era shim, not a fold semantic, and keeping it in `kstrl/tui/` means the *next* money-reading caller (not today's) has to deliberately import from the TUI package to get it, which it won't. **Deeper fix warranted: amend those two docstring passages.** They are the audit trail for this decision, and one is factually false while the other proves less than it claims.

### 3. The `kind == "decompose"` gate: right mechanism, and empirically complete

- Right mechanism: structural, derived from already-folded data, degrades to the safe key. No release-date compare, no stat.
- **Complete, checked rather than assumed.** `RunState.kind` (`reducer.py:167-172`) is `run_kind(run_id) or "factory"`, and `run_kind` returns a *prefix* - so an un-prefixed legacy id would land on the wrong side of the gate. That set is empty: `1a7f3ca` (run-id kinds) is an ancestor of `8484c25` (decompose as an event-stream run), so decompose never wrote a run dir before kinds existed. Every decompose dir on disk is `decompose-` prefixed.
- `run_id` is always the dir name (`runcontext.py:52` is the only `StateStore` construction), so `kind` is never empty for a dir being read.
- Condition two verified against code, not the comment: `decompose.py:1279-1286` emits the architect's `RunPlan` entry and `ComponentStarted` unconditionally at the top of the impl, before `load_spec_input` and any LLM call; `reducer.py:266-278` creates the row from `RunPlan`; the second `RunPlan` (`decompose.py:1516`) carries it too. A post-#281 decompose dir always answers on the first branch.

### 4. Missed readers: none

Full set of architect-key lookups in `kstrl/`: `serve.py:756` (deliberately pessimistic, correct) and the four in `screens/decompose.py` + `dag_table.py:91` (all rewired). Everything else keys on ids that come from the data: `component_table.py:121-123`, `dag_table.py:108`, `screens/component.py:77`, `cli.py:3158`. `observability.py` has no architect reference; `evolution.py:454-465` only documents the namespacing. `runcontext.py:56-63` builds the transcript path from whatever id it is handed, so fixing `transcript_component` fixed it. `cli.py:2065/2107/2131`, `session.py:271/285`, `pipeline.py:613`, `decompose.py:*` are all writers.

**Pre-existing asymmetry worth knowing (not this diff's regression):** the pseudo-row is filtered out of the DAG (`dag_table.py:91`) and the summary (`screens/decompose.py:113`), but not out of `home_data.py:46` (`components_total = len(state.plan_order)`) or the home-preview/overview `ComponentTable` (`component_table.py:121`). The home screen counts and lists the architect as a component. Era-independent, so out of scope here - but "is this key a role or a component?" is now answered in three places with two policies. If anyone wants the deeper fix later, it is one predicate on the class (`RunState.component_ids` excluding `ROLE_KEY_PREFIX` rows), not more per-call filtering.

### 5. A second namespaced role: hardcoding to the architect is correct, keep it

`role_component_key` (`names.py:61`) is called exactly once in the tree (`agents/base.py:453`). The set of roles that ever had a bare on-disk key is closed at one, and any role added later is born namespaced, so it can never accumulate legacy dirs. A generic `role_component_id(state, role)` would be the *worse* API: it would offer a bare-key fallback to roles that must never have one, and would read as sanctioning the bare-then-namespaced sequence #281 removed. This is the rare case where not generalising is the higher altitude.

### Minor (optional, `/simplify`-shaped)

- `screens/decompose.py:113` calls `architect_component_id(state)` inside the comprehension, re-evaluating per component; `dag_table.py:90` hoists it to `pseudo` first. Hoist the former for consistency. Cost is trivial (dict membership), so this is style, not efficiency.
- `app.py:286` reads `transcript_component` *before* `refresh_state` updates it (`app.py:291`), so an old dir tails the stale key for exactly one poll. It self-corrects because the tail block (`app.py:300-305`) sits outside the `if changed:` guard and tailers are per-key with independent offsets (`runcontext.py:56`), and `on_mount` (`screens/decompose.py:163`) already resolves from the store. Not a defect - noting it only so nobody "fixes" the ordering later and breaks the finished-run case.

`tests/test_decompose_screens.py`: 19 passed.

</details>

### Applied and skipped, round 2

Applied: extracted `planned_component_ids` (Reuse 2 MEDIUM), which also hoists the loop-invariant call all four agents flagged; corrected both false docstring claims (Altitude 2), verifying each against the code first.

Skipped, with reasons:

- **Parametrizing the halted-run test onto the existing one** (Simplification 5, Reuse 4). Split verdict between the two agents, both calling it a preference. Reuse's argument wins: the existing test also asserts markup-safety, a different intent, and the merge is runtime-neutral.
- **Threading the resolved key into the four render helpers, and caching it** (Reuse 3, Simplification 2). Both agents' own verdict was NO CHANGE, and measurement showed under 1 us per frame.
- **Hoisting `reducer.py`'s local import in `RunState.kind`** (Efficiency 3). Pre-existing, 40.5 ns, and the agent said mention it rather than gate on it.
- **`home_data.py` / `component_table.py` counting the pseudo-row as a component** (Reuse 2 tail, Altitude 4). Pre-existing and era-independent: true before #281 and unchanged by it. `planned_component_ids` now gives that fix a single place to land when someone takes it.
