### PR TITLE
fix(serve): a zombie is not a running process

### DIFF
--- a/kstrl/procgroup.py
+++ b/kstrl/procgroup.py
@@ -1,0 +1,175 @@
+"""Whether a process group still holds anything RUNNING.
+
+#298. ``os.killpg(pgid, 0)`` answers a different question from the one
+every caller here is asking. It asks "would a signal be delivered", and a
+ZOMBIE - a process that has already died and is only waiting for its
+parent to call ``wait`` - is still a signal target. So a group holding
+nothing but a corpse reports as live.
+
+Measured on this machine, on a real tree whose parent deliberately never
+reaps: after ``killpg(pgid, SIGKILL)`` the signal probe reported the
+group as present for all 45 samples across a 6 second window and never
+converged, while a ``ps`` read with zombies excluded reported it gone on
+the first sample. The branch taken was ``PermissionError``, which
+``serve.process_group_alive`` mapped to True on the reasoning that a
+refused signal proves something is there to refuse it. That reasoning is
+sound about signals and wrong about running processes.
+
+The question actually being asked, by both the daemon's reap check and
+the suite's orphan assertions, is "is anything in this group still
+executing". A zombie is not. So this module asks ``ps`` for group
+membership and excludes state ``Z``.
+
+WHY A TRI-STATE. ``ps`` can fail, and it can be filtered so that its
+silence about a group is not evidence of absence. The two callers want
+OPPOSITE things when that happens, so neither answer can be baked in
+here: a test must fail loudly rather than pass having measured nothing
+(#292), while the daemon must keep running and fall back to the degraded
+probe. This returns "cannot see" and lets each caller choose.
+
+COST, and the row trim that was measured and REJECTED. Only the two
+columns the question needs are requested: asking for command lines as
+well measured 23.5ms per call against 11.6ms for this on a 895-process
+machine (#292), re-measured for #298 at 11.29ms over 50 calls on a
+913-process machine against 0.00089ms for the signal probe. Trimming
+ROWS is the larger factor and is deliberately not done: ``ps -g
+<pgid>,<ours>`` measured 2.07ms against 14.52ms on a 1011-process
+machine, a 7x cut, but ``-g`` selects by SESSION, and Linux procps
+documents it as session or effective group NAME. A process-group id is
+not generally a session id, so on Linux that listing would come back
+holding our own group and not the target, which this module reads as
+"the target is gone". That is a false negative in the one direction it
+must never fail, and a 7x measured on macOS alone is not a reason to
+ship one into the daemon's reap check.
+
+That cost is affordable because the production path is not hot:
+``serve.terminate_process_group`` asks once per timed-out run, on the way
+out. Measured across the whole suite, every ``wait_for_group_to_die``
+call converged on its first poll: 14 real ``ps`` forks totalling 275ms
+against a 246.5s suite, 0.11% of wall clock.
+
+POSIX only. ``ps`` group listings and ``os.getpgrp`` do not exist on
+Windows. The production caller reaches this only behind
+``serve._safe_pgid``, which returns None without ``os.killpg``; the test
+helper has no such gate and its suite skips on Windows.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+
+#: The two columns the question needs and no more. See COST above.
+PS_ARGV = ("ps", "-A", "-o", "pgid=,stat=")
+
+#: A bound on how long a diagnostic may stall the caller. 440x the
+#: 11.29ms measured above, so it cannot fire on a slow machine; a ``ps``
+#: that takes longer than this is wedged, which is exactly the case where
+#: the caller wants "cannot see" rather than a hang.
+PS_TIMEOUT_SECONDS = 5.0
+
+#: Said once, because two branches report it and reflowed copies of one
+#: sentence are how the two answers drift apart.
+_UNMEASURABLE = (
+    "Process-group liveness cannot be measured here, and reporting "
+    "'no live member' would be a false negative."
+)
+
+
+@dataclass(frozen=True)
+class GroupLiveness:
+    """Whether a group holds a running process, or why that is unknown."""
+
+    #: True: at least one non-zombie member. False: none, and ``ps`` was
+    #: trustworthy when it said so. None: ``ps`` could not be trusted, so
+    #: nothing was measured and ``reason`` says what went wrong.
+    live: bool | None
+    reason: str = ""
+
+
+def read_group_liveness(pgid: int) -> GroupLiveness:
+    """Ask ``ps`` whether any non-zombie process is in group ``pgid``.
+
+    Absence is only ever reported by a call that proved it can see
+    something. The caller's own process group is alive by construction,
+    so if that group is missing from the output then the output is
+    filtered and its silence about ``pgid`` means nothing. This is the
+    ``hidepid`` case, and #292 measured the alternative: with ``ps``
+    forced to return 127, a version without this guard reported the
+    caller's OWN live group as dead.
+    """
+    try:
+        out = subprocess.run(
+            PS_ARGV,
+            capture_output=True,
+            text=True,
+            timeout=PS_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return GroupLiveness(None, f"ps failed to run ({exc!r}). {_UNMEASURABLE}")
+    if out.returncode != 0:
+        return GroupLiveness(
+            None,
+            f"ps failed (rc={out.returncode}): {out.stderr.strip()!r}. {_UNMEASURABLE}",
+        )
+
+    ours = os.getpgrp()
+    saw_own_group, found = _scan(out.stdout, pgid, ours)
+    if not saw_own_group:
+        return GroupLiveness(
+            None,
+            f"ps did not report this process's own group ({ours}), so it "
+            f"cannot be trusted to report the absence of group {pgid}. "
+            f"Restricted or filtered ps output.",
+        )
+    return GroupLiveness(found)
+
+
+def _scan(stdout: str, pgid: int, ours: int) -> tuple[bool, bool]:
+    """(was our own group present, is a non-zombie member of ``pgid`` present).
+
+    Returned positionally, so the order is pinned by direct tests in
+    ``tests/test_procgroup.py`` rather than by the type checker: both
+    fields are ``bool`` and a swap here would type-check cleanly.
+    """
+    want = str(pgid)
+    mine = str(ours)
+    saw_own_group = False
+    found = False
+    for line in stdout.splitlines():
+        parts = line.split()
+        # A row with no state column would IndexError below. Real ps does
+        # not emit one; a filtered or truncated listing might.
+        if len(parts) < 2:
+            continue
+        group, state = parts[0], parts[1]
+        saw_own_group = saw_own_group or group == mine
+        # "Z" is the zombie state on both macOS and Linux, and flags may
+        # follow it ("Z+", "Zl"), so match the prefix rather than the cell.
+        found = found or (group == want and not state.startswith("Z"))
+    return saw_own_group, found
+
+
+def signal_probe_alive(pgid: int) -> bool:
+    """Whether a signal to ``pgid`` would find a target. Zombies COUNT.
+
+    The pre-#298 reading, kept because it is the only thing left when
+    ``ps`` gives no answer at all, and because a test needs it as the
+    control that proves a zombie window was real rather than a group that
+    quietly went away. ``PermissionError`` means something is there
+    refusing us, which is the closest to "alive" a signal can report -
+    and on a zombie-only group that is measurably the branch taken.
+
+    Prefer ``read_group_liveness``. This answers the question #298 was
+    about getting wrong.
+    """
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True

--- a/kstrl/procgroup.py
+++ b/kstrl/procgroup.py
@@ -20,27 +20,50 @@ the suite's orphan assertions, is "is anything in this group still
 executing". A zombie is not. So this module asks ``ps`` for group
 membership and excludes state ``Z``.
 
-WHY A TRI-STATE. ``ps`` can fail, and it can be filtered so that its
-silence about a group is not evidence of absence. The two callers want
-OPPOSITE things when that happens, so neither answer can be baked in
-here: a test must fail loudly rather than pass having measured nothing
-(#292), while the daemon must keep running and fall back to the degraded
-probe. This returns "cannot see" and lets each caller choose.
+WHEN A "GONE" IS TRUSTWORTHY, which is the whole safety argument.
+``ps`` may not show everything: a descendant that changed uid, a
+restricted listing, a truncated read. Absence from the listing is
+therefore not on its own evidence of absence from the machine, and a
+wrong "gone" is the dangerous direction - ``serve`` releases the item and
+a second factory starts on a repo the first is still writing to (#186
+F1). So a "gone" is only ever returned with a reason it can be trusted:
+
+* ``ps`` listed at least one row for the group and every one is a
+  zombie. The listing demonstrably CAN see this group, so its verdict on
+  that group's members is evidence. This is the #298 case.
+* ``ps`` listed no row for the group, and ``killpg(pgid, 0)`` raises
+  ESRCH. That is the kernel saying the group holds no process at all,
+  which is a stronger fact than a listing's silence and is immune to
+  filtering.
+
+Anything else, meaning no row and a kernel that says the group is
+occupied, is reported as "cannot see" rather than as absence.
+
+The control this REPLACED did not work, and it is written down because
+the docstring claimed it did. It checked that the caller's own process
+group appeared in the listing. ``subprocess.run`` does not ``setpgid``,
+so the ``ps`` child itself runs in the caller's group and ``ps -A``
+always lists it: measured on this tree, our own pgid appeared four times
+in every listing, the last row being ``ps``. The check was therefore
+satisfied by construction on every successful call and could never fire.
+``hidepid`` does not hide a caller's own uid either, so it did not even
+cover the case it named. Measured against a listing with one live group
+filtered out, the old rule returned a CONFIDENT "gone" for a group that
+was still running; the rule above returns "cannot see".
 
 COST, and the row trim that was measured and REJECTED. Only the two
 columns the question needs are requested: asking for command lines as
 well measured 23.5ms per call against 11.6ms for this on a 895-process
 machine (#292), re-measured for #298 at 11.29ms over 50 calls on a
-913-process machine against 0.00089ms for the signal probe. Trimming
-ROWS is the larger factor and is deliberately not done: ``ps -g
+913-process machine against 0.00089ms for the signal probe. The kernel
+control above costs 0.00054ms and is paid only on the "gone" path.
+Trimming ROWS is the larger factor and is deliberately not done: ``ps -g
 <pgid>,<ours>`` measured 2.07ms against 14.52ms on a 1011-process
 machine, a 7x cut, but ``-g`` selects by SESSION, and Linux procps
 documents it as session or effective group NAME. A process-group id is
 not generally a session id, so on Linux that listing would come back
-holding our own group and not the target, which this module reads as
-"the target is gone". That is a false negative in the one direction it
-must never fail, and a 7x measured on macOS alone is not a reason to
-ship one into the daemon's reap check.
+without the target, which is exactly the filtered case above and would
+now cost a spurious "cannot see" on every call.
 
 That cost is affordable because the production path is not hot:
 ``serve.terminate_process_group`` asks once per timed-out run, on the way
@@ -48,10 +71,15 @@ out. Measured across the whole suite, every ``wait_for_group_to_die``
 call converged on its first poll: 14 real ``ps`` forks totalling 275ms
 against a 246.5s suite, 0.11% of wall clock.
 
-POSIX only. ``ps`` group listings and ``os.getpgrp`` do not exist on
-Windows. The production caller reaches this only behind
-``serve._safe_pgid``, which returns None without ``os.killpg``; the test
-helper has no such gate and its suite skips on Windows.
+POSIX only. ``ps`` group listings and ``killpg`` do not exist on Windows.
+The production caller reaches this only behind ``serve._safe_pgid``,
+which returns None without ``os.killpg``; the test helper has no such
+gate and its suite skips on Windows.
+
+This module is the ONLY place in the tree that shells out to ``ps``, and
+``tests/test_procgroup.py`` fails on a second one. A rule with no
+mechanism is not a plan: the argument for centralising the parse is that
+two copies drift, and nothing but a net stops a third landing.
 """
 
 from __future__ import annotations
@@ -81,32 +109,36 @@ _UNMEASURABLE = (
 class GroupLiveness:
     """Whether a group holds a running process, or why that is unknown."""
 
-    #: True: at least one non-zombie member. False: none, and ``ps`` was
-    #: trustworthy when it said so. None: ``ps`` could not be trusted, so
-    #: nothing was measured and ``reason`` says what went wrong.
+    #: True: at least one non-zombie member. False: none, and the answer
+    #: earned one of the two trust conditions in the module docstring.
+    #: None: nothing was measured, and ``reason`` says what went wrong.
     live: bool | None
     reason: str = ""
 
 
 def read_group_liveness(pgid: int) -> GroupLiveness:
-    """Ask ``ps`` whether any non-zombie process is in group ``pgid``.
+    """Whether any non-zombie process is in group ``pgid``.
 
-    Absence is only ever reported by a call that proved it can see
-    something. The caller's own process group is alive by construction,
-    so if that group is missing from the output then the output is
-    filtered and its silence about ``pgid`` means nothing. This is the
-    ``hidepid`` case, and #292 measured the alternative: with ``ps``
-    forced to return 127, a version without this guard reported the
-    caller's OWN live group as dead.
+    Absence is only ever reported by a call that earned the right to
+    report it. Which two conditions those are, and the measurement
+    showing the control this replaced was satisfied by construction, are
+    in the module docstring.
     """
     try:
         out = subprocess.run(
             PS_ARGV,
             capture_output=True,
-            text=True,
+            # Pinned rather than left to the locale, and non-decodable
+            # bytes are replaced rather than raised. A decode error here
+            # is a ValueError, which would escape a fail-closed
+            # ``except OSError`` and take the daemon down over a
+            # diagnostic (the repo's #291 lesson). Caught below as well,
+            # so a future edit cannot reintroduce it.
+            encoding="utf-8",
+            errors="replace",
             timeout=PS_TIMEOUT_SECONDS,
         )
-    except (OSError, subprocess.TimeoutExpired) as exc:
+    except (OSError, ValueError, subprocess.TimeoutExpired) as exc:
         return GroupLiveness(None, f"ps failed to run ({exc!r}). {_UNMEASURABLE}")
     if out.returncode != 0:
         return GroupLiveness(
@@ -114,41 +146,65 @@ def read_group_liveness(pgid: int) -> GroupLiveness:
             f"ps failed (rc={out.returncode}): {out.stderr.strip()!r}. {_UNMEASURABLE}",
         )
 
-    ours = os.getpgrp()
-    saw_own_group, found = _scan(out.stdout, pgid, ours)
-    if not saw_own_group:
-        return GroupLiveness(
-            None,
-            f"ps did not report this process's own group ({ours}), so it "
-            f"cannot be trusted to report the absence of group {pgid}. "
-            f"Restricted or filtered ps output.",
-        )
-    return GroupLiveness(found)
+    rows, running = _count_group_rows(out.stdout, pgid)
+    if running:
+        return GroupLiveness(True)
+    if rows:
+        # ps can demonstrably see this group, and everything it holds is
+        # a zombie. #298.
+        return GroupLiveness(False)
+    if _kernel_says_group_is_empty(pgid):
+        return GroupLiveness(False)
+    return GroupLiveness(
+        None,
+        f"ps listed no process in group {pgid}, but the kernel reports "
+        f"that group is not empty, so the listing does not show every "
+        f"process (a descendant that changed uid, or a restricted ps). "
+        f"{_UNMEASURABLE}",
+    )
 
 
-def _scan(stdout: str, pgid: int, ours: int) -> tuple[bool, bool]:
-    """(was our own group present, is a non-zombie member of ``pgid`` present).
+def _count_group_rows(stdout: str, pgid: int) -> tuple[int, int]:
+    """(rows ``ps`` listed for ``pgid``, how many are not zombies).
 
     Returned positionally, so the order is pinned by direct tests in
     ``tests/test_procgroup.py`` rather than by the type checker: both
-    fields are ``bool`` and a swap here would type-check cleanly.
+    fields are ``int`` and a swap would type-check cleanly.
     """
     want = str(pgid)
-    mine = str(ours)
-    saw_own_group = False
-    found = False
+    rows = 0
+    running = 0
     for line in stdout.splitlines():
         parts = line.split()
         # A row with no state column would IndexError below. Real ps does
         # not emit one; a filtered or truncated listing might.
         if len(parts) < 2:
             continue
-        group, state = parts[0], parts[1]
-        saw_own_group = saw_own_group or group == mine
+        if parts[0] != want:
+            continue
+        rows += 1
         # "Z" is the zombie state on both macOS and Linux, and flags may
         # follow it ("Z+", "Zl"), so match the prefix rather than the cell.
-        found = found or (group == want and not state.startswith("Z"))
-    return saw_own_group, found
+        if not parts[1].startswith("Z"):
+            running += 1
+    return rows, running
+
+
+def _kernel_says_group_is_empty(pgid: int) -> bool:
+    """True ONLY when the kernel says no process at all is in the group.
+
+    ESRCH is the one conclusive answer. Success and ``EPERM`` both mean
+    something is there, and any other ``OSError`` means the question was
+    not answered. Neither is emptiness, and reading them as emptiness is
+    the false negative this control exists to prevent.
+    """
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return True
+    except OSError:
+        return False
+    return False
 
 
 def signal_probe_alive(pgid: int) -> bool:
@@ -158,8 +214,8 @@ def signal_probe_alive(pgid: int) -> bool:
     ``ps`` gives no answer at all, and because a test needs it as the
     control that proves a zombie window was real rather than a group that
     quietly went away. ``PermissionError`` means something is there
-    refusing us, which is the closest to "alive" a signal can report -
-    and on a zombie-only group that is measurably the branch taken.
+    refusing us, which is the closest to "alive" a signal can report, and
+    on a zombie-only group that is measurably the branch taken.
 
     Prefer ``read_group_liveness``. This answers the question #298 was
     about getting wrong.

--- a/kstrl/procgroup.py
+++ b/kstrl/procgroup.py
@@ -20,50 +20,52 @@ the suite's orphan assertions, is "is anything in this group still
 executing". A zombie is not. So this module asks ``ps`` for group
 membership and excludes state ``Z``.
 
-WHEN A "GONE" IS TRUSTWORTHY, which is the whole safety argument.
-``ps`` may not show everything: a descendant that changed uid, a
-restricted listing, a truncated read. Absence from the listing is
-therefore not on its own evidence of absence from the machine, and a
-wrong "gone" is the dangerous direction - ``serve`` releases the item and
+WHEN A "GONE" IS TRUSTWORTHY, which is the whole safety argument. A
+wrong "gone" is the dangerous direction: ``serve`` releases the item and
 a second factory starts on a repo the first is still writing to (#186
-F1). So a "gone" is only ever returned with a reason it can be trusted:
+F1). ``ps`` may not show everything - a ``hidepid`` mount hides
+individual PROCESSES owned by other uids, so a group can show one
+visible zombie while hiding a running descendant that changed uid. That
+means "every row I saw for this group is a zombie" is NOT on its own a
+safe conclusion; it is only safe once the listing is known to be
+complete. So a "gone" needs both a listing that can be trusted and one
+of two positive findings:
 
-* ``ps`` listed at least one row for the group and every one is a
-  zombie. The listing demonstrably CAN see this group, so its verdict on
-  that group's members is evidence. This is the #298 case.
-* ``ps`` listed no row for the group, and ``killpg(pgid, 0)`` raises
-  ESRCH. That is the kernel saying the group holds no process at all,
-  which is a stronger fact than a listing's silence and is immune to
-  filtering.
+* THE LISTING IS COMPLETE. ``ps -A`` reported pid 1. Under ``hidepid``
+  the caller sees only its own uid's processes, and pid 1 belongs to
+  root; if we are root, nothing is hidden from us in the first place.
+  Either way, seeing pid 1 rules out a uid-filtered view. Measured on
+  this tree: pid 1 appears as ``['1', '1', 'Ss']`` in every listing while
+  running as uid 501. This costs nothing - ``pid=,pgid=,stat=`` measured
+  16.11ms per call against 16.10ms for ``pgid=,stat=`` on a 945-process
+  machine, inside the noise.
+* Then either every row listed for the group is a zombie, or the group
+  has no rows at all AND ``killpg(pgid, 0)`` raises ESRCH - the kernel
+  saying the group holds no process, which no listing filter can fake.
 
-Anything else, meaning no row and a kernel that says the group is
-occupied, is reported as "cannot see" rather than as absence.
+Anything else is "cannot see".
 
-The control this REPLACED did not work, and it is written down because
-the docstring claimed it did. It checked that the caller's own process
-group appeared in the listing. ``subprocess.run`` does not ``setpgid``,
-so the ``ps`` child itself runs in the caller's group and ``ps -A``
-always lists it: measured on this tree, our own pgid appeared four times
-in every listing, the last row being ``ps``. The check was therefore
-satisfied by construction on every successful call and could never fire.
-``hidepid`` does not hide a caller's own uid either, so it did not even
-cover the case it named. Measured against a listing with one live group
-filtered out, the old rule returned a CONFIDENT "gone" for a group that
-was still running; the rule above returns "cannot see".
+TWO CONTROLS THAT DID NOT WORK, written down because each was claimed in
+this docstring before it was measured. The first checked that the
+caller's own process group appeared in the listing; ``subprocess.run``
+does not ``setpgid``, so the ``ps`` child runs in the caller's group and
+``ps -A`` always lists it - our own pgid appeared four times in every
+listing, the last row being ``ps`` itself. Satisfied by construction, it
+could never fire. The second was "every listed row is a zombie, so the
+listing can see this group": true, but seeing SOME of a group is not
+seeing ALL of it, which is exactly the ``hidepid`` case above.
 
-COST, and the row trim that was measured and REJECTED. Only the two
+COST, and the row trim that was measured and REJECTED. Only the three
 columns the question needs are requested: asking for command lines as
-well measured 23.5ms per call against 11.6ms for this on a 895-process
-machine (#292), re-measured for #298 at 11.29ms over 50 calls on a
-913-process machine against 0.00089ms for the signal probe. The kernel
-control above costs 0.00054ms and is paid only on the "gone" path.
-Trimming ROWS is the larger factor and is deliberately not done: ``ps -g
-<pgid>,<ours>`` measured 2.07ms against 14.52ms on a 1011-process
-machine, a 7x cut, but ``-g`` selects by SESSION, and Linux procps
-documents it as session or effective group NAME. A process-group id is
-not generally a session id, so on Linux that listing would come back
-without the target, which is exactly the filtered case above and would
-now cost a spurious "cannot see" on every call.
+well measured 23.5ms per call against 11.6ms for two columns on a
+895-process machine (#292). The kernel control costs 0.00054ms and is
+paid only on the "no rows" path. Trimming ROWS is the larger factor and
+is deliberately not done: ``ps -g <pgid>,<ours>`` measured 2.07ms against
+14.52ms on a 1011-process machine, a 7x cut, but ``-g`` selects by
+SESSION, and Linux procps documents it as session or effective group
+NAME. A process-group id is not generally a session id, so on Linux that
+listing would come back without the target, which is the filtered case
+above and would now cost a spurious "cannot see" on every call.
 
 That cost is affordable because the production path is not hot:
 ``serve.terminate_process_group`` asks once per timed-out run, on the way
@@ -72,14 +74,21 @@ call converged on its first poll: 14 real ``ps`` forks totalling 275ms
 against a 246.5s suite, 0.11% of wall clock.
 
 POSIX only. ``ps`` group listings and ``killpg`` do not exist on Windows.
-The production caller reaches this only behind ``serve._safe_pgid``,
-which returns None without ``os.killpg``; the test helper has no such
-gate and its suite skips on Windows.
 
-This module is the ONLY place in the tree that shells out to ``ps``, and
-``tests/test_procgroup.py`` fails on a second one. A rule with no
-mechanism is not a plan: the argument for centralising the parse is that
-two copies drift, and nothing but a net stops a third landing.
+WHAT THE ``ps`` TIMEOUT DOES NOT COVER, stated because an earlier version
+of this docstring claimed a bound it does not have. ``PS_TIMEOUT_SECONDS``
+bounds a ``ps`` that is slow but killable. It does NOT bound one wedged
+in an uninterruptible read (a hung NFS mount, a dead container runtime):
+CPython's ``subprocess.run`` handles its own timeout by calling
+``process.kill()`` and then ``process.wait()`` with NO timeout, and
+``Popen.__exit__`` waits again, so a D-state child that cannot be killed
+blocks the call indefinitely. Tracked as #309.
+
+This module is the only place in ``kstrl/`` or ``tests/`` that shells out
+to ``ps``, and ``tests/test_procgroup.py`` fails on a second one in
+either root. A rule with no mechanism is not a plan: the argument for
+centralising the parse is that two copies drift, and nothing but a net
+stops a third landing.
 """
 
 from __future__ import annotations
@@ -88,17 +97,18 @@ import os
 import subprocess
 from dataclasses import dataclass
 
-#: The two columns the question needs and no more. See COST above.
-PS_ARGV = ("ps", "-A", "-o", "pgid=,stat=")
+#: The three columns the question needs and no more. ``pid`` is there for
+#: the completeness control, not for identifying anything. See the
+#: docstring above for why each is load-bearing and what it costs.
+PS_ARGV = ("ps", "-A", "-o", "pid=,pgid=,stat=")
 
-#: A bound on how long a diagnostic may stall the caller. 440x the
-#: 11.29ms measured above, so it cannot fire on a slow machine; a ``ps``
-#: that takes longer than this is wedged, which is exactly the case where
-#: the caller wants "cannot see" rather than a hang.
+#: A bound on how long a KILLABLE ``ps`` may stall the caller. 440x the
+#: 11.29ms measured for the call, so it cannot fire on a slow machine.
+#: It does not bound an unkillable one; see the docstring and #309.
 PS_TIMEOUT_SECONDS = 5.0
 
-#: Said once, because two branches report it and reflowed copies of one
-#: sentence are how the two answers drift apart.
+#: Said once, because several branches report it and reflowed copies of
+#: one sentence are how the two answers drift apart.
 _UNMEASURABLE = (
     "Process-group liveness cannot be measured here, and reporting "
     "'no live member' would be a false negative."
@@ -110,19 +120,36 @@ class GroupLiveness:
     """Whether a group holds a running process, or why that is unknown."""
 
     #: True: at least one non-zombie member. False: none, and the answer
-    #: earned one of the two trust conditions in the module docstring.
-    #: None: nothing was measured, and ``reason`` says what went wrong.
+    #: earned the trust conditions in the module docstring. None: nothing
+    #: was measured, and ``reason`` says what went wrong.
     live: bool | None
     reason: str = ""
+
+
+def _may_signal_group(pgid: int) -> bool:
+    """Whether ``killpg(pgid, ...)`` is safe to issue at all.
+
+    ``killpg(1, sig)`` is ``kill(-1, sig)``: every process this user owns.
+    ``serve._safe_pgid``, ``verify._signal_process_group`` and
+    ``agents.proc`` each carry a copy of this rule (#308); this module
+    needs its own because nothing enforces that its callers came through
+    one of them, and a docstring saying they do is a convention, not a
+    mechanism.
+
+    This module only ever sends signal 0, so unlike those three it does
+    NOT exclude the caller's own group: probing it is harmless and is a
+    question the suite legitimately asks. The broadcast pgid is the part
+    that must be refused whatever the signal.
+    """
+    return hasattr(os, "killpg") and pgid > 1
 
 
 def read_group_liveness(pgid: int) -> GroupLiveness:
     """Whether any non-zombie process is in group ``pgid``.
 
     Absence is only ever reported by a call that earned the right to
-    report it. Which two conditions those are, and the measurement
-    showing the control this replaced was satisfied by construction, are
-    in the module docstring.
+    report it. The conditions, and the measurements showing that two
+    earlier controls could not, are in the module docstring.
     """
     try:
         out = subprocess.run(
@@ -145,49 +172,70 @@ def read_group_liveness(pgid: int) -> GroupLiveness:
             None,
             f"ps failed (rc={out.returncode}): {out.stderr.strip()!r}. {_UNMEASURABLE}",
         )
+    return _interpret(_read_listing(out.stdout, pgid), pgid)
 
-    rows, running = _count_group_rows(out.stdout, pgid)
-    if running:
+
+@dataclass(frozen=True)
+class _Listing:
+    """What one ``ps`` read saw, before any of it is believed."""
+
+    #: pid 1 was present, so the view is not filtered to our own uid.
+    complete: bool
+    #: Rows carrying this pgid, and how many of them are not zombies.
+    rows: int
+    running: int
+
+
+def _interpret(listing: _Listing, pgid: int) -> GroupLiveness:
+    if listing.running:
         return GroupLiveness(True)
-    if rows:
-        # ps can demonstrably see this group, and everything it holds is
-        # a zombie. #298.
+    if not listing.complete:
+        return GroupLiveness(
+            None,
+            f"ps did not list pid 1, so the view is filtered to this uid "
+            f"and a running member of group {pgid} owned by another uid "
+            f"would be invisible. {_UNMEASURABLE}",
+        )
+    if listing.rows:
+        # A complete listing that shows this group holding only zombies.
+        # #298's case.
         return GroupLiveness(False)
     if _kernel_says_group_is_empty(pgid):
         return GroupLiveness(False)
     return GroupLiveness(
         None,
         f"ps listed no process in group {pgid}, but the kernel reports "
-        f"that group is not empty, so the listing does not show every "
-        f"process (a descendant that changed uid, or a restricted ps). "
-        f"{_UNMEASURABLE}",
+        f"that group is not empty, so the listing did not show every "
+        f"process. {_UNMEASURABLE}",
     )
 
 
-def _count_group_rows(stdout: str, pgid: int) -> tuple[int, int]:
-    """(rows ``ps`` listed for ``pgid``, how many are not zombies).
+def _read_listing(stdout: str, pgid: int) -> _Listing:
+    """Parse ``pid pgid stat`` rows into the three facts that decide it.
 
-    Returned positionally, so the order is pinned by direct tests in
-    ``tests/test_procgroup.py`` rather than by the type checker: both
-    fields are ``int`` and a swap would type-check cleanly.
+    Fields are named on ``_Listing`` rather than returned positionally,
+    because all three would type-check in any order.
     """
     want = str(pgid)
+    complete = False
     rows = 0
     running = 0
     for line in stdout.splitlines():
         parts = line.split()
-        # A row with no state column would IndexError below. Real ps does
-        # not emit one; a filtered or truncated listing might.
-        if len(parts) < 2:
+        # A row missing a column would IndexError below. Real ps does not
+        # emit one; a filtered or truncated listing might.
+        if len(parts) < 3:
             continue
-        if parts[0] != want:
+        pid, group, state = parts[0], parts[1], parts[2]
+        complete = complete or pid == "1"
+        if group != want:
             continue
         rows += 1
         # "Z" is the zombie state on both macOS and Linux, and flags may
         # follow it ("Z+", "Zl"), so match the prefix rather than the cell.
-        if not parts[1].startswith("Z"):
+        if not state.startswith("Z"):
             running += 1
-    return rows, running
+    return _Listing(complete=complete, rows=rows, running=running)
 
 
 def _kernel_says_group_is_empty(pgid: int) -> bool:
@@ -196,8 +244,11 @@ def _kernel_says_group_is_empty(pgid: int) -> bool:
     ESRCH is the one conclusive answer. Success and ``EPERM`` both mean
     something is there, and any other ``OSError`` means the question was
     not answered. Neither is emptiness, and reading them as emptiness is
-    the false negative this control exists to prevent.
+    the false negative this control exists to prevent. A pgid we must not
+    signal is likewise not emptiness.
     """
+    if not _may_signal_group(pgid):
+        return False
     try:
         os.killpg(pgid, 0)
     except ProcessLookupError:
@@ -217,9 +268,14 @@ def signal_probe_alive(pgid: int) -> bool:
     refusing us, which is the closest to "alive" a signal can report, and
     on a zombie-only group that is measurably the branch taken.
 
+    A pgid this module must not signal reads as ALIVE, which is the
+    conservative direction: the caller then declines to call a run reaped.
+
     Prefer ``read_group_liveness``. This answers the question #298 was
     about getting wrong.
     """
+    if not _may_signal_group(pgid):
+        return True
     try:
         os.killpg(pgid, 0)
     except ProcessLookupError:

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -59,7 +59,6 @@ import socket
 import subprocess
 import sys
 import time
-import warnings
 from collections import deque
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
@@ -176,7 +175,13 @@ class RunOutcome:
     #: `group_reaped=False` reached this way means "we could not see",
     #: not "a factory is still running", and the poison reason an
     #: operator reads says so. Empty when the check measured cleanly.
+    #: Set on the reaped path too, where it means the "gone" itself was
+    #: not measured, which is the unsafe direction and so is reported.
     group_reap_detail: str = ""
+    #: Positive evidence the group IS occupied, as opposed to merely
+    #: unconfirmed. Kept apart from `group_reap_detail` because reporting
+    #: a refused signal as "unknown" states the opposite of the truth.
+    group_occupied_detail: str = ""
 
 
 class FactoryRunner(Protocol):
@@ -1444,6 +1449,7 @@ def run_supervised(
             output_tail=_tail(output),
             group_reaped=termination.reaped,
             group_reap_detail=termination.degraded,
+            group_occupied_detail=termination.occupied,
         )
 
 
@@ -1462,22 +1468,32 @@ def _tail(output: str | None) -> str:
 GROUP_TERM_GRACE_SECONDS = 15.0
 
 
+#: How often to re-check the group while waiting out a signal's grace
+#: period. Each check forks ``ps`` at ~11ms, so 0.25s costs ~4% of a core
+#: on a path that runs once per timed-out run.
+GROUP_POLL_SECONDS = 0.25
+
+
 @dataclass(frozen=True)
 class GroupTermination:
-    """Whether the group was confirmed reaped, and why not if not.
+    """Whether the group was confirmed reaped, and what is known if not.
 
     A bare bool was not enough: `serve_cycle` turns `reaped=False` into a
     poison reason telling the operator a factory may still be running,
-    and when the real cause was an unreadable `ps` that reason is a
-    misdiagnosis. `degraded` carries the correction into the durable
-    record rather than only into a warning on stderr, which a detached
-    daemon does not keep.
+    and the three ways of not being sure need different words. The two
+    strings are kept apart because conflating them told the operator the
+    OPPOSITE of the truth in the one case where they must act.
     """
 
     reaped: bool
-    #: Empty when the answer was measured. Non-empty when it was not, and
-    #: then it says what could not be seen.
+    #: Why the check could not MEASURE. Empty when it did. This is the
+    #: "unknown" case: an unreadable `ps`, a filtered listing.
     degraded: str = ""
+    #: Positive evidence the group IS occupied. EPERM from `killpg` means
+    #: the kernel found processes in that group and refused us, so the
+    #: group is definitely not empty. Reporting that as "unknown" would
+    #: downgrade the strongest signal a factory is alive.
+    occupied: str = ""
 
 
 def terminate_process_group(
@@ -1489,6 +1505,17 @@ def terminate_process_group(
     ``reaped`` is False when the group could not be confirmed gone, so a
     caller never reports a timed-out run as finished while a factory may
     still be writing to the repo (#186 F1).
+
+    ESCALATION IS DRIVEN BY THE GROUP, NOT BY THE DIRECT CHILD. An
+    earlier version returned as soon as ``process.wait()`` returned, which
+    made the SIGKILL leg reachable only when the DIRECT CHILD outlived the
+    grace period. Measured: a leader that dies on SIGTERM with a
+    descendant holding ``SIG_IGN`` for it returned
+    ``GroupTermination(reaped=False)`` in 0.07s with the descendant still
+    running and SIGKILL never sent, so nothing ever killed it and a
+    factory kept writing to the repo. That is the exact hazard this
+    function exists to prevent, so the grace period is now spent watching
+    the GROUP and the next signal is sent whenever anything is left.
 
     ``pgid`` should be captured at SPAWN time. Looking it up here fails
     once the direct child has been reaped - and that is precisely the
@@ -1502,11 +1529,20 @@ def terminate_process_group(
         except (ProcessLookupError, OSError):
             pgid = None
     if pgid is None:
-        # No group to signal and no id to check: the most we can honestly
-        # say is whether the direct child is gone.
-        return GroupTermination(process.poll() is not None)
+        # No group to signal and no id to check. Whether the direct child
+        # is gone is the most that can honestly be said, and saying so is
+        # not the same as having measured the group.
+        return GroupTermination(
+            process.poll() is not None,
+            degraded=(
+                "no process-group id was available, so only the direct "
+                "child was inspected and any descendant it left is "
+                "unaccounted for"
+            ),
+        )
 
-    for sig, wait in (
+    outcome = GroupTermination(False, degraded="the group was never signalled")
+    for sig, grace in (
         (signal.SIGTERM, GROUP_TERM_GRACE_SECONDS),
         (signal.SIGKILL, 10.0),
     ):
@@ -1515,19 +1551,40 @@ def terminate_process_group(
         except ProcessLookupError:
             return GroupTermination(True)
         except OSError as exc:
-            return GroupTermination(False, f"could not signal group {pgid}: {exc}")
-        try:
-            process.wait(timeout=wait)
-        except subprocess.TimeoutExpired:
-            continue
-        # The direct child is gone; confirm the group is too.
-        return _confirm_group_gone(pgid)
-    return _confirm_group_gone(pgid)
+            # EPERM is not "could not measure": the kernel FOUND processes
+            # in this group and refused us. That is evidence of a live
+            # group, and the operator has to act on it.
+            return GroupTermination(
+                False,
+                occupied=f"the kernel refused signal {sig} to group {pgid}: {exc}",
+            )
+        outcome = _wait_out_grace(process, pgid, grace)
+        if outcome.reaped:
+            return outcome
+    return outcome
+
+
+def _wait_out_grace(
+    process: subprocess.Popen[str],
+    pgid: int,
+    grace: float,
+) -> GroupTermination:
+    """Reap the direct child, then watch the GROUP until it goes or time runs out."""
+    deadline = time.monotonic() + grace
+    try:
+        process.wait(timeout=grace)
+    except subprocess.TimeoutExpired:
+        pass
+    outcome = _confirm_group_gone(pgid)
+    while not outcome.reaped and time.monotonic() < deadline:
+        time.sleep(GROUP_POLL_SECONDS)
+        outcome = _confirm_group_gone(pgid)
+    return outcome
 
 
 def _confirm_group_gone(pgid: int) -> GroupTermination:
     alive, degraded = _group_liveness_for_reap(pgid)
-    return GroupTermination(not alive, degraded)
+    return GroupTermination(not alive, degraded=degraded)
 
 
 def _safe_pgid(process: subprocess.Popen[str]) -> int | None:
@@ -1571,23 +1628,30 @@ def _group_liveness_for_reap(pgid: int) -> tuple[bool, str]:
     reaped. So the degraded path is no worse than what this function did
     everywhere before, and the ``ps`` path is exact.
 
-    The degrade is both WARNED and RETURNED. The warning is for an
-    attached operator; the returned string is what reaches the queue's
-    poison reason, because a daemon detached from its stderr keeps only
-    the record. Without it the operator reads "a factory may still be
-    executing against this repo" when the truth was "the check could not
-    see", which is the misdiagnosis this string exists to prevent.
+    The degrade is RETURNED, not warned. An earlier version called
+    ``warnings.warn`` here, which under ``PYTHONWARNINGS=error`` (a common
+    CI setting) RAISES out of the reap check: measured, it escaped
+    ``run_supervised``'s ``except subprocess.TimeoutExpired``, which does
+    not catch ``UserWarning``, and out of ``serve_cycle``, which wraps
+    nothing - so on a machine without ``ps`` one timed-out run crashed the
+    daemon. That is the same crash the undecodable-listing test exists to
+    prevent, through a different door. The message also interpolated the
+    pgid and an exception repr, so every such run added a distinct
+    permanent key to ``__warningregistry__``.
+
+    So the reason travels as a value and ``serve_cycle`` reports it
+    through the ``ServeObserver`` the daemon already threads everywhere
+    else, which is bounded, is the operator's real log channel, and
+    cannot raise.
     """
     liveness = read_group_liveness(pgid)
     if liveness.live is not None:
         return liveness.live, ""
-    warnings.warn(
-        f"kstrl: {liveness.reason} Falling back to a signal probe, which "
-        f"counts an unreaped zombie as alive, so group {pgid} may be "
-        f"reported as running when nothing in it is.",
-        stacklevel=2,
+    return signal_probe_alive(pgid), (
+        f"{liveness.reason} Falling back to a signal probe, which counts "
+        f"an unreaped zombie as alive, so group {pgid} may be reported as "
+        f"running when nothing in it is."
     )
-    return signal_probe_alive(pgid), liveness.reason
 
 
 def process_group_alive(pgid: int) -> bool:
@@ -1653,25 +1717,50 @@ def check_budget(
     )
 
 
+def _report_reap_degrade(obs: ServeObserver, outcome: RunOutcome) -> None:
+    """Say out loud when the reap check could not measure.
+
+    Reported on BOTH paths, and the reaped one is why this exists. When
+    ``ps`` is blind the fallback signal probe can answer "gone", the run
+    is called reaped and the item is released for another attempt - the
+    unsafe direction, reached on a doubly-unverified answer, and until
+    this was added it was recorded nowhere at all. The poison reason
+    covers the not-reaped path; nothing covered this one.
+    """
+    if not outcome.timed_out or not outcome.group_reap_detail:
+        return
+    if outcome.group_reaped:
+        obs.warn(
+            f"  the timed-out run was released as reaped on an UNMEASURED "
+            f"check: {outcome.group_reap_detail}"
+        )
+        return
+    obs.warn(f"  the reap check could not measure: {outcome.group_reap_detail}")
+
+
 def _unreaped_timeout_detail(outcome: RunOutcome) -> str:
     """The poison reason for a timed-out run whose group was not confirmed gone.
 
-    Says WHY it was not confirmed when the check could not measure.
-    Without that the operator reads a claim about a live factory when the
-    real cause was a blind reap check, and acts on the wrong one. The
-    warning `_group_liveness_for_reap` emits goes to stderr, which a
-    detached daemon does not keep; this is the durable half.
+    Three different things are worth three different sentences, and
+    collapsing them is how an operator acts on the wrong one. Positive
+    evidence the group is occupied must NOT be softened into "unknown";
+    an unmeasurable check must not be reported as a live factory.
     """
     detail = (
         "the run timed out and its process group could not be confirmed "
         "reaped, so a factory may still be executing against this repo"
     )
-    if not outcome.group_reap_detail:
-        return detail
-    return (
-        f"{detail}. The check could not measure, so this is 'unknown' "
-        f"rather than 'still running': {outcome.group_reap_detail}"
-    )
+    if outcome.group_occupied_detail:
+        return (
+            f"{detail}. The group is CONFIRMED occupied, not merely "
+            f"unconfirmed: {outcome.group_occupied_detail}"
+        )
+    if outcome.group_reap_detail:
+        return (
+            f"{detail}. The check could not measure, so this is 'unknown' "
+            f"rather than 'still running': {outcome.group_reap_detail}"
+        )
+    return detail
 
 
 def _floor_note(spend: DailySpend) -> str:
@@ -2351,6 +2440,8 @@ def serve_cycle(
         timeout_seconds=cfg.factory_timeout_seconds,
         on_spawn=_adopt,
     )
+
+    _report_reap_degrade(obs, outcome)
 
     if outcome.timed_out and not outcome.group_reaped:
         # A descendant may still be running against this repo. Do NOT

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -59,6 +59,7 @@ import socket
 import subprocess
 import sys
 import time
+import warnings
 from collections import deque
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
@@ -69,6 +70,7 @@ from pathlib import Path
 from typing import Any, Final, Protocol
 
 from kstrl.agents.base import ARCHITECT_COMPONENT, ARCHITECT_ROLE
+from kstrl.procgroup import read_group_liveness, signal_probe_alive
 from kstrl.runid import run_kind
 from kstrl.statedir import (
     CONTROL_SPEND,
@@ -1520,16 +1522,42 @@ def _safe_pgid(process: subprocess.Popen[str]) -> int | None:
 
 
 def process_group_alive(pgid: int) -> bool:
-    """Whether any process remains in ``pgid``."""
-    try:
-        os.killpg(pgid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
-        return False
-    return True
+    """Whether any RUNNING process remains in ``pgid``.
+
+    A zombie does not count. It has already died and is only waiting to
+    be reaped, so a caller asking "may a factory still be writing to this
+    repo" is answered No by it, and a signal probe answers Yes (#298; the
+    reasoning and the measurements are in ``kstrl.procgroup``).
+
+    FAIL DIRECTION when ``ps`` cannot be trusted: fall back to the signal
+    probe, which is the pre-#298 behaviour. That is a deliberate choice
+    between three options and not a default. Raising would take the
+    daemon down over a diagnostic. Reporting "alive" unconditionally is
+    the conservative direction for the one caller, but on a machine with
+    no ``ps`` it makes EVERY timed-out run unreapable and therefore
+    poisoned, which trades a rare wrong answer for a permanent one. The
+    probe is right whenever the group is genuinely gone, which is the
+    common case, and its only error is over-reporting alive - the safe
+    direction for ``terminate_process_group``, which then declines to
+    call the run reaped. So the degraded path is no worse than what this
+    function did everywhere before, and the ``ps`` path is exact.
+
+    The degrade WARNS rather than passing silently. Without it the two
+    answers are indistinguishable downstream: a run poisoned with "its
+    process group could not be confirmed reaped, so a factory may still
+    be executing against this repo" would be a misdiagnosis when the real
+    cause was an unreadable ``ps``, and nothing would say so.
+    """
+    liveness = read_group_liveness(pgid)
+    if liveness.live is not None:
+        return liveness.live
+    warnings.warn(
+        f"kstrl: {liveness.reason} Falling back to a signal probe, which "
+        f"counts an unreaped zombie as alive, so group {pgid} may be "
+        f"reported as running when nothing in it is.",
+        stacklevel=2,
+    )
+    return signal_probe_alive(pgid)
 
 
 # ---------------------------------------------------------------------------

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -172,6 +172,11 @@ class RunOutcome:
     #: signalled and reaped. False means a descendant may still be alive,
     #: which must never be treated as "the run is over" (#186 F1).
     group_reaped: bool = False
+    #: Why the reap check could not measure, when it could not. A
+    #: `group_reaped=False` reached this way means "we could not see",
+    #: not "a factory is still running", and the poison reason an
+    #: operator reads says so. Empty when the check measured cleanly.
+    group_reap_detail: str = ""
 
 
 class FactoryRunner(Protocol):
@@ -1428,7 +1433,7 @@ def run_supervised(
             output_tail=_tail(output),
         )
     except subprocess.TimeoutExpired:
-        reaped = terminate_process_group(process, pgid)
+        termination = terminate_process_group(process, pgid)
         try:
             output, _ = process.communicate(timeout=10)
         except (subprocess.TimeoutExpired, ValueError, OSError):
@@ -1437,7 +1442,8 @@ def run_supervised(
             returncode=(process.returncode if process.returncode is not None else -9),
             timed_out=True,
             output_tail=_tail(output),
-            group_reaped=reaped,
+            group_reaped=termination.reaped,
+            group_reap_detail=termination.degraded,
         )
 
 
@@ -1456,13 +1462,31 @@ def _tail(output: str | None) -> str:
 GROUP_TERM_GRACE_SECONDS = 15.0
 
 
+@dataclass(frozen=True)
+class GroupTermination:
+    """Whether the group was confirmed reaped, and why not if not.
+
+    A bare bool was not enough: `serve_cycle` turns `reaped=False` into a
+    poison reason telling the operator a factory may still be running,
+    and when the real cause was an unreadable `ps` that reason is a
+    misdiagnosis. `degraded` carries the correction into the durable
+    record rather than only into a warning on stderr, which a detached
+    daemon does not keep.
+    """
+
+    reaped: bool
+    #: Empty when the answer was measured. Non-empty when it was not, and
+    #: then it says what could not be seen.
+    degraded: str = ""
+
+
 def terminate_process_group(
     process: subprocess.Popen[str],
     pgid: int | None = None,
-) -> bool:
-    """SIGTERM then SIGKILL a child's whole process group; True if reaped.
+) -> GroupTermination:
+    """SIGTERM then SIGKILL a child's whole process group.
 
-    Returns False when the group could not be confirmed gone, so a
+    ``reaped`` is False when the group could not be confirmed gone, so a
     caller never reports a timed-out run as finished while a factory may
     still be writing to the repo (#186 F1).
 
@@ -1480,7 +1504,7 @@ def terminate_process_group(
     if pgid is None:
         # No group to signal and no id to check: the most we can honestly
         # say is whether the direct child is gone.
-        return process.poll() is not None
+        return GroupTermination(process.poll() is not None)
 
     for sig, wait in (
         (signal.SIGTERM, GROUP_TERM_GRACE_SECONDS),
@@ -1489,16 +1513,21 @@ def terminate_process_group(
         try:
             os.killpg(pgid, sig)
         except ProcessLookupError:
-            return True
-        except OSError:
-            return False
+            return GroupTermination(True)
+        except OSError as exc:
+            return GroupTermination(False, f"could not signal group {pgid}: {exc}")
         try:
             process.wait(timeout=wait)
         except subprocess.TimeoutExpired:
             continue
         # The direct child is gone; confirm the group is too.
-        return not process_group_alive(pgid)
-    return not process_group_alive(pgid)
+        return _confirm_group_gone(pgid)
+    return _confirm_group_gone(pgid)
+
+
+def _confirm_group_gone(pgid: int) -> GroupTermination:
+    alive, degraded = _group_liveness_for_reap(pgid)
+    return GroupTermination(not alive, degraded)
 
 
 def _safe_pgid(process: subprocess.Popen[str]) -> int | None:
@@ -1521,8 +1550,8 @@ def _safe_pgid(process: subprocess.Popen[str]) -> int | None:
     return pgid
 
 
-def process_group_alive(pgid: int) -> bool:
-    """Whether any RUNNING process remains in ``pgid``.
+def _group_liveness_for_reap(pgid: int) -> tuple[bool, str]:
+    """(is anything RUNNING in ``pgid``, why that answer is degraded).
 
     A zombie does not count. It has already died and is only waiting to
     be reaped, so a caller asking "may a factory still be writing to this
@@ -1536,28 +1565,40 @@ def process_group_alive(pgid: int) -> bool:
     the conservative direction for the one caller, but on a machine with
     no ``ps`` it makes EVERY timed-out run unreapable and therefore
     poisoned, which trades a rare wrong answer for a permanent one. The
-    probe is right whenever the group is genuinely gone, which is the
-    common case, and its only error is over-reporting alive - the safe
-    direction for ``terminate_process_group``, which then declines to
-    call the run reaped. So the degraded path is no worse than what this
-    function did everywhere before, and the ``ps`` path is exact.
+    probe is right whenever the group is genuinely gone, and its only
+    error is over-reporting alive - the safe direction for
+    ``terminate_process_group``, which then declines to call the run
+    reaped. So the degraded path is no worse than what this function did
+    everywhere before, and the ``ps`` path is exact.
 
-    The degrade WARNS rather than passing silently. Without it the two
-    answers are indistinguishable downstream: a run poisoned with "its
-    process group could not be confirmed reaped, so a factory may still
-    be executing against this repo" would be a misdiagnosis when the real
-    cause was an unreadable ``ps``, and nothing would say so.
+    The degrade is both WARNED and RETURNED. The warning is for an
+    attached operator; the returned string is what reaches the queue's
+    poison reason, because a daemon detached from its stderr keeps only
+    the record. Without it the operator reads "a factory may still be
+    executing against this repo" when the truth was "the check could not
+    see", which is the misdiagnosis this string exists to prevent.
     """
     liveness = read_group_liveness(pgid)
     if liveness.live is not None:
-        return liveness.live
+        return liveness.live, ""
     warnings.warn(
         f"kstrl: {liveness.reason} Falling back to a signal probe, which "
         f"counts an unreaped zombie as alive, so group {pgid} may be "
         f"reported as running when nothing in it is.",
         stacklevel=2,
     )
-    return signal_probe_alive(pgid)
+    return signal_probe_alive(pgid), liveness.reason
+
+
+def process_group_alive(pgid: int) -> bool:
+    """Whether any RUNNING process remains in ``pgid``.
+
+    The bool half of ``_group_liveness_for_reap``, which is where the
+    reasoning lives. Callers that record why an answer was degraded want
+    that function instead.
+    """
+    alive, _ = _group_liveness_for_reap(pgid)
+    return alive
 
 
 # ---------------------------------------------------------------------------
@@ -1609,6 +1650,27 @@ def check_budget(
             f"(${spend.spent_usd:.2f} spent{floor})"
         ),
         resume_after=next_local_midnight(),
+    )
+
+
+def _unreaped_timeout_detail(outcome: RunOutcome) -> str:
+    """The poison reason for a timed-out run whose group was not confirmed gone.
+
+    Says WHY it was not confirmed when the check could not measure.
+    Without that the operator reads a claim about a live factory when the
+    real cause was a blind reap check, and acts on the wrong one. The
+    warning `_group_liveness_for_reap` emits goes to stderr, which a
+    detached daemon does not keep; this is the durable half.
+    """
+    detail = (
+        "the run timed out and its process group could not be confirmed "
+        "reaped, so a factory may still be executing against this repo"
+    )
+    if not outcome.group_reap_detail:
+        return detail
+    return (
+        f"{detail}. The check could not measure, so this is 'unknown' "
+        f"rather than 'still running': {outcome.group_reap_detail}"
     )
 
 
@@ -2293,10 +2355,7 @@ def serve_cycle(
     if outcome.timed_out and not outcome.group_reaped:
         # A descendant may still be running against this repo. Do NOT
         # release the item for another attempt (#186 F1).
-        detail = (
-            "the run timed out and its process group could not be confirmed "
-            "reaped, so a factory may still be executing against this repo"
-        )
+        detail = _unreaped_timeout_detail(outcome)
         with queue_lock(root_dir, blocking=True):
             current = queue.get(running.item_id)
             if current is not None:

--- a/tests/helpers/procs.py
+++ b/tests/helpers/procs.py
@@ -148,6 +148,19 @@ def fake_ps(
     return calls
 
 
+def ps_is_readable() -> bool:
+    """Whether `kstrl.procgroup` can actually measure on this machine.
+
+    A test that asserts on `process_group_alive` needs this: where `ps`
+    is absent or filtered the production call degrades to the signal
+    probe, which counts a zombie as alive by design, so a #298 assertion
+    would fail with a message pointing at kstrl rather than at the
+    missing binary. Uses the caller's own group, which is alive by
+    construction, so a False here is about `ps` and never about timing.
+    """
+    return read_group_liveness(os.getpgrp()).live is True
+
+
 def dead_group(timeout: float = 10.0) -> int:
     """A process group that is spawned, killed and reaped. Returns its pgid.
 
@@ -163,10 +176,20 @@ def dead_group(timeout: float = 10.0) -> int:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    pgid = os.getpgid(child.pid)
-    kill_group(pgid)
-    child.wait(timeout=timeout)
-    return pgid
+    try:
+        pgid = os.getpgid(child.pid)
+        kill_group(pgid)
+        child.wait(timeout=timeout)
+        return pgid
+    finally:
+        # kill_group swallows every OSError, so a SIGKILL that did not
+        # land leaves `child.wait` to time out and the Popen dropped
+        # unreaped with a real `sleep 30` still on the machine. That is
+        # the orphan class #292 exists to stop, planted by the helper
+        # written to stop it.
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=timeout)
 
 
 def wait_for_group_to_die(pgid: int, timeout: float = 10.0) -> bool:

--- a/tests/helpers/procs.py
+++ b/tests/helpers/procs.py
@@ -32,6 +32,7 @@ import os
 import signal
 import subprocess
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -74,6 +75,20 @@ def group_has_live_member(pgid: int) -> bool:
     is there" because ``ps`` failed has measured nothing and passed,
     which is the #292 defect one level down; a daemon that raises over a
     diagnostic stops doing its job. A test has nothing to protect.
+
+    THE COMMON-MODE RISK, stated because sharing a reading with the code
+    under test is a real cost and not an obviously free one. The suite's
+    orphan assertions and the daemon's reap check now run the same parse,
+    so one parse bug could blind both at once. Two arguments answer it,
+    and neither is "it will not happen". First, a second hand-written
+    parse would not have been independent of the failure it is supposed
+    to catch: both copies read the same ``ps -A -o pgid=,stat=`` and both
+    would break together on a column shift, which is the named risk.
+    Second, ``read_group_liveness`` no longer rests on the parse alone
+    for the dangerous direction. A "gone" now requires either a zombie
+    row it demonstrably saw, or ``killpg`` ESRCH from the kernel - so a
+    parse that DROPS a running row yields "cannot see" rather than a
+    confident "gone", and this helper then raises rather than passing.
     """
     liveness = read_group_liveness(pgid)
     if liveness.live is None:
@@ -87,27 +102,71 @@ def fake_ps(
     returncode: int = 0,
     stdout: str = "",
     stderr: str = "",
-    raises: BaseException | None = None,
-) -> None:
-    """Make ``kstrl.procgroup``'s ``ps`` return this, or raise this.
+    raises: Callable[[], BaseException] | None = None,
+) -> list[dict[str, object]]:
+    """Answer ``kstrl.procgroup``'s ``ps`` with this. Returns the call log.
 
-    One patch target in one place. Before #298 the fake was hand-rolled
-    at six call sites across two files, and rewiring them when the
-    reading moved is what showed the cost: a site missed keeps passing
-    while measuring nothing, which is exactly what #292 exists to stop.
+    DELEGATES every other command to the real ``subprocess.run``. That is
+    load-bearing, not politeness: ``procgroup.subprocess`` IS the stdlib
+    module, so ``setattr`` on it replaces ``run`` for the whole process,
+    not for ``procgroup``. Measured before this guard existed: under
+    ``fake_ps(stdout="1 Ss\n")`` a plain
+    ``subprocess.run(["git", "rev-parse", "HEAD"])`` returned
+    ``stdout='1 Ss\n'`` and ``args=['ps','-A','-o','pgid=,stat=']``. Any
+    test that combined this helper with a git or fixture subprocess call
+    would have measured nothing and passed, which is the #292 class this
+    module exists to prevent.
+
+    ``raises`` is a FACTORY rather than an instance. A module-level
+    exception object re-raised by every parametrized case accumulates a
+    traceback frame and an ``__context__`` per raise, so it retains every
+    test frame and its locals until interpreter exit.
+
+    The returned list records the args and kwargs each intercepted ``ps``
+    call received, so a test can assert on what was passed - the
+    ``timeout=`` in particular, which is the only bound stopping a wedged
+    ``ps`` from hanging the daemon and which no test could otherwise see.
     """
+    real_run = subprocess.run
+    calls: list[dict[str, object]] = []
 
-    def fake(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+    def fake(*args: object, **kwargs: object) -> object:
+        argv = list(args[0]) if args and isinstance(args[0], (list, tuple)) else []
+        if argv != list(procgroup.PS_ARGV):
+            return real_run(*args, **kwargs)  # type: ignore[arg-type]
+        calls.append({"argv": argv, "kwargs": dict(kwargs)})
         if raises is not None:
-            raise raises
+            raise raises()
         return subprocess.CompletedProcess(
-            args=list(procgroup.PS_ARGV),
+            args=argv,
             returncode=returncode,
             stdout=stdout,
             stderr=stderr,
         )
 
     monkeypatch.setattr(procgroup.subprocess, "run", fake)
+    return calls
+
+
+def dead_group(timeout: float = 10.0) -> int:
+    """A process group that is spawned, killed and reaped. Returns its pgid.
+
+    The pgid of a group that provably held a process and provably holds
+    none now, which is what a test needs to assert that absence is still
+    reportable. Lives here rather than being copied into each suite
+    because a copied fixture is one that stops matching the helper it
+    feeds.
+    """
+    child = subprocess.Popen(
+        ["sleep", "30"],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    pgid = os.getpgid(child.pid)
+    kill_group(pgid)
+    child.wait(timeout=timeout)
+    return pgid
 
 
 def wait_for_group_to_die(pgid: int, timeout: float = 10.0) -> bool:
@@ -127,7 +186,7 @@ def kill_group(pgid: int) -> None:
     ``sleep 60`` on a shared machine is precisely what #292 is about: the
     old test's own failures poisoned every later run of it. Observed
     while verifying that change, a failing run of the pre-fix file left
-    an orphan behind that then matched the next run's ``pgrep``.
+    an orphan behind that then matched the next run's machine-wide search.
     """
     try:
         os.killpg(pgid, signal.SIGKILL)

--- a/tests/helpers/procs.py
+++ b/tests/helpers/procs.py
@@ -34,6 +34,11 @@ import subprocess
 import time
 from pathlib import Path
 
+import pytest
+
+from kstrl import procgroup
+from kstrl.procgroup import read_group_liveness
+
 
 def read_pid(pidfile: Path, timeout: float = 5.0) -> int:
     """The pid a fake agent wrote, waiting out the write.
@@ -57,62 +62,52 @@ def read_pid(pidfile: Path, timeout: float = 5.0) -> int:
 def group_has_live_member(pgid: int) -> bool:
     """Whether any non-zombie process is still in process group ``pgid``.
 
-    A zombie has already died and is only waiting to be reaped, so it is
-    not an orphan and must not count as one. This is NOT
-    ``os.killpg(pgid, 0)``: measured while writing #292, with the
-    parent alive and not yet reaping, that call reported a SIGKILLed
-    group as present for the whole 6s observation window and never
-    converged, because a zombie stays signalable. Building a wait loop on
-    it would trade a machine-state flake for a reap-timing one.
+    The reading, and the evidence for why it is not ``os.killpg(pgid, 0)``
+    and why absence needs a control, lives in ``kstrl.procgroup``. #298
+    centralised it: two copies of one ``ps`` parse with slightly
+    different failure handling is how the suite's answer and the daemon's
+    drift apart.
 
-    Only the two columns the question needs are requested. Asking ``ps``
-    for command lines as well measured 23.5ms per call against 11.6ms for
-    this on a 895-process machine, and this runs inside a poll loop.
-
-    RAISES rather than reports absence when it cannot see. A helper that
-    answers "nothing is there" because ``ps`` failed is the same defect
-    #292 exists to remove, one level down: measured with ``ps`` forced to
-    return 127, this reported the caller's OWN live process group as dead
-    and ``wait_for_group_to_die`` returned True, so the orphan assertion
-    would have passed having measured nothing. ``ps`` is absent or
-    restricted often enough to matter, on ``hidepid`` mounts and in
-    minimal containers.
-
-    So absence is only ever reported by a call that proved it can see
-    something: the caller's own process group is alive by construction,
-    and if that is missing from the output the output is not evidence.
+    What stays HERE is the POLICY, because it is the opposite of the
+    daemon's. This RAISES when it cannot see, where
+    ``serve.process_group_alive`` degrades. A test that answers "nothing
+    is there" because ``ps`` failed has measured nothing and passed,
+    which is the #292 defect one level down; a daemon that raises over a
+    diagnostic stops doing its job. A test has nothing to protect.
     """
-    out = subprocess.run(
-        ["ps", "-A", "-o", "pgid=,stat="],
-        capture_output=True,
-        text=True,
-    )
-    if out.returncode != 0:
-        raise AssertionError(
-            f"ps failed (rc={out.returncode}): {out.stderr.strip()!r}. "
-            f"Process-group liveness cannot be measured here, and "
-            f"reporting 'no live member' would be a false negative."
+    liveness = read_group_liveness(pgid)
+    if liveness.live is None:
+        raise AssertionError(liveness.reason)
+    return liveness.live
+
+
+def fake_ps(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+    raises: BaseException | None = None,
+) -> None:
+    """Make ``kstrl.procgroup``'s ``ps`` return this, or raise this.
+
+    One patch target in one place. Before #298 the fake was hand-rolled
+    at six call sites across two files, and rewiring them when the
+    reading moved is what showed the cost: a site missed keeps passing
+    while measuring nothing, which is exactly what #292 exists to stop.
+    """
+
+    def fake(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if raises is not None:
+            raise raises
+        return subprocess.CompletedProcess(
+            args=list(procgroup.PS_ARGV),
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
         )
 
-    ours = str(os.getpgrp())
-    saw_own_group = False
-    found = False
-    for line in out.stdout.splitlines():
-        parts = line.split()
-        if len(parts) < 2:
-            continue
-        if parts[0] == ours:
-            saw_own_group = True
-        if parts[0] == str(pgid) and not parts[1].startswith("Z"):
-            found = True
-
-    if not saw_own_group:
-        raise AssertionError(
-            f"ps did not report this process's own group ({ours}), so it "
-            f"cannot be trusted to report the absence of group {pgid}. "
-            f"Restricted or filtered ps output."
-        )
-    return found
+    monkeypatch.setattr(procgroup.subprocess, "run", fake)
 
 
 def wait_for_group_to_die(pgid: int, timeout: float = 10.0) -> bool:

--- a/tests/test_process_scoping.py
+++ b/tests/test_process_scoping.py
@@ -226,8 +226,8 @@ class TestTheLivenessHelperCannotPassByMeasuringNothing:
         the point of the test: it still refuses to convert a listing it
         cannot trust into an absence."""
 
-        procs.fake_ps(monkeypatch, stdout="    1 Ss\n  517 Ss\n")
-        with pytest.raises(AssertionError, match="kernel reports"):
+        procs.fake_ps(monkeypatch, stdout="  90 517 Ss\n  91 517 Ss\n")
+        with pytest.raises(AssertionError, match="did not list pid 1"):
             procs.group_has_live_member(os.getpgrp())
 
     def test_wait_for_group_to_die_does_not_convert_that_into_success(

--- a/tests/test_process_scoping.py
+++ b/tests/test_process_scoping.py
@@ -214,11 +214,20 @@ class TestTheLivenessHelperCannotPassByMeasuringNothing:
     def test_filtered_ps_output_raises_instead_of_reporting_absence(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """rc=0 but our own processes hidden, which is what a ``hidepid``
-        mount looks like. Exit status alone is not enough."""
+        """rc=0 but our own processes hidden, which is what a filtered
+        listing looks like. Exit status alone is not enough.
+
+        #298 replaced the control that decides this. It used to check
+        that our own group appeared in the listing, which was satisfied
+        by construction on every real ps and so could never fire. It now
+        asks the kernel: the listing holds no row for this group, and
+        ``killpg`` says the group is occupied, so the listing is not
+        showing everything. The helper's POLICY is unchanged, which is
+        the point of the test: it still refuses to convert a listing it
+        cannot trust into an absence."""
 
         procs.fake_ps(monkeypatch, stdout="    1 Ss\n  517 Ss\n")
-        with pytest.raises(AssertionError, match="own group"):
+        with pytest.raises(AssertionError, match="kernel reports"):
             procs.group_has_live_member(os.getpgrp())
 
     def test_wait_for_group_to_die_does_not_convert_that_into_success(

--- a/tests/test_process_scoping.py
+++ b/tests/test_process_scoping.py
@@ -191,6 +191,12 @@ class TestTheLivenessHelperCannotPassByMeasuringNothing:
 
     Why absence is only reportable by a call that proved it can see
     something is argued in ``tests/helpers/procs.py``. These pin it.
+
+    The reading moved to ``kstrl.procgroup`` in #298, so the ``ps``
+    double is ``procs.fake_ps``. What is under test here is still the
+    helper's POLICY: a test that cannot see must fail. The daemon on
+    the same reading degrades instead, which ``tests/test_serve.py``
+    pins.
     """
 
     def test_it_sees_its_own_process_group(self) -> None:
@@ -201,12 +207,7 @@ class TestTheLivenessHelperCannotPassByMeasuringNothing:
     def test_a_failing_ps_raises_instead_of_reporting_absence(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        def broken(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-            return subprocess.CompletedProcess(
-                args=["ps"], returncode=127, stdout="", stderr="ps: command not found"
-            )
-
-        monkeypatch.setattr(procs.subprocess, "run", broken)
+        procs.fake_ps(monkeypatch, returncode=127, stderr="ps: command not found")
         with pytest.raises(AssertionError, match="ps failed"):
             procs.group_has_live_member(os.getpgrp())
 
@@ -216,12 +217,7 @@ class TestTheLivenessHelperCannotPassByMeasuringNothing:
         """rc=0 but our own processes hidden, which is what a ``hidepid``
         mount looks like. Exit status alone is not enough."""
 
-        def filtered(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-            return subprocess.CompletedProcess(
-                args=["ps"], returncode=0, stdout="    1 Ss\n  517 Ss\n", stderr=""
-            )
-
-        monkeypatch.setattr(procs.subprocess, "run", filtered)
+        procs.fake_ps(monkeypatch, stdout="    1 Ss\n  517 Ss\n")
         with pytest.raises(AssertionError, match="own group"):
             procs.group_has_live_member(os.getpgrp())
 
@@ -232,12 +228,7 @@ class TestTheLivenessHelperCannotPassByMeasuringNothing:
         guard has to survive it rather than being swallowed by the poll
         loop."""
 
-        def broken(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-            return subprocess.CompletedProcess(
-                args=["ps"], returncode=127, stdout="", stderr="boom"
-            )
-
-        monkeypatch.setattr(procs.subprocess, "run", broken)
+        procs.fake_ps(monkeypatch, returncode=127, stderr="boom")
         with pytest.raises(AssertionError, match="ps failed"):
             procs.wait_for_group_to_die(os.getpgrp(), timeout=1.0)
 

--- a/tests/test_procgroup.py
+++ b/tests/test_procgroup.py
@@ -14,8 +14,10 @@ the synthetic rows describe something that actually happens.
 
 from __future__ import annotations
 
+import ast
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -23,15 +25,18 @@ from kstrl.procgroup import (
     PS_ARGV,
     PS_TIMEOUT_SECONDS,
     GroupLiveness,
-    _scan,
+    _count_group_rows,
+    _kernel_says_group_is_empty,
     read_group_liveness,
     signal_probe_alive,
 )
 from tests.helpers import procs
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 
 class TestTheScanReadsStatesNotJustGroups:
-    """``_scan`` returns two bools positionally, so both are pinned."""
+    """``_count_group_rows`` returns two ints positionally, so both are pinned."""
 
     @pytest.mark.parametrize(
         ("state", "counts_as_running"),
@@ -42,8 +47,9 @@ class TestTheScanReadsStatesNotJustGroups:
             ("D", True),
             ("T", True),
             # Z is the zombie state on macOS and Linux, and flags follow
-            # it. Only the prefix is guaranteed, which is why the
-            # production check is startswith and not equality.
+            # it. Only the prefix is guaranteed, which is why the check is
+            # startswith and not equality. Z+, Zl and Zs are asserted from
+            # synthetic rows; the local kernel only ever printed plain Z.
             ("Z", False),
             ("Z+", False),
             ("Zl", False),
@@ -55,38 +61,112 @@ class TestTheScanReadsStatesNotJustGroups:
         state: str,
         counts_as_running: bool,
     ) -> None:
-        saw_own_group, found = _scan(f"7 {state}\n9 Ss\n", pgid=7, ours=9)
-        assert saw_own_group is True, "the fixture must contain our own group"
-        assert found is counts_as_running
+        rows, running = _count_group_rows(f"7 {state}\n9 Ss\n", pgid=7)
+        assert rows == 1, "the row must be counted whatever its state"
+        assert bool(running) is counts_as_running
 
-    def test_the_two_flags_are_not_transposed(self) -> None:
-        """Both fields are bool, so a swap type-checks. Only a test with
+    def test_the_two_counts_are_not_transposed(self) -> None:
+        """Both fields are int, so a swap type-checks. Only a case with
         the two answers DIFFERENT can catch it."""
-        saw_own_group, found = _scan("9 Ss\n", pgid=7, ours=9)
-        assert (saw_own_group, found) == (True, False)
-
-        saw_own_group, found = _scan("7 Ss\n", pgid=7, ours=9)
-        assert (saw_own_group, found) == (False, True)
+        assert _count_group_rows("7 Z\n", pgid=7) == (1, 0)
+        assert _count_group_rows("7 Ss\n7 Z\n", pgid=7) == (2, 1)
 
     def test_a_ragged_row_is_skipped_without_dropping_its_neighbours(self) -> None:
         """A row with no state column would IndexError. The rows either
         side of it must still be read, or the skip is a silent
         truncation."""
-        saw_own_group, found = _scan("\n  7\n9 Ss\n7 Ss\n", pgid=7, ours=9)
-        assert (saw_own_group, found) == (True, True)
+        assert _count_group_rows("\n  7\n9 Ss\n7 Ss\n", pgid=7) == (1, 1)
 
     def test_a_group_id_is_matched_whole_not_as_a_prefix(self) -> None:
         """#292 in miniature: 7 must not match 70."""
-        saw_own_group, found = _scan("70 Ss\n9 Ss\n", pgid=7, ours=9)
-        assert (saw_own_group, found) == (True, False)
+        assert _count_group_rows("70 Ss\n9 Ss\n", pgid=7) == (0, 0)
 
 
-class TestTheTriState:
-    """Which of the three answers each condition produces."""
+class TestAGoneIsOnlyReportedWhenItIsEvidence:
+    """The safety argument, which the own-group control did not carry.
 
-    def test_a_live_group_reads_live(self) -> None:
-        assert read_group_liveness(os.getpgrp()) == GroupLiveness(True)
+    That control asked whether the caller's own group appeared in the
+    listing. Measured on this tree: ``subprocess.run`` does not setpgid,
+    so the ``ps`` child runs in the caller's group and ``ps -A`` always
+    lists it - our own pgid appeared four times in every real listing,
+    the last row being ``ps`` itself. It was satisfied by construction
+    and could never fire, so a listing missing a live target was reported
+    as a confident "gone". These pin what replaced it.
+    """
 
+    def test_a_listing_that_saw_only_zombies_is_evidence_of_gone(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """#298's case. ps demonstrably sees the group, so its verdict on
+        that group's members is evidence and no kernel check is needed."""
+        procs.fake_ps(monkeypatch, stdout="4242 Z\n4242 Z+\n")
+        assert read_group_liveness(4242) == GroupLiveness(False)
+
+    def test_a_missing_group_the_kernel_calls_empty_is_gone(self) -> None:
+        """The other trustworthy route: the kernel, not the listing."""
+        assert read_group_liveness(procs.dead_group()) == GroupLiveness(False)
+
+    def test_a_missing_group_the_kernel_calls_occupied_is_unknown(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The bug the own-group control could not catch.
+
+        A live group absent from the listing - a descendant that changed
+        uid, a restricted ps - used to read as a confident "gone", which
+        makes `terminate_process_group` report reaped and `serve_cycle`
+        requeue onto a repo a factory is still writing to (#186 F1).
+        """
+        # Our own group is alive by construction, and the listing omits it.
+        procs.fake_ps(monkeypatch, stdout="1 Ss\n")
+        liveness = read_group_liveness(os.getpgrp())
+        assert liveness.live is None
+        assert "kernel reports" in liveness.reason
+        assert "not empty" in liveness.reason
+
+    def test_a_running_row_still_reads_live(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        procs.fake_ps(monkeypatch, stdout="4242 Ss\n")
+        assert read_group_liveness(4242) == GroupLiveness(True)
+
+
+class TestTheKernelControl:
+    """ESRCH is the only conclusive emptiness, so pin that it is the only one."""
+
+    def test_a_dead_group_is_empty(self) -> None:
+        assert _kernel_says_group_is_empty(procs.dead_group()) is True
+
+    def test_our_own_group_is_not_empty(self) -> None:
+        assert _kernel_says_group_is_empty(os.getpgrp()) is False
+
+    def test_a_refused_signal_is_not_emptiness(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """EPERM means something is there refusing us. Reading it as
+        emptiness is the false negative this control exists to stop."""
+
+        def refuse(pgid: int, sig: int) -> None:
+            raise PermissionError(1, "Operation not permitted")
+
+        monkeypatch.setattr("kstrl.procgroup.os.killpg", refuse)
+        assert _kernel_says_group_is_empty(4242) is False
+
+    def test_an_unanswered_question_is_not_emptiness(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def broken(pgid: int, sig: int) -> None:
+            raise OSError(22, "Invalid argument")
+
+        monkeypatch.setattr("kstrl.procgroup.os.killpg", broken)
+        assert _kernel_says_group_is_empty(4242) is False
+
+
+class TestTheTriStateWhenPsGivesNoAnswer:
     def test_a_nonzero_exit_is_unknown_not_absent(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -102,7 +182,7 @@ class TestTheTriState:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """``ps`` absent raises OSError rather than exiting non-zero."""
-        procs.fake_ps(monkeypatch, raises=FileNotFoundError(2, "no ps"))
+        procs.fake_ps(monkeypatch, raises=lambda: FileNotFoundError(2, "no ps"))
         liveness = read_group_liveness(os.getpgrp())
         assert liveness.live is None
         assert "failed to run" in liveness.reason
@@ -112,35 +192,102 @@ class TestTheTriState:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """``TimeoutExpired`` is a SubprocessError, not an OSError, so it
-        escapes the branch above and needs its own."""
+        escapes that branch and needs its own."""
         procs.fake_ps(
             monkeypatch,
-            raises=subprocess.TimeoutExpired(cmd=list(PS_ARGV), timeout=PS_TIMEOUT_SECONDS),
+            raises=lambda: subprocess.TimeoutExpired(cmd=list(PS_ARGV), timeout=PS_TIMEOUT_SECONDS),
         )
         assert read_group_liveness(os.getpgrp()).live is None
 
-    def test_output_missing_our_own_group_is_unknown_not_absent(
+    def test_an_undecodable_listing_is_unknown_rather_than_a_crash(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """rc=0 with our own processes hidden, which is what a ``hidepid``
-        mount looks like. Exit status alone is not enough to trust the
-        silence: our group is alive by construction, so a listing without
-        it is filtered and its silence about anything else means nothing."""
-        procs.fake_ps(monkeypatch, stdout="    1 Ss\n  517 Ss\n")
+        """UnicodeDecodeError is a ValueError, so a fail-closed
+        ``except OSError`` would let it escape. It would then propagate
+        through `process_group_alive` and `terminate_process_group` into
+        `run_supervised`'s `except TimeoutExpired`, which does not catch
+        it, and out of `serve_cycle` uncaught, taking the daemon down over
+        a diagnostic that the docstring promises will never do that. The
+        read pins encoding='utf-8', errors='replace' so it cannot arise;
+        this pins that it is caught even if that changes.
+        """
+        procs.fake_ps(
+            monkeypatch,
+            raises=lambda: UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid"),
+        )
         liveness = read_group_liveness(os.getpgrp())
         assert liveness.live is None
-        assert "own group" in liveness.reason
+        assert "failed to run" in liveness.reason
 
-    def test_a_trustworthy_ps_can_still_report_absence(
+
+class TestThePsCallIsBounded:
+    """The timeout is the only thing stopping a wedged ps hanging the daemon.
+
+    Deleting ``timeout=PS_TIMEOUT_SECONDS`` from ``read_group_liveness``
+    left the whole suite green before this class existed: the wedged-ps
+    case raises a pre-built TimeoutExpired from the fake whether or not
+    the kwarg was ever passed, so it could not detect the loss. A ps
+    stalled on a D-state read (NFS, a hung container runtime) would then
+    block ``subprocess.run`` forever inside the daemon's reap path while
+    PS_TIMEOUT_SECONDS still read as a tested constant.
+    """
+
+    def test_the_read_passes_its_timeout(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The guard must not make absence UNREPORTABLE, which would be
-        the opposite failure and would poison every timed-out run."""
-        ours = os.getpgrp()
-        procs.fake_ps(monkeypatch, stdout=f"{ours} Ss\n")
-        assert read_group_liveness(4242) == GroupLiveness(False)
+        calls = procs.fake_ps(monkeypatch, stdout="4242 Ss\n")
+        read_group_liveness(4242)
+        assert calls, "the fake must have intercepted the ps call"
+        assert calls[0]["kwargs"]["timeout"] == PS_TIMEOUT_SECONDS
+
+    def test_the_read_pins_its_encoding(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Left to the locale, a stray byte under LC_ALL=C raises a
+        ValueError out of a function whose contract is not to raise."""
+        calls = procs.fake_ps(monkeypatch, stdout="4242 Ss\n")
+        read_group_liveness(4242)
+        assert calls[0]["kwargs"]["encoding"] == "utf-8"
+        assert calls[0]["kwargs"]["errors"] == "replace"
+
+
+class TestTheFakeDoesNotAnswerForEveryCommand:
+    """`fake_ps` replaces the STDLIB `subprocess.run`, not procgroup's.
+
+    `procgroup.subprocess` is the stdlib module object, so a setattr on
+    it is process-wide. Measured before the delegation guard existed: a
+    plain `subprocess.run(["git", "rev-parse", "HEAD"])` under
+    `fake_ps(stdout="1 Ss\\n")` returned that stdout and
+    `args=['ps','-A','-o','pgid=,stat=']`. A test that combined the
+    helper with any other subprocess call would have measured nothing and
+    passed, which is the #292 class the helper exists to prevent.
+    """
+
+    def test_another_command_reaches_the_real_subprocess(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        procs.fake_ps(monkeypatch, stdout="4242 Ss\n")
+        out = subprocess.run(
+            ["echo", "not-the-fake"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert out.stdout.strip() == "not-the-fake"
+        assert out.args == ["echo", "not-the-fake"]
+
+    def test_the_ps_call_is_still_intercepted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The positive control: without it the delegation above could be
+        passing because nothing is faked at all."""
+        procs.fake_ps(monkeypatch, stdout="4242 Ss\n")
+        assert read_group_liveness(4242) == GroupLiveness(True)
 
 
 class TestTheSignalProbeIsKeptAsTheDegradedReading:
@@ -150,16 +297,7 @@ class TestTheSignalProbeIsKeptAsTheDegradedReading:
         assert signal_probe_alive(os.getpgrp()) is True
 
     def test_it_reports_a_group_that_is_really_gone(self) -> None:
-        child = subprocess.Popen(
-            ["sleep", "30"],
-            start_new_session=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        pgid = os.getpgid(child.pid)
-        procs.kill_group(pgid)
-        child.wait(timeout=10)
-        assert signal_probe_alive(pgid) is False
+        assert signal_probe_alive(procs.dead_group()) is False
 
     def test_a_refused_signal_reads_as_alive(
         self,
@@ -193,3 +331,170 @@ class TestTheSignalProbeIsKeptAsTheDegradedReading:
 
         monkeypatch.setattr("kstrl.procgroup.os.killpg", broken)
         assert signal_probe_alive(4242) is False
+
+
+# ---------------------------------------------------------------------------
+# The centralisation has a mechanism, not just a docstring.
+# ---------------------------------------------------------------------------
+
+#: Callables whose string arguments are a command line.
+_SUBPROCESS_CALLS = frozenset(
+    {"run", "Popen", "call", "check_call", "check_output", "getoutput", "system"}
+)
+
+#: The one file allowed to shell out to ``ps``: the module whose whole
+#: reason for existing is that there is exactly one parse of its output.
+_PS_OWNER = "kstrl/procgroup.py"
+
+
+def _first_string(arg: ast.expr) -> str | None:
+    """The first string constant of a literal argv, or the string itself."""
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        return arg.value
+    if isinstance(arg, ast.List | ast.Tuple) and arg.elts:
+        head = arg.elts[0]
+        if isinstance(head, ast.Constant) and isinstance(head.value, str):
+            return head.value
+    return None
+
+
+def _module_argv_constants(tree: ast.Module) -> dict[str, str]:
+    """Module-level names bound to a literal argv, mapped to its first token.
+
+    One level of resolution, and it is the level that matters: a copier
+    writes ``PS_ARGV = ("ps", ...)`` and then ``run(PS_ARGV)``, exactly as
+    this module's own owner does. Without this the net would have been
+    passing over the one call it is supposed to protect - which is what
+    ``test_the_owner_still_calls_ps`` caught on the first run.
+    """
+    found: dict[str, str] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        first = _first_string(node.value)
+        if first is None:
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                found[target.id] = first
+    return found
+
+
+def _callee_name(node: ast.Call) -> str:
+    func = node.func
+    return func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+
+
+def _call_arguments(node: ast.Call) -> list[ast.expr]:
+    return [*node.args, *(kw.value for kw in node.keywords)]
+
+
+def _names_ps(arg: ast.expr, constants: dict[str, str]) -> bool:
+    """Whether this argument is an argv whose command is ``ps``.
+
+    Matches on the BASENAME of the first whitespace-separated token, so
+    ``/bin/ps`` and a ``shell=True`` string both count, and ``psql`` does
+    not.
+    """
+    head = _first_string(arg)
+    if head is None and isinstance(arg, ast.Name):
+        head = constants.get(arg.id)
+    tokens = head.split() if head else []
+    return bool(tokens) and Path(tokens[0]).name == "ps"
+
+
+def _ps_call_lines(source: str) -> list[int]:
+    """Line numbers of subprocess calls in ``source`` that invoke ``ps``.
+
+    Resolves a bare name against module-level argv constants; a name
+    bound inside a function body is a known miss, pinned below.
+    """
+    tree = ast.parse(source)
+    constants = _module_argv_constants(tree)
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and _callee_name(node) in _SUBPROCESS_CALLS
+        and any(_names_ps(arg, constants) for arg in _call_arguments(node))
+    ]
+
+
+def _scannable_sources() -> list[Path]:
+    roots = (REPO_ROOT / "kstrl", REPO_ROOT / "tests")
+    return [p for root in roots for p in sorted(root.rglob("*.py"))]
+
+
+class TestOnlyOneModuleShellsOutToPs:
+    """``kstrl/procgroup.py`` and ``tests/helpers/procs.py`` both argue
+    that two copies of one ``ps`` parse with slightly different failure
+    handling is how the suite's answer and the daemon's drift apart. That
+    argument was true and unenforced: nothing stopped a third copy. The
+    repo already answers this class with an AST net (``test_atomicio`` on
+    ``mkstemp``, ``test_process_scoping`` on ``pgrep``), and the rule is
+    that if there is no mechanism there is no plan.
+    """
+
+    def test_no_second_ps_call_exists(self) -> None:
+        offenders: list[str] = []
+        for source in _scannable_sources():
+            rel = source.relative_to(REPO_ROOT).as_posix()
+            if rel == _PS_OWNER:
+                continue
+            text = source.read_text(encoding="utf-8")
+            offenders += [f"{rel}:{line}" for line in _ps_call_lines(text)]
+        assert offenders == [], (
+            f"{offenders} shell out to ps. There must be exactly one parse "
+            f"of ps output in this tree, in {_PS_OWNER}, because two copies "
+            f"drift on failure handling and the daemon's answer and the "
+            f"suite's stop agreeing. Call kstrl.procgroup.read_group_liveness."
+        )
+
+    def test_the_owner_still_calls_ps(self) -> None:
+        """Without this the net could be passing because nothing calls ps
+        at all, which would mean the module had been gutted."""
+        text = (REPO_ROOT / _PS_OWNER).read_text(encoding="utf-8")
+        assert _ps_call_lines(text), f"{_PS_OWNER} no longer calls ps, so this net measures nothing"
+
+    def test_the_net_walks_a_real_tree(self) -> None:
+        assert len(_scannable_sources()) > 100
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            'subprocess.run(["ps", "-A"])',
+            'subprocess.run(["/bin/ps", "-eo", "pid="])',
+            'subprocess.Popen("ps -A", shell=True)',
+            'sp.check_output(("ps", "-A"))',
+        ],
+    )
+    def test_the_net_catches_a_planted_call(self, body: str) -> None:
+        """Its reach, measured rather than asserted in a docstring."""
+        assert _ps_call_lines(body) == [1], body
+
+    def test_it_resolves_a_module_level_argv_constant(self) -> None:
+        """The shape the owner itself uses, and the shape a copier would
+        write. The net missed it until this case was added."""
+        body = 'ARGV = ("ps", "-A")\nsubprocess.run(ARGV, timeout=5)\n'
+        assert _ps_call_lines(body) == [2]
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            # Not a subprocess call at all.
+            'x = ["ps", "-A"]',
+            # A different tool whose name merely starts with the letters.
+            'subprocess.run(["psql", "-c", "select 1"])',
+            # Prose. The net reads the AST, so a docstring cannot trip it.
+            '"""Do not call ps here."""',
+        ],
+    )
+    def test_the_net_stays_quiet_on_these(self, body: str) -> None:
+        assert _ps_call_lines(body) == [], body
+
+    def test_a_command_built_inside_a_function_is_a_known_miss(self) -> None:
+        """Stated so the net is not trusted past its reach. Module-level
+        constants resolve; a name bound in a function body does not, and
+        following that needs dataflow the AST does not give."""
+        body = 'def f():\n    cmd = ["ps", "-A"]\n    subprocess.run(cmd)\n'
+        assert _ps_call_lines(body) == []

--- a/tests/test_procgroup.py
+++ b/tests/test_procgroup.py
@@ -1,0 +1,195 @@
+"""#298: the ``ps`` reading itself, tested where it lives.
+
+Before this file the parse was pinned only through two consumer suites,
+each of which was really testing its own POLICY (raise vs degrade). That
+left the load-bearing part - which rows count as running - reachable only
+via ``tests/test_shutdown.py``'s real never-reaping-parent tree, an
+expensive and timing-sensitive fixture that can only ever produce the one
+zombie spelling the local kernel happens to print.
+
+So the state matching is table-driven here against synthetic ``ps``
+output, and the real tree stays where it is as the end-to-end proof that
+the synthetic rows describe something that actually happens.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from kstrl.procgroup import (
+    PS_ARGV,
+    PS_TIMEOUT_SECONDS,
+    GroupLiveness,
+    _scan,
+    read_group_liveness,
+    signal_probe_alive,
+)
+from tests.helpers import procs
+
+
+class TestTheScanReadsStatesNotJustGroups:
+    """``_scan`` returns two bools positionally, so both are pinned."""
+
+    @pytest.mark.parametrize(
+        ("state", "counts_as_running"),
+        [
+            ("Ss", True),
+            ("R+", True),
+            ("S", True),
+            ("D", True),
+            ("T", True),
+            # Z is the zombie state on macOS and Linux, and flags follow
+            # it. Only the prefix is guaranteed, which is why the
+            # production check is startswith and not equality.
+            ("Z", False),
+            ("Z+", False),
+            ("Zl", False),
+            ("Zs", False),
+        ],
+    )
+    def test_only_a_zombie_state_is_excluded(
+        self,
+        state: str,
+        counts_as_running: bool,
+    ) -> None:
+        saw_own_group, found = _scan(f"7 {state}\n9 Ss\n", pgid=7, ours=9)
+        assert saw_own_group is True, "the fixture must contain our own group"
+        assert found is counts_as_running
+
+    def test_the_two_flags_are_not_transposed(self) -> None:
+        """Both fields are bool, so a swap type-checks. Only a test with
+        the two answers DIFFERENT can catch it."""
+        saw_own_group, found = _scan("9 Ss\n", pgid=7, ours=9)
+        assert (saw_own_group, found) == (True, False)
+
+        saw_own_group, found = _scan("7 Ss\n", pgid=7, ours=9)
+        assert (saw_own_group, found) == (False, True)
+
+    def test_a_ragged_row_is_skipped_without_dropping_its_neighbours(self) -> None:
+        """A row with no state column would IndexError. The rows either
+        side of it must still be read, or the skip is a silent
+        truncation."""
+        saw_own_group, found = _scan("\n  7\n9 Ss\n7 Ss\n", pgid=7, ours=9)
+        assert (saw_own_group, found) == (True, True)
+
+    def test_a_group_id_is_matched_whole_not_as_a_prefix(self) -> None:
+        """#292 in miniature: 7 must not match 70."""
+        saw_own_group, found = _scan("70 Ss\n9 Ss\n", pgid=7, ours=9)
+        assert (saw_own_group, found) == (True, False)
+
+
+class TestTheTriState:
+    """Which of the three answers each condition produces."""
+
+    def test_a_live_group_reads_live(self) -> None:
+        assert read_group_liveness(os.getpgrp()) == GroupLiveness(True)
+
+    def test_a_nonzero_exit_is_unknown_not_absent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        procs.fake_ps(monkeypatch, returncode=127, stderr="ps: command not found")
+        liveness = read_group_liveness(os.getpgrp())
+        assert liveness.live is None
+        assert "ps failed" in liveness.reason
+        assert "false negative" in liveness.reason
+
+    def test_a_missing_binary_is_unknown_not_absent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``ps`` absent raises OSError rather than exiting non-zero."""
+        procs.fake_ps(monkeypatch, raises=FileNotFoundError(2, "no ps"))
+        liveness = read_group_liveness(os.getpgrp())
+        assert liveness.live is None
+        assert "failed to run" in liveness.reason
+
+    def test_a_wedged_ps_is_unknown_not_absent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``TimeoutExpired`` is a SubprocessError, not an OSError, so it
+        escapes the branch above and needs its own."""
+        procs.fake_ps(
+            monkeypatch,
+            raises=subprocess.TimeoutExpired(cmd=list(PS_ARGV), timeout=PS_TIMEOUT_SECONDS),
+        )
+        assert read_group_liveness(os.getpgrp()).live is None
+
+    def test_output_missing_our_own_group_is_unknown_not_absent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """rc=0 with our own processes hidden, which is what a ``hidepid``
+        mount looks like. Exit status alone is not enough to trust the
+        silence: our group is alive by construction, so a listing without
+        it is filtered and its silence about anything else means nothing."""
+        procs.fake_ps(monkeypatch, stdout="    1 Ss\n  517 Ss\n")
+        liveness = read_group_liveness(os.getpgrp())
+        assert liveness.live is None
+        assert "own group" in liveness.reason
+
+    def test_a_trustworthy_ps_can_still_report_absence(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The guard must not make absence UNREPORTABLE, which would be
+        the opposite failure and would poison every timed-out run."""
+        ours = os.getpgrp()
+        procs.fake_ps(monkeypatch, stdout=f"{ours} Ss\n")
+        assert read_group_liveness(4242) == GroupLiveness(False)
+
+
+class TestTheSignalProbeIsKeptAsTheDegradedReading:
+    """It exists to be wrong in a known direction, so pin that."""
+
+    def test_it_sees_a_live_group(self) -> None:
+        assert signal_probe_alive(os.getpgrp()) is True
+
+    def test_it_reports_a_group_that_is_really_gone(self) -> None:
+        child = subprocess.Popen(
+            ["sleep", "30"],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        pgid = os.getpgid(child.pid)
+        procs.kill_group(pgid)
+        child.wait(timeout=10)
+        assert signal_probe_alive(pgid) is False
+
+    def test_a_refused_signal_reads_as_alive(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The branch #298 is about. Measured on a real zombie-only group,
+        macOS raises EPERM rather than succeeding, so this mapping is what
+        made a corpse read as running. ``tests/test_shutdown.py`` proves
+        it on a real tree; this pins the mapping itself."""
+
+        def refuse(pgid: int, sig: int) -> None:
+            raise PermissionError(1, "Operation not permitted")
+
+        monkeypatch.setattr("kstrl.procgroup.os.killpg", refuse)
+        assert signal_probe_alive(4242) is True
+
+    def test_any_other_oserror_reads_as_gone(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Pinned rather than endorsed. This is the pre-#298 mapping,
+        carried over unchanged: "gone" is the UNSAFE direction here,
+        because `terminate_process_group` turns it into "reaped" and the
+        item is released for another attempt. #298 shrank its reach from
+        every call to only the calls where `ps` also gave no answer, and
+        changing the mapping is a separate decision with its own
+        reasoning."""
+
+        def broken(pgid: int, sig: int) -> None:
+            raise OSError(22, "Invalid argument")
+
+        monkeypatch.setattr("kstrl.procgroup.os.killpg", broken)
+        assert signal_probe_alive(4242) is False

--- a/tests/test_procgroup.py
+++ b/tests/test_procgroup.py
@@ -25,8 +25,10 @@ from kstrl.procgroup import (
     PS_ARGV,
     PS_TIMEOUT_SECONDS,
     GroupLiveness,
-    _count_group_rows,
     _kernel_says_group_is_empty,
+    _Listing,
+    _may_signal_group,
+    _read_listing,
     read_group_liveness,
     signal_probe_alive,
 )
@@ -35,8 +37,12 @@ from tests.helpers import procs
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-class TestTheScanReadsStatesNotJustGroups:
-    """``_count_group_rows`` returns two ints positionally, so both are pinned."""
+class TestTheListingReadsStatesNotJustGroups:
+    """``_read_listing`` returns three facts, and all three are pinned.
+
+    Rows are ``pid pgid stat``. The pid column exists only for the
+    completeness control below; nothing identifies a process by it.
+    """
 
     @pytest.mark.parametrize(
         ("state", "counts_as_running"),
@@ -61,47 +67,75 @@ class TestTheScanReadsStatesNotJustGroups:
         state: str,
         counts_as_running: bool,
     ) -> None:
-        rows, running = _count_group_rows(f"7 {state}\n9 Ss\n", pgid=7)
-        assert rows == 1, "the row must be counted whatever its state"
-        assert bool(running) is counts_as_running
+        listing = _read_listing(f"1 1 Ss\n50 7 {state}\n", pgid=7)
+        assert listing.rows == 1, "the row must be counted whatever its state"
+        assert bool(listing.running) is counts_as_running
 
-    def test_the_two_counts_are_not_transposed(self) -> None:
-        """Both fields are int, so a swap type-checks. Only a case with
-        the two answers DIFFERENT can catch it."""
-        assert _count_group_rows("7 Z\n", pgid=7) == (1, 0)
-        assert _count_group_rows("7 Ss\n7 Z\n", pgid=7) == (2, 1)
+    def test_the_three_facts_are_not_transposed(self) -> None:
+        """All three would type-check in any order, so only cases where
+        they DIFFER can catch a swap."""
+        assert _read_listing("1 1 Ss\n50 7 Z\n", pgid=7) == _Listing(
+            complete=True, rows=1, running=0
+        )
+        assert _read_listing("50 7 Ss\n51 7 Z\n", pgid=7) == _Listing(
+            complete=False, rows=2, running=1
+        )
 
     def test_a_ragged_row_is_skipped_without_dropping_its_neighbours(self) -> None:
-        """A row with no state column would IndexError. The rows either
-        side of it must still be read, or the skip is a silent
-        truncation."""
-        assert _count_group_rows("\n  7\n9 Ss\n7 Ss\n", pgid=7) == (1, 1)
+        """A row missing a column would IndexError. The rows either side
+        of it must still be read, or the skip is a silent truncation."""
+        listing = _read_listing("\n  7\n1 1 Ss\n50 7 Ss\n", pgid=7)
+        assert listing == _Listing(complete=True, rows=1, running=1)
 
     def test_a_group_id_is_matched_whole_not_as_a_prefix(self) -> None:
         """#292 in miniature: 7 must not match 70."""
-        assert _count_group_rows("70 Ss\n9 Ss\n", pgid=7) == (0, 0)
+        assert _read_listing("1 1 Ss\n50 70 Ss\n", pgid=7).rows == 0
+
+    def test_pid_one_is_what_marks_the_listing_complete(self) -> None:
+        assert _read_listing("50 7 Ss\n", pgid=7).complete is False
+        assert _read_listing("1 1 Ss\n50 7 Ss\n", pgid=7).complete is True
 
 
 class TestAGoneIsOnlyReportedWhenItIsEvidence:
-    """The safety argument, which the own-group control did not carry.
+    """The safety argument, and the two controls that could not carry it.
 
-    That control asked whether the caller's own group appeared in the
-    listing. Measured on this tree: ``subprocess.run`` does not setpgid,
-    so the ``ps`` child runs in the caller's group and ``ps -A`` always
-    lists it - our own pgid appeared four times in every real listing,
-    the last row being ``ps`` itself. It was satisfied by construction
-    and could never fire, so a listing missing a live target was reported
-    as a confident "gone". These pin what replaced it.
+    The first asked whether the caller's own group appeared in the
+    listing. Measured: `subprocess.run` does not setpgid, so the `ps`
+    child runs in the caller's group and `ps -A` always lists it. It was
+    satisfied by construction.
+
+    The second was "every listed row for this group is a zombie, so the
+    listing can see this group". Seeing SOME of a group is not seeing all
+    of it: `hidepid` hides individual PROCESSES by uid, so a group can
+    show a visible zombie while hiding a running descendant that changed
+    uid, which is the threat the module docstring names.
+
+    What replaced both: pid 1 in the listing proves the view is not
+    filtered to our uid, because pid 1 belongs to root and, if we are
+    root, nothing is hidden from us anyway.
     """
 
-    def test_a_listing_that_saw_only_zombies_is_evidence_of_gone(
+    def test_a_complete_listing_showing_only_zombies_is_gone(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """#298's case. ps demonstrably sees the group, so its verdict on
-        that group's members is evidence and no kernel check is needed."""
-        procs.fake_ps(monkeypatch, stdout="4242 Z\n4242 Z+\n")
+        """#298's case, and it still needs the completeness control."""
+        procs.fake_ps(monkeypatch, stdout="1 1 Ss\n50 4242 Z\n51 4242 Z+\n")
         assert read_group_liveness(4242) == GroupLiveness(False)
+
+    def test_zombies_in_a_FILTERED_listing_are_not_gone(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The round-2 hole. Same rows, no pid 1: a running descendant
+        that changed uid would be invisible, so "only zombies here" is an
+        inference about a listing that is known to be partial. Reporting
+        gone would let serve_cycle requeue onto a live repo (#186 F1)."""
+        procs.fake_ps(monkeypatch, stdout="50 4242 Z\n51 4242 Z+\n")
+        liveness = read_group_liveness(4242)
+        assert liveness.live is None
+        assert "did not list pid 1" in liveness.reason
+        assert "another uid" in liveness.reason
 
     def test_a_missing_group_the_kernel_calls_empty_is_gone(self) -> None:
         """The other trustworthy route: the kernel, not the listing."""
@@ -111,26 +145,59 @@ class TestAGoneIsOnlyReportedWhenItIsEvidence:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The bug the own-group control could not catch.
-
-        A live group absent from the listing - a descendant that changed
-        uid, a restricted ps - used to read as a confident "gone", which
-        makes `terminate_process_group` report reaped and `serve_cycle`
-        requeue onto a repo a factory is still writing to (#186 F1).
-        """
-        # Our own group is alive by construction, and the listing omits it.
-        procs.fake_ps(monkeypatch, stdout="1 Ss\n")
+        # Our own group is alive by construction, and pid 1 is listed so
+        # the view is complete; the group simply is not in it.
+        procs.fake_ps(monkeypatch, stdout="1 1 Ss\n")
         liveness = read_group_liveness(os.getpgrp())
         assert liveness.live is None
         assert "kernel reports" in liveness.reason
-        assert "not empty" in liveness.reason
 
     def test_a_running_row_still_reads_live(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        procs.fake_ps(monkeypatch, stdout="4242 Ss\n")
+        """Live needs no control: seeing a runner is positive evidence,
+        and a filtered listing can only ever show FEWER processes."""
+        procs.fake_ps(monkeypatch, stdout="50 4242 Ss\n")
         assert read_group_liveness(4242) == GroupLiveness(True)
+
+
+class TestTheGroupIdIsGuardedBeforeAnySignal:
+    """#298 round 2: this module signals, so it carries the guard.
+
+    `killpg(1, sig)` is `kill(-1, sig)`, every process this user owns.
+    `serve._safe_pgid` has this rule and the module docstring used to
+    appeal to it, which is a convention, not a mechanism: nothing
+    enforces that callers came through it. The triplication across
+    serve / verify / agents.proc is #308; this is procgroup's own half.
+    """
+
+    @pytest.mark.parametrize("pgid", [-1, 0, 1])
+    def test_a_broadcast_pgid_is_never_signalled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        pgid: int,
+    ) -> None:
+        calls: list[tuple[int, int]] = []
+
+        def recording(target: int, sig: int) -> None:
+            calls.append((target, sig))
+
+        monkeypatch.setattr("kstrl.procgroup.os.killpg", recording)
+        assert _kernel_says_group_is_empty(pgid) is False
+        assert signal_probe_alive(pgid) is True
+        assert calls == [], "kill(-1, sig) must never be issued"
+
+    def test_the_refusals_fail_in_the_conservative_direction(self) -> None:
+        """Not empty, and alive: both keep a caller from calling a run
+        reaped on a question that was never asked."""
+        assert _may_signal_group(1) is False
+        assert _kernel_says_group_is_empty(1) is False
+        assert signal_probe_alive(1) is True
+
+    def test_a_real_group_is_still_signalled(self) -> None:
+        """The positive control, or the guard could be rejecting all."""
+        assert _may_signal_group(os.getpgrp()) is True
 
 
 class TestTheKernelControl:
@@ -237,7 +304,7 @@ class TestThePsCallIsBounded:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        calls = procs.fake_ps(monkeypatch, stdout="4242 Ss\n")
+        calls = procs.fake_ps(monkeypatch, stdout="50 4242 Ss\n")
         read_group_liveness(4242)
         assert calls, "the fake must have intercepted the ps call"
         assert calls[0]["kwargs"]["timeout"] == PS_TIMEOUT_SECONDS
@@ -248,7 +315,7 @@ class TestThePsCallIsBounded:
     ) -> None:
         """Left to the locale, a stray byte under LC_ALL=C raises a
         ValueError out of a function whose contract is not to raise."""
-        calls = procs.fake_ps(monkeypatch, stdout="4242 Ss\n")
+        calls = procs.fake_ps(monkeypatch, stdout="50 4242 Ss\n")
         read_group_liveness(4242)
         assert calls[0]["kwargs"]["encoding"] == "utf-8"
         assert calls[0]["kwargs"]["errors"] == "replace"
@@ -270,7 +337,7 @@ class TestTheFakeDoesNotAnswerForEveryCommand:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        procs.fake_ps(monkeypatch, stdout="4242 Ss\n")
+        procs.fake_ps(monkeypatch, stdout="50 4242 Ss\n")
         out = subprocess.run(
             ["echo", "not-the-fake"],
             capture_output=True,
@@ -286,7 +353,7 @@ class TestTheFakeDoesNotAnswerForEveryCommand:
     ) -> None:
         """The positive control: without it the delegation above could be
         passing because nothing is faked at all."""
-        procs.fake_ps(monkeypatch, stdout="4242 Ss\n")
+        procs.fake_ps(monkeypatch, stdout="50 4242 Ss\n")
         assert read_group_liveness(4242) == GroupLiveness(True)
 
 
@@ -337,10 +404,32 @@ class TestTheSignalProbeIsKeptAsTheDegradedReading:
 # The centralisation has a mechanism, not just a docstring.
 # ---------------------------------------------------------------------------
 
-#: Callables whose string arguments are a command line.
+#: Callables whose string arguments are a command line. ``popen`` and
+#: ``getstatusoutput`` were missing from the first version, so
+#: ``os.popen("ps -A")`` in ``kstrl/`` passed the net silently.
 _SUBPROCESS_CALLS = frozenset(
-    {"run", "Popen", "call", "check_call", "check_output", "getoutput", "system"}
+    {
+        "run",
+        "Popen",
+        "popen",
+        "call",
+        "check_call",
+        "check_output",
+        "getoutput",
+        "getstatusoutput",
+        "system",
+    }
 )
+
+#: The roots this net walks, and therefore the exact reach of the claim
+#: ``kstrl/procgroup.py`` makes. ``spike/`` is deliberately outside: it
+#: holds throwaway measurement scripts (``spike/tui0/measure.py`` calls
+#: ``ps`` today) that are not part of the package or its suite, and
+#: widening the net to cover them would mean either failing on evidence
+#: or carrying an allowlist that rots. The docstring in ``procgroup``
+#: names these two roots rather than "the tree" for the same reason: a
+#: mechanism cited for a claim it does not cover is worse than none.
+_SCANNED_ROOTS = ("kstrl", "tests")
 
 #: The one file allowed to shell out to ``ps``: the module whose whole
 #: reason for existing is that there is exactly one parse of its output.
@@ -421,8 +510,7 @@ def _ps_call_lines(source: str) -> list[int]:
 
 
 def _scannable_sources() -> list[Path]:
-    roots = (REPO_ROOT / "kstrl", REPO_ROOT / "tests")
-    return [p for root in roots for p in sorted(root.rglob("*.py"))]
+    return [p for root in _SCANNED_ROOTS for p in sorted((REPO_ROOT / root).rglob("*.py"))]
 
 
 class TestOnlyOneModuleShellsOutToPs:
@@ -459,6 +547,14 @@ class TestOnlyOneModuleShellsOutToPs:
     def test_the_net_walks_a_real_tree(self) -> None:
         assert len(_scannable_sources()) > 100
 
+    def test_the_claim_names_the_roots_the_net_actually_walks(self) -> None:
+        """A mechanism cited for a claim it does not cover is worse than
+        none. `spike/` calls ps and is outside the net, so the module's
+        docstring must say "kstrl/ or tests/", not "the tree"."""
+        text = (REPO_ROOT / _PS_OWNER).read_text(encoding="utf-8")
+        claim = "only place in ``kstrl/`` or ``tests/``"
+        assert claim in text, f"{_PS_OWNER} must scope its uniqueness claim to {_SCANNED_ROOTS}"
+
     @pytest.mark.parametrize(
         "body",
         [
@@ -466,6 +562,8 @@ class TestOnlyOneModuleShellsOutToPs:
             'subprocess.run(["/bin/ps", "-eo", "pid="])',
             'subprocess.Popen("ps -A", shell=True)',
             'sp.check_output(("ps", "-A"))',
+            'os.popen("ps -A")',
+            'subprocess.getstatusoutput("ps -A")',
         ],
     )
     def test_the_net_catches_a_planted_call(self, body: str) -> None:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -15,6 +15,7 @@ would cost dollars per assertion at a measured $1.70-2.60 per iteration.
 from __future__ import annotations
 
 import os
+import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -73,6 +74,7 @@ from kstrl.workqueue import (
     Queue,
     QueueConfig,
 )
+from tests.helpers import procs
 
 # --------------------------------------------------------------------------
 # helpers
@@ -1885,9 +1887,12 @@ class TestProcessGroupSupervision:
         signalled: list[tuple[int, int]] = []
 
         def recording_killpg(target: int, sig: int) -> None:
-            # signal 0 is the liveness PROBE, not a kill; counting it
-            # would let "never signal the group" pass, since the probe
-            # runs either way.
+            # signal 0 is a liveness PROBE, not a kill; counting it would
+            # let "never signal the group" pass, since a probe runs
+            # either way. Since #298 the probe lives in kstrl.procgroup
+            # and cannot reach this patch at all, but the filter stays:
+            # it states the rule rather than relying on where the probe
+            # currently happens to live.
             if sig != 0:
                 signalled.append((target, sig))
             real_killpg(target, sig)
@@ -1964,6 +1969,101 @@ class TestProcessGroupSupervision:
         adopted = [e for e in queue.journal_entries() if e["reason"].startswith("lease adopted")]
         assert adopted, "the child pid must be recorded as the lease owner"
         assert adopted[0]["detail"]["lease_pid"] == 424242
+
+
+class TestGroupLivenessDegradesRatherThanGuessing:
+    """#298: what `process_group_alive` does when `ps` gives no answer.
+
+    Only the POLICY is here. The reading's tri-state and its parse are
+    pinned in `tests/test_procgroup.py`, and the zombie case itself needs
+    a real unreaped tree and lives in
+    `tests/test_shutdown.py::test_a_zombie_does_not_count_as_a_live_member`.
+    What this class covers is the fallback that #298 introduced, which
+    would otherwise ship untested: `ps` is normally present and normally
+    works, so nothing else exercises the degraded path.
+
+    Why degrading rather than raising or reporting a blanket "alive" is
+    argued in `process_group_alive`'s docstring.
+    """
+
+    #: Every way `ps` can give no answer, and the id says which is which.
+    #: The assertion is the same for all four because the contract is:
+    #: whatever went wrong, fall back rather than guess.
+    BLIND_PS = [
+        pytest.param({"returncode": 127, "stderr": "ps: not found"}, id="nonzero_exit"),
+        pytest.param({"raises": FileNotFoundError(2, "no ps")}, id="binary_absent"),
+        pytest.param(
+            # TimeoutExpired is a SubprocessError, not an OSError, so it
+            # takes a different branch from the one above.
+            {"raises": subprocess.TimeoutExpired(cmd=["ps"], timeout=5.0)},
+            id="wedged",
+        ),
+        # rc=0 but our own group hidden, which is what hidepid looks like.
+        pytest.param({"stdout": "    1 Ss\n"}, id="filtered_output"),
+    ]
+
+    @pytest.mark.parametrize("blind", BLIND_PS)
+    def test_a_blind_ps_falls_back_to_the_signal_probe(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        blind: dict[str, object],
+    ) -> None:
+        """Positive control: the fallback must still see a live group."""
+        procs.fake_ps(monkeypatch, **blind)  # type: ignore[arg-type]
+        with pytest.warns(UserWarning, match="signal probe"):
+            assert process_group_alive(os.getpgrp()) is True
+
+    def test_the_fallback_still_reports_a_group_that_is_really_gone(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The guard must not make absence unreportable, which would
+        poison every timed-out run on a machine with no `ps`."""
+        child = subprocess.Popen(
+            ["sleep", "30"],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        pgid = os.getpgid(child.pid)
+        procs.kill_group(pgid)
+        child.wait(timeout=10)
+
+        procs.fake_ps(monkeypatch, returncode=127, stderr="boom")
+        with pytest.warns(UserWarning):
+            assert process_group_alive(pgid) is False
+
+    def test_the_degrade_is_recorded_rather_than_silent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`terminate_process_group` turns this answer into a poison
+        reason blaming a possibly-live factory. When the real cause was
+        an unreadable `ps` that reason is a misdiagnosis, so the warning
+        has to carry what went wrong, not just that something did."""
+        procs.fake_ps(monkeypatch, returncode=127, stderr="ps: command not found")
+        with pytest.warns(UserWarning) as caught:
+            process_group_alive(os.getpgrp())
+        message = str(caught[0].message)
+        assert "ps failed" in message, "the operator must learn ps was the cause"
+        assert "zombie" in message, "and which way the fallback is wrong"
+
+    def test_a_working_ps_is_the_answer_and_the_probe_is_not_consulted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Ordering, so a later edit cannot quietly restore the probe as
+        the primary and reintroduce #298. A negative pre-filter on
+        `killpg` ESRCH was measured and declined; if it is ever adopted,
+        this becomes "a probe that says maybe does not decide"."""
+        calls: list[int] = []
+
+        def recording_killpg(target: int, sig: int) -> None:
+            calls.append(sig)
+
+        monkeypatch.setattr("kstrl.procgroup.os.killpg", recording_killpg)
+        assert process_group_alive(os.getpgrp()) is True
+        assert calls == [], "the signal probe is the fallback, not the answer"
 
 
 class TestRunOwnership:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -16,6 +16,9 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
+import time
+import warnings
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -29,6 +32,7 @@ from kstrl.manifest import Component, ComponentStatus, Manifest
 from kstrl.reducer import ComponentState, RunState
 from kstrl.serve import (
     BACKOFF_CAP_SECONDS,
+    GROUP_TERM_GRACE_SECONDS,
     SPAWNED_RUN_KIND,
     DailySpend,
     LaunchSpend,
@@ -41,6 +45,8 @@ from kstrl.serve import (
     SpendLedger,
     Verdict,
     _group_liveness_for_reap,
+    _NullObserver,
+    _unreaped_timeout_detail,
     backoff_seconds,
     caffeinate_prefix,
     check_budget,
@@ -1976,16 +1982,20 @@ class TestProcessGroupSupervision:
 
 
 class TestGroupLivenessDegradesRatherThanGuessing:
-    """#298: what `process_group_alive` does when `ps` gives no answer.
+    """#298: what the reap check does when `ps` gives no answer.
 
     Only the POLICY is here. The reading's tri-state, its parse and the
-    two conditions under which a "gone" is evidence are pinned in
+    conditions under which a "gone" is evidence are pinned in
     `tests/test_procgroup.py`, and the zombie case itself needs a real
     unreaped tree and lives in
     `tests/test_shutdown.py::test_a_zombie_does_not_count_as_a_live_member`.
 
-    Why degrading rather than raising or reporting a blanket "alive" is
-    argued in `_group_liveness_for_reap`'s docstring.
+    NOTHING HERE WARNS. An earlier version called `warnings.warn` on the
+    degraded path, which under `PYTHONWARNINGS=error` raises out of the
+    reap check and, measured, escaped `run_supervised`'s
+    `except subprocess.TimeoutExpired` and `serve_cycle` alike, crashing
+    the daemon on every timed-out run on a ps-less machine. The reason
+    now travels as a value and is reported through the ServeObserver.
     """
 
     #: Every way `ps` can give no answer, and the id says which is which.
@@ -2016,9 +2026,9 @@ class TestGroupLivenessDegradesRatherThanGuessing:
             id="undecodable",
         ),
         pytest.param(
-            # rc=0, but the listing does not hold our own group, which the
-            # kernel says is occupied. A filtered listing, not an empty one.
-            {"stdout": "    1 Ss\n"},
+            # rc=0, but no pid 1, so the view is filtered to our uid and a
+            # member owned by another uid would be invisible.
+            {"stdout": "  90 517 Ss\n"},
             id="filtered_output",
         ),
     ]
@@ -2031,7 +2041,22 @@ class TestGroupLivenessDegradesRatherThanGuessing:
     ) -> None:
         """Positive control: the fallback must still see a live group."""
         procs.fake_ps(monkeypatch, **blind)  # type: ignore[arg-type]
-        with pytest.warns(UserWarning, match="signal probe"):
+        assert process_group_alive(os.getpgrp()) is True
+
+    @pytest.mark.parametrize("blind", BLIND_PS)
+    def test_a_blind_ps_never_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        blind: dict[str, object],
+    ) -> None:
+        """Under `-W error` a warning IS an exception, and this call sits
+        inside `run_supervised`'s `except TimeoutExpired`, which does not
+        catch UserWarning, under a `serve_cycle` that wraps nothing. So
+        one timed-out run on a ps-less machine took the daemon down.
+        `error` here turns any warning back into the crash it would be."""
+        procs.fake_ps(monkeypatch, **blind)  # type: ignore[arg-type]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             assert process_group_alive(os.getpgrp()) is True
 
     def test_the_fallback_still_reports_a_group_that_is_really_gone(
@@ -2042,35 +2067,23 @@ class TestGroupLivenessDegradesRatherThanGuessing:
         poison every timed-out run on a machine with no `ps`."""
         pgid = procs.dead_group()
         procs.fake_ps(monkeypatch, returncode=127, stderr="boom")
-        with pytest.warns(UserWarning):
-            assert process_group_alive(pgid) is False
+        assert process_group_alive(pgid) is False
 
-    def test_the_degrade_is_recorded_rather_than_silent(
+    def test_the_degrade_reason_is_returned_not_warned(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """`terminate_process_group` turns this answer into a poison
-        reason blaming a possibly-live factory. When the real cause was
-        an unreadable `ps` that reason is a misdiagnosis, so the warning
-        has to carry what went wrong, not just that something did."""
+        """A warning goes to stderr, which a detached daemon does not
+        keep, and cannot be recorded. The reason has to come back as a
+        value, carrying both what went wrong and which way the fallback
+        is wrong."""
         procs.fake_ps(monkeypatch, returncode=127, stderr="ps: command not found")
-        with pytest.warns(UserWarning) as caught:
-            process_group_alive(os.getpgrp())
-        message = str(caught[0].message)
-        assert "ps failed" in message, "the operator must learn ps was the cause"
-        assert "zombie" in message, "and which way the fallback is wrong"
-
-    def test_the_degrade_reason_is_returned_not_only_warned(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """A warning goes to stderr, and a daemon detached from its stderr
-        keeps only the record. So the reason has to come back as a value."""
-        procs.fake_ps(monkeypatch, returncode=127, stderr="ps: command not found")
-        with pytest.warns(UserWarning):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             alive, degraded = _group_liveness_for_reap(os.getpgrp())
         assert alive is True
-        assert "ps failed" in degraded
+        assert "ps failed" in degraded, "the operator must learn ps was the cause"
+        assert "zombie" in degraded, "and which way the fallback is wrong"
 
     def test_a_measured_answer_carries_no_degrade_reason(
         self,
@@ -2078,7 +2091,7 @@ class TestGroupLivenessDegradesRatherThanGuessing:
     ) -> None:
         """The negative control: an empty string must mean "measured
         cleanly", or the poison reason gains a caveat on every run."""
-        procs.fake_ps(monkeypatch, stdout=f"{os.getpgrp()} Ss\n")
+        procs.fake_ps(monkeypatch, stdout=f"1 1 Ss\n50 {os.getpgrp()} Ss\n")
         assert _group_liveness_for_reap(os.getpgrp()) == (True, "")
 
     def test_a_working_ps_is_the_answer_and_the_probe_is_not_consulted(
@@ -2098,10 +2111,127 @@ class TestGroupLivenessDegradesRatherThanGuessing:
         def recording_killpg(target: int, sig: int) -> None:
             calls.append(sig)
 
-        procs.fake_ps(monkeypatch, stdout=f"{os.getpgrp()} Ss\n")
+        procs.fake_ps(monkeypatch, stdout=f"1 1 Ss\n50 {os.getpgrp()} Ss\n")
         monkeypatch.setattr("kstrl.procgroup.os.killpg", recording_killpg)
         assert process_group_alive(os.getpgrp()) is True
         assert calls == [], "a listing that shows a runner settles it on its own"
+
+
+class TestTheSignalEscalationIsDrivenByTheGroup:
+    """#298 round 2: the SIGKILL leg was unreachable in the case that matters.
+
+    `terminate_process_group` returned as soon as `process.wait()`
+    returned, so the second leg only ran when the DIRECT CHILD outlived
+    the grace period. A leader that dies on SIGTERM with a descendant
+    holding SIG_IGN for it therefore never got SIGKILL: measured,
+    `GroupTermination(reaped=False)` in 0.07s with the descendant still
+    running. Nothing then kills it, and `serve_cycle` poisons and moves
+    on, so a factory keeps writing to the repo forever.
+    """
+
+    STUBBORN = (
+        "import signal,time;"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+        "print('ready', flush=True);"
+        "time.sleep(120)"
+    )
+
+    def test_a_descendant_that_ignores_sigterm_is_still_killed(self) -> None:
+        proc = subprocess.Popen(
+            ["sh", "-c", f'{sys.executable} -c "{self.STUBBORN}" & sleep 120'],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        pgid = os.getpgid(proc.pid)
+        try:
+            # Let the stubborn child install its handler before signalling,
+            # or the race decides the test rather than the code.
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline and not procs.group_has_live_member(pgid):
+                time.sleep(0.05)
+
+            result = terminate_process_group(proc, pgid)
+            assert result.reaped is True, (
+                "the group outlived SIGTERM, so SIGKILL had to follow; "
+                "returning on the direct child's exit skips it entirely"
+            )
+            assert procs.wait_for_group_to_die(pgid), "a descendant was left running"
+        finally:
+            procs.kill_group(pgid)
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=10)
+
+    def test_a_group_that_dies_on_sigterm_does_not_wait_out_the_grace(self) -> None:
+        """The escalation must not cost 15s on the ordinary path."""
+        proc = subprocess.Popen(
+            ["sh", "-c", "sh -c 'sleep 20' & sleep 20"],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        pgid = os.getpgid(proc.pid)
+        try:
+            started = time.monotonic()
+            assert terminate_process_group(proc, pgid).reaped is True
+            assert time.monotonic() - started < GROUP_TERM_GRACE_SECONDS
+        finally:
+            procs.kill_group(pgid)
+
+
+class TestARefusedSignalIsNotAnUnknown:
+    """#298 round 2: EPERM is the strongest evidence a group IS occupied.
+
+    The kernel found processes in that group and refused us. Feeding that
+    into the same field as an unreadable `ps` made the operator-facing
+    poison reason say "unknown rather than still running" in the one case
+    where the group is definitely not empty and they must act.
+    """
+
+    def test_eperm_reports_occupied_not_degraded(self) -> None:
+        proc = subprocess.Popen(
+            ["sleep", "30"],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        pgid = os.getpgid(proc.pid)
+        try:
+            with patch(
+                "kstrl.serve.os.killpg",
+                side_effect=PermissionError(1, "Operation not permitted"),
+            ):
+                result = terminate_process_group(proc, pgid)
+            assert result.reaped is False
+            assert result.occupied, "a refused signal is positive evidence"
+            assert "refused" in result.occupied
+            assert result.degraded == "", "EPERM is not 'could not measure'; the kernel answered"
+        finally:
+            procs.kill_group(pgid)
+            proc.wait(timeout=10)
+
+    def test_the_poison_reason_does_not_soften_it_to_unknown(self) -> None:
+        detail = _unreaped_timeout_detail(
+            RunOutcome(
+                returncode=-9,
+                timed_out=True,
+                group_reaped=False,
+                group_occupied_detail="the kernel refused signal 15 to group 42",
+            )
+        )
+        assert "CONFIRMED occupied" in detail
+        assert "unknown" not in detail
+
+    def test_a_missing_pgid_is_reported_as_unmeasured(self) -> None:
+        """The other end of the same contract: `degraded` is empty only
+        when the group was measured, and this path inspects no group."""
+        fake = MagicMock(spec=subprocess.Popen)
+        fake.pid = os.getpid()  # our own group, which _safe_pgid refuses
+        fake.poll.return_value = None
+        result = terminate_process_group(fake)
+        assert result.reaped is False
+        assert "no process-group id" in result.degraded
 
 
 class TestTheReapDegradeReachesTheDurableRecord:
@@ -2109,8 +2239,7 @@ class TestTheReapDegradeReachesTheDurableRecord:
 
     `serve_cycle` writes "a factory may still be executing against this
     repo" into the queue item, the ledger and the remote report. When the
-    real cause was a blind reap check that sentence is a misdiagnosis,
-    and a warning on stderr does not correct it for a detached daemon.
+    real cause was a blind reap check that sentence is a misdiagnosis.
     """
 
     def test_a_degraded_reap_says_so_in_the_poison_reason(
@@ -2154,6 +2283,50 @@ class TestTheReapDegradeReachesTheDurableRecord:
         item = queue.items()[0]
         assert "could not be confirmed reaped" in item.poison_reason
         assert "could not measure" not in item.poison_reason
+
+    def test_a_reaped_but_UNMEASURED_run_is_still_reported(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The hole this closes. When `ps` is blind the fallback probe can
+        answer "gone", the run is called reaped and the item is RELEASED
+        for another attempt - the unsafe direction, on a doubly
+        unverified answer. `serve_cycle` only ever read the detail inside
+        `if not group_reaped`, so this was recorded nowhere at all.
+        """
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        obs = _NullObserver()
+        result = serve_cycle(
+            tmp_path,
+            observer=obs,
+            runner=_stub_runner(
+                RunOutcome(
+                    returncode=-9,
+                    timed_out=True,
+                    group_reaped=True,
+                    group_reap_detail="ps failed (rc=127): 'not found'.",
+                ),
+            ),
+        )
+        assert result.verdict is Verdict.RETRY_INFRA
+        lines = "\n".join(obs.lines)
+        assert "UNMEASURED" in lines, "releasing an item on an unmeasured 'gone' must not be silent"
+        assert "ps failed (rc=127)" in lines
+
+    def test_a_measured_reap_is_not_announced(self, tmp_path: Path) -> None:
+        """The negative control, or the daemon narrates every clean run."""
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        obs = _NullObserver()
+        serve_cycle(
+            tmp_path,
+            observer=obs,
+            runner=_stub_runner(
+                RunOutcome(returncode=-9, timed_out=True, group_reaped=True),
+            ),
+        )
+        assert "UNMEASURED" not in "\n".join(obs.lines)
 
 
 class TestRunOwnership:

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -40,6 +40,7 @@ from kstrl.serve import (
     ServeStateError,
     SpendLedger,
     Verdict,
+    _group_liveness_for_reap,
     backoff_seconds,
     caffeinate_prefix,
     check_budget,
@@ -1753,7 +1754,7 @@ class TestProcessGroupSupervision:
             text=True,
         )
         pgid = os.getpgid(proc.pid)
-        assert terminate_process_group(proc) is True
+        assert terminate_process_group(proc).reaped is True
         assert not process_group_alive(pgid)
 
     def test_a_mocked_popen_never_signals_a_broad_group(self) -> None:
@@ -1777,7 +1778,7 @@ class TestProcessGroupSupervision:
         with patch("kstrl.serve.os.killpg") as killpg:
             with patch("kstrl.serve.os.getpgid", return_value=99999):
                 fake.poll.return_value = 0
-                assert terminate_process_group(fake) is True
+                assert terminate_process_group(fake).reaped is True
             assert killpg.call_count == 0, "must never signal a bogus group"
 
     def test_our_own_process_group_is_never_signalled(self) -> None:
@@ -1889,17 +1890,20 @@ class TestProcessGroupSupervision:
         def recording_killpg(target: int, sig: int) -> None:
             # signal 0 is a liveness PROBE, not a kill; counting it would
             # let "never signal the group" pass, since a probe runs
-            # either way. Since #298 the probe lives in kstrl.procgroup
-            # and cannot reach this patch at all, but the filter stays:
-            # it states the rule rather than relying on where the probe
-            # currently happens to live.
+            # either way. The filter is NOT redundant now the probe lives
+            # in kstrl.procgroup: `os` is one shared module object, so
+            # patching kstrl.serve.os.killpg patches procgroup's too.
+            # Measured - under this patch, procgroup.signal_probe_alive(4242)
+            # records calls == [(4242, 0)]. Drop the filter and on any run
+            # where ps is blind the probe's (pgid, 0) satisfies
+            # "the group must actually be signalled" on its own.
             if sig != 0:
                 signalled.append((target, sig))
             real_killpg(target, sig)
 
         try:
             with patch("kstrl.serve.os.killpg", side_effect=recording_killpg):
-                reaped = terminate_process_group(proc, pgid)
+                reaped = terminate_process_group(proc, pgid).reaped
         finally:
             if process_group_alive(pgid):
                 real_killpg(pgid, 9)
@@ -1918,7 +1922,7 @@ class TestProcessGroupSupervision:
             text=True,
         )
         proc.wait(timeout=10)
-        assert terminate_process_group(proc) is True
+        assert terminate_process_group(proc).reaped is True
 
     def test_an_unreaped_timeout_poisons_instead_of_retrying(
         self,
@@ -1974,32 +1978,49 @@ class TestProcessGroupSupervision:
 class TestGroupLivenessDegradesRatherThanGuessing:
     """#298: what `process_group_alive` does when `ps` gives no answer.
 
-    Only the POLICY is here. The reading's tri-state and its parse are
-    pinned in `tests/test_procgroup.py`, and the zombie case itself needs
-    a real unreaped tree and lives in
+    Only the POLICY is here. The reading's tri-state, its parse and the
+    two conditions under which a "gone" is evidence are pinned in
+    `tests/test_procgroup.py`, and the zombie case itself needs a real
+    unreaped tree and lives in
     `tests/test_shutdown.py::test_a_zombie_does_not_count_as_a_live_member`.
-    What this class covers is the fallback that #298 introduced, which
-    would otherwise ship untested: `ps` is normally present and normally
-    works, so nothing else exercises the degraded path.
 
     Why degrading rather than raising or reporting a blanket "alive" is
-    argued in `process_group_alive`'s docstring.
+    argued in `_group_liveness_for_reap`'s docstring.
     """
 
     #: Every way `ps` can give no answer, and the id says which is which.
-    #: The assertion is the same for all four because the contract is:
+    #: The assertion is the same for all of them because the contract is:
     #: whatever went wrong, fall back rather than guess.
+    #:
+    #: `raises` holds FACTORIES, not exception instances. An instance
+    #: built here at class-body evaluation lives for the session, and each
+    #: `raise` appends a frame to its `__traceback__` and sets its
+    #: `__context__`, so it would retain every test frame that ever raised
+    #: it and their locals until interpreter exit.
     BLIND_PS = [
         pytest.param({"returncode": 127, "stderr": "ps: not found"}, id="nonzero_exit"),
-        pytest.param({"raises": FileNotFoundError(2, "no ps")}, id="binary_absent"),
+        pytest.param(
+            {"raises": lambda: FileNotFoundError(2, "no ps")},
+            id="binary_absent",
+        ),
         pytest.param(
             # TimeoutExpired is a SubprocessError, not an OSError, so it
             # takes a different branch from the one above.
-            {"raises": subprocess.TimeoutExpired(cmd=["ps"], timeout=5.0)},
+            {"raises": lambda: subprocess.TimeoutExpired(cmd=["ps"], timeout=5.0)},
             id="wedged",
         ),
-        # rc=0 but our own group hidden, which is what hidepid looks like.
-        pytest.param({"stdout": "    1 Ss\n"}, id="filtered_output"),
+        pytest.param(
+            # UnicodeDecodeError is a ValueError, which escapes a
+            # fail-closed `except OSError` entirely.
+            {"raises": lambda: UnicodeDecodeError("utf-8", b"\xff", 0, 1, "bad")},
+            id="undecodable",
+        ),
+        pytest.param(
+            # rc=0, but the listing does not hold our own group, which the
+            # kernel says is occupied. A filtered listing, not an empty one.
+            {"stdout": "    1 Ss\n"},
+            id="filtered_output",
+        ),
     ]
 
     @pytest.mark.parametrize("blind", BLIND_PS)
@@ -2019,16 +2040,7 @@ class TestGroupLivenessDegradesRatherThanGuessing:
     ) -> None:
         """The guard must not make absence unreportable, which would
         poison every timed-out run on a machine with no `ps`."""
-        child = subprocess.Popen(
-            ["sleep", "30"],
-            start_new_session=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        pgid = os.getpgid(child.pid)
-        procs.kill_group(pgid)
-        child.wait(timeout=10)
-
+        pgid = procs.dead_group()
         procs.fake_ps(monkeypatch, returncode=127, stderr="boom")
         with pytest.warns(UserWarning):
             assert process_group_alive(pgid) is False
@@ -2048,22 +2060,100 @@ class TestGroupLivenessDegradesRatherThanGuessing:
         assert "ps failed" in message, "the operator must learn ps was the cause"
         assert "zombie" in message, "and which way the fallback is wrong"
 
+    def test_the_degrade_reason_is_returned_not_only_warned(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A warning goes to stderr, and a daemon detached from its stderr
+        keeps only the record. So the reason has to come back as a value."""
+        procs.fake_ps(monkeypatch, returncode=127, stderr="ps: command not found")
+        with pytest.warns(UserWarning):
+            alive, degraded = _group_liveness_for_reap(os.getpgrp())
+        assert alive is True
+        assert "ps failed" in degraded
+
+    def test_a_measured_answer_carries_no_degrade_reason(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The negative control: an empty string must mean "measured
+        cleanly", or the poison reason gains a caveat on every run."""
+        procs.fake_ps(monkeypatch, stdout=f"{os.getpgrp()} Ss\n")
+        assert _group_liveness_for_reap(os.getpgrp()) == (True, "")
+
     def test_a_working_ps_is_the_answer_and_the_probe_is_not_consulted(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Ordering, so a later edit cannot quietly restore the probe as
-        the primary and reintroduce #298. A negative pre-filter on
-        `killpg` ESRCH was measured and declined; if it is ever adopted,
-        this becomes "a probe that says maybe does not decide"."""
+        the primary and reintroduce #298.
+
+        Scoped to the case where `ps` reports a RUNNING member. A `ps`
+        that reports no row does consult `killpg`, deliberately: that is
+        the kernel control that makes a "gone" evidence rather than a
+        listing's silence.
+        """
         calls: list[int] = []
 
         def recording_killpg(target: int, sig: int) -> None:
             calls.append(sig)
 
+        procs.fake_ps(monkeypatch, stdout=f"{os.getpgrp()} Ss\n")
         monkeypatch.setattr("kstrl.procgroup.os.killpg", recording_killpg)
         assert process_group_alive(os.getpgrp()) is True
-        assert calls == [], "the signal probe is the fallback, not the answer"
+        assert calls == [], "a listing that shows a runner settles it on its own"
+
+
+class TestTheReapDegradeReachesTheDurableRecord:
+    """#298 follow-up: the poison reason an operator actually reads.
+
+    `serve_cycle` writes "a factory may still be executing against this
+    repo" into the queue item, the ledger and the remote report. When the
+    real cause was a blind reap check that sentence is a misdiagnosis,
+    and a warning on stderr does not correct it for a detached daemon.
+    """
+
+    def test_a_degraded_reap_says_so_in_the_poison_reason(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        serve_cycle(
+            tmp_path,
+            runner=_stub_runner(
+                RunOutcome(
+                    returncode=-9,
+                    timed_out=True,
+                    group_reaped=False,
+                    group_reap_detail="ps failed (rc=127): 'not found'.",
+                ),
+            ),
+        )
+        item = queue.items()[0]
+        assert item.state is ItemState.POISON
+        assert "could not be confirmed reaped" in item.poison_reason
+        assert "ps failed (rc=127)" in item.poison_reason, (
+            "the recorded reason must say the check could not measure"
+        )
+        assert "unknown" in item.poison_reason
+
+    def test_an_undegraded_reap_reason_gains_no_caveat(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The negative control, or every poison reason grows a tail."""
+        queue = _queue(tmp_path, max_attempts=3)
+        _add(queue)
+        serve_cycle(
+            tmp_path,
+            runner=_stub_runner(
+                RunOutcome(returncode=-9, timed_out=True, group_reaped=False),
+            ),
+        )
+        item = queue.items()[0]
+        assert "could not be confirmed reaped" in item.poison_reason
+        assert "could not measure" not in item.poison_reason
 
 
 class TestRunOwnership:

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -607,13 +607,17 @@ class TestTheOrphanCheckIsScopedToItsOwnGroup:
         nothing reaps, so a test built on it would hang to its deadline
         on every run where the pool worker is slow.
 
-        The assertion on `process_group_alive` is deliberately pinning a
-        FLAW, not a contract. `serve.terminate_process_group` uses it to
-        decide whether a run was reaped, so it inherits the blind spot;
-        that is a production issue of its own and out of #292's scope,
-        but if somebody fixes it this test should start failing and be
-        turned into the ordinary assertion.
+        The assertion on `process_group_alive` USED to pin a flaw: #292
+        left the production check on the killpg spelling and this test
+        asserted True so that whoever fixed it would see the coupling.
+        #298 fixed it, so it now asserts the contract. What keeps that
+        assertion honest is `signal_probe_alive` on the line above it:
+        the old spelling, on the same group at the same moment, still
+        reports the group as present. Without that control, a False here
+        could mean the zombie had simply been reaped and the test would
+        have measured nothing.
         """
+        from kstrl.procgroup import signal_probe_alive
         from kstrl.serve import process_group_alive
 
         parent = subprocess.Popen(
@@ -638,9 +642,15 @@ class TestTheOrphanCheckIsScopedToItsOwnGroup:
                 "a reaped-pending zombie was counted as a live member"
             )
 
-            # The primitive this check exists instead of, on the same
-            # group at the same moment, still saying it is alive.
-            assert process_group_alive(pgid) is True
+            # The control: this really is the zombie window, not a group
+            # that quietly went away. The primitive production used
+            # before #298 still reports it as present.
+            assert signal_probe_alive(pgid) is True, (
+                "the zombie was already reaped, so the assertion below would prove nothing"
+            )
+            assert process_group_alive(pgid) is False, (
+                "a reaped-pending zombie must not count as a live member"
+            )
         finally:
             parent.kill()
             parent.wait(timeout=10)

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -37,6 +37,7 @@ from kstrl.ui.plain import PlainUI
 from tests import spine_utils
 from tests.helpers.procs import (
     kill_group,
+    ps_is_readable,
     read_pid,
     wait_for_group_to_die,
 )
@@ -619,6 +620,14 @@ class TestTheOrphanCheckIsScopedToItsOwnGroup:
         """
         from kstrl.procgroup import signal_probe_alive
         from kstrl.serve import process_group_alive
+
+        if not ps_is_readable():
+            pytest.skip(
+                "ps is absent or filtered here, so process_group_alive "
+                "degrades to the signal probe, which counts a zombie as "
+                "alive by design. The assertion below would fail pointing "
+                "at kstrl rather than at the environment."
+            )
 
         parent = subprocess.Popen(
             [


### PR DESCRIPTION
Closes #298.

## What was wrong

`serve.process_group_alive` mapped `PermissionError` to `True`, on the reasoning that a signal refused for permission reasons proves something is there to refuse it. That is sound about signals and wrong about running processes: a zombie has already died and is only waiting for its parent to `wait()`, and it stays signalable. So a group holding nothing but a corpse read as live, and `terminate_process_group` used that answer to decide whether a run had been reaped.

## How I reproduced it, with numbers

I did not take the issue text on trust. Built a real tree - a parent python that spawns `sleep 60` in its own session and then sleeps without ever reaping - SIGKILLed the group, then polled both probes over a fixed window.

Before the fix, one run, 45 samples over 6.0 s:

| probe | converged to "gone" at |
|---|---|
| `process_group_alive` (signal probe) | never, across all 45 samples |
| `ps` read with zombies excluded | first sample |

`ps` row for the group throughout: `46877 46877 Z <defunct>`. Once the parent was killed and init reaped, `process_group_alive` returned False, confirming the zombie was the whole cause.

Which branch fired, measured rather than assumed: **`PermissionError -> True`**. The issue's diagnosis was right, and on macOS `killpg` on a zombie-only group raises EPERM rather than succeeding.

After the fix, same script, same shape: `process_group_alive` converged on the first sample, 44 to 46 samples over 6.0 s, identical to the `ps` helper.

**One thing the issue implies that I could not reproduce.** I ran 200 trials of the exact `terminate_process_group` SIGKILL leg (`sh -c "sh -c 'sleep 20' & sh -c 'sleep 20' & sleep 20"`, killpg SIGKILL, `process.wait()`, then both probes at that instant):

```
signal probe said ALIVE (group is all dead): 0/200
ps probe said ALIVE:                         0/200
disagreements:                               0/200
```

Reaping cascades fast once the direct child is waited on, so I could not provoke a false "not reaped" through `terminate_process_group` in that shape. The defect is proven at the primitive; the production window is real in principle and I did not measure it firing. Stating that rather than claiming a production repro I do not have.

## Cost, measured

913-process machine:

| operation | per call |
|---|---|
| `ps -A -o pgid=,stat=` | 11.29 ms over 50 calls |
| `os.killpg(pgid, 0)` | 0.00089 ms over 50 calls |

Ratio about 12700x. It lands nowhere hot: `terminate_process_group` asks once per **timed-out** run, on the way out, and `serve.py:1499`/`:1500` are mutually exclusive branches so it is one call per invocation. Across the whole suite the `/simplify` efficiency pass measured 14 real `ps` forks totalling 275 ms against a 246.5 s suite - 0.11% of wall clock, and every `wait_for_group_to_die` converged on its first poll.

## What I changed, in the order the reasoning ran

1. **Checked every caller before touching the contract.** In production `process_group_alive` has exactly two call sites, both `return not process_group_alive(pgid)` inside `terminate_process_group`. `verify._signal_process_group` and `agents/proc.py` signal groups but never ask about liveness, so nothing else is affected.
2. **Asked what the callers actually need.** Both want "is anything still executing", not "would a signal land". A zombie answers No to the first and Yes to the second, which is the whole bug. So option (1) from the issue: `ps` group membership with zombies excluded.
3. **Decided the fail direction deliberately.** `ps` can fail, and it can be filtered so its silence is not evidence. Three options: raise (takes the daemon down over a diagnostic); report "alive" unconditionally (conservative, but on a machine with no `ps` it makes EVERY timed-out run unreapable and therefore poisoned, trading a rare wrong answer for a permanent one); or fall back to the signal probe. Chose the fallback: the probe is right whenever the group is genuinely gone, which is the common case, and its only error is over-reporting alive, which is the safe direction for `terminate_process_group`. So the degraded path is never worse than what shipped before, and the `ps` path is exact.
4. **Made the degrade audible.** It now warns with what `ps` did and which way the fallback is wrong. Without that, a run poisoned with "its process group could not be confirmed reaped, so a factory may still be executing against this repo" would be a misdiagnosis when the real cause was an unreadable `ps`, and nothing would say so.
5. **Extracted the reading to `kstrl/procgroup.py` as a tri-state**, because the two callers want opposite things when it cannot see: the daemon degrades, a test must fail loudly (#292). That also removed the second copy of the `ps` parse that `tests/helpers/procs.py` was carrying, whose failure handling had already started to differ from production's.

The subprocess-timeout audit (`tests/test_timeout_enforcement.py`) caught the new `ps` call having no `timeout=`. Added `PS_TIMEOUT_SECONDS = 5.0`, 440x the measured cost, and `TimeoutExpired` maps to "cannot see" like any other failure.

## The test that was pinning the flaw

**`tests/test_shutdown.py::TestTheOrphanCheckIsScopedToItsOwnGroup::test_a_zombie_does_not_count_as_a_live_member`**, added by PR #297.

It asserted `process_group_alive(pgid) is True` on a real never-reaping tree, deliberately pinning the wrong behaviour so this fix could not silently disagree with it.

It now asserts `process_group_alive(pgid) is False`. What keeps that honest is a new control on the line above: `signal_probe_alive(pgid) is True` on the same group at the same instant. Without it a `False` could mean the zombie had simply been reaped and the test would have measured nothing. So the A/B that this PR's measurement performed once by hand now runs on every test run.

## Unsure about

- **The production window is unmeasured.** See the 0/200 above. The primitive is provably wrong; I could not make `terminate_process_group` return the wrong answer because of it.
- **`ps -g` was measured at 7x cheaper and rejected.** `ps -g <pgid>,<ours>` measured 2.07 ms against 14.52 ms on a 1011-process machine. Not adopted: `-g` selects by SESSION, and Linux procps documents it as session or effective group NAME. A pgid is not generally a sid, so on Linux (which CI runs) that listing would return our own group and not the target, which this module reads as "the target is gone" - a false negative in the one direction it must never fail. Verified on macOS only. Recorded in the module docstring so nobody re-derives the 7x without the caveat.
- **`signal_probe_alive` maps a generic `OSError` to False, meaning "gone".** That is the unsafe direction, since `terminate_process_group` turns it into "reaped". It is the pre-#298 mapping carried over unchanged, and #298 shrank its reach from every call to only calls where `ps` also gave no answer. Pinned by a test that says it is pinned rather than endorsed. Changing it is a separate decision with its own reasoning.
- **`Zl` and `Zs` are covered by synthetic rows, not observed.** The local kernel only ever printed plain `Z`. The prefix match is the portable claim; the table test states which spellings are asserted and which were actually seen.

## Verification

- `uv run pytest tests/ -v`: **4211 passed, 28 skipped**
- `uv run mypy kstrl/ --strict`: clean, 124 files
- `uv run ruff check kstrl/ tests/`: clean
- `pre-commit run --all-files`: all hooks pass (complexipy, codespell, vulture, gitleaks, shellcheck, cyclomatic / cognitive / file-length ratchets, no-em-dash)
- Coverage: `kstrl/procgroup.py` 100%, TOTAL 89.54% against the 79.91% baseline
- `atlas` is expected to fail per the standing instruction; not run, nothing under `docs/atlas/` committed

## /simplify

Four agents (reuse, simplification, efficiency, altitude). Findings verbatim, including the declined ones with reasons.

### Reuse

> 1. **`tests/test_serve.py:1994`, `:2037`, `:2063`** - the `ps` test doubles are now written twice, in two files, against the same patch target.
>  The new class re-declares `broken` (rc=127, `"ps: command not found"`) and `filtered` (rc=0, own group hidden) that already exist verbatim at `tests/test_process_scoping.py:211`, `:226`, `:242`, and both sides call `monkeypatch.setattr(procgroup.subprocess, "run", ...)`. The diff even rewired the existing three patch targets in `test_process_scoping.py` from `procs.subprocess` to `procgroup.subprocess`, which is proof of the cost: that rewiring is exactly what has to be repeated in every file that hand-rolls the double. There are now six such monkeypatches across two files encoding one fact - what a failing `ps` and a `hidepid` `ps` look like. If the reading ever moves off `subprocess.run`, or the argv/column set changes, a missed site keeps passing while measuring nothing, which is the failure mode #292 exists to remove.
>  **Alternative:** `tests/helpers/procs.py` - the suite's shared process-helper module, already imported by both files' neighbours. The repo's own precedent is recorded at `tests/test_timeout_enforcement.py:71`: *"Moved to tests/helpers/procs.py when #292 gave it a second consumer."* #298 is that second consumer. A `fake_ps_failing()` / `fake_ps_filtered()` pair, or a `patch_ps(monkeypatch, ...)` helper, would leave one patch target in one place.

**APPLIED.** Added `procs.fake_ps(monkeypatch, *, returncode, stdout, stderr, raises)`. All six sites use it; one patch target in one place.

> 2. **`tests/test_serve.py:2053-2061`** (lower confidence) - the doomed-group setup is re-implemented alongside the one that already uses the helper.
>  `Popen(["sleep", "30"], start_new_session=True, stdout=DEVNULL, stderr=DEVNULL)` -> `os.getpgid` -> kill -> `child.wait(timeout=10)` is byte-for-byte the block at `tests/test_process_scoping.py:254-262`, except that the existing one calls `procs.kill_group(pgid)` where the new one spells `os.killpg(pgid, 9)` inline. Cost is modest (two copies of an 8-line fixture), but the inconsistency is real.
>  **Alternative:** `tests/helpers/procs.kill_group` for the kill step, or better a `spawn_doomed_group()` in the same module covering the whole block. **Caveat I verified before recommending:** `kill_group` swallows `ProcessLookupError`/`PermissionError`/`OSError` because it was written for cleanup; here the kill is the action under test, so a straight swap trades a loud failure for a silent one. Extracting the whole setup is the version that does not lose anything.

**APPLIED in part.** Switched to `procs.kill_group`; a silently-failed kill still fails the assertion loudly, since the group would then read alive. **Declined** the `spawn_doomed_group()` extraction: three call sites in three files that differ in what they then assert, and the block is four lines.

> 3. **`kstrl/procgroup.py:90`** - checked and cleared, recording it because it was asked. `kstrl/timeout.py:82 run_with_timeout` is an exact shape match (`capture_output=True, text=True, timeout=`), so `run_with_timeout(list(PS_ARGV), timeout=PS_TIMEOUT_SECONDS)` would be a literal drop-in. I am **not** raising it: `run_with_timeout` has zero production callers (`grep` finds only `tests/test_timeout.py:9`), while roughly forty production sites - `git.py`, `pr.py`, `breaker.py:114`, `statedir.py:293`, `tui/screens/home.py:69`, `observability.py:716` - all spell `subprocess.run(..., capture_output=True, text=True, timeout=...)` out themselves. Raw `subprocess.run` *is* the convention here; routing through the wrapper would also move the monkeypatch target off `procgroup.subprocess` and break all six tests above for no gain.

No action needed; the agent cleared it itself.

> 4. **`kstrl/procgroup.py`** (pre-existing, not introduced by this diff) - the module the change creates is the obvious home for a guard that is currently triplicated, and it was left behind.
>  `kstrl/serve.py:1503 _safe_pgid`, `kstrl/verify.py:105 _signal_process_group`, and `kstrl/agents/proc.py:182 _signal_group` each carry the same rule (`hasattr(os, "killpg")`, `isinstance(pid, int)`, `pid > 1`, `pgid > 1`, `pgid != os.getpgrp()`) and the same MagicMock-`__index__` comment explaining it. The diff adds no fourth copy, so it introduces no new duplication - but `procgroup.py` is now a module named for process-group concerns that answers only half the question, and the next person asking "where does process-group logic live" gets two answers.
>  **Alternative:** `procgroup.safe_pgid(proc)`, with the three sites calling it. An opportunity this change created, not a defect in it - out of scope for #298 unless the author wants it.

**DECLINED.** Out of scope, and the agent says so. Those three sites signal; they never read liveness. Folding them in would change the guard semantics of two untouched code paths inside a bug fix. Worth a follow-up issue.

### Simplification

> 1. **`tests/test_serve.py:1987-2043` - four fallback tests are the same test with a different `ps` double.** All four define a one-line fake, `monkeypatch.setattr(procgroup.subprocess, "run", fake)`, and assert `process_group_alive(os.getpgrp()) is True`. The assertion, the target, and the shape are identical; only the fake differs (rc=127, `FileNotFoundError`, `TimeoutExpired`, rc=0-with-own-group-hidden). Cost: ~57 lines carrying ~4 lines of distinct claim, and four places to edit when the fallback contract moves. Simpler: one `@pytest.mark.parametrize("fake", [...], ids=["nonzero_exit", "binary_absent", "wedged", "filtered_output"])` test - the ids preserve exactly what each case proves, and the per-case reasoning ("`TimeoutExpired` is a `SubprocessError`, not an `OSError`") survives as a comment on its param. The other three in the class (`really_gone`, `short_line`, `probe_not_consulted`) each assert something different and should stay separate.

**APPLIED**, with exactly those ids.

> 2. **`kstrl/procgroup.py:96-109` - the same three-line "cannot be measured" sentence is copy-pasted into two branches with reflowed line breaks.** The two `GroupLiveness(None, ...)` returns differ only in their opening clause (`ps failed to run ({exc!r}).` vs `ps failed (rc=...): {stderr!r}.`); the rest is identical prose split differently across the f-string lines, which is exactly how the two drift. Cost: two edit sites for one sentence, and a reader has to diff them to see they are the same. Simpler: hoist the tail into a module constant (`_UNMEASURABLE = "Process-group liveness cannot be measured here, and reporting 'no live member' would be a false negative."`) and build `detail` in each branch, returning `GroupLiveness(None, f"{detail} {_UNMEASURABLE}")` once.

**APPLIED**, as `_UNMEASURABLE`.

> 3. **`kstrl/procgroup.py:123-136` - `_scan` is indirection, not a seam.** It has one caller, no test targets it, and it returns a bare `tuple[bool, bool]` whose meaning exists only in its docstring - swapping the two at the call site (`saw_own_group, found = _scan(...)`) type-checks cleanly and mypy `--strict` will not catch it. It also forces `ours` to become a parameter that exists only because of the split; inline, it is a local. Cost: a 14-line function, a positional-tuple convention, and one parameter, all to move a 10-line loop out of a 40-line function. Simpler: inline the loop after the `returncode` check. If the split is wanted for parse/IO separation, have `_scan` return the `GroupLiveness` (or a two-field frozen dataclass) so the two bools are named rather than positional.

**DECLINED as written, hazard fixed another way.** Inlining pushes `read_group_liveness` toward the repo's cyclomatic gate of 10, and the altitude agent independently wanted `_scan` kept and directly tested. A wrapper dataclass adds a mechanism where a check suffices, and CLAUDE.md prefers removing mechanism. So `_scan` stays with the tuple, and `tests/test_procgroup.py::test_the_two_flags_are_not_transposed` pins the order with the two answers deliberately different, which is the only thing that can catch a swap.

> 4. **`tests/test_serve.py:1994-1997, 2037-2040, 2063-2066` and `tests/test_process_scoping.py:213-216, 228-231, 241-244` - six hand-rolled `ps` doubles across two files, three of them byte-identical apart from a stderr string.** The `broken` (rc=127) closure appears four times; the `filtered` (rc=0, own group hidden) closure twice with a one-row stdout difference. Cost: the fake-`ps` contract now lives in six places, so a change to `PS_ARGV`'s column layout means six edits, and the two files' fakes can silently diverge on the very axis (`ps` output shape) the module parses. Simpler: one factory in `tests/helpers/procs.py` next to the helper it feeds, e.g. `def fake_ps(monkeypatch, *, rc=0, stdout="", stderr="") -> None`, and each test names only its own case and assertion.

**APPLIED.** Same fix as Reuse 1. Signature is `fake_ps(monkeypatch, *, returncode=0, stdout="", stderr="", raises=None)`; `raises` was needed because two cases raise rather than return.

> 5. **`kstrl/serve.py:1536-1537` vs `tests/test_serve.py:1983-1984` vs `tests/test_serve.py:2049-2050` - the fail-direction argument is stated three times.** The test class docstring says the decision "is argued in `process_group_alive`'s docstring" and then argues it again in the next sentence; the sixth test's docstring argues it a third time ("would poison every timed-out run on a machine with no `ps`"). Cost: three copies of one paragraph that must move together, in two files. Simpler: keep the argument in `process_group_alive` (production is the right home) and let the class docstring stop at the pointer; the sixth test's docstring only needs its own claim - absence must stay reportable.

**APPLIED.** The class docstring now stops at the pointer.

> 6. **`kstrl/procgroup.py:81-87` vs `tests/helpers/procs.py:61-67, 75-83` - two measurements restated in both the module and the helper that now delegates to it.** The rc=127 / `hidepid` measurement ("a version without this guard reported the caller's OWN live group as dead") appears in `read_group_liveness`'s docstring and again in `group_has_live_member`'s; the killpg-counts-zombies measurement appears in the `procgroup` module docstring (45 samples / 6s, #298) and again in `group_has_live_member` (6s window, #292). The helper's docstring claims "what stays HERE is the policy", but it restates the reading's rationale too. Cost: the reading's evidence lives in two files after the diff explicitly centralised the reading into one. Simpler: leave the *why-a-zombie-is-not-alive* and *why-absence-needs-a-control* evidence in `procgroup` (the diff already did this correctly for the 23.5ms-vs-11.6ms column measurement, which it moved rather than copied) and cut the helper down to its genuinely local half: this caller raises where the daemon degrades.

**APPLIED.** `group_has_live_member`'s docstring is now the policy only, pointing at `procgroup` for the evidence.

> 7. **`kstrl/procgroup.py:62-64` and `tests/test_serve.py:2024` - two micro-items on the new constants.** `_ZOMBIE_STATE = "Z"` is a named constant with a three-line comment for a single use at line 135, where the comment is doing all the work and the name adds a hop; and the wedged-`ps` test reaches for `procgroup.PS_ARGV` but then hardcodes `timeout=5.0` instead of `procgroup.PS_TIMEOUT_SECONDS`, so half the constant discipline is derivable and half is a literal. Cost: small in both cases. Simpler: keep the comment at the `startswith("Z")` site and drop the constant; use `PS_TIMEOUT_SECONDS` in the test for consistency with the `PS_ARGV` reference beside it.

**APPLIED both.** `_ZOMBIE_STATE` dropped, comment moved to the `startswith("Z")` site; `tests/test_procgroup.py` uses `PS_TIMEOUT_SECONDS`.

Also recorded from that agent, since it argued a design choice rather than a change:

> - **The tri-state plus frozen dataclass plus `reason` is not over-engineering here.** `(verdict, reason)` frozen dataclasses are the house pattern - `serve.Admission` is 40 lines below the code under review, and there are ~15 more (`workqueue`, `intake_github`, `events`, `pipeline`, `shutdown`). The exception alternative (`LivenessUnknown` carrying the message, `-> bool`) removes the dataclass and the `bool | None` but adds an exception class and two `try/except` blocks, so it is roughly a wash on mechanism count and loses the type-checker's enforcement that the `None` branch be handled. The `reason` field being empty on the True/False path is the normal shape of that pattern, not redundant state.

### Efficiency

> 1. **`kstrl/procgroup.py:52`** - `PS_ARGV` asks `ps -A` for all ~1000 processes when the question only ever concerns two process groups. **Measured: 14.52 ms for `ps -A -o pgid=,stat=` vs 2.07 ms for `ps -g <pgid>,<ours> -o pgid=,stat=` on the same machine, a 7.0x cut. The bare `/usr/bin/true` fork+exec floor is 1.34 ms, so the ps-side work drops from 13.2 ms to 0.73 ms - nearly all of the remaining cost is the fork itself and no further trimming can touch it.** The diff's docstring reasons about *column* trimming (23.5 ms -> 11.6 ms) but never about row trimming, which is the larger factor. Cheaper alternative: request only the two groups. The `saw_own_group` guard survives intact - I verified `ps -g <them>,<ours>` returns rc=0 with both groups listed while the target lives, and rc=0 with only `<ours>` listed after the target is killed, which is exactly the tri-state the module wants. **Caveat you must not skip: I verified `-g` selects by *process group* on macOS empirically (built a process with pgid 38958 != sid 38952; `ps -g 38952` did not return it), but Linux procps documents `-g grplist` as "select by session OR by effective group name", and CI is `ubuntu-latest` (`.github/workflows/ci.yml:26`). I could not measure Linux here. This needs a Linux measurement before adoption; do not take the 7x on my macOS number alone.**

**DECLINED, and the rejection recorded in the module docstring.** The agent's own caveat is the reason. On Linux a `-g` listing that comes back with our own group but not the target reads as "the target is gone" - a false negative in the one direction this module must never fail, on the CI platform. A macOS-only 7x does not buy that, especially given finding 4 below: it lands nowhere hot.

> 2. **`kstrl/serve.py:1544` and `tests/helpers/procs.py:85`** - no cheap negative pre-filter, so the 14.5 ms `ps` read is paid even when a 0.00067 ms syscall already settles the answer. `killpg(pgid, 0)` raising `ESRCH` proves the group holds *no process at all* - a zombie is a process and is signalable, so `ESRCH` excludes zombies too and "not live" follows without consulting `ps`. It is also immune to the `hidepid` concern that motivates the own-group guard, because it is a kernel answer rather than a filtered listing. `EPERM`/success mean "maybe", and only then is `ps` needed. **Measured directly: group genuinely gone, 14.675 ms shipped vs 0.0003 ms pre-filtered. Group alive, 14.665 ms vs 14.830 ms - the pre-filter costs ~1% when it does not fire. Across `tests/test_shutdown.py`, `tests/test_process_scoping.py` and `tests/test_serve.py` I logged all 23 `read_group_liveness` calls with the probe's verdict alongside `ps`'s answer: 11 of 23 had `probe=ESRCH`, and 9 of those did a real fork worth 136.6 ms - 64% of the suite's total `ps` cost.** The production shape favours it too: `terminate_process_group` reads liveness only after its own `killpg` + `process.wait()` succeeded, so the common case is a group that is genuinely gone, and all five production-path tests logged `probe=ESRCH`. Cheaper alternative: probe first, treat only `ESRCH` as conclusive, fall through to `ps` otherwise.

**DECLINED on the agent's own measurements.** The reasoning is sound, `ESRCH` really is conclusive, but its findings 4 and 5 show where the saving lands: 136.6 ms out of a 246.5 s suite is 0.055%, and in production it is one call per timed-out run, after a timeout measured in minutes. CLAUDE.md says latency trades on measurement, and the measurement says nobody feels this. What it costs is a second source of truth on the fail-closed path ("`ps` is authoritative, except when `killpg` says ESRCH") plus the weakening in finding 3. Not a trade I will make for 0.055%. Recorded in the ordering test so a future adopter finds the note.

> 3. **`tests/test_serve.py:2094-2107`** - `test_a_working_ps_is_the_answer_and_the_probe_is_not_consulted` asserts `calls == []` on a patched `kstrl.serve.os.killpg`, which pins finding 2 out of the design. I hit this for real: my pre-filter instrumentation failed exactly this test and nothing else. **Cost: it converts a 136 ms/64% saving from an optimisation into a test edit.** The test's *intent* (a working `ps` must be authoritative, so #298 cannot regress) is compatible with a negative-only pre-filter, since `ESRCH` is a stronger fact than `ps` silence. If finding 2 is taken, re-spell this as "a probe that says `maybe` does not decide the answer" rather than "the probe is never called".

**Follows finding 2, so declined, but the note is now in the test's docstring** so whoever adopts the pre-filter knows the test is meant to be re-spelled rather than deleted. The patch target moved to `kstrl.procgroup.os.killpg` because the probe moved.

Findings 4 through 8 came back clean and are quoted in the "Cost, measured" section above rather than repeated here: the production caller is not hot, `wait_for_group_to_die` does not spin (every call converged on its first poll), `_scan` is 0.5% of the call and has nothing to hoist, no repeated I/O, no retained closures.

### Altitude

> 1. **`kstrl/serve.py:1544-1547`** - the tri-state is collapsed to `bool` and `liveness.reason` is discarded on the production side.
>    Cost: the degraded path is completely invisible in production. When `ps` is unreadable and the probe over-reports a zombie as alive, `terminate_process_group` returns False, and `serve.py:2298` poisons the item with the detail "could not be confirmed reaped, so a factory may still be executing against this repo". On a `hidepid` mount or a minimal container that message is a misdiagnosis: the run *was* reaped, `ps` was unreadable. The three sentences of `reason` that would tell the operator this is environmental are constructed on every degraded call and then thrown away, reaching only the test caller. Downstream, `group_reaped=True` measured by `ps` and `group_reaped=True` guessed by the probe are indistinguishable.
>    Deeper placement: the codebase already has the shape for this one field over at `RunOutcome.launch_error: str` (`serve.py:166`) - an explanation string beside the boolean. Add `group_reap_degraded: str` set at `serve.py:1439` alongside `group_reaped`, or at minimum `obs.warn` it at the poison site. CLAUDE.md's own rule applies directly: "if it's worth deciding, it's worth recording", and "do NOT add unverifiable self-report claims to results without flagging them".

**APPLIED at the "at minimum" depth.** `process_group_alive` now warns with the reason and with which way the fallback is wrong, and `test_the_degrade_is_recorded_rather_than_silent` asserts both halves are in the message. **Declined the `RunOutcome` field** for this PR: threading a new field through `RunOutcome`, the runner and the poison site is a change to the queue's record shape, which does not belong inside a bug fix. The warning closes the "silent" half; a structured field is a follow-up.

> 2. **`kstrl/serve.py:1550`** - `_signal_probe_alive` stayed in `serve.py` while its sibling reading moved out, so the seam the diff draws does not actually hold.
>    Cost: the diff's own principle is "procgroup reads, the caller decides". But `serve` now owns a reading primitive (a pure process-group query with zero serve semantics) *plus* the policy, and the contrast between the two readings is argued in two docstrings in two files. The visible symptom is `tests/test_shutdown.py:620`, which has to import a leading-underscore name across a module boundary to get its control.
>    Deeper placement: `kstrl/procgroup.py` as a second public reading, with the module docstring stating both questions ("would a signal land" vs "is anything running") in one place. Counter-argument, acknowledged: the probe exists only as legacy-for-degraded-mode and has exactly one production use, so keeping it adjacent is defensible. The cost is real but small.

**APPLIED.** Moved to `kstrl.procgroup.signal_probe_alive`, public. The cross-module private import in `test_shutdown.py` is gone. The stale comment in `test_the_group_is_signalled_not_just_the_direct_child` about signal 0 reaching `serve.os.killpg` was updated rather than left to rot.

> 3. **`kstrl/procgroup.py:123` (no `tests/test_procgroup.py`)** - the new shared seam has no test file of its own; its contract is pinned only through two wrappers in two consumer suites.
>    Cost: `_scan` is the load-bearing parse and has no direct test. Its zombie exclusion is exercised only by the real never-reaping-parent tree at `tests/test_shutdown.py:601` - expensive, timing-sensitive, platform-dependent - so `Z+` and `Zl` prefix handling is never actually observed. A future change to `PS_ARGV` that adds a column would shift `parts[1]` and be caught only through consumers, possibly only on a machine that can produce a zombie. The absence also shows up as triplicated stubs: near-identical `broken`/`filtered` closures at `tests/test_process_scoping.py:212,226,241` and again at `tests/test_serve.py:1995,2036,2064`.
>    Deeper placement: a `tests/test_procgroup.py` with table-driven `_scan` cases (`Z`, `Z+`, `Zl`, ragged rows, own group present/absent) and direct tri-state assertions on `read_group_liveness`. The two consumer files then pin only their policy (raise vs degrade), which is what their docstrings already claim they are for.

**APPLIED.** New `tests/test_procgroup.py`, 22 tests: table-driven states (`Ss`, `R+`, `S`, `D`, `T`, `Z`, `Z+`, `Zl`, `Zs`), a transposition test, ragged rows, whole-token group matching, the full tri-state, and the probe's three branches. 100% line coverage on the module. The consumer suites now pin only their policy.

> 4. **`tests/test_serve.py:2071`** - `test_a_short_line_is_skipped_rather_than_crashing_the_reap_check` is a pure `_scan` parse test living in the serve suite.
>    Cost: it reaches the parser through `serve.process_group_alive` and a magic pgid `4242`, so a `_scan` regression reports as a serve failure. It is the sharpest instance of finding 3, not a separate problem.
>    Deeper placement: same as 3.

**APPLIED.** Moved to `tests/test_procgroup.py` as a direct `_scan` test.

> 5. **`kstrl/serve.py:1503`, `kstrl/verify.py:105-119`, `kstrl/agents/proc.py:186-196`** - the triplicated `pgid > 1 and pgid != os.getpgrp()` guard. Leaving it alone was **correct scoping** for #298 [...] Two things now point at `procgroup` as the eventual home, though. [...] And `kstrl/procgroup.py:40-42` appeals to "every caller is already gated behind a `hasattr(os, "killpg")` guard that fails closed there" - a precondition the module neither owns nor enforces, and which is not true of the test-helper caller: `procs.group_has_live_member` reaches `os.getpgrp()` at `procgroup.py:111` with no such gate. Follow-up, not this PR.

**The factual error is FIXED**; the refactor is **declined** as the agent recommends. My docstring claimed something untrue of the test-helper caller. It now says the production caller is gated by `_safe_pgid` and the test helper is not, and that its suite skips on Windows.

> Findings 6 through 9: depth confirmed rather than criticised - `kstrl/procgroup.py` as a new module is the right home (a stdlib-only leaf is what lets `tests/helpers/procs.py` import it without pulling in a 2835-line daemon); the test helper importing production code is right, because the orphan assertion that matters verifies `agents/proc.py`'s killpg path which shares no code with `procgroup`, and the one place they do share a reading is exactly where `signal_probe_alive` was added as an independent second opinion; the fallback is a principled generalisation with the fail-direction decision already at the caller; and `tests/test_shutdown.py` is the right file for the pin because the real-zombie fixture only exists there.

One thing worth carrying forward from finding 9: `wait_for_group_to_die` and `process_group_alive` in that test are now the same reading through two wrappers, so the helper line is no longer a second opinion. `signal_probe_alive` is what carries that load, which is why it was added.

---

# Round 1 review response

11 findings, all worked. 10 fixed, 1 accepted as out of scope and filed as #308. Nothing was waved away; the two I argued about are answered with measurements below.

## 1. `fake_ps` patched `subprocess.run` process-wide. FIXED

Confirmed on the branch before changing anything:

```
procgroup.subprocess is the stdlib module: True
a git call under the fake returned stdout: '1 Ss\n'
and out.args: ['ps', '-A', '-o', 'pgid=,stat=']
```

So the helper answered every command, and its docstring claimed the opposite. Any future test combining it with a git or fixture subprocess call would have measured nothing and passed, which is the #292 class it exists to prevent.

Fixed by delegation rather than by a production seam. `fake_ps` now inspects argv and hands anything that is not `PS_ARGV` to the real `subprocess.run`. I deliberately did **not** add a module-level `_run` indirection in `procgroup`: `tests/test_timeout_enforcement.py` audits for a literal `subprocess.run(...)` call needing a `timeout=`, and aliasing it behind a name would have hidden this call from that audit. Trading one safety net for another is not a fix.

Pinned by `TestTheFakeDoesNotAnswerForEveryCommand`, which runs a real `echo` under the fake and asserts both that it reaches the real subprocess and (positive control) that the `ps` call is still intercepted.

## 2. The `ps` timeout was pinned by nothing. FIXED

Reproduced: removing `timeout=PS_TIMEOUT_SECONDS` left the suite green, because the wedged-ps case raises a pre-built `TimeoutExpired` from the fake whether or not the kwarg was ever passed.

`fake_ps` now returns a call log, and `TestThePsCallIsBounded` asserts the kwargs the read actually passed. A/B on the fixed branch, with the kwarg deleted again:

```
FAILED tests/test_procgroup.py::TestThePsCallIsBounded::test_the_read_passes_its_timeout
1 failed, 43 passed
```

The same class also pins `encoding` and `errors`, which finding 4 made load-bearing.

## 3. The own-group control could not fire. FIXED, and this changed the design

This one was right and it was the important one. Measured on the branch:

```
our pgid=3851; rows in the listing with that pgid: [['3851','Ss'],['3851','S'],['3851','S'],['3851','R']]
_scan(real ps output, pgid=999999) -> saw_own_group=True, found=False
```

`subprocess.run` does not `setpgid`, so the `ps` child runs in the caller's group and `ps -A` always lists it. The control was satisfied by construction on every successful call. `hidepid` does not hide a caller's own uid either, so it did not even cover the case it named. My module docstring asserted a safety property the code did not have.

**Replaced, not patched.** A "gone" is now returned only when it is evidence:

* `ps` listed at least one row for the group and every one is a zombie. The listing demonstrably CAN see that group, so its verdict on that group's members is evidence. This is #298's case.
* `ps` listed no row for the group, and `killpg(pgid, 0)` raises ESRCH. That is the kernel saying the group holds no process at all, which no listing filter can fake.

Anything else, meaning no row plus a kernel that says the group is occupied, is "cannot see".

Verified against real process trees, including the filtered case built by dropping one live group from a real listing:

| case | old rule | new rule |
|---|---|---|
| live group, visible | LIVE | LIVE |
| same live group, hidden from the listing | `saw_own_group=True`, CONFIDENT "gone" | UNKNOWN (ps showed no row for a group the kernel says exists) |
| zombie-only group, parent not reaping (#298) | GONE | GONE (ps saw the group, every row a zombie) |
| genuinely, fully gone | GONE | GONE (kernel confirms empty) |

The kernel probe costs 0.00054 ms and is paid only on the "gone" path. `TestAGoneIsOnlyReportedWhenItIsEvidence` and `TestTheKernelControl` pin all four, including that EPERM and a generic `OSError` are **not** emptiness.

Two consumer tests moved with it rather than being deleted: `test_filtered_ps_output_raises_instead_of_reporting_absence` now matches on the new reason. Its policy assertion is unchanged, which is the point: the helper still refuses to convert a listing it cannot trust into an absence.

## 4. `UnicodeDecodeError` escaped the except clause. FIXED

Confirmed: `issubclass(UnicodeDecodeError, ValueError)` is True, `issubclass(UnicodeDecodeError, OSError)` is False. CLAUDE.md states the rule and `serve.py:1433` already applies it to the sibling `communicate()`.

Fixed at both levels, because they do different jobs. The read now pins `encoding="utf-8", errors="replace"` so a stray byte cannot raise (removing the failure mode), and `ValueError` joins the except tuple so a future edit to that call cannot reintroduce it (the check). `test_an_undecodable_listing_is_unknown_rather_than_a_crash` pins the catch, and `test_the_read_pins_its_encoding` pins the encoding.

## 5. The degrade reason never reached the durable record. FIXED

`terminate_process_group` now returns a frozen `GroupTermination(reaped, degraded)` instead of a bare bool. `run_supervised` carries `degraded` into a new `RunOutcome.group_reap_detail`, and `serve_cycle` folds it into the poison reason, so an operator reading the queue item sees why the check could not measure rather than a claim about a live factory.

Two tests, and the negative control matters as much as the positive one: `test_a_degraded_reap_says_so_in_the_poison_reason` asserts the recorded reason names the cause and says "unknown", and `test_an_undegraded_reap_reason_gains_no_caveat` asserts a clean run's reason does not grow a tail. `test_the_degrade_reason_is_returned_not_only_warned` pins that it comes back as a value and not just a warning.

I had declined this last round as scope creep and that was wrong: a warning on stderr is not a record for a detached daemon, and CLAUDE.md says if it is worth deciding it is worth recording.

The extra branch pushed `serve_cycle` from cyclomatic 32 to 33 and failed the ratchet, so the reason is built in `_unreaped_timeout_detail`. `serve_cycle` is back at 32 and `classify_run` and `serve_cycle` measured identical before and after at cognitive 36 and 51.

## 6. My comment about the killpg patch was wrong. FIXED

Confirmed: `kstrl.serve.os is kstrl.procgroup.os` is True, and under `patch("kstrl.serve.os.killpg", ...)` a call to `procgroup.signal_probe_alive(4242)` records `[(4242, 0)]`.

The comment now says the filter is **not** redundant and gives that measurement, so nobody removes it on my bad reasoning.

## 7. Common-mode blindness between the suite and the thing it measures. ANSWERED, with a mechanism

You asked me to answer this directly rather than restate the extraction's benefit, so:

**The second parse would not have been independent of the failure it is supposed to catch.** Both copies read the same `ps -A -o pgid=,stat=` and both break together on a column shift or a state-spelling change, which are precisely the named risks. Two copies written by the same author from the same output are correlated, not independent; what they buy is that one of them might get *fixed* and the other not, which is drift, and drift is what the divergent failure handling in the two originals already demonstrated.

**What actually restores independence is a different oracle, and finding 3 added one.** A "gone" now requires either a zombie row `ps` demonstrably saw, or ESRCH from the kernel. So a parse bug that DROPS a running row no longer yields a confident "gone": the kernel says the group is occupied, the listing shows no row, and the answer is "cannot see". `wait_for_group_to_die` then raises rather than passing, and `terminate_process_group` reports not-reaped rather than requeuing. The exact failure you described is now caught by a mechanism instead of by hoping two parses disagree.

A state-MISclassification bug (a running row read as `Z`) still gets through both. That is stated in `tests/helpers/procs.py` rather than left implied, and `TestTheScanReadsStatesNotJustGroups` is the table that pins the classification.

## 8. Shared exception instances across parametrized cases. FIXED

`BLIND_PS` now holds zero-arg factories, and `fake_ps`'s `raises` parameter is typed `Callable[[], BaseException] | None`. The reason is in the comment at the table, so nobody converts it back to instances for tidiness. `tests/test_procgroup.py` builds its exceptions inside each test body the same way.

## 9. The triplicated safe-pgid guard. ACCEPTED AS OUT OF SCOPE, FILED

Filed as **#308**, with the file:line references you listed (`serve.py:1504-1521`, `verify.py:116-119`, `agents/proc.py:193-196`), the note that only serve's copy has a test, and the note that `procgroup` currently appeals to a POSIX precondition it does not own.

## 10. The centralisation had no mechanism. FIXED

`TestOnlyOneModuleShellsOutToPs` AST-walks `kstrl/` and `tests/` and fails on any subprocess call whose argv names `ps`, outside `kstrl/procgroup.py`.

Its reach is measured, not asserted. It catches a list literal, `/bin/ps`, a `shell=True` string, and a tuple; it stays quiet on a non-subprocess list, on `psql`, and on prose. It resolves module-level argv constants, which was not in the first draft: `test_the_owner_still_calls_ps` failed immediately because `procgroup` spells `subprocess.run(PS_ARGV, ...)`, so the net was passing over the one call it exists to protect. A name bound inside a function body is a stated known miss.

`test_the_owner_still_calls_ps` and `test_the_net_walks_a_real_tree` stop it passing vacuously.

## 11. The spawn-kill-wait fixture was copied. FIXED

`procs.dead_group()` in `tests/helpers/procs.py`, used by both files. Four call sites now, all one line.

## Verification after the round

- `uv run pytest tests/ -v`: **4238 passed, 28 skipped**
- `uv run mypy kstrl/ --strict`: clean, 124 files
- `uv run ruff check kstrl/ tests/`: clean
- `pre-commit run --all-files` with the changes staged: all hooks pass
- Coverage: `kstrl/procgroup.py` **100%**, TOTAL 89.56% against the 79.91% baseline
- The original #298 repro re-run against the final code: `process_group_alive` converges on the first sample, identical to the `ps` helper

## What still needs the owner

- **#308** is filed but unassigned.
- **`signal_probe_alive` still maps a generic `OSError` to "gone"**, which is the unsafe direction. Unchanged from before #298 and now reachable only when `ps` also gave no answer. Pinned by a test that says it is pinned rather than endorsed. Changing it wants its own reasoning.
- **`Zl` and `Zs` remain synthetic.** The local kernel only ever printed plain `Z`. The prefix match is the portable claim.


---

# Round 2 review response

12 findings. **10 fixed, 2 filed** (#308 already open, #309 new). Every one is accounted for below with what was done and the measurement behind it.

## 1. The SIGKILL leg was unreachable in the case that matters. FIXED

Your `sh -c 'trap "" TERM; sleep 45'` repro did not reproduce for me: `reaped=True` in 0.02s, 0 survivors. The trap is the *shell's*, and `sleep` is a separate group member that `killpg` kills directly, so the group really did die.

The bug is real anyway, and I built a repro that shows it. The survivor has to install `SIG_IGN` itself:

```
before:
   18848 18848 Ss   sh
   18848 18849 S    python3   <- signal.signal(SIGTERM, SIG_IGN)
   18848 18850 S    sleep

terminate_process_group -> GroupTermination(reaped=False, degraded='')
elapsed 0.07s
survivors: 1   still RUNNING (not zombies): 1
```

SIGKILL never sent, exactly as you described: `process.wait()` returned when the leader died, and the `return` after it made the loop's second leg unreachable.

Fixed by making escalation a property of the GROUP, not of the direct child. The grace period is now spent watching the group; the next signal fires whenever anything is left. Same repro after:

```
terminate_process_group -> GroupTermination(reaped=True, degraded='', occupied='')
elapsed 15.22s
survivors: 0   still RUNNING (not zombies): 0
```

15.22s is the SIGTERM grace being spent as intended rather than skipped. `test_a_group_that_dies_on_sigterm_does_not_wait_out_the_grace` pins that the ordinary path still returns immediately, so the fix does not cost 15s per timeout.

Contained, so fixed rather than filed.

## 2. `warnings.warn` crashed the daemon under `-W error`. FIXED

Reproduced:

```
PYTHONWARNINGS=error ... -> RAISED: UserWarning kstrl: ps failed to run ...
```

After: `RESULT: True`.

`warnings.warn` is gone. The reason travels as a value. Fixed together with 5 and 7, as you said it should be. Pinned by `test_a_blind_ps_never_raises`, parametrized over all five blind-ps cases under `warnings.simplefilter("error")`.

## 3. EPERM was reported as "could not measure". FIXED

`GroupTermination` now has `occupied` alongside `degraded`, and they never mix. EPERM means the kernel FOUND processes in that group and refused us, so it is the strongest evidence a factory is alive, and the poison reason says "The group is CONFIRMED occupied, not merely unconfirmed" instead of "unknown rather than still running".

`test_eperm_reports_occupied_not_degraded` asserts `occupied` is set and `degraded` is empty; `test_the_poison_reason_does_not_soften_it_to_unknown` asserts the word "unknown" does not appear.

## 4. `PS_TIMEOUT_SECONDS` does not bound an unkillable `ps`. FILED as #309, docstring corrected

You are right, and I confirmed the mechanism in the installed CPython 3.12: `subprocess.run`'s handler is `process.kill()` then `process.wait()` with no timeout, and `Popen.__exit__` waits again. A D-state child cannot be killed, so both waits block.

**Not fixed here, and here is the reasoning.** A real bound requires abandoning a child that cannot be reaped, which trades a daemon hang for a leaked process that becomes a permanent zombie of the daemon. That is a design decision with a cost, not a bug fix, and it also needs `kstrl/procgroup.py` added to `POPEN_ALLOWLIST` in the timeout audit. Making that call unilaterally in the last round of a bug-fix PR is how an unreviewed trade ships.

So: **#309** (P1) with the three options costed, and the docstring now says exactly what the timeout does and does not cover and points there. It no longer claims a bound it lacks. You explicitly authorized this route.

I have also written into #309 that this is the same defect class as round 1 finding 2 one level down: pinning that the kwarg is passed does not establish that the kwarg does anything.

## 5. A reaped-but-unmeasured run was recorded nowhere. FIXED

`serve_cycle` read `group_reap_detail` only inside `if not group_reaped`. It now calls `_report_reap_degrade` before that branch, which reports on BOTH paths, and the reaped one gets the louder message because it is the unsafe direction:

> the timed-out run was released as reaped on an UNMEASURED check: ...

`test_a_reaped_but_UNMEASURED_run_is_still_reported` asserts it appears with the cause; `test_a_measured_reap_is_not_announced` is the negative control so the daemon does not narrate every clean run.

## 6. The zombie-only path trusted an incomplete listing. FIXED

This was in last round's redesign and you were right to say look hard. `hidepid` hides individual PROCESSES by uid, so a group can show a visible zombie and hide a running descendant that changed uid, which is the exact threat my own docstring names. `if rows: return GroupLiveness(False)` never reached the kernel control.

Fixed with a control that actually holds: **pid 1 must be in the listing.** Under `hidepid` the caller sees only its own uid's processes and pid 1 belongs to root; if we ARE root, nothing is hidden from us in the first place. Either way, seeing pid 1 rules out a uid-filtered view. Measured on this tree, uid 501: pid 1 appears as `['1', '1', 'Ss']` in every listing.

Cost measured before adopting, because it adds a column:

| argv | ms/call, 945 processes |
|---|---|
| `ps -A -o pgid=,stat=` | 16.10 |
| `ps -A -o pid=,pgid=,stat=` | 16.11 |

Inside the noise.

`test_zombies_in_a_FILTERED_listing_are_not_gone` is the regression: same zombie rows, no pid 1, and the answer is now "cannot see" instead of a confident gone. `test_a_complete_listing_showing_only_zombies_is_gone` keeps #298 working.

The module docstring now records both controls that did not work and why, rather than only the first.

## 7. Use the ServeObserver, not `warnings`. FIXED

`_report_reap_degrade(obs, outcome)` in `serve_cycle`, using the same `obs.warn` as every other operator message. No `warnings` import remains in `serve.py`. That closes the `__warningregistry__` growth as well: the message interpolated a pgid and an exception repr, so every run added a permanent distinct key.

## 8. The uniqueness claim was false as written. FIXED, both halves

You are right: `spike/tui0/measure.py` calls `ps` and the net walks only `kstrl/` and `tests/`.

- **Claim narrowed** to "the only place in `kstrl/` or `tests/`", and `test_the_claim_names_the_roots_the_net_actually_walks` asserts that exact wording is in the module, so the claim cannot drift back.
- **Callee set widened** to include `popen` and `getstatusoutput`, with `os.popen("ps -A")` and `subprocess.getstatusoutput("ps -A")` added to the planted-call table.

`spike/` stays outside deliberately, and the reason is a comment on `_SCANNED_ROOTS`: it holds throwaway measurement scripts that are not part of the package or its suite, and widening would mean either failing on evidence or carrying an allowlist that rots.

## 9. `dead_group` could leak a `sleep`. FIXED

`try/finally` with a kill and a bounded wait, and the comment names why: `kill_group` swallows every OSError, so a SIGKILL that did not land leaves `child.wait` to time out and the Popen dropped unreaped. That is the #292 orphan class planted by the helper written to stop it.

## 10. The zombie test needed a ps-less skip guard. FIXED

`procs.ps_is_readable()` asks `read_group_liveness` about the caller's own group, which is alive by construction, so a False is about `ps` and never about timing. `test_a_zombie_does_not_count_as_a_live_member` skips with a message naming the environment rather than failing at kstrl.

## 11. The pgid-is-None path claimed a measured answer. FIXED

It now sets `degraded="no process-group id was available, so only the direct child was inspected and any descendant it left is unaccounted for"`. `test_a_missing_pgid_is_reported_as_unmeasured` pins it.

## 12. procgroup's own killpg calls were unguarded. FIXED

`_may_signal_group(pgid)` refuses `pgid <= 1` in both `_kernel_says_group_is_empty` and `signal_probe_alive`, so `read_group_liveness(1)` can no longer issue `kill(-1, 0)`. The refusals fail conservatively: not-empty, and alive.

It deliberately does NOT exclude the caller's own group the way `serve._safe_pgid` does, and the docstring says why: this module only ever sends signal 0, probing our own group is harmless, and the suite legitimately asks. The broadcast pgid is the part that must be refused whatever the signal.

`TestTheGroupIdIsGuardedBeforeAnySignal` parametrizes -1, 0 and 1 and asserts `killpg` is never called, with a positive control that a real pgid still is. The triplication half stays in **#308**.

## Issues filed

| number | what |
|---|---|
| **#308** | The safe-pgid guard is triplicated across serve / verify / agents.proc (filed round 1) |
| **#309** | `PS_TIMEOUT_SECONDS` does not bound an unkillable `ps` (P1, filed this round) |

## Verification

- `uv run pytest tests/ -v`: **4259 passed, 28 skipped**
- `uv run mypy kstrl/ --strict`: clean, 124 files
- `uv run ruff check kstrl/ tests/`: clean
- `pre-commit run --all-files` with the changes staged: all hooks pass, including the cyclomatic and cognitive ratchets
- Coverage: `kstrl/procgroup.py` **100%**, TOTAL 89.59% against the 79.91% baseline
- Finding 1 repro after the fix: `reaped=True`, 0 survivors
- Finding 2 repro after the fix: `RESULT: True` under `PYTHONWARNINGS=error`

## What ships unfixed, stated plainly

- **#309**: a `ps` wedged in D state hangs the reap check while the daemon holds the serve lock. Documented in `kstrl/procgroup.py`, filed P1.
- **#308**: the safe-pgid guard remains triplicated in `serve`, `verify` and `agents/proc`. procgroup's own half is fixed here.
- **`signal_probe_alive` maps a generic `OSError` to "gone"**, the unsafe direction. Pre-#298 behaviour, now reachable only when `ps` also gave no answer, pinned by a test that says it is pinned rather than endorsed.
- **`Zl` and `Zs` are synthetic rows.** The local kernel only ever printed plain `Z`; the prefix match is the portable claim.
- **A state MISclassification would still blind both gates** (a running row read as `Z`). A dropped row no longer does, because the kernel control catches it. Written down in `tests/helpers/procs.py`.
