### PR TITLE
fix(tui): a home-shell screen names a broken config instead of raising on it

### DIFF
--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -2994,24 +2994,30 @@ def config_show(
             prd_default=root_dir / "scripts/kstrl/prd.json",
         )
 
-    from kstrl.config_preflight import collect_config_problems
+    from kstrl.config_preflight import SURFACE_REJECTIONS, collect_config_problems
 
     def _problems() -> list[str]:
         try:
             return collect_config_problems(root_dir, warn=_preflight_warn)
-        except ValueError as document_exc:
+        except SURFACE_REJECTIONS as document_exc:
             # The document will not parse, so no section resolved and
             # the parse error IS the whole report.
             return [str(document_exc)]
 
     try:
         report = build_config_report(root_dir, overlay=_overlay)
-    except ValueError as exc:
+    except SURFACE_REJECTIONS as exc:
         # No rows are possible: the base config itself was rejected, or
         # the document will not parse. Report it in the same shape as the
         # success-with-problems path below, and in the seam's words -
         # section, key, offending value - rather than the bare coercion
         # message this used to print.
+        #
+        # The tuple is IMPORTED, and `config` being preflight-exempt is
+        # exactly why it has to be: no entry seam catches this first.
+        # `except ValueError` here let `[run] max_iterations = ["3"]`
+        # out as a raw TypeError traceback, from the one command whose
+        # whole job is explaining a broken config (#289).
         _echo_config_problems(_problems() or [str(exc)])
         sys.exit(1)
 

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -2994,15 +2994,11 @@ def config_show(
             prd_default=root_dir / "scripts/kstrl/prd.json",
         )
 
-    from kstrl.config_preflight import SURFACE_REJECTIONS, collect_config_problems
-
-    def _problems() -> list[str]:
-        try:
-            return collect_config_problems(root_dir, warn=_preflight_warn)
-        except SURFACE_REJECTIONS as document_exc:
-            # The document will not parse, so no section resolved and
-            # the parse error IS the whole report.
-            return [str(document_exc)]
+    from kstrl.config_preflight import (
+        SURFACE_REJECTIONS,
+        config_problem_lines,
+        raise_if_defect,
+    )
 
     try:
         report = build_config_report(root_dir, overlay=_overlay)
@@ -3018,7 +3014,12 @@ def config_show(
         # `except ValueError` here let `[run] max_iterations = ["3"]`
         # out as a raw TypeError traceback, from the one command whose
         # whole job is explaining a broken config (#289).
-        _echo_config_problems(_problems() or [str(exc)])
+        #
+        # Except when the RuntimeError is one kstrl never defined: that
+        # is our defect, and printing it under "configuration problems"
+        # both blames the operator and loses the traceback.
+        raise_if_defect(exc)
+        _echo_config_problems(config_problem_lines(root_dir, warn=_preflight_warn) or [str(exc)])
         sys.exit(1)
 
     toml_path = report.toml_path
@@ -3041,7 +3042,7 @@ def config_show(
     # resolved (a rejected section costs its rows, not the report); the
     # problems below cover every section, the eleven this report does not
     # render included, in the words the rest of the CLI uses.
-    problems = _problems()
+    problems = config_problem_lines(root_dir, warn=_preflight_warn)
     if problems:
         _echo_config_problems(problems)
         sys.exit(1)

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -67,7 +67,7 @@ from kstrl.config import (
     resolve_config_file,
     toml_parse_scope,
 )
-from kstrl.config_report import scrubbed_environ
+from kstrl.config_report import environ_lock, scrubbed_environ
 
 #: Exceptions a loader raises for input the operator has to fix, and the
 #: complete set of them: these loaders read a file and coerce values, so
@@ -103,6 +103,36 @@ REJECTIONS = (ValueError, TypeError, RuntimeError)
 #: reads the project's pyproject.toml, so ``init_wizard._detected_text``
 #: needs ``OSError`` for a document this module never opens.
 SURFACE_REJECTIONS = (*REJECTIONS, OSError)
+
+
+def raise_if_defect(exc: BaseException) -> None:
+    """Re-raise ``exc`` when it is kstrl's bug, not the operator's file.
+
+    :data:`REJECTIONS` names ``RuntimeError`` only for the domain errors
+    that DERIVE from it - ``ServeError`` for ``[serve]
+    max_consecutive_poison = 0``, and its ``QueueError``, ``InboxError``
+    and ``IntakeError`` siblings - which are operator input and are
+    reported as such. Everything else that arrives as a ``RuntimeError``
+    is ours: reporting it as "configuration unreadable" blames the
+    operator for our defect and eats the traceback that would locate it.
+
+    The test is DERIVED, not a list. The first cut wrote ``type(exc) is
+    RuntimeError``, which is true only of a bare one, so
+    ``NotImplementedError`` and ``RecursionError`` - both direct
+    ``RuntimeError`` subclasses, both unambiguously defects - were
+    reported as the operator's broken file. A hand-written tuple of the
+    four domain errors would have fixed those two and gone stale the
+    next time a fifth is added, which is the failure mode this codebase
+    keeps recording. So the question asked is "did kstrl define this
+    class": ten ``RuntimeError`` subclasses live in ``kstrl/`` today and
+    every one of them is a condition we chose to raise, while
+    ``builtins`` and any dependency's ``RuntimeError`` is not something
+    we modelled and so not something we can honestly blame a file for.
+    ``tests/test_tui_config_guard.py`` pins both halves.
+    """
+    if isinstance(exc, RuntimeError) and type(exc).__module__.split(".")[0] != "kstrl":
+        raise exc
+
 
 T = TypeVar("T")
 
@@ -264,6 +294,33 @@ def collect_config_problems(
     return problems
 
 
+def config_problem_lines(
+    root_dir: Path,
+    *,
+    warn: Callable[[str], None],
+) -> list[str]:
+    """Every line the entry check would print for ``root_dir``.
+
+    :func:`collect_config_problems` with the one failure it does not
+    return folded back in: a document that will not parse raises, and
+    the answer to "what is wrong with this configuration" is then that
+    parse error and nothing else, because no section could be resolved
+    behind it.
+
+    Split out because ``ks config show`` and the TUI config screen are
+    the two surfaces whose whole job is explaining a broken config, and
+    they were carrying a copy of this each. The copies had already
+    drifted in their handling of the empty case; a third surface would
+    have made it three. Callers supply their own ``warn`` because one
+    prints to stderr and the other must stay silent on a screen.
+    """
+    try:
+        return collect_config_problems(root_dir, warn=warn)
+    except SURFACE_REJECTIONS as exc:
+        raise_if_defect(exc)
+        return [str(exc)]
+
+
 def load_or_report(
     loader: Callable[[Path], T],
     root_dir: Path,
@@ -298,19 +355,12 @@ def load_or_report(
         try:
             return loader(root_dir), None
         except SURFACE_REJECTIONS as exc:
-            if type(exc) is RuntimeError:
-                # A BARE RuntimeError is a defect in kstrl, not the
-                # operator's file, and reporting it as "configuration
-                # unreadable" would blame them for it and eat the
-                # traceback. REJECTIONS names RuntimeError only for the
-                # domain errors that DERIVE from it - ServeError,
-                # QueueError, InboxError, IntakeError - which are
-                # operator input and are still reported here. This is
-                # the same line EvolutionConfig.load_or_none draws, and
-                # it is drawn here too because that method's reason (a
-                # widening can only ever swallow a defect) is about the
-                # exception, not about the call site.
-                raise
+            # A RuntimeError kstrl did not define is a defect in kstrl,
+            # not the operator's file. This is the same line
+            # EvolutionConfig.load_or_none draws, and it is drawn here
+            # too because that method's reason (a widening can only ever
+            # swallow a defect) is about the exception, not the site.
+            raise_if_defect(exc)
             # Looked up HERE, not before the try: `_section_for` calls
             # `config_sections()`, whose 22 deferred imports cost a
             # measured 6.2 ms on their first call in a process that has
@@ -415,6 +465,19 @@ def _blamed_env_var(
     no other thread of ours is alive. That is the constraint
     ``config_report.scrubbed_environ``, reused here, already documents.
     """
+    # The lock spans the WHOLE sweep, not just the scrubbed_environ
+    # block: the per-variable pops below mutate os.environ outside it,
+    # and they are the longer window of the two.
+    with environ_lock():
+        return _blame_sweep(loader, root_dir, message)
+
+
+def _blame_sweep(
+    loader: Callable[[Path], Any],
+    root_dir: Path,
+    message: str,
+) -> str | None:
+    """:func:`_blamed_env_var`'s body, under the environment lock."""
     with scrubbed_environ():
         try:
             loader(root_dir)

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -90,11 +90,18 @@ from kstrl.config_report import scrubbed_environ
 REJECTIONS = (ValueError, TypeError, RuntimeError)
 
 #: :data:`REJECTIONS` plus the read failure a long-lived surface has to
-#: survive. The entry check never needs it: it reads the document once
-#: itself and turns an unreadable file into a ``ConfigError`` before any
-#: loader runs. A screen re-reading the file minutes later has no such
-#: pass in front of it, and a ``chmod`` between two refreshes raises
-#: ``OSError`` straight out of ``load_toml_section``.
+#: survive, for anything loading config AFTER command entry.
+#:
+#: ``OSError`` carries two unrelated rationales and both are why this
+#: cannot be fixed by normalizing it inside ``load_toml_document``.
+#: First, the entry check reads the document once itself and turns an
+#: unreadable kstrl.toml into a ``ConfigError`` before any loader runs;
+#: a screen re-reading the file minutes later has no such pass in front
+#: of it, and a ``chmod`` between two refreshes raises ``OSError``
+#: straight out of ``load_toml_section``. Second, a loader may read a
+#: file that is not kstrl.toml at all: ``resolve_verify_commands``
+#: reads the project's pyproject.toml, so ``init_wizard._detected_text``
+#: needs ``OSError`` for a document this module never opens.
 SURFACE_REJECTIONS = (*REJECTIONS, OSError)
 
 T = TypeVar("T")
@@ -333,13 +340,11 @@ def _detail(
     False says why (:func:`load_or_report`).
     """
     message = str(exc)
-    blamed = (
-        _blamed_env_var(section.loader, root_dir, message) if blame_env else None
-    ) or _blamed_toml_value(
-        section.sections,
-        toml_path,
-        message,
-    )
+    # Two statements, not one expression: the environment-then-file
+    # order is the rule the docstring above states, and an `or` split
+    # across a ternary hides it.
+    blamed = _blamed_env_var(section.loader, root_dir, message) if blame_env else None
+    blamed = blamed or _blamed_toml_value(section.sections, toml_path, message)
     line = f"{section.label} {message}"
     return f"{line} ({blamed})" if blamed else line
 
@@ -429,7 +434,7 @@ def _blamed_toml_value(
     """
     hits = []
     for name in sections:
-        with suppress(*REJECTIONS, OSError):
+        with suppress(*SURFACE_REJECTIONS):
             for key, value in load_toml_section(toml_path, name).items():
                 if repr(value) in message:
                     hits.append(f"kstrl.toml has [{name}] {key} = {value!r}")

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -292,15 +292,41 @@ def load_or_report(
     Wider than :data:`REJECTIONS` by ``OSError``: see
     :data:`SURFACE_REJECTIONS`.
     """
-    section = _section_for(loader)
-    toml_path = resolve_config_file(root_dir)
     # Scoped per call, never across calls: a screen's refresh action
     # exists to see the file as it is NOW (see ``toml_parse_scope``).
     with toml_parse_scope():
         try:
             return loader(root_dir), None
         except SURFACE_REJECTIONS as exc:
-            return None, _detail(section, toml_path, root_dir, exc, blame_env=blame_env)
+            if type(exc) is RuntimeError:
+                # A BARE RuntimeError is a defect in kstrl, not the
+                # operator's file, and reporting it as "configuration
+                # unreadable" would blame them for it and eat the
+                # traceback. REJECTIONS names RuntimeError only for the
+                # domain errors that DERIVE from it - ServeError,
+                # QueueError, InboxError, IntakeError - which are
+                # operator input and are still reported here. This is
+                # the same line EvolutionConfig.load_or_none draws, and
+                # it is drawn here too because that method's reason (a
+                # widening can only ever swallow a defect) is about the
+                # exception, not about the call site.
+                raise
+            # Looked up HERE, not before the try: `_section_for` calls
+            # `config_sections()`, whose 22 deferred imports cost a
+            # measured 6.2 ms on their first call in a process that has
+            # imported kstrl.tui.app, and that first call otherwise
+            # lands on the Textual event loop inside on_mount even when
+            # kstrl.toml is perfectly valid (4.7 us warm). Only the
+            # failure path needs a label, so only it pays. An
+            # unenrolled loader still raises LookupError, on the path
+            # that would have had to name it.
+            return None, _detail(
+                _section_for(loader),
+                resolve_config_file(root_dir),
+                root_dir,
+                exc,
+                blame_env=blame_env,
+            )
 
 
 def _section_for(loader: Callable[[Path], Any]) -> ConfigSection:

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -286,6 +286,13 @@ def collect_config_problems(
             try:
                 section.loader(root_dir)
             except REJECTIONS as exc:
+                # Same rule as every other catcher of this tuple: a
+                # RuntimeError kstrl did not define is our defect, and
+                # listing it under "configuration problems" blames the
+                # operator's file for it. This is the seam all three
+                # reporting surfaces route through, so the hole would
+                # have been one call deep from each of them.
+                raise_if_defect(exc)
                 detail = _detail(section, toml_path, root_dir, exc, blame_env=True)
                 if section.fatal or not required.isdisjoint(section.sections):
                     problems.append(detail)

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -58,7 +58,7 @@ from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 from kstrl.config import (
     ConfigError,
@@ -88,6 +88,16 @@ from kstrl.config_report import scrubbed_environ
 #: ``[serve] max_consecutive_poison = 0`` that way, and ``QueueError``,
 #: ``InboxError`` and ``IntakeError`` are its siblings.
 REJECTIONS = (ValueError, TypeError, RuntimeError)
+
+#: :data:`REJECTIONS` plus the read failure a long-lived surface has to
+#: survive. The entry check never needs it: it reads the document once
+#: itself and turns an unreadable file into a ``ConfigError`` before any
+#: loader runs. A screen re-reading the file minutes later has no such
+#: pass in front of it, and a ``chmod`` between two refreshes raises
+#: ``OSError`` straight out of ``load_toml_section``.
+SURFACE_REJECTIONS = (*REJECTIONS, OSError)
+
+T = TypeVar("T")
 
 
 @dataclass(frozen=True)
@@ -239,7 +249,7 @@ def collect_config_problems(
             try:
                 section.loader(root_dir)
             except REJECTIONS as exc:
-                detail = _detail(section, toml_path, root_dir, exc)
+                detail = _detail(section, toml_path, root_dir, exc, blame_env=True)
                 if section.fatal or not required.isdisjoint(section.sections):
                     problems.append(detail)
                 else:
@@ -247,21 +257,85 @@ def collect_config_problems(
     return problems
 
 
+def load_or_report(
+    loader: Callable[[Path], T],
+    root_dir: Path,
+    *,
+    blame_env: bool,
+) -> tuple[T | None, str | None]:
+    """One section, resolved, or the line this module would have printed.
+
+    Exactly one of the pair is ever None. For a long-lived surface that
+    loads a section AFTER command entry - a TUI screen the home shell
+    opens - and so has no seam in front of it to fail on its behalf.
+    The message is produced by the same ``_detail`` the entry check
+    uses, so the same broken file reads the same way on both surfaces,
+    which is what #289 was about; ``tests/test_tui_config_guard.py``
+    pins the two strings equal rather than trusting that.
+
+    ``blame_env`` is required rather than defaulted because getting it
+    wrong is not a cosmetic mistake. Naming the offending variable means
+    measuring it (``_blamed_env_var``), and measuring it means clearing
+    ``os.environ``, which is PROCESS-WIDE. At command entry nothing else
+    of ours is running; on a screen a launched run may be on another
+    thread, spawning subprocesses that inherit the environment. Pass
+    False there and the line keeps everything except the variable's
+    name. ``kstrl.tui.config_guard`` is where that decision is made.
+
+    Wider than :data:`REJECTIONS` by ``OSError``: see
+    :data:`SURFACE_REJECTIONS`.
+    """
+    section = _section_for(loader)
+    toml_path = resolve_config_file(root_dir)
+    # Scoped per call, never across calls: a screen's refresh action
+    # exists to see the file as it is NOW (see ``toml_parse_scope``).
+    with toml_parse_scope():
+        try:
+            return loader(root_dir), None
+        except SURFACE_REJECTIONS as exc:
+            return None, _detail(section, toml_path, root_dir, exc, blame_env=blame_env)
+
+
+def _section_for(loader: Callable[[Path], Any]) -> ConfigSection:
+    """The registry entry for ``loader``.
+
+    A caller passes the loader rather than a section name so that it
+    cannot label itself with a section the entry check does not know,
+    and so that the label and the blame helpers come from the one table
+    :func:`config_sections` already keeps complete.
+
+    Compared with ``==``, not ``is``: ``EvolutionConfig.load`` is a bound
+    classmethod and Python builds a fresh object on every attribute
+    access, so ``is`` is False even for the same method, while ``==``
+    compares ``__func__`` and ``__self__``.
+    """
+    for section in config_sections():
+        if section.loader == loader:
+            return section
+    raise LookupError(f"{loader!r} is not a loader config_sections() names")
+
+
 def _detail(
     section: ConfigSection,
     toml_path: Path,
     root_dir: Path,
     exc: Exception,
+    *,
+    blame_env: bool,
 ) -> str:
     """One line: which section, what the loader said, and which input.
 
     The environment is asked FIRST because the environment wins: with
     the same bad value in both places, the variable is the one taking
     effect, so naming the file's key would send the operator to a line
-    that changing does not help.
+    that changing does not help. ``blame_env`` False skips that question
+    entirely rather than answering it unsafely; the caller that passes
+    False says why (:func:`load_or_report`).
     """
     message = str(exc)
-    blamed = _blamed_env_var(section.loader, root_dir, message) or _blamed_toml_value(
+    blamed = (
+        _blamed_env_var(section.loader, root_dir, message) if blame_env else None
+    ) or _blamed_toml_value(
         section.sections,
         toml_path,
         message,

--- a/kstrl/config_report.py
+++ b/kstrl/config_report.py
@@ -16,6 +16,7 @@ only when no session is active.
 from __future__ import annotations
 
 import os
+import threading
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -105,20 +106,57 @@ def normalize_ui_mode(value: str) -> str:
     return normalized
 
 
+#: Held for the whole of any block that blanks or pops ``os.environ``,
+#: and by every thread of ours that READS ``KSTRL_*`` while another
+#: thread might be doing so.
+#:
+#: A lock rather than a refusal, and the difference was measured. #289
+#: first closed this race by adding the app's safe-mode worker to
+#: ``env_scrub_is_safe``'s refusal condition, which turned two working
+#: surfaces intermittent: on an EMPTY project the worker's flag is set
+#: for 51 to 84 ms out of every 5 s, so the config screen's refresh was
+#: denied at random with a message falsely blaming a launched run, and
+#: the evolve banner silently dropped the environment variable it was
+#: supposed to name. On a project whose events.jsonl makes the check
+#: exceed its own interval the flag never clears and the refusal is
+#: permanent. Waiting 84 ms is not a cost worth making a feature
+#: unreliable to avoid.
+#:
+#: RLock, not Lock: ``_blamed_env_var`` holds this across a
+#: ``scrubbed_environ`` block that takes it again.
+_ENVIRON_LOCK = threading.RLock()
+
+
+@contextmanager
+def environ_lock() -> Iterator[None]:
+    """Exclusive access to ``os.environ`` against other kstrl threads.
+
+    Take it around a block that MUTATES the environment, and around a
+    read of ``KSTRL_*`` on any thread that could run beside one. It
+    cannot help against a subprocess inheriting the environment, which
+    is why a launched run is still a refusal in
+    ``tui.config_guard.env_scrub_is_safe`` rather than a wait.
+    """
+    with _ENVIRON_LOCK:
+        yield
+
+
 @contextmanager
 def scrubbed_environ() -> Iterator[None]:
     """Temporarily clear os.environ so a loader sees toml + defaults only.
 
     A field whose value changes when the environment disappears was
-    env-set. PROCESS-WIDE: see the module docstring's thread warning.
+    env-set. PROCESS-WIDE, and therefore serialized on
+    :func:`environ_lock`: see the module docstring's thread warning.
     """
-    saved = dict(os.environ)
-    os.environ.clear()
-    try:
-        yield
-    finally:
+    with _ENVIRON_LOCK:
+        saved = dict(os.environ)
         os.environ.clear()
-        os.environ.update(saved)
+        try:
+            yield
+        finally:
+            os.environ.clear()
+            os.environ.update(saved)
 
 
 # Rows whose None means something more specific than "no value", and
@@ -363,7 +401,7 @@ def build_config_report(
     ``[run]`` value leaves nothing to render beside the failure.
     """
     from kstrl.config import toml_parse_scope
-    from kstrl.config_preflight import REJECTIONS
+    from kstrl.config_preflight import SURFACE_REJECTIONS, raise_if_defect
 
     toml_path = resolve_config_file(root_dir)
     phase_sections = _phase_sections()
@@ -378,10 +416,23 @@ def build_config_report(
         was added to remove. WHY a section was rejected is
         ``config_preflight``'s job to report; None here means only "no
         row can be built from this".
+
+        It is the SURFACE set, not the entry set, because this function
+        has both kinds of caller. The entry check reads kstrl.toml once
+        itself and turns an unreadable file into a ConfigError before
+        any loader runs; the TUI config screen's refresh action calls
+        this minutes later with no such pass in front of it, so a chmod
+        or an unreadable pyproject.toml between two refreshes arrives
+        here as a bare OSError. `except REJECTIONS` let that kill the
+        whole report on the one screen whose job is showing config.
         """
         try:
             return loader(root_dir)
-        except REJECTIONS:
+        except SURFACE_REJECTIONS as exc:
+            # A RuntimeError kstrl never defined is our bug, and
+            # returning None for it would silently drop a whole section
+            # from a report the operator is reading to find the truth.
+            raise_if_defect(exc)
             return None
 
     # One parse of kstrl.toml for the whole report. Without this the

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -140,6 +140,18 @@ class EvolutionConfig:
         input, and two lists that disagree would degrade the same value
         at startup and then raise on it mid-run.
 
+        It is deliberately NOT
+        ``config_preflight.SURFACE_REJECTIONS``, which is this tuple
+        plus ``RuntimeError``. #289 tried importing that instead, on
+        the reasoning above, and
+        ``test_decompose.py::test_the_artifact_is_written_before_any_journal_work``
+        failed: that test raises ``RuntimeError`` from :meth:`load` on
+        purpose, to assert that an error the guard does NOT catch still
+        leaves the halt artifact on disk. No coercion in :meth:`load`
+        produces one, so widening to it could only ever swallow a
+        defect, and the entry check degrading where this raises is the
+        price of keeping that defect visible mid-run.
+
         The cost of that widening, stated because it is real: a
         ``TypeError`` from a DEFECT inside :meth:`load` - a None where a
         path belongs, a signature that stopped matching - now reads as

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -1128,9 +1128,17 @@ class EvolutionJournal:
             )
 
             try:
-                filepath.write_text(content)
+                # encoding named, ValueError caught: the description
+                # and suggested_change come from an LLM, so one curly
+                # quote makes this a UnicodeEncodeError under LC_ALL=C,
+                # and that is a ValueError, which the OSError handler
+                # below does not catch (measured: US-ASCII preferred
+                # encoding, write_text raises). A proposal write is
+                # explicitly non-fatal; without this it took the run
+                # down instead.
+                filepath.write_text(content, encoding="utf-8")
                 written.append(filepath)
-            except OSError as exc:
+            except (OSError, ValueError) as exc:
                 logger.warning(
                     "proposal write failed (non-fatal): %s: %s",
                     filepath,

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -713,7 +713,9 @@ class EvolutionJournal:
                 not self.config.experiments_path.exists()
                 or self.config.experiments_path.stat().st_size == 0
             )
-            with open(self.config.experiments_path, "a") as f:
+            # The other side of the two-sided contract: this is the
+            # file get_experiment_trends decodes as utf-8.
+            with open(self.config.experiments_path, "a", encoding="utf-8") as f:
                 if needs_header:
                     f.write(header + "\n")
                 f.write(row + "\n")
@@ -1251,10 +1253,20 @@ class EvolutionJournal:
     # ------------------------------------------------------------------
 
     def get_experiment_trends(self, last_n: int = 10) -> list[dict[str, Any]]:
-        """Read experiments.tsv and return the last N entries as dicts."""
+        """Read experiments.tsv and return the last N entries as dicts.
+
+        Encoding is named and ``ValueError`` is caught beside
+        ``OSError``, which is the house rule for a reader of any file
+        kstrl writes (CLAUDE.md): ``UnicodeDecodeError`` IS a
+        ``ValueError`` and escapes a fail-closed ``except OSError``.
+        Measured before this line: a single non-utf-8 byte in
+        experiments.tsv raised straight out of ``EvolveScreen.on_mount``
+        two lines after the #289 config banner, which is that issue's
+        own crash from that issue's own screen.
+        """
         try:
-            text = self.config.experiments_path.read_text()
-        except OSError:
+            text = self.config.experiments_path.read_text(encoding="utf-8")
+        except (OSError, ValueError):
             return []
 
         reader = csv.DictReader(io.StringIO(text), delimiter="\t")

--- a/kstrl/observability.py
+++ b/kstrl/observability.py
@@ -409,12 +409,20 @@ def read_progress_events(path: Path) -> list[dict[str, Any]]:
     Malformed lines (a crash mid-write leaves at most one) are skipped
     rather than raised: the log is an observability surface and a torn
     tail line must not make `ks status` unusable.
+
+    ``encoding="utf-8"`` is named and ``ValueError`` is caught for the
+    same reason: kstrl writes this file as utf-8 through ``atomicio``,
+    so a reader that leaves the codec to the locale decodes it wrongly
+    under ``LC_ALL=C``, and ``UnicodeDecodeError`` is a ``ValueError``,
+    which walks straight out of a fail-closed ``except OSError``. Two
+    callers meet that: ``ks status``, and ``EvolutionJournal`` on the
+    TUI evolve screen, where it reached the Textual event loop (#289).
     """
     if not path.exists():
         return []
     events: list[dict[str, Any]] = []
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line:
@@ -425,7 +433,11 @@ def read_progress_events(path: Path) -> list[dict[str, Any]]:
                     continue
                 if isinstance(parsed, dict):
                     events.append(parsed)
-    except OSError:
+    except (OSError, ValueError):
+        # ValueError is UnicodeDecodeError: bytes this reader cannot
+        # decode at all, as opposed to the torn line the inner handler
+        # skips. Same answer as an unreadable file - no events - because
+        # the alternative is a traceback out of an observability read.
         return []
     return events
 

--- a/kstrl/proposals.py
+++ b/kstrl/proposals.py
@@ -58,8 +58,8 @@ def existing_proposal_titles(proposals_dir: Path) -> set[str]:
         return titles
     for path in sorted(proposals_dir.glob("prop-*.md")):
         try:
-            first_line = path.read_text().splitlines()[0]
-        except (OSError, IndexError):
+            first_line = path.read_text(encoding="utf-8").splitlines()[0]
+        except (OSError, ValueError, IndexError):
             continue
         m = PROPOSAL_TITLE_RE.match(first_line)
         if m:
@@ -77,7 +77,7 @@ def parse_proposal_file(path: Path) -> Proposal:
         "applied": "",
     }
     convention_lines: list[str] = []
-    for line in path.read_text().splitlines():
+    for line in path.read_text(encoding="utf-8").splitlines():
         m = PROPOSAL_TITLE_RE.match(line)
         if m and not parsed["id"]:
             parsed["id"], parsed["title"] = m.group(1), m.group(2)
@@ -110,7 +110,11 @@ def list_proposals(proposals_dir: Path) -> list[Proposal]:
     for path in sorted(proposals_dir.glob("prop-*.md")):
         try:
             proposals.append(parse_proposal_file(path))
-        except OSError:
+        except (OSError, ValueError):
+            # ValueError beside OSError because UnicodeDecodeError is
+            # one: measured, a single non-utf-8 byte in a prop-*.md
+            # raised out of EvolveScreen.on_mount, one line BEFORE the
+            # #289 banner guard (CLAUDE.md, encoding is two-sided).
             continue
     return proposals
 
@@ -144,7 +148,7 @@ def append_to_agent_learnings(
     if not head.endswith("\n"):
         head += "\n"
     try:
-        claude_md.write_text(head + entry + content[insert_at:])
+        claude_md.write_text(head + entry + content[insert_at:], encoding="utf-8")
     except OSError:
         return False
     return True
@@ -153,7 +157,7 @@ def append_to_agent_learnings(
 def mark_applied(path: Path, when: str | None = None) -> str:
     """Stamp the proposal file as applied; returns the timestamp."""
     applied_at = when or datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    with open(path, "a") as f:
+    with open(path, "a", encoding="utf-8") as f:
         f.write(f"\n**Applied**: {applied_at}\n")
     return applied_at
 

--- a/kstrl/safemode.py
+++ b/kstrl/safemode.py
@@ -120,9 +120,18 @@ def _autonomy_reasons(root_dir: Path) -> list[SafeModeReason]:
         AutonomyState,
         resolve_runtime_level,
     )
+    from kstrl.config_report import environ_lock
     from kstrl.policy import PolicyConfig
 
-    config = AutonomyConfig.load(root_dir)
+    # These loaders read KSTRL_AUTONOMY_* and KSTRL_POLICY_*, and this
+    # function runs on a worker thread every 5 seconds in every TUI
+    # mode. A surface blanking os.environ to work out which variable
+    # broke a config would otherwise make this read the DEFAULT ladder
+    # and report a degraded factory as nominal, which is the silent
+    # wrong answer the safe-mode chip exists to prevent (#289).
+    with environ_lock():
+        config = AutonomyConfig.load(root_dir)
+        policy_enabled = PolicyConfig.load(root_dir).enabled
     if not config.enabled:
         # A ladder that is switched off is not a ladder that fell down.
         # ``[autonomy] enabled`` is False by default, so reporting a
@@ -138,7 +147,7 @@ def _autonomy_reasons(root_dir: Path) -> list[SafeModeReason]:
     level, clamps = resolve_runtime_level(
         state,
         config,
-        policy_enabled=PolicyConfig.load(root_dir).enabled,
+        policy_enabled=policy_enabled,
         root_dir=root_dir,
     )
     if int(level) < state.level:
@@ -157,9 +166,13 @@ def _autonomy_reasons(root_dir: Path) -> list[SafeModeReason]:
 
 
 def _queue_reasons(root_dir: Path) -> list[SafeModeReason]:
+    from kstrl.config_report import environ_lock
     from kstrl.workqueue import Queue, QueueConfig
 
-    pause = Queue(root_dir, QueueConfig.load(root_dir)).pause_state()
+    # KSTRL_QUEUE_*; see _autonomy_reasons for why the lock is here.
+    with environ_lock():
+        config = QueueConfig.load(root_dir)
+    pause = Queue(root_dir, config).pause_state()
     # ``active`` rather than ``paused``: a lapsed ``resume_after`` means
     # the queue is admitting work again, which is what the daemon's own
     # ``is_paused`` asks.

--- a/kstrl/tui/config_guard.py
+++ b/kstrl/tui/config_guard.py
@@ -43,24 +43,64 @@ without taking a banner it does not show.
 from __future__ import annotations
 
 
+def _handle_is_live(handle: object) -> bool:
+    """A command handle that exists and has not finished."""
+    done = getattr(handle, "done", None)
+    return handle is not None and callable(done) and not bool(done())
+
+
 def env_scrub_is_safe(app: object) -> bool:
-    """Whether clearing ``os.environ`` right now would race a run.
+    """Whether clearing ``os.environ`` right now would race a thread.
 
-    ``app`` is typed ``object`` rather than ``App`` on purpose: the
-    attributes read here belong to ``KstrlTuiApp``, not to Textual's
-    ``App``, and the screens are also mounted on bare test harnesses
-    that have neither. Absent means "no run", which is the safe answer
-    for a harness and the true one for a shell that has launched
-    nothing.
+    THREE readers, and missing any one of them makes this predicate a
+    lie rather than a guard:
 
-    Deliberately NOT ``KstrlTuiApp.session_in_flight``, which walks the
-    same three attributes but also requires ``Mode.HOME``. The hazard
-    does not care which mode the app is in: a dash or embedded run is
-    just as able to read the environment while it is empty.
+    1. A home-launched session (``run_context.handle``), which runs the
+       factory on another thread whose subprocesses inherit the
+       environment.
+    2. An EMBEDDED-mode orchestrator (``app.orchestrator``). Same
+       hazard, DIFFERENT attribute: ``embed.py`` starts the command
+       thread and passes it as ``orchestrator=``, while ``run_context``
+       comes from ``RunContext.observe``, which leaves ``handle`` None.
+       Reading only ``run_context`` returned True with an agent
+       mid-spawn.
+    3. The app's own safe-mode worker (``_safe_mode_running``).
+       ``app.py`` schedules ``_check_safe_mode`` every 5 seconds in
+       EVERY mode, and ``safemode.safe_mode_reasons`` loads
+       ``AutonomyConfig``, ``PolicyConfig`` and ``QueueConfig``, all of
+       which read ``KSTRL_*``. Measured before this clause existed:
+       with 84 variables set, a thread polling
+       ``KSTRL_AUTONOMY_LEVEL`` across 50 blaming ``load_or_report``
+       calls saw it MISSING for 95990 of 36.8M reads. A safe-mode tick
+       landing in that window reports the default ladder, so a degraded
+       factory reads nominal on the chip for one tick, which is the
+       silent wrong answer the chip exists to prevent.
+
+    WHY A FLAG READ IS ENOUGH, AND NO LOCK IS NEEDED. Every caller runs
+    on the Textual UI thread (a message handler or an action), the
+    scrub that follows is synchronous and never awaits, and a worker is
+    only ever STARTED from that same thread by a timer callback. So no
+    worker can begin between this check and the scrub, and
+    ``_safe_mode_running`` is cleared in the worker's ``finally`` only
+    after its last config read, which makes True strictly wider than
+    the danger window. Calling this off the UI thread would break that
+    argument, and nothing does.
+
+    ``app`` is typed ``object`` rather than ``App`` on purpose: these
+    attributes belong to ``KstrlTuiApp``, not to Textual's ``App``, and
+    the screens are also mounted on bare test harnesses that have
+    neither. Absent means "not running", which is the safe answer for a
+    harness and the true one for a shell that has launched nothing.
+
+    Deliberately NOT ``KstrlTuiApp.session_in_flight``, which reads one
+    of the three and also requires ``Mode.HOME``. The hazard does not
+    care which mode the app is in.
     """
-    run_context = getattr(app, "run_context", None)
-    handle = getattr(run_context, "handle", None)
-    return handle is None or bool(handle.done())
+    if _handle_is_live(getattr(getattr(app, "run_context", None), "handle", None)):
+        return False
+    if _handle_is_live(getattr(app, "orchestrator", None)):
+        return False
+    return not bool(getattr(app, "_safe_mode_running", False))
 
 
 __all__ = ["env_scrub_is_safe"]

--- a/kstrl/tui/config_guard.py
+++ b/kstrl/tui/config_guard.py
@@ -1,0 +1,105 @@
+"""The one guarded configuration load the home shell's screens use.
+
+`ks <command>` resolves every kstrl.toml section at command entry
+(``config_preflight``, #272), so a typo produces one named line and
+exit 1 before anything is built. The home shell runs that same check -
+``cli.cli`` calls ``preflight_config`` before opening it - and the gap
+#289 names is not that the shell skipped it.
+
+The gap is that the check has exactly one DEGRADING section,
+``[evolution]``, which warns and lets the command proceed because the
+journal is an optional audit trail. A command that is ABOUT that
+section says so with ``_PREFLIGHT_REQUIRED`` and gets the error line
+instead. A SCREEN cannot: it is not a click command, it is entered
+after startup, and it constructs its config on demand. So the evolve
+screen - the screen that section is entirely about - opened on a
+warning and then raised ``ValueError`` out of ``on_mount``, taking the
+shell down where the CLI had just named the key and the value.
+
+Two properties this keeps, both stated because both were tempting to
+drop:
+
+- It does NOT degrade to an empty view. A screen whose subject is the
+  evolution journal showing no patterns because the journal config
+  will not parse is worse than an error: "no patterns" is a real state
+  and an operator cannot tell the two apart. The banner says which
+  section, what the loader said, and which input set it.
+- It does NOT restate the entry check's wording. The message comes
+  from ``config_preflight.load_or_report``, which builds it with the
+  same helper ``preflight_config`` uses, so the two surfaces cannot
+  drift. ``tests/test_tui_config_guard.py`` pins them equal.
+
+THREAD HAZARD, inherited: naming the environment variable is measured
+by clearing ``os.environ``, which is process-wide (see
+``config_report.scrubbed_environ``). A home-shell session runs the
+factory on another thread of this process, and those subprocesses
+inherit the environment. :func:`env_scrub_is_safe` is the same gate
+``ConfigScreen.action_refresh`` already applied to its own refresh,
+lifted here so both screens and that one ask the question once.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+
+from rich.text import Text
+from textual.widgets import Static
+
+from kstrl.config_preflight import load_or_report
+
+T = TypeVar("T")
+
+
+def env_scrub_is_safe(app: object) -> bool:
+    """Whether clearing ``os.environ`` right now would race a run.
+
+    ``app`` is typed ``object`` rather than ``App`` on purpose: the
+    attributes read here belong to ``KstrlTuiApp``, not to Textual's
+    ``App``, and the screens are also mounted on bare test harnesses
+    that have neither. Absent means "no run", which is the safe answer
+    for a harness and the true one for a shell that has launched
+    nothing.
+    """
+    run_context = getattr(app, "run_context", None)
+    handle = getattr(run_context, "handle", None)
+    return handle is None or bool(handle.done())
+
+
+def load_config(
+    app: object,
+    loader: Callable[[Path], T],
+    root_dir: Path,
+) -> tuple[T | None, str | None]:
+    """The section for ``root_dir``, or the line the CLI prints for it.
+
+    Exactly one of the pair is None. Screens render the second through
+    :class:`ConfigProblemBanner` and then stop, rather than showing an
+    empty table that means something else.
+    """
+    return load_or_report(loader, root_dir, blame_env=env_scrub_is_safe(app))
+
+
+class ConfigProblemBanner(Static):
+    """Full-width alert line, hidden while the configuration resolves.
+
+    Hidden-while-clean is safe here and would not be on a status chip:
+    this banner never has to carry the meaning "checked and fine" on
+    its own, because the screen's own content is that answer.
+    """
+
+    def show(self, problem: str | None) -> None:
+        if problem is None:
+            self.display = False
+            self.update("")
+            return
+        self.display = True
+        # A Text, never a str: the line's first token is the section
+        # name in brackets, which Rich reads as markup and DELETES. The
+        # measured result was "configuration unreadable:  invalid
+        # literal for int()" - the fault named, the section missing.
+        self.update(Text(f"▲ configuration unreadable: {problem}"))
+
+
+__all__ = ["ConfigProblemBanner", "env_scrub_is_safe", "load_config"]

--- a/kstrl/tui/config_guard.py
+++ b/kstrl/tui/config_guard.py
@@ -1,4 +1,4 @@
-"""The one guarded configuration load the home shell's screens use.
+"""When a home-shell screen may clear os.environ to blame a variable.
 
 `ks <command>` resolves every kstrl.toml section at command entry
 (``config_preflight``, #272), so a typo produces one named line and
@@ -16,40 +16,31 @@ screen - the screen that section is entirely about - opened on a
 warning and then raised ``ValueError`` out of ``on_mount``, taking the
 shell down where the CLI had just named the key and the value.
 
-Two properties this keeps, both stated because both were tempting to
-drop:
+Two properties the fix keeps, both stated because both were tempting
+to drop:
 
 - It does NOT degrade to an empty view. A screen whose subject is the
   evolution journal showing no patterns because the journal config
   will not parse is worse than an error: "no patterns" is a real state
-  and an operator cannot tell the two apart. The banner says which
-  section, what the loader said, and which input set it.
+  and an operator cannot tell the two apart.
 - It does NOT restate the entry check's wording. The message comes
   from ``config_preflight.load_or_report``, which builds it with the
   same helper ``preflight_config`` uses, so the two surfaces cannot
   drift. ``tests/test_tui_config_guard.py`` pins them equal.
 
-THREAD HAZARD, inherited: naming the environment variable is measured
-by clearing ``os.environ``, which is process-wide (see
+What is left in THIS module is the one decision a screen has to make
+that the entry check never faces. Naming the environment variable is
+measured by clearing ``os.environ``, which is process-wide (see
 ``config_report.scrubbed_environ``). A home-shell session runs the
-factory on another thread of this process, and those subprocesses
-inherit the environment. :func:`env_scrub_is_safe` is the same gate
-``ConfigScreen.action_refresh`` already applied to its own refresh,
-lifted here so both screens and that one ask the question once.
+factory on another thread of this process and those subprocesses
+inherit the environment, so the question is asked once, here, for the
+three surfaces that ask it. The rendering lives on the widget
+(``tui/widgets/config_problem.py``); this module stays logic only and
+imports no widget, so ``screens/config.py`` can take the predicate
+without taking a banner it does not show.
 """
 
 from __future__ import annotations
-
-from collections.abc import Callable
-from pathlib import Path
-from typing import TypeVar
-
-from rich.text import Text
-from textual.widgets import Static
-
-from kstrl.config_preflight import load_or_report
-
-T = TypeVar("T")
 
 
 def env_scrub_is_safe(app: object) -> bool:
@@ -61,45 +52,15 @@ def env_scrub_is_safe(app: object) -> bool:
     that have neither. Absent means "no run", which is the safe answer
     for a harness and the true one for a shell that has launched
     nothing.
+
+    Deliberately NOT ``KstrlTuiApp.session_in_flight``, which walks the
+    same three attributes but also requires ``Mode.HOME``. The hazard
+    does not care which mode the app is in: a dash or embedded run is
+    just as able to read the environment while it is empty.
     """
     run_context = getattr(app, "run_context", None)
     handle = getattr(run_context, "handle", None)
     return handle is None or bool(handle.done())
 
 
-def load_config(
-    app: object,
-    loader: Callable[[Path], T],
-    root_dir: Path,
-) -> tuple[T | None, str | None]:
-    """The section for ``root_dir``, or the line the CLI prints for it.
-
-    Exactly one of the pair is None. Screens render the second through
-    :class:`ConfigProblemBanner` and then stop, rather than showing an
-    empty table that means something else.
-    """
-    return load_or_report(loader, root_dir, blame_env=env_scrub_is_safe(app))
-
-
-class ConfigProblemBanner(Static):
-    """Full-width alert line, hidden while the configuration resolves.
-
-    Hidden-while-clean is safe here and would not be on a status chip:
-    this banner never has to carry the meaning "checked and fine" on
-    its own, because the screen's own content is that answer.
-    """
-
-    def show(self, problem: str | None) -> None:
-        if problem is None:
-            self.display = False
-            self.update("")
-            return
-        self.display = True
-        # A Text, never a str: the line's first token is the section
-        # name in brackets, which Rich reads as markup and DELETES. The
-        # measured result was "configuration unreadable:  invalid
-        # literal for int()" - the fault named, the section missing.
-        self.update(Text(f"▲ configuration unreadable: {problem}"))
-
-
-__all__ = ["ConfigProblemBanner", "env_scrub_is_safe", "load_config"]
+__all__ = ["env_scrub_is_safe"]

--- a/kstrl/tui/config_guard.py
+++ b/kstrl/tui/config_guard.py
@@ -50,41 +50,38 @@ def _handle_is_live(handle: object) -> bool:
 
 
 def env_scrub_is_safe(app: object) -> bool:
-    """Whether clearing ``os.environ`` right now would race a thread.
+    """Whether clearing ``os.environ`` right now would race a run.
 
-    THREE readers, and missing any one of them makes this predicate a
-    lie rather than a guard:
+    TWO readers, both of them a live command handle, because both spawn
+    SUBPROCESSES that inherit the environment and a subprocess cannot be
+    made to wait on a lock:
 
-    1. A home-launched session (``run_context.handle``), which runs the
-       factory on another thread whose subprocesses inherit the
-       environment.
+    1. A home-launched session (``run_context.handle``).
     2. An EMBEDDED-mode orchestrator (``app.orchestrator``). Same
        hazard, DIFFERENT attribute: ``embed.py`` starts the command
        thread and passes it as ``orchestrator=``, while ``run_context``
        comes from ``RunContext.observe``, which leaves ``handle`` None.
        Reading only ``run_context`` returned True with an agent
        mid-spawn.
-    3. The app's own safe-mode worker (``_safe_mode_running``).
-       ``app.py`` schedules ``_check_safe_mode`` every 5 seconds in
-       EVERY mode, and ``safemode.safe_mode_reasons`` loads
-       ``AutonomyConfig``, ``PolicyConfig`` and ``QueueConfig``, all of
-       which read ``KSTRL_*``. Measured before this clause existed:
-       with 84 variables set, a thread polling
-       ``KSTRL_AUTONOMY_LEVEL`` across 50 blaming ``load_or_report``
-       calls saw it MISSING for 95990 of 36.8M reads. A safe-mode tick
-       landing in that window reports the default ladder, so a degraded
-       factory reads nominal on the chip for one tick, which is the
-       silent wrong answer the chip exists to prevent.
 
-    WHY A FLAG READ IS ENOUGH, AND NO LOCK IS NEEDED. Every caller runs
-    on the Textual UI thread (a message handler or an action), the
-    scrub that follows is synchronous and never awaits, and a worker is
-    only ever STARTED from that same thread by a timer callback. So no
-    worker can begin between this check and the scrub, and
-    ``_safe_mode_running`` is cleared in the worker's ``finally`` only
-    after its last config read, which makes True strictly wider than
-    the danger window. Calling this off the UI thread would break that
-    argument, and nothing does.
+    THE THIRD READER IS NOT HERE, AND THAT IS THE POINT. The app's own
+    safe-mode worker also reads ``KSTRL_*``, every 5 seconds, in every
+    mode. Round one of #289 added it to THIS condition, and that was
+    wrong: it closed a race by making two working features
+    intermittent. Measured on an EMPTY project with no run of any kind,
+    ``run_context`` None, the worker's flag was set for 51 to 84 ms out
+    of every 5 s, so ``ConfigScreen.action_refresh`` was denied at
+    random with a message falsely blaming a launched run, and the
+    evolve banner silently dropped the variable it exists to name. On a
+    project whose events.jsonl makes the check exceed its own interval
+    (``app.py`` measures 5.65 s at 500 MiB) the flag never clears and
+    the refusal is permanent.
+
+    That reader is SERIALIZED instead, on ``config_report.environ_lock``,
+    which ``safemode`` takes around its config loads and every scrub
+    takes for its whole duration. The scrub waits at most a few
+    milliseconds rather than being refused, and the race is still
+    closed. Refusal is kept only where waiting cannot work.
 
     ``app`` is typed ``object`` rather than ``App`` on purpose: these
     attributes belong to ``KstrlTuiApp``, not to Textual's ``App``, and
@@ -93,14 +90,12 @@ def env_scrub_is_safe(app: object) -> bool:
     harness and the true one for a shell that has launched nothing.
 
     Deliberately NOT ``KstrlTuiApp.session_in_flight``, which reads one
-    of the three and also requires ``Mode.HOME``. The hazard does not
-    care which mode the app is in.
+    of the two and also requires ``Mode.HOME``. The hazard does not care
+    which mode the app is in.
     """
     if _handle_is_live(getattr(getattr(app, "run_context", None), "handle", None)):
         return False
-    if _handle_is_live(getattr(app, "orchestrator", None)):
-        return False
-    return not bool(getattr(app, "_safe_mode_running", False))
+    return not _handle_is_live(getattr(app, "orchestrator", None))
 
 
 __all__ = ["env_scrub_is_safe"]

--- a/kstrl/tui/home.py
+++ b/kstrl/tui/home.py
@@ -15,6 +15,7 @@ ANSI_RESTORE = "\x1b[?1049l\x1b[?25h\x1b[0m"
 
 
 def run_home_shell(root_dir: Path) -> int:
+    from kstrl.config_preflight import SURFACE_REJECTIONS
     from kstrl.config_report import ConfigReport, build_config_report
     from kstrl.tui.app import KstrlTuiApp, Mode
 
@@ -23,7 +24,12 @@ def run_home_shell(root_dir: Path) -> int:
     config_report: ConfigReport | None
     try:
         config_report = build_config_report(root_dir)
-    except ValueError:
+    except SURFACE_REJECTIONS:
+        # Same imported tuple as the screen's refresh action: `except
+        # ValueError` was one exception narrower than the entry check,
+        # so a toml array where a number belongs escaped as a TypeError
+        # (#289). Latent today, because `cli.cli` rejects that file
+        # before this runs, and one exemption away from being live.
         config_report = None  # the screen renders the guidance line
 
     app = KstrlTuiApp(

--- a/kstrl/tui/home.py
+++ b/kstrl/tui/home.py
@@ -15,7 +15,7 @@ ANSI_RESTORE = "\x1b[?1049l\x1b[?25h\x1b[0m"
 
 
 def run_home_shell(root_dir: Path) -> int:
-    from kstrl.config_preflight import SURFACE_REJECTIONS
+    from kstrl.config_preflight import SURFACE_REJECTIONS, raise_if_defect
     from kstrl.config_report import ConfigReport, build_config_report
     from kstrl.tui.app import KstrlTuiApp, Mode
 
@@ -24,12 +24,18 @@ def run_home_shell(root_dir: Path) -> int:
     config_report: ConfigReport | None
     try:
         config_report = build_config_report(root_dir)
-    except SURFACE_REJECTIONS:
+    except SURFACE_REJECTIONS as exc:
         # Same imported tuple as the screen's refresh action: `except
         # ValueError` was one exception narrower than the entry check,
         # so a toml array where a number belongs escaped as a TypeError
         # (#289). Latent today, because `cli.cli` rejects that file
         # before this runs, and one exemption away from being live.
+        #
+        # The tuple carries RuntimeError for the domain errors deriving
+        # from it, so widening it also widened what a silent `None`
+        # could hide: a defect of ours would have opened the shell with
+        # an empty config screen instead of failing.
+        raise_if_defect(exc)
         config_report = None  # the screen renders the guidance line
 
     app = KstrlTuiApp(

--- a/kstrl/tui/screens/config.py
+++ b/kstrl/tui/screens/config.py
@@ -25,6 +25,7 @@ from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Input, Static
 
 from kstrl.tui import theme
+from kstrl.tui.config_guard import env_scrub_is_safe
 from kstrl.tui.widgets.context_bar import ContextBar
 
 if TYPE_CHECKING:
@@ -205,10 +206,10 @@ class ConfigScreen(Screen[None]):
 
     def action_refresh(self) -> None:
         # The env-scrub is process-wide: never while a launched
-        # session's thread could be reading os.environ.
-        run_context = getattr(self.app, "run_context", None)
-        handle = run_context.handle if run_context is not None else None
-        if handle is not None and not handle.done():
+        # session's thread could be reading os.environ. The predicate
+        # lives in config_guard because the evolve and inbox screens
+        # ask the same question about the same scrub (#289).
+        if not env_scrub_is_safe(self.app):
             self.app.notify(
                 "config refresh is disabled while a run is in flight "
                 "(source detection scrubs the environment)",

--- a/kstrl/tui/screens/config.py
+++ b/kstrl/tui/screens/config.py
@@ -15,6 +15,7 @@ about LIVE diff updates starving input, which does not apply here.
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rich.text import Text
@@ -205,6 +206,24 @@ class ConfigScreen(Screen[None]):
             return
         self.app.pop_screen()
 
+    @staticmethod
+    def _problem_lines(root_dir: Path, exc: Exception) -> list[str]:
+        """The entry check's lines for this root, or the raw failure.
+
+        Safe to blame the environment here: the caller has already
+        established through `env_scrub_is_safe` that no thread of ours
+        is reading it, which is the same condition `build_config_report`
+        needed to run at all.
+        """
+        from kstrl.config_preflight import collect_config_problems
+
+        try:
+            return collect_config_problems(root_dir, warn=lambda _m: None) or [str(exc)]
+        except SURFACE_REJECTIONS as document_exc:
+            # The document will not parse, so no section resolved and
+            # that parse error is the whole report.
+            return [str(document_exc)]
+
     def action_refresh(self) -> None:
         # The env-scrub is process-wide: never while a launched
         # session's thread could be reading os.environ. The predicate
@@ -229,7 +248,17 @@ class ConfigScreen(Screen[None]):
             # out of int(), which `except ValueError` let through and
             # which this refresh action can meet, because it exists to
             # re-read a file the operator has just edited (#289).
-            self.app.notify(f"config failed to resolve: {exc}", severity="error")
+            #
+            # Reported in the SEAM's words, not the bare coercion
+            # message: this is the screen an operator opens to look at
+            # configuration, so "int() argument must be a string ... not
+            # 'list'" with no section, key or value is the one place
+            # that answer is least useful. collect_config_problems is
+            # the same traversal `ks config show` prints.
+            self.app.notify(
+                "config failed to resolve:\n" + "\n".join(self._problem_lines(root_dir, exc)),
+                severity="error",
+            )
             return
         self.app.config_report = report  # type: ignore[attr-defined]
         if report.unresolved:

--- a/kstrl/tui/screens/config.py
+++ b/kstrl/tui/screens/config.py
@@ -15,7 +15,6 @@ about LIVE diff updates starving input, which does not apply here.
 from __future__ import annotations
 
 import re
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rich.text import Text
@@ -25,7 +24,11 @@ from textual.containers import Vertical
 from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Input, Static
 
-from kstrl.config_preflight import SURFACE_REJECTIONS
+from kstrl.config_preflight import (
+    SURFACE_REJECTIONS,
+    config_problem_lines,
+    raise_if_defect,
+)
 from kstrl.tui import theme
 from kstrl.tui.config_guard import env_scrub_is_safe
 from kstrl.tui.widgets.context_bar import ContextBar
@@ -206,24 +209,6 @@ class ConfigScreen(Screen[None]):
             return
         self.app.pop_screen()
 
-    @staticmethod
-    def _problem_lines(root_dir: Path, exc: Exception) -> list[str]:
-        """The entry check's lines for this root, or the raw failure.
-
-        Safe to blame the environment here: the caller has already
-        established through `env_scrub_is_safe` that no thread of ours
-        is reading it, which is the same condition `build_config_report`
-        needed to run at all.
-        """
-        from kstrl.config_preflight import collect_config_problems
-
-        try:
-            return collect_config_problems(root_dir, warn=lambda _m: None) or [str(exc)]
-        except SURFACE_REJECTIONS as document_exc:
-            # The document will not parse, so no section resolved and
-            # that parse error is the whole report.
-            return [str(document_exc)]
-
     def action_refresh(self) -> None:
         # The env-scrub is process-wide: never while a launched
         # session's thread could be reading os.environ. The predicate
@@ -254,9 +239,20 @@ class ConfigScreen(Screen[None]):
             # configuration, so "int() argument must be a string ... not
             # 'list'" with no section, key or value is the one place
             # that answer is least useful. collect_config_problems is
-            # the same traversal `ks config show` prints.
+            # the same traversal `ks config show` prints - the same
+            # FUNCTION, since #304: this screen carried a copy of it
+            # that had already drifted from the CLI's in the empty case.
+            #
+            # A RuntimeError kstrl never defined is our defect, not a
+            # configuration problem, and must not be notified as one.
+            raise_if_defect(exc)
+            # Safe to blame the environment inside that traversal: the
+            # refusal above has established that no thread of ours is
+            # reading os.environ, which is the same condition
+            # build_config_report needed to run at all.
             self.app.notify(
-                "config failed to resolve:\n" + "\n".join(self._problem_lines(root_dir, exc)),
+                "config failed to resolve:\n"
+                + "\n".join(config_problem_lines(root_dir, warn=lambda _m: None) or [str(exc)]),
                 severity="error",
             )
             return

--- a/kstrl/tui/screens/config.py
+++ b/kstrl/tui/screens/config.py
@@ -24,6 +24,7 @@ from textual.containers import Vertical
 from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Input, Static
 
+from kstrl.config_preflight import SURFACE_REJECTIONS
 from kstrl.tui import theme
 from kstrl.tui.config_guard import env_scrub_is_safe
 from kstrl.tui.widgets.context_bar import ContextBar
@@ -223,7 +224,11 @@ class ConfigScreen(Screen[None]):
             return
         try:
             report = build_config_report(root_dir)
-        except ValueError as exc:
+        except SURFACE_REJECTIONS as exc:
+            # Measured: `[run] max_iterations = ["3"]` raises TypeError
+            # out of int(), which `except ValueError` let through and
+            # which this refresh action can meet, because it exists to
+            # re-read a file the operator has just edited (#289).
             self.app.notify(f"config failed to resolve: {exc}", severity="error")
             return
         self.app.config_report = report  # type: ignore[attr-defined]

--- a/kstrl/tui/screens/evolve.py
+++ b/kstrl/tui/screens/evolve.py
@@ -31,8 +31,8 @@ from kstrl.evolution import EvolutionConfig, EvolutionJournal
 from kstrl.interaction import PromptKind, PromptRequest
 from kstrl.proposals import Proposal, apply_proposal, list_proposals
 from kstrl.tui import theme
-from kstrl.tui.config_guard import ConfigProblemBanner, load_config
 from kstrl.tui.screens.options import OptionsModal
+from kstrl.tui.widgets.config_problem import ConfigProblemBanner
 from kstrl.tui.widgets.context_bar import ContextBar
 
 TREND_ROWS = 14
@@ -96,7 +96,7 @@ class EvolveScreen(Screen[None]):
         # Above the tabs, not inside one: an unreadable [evolution]
         # section empties patterns AND trends, and the operator may be
         # looking at proposals when it happens.
-        yield ConfigProblemBanner(id="config-problem")
+        yield ConfigProblemBanner()
         with TabbedContent(id="evolve-tabs"):
             with TabPane("proposals", id="tab-proposals"):
                 with Horizontal(id="proposals-split"):
@@ -188,8 +188,7 @@ class EvolveScreen(Screen[None]):
         empty tables would be worse than the traceback it replaces:
         "no patterns yet" is a real state on this screen.
         """
-        config, problem = load_config(self.app, EvolutionConfig.load, root_dir)
-        self.query_one(ConfigProblemBanner).show(problem)
+        config = self.query_one(ConfigProblemBanner).load(EvolutionConfig.load, root_dir)
         patterns_table = self.query_one("#patterns-table", DataTable)
         patterns_table.clear()
         trends_table = self.query_one("#trends-table", DataTable)

--- a/kstrl/tui/screens/evolve.py
+++ b/kstrl/tui/screens/evolve.py
@@ -31,6 +31,7 @@ from kstrl.evolution import EvolutionConfig, EvolutionJournal
 from kstrl.interaction import PromptKind, PromptRequest
 from kstrl.proposals import Proposal, apply_proposal, list_proposals
 from kstrl.tui import theme
+from kstrl.tui.config_guard import ConfigProblemBanner, load_config
 from kstrl.tui.screens.options import OptionsModal
 from kstrl.tui.widgets.context_bar import ContextBar
 
@@ -92,6 +93,10 @@ class EvolveScreen(Screen[None]):
 
     def compose(self) -> ComposeResult:
         yield ContextBar("evolve", "the harness improving itself")
+        # Above the tabs, not inside one: an unreadable [evolution]
+        # section empties patterns AND trends, and the operator may be
+        # looking at proposals when it happens.
+        yield ConfigProblemBanner(id="config-problem")
         with TabbedContent(id="evolve-tabs"):
             with TabPane("proposals", id="tab-proposals"):
                 with Horizontal(id="proposals-split"):
@@ -175,9 +180,23 @@ class EvolveScreen(Screen[None]):
             )
 
     def _load_patterns_and_trends(self, root_dir: Path) -> None:
-        journal = EvolutionJournal(EvolutionConfig.load(root_dir))
+        """Both journal-backed tabs, or the reason neither can be shown.
+
+        Guarded because this screen is reachable from the home shell,
+        which is not a click command and so never runs the entry check
+        that would have stopped `ks evolve` (#289). Degrading to two
+        empty tables would be worse than the traceback it replaces:
+        "no patterns yet" is a real state on this screen.
+        """
+        config, problem = load_config(self.app, EvolutionConfig.load, root_dir)
+        self.query_one(ConfigProblemBanner).show(problem)
         patterns_table = self.query_one("#patterns-table", DataTable)
         patterns_table.clear()
+        trends_table = self.query_one("#trends-table", DataTable)
+        trends_table.clear()
+        if config is None:
+            return
+        journal = EvolutionJournal(config)
         for pattern in journal.get_cross_run_patterns():
             patterns_table.add_row(
                 Text(pattern.check_name, style="bold"),
@@ -186,8 +205,6 @@ class EvolveScreen(Screen[None]):
                 Text(str(len(pattern.affected_components)), justify="right"),
                 Text(pattern.category, style=theme.MUTED),
             )
-        trends_table = self.query_one("#trends-table", DataTable)
-        trends_table.clear()
         for row in journal.get_experiment_trends(last_n=TREND_ROWS):
             trends_table.add_row(*self._trend_cells(row))
 

--- a/kstrl/tui/screens/inbox.py
+++ b/kstrl/tui/screens/inbox.py
@@ -27,6 +27,7 @@ from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Static
 
 from kstrl.inbox import Inbox, InboxConfig, InboxError, InboxItem
+from kstrl.tui.config_guard import ConfigProblemBanner, load_config
 from kstrl.tui.widgets.context_bar import ContextBar
 
 _PRIORITY_STYLE = {"high": "bold red", "normal": "", "low": "dim"}
@@ -57,10 +58,12 @@ class InboxScreen(Screen[None]):
         self._root = Path(root_dir) if root_dir else Path.cwd()
         self._show_decided = False
         self._items: list[InboxItem] = []
+        self._unreadable = False
 
     # -- composition -------------------------------------------------------
     def compose(self) -> ComposeResult:
         yield ContextBar("inbox")
+        yield ConfigProblemBanner(id="config-problem")
         with Horizontal():
             yield DataTable(id="inbox-table")
             yield Static("", id="inbox-detail")
@@ -73,14 +76,28 @@ class InboxScreen(Screen[None]):
         self.action_refresh()
 
     # -- data --------------------------------------------------------------
-    def _inbox(self) -> Inbox:
-        return Inbox(self._root, InboxConfig.load(self._root))
+    def _inbox(self) -> Inbox | None:
+        """The inbox, or None with the banner saying why (#289).
+
+        Re-read per call rather than cached: this screen outlives edits
+        to kstrl.toml, which is the same reason the config screen has a
+        refresh action. That is also why the guard is here and not only
+        at mount - the file can break between two keystrokes.
+        """
+        config, problem = load_config(self.app, InboxConfig.load, self._root)
+        self.query_one(ConfigProblemBanner).show(problem)
+        self._unreadable = problem is not None
+        return None if config is None else Inbox(self._root, config)
 
     def action_refresh(self) -> None:
         box = self._inbox()
-        self._items = box.items() if self._show_decided else box.open_items()
         table = self.query_one("#inbox-table", DataTable)
         table.clear()
+        if box is None:
+            self._items = []
+            self._render_detail()
+            return
+        self._items = box.items() if self._show_decided else box.open_items()
         for item in self._items:
             repeat = f" x{item.occurrences}" if item.occurrences > 1 else ""
             table.add_row(
@@ -106,9 +123,12 @@ class InboxScreen(Screen[None]):
         detail = self.query_one("#inbox-detail", Static)
         item = self._selected()
         if item is None:
+            # "Inbox clear" is a claim about the log. It must never be
+            # made from an empty list that only means the config would
+            # not load - the banner is carrying that answer instead.
             detail.update(
                 Text("Inbox clear: nothing is waiting on you.", style="dim")
-                if not self._items
+                if not self._items and not self._unreadable
                 else Text("")
             )
             return
@@ -141,6 +161,11 @@ class InboxScreen(Screen[None]):
         if item is None:
             return
         box = self._inbox()
+        if box is None:
+            # The file broke since the list was drawn. Redraw through
+            # the one path that renders that state.
+            self.action_refresh()
+            return
         try:
             if action == "approve":
                 box.approve(item.id, actor=self._actor(), comment=comment)

--- a/kstrl/tui/screens/inbox.py
+++ b/kstrl/tui/screens/inbox.py
@@ -27,7 +27,7 @@ from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Static
 
 from kstrl.inbox import Inbox, InboxConfig, InboxError, InboxItem
-from kstrl.tui.config_guard import ConfigProblemBanner, load_config
+from kstrl.tui.widgets.config_problem import ConfigProblemBanner
 from kstrl.tui.widgets.context_bar import ContextBar
 
 _PRIORITY_STYLE = {"high": "bold red", "normal": "", "low": "dim"}
@@ -58,12 +58,11 @@ class InboxScreen(Screen[None]):
         self._root = Path(root_dir) if root_dir else Path.cwd()
         self._show_decided = False
         self._items: list[InboxItem] = []
-        self._unreadable = False
 
     # -- composition -------------------------------------------------------
     def compose(self) -> ComposeResult:
         yield ContextBar("inbox")
-        yield ConfigProblemBanner(id="config-problem")
+        yield ConfigProblemBanner()
         with Horizontal():
             yield DataTable(id="inbox-table")
             yield Static("", id="inbox-detail")
@@ -84,13 +83,18 @@ class InboxScreen(Screen[None]):
         refresh action. That is also why the guard is here and not only
         at mount - the file can break between two keystrokes.
         """
-        config, problem = load_config(self.app, InboxConfig.load, self._root)
-        self.query_one(ConfigProblemBanner).show(problem)
-        self._unreadable = problem is not None
+        config = self.query_one(ConfigProblemBanner).load(InboxConfig.load, self._root)
         return None if config is None else Inbox(self._root, config)
 
     def action_refresh(self) -> None:
-        box = self._inbox()
+        self._redraw(self._inbox())
+
+    def _redraw(self, box: Inbox | None) -> None:
+        """The table and detail for a box already loaded, or for None.
+
+        Split from the load so a caller holding the answer does not
+        throw it away and load again to get the same one.
+        """
         table = self.query_one("#inbox-table", DataTable)
         table.clear()
         if box is None:
@@ -125,10 +129,12 @@ class InboxScreen(Screen[None]):
         if item is None:
             # "Inbox clear" is a claim about the log. It must never be
             # made from an empty list that only means the config would
-            # not load - the banner is carrying that answer instead.
+            # not load, so the banner is asked rather than a second
+            # copy of its answer being kept beside it.
+            unreadable = self.query_one(ConfigProblemBanner).problem is not None
             detail.update(
                 Text("Inbox clear: nothing is waiting on you.", style="dim")
-                if not self._items and not self._unreadable
+                if not self._items and not unreadable
                 else Text("")
             )
             return
@@ -162,9 +168,9 @@ class InboxScreen(Screen[None]):
             return
         box = self._inbox()
         if box is None:
-            # The file broke since the list was drawn. Redraw through
-            # the one path that renders that state.
-            self.action_refresh()
+            # The file broke since the list was drawn. Render that
+            # state from the answer already in hand.
+            self._redraw(None)
             return
         try:
             if action == "approve":

--- a/kstrl/tui/screens/inbox.py
+++ b/kstrl/tui/screens/inbox.py
@@ -183,7 +183,13 @@ class InboxScreen(Screen[None]):
             self.notify(str(exc), severity="error")
             return
         self.notify(f"{action}d: {item.title}")
-        self.action_refresh()
+        # _redraw, not action_refresh: this holds the Inbox already and
+        # `box.items()` re-reads the log from disk, so the post-decision
+        # state renders identically with one config load instead of two.
+        # Throwing the answer away to load it again is the exact waste
+        # _redraw was split out to prevent, and on a broken kstrl.toml
+        # it doubled the os.environ scrub window per keystroke.
+        self._redraw(box)
 
     @staticmethod
     def _actor() -> str:

--- a/kstrl/tui/screens/init_wizard.py
+++ b/kstrl/tui/screens/init_wizard.py
@@ -22,6 +22,7 @@ from textual.message import Message
 from textual.screen import Screen
 from textual.widgets import Button, Footer, Input, Select, Static
 
+from kstrl.config_preflight import SURFACE_REJECTIONS
 from kstrl.init_cmd import run_init
 from kstrl.init_wizard import (
     AGENT_TYPES,
@@ -67,16 +68,24 @@ def _detected_text(root: Path) -> Text:
     they cannot share a line.
 
     VerifyConfig.load raises ValueError on malformed TOML by design
-    (config._load_toml), and this is the screen an operator opens to
-    repair a broken scaffold, so it reports one rather than taking the
-    app down on mount.
+    (config.load_toml_document), and this is the screen an operator
+    opens to repair a broken scaffold, so it reports one rather than
+    taking the app down on mount.
+
+    The rejection set is IMPORTED, not restated. It was
+    ``(ValueError, OSError)``, one exception narrower than the entry
+    check: ``[verify] self_critique_min_bullets = ["3"]`` coerces
+    through ``int()`` and raises TypeError, which this guard did not
+    catch (#289). This screen keeps its own one-line message rather
+    than the shared banner, because the row it is replacing belongs to
+    a labelled block that has no room for a section and a value.
     """
     rows: list[tuple[str, str]] = [
         ("detected", detect_context(root).get("language", "unknown")),
     ]
     try:
         commands = resolve_verify_commands(VerifyConfig.load(root), root)
-    except (ValueError, OSError):
+    except SURFACE_REJECTIONS:
         rows.append(("verify", "kstrl.toml is unreadable; cannot show gate commands"))
     else:
         rows += [

--- a/kstrl/tui/screens/init_wizard.py
+++ b/kstrl/tui/screens/init_wizard.py
@@ -22,7 +22,7 @@ from textual.message import Message
 from textual.screen import Screen
 from textual.widgets import Button, Footer, Input, Select, Static
 
-from kstrl.config_preflight import SURFACE_REJECTIONS
+from kstrl.config_preflight import SURFACE_REJECTIONS, raise_if_defect
 from kstrl.init_cmd import run_init
 from kstrl.init_wizard import (
     AGENT_TYPES,
@@ -85,7 +85,8 @@ def _detected_text(root: Path) -> Text:
     ]
     try:
         commands = resolve_verify_commands(VerifyConfig.load(root), root)
-    except SURFACE_REJECTIONS:
+    except SURFACE_REJECTIONS as exc:
+        raise_if_defect(exc)
         rows.append(("verify", "kstrl.toml is unreadable; cannot show gate commands"))
     else:
         rows += [

--- a/kstrl/tui/session.py
+++ b/kstrl/tui/session.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from kstrl.agents.base import ARCHITECT_COMPONENT
 from kstrl.commandrun import open_command_run
 from kstrl.config import KstrlConfig
-from kstrl.config_preflight import SURFACE_REJECTIONS
+from kstrl.config_preflight import SURFACE_REJECTIONS, raise_if_defect
 from kstrl.events import CallbackSink, EventBus, RunPaths
 from kstrl.git import resolve_base_branch
 from kstrl.interaction import QueueInteractionChannel
@@ -202,6 +202,10 @@ def _prepare_factory(spec: FactoryLaunch, root_dir: Path) -> PreparedLaunch:
         # float() and escaped, taking the shell down at launch (#289).
         # Reachable only by editing kstrl.toml with the shell already
         # open, because the entry check rejects that file otherwise.
+        #
+        # A RuntimeError kstrl did not define is not a launch problem to
+        # report to the operator, it is a bug of ours wearing one.
+        raise_if_defect(exc)
         raise LaunchError(f"failed to load configuration: {exc}") from exc
     _preflight_agent(base_config)
     if spec.max_parallel is not None:
@@ -251,7 +255,9 @@ def _prepare_decompose(
     try:
         config = KstrlConfig.load(root_dir)
     except SURFACE_REJECTIONS as exc:
-        # The same widening as _prepare_factory, for the same reason.
+        # The same widening as _prepare_factory, for the same reason,
+        # and the same guard against it hiding one of our own defects.
+        raise_if_defect(exc)
         raise LaunchError(f"failed to load configuration: {exc}") from exc
     _preflight_agent(config)
     agent = get_agent(

--- a/kstrl/tui/session.py
+++ b/kstrl/tui/session.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 from kstrl.agents.base import ARCHITECT_COMPONENT
 from kstrl.commandrun import open_command_run
 from kstrl.config import KstrlConfig
+from kstrl.config_preflight import SURFACE_REJECTIONS
 from kstrl.events import CallbackSink, EventBus, RunPaths
 from kstrl.git import resolve_base_branch
 from kstrl.interaction import QueueInteractionChannel
@@ -194,7 +195,13 @@ def _prepare_factory(spec: FactoryLaunch, root_dir: Path) -> PreparedLaunch:
             root_dir,
             single_pr=manifest.single_pr,
         )
-    except (OSError, ValueError) as exc:
+    except SURFACE_REJECTIONS as exc:
+        # IMPORTED, not restated. This used to be (OSError, ValueError),
+        # which is narrower than the entry check's own set: measured,
+        # `[timeout] git_operation = ["30"]` raises TypeError out of
+        # float() and escaped, taking the shell down at launch (#289).
+        # Reachable only by editing kstrl.toml with the shell already
+        # open, because the entry check rejects that file otherwise.
         raise LaunchError(f"failed to load configuration: {exc}") from exc
     _preflight_agent(base_config)
     if spec.max_parallel is not None:
@@ -243,7 +250,8 @@ def _prepare_decompose(
 
     try:
         config = KstrlConfig.load(root_dir)
-    except (OSError, ValueError) as exc:
+    except SURFACE_REJECTIONS as exc:
+        # The same widening as _prepare_factory, for the same reason.
         raise LaunchError(f"failed to load configuration: {exc}") from exc
     _preflight_agent(config)
     agent = get_agent(

--- a/kstrl/tui/styles.tcss
+++ b/kstrl/tui/styles.tcss
@@ -120,8 +120,10 @@ DataTable {
 /* Same alert grammar as the safe-mode banner, but height: auto - this
  * one carries a section, a loader message and the input that set it,
  * and a truncated repair instruction is not a repair instruction. It
- * collapses to nothing while the config resolves (display: none). */
-#config-problem {
+ * collapses to nothing while the config resolves (display: none).
+ * Selected by TYPE, not by id: a screen that mistyped an id would get
+ * an unstyled, always-visible bar and no error saying so. */
+ConfigProblemBanner {
     display: none;
     height: auto;
     background: $error 18%;

--- a/kstrl/tui/styles.tcss
+++ b/kstrl/tui/styles.tcss
@@ -117,6 +117,19 @@ DataTable {
     padding: 0 2;
 }
 
+/* Same alert grammar as the safe-mode banner, but height: auto - this
+ * one carries a section, a loader message and the input that set it,
+ * and a truncated repair instruction is not a repair instruction. It
+ * collapses to nothing while the config resolves (display: none). */
+#config-problem {
+    display: none;
+    height: auto;
+    background: $error 18%;
+    color: $error;
+    text-style: bold;
+    padding: 0 2;
+}
+
 /* ---- overview board ---------------------------------------------------- */
 
 #component-table {

--- a/kstrl/tui/widgets/config_problem.py
+++ b/kstrl/tui/widgets/config_problem.py
@@ -1,0 +1,76 @@
+"""The banner a screen shows instead of a config it could not read.
+
+Sibling of ``safe_mode_chip.SafeModeBanner`` and deliberately the same
+alert grammar: a full-width line, hidden while nominal, one glyph and
+then the words. It differs in two ways that are about its content, not
+its taste. It is styled by TYPE rather than by id, because a screen
+that mistyped the id would get an unstyled always-visible bar with no
+error, and it is ``height: auto``, because the line carries a section,
+a loader message and the input that set it, and a truncated repair
+instruction is not a repair instruction.
+
+The load lives here rather than beside the call site so that reading
+the config and rendering the failure cannot come apart: a screen that
+remembered the first and forgot the second would degrade silently,
+which is the failure #289 exists to remove.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+
+from rich.text import Text
+from textual.widgets import Static
+
+from kstrl.config_preflight import load_or_report
+from kstrl.tui.config_guard import env_scrub_is_safe
+
+T = TypeVar("T")
+
+
+class ConfigProblemBanner(Static):
+    """Hidden while the configuration resolves; the reason when it does not.
+
+    Hidden-while-clean is safe here and would not be on a status chip:
+    this banner never has to carry the meaning "checked and fine" on
+    its own, because the screen's own content is that answer.
+    """
+
+    #: The line currently shown, or None while the config resolves. The
+    #: one copy of that fact: a screen asks the banner rather than
+    #: keeping a bool beside it that has to be kept in step.
+    problem: str | None = None
+
+    def load(self, loader: Callable[[Path], T], root_dir: Path) -> T | None:
+        """The section for ``root_dir``, or None with the reason shown.
+
+        One call, so a screen cannot do the load and forget the render.
+        ``blame_env`` is answered from the app: naming the offending
+        environment variable is measured by clearing ``os.environ``,
+        which is process-wide (see :func:`env_scrub_is_safe`).
+        """
+        config, problem = load_or_report(
+            loader,
+            root_dir,
+            blame_env=env_scrub_is_safe(self.app),
+        )
+        self.show(problem)
+        return config
+
+    def show(self, problem: str | None) -> None:
+        self.problem = problem
+        if problem is None:
+            self.display = False
+            self.update("")
+            return
+        self.display = True
+        # A Text, never a str: the line's first token is the section
+        # name in brackets, which Rich reads as markup and DELETES. The
+        # measured result was "configuration unreadable:  invalid
+        # literal for int()" - the fault named, the section missing.
+        self.update(Text(f"▲ configuration unreadable: {problem}"))
+
+
+__all__ = ["ConfigProblemBanner"]

--- a/tests/helpers/tui_screens.py
+++ b/tests/helpers/tui_screens.py
@@ -1,0 +1,43 @@
+"""Opening a home-shell screen on a project directory, once.
+
+Two test files push ``EvolveScreen`` at a tmp_path and assert on what it
+renders: one about a broken kstrl.toml, one about undecodable data
+files. The pauses below are not incidental - they are the empirical
+precedent from ``tests/test_evolve_screen.py`` for THIS screen - so a
+second copy of them is a second thing to get subtly wrong.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from textual.pilot import Pilot
+
+from kstrl.tui.app import KstrlTuiApp, Mode
+from kstrl.tui.screens.evolve import EvolveScreen
+
+
+def home_app(root_dir: Path) -> KstrlTuiApp:
+    """The home shell on ``root_dir``, polling fast enough to test."""
+    return KstrlTuiApp(root_dir=root_dir, mode=Mode.HOME, poll_interval=0.05)
+
+
+@asynccontextmanager
+async def evolve_screen(root_dir: Path) -> AsyncIterator[tuple[EvolveScreen, Pilot[None]]]:
+    """The evolve screen open on ``root_dir``.
+
+    The 0.2s pauses mirror ``tests/test_evolve_screen.py``, which is
+    the empirical precedent for this screen: it composes a
+    TabbedContent whose panes mount on a later frame, and every test
+    there waits the same way.
+    """
+    app = home_app(root_dir)
+    async with app.run_test(size=(140, 40)) as pilot:
+        await pilot.pause(0.2)
+        app.push_screen(EvolveScreen())
+        await pilot.pause(0.2)
+        screen = app.screen
+        assert isinstance(screen, EvolveScreen)
+        yield screen, pilot

--- a/tests/test_evolve_screen_encoding.py
+++ b/tests/test_evolve_screen_encoding.py
@@ -1,0 +1,164 @@
+"""The evolve screen against files kstrl wrote and cannot read back.
+
+Split out of ``test_tui_config_guard.py`` when the file-length ratchet
+fired a second time, and it was right a second time: that file is about
+a broken kstrl.toml, and this one is about a broken DATA file. Different
+contract, different write side, different fix.
+
+The contract is the one CLAUDE.md states: kstrl writes utf-8, so every
+reader of a file kstrl writes must NAME utf-8 and must catch
+``ValueError`` alongside ``OSError``, because ``UnicodeDecodeError`` is
+a ``ValueError`` and walks straight out of a fail-closed ``except
+OSError``. ``EvolveScreen.on_mount`` reads three such files in a row and
+all three had the defect; the round-one fix caught two of them and the
+test that claimed "both" is why the third survived a review.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from textual.widgets import DataTable
+
+from kstrl.evolution import EvolutionConfig
+from kstrl.tui.widgets.config_problem import ConfigProblemBanner
+from tests.helpers.tui_screens import evolve_screen
+
+
+def test_a_non_utf8_experiments_file_does_not_crash_the_evolve_screen(
+    tmp_path: Path,
+) -> None:
+    """Finding 4, and the crash class #289 is about.
+
+    UnicodeDecodeError IS a ValueError, so it escaped the `except
+    OSError` in get_experiment_trends and raised out of on_mount two
+    lines after the config banner. CLAUDE.md names this rule verbatim.
+    """
+    from kstrl.evolution import EvolutionJournal
+
+    kstrl_dir = tmp_path / ".kstrl"
+    kstrl_dir.mkdir()
+    (kstrl_dir / "experiments.tsv").write_bytes(b"run_id\tcompleted\n2026-\xe9x\t1\n")
+    journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
+    assert journal.get_experiment_trends(last_n=5) == []
+
+
+def test_a_non_utf8_proposal_does_not_crash_the_evolve_screen(tmp_path: Path) -> None:
+    """The same defect one line earlier in the same on_mount:
+    list_proposals read with no encoding behind `except OSError`."""
+    from kstrl.proposals import existing_proposal_titles, list_proposals
+
+    proposals = tmp_path / ".kstrl" / "proposals"
+    proposals.mkdir(parents=True)
+    (proposals / "prop-001.md").write_bytes(
+        b"# PROP-001: \xe9\xe9\xe9 title\n**Type**: computational\n"
+    )
+    assert list_proposals(proposals) == []
+    assert existing_proposal_titles(proposals) == set()
+
+
+def test_a_non_utf8_journal_does_not_crash_the_evolve_screen(tmp_path: Path) -> None:
+    """The THIRD undecodable reader on the same on_mount.
+
+    ``get_cross_run_patterns`` reads the journal through
+    ``observability.read_progress_events``, which opened with the
+    locale encoding behind ``except OSError``. Measured on bea6c30:
+    UnicodeDecodeError out of ``for line in f`` at observability.py:418,
+    straight into the Textual event loop, with the two sibling readers
+    already fixed. "Both" was three.
+    """
+    from kstrl.evolution import EvolutionJournal
+
+    kstrl_dir = tmp_path / ".kstrl"
+    kstrl_dir.mkdir()
+    (kstrl_dir / "evolution.jsonl").write_bytes(
+        b'{"event_type": "component_result", "run_id": "r1", "component_id": "\xe9x"}\n'
+    )
+    journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
+    assert journal.get_cross_run_patterns() == []
+
+
+def test_the_journal_reader_is_shared_with_ks_status() -> None:
+    """So the fix is not the evolve screen's alone.
+
+    ``read_progress_events`` is the one reader for the progress log:
+    ``ks status`` renders from it, the reducer replays from it and the
+    evolution journal derives its cross-run patterns from it. Another
+    agent flagged the same gap from ``ks status``; it is the same line.
+    """
+    src = Path(__file__).resolve().parent.parent / "kstrl"
+    cli = (src / "cli.py").read_text(encoding="utf-8")
+    reducer = (src / "reducer.py").read_text(encoding="utf-8")
+    evolution = (src / "evolution.py").read_text(encoding="utf-8")
+    assert "read_progress_events(progress_log_path)" in cli
+    assert "read_progress_events(v1_path)" in reducer
+    assert "read_progress_events(self.config.journal_path)" in evolution
+    observability = (src / "observability.py").read_text(encoding="utf-8")
+    assert 'with open(path, encoding="utf-8") as f:' in observability
+    assert "except (OSError, ValueError):" in observability
+
+
+async def test_the_evolve_screen_survives_all_three_undecodable_files(tmp_path: Path) -> None:
+    """The three above, through the screen, which is where it mattered."""
+    kstrl_dir = tmp_path / ".kstrl"
+    (kstrl_dir / "proposals").mkdir(parents=True)
+    (kstrl_dir / "proposals" / "prop-001.md").write_bytes(b"# PROP-001: \xe9\xe9\xe9\n")
+    (kstrl_dir / "experiments.tsv").write_bytes(b"run_id\tcompleted\n2026-\xe9x\t1\n")
+    (kstrl_dir / "evolution.jsonl").write_bytes(
+        b'{"event_type": "component_result", "run_id": "r1", "component_id": "\xe9x"}\n'
+    )
+    async with evolve_screen(tmp_path) as (screen, _pilot):
+        assert screen.query_one("#trends-table", DataTable).row_count == 0
+        assert screen.query_one("#proposals-table", DataTable).row_count == 0
+        assert screen.query_one("#patterns-table", DataTable).row_count == 0
+        # The config itself is fine, so the banner must NOT claim it is
+        # unreadable: these are data files, not configuration.
+        assert screen.query_one(ConfigProblemBanner).display is False
+
+
+def test_experiments_tsv_is_written_with_the_encoding_it_is_read_with(tmp_path: Path) -> None:
+    """Encoding is a two-sided contract (CLAUDE.md): naming utf-8 on the
+    read while the write follows the locale just moves the failure."""
+    root = Path(__file__).resolve().parent.parent
+    source = (root / "kstrl" / "evolution.py").read_text(encoding="utf-8")
+    assert 'open(self.config.experiments_path, "a", encoding="utf-8")' in source
+    assert 'read_text(encoding="utf-8")' in source
+
+
+def test_a_proposal_survives_being_written_under_an_ascii_locale(tmp_path: Path) -> None:
+    """The WRITE side of the proposal reader fixed two tests up.
+
+    `save_proposals` wrote prop-*.md with the locale encoding, and its
+    text is LLM output: one curly quote makes that a UnicodeEncodeError,
+    which is a ValueError and so walks out of the adjacent `except
+    OSError`. Measured: under a US-ASCII preferred encoding,
+    `write_text` raises. That write is explicitly non-fatal ("proposal
+    write failed (non-fatal)"), so this took the run down instead.
+
+    A child process, because `locale.getpreferredencoding` is read at
+    interpreter start; the helper is IMPORTED from test_atomicio rather
+    than copied, which is what #291 set it up for.
+    """
+    from tests.test_atomicio import run_under_c_locale
+
+    body = (
+        "from pathlib import Path\n"
+        "from kstrl.evolution import EvolutionConfig, EvolutionJournal, HarnessProposal\n"
+        "out = Path(sys.argv[1])\n"
+        "journal = EvolutionJournal(EvolutionConfig.load(out))\n"
+        "written = journal.save_proposals([HarnessProposal(\n"
+        "    id='PROP-001',\n"
+        "    title='quote',\n"
+        "    description='the agent\\u2019s note',\n"
+        "    proposal_type='computational',\n"
+        "    target='claude_md',\n"
+        "    suggested_change='c',\n"
+        "    source_patterns=[],\n"
+        ")], out)\n"
+        "print(len(written))\n"
+    )
+    result = run_under_c_locale(tmp_path, body, str(tmp_path))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "1", result.stdout
+    written = (tmp_path / "prop-001.md").read_bytes()
+    assert "the agent\u2019s note".encode() in written

--- a/tests/test_tui_config_guard.py
+++ b/tests/test_tui_config_guard.py
@@ -657,6 +657,30 @@ def test_the_config_screen_and_ks_config_show_share_one_problem_reporter() -> No
     assert "config_problem_lines(root_dir, warn=" in cli
 
 
+def test_the_entry_check_does_not_list_our_own_defect_as_a_config_problem(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The seam all three reporting surfaces route through.
+
+    ``ks config show``, the TUI config screen and the entry check
+    itself all reach ``collect_config_problems``, so a RuntimeError
+    kstrl never defined being listed there as the operator's broken
+    file is the same defect as findings 2 and 6, one call deeper and
+    reachable from all of them.
+    """
+    import kstrl.evolution
+
+    def _explode(root_dir: Path | None = None) -> None:
+        raise NotImplementedError("a loader we forgot to finish")
+
+    monkeypatch.setattr(kstrl.evolution.EvolutionConfig, "load", _explode)
+    with pytest.raises(NotImplementedError):
+        collect_config_problems(tmp_path, warn=lambda _m: None)
+    with pytest.raises(NotImplementedError):
+        config_problem_lines(tmp_path, warn=lambda _m: None)
+
+
 def test_the_shared_reporter_gives_the_document_error_when_nothing_parses(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_tui_config_guard.py
+++ b/tests/test_tui_config_guard.py
@@ -35,19 +35,24 @@ from textual.screen import Screen
 from textual.widgets import DataTable, Static
 
 from kstrl.config import ConfigError
-from kstrl.config_preflight import collect_config_problems, load_or_report, preflight_config
+from kstrl.config_preflight import (
+    collect_config_problems,
+    config_problem_lines,
+    load_or_report,
+    preflight_config,
+    raise_if_defect,
+)
 from kstrl.config_report import build_config_report
 from kstrl.evolution import EvolutionConfig
 from kstrl.inbox import Inbox, InboxConfig, ItemKind
 from kstrl.launch import FactoryLaunch
 from kstrl.timeout import TimeoutConfig
-from kstrl.tui.app import KstrlTuiApp, Mode
 from kstrl.tui.config_guard import env_scrub_is_safe
-from kstrl.tui.screens.evolve import EvolveScreen
 from kstrl.tui.screens.inbox import InboxScreen
 from kstrl.tui.screens.init_wizard import _detected_text
 from kstrl.tui.session import LaunchError, start_run_session
 from kstrl.tui.widgets.config_problem import ConfigProblemBanner
+from tests.helpers.tui_screens import evolve_screen, home_app
 from tests.spine_utils import make_manifest
 
 BAD_KNOB = '[evolution]\nlookback_runs = "many"\n'
@@ -64,29 +69,6 @@ class _Harness(App[None]):
 
 def _banner_text(screen: Screen[Any]) -> str:
     return str(screen.query_one(ConfigProblemBanner).render())
-
-
-def _home_app(tmp_path: Path) -> KstrlTuiApp:
-    return KstrlTuiApp(root_dir=tmp_path, mode=Mode.HOME, poll_interval=0.05)
-
-
-@asynccontextmanager
-async def _evolve(tmp_path: Path) -> AsyncIterator[tuple[EvolveScreen, Pilot[None]]]:
-    """The evolve screen open on ``tmp_path``.
-
-    The 0.2s pauses mirror ``tests/test_evolve_screen.py``, which is
-    the empirical precedent for THIS screen: it composes a
-    TabbedContent whose panes mount on a later frame, and every test
-    there waits the same way.
-    """
-    app = _home_app(tmp_path)
-    async with app.run_test(size=(140, 40)) as pilot:
-        await pilot.pause(0.2)
-        app.push_screen(EvolveScreen())
-        await pilot.pause(0.2)
-        screen = app.screen
-        assert isinstance(screen, EvolveScreen)
-        yield screen, pilot
 
 
 @asynccontextmanager
@@ -136,7 +118,7 @@ def test_ks_evolve_still_stops_on_the_same_file(tmp_path: Path) -> None:
 class TestEvolveScreen:
     async def test_a_bad_knob_is_named_instead_of_raised(self, tmp_path: Path) -> None:
         (tmp_path / "kstrl.toml").write_text(BAD_KNOB, encoding="utf-8")
-        async with _evolve(tmp_path) as (screen, _pilot):
+        async with evolve_screen(tmp_path) as (screen, _pilot):
             text = _banner_text(screen)
             assert "configuration unreadable" in text
             # The section name survives: it is bracketed, and Rich reads
@@ -153,14 +135,14 @@ class TestEvolveScreen:
     ) -> None:
         """Not a silent degrade: no rows, and a line saying why."""
         (tmp_path / "kstrl.toml").write_text(BAD_KNOB, encoding="utf-8")
-        async with _evolve(tmp_path) as (screen, _pilot):
+        async with evolve_screen(tmp_path) as (screen, _pilot):
             assert screen.query_one("#patterns-table", DataTable).row_count == 0
             assert screen.query_one("#trends-table", DataTable).row_count == 0
             assert "[evolution]" in _banner_text(screen)
 
     async def test_a_malformed_document_is_named_too(self, tmp_path: Path) -> None:
         (tmp_path / "kstrl.toml").write_text(BAD_DOCUMENT, encoding="utf-8")
-        async with _evolve(tmp_path) as (screen, _pilot):
+        async with evolve_screen(tmp_path) as (screen, _pilot):
             text = _banner_text(screen)
             assert "Invalid TOML" in text
             assert "line 1" in text
@@ -171,7 +153,7 @@ class TestEvolveScreen:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "lots")
-        async with _evolve(tmp_path) as (screen, _pilot):
+        async with evolve_screen(tmp_path) as (screen, _pilot):
             assert "set by KSTRL_EVOLUTION_LOOKBACK_RUNS=lots" in _banner_text(screen)
 
     async def test_the_banner_is_hidden_on_a_config_that_resolves(
@@ -179,7 +161,7 @@ class TestEvolveScreen:
         tmp_path: Path,
     ) -> None:
         (tmp_path / "kstrl.toml").write_text(GOOD_KNOB, encoding="utf-8")
-        async with _evolve(tmp_path) as (screen, _pilot):
+        async with evolve_screen(tmp_path) as (screen, _pilot):
             assert screen.query_one(ConfigProblemBanner).display is False
             assert screen.query_one(ConfigProblemBanner).problem is None
 
@@ -189,7 +171,7 @@ class TestEvolveScreen:
     ) -> None:
         toml = tmp_path / "kstrl.toml"
         toml.write_text(BAD_KNOB, encoding="utf-8")
-        async with _evolve(tmp_path) as (screen, pilot):
+        async with evolve_screen(tmp_path) as (screen, pilot):
             assert screen.query_one(ConfigProblemBanner).display is True
             toml.write_text(GOOD_KNOB, encoding="utf-8")
             screen.action_reload()
@@ -369,6 +351,77 @@ class TestSharedGuard:
         with pytest.raises(RuntimeError, match="journal config exploded"):
             load_or_report(EvolutionConfig.load, tmp_path, blame_env=False)
 
+    @pytest.mark.parametrize(
+        "defect",
+        [
+            RuntimeError("bare"),
+            NotImplementedError("abstract loader"),
+            RecursionError("cycle in the config graph"),
+        ],
+        ids=["bare", "not_implemented", "recursion"],
+    )
+    def test_every_runtimeerror_kstrl_did_not_define_is_re_raised(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        defect: RuntimeError,
+    ) -> None:
+        """Round-two review, finding 2.
+
+        The first cut of the test above wrote ``type(exc) is
+        RuntimeError``, which is true only of a BARE one.
+        NotImplementedError and RecursionError are direct RuntimeError
+        subclasses and unambiguously defects, and both were reported to
+        the operator as "configuration unreadable" with the traceback
+        eaten. RecursionError is the one that hurts: a cycle in the
+        config graph would have been rendered as their broken file.
+        """
+        import kstrl.evolution
+
+        def _explode(root_dir: Path | None = None) -> None:
+            raise defect
+
+        monkeypatch.setattr(kstrl.evolution.EvolutionConfig, "load", _explode)
+        with pytest.raises(type(defect)):
+            load_or_report(EvolutionConfig.load, tmp_path, blame_env=False)
+
+    def test_the_domain_rule_is_derived_from_kstrl_not_listed(self) -> None:
+        """No ledger to go stale.
+
+        The reviewer's suggested fix was a tuple of the four domain
+        errors named in REJECTIONS' docstring. kstrl defines TEN
+        RuntimeError subclasses, so that tuple would have been wrong on
+        the day it was written and staler with each new one. The rule
+        asks a derivable question instead - did kstrl define this class
+        - and this test walks the package to check the answer holds for
+        every one of them.
+        """
+        import ast
+        import importlib
+
+        src = Path(__file__).resolve().parent.parent / "kstrl"
+        subclasses: list[type[BaseException]] = []
+        for path in sorted(src.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            module = path.relative_to(src.parent).with_suffix("").as_posix().replace("/", ".")
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ClassDef):
+                    continue
+                if not any(
+                    isinstance(base, ast.Name) and base.id == "RuntimeError" for base in node.bases
+                ):
+                    continue
+                subclasses.append(getattr(importlib.import_module(module), node.name))
+        assert len(subclasses) >= 10, subclasses
+        for cls in subclasses:
+            raise_if_defect(cls("operator input"))  # must not raise
+        for defect in (RuntimeError, NotImplementedError, RecursionError):
+            with pytest.raises(defect):
+                raise_if_defect(defect("ours"))
+        # And nothing outside RuntimeError is this rule's business.
+        raise_if_defect(ValueError("a knob"))
+        raise_if_defect(OSError("a file"))
+
     def test_a_domain_runtimeerror_is_still_reported(self, tmp_path: Path) -> None:
         """The other side of the same line: ServeError and friends are
         operator input and must still reach the banner."""
@@ -484,13 +537,23 @@ def test_ks_config_show_names_the_section_instead_of_a_traceback(tmp_path: Path)
     assert "[run]" in result.output
 
 
-def test_the_env_scrub_predicate_sees_all_three_readers() -> None:
-    """Finding 2 and 3.
+def test_the_env_scrub_predicate_sees_both_launched_run_handles() -> None:
+    """Round 1 finding 3, and the correction round 2 made to finding 2.
 
-    The safe-mode worker reads KSTRL_* every 5 seconds in EVERY mode,
-    and an embedded orchestrator hangs off a different attribute than a
-    home-launched session. A predicate that reads only run_context is
-    not a guard, it is a lie with a docstring.
+    An embedded orchestrator hangs off a different attribute than a
+    home-launched session, so a predicate that reads only run_context
+    is not a guard, it is a lie with a docstring. Both handles are read.
+
+    The app's own 5-second safe-mode worker is NOT one of them, and the
+    reason is the difference between refusal and serialization: a
+    launched run spawns subprocesses that inherit the environment at
+    exec and cannot wait on a lock, so the scrub must be refused while
+    one is live; the safe-mode worker is our own bounded thread and can
+    simply take the lock. Round 1 put it in the refusal condition
+    instead, and the measured cost was that the flag is set for 51 to
+    84 ms of every 5 s tick on an empty project, which made the config
+    screen's refresh and the banner's env blame intermittent on a
+    machine with no run at all.
     """
 
     class _Handle:
@@ -522,78 +585,32 @@ def test_the_env_scrub_predicate_sees_all_three_readers() -> None:
     # run_context, whose handle stays None (RunContext.observe).
     assert env_scrub_is_safe(_App(orchestrator=_Handle(False))) is False
     assert env_scrub_is_safe(_App(orchestrator=_Handle(True))) is True
-    # Finding 2: the app's own 5-second safe-mode worker.
-    assert env_scrub_is_safe(_App(safe_mode=True)) is False
+    # Round 2 findings 3 and 4: the app's own safe-mode worker is
+    # serialized against the scrub, not refused around it.
+    assert env_scrub_is_safe(_App(safe_mode=True)) is True
 
 
-def test_the_safe_mode_worker_still_reads_the_environment() -> None:
-    """The reason finding 2's clause exists, pinned in the source it
-    depends on. If safe_mode_reasons stops loading config, this clause
-    is dead weight and should go; if it keeps loading it, the clause
-    must stay."""
-    root = Path(__file__).resolve().parent.parent
-    safemode = (root / "kstrl" / "safemode.py").read_text(encoding="utf-8")
+def test_the_safe_mode_worker_takes_the_lock_the_scrub_holds() -> None:
+    """The mechanism that replaced round 1's refusal clause.
+
+    The worker still reads KSTRL_* every 5 seconds in every mode, so
+    the race round 1 found is real. It is closed by serialization now:
+    both config loads in safemode.py sit inside ``environ_lock()``, the
+    same reentrant lock ``scrubbed_environ`` holds while os.environ is
+    empty, so the worker waits a few milliseconds instead of the config
+    screen refusing to work for the duration of the flag.
+    """
+    src = Path(__file__).resolve().parent.parent / "kstrl"
+    safemode = (src / "safemode.py").read_text(encoding="utf-8")
     assert "AutonomyConfig.load" in safemode
     assert "PolicyConfig.load" in safemode
     assert "QueueConfig.load" in safemode
-    app = (root / "kstrl" / "tui" / "app.py").read_text(encoding="utf-8")
+    assert safemode.count("with environ_lock():") == 2
+    report = (src / "config_report.py").read_text(encoding="utf-8")
+    assert "_ENVIRON_LOCK = threading.RLock()" in report
+    app = (src / "tui" / "app.py").read_text(encoding="utf-8")
     assert "SAFE_MODE_INTERVAL_SECONDS" in app
     assert "self._safe_mode_running = True" in app
-
-
-def test_a_non_utf8_experiments_file_does_not_crash_the_evolve_screen(
-    tmp_path: Path,
-) -> None:
-    """Finding 4, and the crash class #289 is about.
-
-    UnicodeDecodeError IS a ValueError, so it escaped the `except
-    OSError` in get_experiment_trends and raised out of on_mount two
-    lines after the config banner. CLAUDE.md names this rule verbatim.
-    """
-    from kstrl.evolution import EvolutionJournal
-
-    kstrl_dir = tmp_path / ".kstrl"
-    kstrl_dir.mkdir()
-    (kstrl_dir / "experiments.tsv").write_bytes(b"run_id\tcompleted\n2026-\xe9x\t1\n")
-    journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
-    assert journal.get_experiment_trends(last_n=5) == []
-
-
-def test_a_non_utf8_proposal_does_not_crash_the_evolve_screen(tmp_path: Path) -> None:
-    """The same defect one line earlier in the same on_mount:
-    list_proposals read with no encoding behind `except OSError`."""
-    from kstrl.proposals import existing_proposal_titles, list_proposals
-
-    proposals = tmp_path / ".kstrl" / "proposals"
-    proposals.mkdir(parents=True)
-    (proposals / "prop-001.md").write_bytes(
-        b"# PROP-001: \xe9\xe9\xe9 title\n**Type**: computational\n"
-    )
-    assert list_proposals(proposals) == []
-    assert existing_proposal_titles(proposals) == set()
-
-
-async def test_the_evolve_screen_survives_both_undecodable_files(tmp_path: Path) -> None:
-    """The two above, through the screen, which is where it mattered."""
-    kstrl_dir = tmp_path / ".kstrl"
-    (kstrl_dir / "proposals").mkdir(parents=True)
-    (kstrl_dir / "proposals" / "prop-001.md").write_bytes(b"# PROP-001: \xe9\xe9\xe9\n")
-    (kstrl_dir / "experiments.tsv").write_bytes(b"run_id\tcompleted\n2026-\xe9x\t1\n")
-    async with _evolve(tmp_path) as (screen, _pilot):
-        assert screen.query_one("#trends-table", DataTable).row_count == 0
-        assert screen.query_one("#proposals-table", DataTable).row_count == 0
-        # The config itself is fine, so the banner must NOT claim it is
-        # unreadable: these are data files, not configuration.
-        assert screen.query_one(ConfigProblemBanner).display is False
-
-
-def test_experiments_tsv_is_written_with_the_encoding_it_is_read_with(tmp_path: Path) -> None:
-    """Encoding is a two-sided contract (CLAUDE.md): naming utf-8 on the
-    read while the write follows the locale just moves the failure."""
-    root = Path(__file__).resolve().parent.parent
-    source = (root / "kstrl" / "evolution.py").read_text(encoding="utf-8")
-    assert 'open(self.config.experiments_path, "a", encoding="utf-8")' in source
-    assert 'read_text(encoding="utf-8")' in source
 
 
 async def test_the_config_screen_refresh_reports_the_seam_wording(tmp_path: Path) -> None:
@@ -608,7 +625,7 @@ async def test_the_config_screen_refresh_reports_the_seam_wording(tmp_path: Path
     from kstrl.tui.screens.config import ConfigScreen
 
     (tmp_path / "kstrl.toml").write_text(ARRAY_FOR_A_RUN_NUMBER, encoding="utf-8")
-    app = _home_app(tmp_path)
+    app = home_app(tmp_path)
     notices: list[str] = []
     async with app.run_test(size=(140, 40)) as pilot:
         await pilot.pause(0.2)
@@ -621,3 +638,62 @@ async def test_the_config_screen_refresh_reports_the_seam_wording(tmp_path: Path
         await pilot.pause(0.2)
     assert notices, "refresh reported nothing"
     assert any("[run]" in n for n in notices), notices
+
+
+def test_the_config_screen_and_ks_config_show_share_one_problem_reporter() -> None:
+    """Round-two review, finding 10.
+
+    The screen carried its own ``_problem_lines`` next to the CLI's
+    ``_problems``: same traversal, same fallback, two copies, and they
+    had already drifted on the empty case. One function now, and the
+    only thing either caller supplies is where warnings go.
+    """
+    src = Path(__file__).resolve().parent.parent / "kstrl"
+    screen = (src / "tui" / "screens" / "config.py").read_text(encoding="utf-8")
+    cli = (src / "cli.py").read_text(encoding="utf-8")
+    assert "def _problem_lines" not in screen
+    assert "def _problems()" not in cli
+    assert "config_problem_lines(root_dir, warn=" in screen
+    assert "config_problem_lines(root_dir, warn=" in cli
+
+
+def test_the_shared_reporter_gives_the_document_error_when_nothing_parses(
+    tmp_path: Path,
+) -> None:
+    """The case the two copies had drifted on."""
+    (tmp_path / "kstrl.toml").write_text(BAD_DOCUMENT, encoding="utf-8")
+    lines = config_problem_lines(tmp_path, warn=lambda _m: None)
+    assert len(lines) == 1
+    assert "kstrl.toml" in lines[0]
+
+
+def test_a_report_survives_a_section_whose_loader_hits_the_filesystem(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Round-two review, finding 9.
+
+    ``build_config_report._resolve`` caught the ENTRY set, which has no
+    OSError in it, so an unreadable file met while resolving one phase
+    section killed the whole report - on the one screen whose job is
+    showing configuration, the same defect #272 removed for coercion
+    errors. A rejected section costs its rows and is named in
+    ``unresolved``; it does not cost the report.
+    """
+    import kstrl.config_report
+
+    real = kstrl.config_report._phase_sections
+
+    def _one_unreadable_section() -> list[tuple[str, object, list[str]]]:
+        sections = real()
+        name, _loader, knobs = sections[0]
+
+        def _unreadable(_root: Path) -> object:
+            raise PermissionError(13, "Permission denied")
+
+        return [(name, _unreadable, knobs), *sections[1:]]
+
+    monkeypatch.setattr(kstrl.config_report, "_phase_sections", _one_unreadable_section)
+    report = build_config_report(tmp_path)
+    assert report.unresolved == (real()[0][0],)
+    assert report.rows, "the rest of the report was lost with the section"

--- a/tests/test_tui_config_guard.py
+++ b/tests/test_tui_config_guard.py
@@ -21,26 +21,39 @@ evolve screen is the screen that section is about.
 
 from __future__ import annotations
 
+import ast
 import os
 import stat
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from textual.app import App, ComposeResult
+from textual.pilot import Pilot
+from textual.screen import Screen
 from textual.widgets import DataTable, Static
 
 from kstrl.config import ConfigError
 from kstrl.config_preflight import collect_config_problems, load_or_report, preflight_config
+from kstrl.config_report import build_config_report
 from kstrl.evolution import EvolutionConfig
 from kstrl.inbox import Inbox, InboxConfig, ItemKind
+from kstrl.launch import FactoryLaunch
+from kstrl.timeout import TimeoutConfig
 from kstrl.tui.app import KstrlTuiApp, Mode
-from kstrl.tui.config_guard import ConfigProblemBanner, env_scrub_is_safe, load_config
+from kstrl.tui.config_guard import env_scrub_is_safe
 from kstrl.tui.screens.evolve import EvolveScreen
 from kstrl.tui.screens.inbox import InboxScreen
+from kstrl.tui.screens.init_wizard import _detected_text
+from kstrl.tui.session import LaunchError, start_run_session
+from kstrl.tui.widgets.config_problem import ConfigProblemBanner
+from tests.spine_utils import make_manifest
 
 BAD_KNOB = '[evolution]\nlookback_runs = "many"\n'
 BAD_DOCUMENT = "[evolution\nlookback_runs = 5\n"
+GOOD_KNOB = "[evolution]\nlookback_runs = 5\n"
 
 
 class _Harness(App[None]):
@@ -50,13 +63,47 @@ class _Harness(App[None]):
         yield from ()
 
 
-def _banner_text(screen: object) -> str:
-    banner = cast(Any, screen).query_one(ConfigProblemBanner)
-    return str(banner.render())
+def _banner_text(screen: Screen[Any]) -> str:
+    return str(screen.query_one(ConfigProblemBanner).render())
 
 
 def _home_app(tmp_path: Path) -> KstrlTuiApp:
     return KstrlTuiApp(root_dir=tmp_path, mode=Mode.HOME, poll_interval=0.05)
+
+
+@asynccontextmanager
+async def _evolve(tmp_path: Path) -> AsyncIterator[tuple[EvolveScreen, Pilot[None]]]:
+    """The evolve screen open on ``tmp_path``.
+
+    The 0.2s pauses mirror ``tests/test_evolve_screen.py``, which is
+    the empirical precedent for THIS screen: it composes a
+    TabbedContent whose panes mount on a later frame, and every test
+    there waits the same way.
+    """
+    app = _home_app(tmp_path)
+    async with app.run_test(size=(140, 40)) as pilot:
+        await pilot.pause(0.2)
+        app.push_screen(EvolveScreen())
+        await pilot.pause(0.2)
+        screen = app.screen
+        assert isinstance(screen, EvolveScreen)
+        yield screen, pilot
+
+
+@asynccontextmanager
+async def _inbox(tmp_path: Path) -> AsyncIterator[tuple[InboxScreen, Pilot[None]]]:
+    """The inbox screen open on ``tmp_path``.
+
+    A bare pause, mirroring ``tests/test_inbox.py``: this screen mounts
+    its table directly, with no tab panes to wait for.
+    """
+    app = _Harness()
+    async with app.run_test() as pilot:
+        await app.push_screen(InboxScreen(tmp_path))
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, InboxScreen)
+        yield screen, pilot
 
 
 # --------------------------------------------------------------------------
@@ -90,15 +137,12 @@ def test_ks_evolve_still_stops_on_the_same_file(tmp_path: Path) -> None:
 class TestEvolveScreen:
     async def test_a_bad_knob_is_named_instead_of_raised(self, tmp_path: Path) -> None:
         (tmp_path / "kstrl.toml").write_text(BAD_KNOB, encoding="utf-8")
-        app = _home_app(tmp_path)
-        async with app.run_test(size=(140, 40)) as pilot:
-            await pilot.pause(0.2)
-            app.push_screen(EvolveScreen())
-            await pilot.pause(0.2)
-            screen = app.screen
-            assert isinstance(screen, EvolveScreen)
+        async with _evolve(tmp_path) as (screen, _pilot):
             text = _banner_text(screen)
             assert "configuration unreadable" in text
+            # The section name survives: it is bracketed, and Rich reads
+            # a bracketed token as markup and deletes it, so this pins
+            # the banner rendering a Text rather than a str.
             assert "[evolution]" in text
             assert "invalid literal for int() with base 10: 'many'" in text
             assert "lookback_runs" in text
@@ -110,26 +154,14 @@ class TestEvolveScreen:
     ) -> None:
         """Not a silent degrade: no rows, and a line saying why."""
         (tmp_path / "kstrl.toml").write_text(BAD_KNOB, encoding="utf-8")
-        app = _home_app(tmp_path)
-        async with app.run_test(size=(140, 40)) as pilot:
-            await pilot.pause(0.2)
-            app.push_screen(EvolveScreen())
-            await pilot.pause(0.2)
-            screen = app.screen
-            assert isinstance(screen, EvolveScreen)
+        async with _evolve(tmp_path) as (screen, _pilot):
             assert screen.query_one("#patterns-table", DataTable).row_count == 0
             assert screen.query_one("#trends-table", DataTable).row_count == 0
             assert "[evolution]" in _banner_text(screen)
 
     async def test_a_malformed_document_is_named_too(self, tmp_path: Path) -> None:
         (tmp_path / "kstrl.toml").write_text(BAD_DOCUMENT, encoding="utf-8")
-        app = _home_app(tmp_path)
-        async with app.run_test(size=(140, 40)) as pilot:
-            await pilot.pause(0.2)
-            app.push_screen(EvolveScreen())
-            await pilot.pause(0.2)
-            screen = app.screen
-            assert isinstance(screen, EvolveScreen)
+        async with _evolve(tmp_path) as (screen, _pilot):
             text = _banner_text(screen)
             assert "Invalid TOML" in text
             assert "line 1" in text
@@ -140,28 +172,17 @@ class TestEvolveScreen:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "lots")
-        app = _home_app(tmp_path)
-        async with app.run_test(size=(140, 40)) as pilot:
-            await pilot.pause(0.2)
-            app.push_screen(EvolveScreen())
-            await pilot.pause(0.2)
-            screen = app.screen
-            assert isinstance(screen, EvolveScreen)
+        async with _evolve(tmp_path) as (screen, _pilot):
             assert "set by KSTRL_EVOLUTION_LOOKBACK_RUNS=lots" in _banner_text(screen)
 
     async def test_the_banner_is_hidden_on_a_config_that_resolves(
         self,
         tmp_path: Path,
     ) -> None:
-        (tmp_path / "kstrl.toml").write_text("[evolution]\nlookback_runs = 5\n", encoding="utf-8")
-        app = _home_app(tmp_path)
-        async with app.run_test(size=(140, 40)) as pilot:
-            await pilot.pause(0.2)
-            app.push_screen(EvolveScreen())
-            await pilot.pause(0.2)
-            screen = app.screen
-            assert isinstance(screen, EvolveScreen)
+        (tmp_path / "kstrl.toml").write_text(GOOD_KNOB, encoding="utf-8")
+        async with _evolve(tmp_path) as (screen, _pilot):
             assert screen.query_one(ConfigProblemBanner).display is False
+            assert screen.query_one(ConfigProblemBanner).problem is None
 
     async def test_reload_clears_the_banner_once_the_file_is_repaired(
         self,
@@ -169,15 +190,9 @@ class TestEvolveScreen:
     ) -> None:
         toml = tmp_path / "kstrl.toml"
         toml.write_text(BAD_KNOB, encoding="utf-8")
-        app = _home_app(tmp_path)
-        async with app.run_test(size=(140, 40)) as pilot:
-            await pilot.pause(0.2)
-            app.push_screen(EvolveScreen())
-            await pilot.pause(0.2)
-            screen = app.screen
-            assert isinstance(screen, EvolveScreen)
+        async with _evolve(tmp_path) as (screen, pilot):
             assert screen.query_one(ConfigProblemBanner).display is True
-            toml.write_text("[evolution]\nlookback_runs = 5\n", encoding="utf-8")
+            toml.write_text(GOOD_KNOB, encoding="utf-8")
             screen.action_reload()
             await pilot.pause(0.2)
             assert screen.query_one(ConfigProblemBanner).display is False
@@ -192,12 +207,7 @@ class TestInboxScreen:
         tmp_path: Path,
     ) -> None:
         (tmp_path / "kstrl.toml").write_text(BAD_DOCUMENT, encoding="utf-8")
-        app = _Harness()
-        async with app.run_test() as pilot:
-            await app.push_screen(InboxScreen(tmp_path))
-            await pilot.pause()
-            screen = app.screen
-            assert isinstance(screen, InboxScreen)
+        async with _inbox(tmp_path) as (screen, _pilot):
             text = _banner_text(screen)
             assert "configuration unreadable" in text
             assert "[inbox]" in text
@@ -217,12 +227,7 @@ class TestInboxScreen:
             dedupe_key="p1",
         )
         (tmp_path / "kstrl.toml").write_text(BAD_DOCUMENT, encoding="utf-8")
-        app = _Harness()
-        async with app.run_test() as pilot:
-            await app.push_screen(InboxScreen(tmp_path))
-            await pilot.pause()
-            screen = app.screen
-            assert isinstance(screen, InboxScreen)
+        async with _inbox(tmp_path) as (screen, _pilot):
             assert screen._items == []
             detail = str(screen.query_one("#inbox-detail", Static).render())
             assert "Inbox clear" not in detail
@@ -238,12 +243,7 @@ class TestInboxScreen:
             component="comp-a",
             dedupe_key="p1",
         )
-        app = _Harness()
-        async with app.run_test() as pilot:
-            await app.push_screen(InboxScreen(tmp_path))
-            await pilot.pause()
-            screen = app.screen
-            assert isinstance(screen, InboxScreen)
+        async with _inbox(tmp_path) as (screen, pilot):
             assert len(screen._items) == 1
             (tmp_path / "kstrl.toml").write_text(BAD_DOCUMENT, encoding="utf-8")
             screen.action_approve()
@@ -267,7 +267,11 @@ class TestSharedGuard:
             warn=lambda _m: None,
             required=frozenset({"evolution"}),
         )
-        _config, from_screen = load_config(_Harness(), EvolutionConfig.load, tmp_path)
+        _config, from_screen = load_or_report(
+            EvolutionConfig.load,
+            tmp_path,
+            blame_env=True,
+        )
         assert from_cli == [from_screen]
 
     def test_env_blame_is_skipped_while_a_run_is_in_flight(
@@ -341,7 +345,7 @@ class TestSharedGuard:
         front of it, and a chmod between two refreshes lands here.
         """
         toml = tmp_path / "kstrl.toml"
-        toml.write_text("[evolution]\nlookback_runs = 3\n", encoding="utf-8")
+        toml.write_text(GOOD_KNOB, encoding="utf-8")
         toml.chmod(0o000)
         try:
             _config, problem = load_or_report(
@@ -364,12 +368,11 @@ class TestSharedGuard:
 #: REJECTIONS names TypeError and why a hand-written
 #: ``(OSError, ValueError)`` guard is not equivalent to it.
 ARRAY_FOR_A_NUMBER = '[timeout]\ngit_operation = ["30"]\n'
+ARRAY_FOR_A_RUN_NUMBER = '[run]\nmax_iterations = ["3"]\n'
 
 
 def test_the_array_case_really_is_a_typeerror(tmp_path: Path) -> None:
     """The premise, measured rather than assumed."""
-    from kstrl.timeout import TimeoutConfig
-
     (tmp_path / "kstrl.toml").write_text(ARRAY_FOR_A_NUMBER, encoding="utf-8")
     with pytest.raises(TypeError):
         TimeoutConfig.load(tmp_path)
@@ -377,27 +380,16 @@ def test_the_array_case_really_is_a_typeerror(tmp_path: Path) -> None:
 
 
 def test_a_launched_run_reports_the_array_instead_of_raising(tmp_path: Path) -> None:
-    """`kstrl/tui/session.py` assembles seven sections at launch.
+    """``kstrl/tui/session.py`` assembles seven sections at launch.
 
     Its guard was ``(OSError, ValueError)``, so this file escaped as a
     TypeError and took the shell down. Reachable only by editing
     kstrl.toml with the shell already open: the entry check would have
     refused to open it otherwise.
     """
-    from kstrl.launch import FactoryLaunch
-    from kstrl.manifest import Manifest
-    from kstrl.tui.session import LaunchError, start_run_session
-
     manifest_dir = tmp_path / "scripts" / "kstrl"
     manifest_dir.mkdir(parents=True)
-    Manifest(
-        version="1",
-        spec_file="s",
-        project_name="demo",
-        base_branch="main",
-        single_pr=False,
-        components=[],
-    ).save(manifest_dir / "manifest.json")
+    make_manifest([]).save(manifest_dir / "manifest.json")
     (tmp_path / "kstrl.toml").write_text(ARRAY_FOR_A_NUMBER, encoding="utf-8")
 
     with pytest.raises(LaunchError, match="failed to load configuration"):
@@ -409,10 +401,145 @@ def test_the_init_wizard_reports_the_array_instead_of_raising(tmp_path: Path) ->
 
     Its guard was one exception narrower than the entry check too.
     """
-    from kstrl.tui.screens.init_wizard import _detected_text
-
     (tmp_path / "kstrl.toml").write_text(
         '[verify]\nself_critique_min_bullets = ["3"]\n',
         encoding="utf-8",
     )
     assert "kstrl.toml is unreadable" in _detected_text(tmp_path).plain
+
+
+def test_build_config_report_raises_what_its_tui_callers_now_catch(tmp_path: Path) -> None:
+    """Both TUI readers of the report caught only ValueError.
+
+    The config screen's refresh action is the live one: it exists to
+    re-read a file the operator has just edited, so it is the surface
+    that meets a broken document with the shell already open. The walk
+    below is what stops a third reader repeating it.
+    """
+    (tmp_path / "kstrl.toml").write_text(ARRAY_FOR_A_RUN_NUMBER, encoding="utf-8")
+    with pytest.raises(TypeError):
+        build_config_report(tmp_path)
+
+
+# --------------------------------------------------------------------------
+# The mechanism, not the memory
+# --------------------------------------------------------------------------
+#: Sites that resolve config in kstrl/tui/ and are deliberately not
+#: routed through the banner, keyed by (file, enclosing function). Each
+#: still has to catch SURFACE_REJECTIONS; this only records that the
+#: banner is not the right renderer for it.
+_NOT_THE_BANNER = frozenset(
+    {
+        # Reads pyproject.toml through resolve_verify_commands, and
+        # renders its own labelled row inside a block with no space for
+        # a section and a value.
+        ("kstrl/tui/screens/init_wizard.py", "_detected_text"),
+    }
+)
+
+
+def _guarded_by_the_shared_tuple(node: ast.Try) -> bool:
+    for handler in node.handlers:
+        if handler.type is None:
+            continue
+        for name in ast.walk(handler.type):
+            if isinstance(name, ast.Name) and name.id == "SURFACE_REJECTIONS":
+                return True
+    return False
+
+
+def _config_loads(tree: ast.AST) -> list[ast.Call]:
+    """Calls that resolve a kstrl.toml section from disk."""
+    found: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "build_config_report":
+            found.append(node)
+        elif (
+            isinstance(func, ast.Attribute)
+            and func.attr == "load"
+            and isinstance(func.value, ast.Name)
+            and func.value.id.endswith("Config")
+        ):
+            found.append(node)
+    return found
+
+
+def _guarded_call_ids(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[int]:
+    """Ids of the config loads inside a try that catches the tuple."""
+    guarded: set[int] = set()
+    for node in ast.walk(function):
+        if isinstance(node, ast.Try) and _guarded_by_the_shared_tuple(node):
+            guarded.update(id(call) for call in _config_loads(node))
+    return guarded
+
+
+def _unguarded_config_loads(tree: ast.AST) -> list[tuple[int, str]]:
+    """(line, enclosing function) for every unguarded config load."""
+    found: list[tuple[int, str]] = []
+    for function in ast.walk(tree):
+        if not isinstance(function, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        guarded = _guarded_call_ids(function)
+        found += [
+            (call.lineno, function.name)
+            for call in _config_loads(function)
+            if id(call) not in guarded
+        ]
+    return found
+
+
+def test_no_tui_surface_loads_config_behind_a_hand_written_guard() -> None:
+    """The house pattern is a walk, not a memory (CLAUDE.md).
+
+    Every site the #289 survey found was a hand-written exception tuple
+    that had drifted one exception narrower than the entry check, and
+    two of them were missed on the first pass of this very fix. So the
+    rule is enforced rather than remembered: inside kstrl/tui/, a call
+    that resolves a config section must either go through the banner's
+    ``load`` (which routes to ``config_preflight.load_or_report``) or
+    sit inside a ``try`` that catches ``SURFACE_REJECTIONS``.
+    """
+    root = Path(__file__).resolve().parent.parent
+    offenders = [
+        f"{path.relative_to(root).as_posix()}:{lineno} in {name}()"
+        for path in sorted((root / "kstrl" / "tui").rglob("*.py"))
+        for lineno, name in _unguarded_config_loads(ast.parse(path.read_text(encoding="utf-8")))
+    ]
+    assert offenders == [], (
+        "config resolved in kstrl/tui/ without SURFACE_REJECTIONS or the banner: "
+        + ", ".join(offenders)
+    )
+
+
+def test_every_named_exception_to_the_banner_still_exists() -> None:
+    """An allow-list nobody prunes is a lie. These are guarded by
+    SURFACE_REJECTIONS and render their own message instead."""
+    root = Path(__file__).resolve().parent.parent
+    for rel, function in _NOT_THE_BANNER:
+        source = (root / rel).read_text(encoding="utf-8")
+        assert f"def {function}(" in source, f"{rel} no longer defines {function}"
+        assert "SURFACE_REJECTIONS" in source, f"{rel} no longer imports the shared tuple"
+
+
+def test_the_walk_would_have_caught_the_original_defect() -> None:
+    """The walk is only worth having if it fails on the bug."""
+    unguarded = ast.parse(
+        "def reload(self):\n    journal = EvolutionJournal(EvolutionConfig.load(root_dir))\n"
+    ).body[0]
+    assert isinstance(unguarded, ast.FunctionDef)
+    assert len(_config_loads(unguarded)) == 1
+
+    guarded = ast.parse(
+        "def reload(self):\n"
+        "    try:\n"
+        "        return EvolutionConfig.load(root_dir)\n"
+        "    except SURFACE_REJECTIONS:\n"
+        "        return None\n"
+    ).body[0]
+    assert isinstance(guarded, ast.FunctionDef)
+    tries = [n for n in ast.walk(guarded) if isinstance(n, ast.Try)]
+    assert _guarded_by_the_shared_tuple(tries[0]) is True
+    assert len(_config_loads(tries[0])) == 1

--- a/tests/test_tui_config_guard.py
+++ b/tests/test_tui_config_guard.py
@@ -1,0 +1,418 @@
+"""#289: a home-shell screen must name a broken config, not raise on it.
+
+The measurement this file replaces a claim with: on 5abbc91, pushing
+``EvolveScreen`` at a project whose kstrl.toml holds
+``[evolution] lookback_runs = "many"`` raised
+
+    ValueError: invalid literal for int() with base 10: 'many'
+
+out of ``EvolveScreen.on_mount`` -> ``reload`` ->
+``_load_patterns_and_trends`` -> ``EvolutionConfig.load``, which in a
+real shell is an unhandled exception in a message handler and takes the
+app down. ``ks evolve --root <same dir>`` printed one named line and
+exited 1 for the same file. ``InboxScreen`` had the same shape on a
+malformed document.
+
+The screens are reachable because the entry check DEGRADES
+``[evolution]``: it warns and lets the shell open (measured - see
+``test_the_shell_opens_on_the_value_that_crashes_the_screen``), and the
+evolve screen is the screen that section is about.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable, Static
+
+from kstrl.config import ConfigError
+from kstrl.config_preflight import collect_config_problems, load_or_report, preflight_config
+from kstrl.evolution import EvolutionConfig
+from kstrl.inbox import Inbox, InboxConfig, ItemKind
+from kstrl.tui.app import KstrlTuiApp, Mode
+from kstrl.tui.config_guard import ConfigProblemBanner, env_scrub_is_safe, load_config
+from kstrl.tui.screens.evolve import EvolveScreen
+from kstrl.tui.screens.inbox import InboxScreen
+
+BAD_KNOB = '[evolution]\nlookback_runs = "many"\n'
+BAD_DOCUMENT = "[evolution\nlookback_runs = 5\n"
+
+
+class _Harness(App[None]):
+    """A bare app: no run_context, so the env sweep is allowed."""
+
+    def compose(self) -> ComposeResult:
+        yield from ()
+
+
+def _banner_text(screen: object) -> str:
+    banner = cast(Any, screen).query_one(ConfigProblemBanner)
+    return str(banner.render())
+
+
+def _home_app(tmp_path: Path) -> KstrlTuiApp:
+    return KstrlTuiApp(root_dir=tmp_path, mode=Mode.HOME, poll_interval=0.05)
+
+
+# --------------------------------------------------------------------------
+# Why the screen is reachable at all
+# --------------------------------------------------------------------------
+def test_the_shell_opens_on_the_value_that_crashes_the_screen(tmp_path: Path) -> None:
+    """The entry check warns for [evolution] and lets the shell open.
+
+    This is the whole reason #289 is not covered by #272: the seam ran,
+    and classified this section as degrading.
+    """
+    (tmp_path / "kstrl.toml").write_text(BAD_KNOB, encoding="utf-8")
+    warnings: list[str] = []
+    preflight_config(tmp_path, warn=warnings.append)
+    assert len(warnings) == 1
+    assert "[evolution]" in warnings[0]
+    assert "continuing without it" in warnings[0]
+
+
+def test_ks_evolve_still_stops_on_the_same_file(tmp_path: Path) -> None:
+    """The command that IS the journal keeps its fatal classification."""
+    (tmp_path / "kstrl.toml").write_text(BAD_KNOB, encoding="utf-8")
+    with pytest.raises(ConfigError) as caught:
+        preflight_config(tmp_path, warn=lambda _m: None, required=frozenset({"evolution"}))
+    assert "[evolution]" in str(caught.value)
+
+
+# --------------------------------------------------------------------------
+# The evolve screen
+# --------------------------------------------------------------------------
+class TestEvolveScreen:
+    async def test_a_bad_knob_is_named_instead_of_raised(self, tmp_path: Path) -> None:
+        (tmp_path / "kstrl.toml").write_text(BAD_KNOB, encoding="utf-8")
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(EvolveScreen())
+            await pilot.pause(0.2)
+            screen = app.screen
+            assert isinstance(screen, EvolveScreen)
+            text = _banner_text(screen)
+            assert "configuration unreadable" in text
+            assert "[evolution]" in text
+            assert "invalid literal for int() with base 10: 'many'" in text
+            assert "lookback_runs" in text
+            assert screen.query_one(ConfigProblemBanner).display is True
+
+    async def test_the_tables_are_empty_and_the_emptiness_is_explained(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Not a silent degrade: no rows, and a line saying why."""
+        (tmp_path / "kstrl.toml").write_text(BAD_KNOB, encoding="utf-8")
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(EvolveScreen())
+            await pilot.pause(0.2)
+            screen = app.screen
+            assert isinstance(screen, EvolveScreen)
+            assert screen.query_one("#patterns-table", DataTable).row_count == 0
+            assert screen.query_one("#trends-table", DataTable).row_count == 0
+            assert "[evolution]" in _banner_text(screen)
+
+    async def test_a_malformed_document_is_named_too(self, tmp_path: Path) -> None:
+        (tmp_path / "kstrl.toml").write_text(BAD_DOCUMENT, encoding="utf-8")
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(EvolveScreen())
+            await pilot.pause(0.2)
+            screen = app.screen
+            assert isinstance(screen, EvolveScreen)
+            text = _banner_text(screen)
+            assert "Invalid TOML" in text
+            assert "line 1" in text
+
+    async def test_the_environment_variable_is_named_when_it_is_the_cause(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "lots")
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(EvolveScreen())
+            await pilot.pause(0.2)
+            screen = app.screen
+            assert isinstance(screen, EvolveScreen)
+            assert "set by KSTRL_EVOLUTION_LOOKBACK_RUNS=lots" in _banner_text(screen)
+
+    async def test_the_banner_is_hidden_on_a_config_that_resolves(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text("[evolution]\nlookback_runs = 5\n", encoding="utf-8")
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(EvolveScreen())
+            await pilot.pause(0.2)
+            screen = app.screen
+            assert isinstance(screen, EvolveScreen)
+            assert screen.query_one(ConfigProblemBanner).display is False
+
+    async def test_reload_clears_the_banner_once_the_file_is_repaired(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        toml = tmp_path / "kstrl.toml"
+        toml.write_text(BAD_KNOB, encoding="utf-8")
+        app = _home_app(tmp_path)
+        async with app.run_test(size=(140, 40)) as pilot:
+            await pilot.pause(0.2)
+            app.push_screen(EvolveScreen())
+            await pilot.pause(0.2)
+            screen = app.screen
+            assert isinstance(screen, EvolveScreen)
+            assert screen.query_one(ConfigProblemBanner).display is True
+            toml.write_text("[evolution]\nlookback_runs = 5\n", encoding="utf-8")
+            screen.action_reload()
+            await pilot.pause(0.2)
+            assert screen.query_one(ConfigProblemBanner).display is False
+
+
+# --------------------------------------------------------------------------
+# The inbox screen: the same shape, found by the survey #289 asked for
+# --------------------------------------------------------------------------
+class TestInboxScreen:
+    async def test_a_malformed_document_is_named_instead_of_raised(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text(BAD_DOCUMENT, encoding="utf-8")
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await app.push_screen(InboxScreen(tmp_path))
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, InboxScreen)
+            text = _banner_text(screen)
+            assert "configuration unreadable" in text
+            assert "[inbox]" in text
+            assert "Invalid TOML" in text
+
+    async def test_it_never_claims_the_inbox_is_clear(self, tmp_path: Path) -> None:
+        """An item IS waiting; the config is what cannot be read.
+
+        "Inbox clear: nothing is waiting on you." from an empty list
+        that only means the config failed is the silent degrade #289
+        rules out, and here it would be false as well as silent.
+        """
+        Inbox(tmp_path, InboxConfig()).add(
+            ItemKind.POLICY_EXCEPTION,
+            "comp-a: denied path",
+            component="comp-a",
+            dedupe_key="p1",
+        )
+        (tmp_path / "kstrl.toml").write_text(BAD_DOCUMENT, encoding="utf-8")
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await app.push_screen(InboxScreen(tmp_path))
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, InboxScreen)
+            assert screen._items == []
+            detail = str(screen.query_one("#inbox-detail", Static).render())
+            assert "Inbox clear" not in detail
+
+    async def test_a_decision_taken_after_the_file_broke_redraws(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The list was drawn from a good file; the file then broke."""
+        Inbox(tmp_path, InboxConfig()).add(
+            ItemKind.POLICY_EXCEPTION,
+            "comp-a: denied path",
+            component="comp-a",
+            dedupe_key="p1",
+        )
+        app = _Harness()
+        async with app.run_test() as pilot:
+            await app.push_screen(InboxScreen(tmp_path))
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, InboxScreen)
+            assert len(screen._items) == 1
+            (tmp_path / "kstrl.toml").write_text(BAD_DOCUMENT, encoding="utf-8")
+            screen.action_approve()
+            await pilot.pause()
+            assert screen._items == []
+            assert "Invalid TOML" in _banner_text(screen)
+            # The decision did NOT land: refusing is the honest answer
+            # when the file that configures the log will not parse.
+            assert len(Inbox(tmp_path, InboxConfig()).open_items()) == 1
+
+
+# --------------------------------------------------------------------------
+# The shared pattern
+# --------------------------------------------------------------------------
+class TestSharedGuard:
+    def test_the_screen_says_exactly_what_the_command_says(self, tmp_path: Path) -> None:
+        """The point of #289: one file, one wording, two surfaces."""
+        (tmp_path / "kstrl.toml").write_text(BAD_KNOB, encoding="utf-8")
+        from_cli = collect_config_problems(
+            tmp_path,
+            warn=lambda _m: None,
+            required=frozenset({"evolution"}),
+        )
+        _config, from_screen = load_config(_Harness(), EvolutionConfig.load, tmp_path)
+        assert from_cli == [from_screen]
+
+    def test_env_blame_is_skipped_while_a_run_is_in_flight(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Measuring the blame clears os.environ process-wide.
+
+        A launched home-shell session runs the factory on another
+        thread of THIS process and its subprocesses inherit the
+        environment, so the variable's name is given up rather than the
+        run corrupted. Everything else in the line survives.
+        """
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "lots")
+        _config, problem = load_or_report(EvolutionConfig.load, tmp_path, blame_env=False)
+        assert problem is not None
+        assert "[evolution]" in problem
+        assert "invalid literal for int() with base 10: 'lots'" in problem
+        assert "set by" not in problem
+
+        _again, blamed = load_or_report(EvolutionConfig.load, tmp_path, blame_env=True)
+        assert blamed is not None
+        assert "set by KSTRL_EVOLUTION_LOOKBACK_RUNS=lots" in blamed
+
+    def test_env_scrub_is_safe_reads_the_launched_session(self) -> None:
+        class _Handle:
+            def __init__(self, done: bool) -> None:
+                self._done = done
+
+            def done(self) -> bool:
+                return self._done
+
+        class _Ctx:
+            def __init__(self, handle: object | None) -> None:
+                self.handle = handle
+
+        class _App:
+            def __init__(self, ctx: object | None) -> None:
+                self.run_context = ctx
+
+        assert env_scrub_is_safe(object()) is True  # no attribute at all
+        assert env_scrub_is_safe(_App(None)) is True
+        assert env_scrub_is_safe(_App(_Ctx(None))) is True
+        assert env_scrub_is_safe(_App(_Ctx(_Handle(True)))) is True
+        assert env_scrub_is_safe(_App(_Ctx(_Handle(False)))) is False
+
+    def test_a_clean_config_returns_the_object_and_no_problem(self, tmp_path: Path) -> None:
+        (tmp_path / "kstrl.toml").write_text("[evolution]\nlookback_runs = 3\n", encoding="utf-8")
+        config, problem = load_or_report(EvolutionConfig.load, tmp_path, blame_env=True)
+        assert problem is None
+        assert config is not None
+        assert config.lookback_runs == 3
+
+    def test_an_unenrolled_loader_is_a_defect_not_a_message(self, tmp_path: Path) -> None:
+        """The label comes from config_sections(), so a screen cannot
+        invent a section the entry check does not know."""
+
+        def _not_a_registered_loader(_root: Path) -> int:
+            return 1
+
+        with pytest.raises(LookupError):
+            load_or_report(_not_a_registered_loader, tmp_path, blame_env=False)
+
+    @pytest.mark.skipif(os.name == "nt" or os.getuid() == 0, reason="root reads a 0000 file")
+    def test_an_unreadable_file_is_reported_not_raised(self, tmp_path: Path) -> None:
+        """OSError is in scope for a surface, not for the entry check.
+
+        The entry check reads the document itself before any loader
+        runs; a screen re-reading minutes later has no such pass in
+        front of it, and a chmod between two refreshes lands here.
+        """
+        toml = tmp_path / "kstrl.toml"
+        toml.write_text("[evolution]\nlookback_runs = 3\n", encoding="utf-8")
+        toml.chmod(0o000)
+        try:
+            _config, problem = load_or_report(
+                EvolutionConfig.load,
+                tmp_path,
+                blame_env=False,
+            )
+        finally:
+            toml.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        assert problem is not None
+        assert "[evolution]" in problem
+        assert "Permission denied" in problem
+
+
+# --------------------------------------------------------------------------
+# The rest of the survey #289 asked for: guards NARROWER than the seam
+# --------------------------------------------------------------------------
+#: A toml array where a number belongs. ``float()`` and ``int()`` raise
+#: TypeError for it, not ValueError, which is why the entry check's
+#: REJECTIONS names TypeError and why a hand-written
+#: ``(OSError, ValueError)`` guard is not equivalent to it.
+ARRAY_FOR_A_NUMBER = '[timeout]\ngit_operation = ["30"]\n'
+
+
+def test_the_array_case_really_is_a_typeerror(tmp_path: Path) -> None:
+    """The premise, measured rather than assumed."""
+    from kstrl.timeout import TimeoutConfig
+
+    (tmp_path / "kstrl.toml").write_text(ARRAY_FOR_A_NUMBER, encoding="utf-8")
+    with pytest.raises(TypeError):
+        TimeoutConfig.load(tmp_path)
+    assert not isinstance(TypeError(), ValueError)
+
+
+def test_a_launched_run_reports_the_array_instead_of_raising(tmp_path: Path) -> None:
+    """`kstrl/tui/session.py` assembles seven sections at launch.
+
+    Its guard was ``(OSError, ValueError)``, so this file escaped as a
+    TypeError and took the shell down. Reachable only by editing
+    kstrl.toml with the shell already open: the entry check would have
+    refused to open it otherwise.
+    """
+    from kstrl.launch import FactoryLaunch
+    from kstrl.manifest import Manifest
+    from kstrl.tui.session import LaunchError, start_run_session
+
+    manifest_dir = tmp_path / "scripts" / "kstrl"
+    manifest_dir.mkdir(parents=True)
+    Manifest(
+        version="1",
+        spec_file="s",
+        project_name="demo",
+        base_branch="main",
+        single_pr=False,
+        components=[],
+    ).save(manifest_dir / "manifest.json")
+    (tmp_path / "kstrl.toml").write_text(ARRAY_FOR_A_NUMBER, encoding="utf-8")
+
+    with pytest.raises(LaunchError, match="failed to load configuration"):
+        start_run_session(FactoryLaunch(), tmp_path)
+
+
+def test_the_init_wizard_reports_the_array_instead_of_raising(tmp_path: Path) -> None:
+    """The wizard is the screen an operator opens to repair a scaffold.
+
+    Its guard was one exception narrower than the entry check too.
+    """
+    from kstrl.tui.screens.init_wizard import _detected_text
+
+    (tmp_path / "kstrl.toml").write_text(
+        '[verify]\nself_critique_min_bullets = ["3"]\n',
+        encoding="utf-8",
+    )
+    assert "kstrl.toml is unreadable" in _detected_text(tmp_path).plain

--- a/tests/test_tui_config_guard.py
+++ b/tests/test_tui_config_guard.py
@@ -21,7 +21,6 @@ evolve screen is the screen that section is about.
 
 from __future__ import annotations
 
-import ast
 import os
 import stat
 from collections.abc import AsyncIterator
@@ -328,13 +327,60 @@ class TestSharedGuard:
 
     def test_an_unenrolled_loader_is_a_defect_not_a_message(self, tmp_path: Path) -> None:
         """The label comes from config_sections(), so a screen cannot
-        invent a section the entry check does not know."""
+        invent a section the entry check does not know.
 
-        def _not_a_registered_loader(_root: Path) -> int:
-            return 1
+        Raised on the FAILURE path only: the lookup moved into the
+        except branch because `config_sections()` costs a measured
+        6.2 ms on its first call and the happy path never needs a
+        label. An unenrolled loader that resolves cleanly has nothing
+        to mislabel.
+        """
+
+        def _rejecting_unenrolled_loader(_root: Path) -> int:
+            raise ValueError("nope")
 
         with pytest.raises(LookupError):
-            load_or_report(_not_a_registered_loader, tmp_path, blame_env=False)
+            load_or_report(_rejecting_unenrolled_loader, tmp_path, blame_env=False)
+
+        def _clean_unenrolled_loader(_root: Path) -> int:
+            return 1
+
+        assert load_or_report(_clean_unenrolled_loader, tmp_path, blame_env=False) == (1, None)
+
+    def test_a_bare_runtimeerror_is_re_raised_not_blamed_on_the_operator(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Round-one review, finding 10.
+
+        SURFACE_REJECTIONS names RuntimeError for the domain errors
+        that DERIVE from it, which are operator input. A bare one is a
+        kstrl defect, and rendering it as "configuration unreadable"
+        would blame the operator's file and eat the traceback. This is
+        the same line EvolutionConfig.load_or_none draws.
+        """
+        import kstrl.evolution
+
+        def _explode(root_dir: Path | None = None) -> None:
+            raise RuntimeError("journal config exploded")
+
+        monkeypatch.setattr(kstrl.evolution.EvolutionConfig, "load", _explode)
+        with pytest.raises(RuntimeError, match="journal config exploded"):
+            load_or_report(EvolutionConfig.load, tmp_path, blame_env=False)
+
+    def test_a_domain_runtimeerror_is_still_reported(self, tmp_path: Path) -> None:
+        """The other side of the same line: ServeError and friends are
+        operator input and must still reach the banner."""
+        from kstrl.serve import ServeConfig
+
+        (tmp_path / "kstrl.toml").write_text(
+            "[serve]\nmax_consecutive_poison = 0\n",
+            encoding="utf-8",
+        )
+        _config, problem = load_or_report(ServeConfig.load, tmp_path, blame_env=False)
+        assert problem is not None
+        assert "[serve]" in problem
 
     @pytest.mark.skipif(os.name == "nt" or os.getuid() == 0, reason="root reads a 0000 file")
     def test_an_unreadable_file_is_reported_not_raised(self, tmp_path: Path) -> None:
@@ -422,124 +468,156 @@ def test_build_config_report_raises_what_its_tui_callers_now_catch(tmp_path: Pat
 
 
 # --------------------------------------------------------------------------
-# The mechanism, not the memory
+# Round-one review findings, each with the measurement that found it
 # --------------------------------------------------------------------------
-#: Sites that resolve config in kstrl/tui/ and are deliberately not
-#: routed through the banner, keyed by (file, enclosing function). Each
-#: still has to catch SURFACE_REJECTIONS; this only records that the
-#: banner is not the right renderer for it.
-_NOT_THE_BANNER = frozenset(
-    {
-        # Reads pyproject.toml through resolve_verify_commands, and
-        # renders its own labelled row inside a block with no space for
-        # a section and a value.
-        ("kstrl/tui/screens/init_wizard.py", "_detected_text"),
-    }
-)
+def test_ks_config_show_names_the_section_instead_of_a_traceback(tmp_path: Path) -> None:
+    """Finding 1. `config` is preflight-EXEMPT, which is exactly why its
+    own guard has to be the shared tuple: nothing catches it first."""
+    from click.testing import CliRunner
+
+    from kstrl.cli import cli
+
+    (tmp_path / "kstrl.toml").write_text(ARRAY_FOR_A_RUN_NUMBER, encoding="utf-8")
+    result = CliRunner().invoke(cli, ["config", "show", "--root", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "Traceback" not in result.output
+    assert "[run]" in result.output
 
 
-def _guarded_by_the_shared_tuple(node: ast.Try) -> bool:
-    for handler in node.handlers:
-        if handler.type is None:
-            continue
-        for name in ast.walk(handler.type):
-            if isinstance(name, ast.Name) and name.id == "SURFACE_REJECTIONS":
-                return True
-    return False
+def test_the_env_scrub_predicate_sees_all_three_readers() -> None:
+    """Finding 2 and 3.
 
-
-def _config_loads(tree: ast.AST) -> list[ast.Call]:
-    """Calls that resolve a kstrl.toml section from disk."""
-    found: list[ast.Call] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if isinstance(func, ast.Name) and func.id == "build_config_report":
-            found.append(node)
-        elif (
-            isinstance(func, ast.Attribute)
-            and func.attr == "load"
-            and isinstance(func.value, ast.Name)
-            and func.value.id.endswith("Config")
-        ):
-            found.append(node)
-    return found
-
-
-def _guarded_call_ids(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[int]:
-    """Ids of the config loads inside a try that catches the tuple."""
-    guarded: set[int] = set()
-    for node in ast.walk(function):
-        if isinstance(node, ast.Try) and _guarded_by_the_shared_tuple(node):
-            guarded.update(id(call) for call in _config_loads(node))
-    return guarded
-
-
-def _unguarded_config_loads(tree: ast.AST) -> list[tuple[int, str]]:
-    """(line, enclosing function) for every unguarded config load."""
-    found: list[tuple[int, str]] = []
-    for function in ast.walk(tree):
-        if not isinstance(function, ast.FunctionDef | ast.AsyncFunctionDef):
-            continue
-        guarded = _guarded_call_ids(function)
-        found += [
-            (call.lineno, function.name)
-            for call in _config_loads(function)
-            if id(call) not in guarded
-        ]
-    return found
-
-
-def test_no_tui_surface_loads_config_behind_a_hand_written_guard() -> None:
-    """The house pattern is a walk, not a memory (CLAUDE.md).
-
-    Every site the #289 survey found was a hand-written exception tuple
-    that had drifted one exception narrower than the entry check, and
-    two of them were missed on the first pass of this very fix. So the
-    rule is enforced rather than remembered: inside kstrl/tui/, a call
-    that resolves a config section must either go through the banner's
-    ``load`` (which routes to ``config_preflight.load_or_report``) or
-    sit inside a ``try`` that catches ``SURFACE_REJECTIONS``.
+    The safe-mode worker reads KSTRL_* every 5 seconds in EVERY mode,
+    and an embedded orchestrator hangs off a different attribute than a
+    home-launched session. A predicate that reads only run_context is
+    not a guard, it is a lie with a docstring.
     """
+
+    class _Handle:
+        def __init__(self, done: bool) -> None:
+            self._done = done
+
+        def done(self) -> bool:
+            return self._done
+
+    class _Ctx:
+        def __init__(self, handle: object | None) -> None:
+            self.handle = handle
+
+    class _App:
+        def __init__(
+            self,
+            ctx: object | None = None,
+            orchestrator: object | None = None,
+            safe_mode: bool = False,
+        ) -> None:
+            self.run_context = ctx
+            self.orchestrator = orchestrator
+            self._safe_mode_running = safe_mode
+
+    assert env_scrub_is_safe(_App()) is True
+    assert env_scrub_is_safe(_App(ctx=_Ctx(_Handle(True)))) is True
+    assert env_scrub_is_safe(_App(ctx=_Ctx(_Handle(False)))) is False
+    # Finding 3: EMBEDDED mode keeps the live handle here, not on
+    # run_context, whose handle stays None (RunContext.observe).
+    assert env_scrub_is_safe(_App(orchestrator=_Handle(False))) is False
+    assert env_scrub_is_safe(_App(orchestrator=_Handle(True))) is True
+    # Finding 2: the app's own 5-second safe-mode worker.
+    assert env_scrub_is_safe(_App(safe_mode=True)) is False
+
+
+def test_the_safe_mode_worker_still_reads_the_environment() -> None:
+    """The reason finding 2's clause exists, pinned in the source it
+    depends on. If safe_mode_reasons stops loading config, this clause
+    is dead weight and should go; if it keeps loading it, the clause
+    must stay."""
     root = Path(__file__).resolve().parent.parent
-    offenders = [
-        f"{path.relative_to(root).as_posix()}:{lineno} in {name}()"
-        for path in sorted((root / "kstrl" / "tui").rglob("*.py"))
-        for lineno, name in _unguarded_config_loads(ast.parse(path.read_text(encoding="utf-8")))
-    ]
-    assert offenders == [], (
-        "config resolved in kstrl/tui/ without SURFACE_REJECTIONS or the banner: "
-        + ", ".join(offenders)
+    safemode = (root / "kstrl" / "safemode.py").read_text(encoding="utf-8")
+    assert "AutonomyConfig.load" in safemode
+    assert "PolicyConfig.load" in safemode
+    assert "QueueConfig.load" in safemode
+    app = (root / "kstrl" / "tui" / "app.py").read_text(encoding="utf-8")
+    assert "SAFE_MODE_INTERVAL_SECONDS" in app
+    assert "self._safe_mode_running = True" in app
+
+
+def test_a_non_utf8_experiments_file_does_not_crash_the_evolve_screen(
+    tmp_path: Path,
+) -> None:
+    """Finding 4, and the crash class #289 is about.
+
+    UnicodeDecodeError IS a ValueError, so it escaped the `except
+    OSError` in get_experiment_trends and raised out of on_mount two
+    lines after the config banner. CLAUDE.md names this rule verbatim.
+    """
+    from kstrl.evolution import EvolutionJournal
+
+    kstrl_dir = tmp_path / ".kstrl"
+    kstrl_dir.mkdir()
+    (kstrl_dir / "experiments.tsv").write_bytes(b"run_id\tcompleted\n2026-\xe9x\t1\n")
+    journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
+    assert journal.get_experiment_trends(last_n=5) == []
+
+
+def test_a_non_utf8_proposal_does_not_crash_the_evolve_screen(tmp_path: Path) -> None:
+    """The same defect one line earlier in the same on_mount:
+    list_proposals read with no encoding behind `except OSError`."""
+    from kstrl.proposals import existing_proposal_titles, list_proposals
+
+    proposals = tmp_path / ".kstrl" / "proposals"
+    proposals.mkdir(parents=True)
+    (proposals / "prop-001.md").write_bytes(
+        b"# PROP-001: \xe9\xe9\xe9 title\n**Type**: computational\n"
     )
+    assert list_proposals(proposals) == []
+    assert existing_proposal_titles(proposals) == set()
 
 
-def test_every_named_exception_to_the_banner_still_exists() -> None:
-    """An allow-list nobody prunes is a lie. These are guarded by
-    SURFACE_REJECTIONS and render their own message instead."""
+async def test_the_evolve_screen_survives_both_undecodable_files(tmp_path: Path) -> None:
+    """The two above, through the screen, which is where it mattered."""
+    kstrl_dir = tmp_path / ".kstrl"
+    (kstrl_dir / "proposals").mkdir(parents=True)
+    (kstrl_dir / "proposals" / "prop-001.md").write_bytes(b"# PROP-001: \xe9\xe9\xe9\n")
+    (kstrl_dir / "experiments.tsv").write_bytes(b"run_id\tcompleted\n2026-\xe9x\t1\n")
+    async with _evolve(tmp_path) as (screen, _pilot):
+        assert screen.query_one("#trends-table", DataTable).row_count == 0
+        assert screen.query_one("#proposals-table", DataTable).row_count == 0
+        # The config itself is fine, so the banner must NOT claim it is
+        # unreadable: these are data files, not configuration.
+        assert screen.query_one(ConfigProblemBanner).display is False
+
+
+def test_experiments_tsv_is_written_with_the_encoding_it_is_read_with(tmp_path: Path) -> None:
+    """Encoding is a two-sided contract (CLAUDE.md): naming utf-8 on the
+    read while the write follows the locale just moves the failure."""
     root = Path(__file__).resolve().parent.parent
-    for rel, function in _NOT_THE_BANNER:
-        source = (root / rel).read_text(encoding="utf-8")
-        assert f"def {function}(" in source, f"{rel} no longer defines {function}"
-        assert "SURFACE_REJECTIONS" in source, f"{rel} no longer imports the shared tuple"
+    source = (root / "kstrl" / "evolution.py").read_text(encoding="utf-8")
+    assert 'open(self.config.experiments_path, "a", encoding="utf-8")' in source
+    assert 'read_text(encoding="utf-8")' in source
 
 
-def test_the_walk_would_have_caught_the_original_defect() -> None:
-    """The walk is only worth having if it fails on the bug."""
-    unguarded = ast.parse(
-        "def reload(self):\n    journal = EvolutionJournal(EvolutionConfig.load(root_dir))\n"
-    ).body[0]
-    assert isinstance(unguarded, ast.FunctionDef)
-    assert len(_config_loads(unguarded)) == 1
+async def test_the_config_screen_refresh_reports_the_seam_wording(tmp_path: Path) -> None:
+    """Finding 8.
 
-    guarded = ast.parse(
-        "def reload(self):\n"
-        "    try:\n"
-        "        return EvolutionConfig.load(root_dir)\n"
-        "    except SURFACE_REJECTIONS:\n"
-        "        return None\n"
-    ).body[0]
-    assert isinstance(guarded, ast.FunctionDef)
-    tries = [n for n in ast.walk(guarded) if isinstance(n, ast.Try)]
-    assert _guarded_by_the_shared_tuple(tries[0]) is True
-    assert len(_config_loads(tries[0])) == 1
+    This is the screen an operator opens to look at configuration, so
+    "int() argument must be a string ... not 'list'" with no section,
+    key or value is the one place that answer is least useful. The
+    notify now carries collect_config_problems' lines, which is the
+    same traversal `ks config show` prints.
+    """
+    from kstrl.tui.screens.config import ConfigScreen
+
+    (tmp_path / "kstrl.toml").write_text(ARRAY_FOR_A_RUN_NUMBER, encoding="utf-8")
+    app = _home_app(tmp_path)
+    notices: list[str] = []
+    async with app.run_test(size=(140, 40)) as pilot:
+        await pilot.pause(0.2)
+        app.push_screen(ConfigScreen())
+        await pilot.pause(0.2)
+        screen = app.screen
+        assert isinstance(screen, ConfigScreen)
+        app.notify = lambda message, **kw: notices.append(str(message))  # type: ignore[method-assign,assignment]
+        screen.action_refresh()
+        await pilot.pause(0.2)
+    assert notices, "refresh reported nothing"
+    assert any("[run]" in n for n in notices), notices

--- a/tests/test_tui_config_walk.py
+++ b/tests/test_tui_config_walk.py
@@ -1,0 +1,303 @@
+"""The mechanism that stops #289's defect class coming back.
+
+Split out of ``test_tui_config_guard.py`` when the file-length ratchet
+fired, and the ratchet was right: that file tests what the screens DO
+with a broken kstrl.toml, and this one tests a static property of the
+source. Two jobs, two files.
+
+The property: inside ``kstrl/tui/``, a call that resolves a config
+section must either go through the banner (which routes to
+``config_preflight.load_or_report``) or sit in the body of a ``try``
+that cannot let the rejection escape to the Textual event loop.
+
+Why a walk and not a review checklist. Every site the #289 survey found
+was a hand-written exception tuple that had drifted one exception
+narrower than the entry check. Two were missed on the first pass of the
+fix. A third, the largest, was missed by the FIRST VERSION OF THIS WALK,
+which matched only ``build_config_report(...)`` and
+``<Name>Config.load(...)`` and so could not see the seven sections
+``assemble_factory_configs`` loads behind a plain name. Reverting that
+site left the walk passing. Hence the derivation below, which names no
+function at all.
+
+This is the house pattern: ``test_atomicio`` walks for ``mkstemp``,
+``test_process_scoping`` for ``pgrep``, ``test_config_preflight`` for
+unenrolled config dataclasses, ``test_prompt_versions`` for unenrolled
+``*_PROMPT``.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# The mechanism, not the memory
+# --------------------------------------------------------------------------
+# Round one of this walk matched only `build_config_report(...)` and
+# `<Name ending in Config>.load(...)`, and review measured the hole:
+# reverting kstrl/tui/session.py alone left it PASSING, because that
+# site loads seven sections through `assemble_factory_configs`, a plain
+# name the pattern could not see. Naming that function in a list would
+# be the memory this test exists to replace, so the set of
+# config-loading helpers is DERIVED from kstrl/ instead: any function
+# whose own body resolves a section is one, and a call to it from
+# kstrl/tui/ counts as a config load.
+
+
+def _config_load_attr(node: ast.AST) -> bool:
+    """``<Something>Config.load(...)``, the shape every loader has."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "load"
+        and isinstance(func.value, ast.Name)
+        and func.value.id.endswith("Config")
+    )
+
+
+def _config_loading_helpers(package: Path) -> frozenset[str]:
+    """Functions in ``package`` that can PROPAGATE a config rejection.
+
+    Derived, not listed. A function qualifies when it resolves a
+    section and does not guard it, so the rejection reaches its caller.
+    `assemble_factory_configs` (seven sections, no try) and
+    `build_config_report` both fall out of this; so does whatever the
+    next one is called.
+
+    "and does not guard it" is what keeps the rule at the right depth.
+    A first version asked only "does it load", which flagged
+    `init_wizard.on_mount` and `session.start_run_session` for calling
+    helpers that already convert the rejection themselves. The guard
+    belongs at the innermost function that can raise, not at every
+    caller above it.
+    """
+    names: set[str] = set()
+    for path in sorted(package.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for function in ast.walk(tree):
+            if not isinstance(function, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            # frozenset(): direct loads only, no recursion needed - a
+            # helper that only calls another helper cannot raise
+            # anything the inner one did not already let out.
+            if _unguarded_config_loads(function, frozenset()):
+                names.add(function.name)
+    return frozenset(names)
+
+
+def _guarding_handler(node: ast.Try) -> bool:
+    """Whether this try cannot let a config rejection escape.
+
+    ``SURFACE_REJECTIONS`` is the rule. A bare ``except Exception`` also
+    satisfies the PROPERTY being enforced - nothing escapes as an
+    unhandled exception - and `app._safe_mode_worker` uses one
+    deliberately, with its reason written next to it.
+    """
+    for handler in node.handlers:
+        if handler.type is None:
+            return True
+        for name in ast.walk(handler.type):
+            if isinstance(name, ast.Name) and name.id in {
+                "SURFACE_REJECTIONS",
+                "Exception",
+                "BaseException",
+            }:
+                return True
+    return False
+
+
+def _own_nodes(function: ast.FunctionDef | ast.AsyncFunctionDef) -> Iterator[ast.AST]:
+    """Every node in ``function`` except those inside a nested function.
+
+    So a call is attributed to the innermost function that contains it.
+    Plain ``ast.walk`` reported one call three times, once per ancestor,
+    which makes the offender list wrong and an exemption unkeyable.
+    """
+    stack: list[ast.AST] = list(function.body)
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def _config_loads(nodes: Iterable[ast.AST], helpers: frozenset[str]) -> list[ast.Call]:
+    """Calls that resolve a kstrl.toml section, directly or via a helper."""
+    found: list[ast.Call] = []
+    for node in nodes:
+        if not isinstance(node, ast.Call):
+            continue
+        if _config_load_attr(node):
+            found.append(node)
+        elif isinstance(node.func, ast.Name) and node.func.id in helpers:
+            found.append(node)
+    return found
+
+
+def _guarded_call_ids(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    helpers: frozenset[str],
+) -> set[int]:
+    """Ids of the config loads a handler on this function actually covers.
+
+    Only ``Try.body``. Walking the whole ``Try`` node counted a load in
+    an ``except`` or ``finally`` block as guarded, which is backwards:
+    a fallback of the shape ``try: primary() except SURFACE_REJECTIONS:
+    cfg = InboxConfig.load(root)`` runs OUTSIDE any handler, and that
+    is precisely the retry shape this rule should police.
+    """
+    guarded: set[int] = set()
+    for node in _own_nodes(function):
+        if not isinstance(node, ast.Try) or not _guarding_handler(node):
+            continue
+        for statement in node.body:
+            guarded.update(id(call) for call in _config_loads(ast.walk(statement), helpers))
+    return guarded
+
+
+def _unguarded_config_loads(tree: ast.AST, helpers: frozenset[str]) -> list[tuple[int, str]]:
+    """(line, enclosing function) for every unguarded config load."""
+    found: list[tuple[int, str]] = []
+    for function in ast.walk(tree):
+        if not isinstance(function, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        guarded = _guarded_call_ids(function, helpers)
+        found += [
+            (call.lineno, function.name)
+            for call in _config_loads(_own_nodes(function), helpers)
+            if id(call) not in guarded
+        ]
+    return found
+
+
+#: The one site that resolves config in kstrl/tui/ and is guarded by a
+#: mechanism no AST rule can see, keyed by (file, innermost function).
+#: Unlike the decorative set this replaces, the walk below actually
+#: consults it and a second test re-checks its stated reason.
+_GUARDED_OFF_THE_EVENT_LOOP = {
+    (
+        "kstrl/tui/session.py",
+        "target",
+    ): (
+        "runs on the command thread, not the event loop: "
+        "start_command_thread wraps it in `except BaseException` and "
+        "surfaces the error through CommandHandle.error_box"
+    ),
+}
+
+
+def test_no_tui_surface_loads_config_behind_a_hand_written_guard() -> None:
+    """The house pattern is a walk, not a memory (CLAUDE.md).
+
+    Every site the #289 survey found was a hand-written exception tuple
+    that had drifted one exception narrower than the entry check, two
+    were missed on the first pass of this fix, and a third was missed
+    by the first version of this very walk. So the rule is enforced
+    rather than remembered: inside kstrl/tui/, a call that resolves a
+    config section must either go through the banner's ``load`` (which
+    routes to ``config_preflight.load_or_report``) or sit in the body
+    of a ``try`` that cannot let the rejection escape.
+    """
+    root = Path(__file__).resolve().parent.parent
+    helpers = _config_loading_helpers(root / "kstrl") - {"load", "load_or_report"}
+    offenders = [
+        f"{rel}:{lineno} in {name}()"
+        for path in sorted((root / "kstrl" / "tui").rglob("*.py"))
+        for rel in [path.relative_to(root).as_posix()]
+        for lineno, name in _unguarded_config_loads(
+            ast.parse(path.read_text(encoding="utf-8")), helpers
+        )
+        if (rel, name) not in _GUARDED_OFF_THE_EVENT_LOOP
+    ]
+    assert offenders == [], (
+        "config resolved in kstrl/tui/ without a guard or the banner: " + ", ".join(offenders)
+    )
+
+
+def test_the_walk_derives_the_helper_set_rather_than_listing_it() -> None:
+    """The hole review measured: `assemble_factory_configs` is the name
+    the first version could not see, and nothing names it here."""
+    import inspect
+
+    root = Path(__file__).resolve().parent.parent
+    helpers = _config_loading_helpers(root / "kstrl")
+    assert "assemble_factory_configs" in helpers
+    assert "build_config_report" in helpers
+    # A helper that converts the rejection itself is NOT in the set,
+    # which is what stops the walk flagging everyone who calls it.
+    assert "_detected_text" not in helpers
+    assert "_prepare_factory" not in helpers
+    # Derived means derived: the deriving code names no function.
+    source = inspect.getsource(_config_loading_helpers)
+    body = source.split('"""')[2]
+    assert "assemble_factory_configs" not in body
+    assert "build_config_report" not in body
+
+
+def test_the_off_loop_exemption_still_names_a_real_site_and_a_true_reason() -> None:
+    """An allow-list nobody prunes is a lie, so this prunes it.
+
+    Both halves are checked: the exempted site must still be a site the
+    walk would otherwise flag, and the reason it is exempt must still
+    hold in the code that provides it.
+    """
+    root = Path(__file__).resolve().parent.parent
+    helpers = _config_loading_helpers(root / "kstrl")
+    for rel, function in _GUARDED_OFF_THE_EVENT_LOOP:
+        flagged = _unguarded_config_loads(
+            ast.parse((root / rel).read_text(encoding="utf-8")), helpers
+        )
+        assert any(name == function for _line, name in flagged), (
+            f"{rel}:{function} no longer loads config unguarded; drop the exemption"
+        )
+    # The mechanism the exemption rests on.
+    bridge = (root / "kstrl" / "tui" / "bridge.py").read_text(encoding="utf-8")
+    assert "except BaseException as exc:" in bridge
+    assert "error_box.append(exc)" in bridge
+
+
+def test_the_walk_would_have_caught_the_original_defect() -> None:
+    """The walk is only worth having if it fails on the bugs."""
+    helpers = frozenset({"assemble_factory_configs"})
+
+    unguarded = ast.parse(
+        "def reload(self):\n    journal = EvolutionJournal(EvolutionConfig.load(root_dir))\n"
+    ).body[0]
+    assert isinstance(unguarded, ast.FunctionDef)
+    assert len(_config_loads(_own_nodes(unguarded), helpers)) == 1
+
+    # The site the first version of the walk could not see.
+    indirect = ast.parse(
+        "def prepare(spec, root):\n    return assemble_factory_configs(root)\n"
+    ).body[0]
+    assert isinstance(indirect, ast.FunctionDef)
+    assert _unguarded_config_loads(indirect, helpers) == [(2, "prepare")]
+
+    guarded = ast.parse(
+        "def reload(self):\n"
+        "    try:\n"
+        "        return EvolutionConfig.load(root_dir)\n"
+        "    except SURFACE_REJECTIONS:\n"
+        "        return None\n"
+    ).body[0]
+    assert isinstance(guarded, ast.FunctionDef)
+    assert _unguarded_config_loads(guarded, helpers) == []
+
+
+def test_a_load_in_an_except_block_is_not_counted_as_guarded() -> None:
+    """`ast.walk` over a Try yields its handlers too, so the first
+    version called this guarded. Nothing catches it."""
+    fallback = ast.parse(
+        "def load(self):\n"
+        "    try:\n"
+        "        return primary()\n"
+        "    except SURFACE_REJECTIONS:\n"
+        "        return InboxConfig.load(root)\n"
+    ).body[0]
+    assert isinstance(fallback, ast.FunctionDef)
+    assert _unguarded_config_loads(fallback, frozenset()) == [(5, "load")]

--- a/tests/test_tui_config_walk.py
+++ b/tests/test_tui_config_walk.py
@@ -20,6 +20,36 @@ which matched only ``build_config_report(...)`` and
 site left the walk passing. Hence the derivation below, which names no
 function at all.
 
+WHAT THE SECOND VERSION COULD NOT SEE, AND WHAT THIS ONE CAN
+------------------------------------------------------------
+Review measured five more blind spots and one false-positive engine,
+and the fix for all six is the same: resolve names instead of matching
+strings.
+
+Now seen: ``evolution.EvolutionConfig.load(root)`` and any other dotted
+owner; ``IC.load(root)`` where ``IC`` is an alias for a ``*Config``
+class, resolved through the importing file's own bindings;
+``config_report.build_config_report(root)`` and any other helper reached
+through a module attribute; and a load at MODULE level, which the
+previous version could not report at all because it only ever walked
+into function bodies.
+
+Now not guessed at: the helper set was matched by bare name and
+contained thirty of them, including ``run``, ``serve``, ``evolve``,
+``factory`` and ``__init__``, so any call to a function that happened to
+share a name with one was a config load as far as this walk was
+concerned. Helpers are now keyed by ``(module, name)`` and a call site
+resolves through its own imports, so ``run(...)`` counts only when
+``run`` is the one kstrl defines and loads config in.
+
+STILL NOT SEEN, DELIBERATELY
+----------------------------
+``self._cfg_cls.load(root)`` - a loader held in an attribute - needs
+type inference, not name resolution, and nothing in kstrl writes that
+shape today. Matching every ``.load(`` instead would sweep in
+``Manifest.load`` and ``json.load``, which is a rule nobody keeps. The
+limit is recorded here rather than left to be discovered.
+
 This is the house pattern: ``test_atomicio`` walks for ``mkstemp``,
 ``test_process_scoping`` for ``pgrep``, ``test_config_preflight`` for
 unenrolled config dataclasses, ``test_prompt_versions`` for unenrolled
@@ -30,66 +60,166 @@ from __future__ import annotations
 
 import ast
 from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
 from pathlib import Path
 
+Scope = ast.Module | ast.FunctionDef | ast.AsyncFunctionDef
+
 # --------------------------------------------------------------------------
-# The mechanism, not the memory
+# Name resolution: what a call site in one file is actually calling
 # --------------------------------------------------------------------------
-# Round one of this walk matched only `build_config_report(...)` and
-# `<Name ending in Config>.load(...)`, and review measured the hole:
-# reverting kstrl/tui/session.py alone left it PASSING, because that
-# site loads seven sections through `assemble_factory_configs`, a plain
-# name the pattern could not see. Naming that function in a list would
-# be the memory this test exists to replace, so the set of
-# config-loading helpers is DERIVED from kstrl/ instead: any function
-# whose own body resolves a section is one, and a call to it from
-# kstrl/tui/ counts as a config load.
 
 
-def _config_load_attr(node: ast.AST) -> bool:
-    """``<Something>Config.load(...)``, the shape every loader has."""
-    if not isinstance(node, ast.Call):
-        return False
-    func = node.func
-    return (
-        isinstance(func, ast.Attribute)
-        and func.attr == "load"
-        and isinstance(func.value, ast.Name)
-        and func.value.id.endswith("Config")
-    )
+@dataclass(frozen=True)
+class Bindings:
+    """What the names in one file refer to, from its own imports.
 
-
-def _config_loading_helpers(package: Path) -> frozenset[str]:
-    """Functions in ``package`` that can PROPAGATE a config rejection.
-
-    Derived, not listed. A function qualifies when it resolves a
-    section and does not guard it, so the rejection reaches its caller.
-    `assemble_factory_configs` (seven sections, no try) and
-    `build_config_report` both fall out of this; so does whatever the
-    next one is called.
-
-    "and does not guard it" is what keeps the rule at the right depth.
-    A first version asked only "does it load", which flagged
-    `init_wizard.on_mount` and `session.start_run_session` for calling
-    helpers that already convert the rejection themselves. The guard
-    belongs at the innermost function that can raise, not at every
-    caller above it.
+    Three maps rather than one because a call site can name a helper
+    (``assemble_factory_configs(...)``), a module holding one
+    (``config_report.build_config_report(...)``) or a config class
+    under any alias (``IC.load(...)``), and each needs a different
+    lookup. Populated from every ``import`` in the file at ANY depth:
+    kstrl's TUI modules import inside functions to keep startup cheap,
+    so a module-level-only scan sees almost none of them.
     """
-    names: set[str] = set()
-    for path in sorted(package.rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-        for function in ast.walk(tree):
-            if not isinstance(function, ast.FunctionDef | ast.AsyncFunctionDef):
-                continue
-            # frozenset(): direct loads only, no recursion needed - a
-            # helper that only calls another helper cannot raise
-            # anything the inner one did not already let out.
-            if _unguarded_config_loads(function, frozenset()):
-                names.add(function.name)
-    return frozenset(names)
+
+    functions: dict[str, tuple[str, str]] = field(default_factory=dict)
+    modules: dict[str, str] = field(default_factory=dict)
+    config_classes: set[str] = field(default_factory=set)
 
 
-def _guarding_handler(node: ast.Try) -> bool:
+def _is_config_class(name: str) -> bool:
+    return name.endswith("Config")
+
+
+def _bind_from_import(module: str, names: list[ast.alias], bindings: Bindings) -> None:
+    """Record one ``from <module> import ...`` under its local names."""
+    for alias in names:
+        local = alias.asname or alias.name
+        # An imported name may be a function or a submodule and the AST
+        # cannot tell which, so record both readings. A wrong one cannot
+        # produce a false hit: it only ever fails to match the derived
+        # helper set.
+        bindings.functions[local] = (module, alias.name)
+        bindings.modules[local] = f"{module}.{alias.name}"
+        if _is_config_class(alias.name):
+            # Keyed by the LOCAL name, which is the point: `import
+            # InboxConfig as IC` makes `IC.load` a config load and no
+            # name-shape rule can see it.
+            bindings.config_classes.add(local)
+
+
+def collect_bindings(tree: ast.AST) -> Bindings:
+    """Resolve the file's imported names to their defining module."""
+    bindings = Bindings()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                bindings.modules[alias.asname or alias.name] = alias.name
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            _bind_from_import(node.module, node.names, bindings)
+    return bindings
+
+
+def dotted_name(node: ast.AST) -> str | None:
+    """``a.b.c`` for an attribute chain rooted at a plain name, else None."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if not isinstance(node, ast.Name):
+        return None
+    parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def is_config_class_load(call: ast.Call, bindings: Bindings) -> bool:
+    """``<anything naming a config class>.load(...)``.
+
+    The owner is flattened first, so a dotted module prefix is stripped
+    rather than being the reason the call is missed.
+    """
+    func = call.func
+    if not isinstance(func, ast.Attribute) or func.attr != "load":
+        return False
+    owner = dotted_name(func.value)
+    if owner is None:
+        return False
+    last = owner.rsplit(".", 1)[-1]
+    return _is_config_class(last) or last in bindings.config_classes
+
+
+def call_target(call: ast.Call, bindings: Bindings, module: str) -> tuple[str, str] | None:
+    """The ``(module, name)`` a call refers to, as best a file can say."""
+    func = call.func
+    if isinstance(func, ast.Name):
+        return bindings.functions.get(func.id, (module, func.id))
+    dotted = dotted_name(func)
+    if dotted is None or "." not in dotted:
+        return None
+    prefix, name = dotted.rsplit(".", 1)
+    return (bindings.modules.get(prefix, prefix), name)
+
+
+# --------------------------------------------------------------------------
+# Scopes: the unit a load is attributed to
+# --------------------------------------------------------------------------
+
+
+def module_name(path: Path, root: Path) -> str:
+    """``kstrl/tui/session.py`` -> ``kstrl.tui.session``."""
+    dotted = path.relative_to(root).with_suffix("").as_posix().replace("/", ".")
+    return dotted.removesuffix(".__init__")
+
+
+def scopes(tree: ast.Module) -> list[tuple[Scope, str]]:
+    """Every executable scope in a module, with its qualified name.
+
+    The module itself is one of them: a load at import time is a load,
+    and the previous version of this walk started at ``FunctionDef`` and
+    so could not report one. Qualified because a bare function name is
+    not a key - ``kstrl/tui/session.py`` has two ``def target()``
+    closures, and an exemption written against "target" silently
+    covered both.
+    """
+    found: list[tuple[Scope, str]] = [(tree, "<module>")]
+
+    def descend(node: ast.AST, prefix: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+                qualified = f"{prefix}.{child.name}" if prefix else child.name
+                if not isinstance(child, ast.ClassDef):
+                    found.append((child, qualified))
+                descend(child, qualified)
+            else:
+                descend(child, prefix)
+
+    descend(tree, "")
+    return found
+
+
+def own_nodes(scope: Scope) -> Iterator[ast.AST]:
+    """Every node in ``scope`` except those inside a nested function.
+
+    So a call is attributed to the innermost scope that contains it.
+    Plain ``ast.walk`` reported one call three times, once per ancestor,
+    which makes the offender list wrong and an exemption unkeyable.
+    """
+    stack: list[ast.AST] = list(scope.body)
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+
+
+# --------------------------------------------------------------------------
+# The rule
+# --------------------------------------------------------------------------
+
+
+def guarding_handler(node: ast.Try) -> bool:
     """Whether this try cannot let a config rejection escape.
 
     ``SURFACE_REJECTIONS`` is the rule. A bare ``except Exception`` also
@@ -110,40 +240,29 @@ def _guarding_handler(node: ast.Try) -> bool:
     return False
 
 
-def _own_nodes(function: ast.FunctionDef | ast.AsyncFunctionDef) -> Iterator[ast.AST]:
-    """Every node in ``function`` except those inside a nested function.
-
-    So a call is attributed to the innermost function that contains it.
-    Plain ``ast.walk`` reported one call three times, once per ancestor,
-    which makes the offender list wrong and an exemption unkeyable.
-    """
-    stack: list[ast.AST] = list(function.body)
-    while stack:
-        node = stack.pop()
-        yield node
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
-            continue
-        stack.extend(ast.iter_child_nodes(node))
-
-
-def _config_loads(nodes: Iterable[ast.AST], helpers: frozenset[str]) -> list[ast.Call]:
+def config_loads(
+    nodes: Iterable[ast.AST],
+    helpers: frozenset[tuple[str, str]],
+    bindings: Bindings,
+    module: str,
+) -> list[ast.Call]:
     """Calls that resolve a kstrl.toml section, directly or via a helper."""
     found: list[ast.Call] = []
     for node in nodes:
         if not isinstance(node, ast.Call):
             continue
-        if _config_load_attr(node):
-            found.append(node)
-        elif isinstance(node.func, ast.Name) and node.func.id in helpers:
+        if is_config_class_load(node, bindings) or call_target(node, bindings, module) in helpers:
             found.append(node)
     return found
 
 
 def _guarded_call_ids(
-    function: ast.FunctionDef | ast.AsyncFunctionDef,
-    helpers: frozenset[str],
+    scope: Scope,
+    helpers: frozenset[tuple[str, str]],
+    bindings: Bindings,
+    module: str,
 ) -> set[int]:
-    """Ids of the config loads a handler on this function actually covers.
+    """Ids of the config loads a handler in this scope actually covers.
 
     Only ``Try.body``. Walking the whole ``Try`` node counted a load in
     an ``except`` or ``finally`` block as guarded, which is backwards:
@@ -152,43 +271,115 @@ def _guarded_call_ids(
     is precisely the retry shape this rule should police.
     """
     guarded: set[int] = set()
-    for node in _own_nodes(function):
-        if not isinstance(node, ast.Try) or not _guarding_handler(node):
+    for node in own_nodes(scope):
+        if not isinstance(node, ast.Try) or not guarding_handler(node):
             continue
         for statement in node.body:
-            guarded.update(id(call) for call in _config_loads(ast.walk(statement), helpers))
+            guarded.update(
+                id(call) for call in config_loads(ast.walk(statement), helpers, bindings, module)
+            )
     return guarded
 
 
-def _unguarded_config_loads(tree: ast.AST, helpers: frozenset[str]) -> list[tuple[int, str]]:
-    """(line, enclosing function) for every unguarded config load."""
+def unguarded_config_loads(
+    tree: ast.Module,
+    helpers: frozenset[tuple[str, str]],
+    module: str = "<test>",
+) -> list[tuple[int, str]]:
+    """(line, qualified scope) for every unguarded config load."""
+    bindings = collect_bindings(tree)
     found: list[tuple[int, str]] = []
-    for function in ast.walk(tree):
-        if not isinstance(function, ast.FunctionDef | ast.AsyncFunctionDef):
-            continue
-        guarded = _guarded_call_ids(function, helpers)
+    for scope, qualified in scopes(tree):
+        guarded = _guarded_call_ids(scope, helpers, bindings, module)
         found += [
-            (call.lineno, function.name)
-            for call in _config_loads(_own_nodes(function), helpers)
+            (call.lineno, qualified)
+            for call in config_loads(own_nodes(scope), helpers, bindings, module)
             if id(call) not in guarded
         ]
     return found
 
 
-#: The one site that resolves config in kstrl/tui/ and is guarded by a
-#: mechanism no AST rule can see, keyed by (file, innermost function).
-#: Unlike the decorative set this replaces, the walk below actually
-#: consults it and a second test re-checks its stated reason.
+# --------------------------------------------------------------------------
+# The mechanism, not the memory
+# --------------------------------------------------------------------------
+# Round one of this walk matched only `build_config_report(...)` and
+# `<Name ending in Config>.load(...)`, and review measured the hole:
+# reverting kstrl/tui/session.py alone left it PASSING, because that
+# site loads seven sections through `assemble_factory_configs`, a plain
+# name the pattern could not see. Naming that function in a list would
+# be the memory this test exists to replace, so the set of
+# config-loading helpers is DERIVED from kstrl/ instead: any function
+# whose own body resolves a section is one, and a call to it from
+# kstrl/tui/ counts as a config load.
+
+
+def config_loading_helpers(package: Path, root: Path) -> frozenset[tuple[str, str]]:
+    """Functions in ``package`` that can PROPAGATE a config rejection.
+
+    Derived, not listed. A function qualifies when it resolves a
+    section and does not guard it, so the rejection reaches its caller.
+    `assemble_factory_configs` (seven sections, no try) and
+    `build_config_report` both fall out of this; so does whatever the
+    next one is called.
+
+    "and does not guard it" is what keeps the rule at the right depth.
+    A first version asked only "does it load", which flagged
+    `init_wizard.on_mount` and `session.start_run_session` for calling
+    helpers that already convert the rejection themselves. The guard
+    belongs at the innermost function that can raise, not at every
+    caller above it.
+
+    Keyed by ``(module, name)`` and restricted to module-level
+    functions, which are the only ones another module can call by name.
+    The bare-name version of this set held thirty entries including
+    `run`, `serve`, `evolve` and `__init__`, so a call to any unrelated
+    function with a colliding name was read as a config load.
+    """
+    found: set[tuple[str, str]] = set()
+    for path in sorted(package.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        module = module_name(path, root)
+        bindings = collect_bindings(tree)
+        for node in tree.body:
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            # Direct loads only, no recursion needed - a helper that
+            # only calls another helper cannot raise anything the inner
+            # one did not already let out.
+            guarded = _guarded_call_ids(node, frozenset(), bindings, module)
+            if any(
+                id(call) not in guarded
+                for call in config_loads(own_nodes(node), frozenset(), bindings, module)
+            ):
+                found.add((module, node.name))
+    return frozenset(found)
+
+
+#: The sites that resolve config in kstrl/tui/ and are guarded by a
+#: mechanism no AST rule can see, keyed by (file, QUALIFIED scope).
+#: Qualified because session.py has two `def target()` closures and a
+#: bare-name key exempted both while naming one. Unlike the decorative
+#: set this replaces, the walk below actually consults it and a second
+#: test re-checks its stated reason.
 _GUARDED_OFF_THE_EVENT_LOOP = {
     (
         "kstrl/tui/session.py",
-        "target",
+        "_prepare_decompose.build.target",
     ): (
-        "runs on the command thread, not the event loop: "
+        "loads config through commandrun.open_command_run, but runs on "
+        "the command thread rather than the event loop: "
         "start_command_thread wraps it in `except BaseException` and "
         "surfaces the error through CommandHandle.error_box"
     ),
 }
+#: Kept as prose because it is the measurement, not the rule: the
+#: bare-name key this replaces read ("kstrl/tui/session.py", "target"),
+#: and session.py has TWO `def target()` closures. The one it named,
+#: `_prepare_factory.build.target`, resolves no config at all - it calls
+#: `run_factory`, and the loading happens inside `_run_factory_locked`
+#: below it. The one it actually exempted is the decompose closure
+#: above. The exemption's own test passed throughout, because it asked
+#: only whether SOME scope called `target` was flagged.
 
 
 def test_no_tui_surface_loads_config_behind_a_hand_written_guard() -> None:
@@ -204,13 +395,15 @@ def test_no_tui_surface_loads_config_behind_a_hand_written_guard() -> None:
     of a ``try`` that cannot let the rejection escape.
     """
     root = Path(__file__).resolve().parent.parent
-    helpers = _config_loading_helpers(root / "kstrl") - {"load", "load_or_report"}
+    helpers = config_loading_helpers(root / "kstrl", root)
     offenders = [
-        f"{rel}:{lineno} in {name}()"
+        f"{rel}:{lineno} in {name}"
         for path in sorted((root / "kstrl" / "tui").rglob("*.py"))
         for rel in [path.relative_to(root).as_posix()]
-        for lineno, name in _unguarded_config_loads(
-            ast.parse(path.read_text(encoding="utf-8")), helpers
+        for lineno, name in unguarded_config_loads(
+            ast.parse(path.read_text(encoding="utf-8")),
+            helpers,
+            module_name(path, root),
         )
         if (rel, name) not in _GUARDED_OFF_THE_EVENT_LOOP
     ]
@@ -225,18 +418,37 @@ def test_the_walk_derives_the_helper_set_rather_than_listing_it() -> None:
     import inspect
 
     root = Path(__file__).resolve().parent.parent
-    helpers = _config_loading_helpers(root / "kstrl")
-    assert "assemble_factory_configs" in helpers
-    assert "build_config_report" in helpers
+    helpers = config_loading_helpers(root / "kstrl", root)
+    assert ("kstrl.launch", "assemble_factory_configs") in helpers
+    assert ("kstrl.config_report", "build_config_report") in helpers
     # A helper that converts the rejection itself is NOT in the set,
     # which is what stops the walk flagging everyone who calls it.
-    assert "_detected_text" not in helpers
-    assert "_prepare_factory" not in helpers
+    assert ("kstrl.tui.screens.init_wizard", "_detected_text") not in helpers
+    assert ("kstrl.tui.session", "_prepare_factory") not in helpers
     # Derived means derived: the deriving code names no function.
-    source = inspect.getsource(_config_loading_helpers)
+    source = inspect.getsource(config_loading_helpers)
     body = source.split('"""')[2]
     assert "assemble_factory_configs" not in body
     assert "build_config_report" not in body
+
+
+def test_the_helper_set_is_qualified_rather_than_a_bag_of_bare_names() -> None:
+    """Review's measurement: the bare-name set held thirty entries,
+    among them `run`, `serve`, `evolve`, `factory` and `__init__`, so a
+    call to any unrelated function sharing one of those names read as a
+    config load. Keys carry their module now, and an unresolvable name
+    from an unrelated module resolves to a pair nothing matches."""
+    root = Path(__file__).resolve().parent.parent
+    helpers = config_loading_helpers(root / "kstrl", root)
+    collisions = {"run", "serve", "evolve", "factory", "feature", "sense", "__init__"}
+    assert collisions & {name for _module, name in helpers}, (
+        "the generic names review measured are gone from kstrl entirely; "
+        "this test no longer measures anything"
+    )
+    # ... and none of them can be hit from a file that did not import
+    # the kstrl function of that name.
+    innocent = ast.parse("def show():\n    run(thing)\n    factory()\n")
+    assert unguarded_config_loads(innocent, helpers, "kstrl.tui.screens.made_up") == []
 
 
 def test_the_off_loop_exemption_still_names_a_real_site_and_a_true_reason() -> None:
@@ -247,13 +459,16 @@ def test_the_off_loop_exemption_still_names_a_real_site_and_a_true_reason() -> N
     hold in the code that provides it.
     """
     root = Path(__file__).resolve().parent.parent
-    helpers = _config_loading_helpers(root / "kstrl")
-    for rel, function in _GUARDED_OFF_THE_EVENT_LOOP:
-        flagged = _unguarded_config_loads(
-            ast.parse((root / rel).read_text(encoding="utf-8")), helpers
+    helpers = config_loading_helpers(root / "kstrl", root)
+    for rel, scope in _GUARDED_OFF_THE_EVENT_LOOP:
+        path = root / rel
+        flagged = unguarded_config_loads(
+            ast.parse(path.read_text(encoding="utf-8")),
+            helpers,
+            module_name(path, root),
         )
-        assert any(name == function for _line, name in flagged), (
-            f"{rel}:{function} no longer loads config unguarded; drop the exemption"
+        assert any(name == scope for _line, name in flagged), (
+            f"{rel}:{scope} no longer loads config unguarded; drop the exemption"
         )
     # The mechanism the exemption rests on.
     bridge = (root / "kstrl" / "tui" / "bridge.py").read_text(encoding="utf-8")
@@ -261,22 +476,37 @@ def test_the_off_loop_exemption_still_names_a_real_site_and_a_true_reason() -> N
     assert "error_box.append(exc)" in bridge
 
 
+def test_the_exemption_key_distinguishes_two_closures_of_the_same_name() -> None:
+    """Review's measurement: session.py defines `target` twice, so the
+    old (file, bare name) key exempted both while claiming one."""
+    root = Path(__file__).resolve().parent.parent
+    session = root / "kstrl" / "tui" / "session.py"
+    targets = {
+        name
+        for name in (
+            qualified for _scope, qualified in scopes(ast.parse(session.read_text("utf-8")))
+        )
+        if name.endswith(".target")
+    }
+    assert len(targets) > 1, "session.py no longer has colliding closures to distinguish"
+    assert all(key in targets for _rel, key in _GUARDED_OFF_THE_EVENT_LOOP)
+
+
 def test_the_walk_would_have_caught_the_original_defect() -> None:
     """The walk is only worth having if it fails on the bugs."""
-    helpers = frozenset({"assemble_factory_configs"})
+    helpers = frozenset({("kstrl.launch", "assemble_factory_configs")})
+    prelude = "from kstrl.launch import assemble_factory_configs\n"
 
     unguarded = ast.parse(
         "def reload(self):\n    journal = EvolutionJournal(EvolutionConfig.load(root_dir))\n"
-    ).body[0]
-    assert isinstance(unguarded, ast.FunctionDef)
-    assert len(_config_loads(_own_nodes(unguarded), helpers)) == 1
+    )
+    assert unguarded_config_loads(unguarded, helpers) == [(2, "reload")]
 
     # The site the first version of the walk could not see.
     indirect = ast.parse(
-        "def prepare(spec, root):\n    return assemble_factory_configs(root)\n"
-    ).body[0]
-    assert isinstance(indirect, ast.FunctionDef)
-    assert _unguarded_config_loads(indirect, helpers) == [(2, "prepare")]
+        prelude + "def prepare(spec, root):\n    return assemble_factory_configs(root)\n"
+    )
+    assert unguarded_config_loads(indirect, helpers) == [(3, "prepare")]
 
     guarded = ast.parse(
         "def reload(self):\n"
@@ -284,9 +514,8 @@ def test_the_walk_would_have_caught_the_original_defect() -> None:
         "        return EvolutionConfig.load(root_dir)\n"
         "    except SURFACE_REJECTIONS:\n"
         "        return None\n"
-    ).body[0]
-    assert isinstance(guarded, ast.FunctionDef)
-    assert _unguarded_config_loads(guarded, helpers) == []
+    )
+    assert unguarded_config_loads(guarded, helpers) == []
 
 
 def test_a_load_in_an_except_block_is_not_counted_as_guarded() -> None:
@@ -298,6 +527,47 @@ def test_a_load_in_an_except_block_is_not_counted_as_guarded() -> None:
         "        return primary()\n"
         "    except SURFACE_REJECTIONS:\n"
         "        return InboxConfig.load(root)\n"
-    ).body[0]
-    assert isinstance(fallback, ast.FunctionDef)
-    assert _unguarded_config_loads(fallback, frozenset()) == [(5, "load")]
+    )
+    assert unguarded_config_loads(fallback, frozenset()) == [(5, "load")]
+
+
+def test_the_shapes_the_second_version_could_not_see() -> None:
+    """Four blind spots review measured, each one line of source.
+
+    Every one of these is a real config load that the walk reported as
+    clean, which is the only failure mode that matters for a test whose
+    whole job is noticing.
+    """
+    helpers = frozenset({("kstrl.config_report", "build_config_report")})
+
+    dotted_owner = ast.parse("def show():\n    return evolution.EvolutionConfig.load(root)\n")
+    assert unguarded_config_loads(dotted_owner, helpers) == [(2, "show")]
+
+    aliased_class = ast.parse(
+        "from kstrl.inbox import InboxConfig as IC\ndef show():\n    return IC.load(root)\n"
+    )
+    assert unguarded_config_loads(aliased_class, helpers) == [(3, "show")]
+
+    module_attribute = ast.parse(
+        "from kstrl import config_report\n"
+        "def show():\n"
+        "    return config_report.build_config_report(root)\n"
+    )
+    assert unguarded_config_loads(module_attribute, helpers) == [(3, "show")]
+
+    at_import_time = ast.parse("REPORT = build_config_report(root)\n")
+    assert unguarded_config_loads(at_import_time, helpers, "kstrl.config_report") == [
+        (1, "<module>")
+    ]
+
+
+def test_an_unresolvable_loader_attribute_is_a_stated_limit_not_a_silent_one() -> None:
+    """`self._cfg_cls.load(root)` needs type inference, so it is missed.
+
+    Pinned rather than left to be discovered: if someone teaches the
+    walk to resolve it, this test is the one that says so, and the
+    module docstring is what has to change with it.
+    """
+    held_in_an_attribute = ast.parse("def show(self):\n    return self._cfg_cls.load(root)\n")
+    assert unguarded_config_loads(held_in_an_attribute, frozenset()) == []
+    assert "self._cfg_cls.load(root)" in __doc__ if __doc__ else False


### PR DESCRIPTION
Fixes #289.

## What was wrong

`kstrl/tui/screens/evolve.py:178` called `EvolutionConfig.load` with no guard, on a screen the home shell opens. The same broken `kstrl.toml` gave a clean named error on the CLI and a traceback in the TUI.

## How I reproduced it

Measured on `5abbc91`, not taken from the issue text. `kstrl.toml` holding `[evolution] lookback_runs = "many"`, then `EvolveScreen` pushed onto a `KstrlTuiApp`:

```
File ".../kstrl/tui/screens/evolve.py", line 121, in on_mount
    self.reload()
File ".../kstrl/tui/screens/evolve.py", line 130, in reload
    self._load_patterns_and_trends(root_dir)
File ".../kstrl/tui/screens/evolve.py", line 178, in _load_patterns_and_trends
    journal = EvolutionJournal(EvolutionConfig.load(root_dir))
File ".../kstrl/evolution.py", line 108, in load
    config.lookback_runs = int(section["lookback_runs"])
ValueError: invalid literal for int() with base 10: 'many'
```

In a real shell that is an unhandled exception in a message handler, which takes the app down. The CLI on the same directory:

```
$ ks evolve --root <same dir>
error: configuration rejected before anything was started; fix it and run again:
  [evolution] invalid literal for int() with base 10: 'many' (kstrl.toml has [evolution] lookback_runs = 'many')
$ echo $?
1
```

### One correction to the issue's framing

The issue says the home shell "never runs the command preflight PR #287 installs". That is not quite right, and the difference is the whole design. `cli.cli:811` **does** call `preflight_config` before opening the shell. Measured:

```
preflight_config(<dir with the bad knob>)  ->  PASSED (shell would open)
  warn: [evolution] invalid literal for int() with base 10: 'many'
        (kstrl.toml has [evolution] lookback_runs = 'many') - continuing without it
```

The seam ran and classified `[evolution]` as **degrading**, which is correct for every other command: the journal is an optional audit trail. `_PREFLIGHT_REQUIRED` is how a command that is *about* a section promotes it to fatal, and `ks evolve` uses it. A screen cannot, because it is not a click command. So the shell opens on a warning and the screen that section is entirely about then raises. `tests/test_tui_config_guard.py::test_the_shell_opens_on_the_value_that_crashes_the_screen` pins that, so the reason this is not covered by #272 is now a test rather than a paragraph.

## What the survey found

The issue asked whether other home-shell screens have the same exposure. Four more sites, all measured, none guessed:

| Site | Shape | Reachable |
|---|---|---|
| `screens/inbox.py:77` `InboxConfig.load` | **Unguarded**, same as evolve | A malformed document raised straight out of `on_mount` |
| `tui/session.py` (x2) | Guarded, but `(OSError, ValueError)` - one exception narrower than the seam's `REJECTIONS` | `[timeout] git_operation = ["30"]` raises **TypeError** out of `float()` and escaped, taking the shell down at launch |
| `screens/init_wizard.py:78` | Same narrow tuple | `[verify] self_critique_min_bullets = ["3"]` coerces through `int()`, same escape |
| `screens/config.py:226` and `tui/home.py:26` | `except ValueError` around `build_config_report` | `[run] max_iterations = ["3"]` raises TypeError and escaped. Found by the `/simplify` altitude pass, **after** I had already claimed the survey was complete |

`screens/config.py` is the live one: that refresh action exists precisely to re-read a file the operator has just edited. `tui/home.py` is latent only because `cli.cli` rejects such a file first.

So the class is not "one unguarded call". It is "a surface that loads config after command entry, behind a hand-written exception tuple that has drifted narrower than the seam's".

## What I changed, in the order the reasoning ran

1. **Reproduced** the evolve crash and the CLI's clean error on the same file, then measured that the shell's own preflight passes it as a warning. That is what identified the real gap.
2. **Surveyed** the other screens before choosing a fix, and found inbox unguarded and three guards too narrow.
3. **`config_preflight.load_or_report(loader, root_dir, *, blame_env)`** resolves one section and, on rejection, returns the line `_detail` would have printed at command entry. The *same helper*, so the two surfaces cannot drift; a test pins the strings byte-equal. `_section_for` looks the loader up in `config_sections()`, so a caller cannot label itself with a section the entry check does not know, and an unenrolled loader is a `LookupError` (a kstrl defect) rather than a mislabelled message.
4. **`SURFACE_REJECTIONS = (*REJECTIONS, OSError)`**, imported by every post-entry loader instead of hand-written. It carries two rationales: the entry check reads the document itself before any loader runs, so it never needs `OSError`, while a screen re-reading minutes later meets a `chmod`; and a loader may read a file that is not `kstrl.toml` at all (`resolve_verify_commands` reads `pyproject.toml`).
5. **`ConfigProblemBanner.load(loader, root)`** does the read and the render in one call, so a screen cannot do the first and forget the second. Not an empty list, not a traceback: a line naming the section, the loader's own message, and the input that set it.
6. **`env_scrub_is_safe`** was already written inline in `ConfigScreen.action_refresh` and is now shared. Naming the environment variable is *measured* by clearing `os.environ`, which is process-wide, and a home-shell session runs the factory on another thread whose subprocesses inherit the environment. On a screen with a run in flight the variable's name is given up rather than the run corrupted; everything else in the line survives.
7. **A walk, not a memory.** Missing two sites by hand is the argument for a mechanism, and this codebase has the pattern (`test_atomicio` walks for `mkstemp`, `test_process_scoping` for `pgrep`). `test_no_tui_surface_loads_config_behind_a_hand_written_guard` AST-walks `kstrl/tui/` and fails on a config load that neither goes through the banner nor sits in a `try` catching `SURFACE_REJECTIONS`. Verified against the real defect: reverting the evolve guard makes it fail naming `evolve.py:191`.

What an operator sees now:

```
▲ configuration unreadable: [evolution] invalid literal for int() with base 10: 'many' (kstrl.toml has [evolution] lookback_runs = 'many')
```

byte-identical to the CLI's line, with the tables empty *and explained*.

## What I am unsure about

- **The banner's promise is narrower than it reads.** It says the config is unreadable. It does not cover the journal *files*: `evolution.get_experiment_trends` returns `[]` on `OSError` reading `experiments.tsv`, and `_read_journal_entries` does the same. `chmod` the journal instead of the config and the banner stays clean while the table goes empty, which is exactly the ambiguity #289 objects to, one layer down. Pre-existing, deliberately not widened here, and worth its own issue.
- **Five renderings of "kstrl.toml is unreadable" still exist** in the TUI: this banner, the wizard's labelled row, the config screen's notify, `LaunchError`, and a safe-mode reason from `app.py:225`. The seam stops them *disagreeing about the facts*; it does not merge them.
- **`_section_for` compares bound classmethods with `==`.** `EvolutionConfig.load is EvolutionConfig.load` is False and `==` is True. Documented next to the code, and a test covers the lookup, but it is the subtlest thing in the diff.
- **`_PREFLIGHT_REQUIRED` was deliberately not used at shell entry.** Promoting `[evolution]` for the whole shell would refuse to open the config screen and the init wizard, which are the two repair surfaces. I think per-screen is right for an about-ness decision on a multi-screen surface, but it is a judgement call.
- **The `pilot.pause(0.2)` in the evolve tests is inherited, not derived.** It mirrors `tests/test_evolve_screen.py`; a `/simplify` agent measured five green runs without it, which is not proof against CI flake, so I kept the house value.

## Definition of done

- `uv run pytest tests/ -q`: **4206 passed, 28 skipped**.
- `uv run mypy kstrl/ --strict`: clean, 125 source files.
- `uv run ruff check kstrl/ tests/`: clean.
- Pre-commit at commit time (`--staged`, which is the gate this hook uses): **every hook passed**, complexipy included. Note `pre-commit run --all-files` exits 1 on this repo at `origin/main` too, because it reports every function over 15 tree-wide; that is not the gate, and reading it as one is how I first mis-verified this.
- Coverage: local combined **89.55%** against the 79.91% ratchet. `config_preflight.py` 99.12%, `tui/widgets/config_problem.py` 100%, `tui/config_guard.py` 100%.
- No `*_PROMPT` constant touched, so no H2/H3 calibration is implicated.
- `atlas` will fail. Per the owner's standing instruction, that is expected and accepted.

### Tests

`tests/test_tui_config_guard.py`, 24 cases. Behaviour, not presence:

- The evolve screen mounts on a bad knob, on a malformed document, and on a bad `KSTRL_EVOLUTION_LOOKBACK_RUNS`, showing the section, the coercion failure, and the variable. Both tables are empty **and** the emptiness is explained.
- The banner is hidden on a config that resolves, and clears when the file is repaired and `r` is pressed.
- `[evolution]` in the message survives Rich markup. The first version rendered a `str` and Rich **deleted** the bracketed section name: the measured output was `configuration unreadable:  invalid literal for int()`, the fault named and the section missing. The banner renders a `Text`, and that assertion is the pin.
- The inbox screen reports a malformed document, and can no longer print "Inbox clear: nothing is waiting on you" from a list that is empty only because the config would not load, in a case where an item **is** waiting. A decision taken after the file broke redraws and does not land.
- The screen's line equals the CLI's line for the same file, compared directly against `collect_config_problems`.
- The env sweep is skipped with `blame_env=False` and the rest of the line survives; `env_scrub_is_safe` covered in all five shapes.
- The four survey sites: the TypeError premise itself, the launch path, the wizard, and `build_config_report`.
- The AST walk, plus a test that the walk fails on the original defect, plus a test that the one named exception to the banner rule still exists.

## /simplify

Four cleanup agents (reuse, simplification, efficiency, altitude) over the first commit. Findings verbatim below, in collapsed blocks. What I did with them:

| Finding | Applied? |
|---|---|
| Fold `load_config` into `ConfigProblemBanner.load` so the load and the render cannot come apart (simplification 1, reuse) | **Applied.** Deletes `load_config`, the `app` parameter, the pair-unpacking at both sites. |
| `InboxScreen._unreadable` is a second copy of the banner's state (simplification 2) | **Applied.** The banner keeps `problem`; the screen asks it. |
| The banner is styled by id, so a screen that mistypes it gets an unstyled always-visible bar (simplification 6) | **Applied.** Type selector. |
| `ConfigProblemBanner` is in the wrong layer; every other widget is in `kstrl/tui/widgets/` (reuse 4, altitude 7, simplification 12) | **Applied.** `tui/widgets/config_problem.py`; `config_guard.py` is logic only. |
| `_decide` loads twice on the broken path (simplification 5) | **Applied.** `_redraw(box)` split off the load. |
| The `blamed` ternary-inside-`or` hides the environment-first rule (simplification 4) | **Applied.** Two statements. |
| `suppress(*REJECTIONS, OSError)` spelled longhand below its own constant (reuse 2) | **Applied.** |
| `screens/config.py:226` catches only `ValueError` around `build_config_report`, in a file this diff edits (altitude 1) | **Applied.** Reproduced independently before fixing. This is the finding I am most glad of: I had already called the survey complete. |
| `tui/home.py:26`, the same (altitude 2) | **Applied.** |
| No mechanism enforces `SURFACE_REJECTIONS`; the house pattern is an AST walk (altitude 3) | **Applied.** And verified to fail on the real defect, not just a synthetic one. |
| `SURFACE_REJECTIONS`'s docstring documents one of its two rationales (altitude 4, caveat) | **Applied** to the docstring. |
| Test hygiene: `make_manifest`, `GOOD_KNOB`, hoisted imports, drop `cast`, one context manager per screen (reuse 5, simplification 7/9/10/11) | **Applied.** |
| `EvolutionConfig.load_or_none` catches `(ValueError, TypeError, OSError)` while `SURFACE_REJECTIONS` adds `RuntimeError`; import it (reuse 1) | **Applied, then REVERTED by measurement.** It broke `test_decompose.py::test_the_artifact_is_written_before_any_journal_work`, which raises `RuntimeError` from `load` on purpose to assert that an error the guard does *not* catch still leaves the halt artifact on disk. The narrower tuple is deliberate. The docstring now says so and names the test, so the divergence is documented and tested rather than silent. |
| `env_scrub_is_safe` re-derives `KstrlTuiApp.session_in_flight` (reuse 3) | **Declined.** They are not the same predicate: `session_in_flight` also requires `Mode.HOME`, and the `os.environ` hazard does not care about the mode. Reusing it would permit the scrub while a dash or embedded run is live. Noted in the docstring so a reader does not think one is a copy of the other. |
| Cache `config_sections()` in a dict keyed by loader, to delete the `==`-not-`is` paragraph (simplification 3) | **Declined.** A dict lookup relies on the *same* fact about bound methods, via `hash` instead of `==`, so it hides the subtlety rather than removing it. The efficiency agent measured the scan at 4.8 us, so there is no speed case either. |
| Normalize `OSError` into `ConfigError` inside `load_toml_document` so `SURFACE_REJECTIONS` collapses (altitude 4) | **Declined,** on the finding's own caveat: `init_wizard`'s `OSError` comes from `pyproject.toml` via `resolve_verify_commands`, a file that function never opens, so the tuple would still be needed. It would also change `collect_config_problems`'s distinct "could not be read" message. |
| A declarative `REQUIRES_CONFIG` table on screens, mirroring `_PREFLIGHT_REQUIRED` (altitude 5) | **Declined.** A table of two rows is more machinery than the two call sites it replaces. Worth revisiting at the fourth screen. |
| A `ConfigGuardedScreen` base or mixin (altitude 6) | **Declined as such,** but its actual complaint (a two-step contract a screen can half-remember) is answered by folding the load onto the widget and styling by type. |
| Lift `_home_app` / `_Harness` / `_open` / `_box` into a new `tests/helpers/tui.py` and update three existing test files (reuse 6, 7, 8, 9) | **Declined for this PR.** It widens the diff into three test files this fix does not touch. The duplication *inside* my own file is gone (one context manager per screen). |
| Move `test_a_launched_run_reports_the_array_instead_of_raising` to `tests/test_launch_session.py` (reuse 5, second half) | **Declined.** The four survey sites read as one piece of evidence for #289; splitting them across files loses that. The manifest literal it duplicated is now `make_manifest([])`. |
| Use bare `pilot.pause()` instead of `pause(0.2)`; measured 3.8s to 2.1s on the file (simplification 8) | **Declined.** Five green runs on an idle machine is not proof against CI flake, as the finding itself says, and `tests/test_evolve_screen.py` uses 0.2 for this same screen. Kept the house value and wrote down why, which was the other half of the complaint. |
| `get_experiment_trends` returns `[]` on `OSError`, contradicting this screen's stated principle one layer down (altitude 8) | **Declined as out of scope,** and disclosed above rather than buried. |
| Five renderings of "kstrl.toml is unreadable" in the TUI (altitude 9) | **Declined.** Pre-existing; disclosed above. |
| Efficiency: nothing above measurement noise. `config_sections()` 4.8 us warm, its 62 ms cold cost already paid by the entry seam; `toml_parse_scope` costs 1.9 us on the happy path and saves 37.5 ms on the env-fault path; the module-level import adds 0 ms on the real `ks` path | **No change,** as advised. |

<details>
<summary>Reuse agent, verbatim</summary>

Findings against the current working tree, ordered by cost.

**1. `SURFACE_REJECTIONS` duplicates a hand-written tuple that already exists, and they now disagree.**
`kstrl/config_preflight.py:98` defines `SURFACE_REJECTIONS = (*REJECTIONS, OSError)`. `kstrl/evolution.py:157` already hand-writes `except (ValueError, TypeError, OSError) as exc:` for the same job (load a section, degrade with a message). The two are not equal: the new constant includes `RuntimeError`, the existing copy does not. The docstring of `EvolutionConfig.load_or_none` (`kstrl/evolution.py:128-141`) is an explicit argument that these two lists must never diverge ("two lists that disagree would degrade the same value at startup and then raise on it mid-run") - the diff created the constant that makes divergence impossible and left the copy divergent. Use `SURFACE_REJECTIONS` at `kstrl/evolution.py:157`.

**2. The new constant is spelled out longhand 334 lines below its own definition.**
`kstrl/config_preflight.py:432` reads `with suppress(*REJECTIONS, OSError):` - that expression *is* `SURFACE_REJECTIONS`, in the file that just named it. Use `with suppress(*SURFACE_REJECTIONS):`.

**3. `env_scrub_is_safe` re-derives `KstrlTuiApp.session_in_flight()`.**
`kstrl/tui/config_guard.py:55-67` walks `app.run_context` -> `.handle` -> `.done()`. `kstrl/tui/app.py:390-398` `session_in_flight()` walks the same three attributes. Caveat that matters: `session_in_flight` additionally gates on `self.mode is Mode.HOME`, so they are **not** swap-in equivalents - calling it from the guard would permit the process-wide `os.environ` scrub while a dash/embedded-mode run is live. The correct reuse direction is the other way: make `session_in_flight` return `self.mode is Mode.HOME and not env_scrub_is_safe(self)`, so the attribute walk exists once and a fourth reader cannot appear. Do not invert it.

**4. `ConfigProblemBanner` duplicates `SafeModeBanner`, and its CSS duplicates that banner's CSS.**
`kstrl/tui/config_guard.py:70-96` vs `kstrl/tui/widgets/safe_mode_chip.py:69-82`: same `Static` subclass, same hide-on-clean / `display = True` + `update()` toggle, same `▲` prefix, and docstrings that are near-verbatim rewrites of each other. A third inline copy of the same toggle is at `kstrl/tui/screens/decompose.py:273-293` (`#triage-banner`). `kstrl/tui/styles.tcss:124-131` (`#config-problem`) is `kstrl/tui/styles.tcss:104-110` (`#safe-mode-banner`) with `$warning`->`$error` and `height: 1`->`auto`. Fix: one `AlertBanner(Static)` in `kstrl/tui/widgets/` exposing `show(body: str | Text | None)`; `SafeModeBanner.update_reasons` becomes `self.show(render_banner(reasons) if reasons else None)`. Placement point too: every other TUI widget lives in `kstrl/tui/widgets/`; this one is the only widget class under `kstrl/tui/`.

**5. `test_a_launched_run_reports_the_array_instead_of_raising` is a copy of an existing test's setup.**
`tests/test_tui_config_guard.py:379-404` vs `tests/test_launch_session.py:206-228` (`test_invalid_agent_config_fails_before_run_state`): identical `manifest_dir` mkdir, identical 8-line `Manifest(...)` literal, identical `pytest.raises(LaunchError)` + `start_run_session(FactoryLaunch(), tmp_path)`. The literal is `tests.spine_utils.make_manifest([])` (already imported by `tests/test_config_preflight.py`). The test itself belongs next to its sibling in `tests/test_launch_session.py`, which already has the fixture shape.

**6. `_home_app` is a third byte-identical copy.**
`tests/test_tui_config_guard.py:58-59` == `tests/test_evolve_screen.py:83-84` == `tests/test_launch_session.py:93-94`. Lift one into `tests/helpers/` (`tests/helpers/tui.py` alongside `procs.py`/`fake_run.py`) and import it in all three.

**7. `_Harness` duplicates the harness in `tests/test_inbox.py`.**
`tests/test_tui_config_guard.py:46-50` is the same class body as the nested `_Harness` at `tests/test_inbox.py:757-759`. Same fix as 6.

**8. The push-screen dance repeats six times where a helper already exists.**
`tests/test_tui_config_guard.py` lines 94-99, 114-119, 127-132, 144-149, 158-163, 173-178 each do `app.push_screen(EvolveScreen())` / `await pilot.pause(0.2)` / `screen = app.screen` / `assert isinstance(...)`. `tests/test_evolve_screen.py:80-84` is exactly that, already factored as `async def _open(app, pilot) -> EvolveScreen`. Reuse `_open` (moving it to the shared helper module from 6).

**9. Inbox seeding bypasses the existing builder.**
`tests/test_tui_config_guard.py:213-218, 235-240, 255` hand-write `Inbox(tmp_path, InboxConfig())`; `tests/test_inbox.py:35-36` `_box(tmp_path, **kwargs)` is that wrapper.

## Genuinely clean

- `load_or_report` / `_section_for` are not duplicates. The nearest existing thing is `config_report.build_config_report._resolve`, but it is a nested closure that deliberately discards *why* a section failed; nothing in the tree produced the detail line before. `_section_for`'s loader-to-section lookup is the reverse of `config_report._phase_sections`'s name-to-loader map, not a second copy of it.
- `EvolutionConfig.load_or_none` and `EvolutionJournal.open` overlap in purpose but are not substitutable here: neither yields the CLI-worded detail the banner requires, and `open` additionally returns None when the journal is disabled. Only their exception tuple is duplicated (finding 1).
- Lifting `env_scrub_is_safe` out of `ConfigScreen.action_refresh` and importing `SURFACE_REJECTIONS` in `session.py` / `init_wizard.py` rather than restating it are both de-duplications in the right direction.
- `_banner_text` is a two-line wrapper over `str(widget.render())`, the idiom already used inline in `tests/test_tui_safe_mode.py`. Fine.

## One consistency note outside my angle

`config_report._resolve` (`kstrl/config_report.py:384`) still catches `REJECTIONS`, not `SURFACE_REJECTIONS`, so `ks config show` still aborts on the unreadable-file case (`OSError`) that the new screen path survives - the same asymmetry the diff set out to remove, one surface over.

</details>

<details>
<summary>Simplification agent, verbatim</summary>

**1. `kstrl/tui/config_guard.py:70` (+ `evolve.py:191-192`, `inbox.py:87-89`) - the three-step contract can be one call.**
Every site does the same three things: call `load_config(self.app, Loader.load, root)`, unpack a pair, then hand half of it back to the banner. The pair only exists so the caller can pass `problem` to a widget it already owns, and `app` is only passed so the helper can compute one keyword.
Cost: three coupled steps a new screen must copy in the right order; forget the `show(problem)` line and the screen degrades silently, which is the exact failure this PR exists to remove.
Simpler form: put the load on the widget. Call site becomes `config = self.query_one(ConfigProblemBanner).load(EvolutionConfig.load, root_dir)`. That deletes `load_config` entirely, deletes the `app` parameter, deletes the pair return at both sites, and deletes `_unreadable` (finding 2). Measured: I applied it, and `uv run mypy kstrl/ --strict` (Success, 124 files), `uv run ruff check` (clean), `uv run pytest tests/test_tui_config_guard.py` (20 passed) all hold.

**2. `kstrl/tui/screens/inbox.py:61,89,131` - `_unreadable` is a second copy of the banner's state.**
It is written on the same line that writes the banner and read in one place. Its invariant "equals `banner.display`" is hand-maintained.
Cost: two facts to keep in sync where one exists; any future path that writes the banner without going through `_inbox()` desynchronises the "Inbox clear" claim.
Simpler form: delete the field and read `self.query_one(ConfigProblemBanner).display` at `inbox.py:131`. Measured working. (Caveat worth knowing: Textual's `display` also returns False while a node is closing/pruning, which cannot happen inside `_render_detail`. If that feels too clever, store `self._problem: str | None` and let both the banner call and the detail guard read that one field - still one fact, not two.)

**3. `kstrl/config_preflight.py:299-315` - `_section_for` rebuilds the whole registry to do a linear scan.**
`config_sections()` runs 22 deferred imports and constructs 22 dataclasses on every call; `_section_for` calls it once per `load_or_report`, then scans. The `==`-not-`is` subtlety needs a four-line docstring paragraph warning the next reader off an "obvious" fix.
Cost: a footgun documented rather than removed, plus O(n) per screen refresh.
Simpler form: a cached dict, since bound classmethods hash and compare stably (I verified `hash(EvolutionConfig.load) == hash(EvolutionConfig.load)` and dict round-trip), with `_section_for` doing the lookup and re-raising `KeyError` as the same `LookupError`. Measured: 62 tests pass, mypy strict clean. Timing: 0.05 us vs a 305 us registry rebuild per call - irrelevant to a TUI refresh, so the win to claim is the deleted paragraph, not the microseconds. Keying by loader rather than by section name is the right call and should stay: it is what keeps the return type `T | None` instead of `Any`.

**4. `kstrl/config_preflight.py:336-342` - the `blamed` expression formats badly.**
`(_blamed_env_var(...) if blame_env else None) or _blamed_toml_value(...)` is a conditional inside a paren inside an `or`, and ruff-format splits it across the `or` so the two branches no longer line up visually.
Cost: the "environment first, file second" rule the docstring above it states is now harder to see in the code than it was before the change.
Simpler form: two statements.

**5. `kstrl/tui/screens/inbox.py:163-168` - `_decide` loads the config twice on the broken path.**
`_decide` calls `_inbox()` (config load + banner write), and when it returns None calls `action_refresh()`, which calls `_inbox()` again (second load, second banner write).
Cost: the comment says "redraw through the one path that renders that state", but the path is entered by discarding a result already in hand; the two loads can also disagree if the file changes between them.
Simpler form: split the render off the load: `def action_refresh(self): self._redraw(self._inbox())`, then `_decide` does `if box is None: self._redraw(None); return`.

**6. `kstrl/tui/styles.tcss:124` - the banner is styled by id, so every screen must remember the magic string.**
Both `compose` methods write `ConfigProblemBanner(id="config-problem")`; a third screen that omits it gets an unstyled, always-visible banner with no error.
Cost: a widget whose appearance is not a property of the widget.
Simpler form: use the type selector `ConfigProblemBanner { ... }` in `styles.tcss` (or `DEFAULT_CSS` on the class), and let screens write `yield ConfigProblemBanner()`.

**7. `tests/test_tui_config_guard.py:88-185` - six evolve tests share an identical seven-line preamble; three inbox tests share a five-line one.**
Cost: a change to how the screen is opened is a nine-place edit.
Simpler form: one `@asynccontextmanager` helper per screen yielding `(screen, pilot)`; each test body drops to its write plus its assertions.

**8. `tests/test_tui_config_guard.py:95 et al` - two pause idioms in one file, unexplained.**
Evolve tests use `await pilot.pause(0.2)` twice per test; inbox tests use bare `await pilot.pause()`. Nothing says why one screen needs 400 ms of wall clock.
Cost: a magic number that the next test will copy without knowing whether it is load-bearing.
Simpler form: use the bare `pause()` everywhere. Measured: 5 consecutive runs, 20 passed each, file time 3.8 s -> 2.1 s. Five green runs on an idle machine is not proof against CI flake, so if the sleep is deliberate it needs one sentence saying what it is waiting for.

**9. `tests/test_tui_config_guard.py:53-55` - `cast(Any, screen)` is unnecessary.**
It exists only because the parameter is typed `object`. Simpler form: `def _banner_text(screen: Screen[Any]) -> str`. Drops the `cast` import.

**10. `tests/test_tui_config_guard.py:156,180,319,344` - the good-config literal is inlined four times** next to `BAD_KNOB`/`BAD_DOCUMENT` constants that were extracted. Add `GOOD_KNOB` for symmetry.

**11. `tests/test_tui_config_guard.py:371,387-389,412` - three tests use function-local imports** while the module has a top-level import block. No cycle justifies it. Move them up.

**12. `kstrl/tui/config_guard.py` placement.** Every other `Static` subclass in the TUI lives in `kstrl/tui/widgets/`. This module mixes a widget with two pure functions and pulls `rich`/`textual` into what reads as a config helper. Low priority, but if finding 1 lands the file becomes almost entirely the widget, at which point `kstrl/tui/widgets/config_problem_banner.py` is the natural home.

## What is genuinely clean

- **`SURFACE_REJECTIONS` imported, not restated** (`session.py:198,253`, `init_wizard.py:88`). This deletes three hand-written exception tuples that had already drifted from the entry check. Exactly the right direction: the diff removes duplicated knowledge rather than adding a check over it.
- **`env_scrub_is_safe` lifted out of `ConfigScreen.action_refresh`.** Four lines of attribute-walking replaced by one named predicate, with the original site converted rather than left behind. No dead code.
- **`blame_env` threading is minimal.** It reaches exactly two levels, both callers are explicit, and refusing a default is defensible given the process-wide `os.environ` mutation behind it.
- **`_load_patterns_and_trends` restructuring**: moving both `table.clear()` calls above the guard is the minimal edit, not a rewrite, and leaves no duplicated clear.

</details>

<details>
<summary>Efficiency agent, verbatim</summary>

Benchmarks run against a `git archive` snapshot of HEAD (and HEAD~1). All numbers are best-of-N with `time.perf_counter`, method stated per item.

**1. `kstrl/config_preflight.py:288` - `_section_for(loader)` runs on the happy path, but only the `except` branch consumes it. CHEAP, no change.**
Method: best of 7 x 200 iterations, warm process, shipped 21 KB `kstrl.toml.example`.
- `config_sections()` warm: **0.0048 ms**. `_section_for()` warm (full 22-entry linear scan, last entry): **0.0051 ms**.
- Whole `load_or_report` happy path: **0.4628 ms**. So the "22 deferred imports + 22 dataclasses per call" is **1.1%** of the call it sits in.
- The 22 deferred imports cost **62.2 ms** on the FIRST call only, and that is already sunk before any screen exists: I verified `import kstrl.cli` leaves `kstrl.config_preflight` out of `sys.modules`, and the shell entry (`kstrl/cli.py:811`) imports and runs `preflight_config` before `run_home_shell`. Every screen refresh therefore hits the warm path.
- Cheaper alternative (moving `_section_for` + `resolve_config_file` inside the `except`) buys 5 microseconds. Not worth the edit on latency grounds.
- The one conditional risk worth stating: this "always warm" argument depends on the entry seam. `_PREFLIGHT_EXEMPT = {"init", "config", "sense"}`; none of those reach `EvolveScreen`/`InboxScreen` today. A future entry point that pushes either screen without the seam would pay 62 ms of deferred imports on the UI thread at first refresh.

**2. `kstrl/config_preflight.py:292` - the per-call `toml_parse_scope` earns its place. Keep.**
Method: best of 5, shipped example config, 83-variable environment. Compared against a hand-rolled `load_or_report` with the scope removed.
- Happy path: **0.4628 ms with vs 0.4609 ms without** (+1.9 us, 0.4%). Free.
- Error path, env-caused fault (full blame sweep): **1.373 ms with vs 38.866 ms without**. 28x, because `_blamed_env_var` re-invokes the loader once per variable and each of those would reparse the 21 KB file.
- File-caused fault (gated sweep): 1.507 vs 1.510 ms, identical, as expected from the one-load gate.

**3. `kstrl/config_preflight.py:347` - the env blame sweep per rejected section per refresh. CHEAP, no change.**
Method: best of 5, `[evolution]` broken, environment padded to a fixed size.
| | blame_env=True | blame_env=False |
|---|---|---|
| env fault, 84 vars | 1.320 ms | 0.443 ms |
| env fault, 300 vars | 3.778 ms | 0.430 ms |
| file fault, 84 vars | 1.390 ms | 0.852 ms |
| file fault, 300 vars | 1.842 ms | 0.871 ms |
It runs only when the config is actually broken, and only on a user keypress: `grep set_interval kstrl/tui/` finds timers only in `kstrl/tui/app.py:158-172` and `kstrl/tui/screens/home.py:205`. Neither evolve nor inbox auto-refreshes, so there is no hot loop behind this.

**4. `kstrl/tui/screens/inbox.py:163` + `:180` - `_inbox()` twice per decision. Pre-existing shape, and cheap.**
Method: best of 5 x 200 inside a live `run_test` pilot.
- Second `_inbox()` call: **0.4631 ms**. Pre-diff equivalent (`Inbox(root, InboxConfig.load(root))`): **0.4383 ms**, so the diff adds **25 us** per call, not the call itself - HEAD~1's `_decide` already loaded the config twice.
- Against `action_refresh()` with 20 rows and the event loop pumped (**51.2 ms**), the redundant load is **0.9%**. Passing `box` into a private `_redraw(box)` would remove it and is not justified by this number.

**5. `kstrl/tui/config_guard.py:87-91` - `show(None)` calls `Static.update("")` unconditionally, every refresh, on an already-hidden already-empty banner. Inside the noise floor, no change.**
Method: `action_refresh()` + `await pilot.pause()` so deferred layout is paid inside the window; best of 5 x 30; two independent runs.
- Run A: shipped 51.230 ms, `show()` no-oped 51.109 ms (+0.121 ms), whole guard bypassed 53.122 ms (**-1.892 ms**, i.e. slower without it).
- Run B: shipped 56.145 ms, no-oped 52.836 ms (+3.309 ms), bypassed 56.965 ms (-0.820 ms).
The sign flips between runs; run-to-run spread is +/-3 ms on a ~52 ms refresh, which is dominated by `DataTable` clear/add_row. In isolation `banner.show(None)` is 0.0021 ms and `query_one(ConfigProblemBanner)` is 0.0005 ms.

**6. Module-level `from kstrl.config_preflight import SURFACE_REJECTIONS` in `kstrl/tui/session.py:25` and `kstrl/tui/screens/init_wizard.py:25` - zero on the real path.**
Method: fresh subprocess per sample, 9 samples, HEAD vs HEAD~1 trees.
- Isolated delta: importing `kstrl.config_preflight` on top of the HEAD~1 module pulls exactly 2 new modules at **0.80-0.88 ms**.
- Whole-module fresh import, min: `kstrl.tui.session` 117.52 (HEAD~1) -> 118.03 ms (HEAD); `kstrl.tui.screens.init_wizard` 71.57 -> 74.08 ms; `kstrl.tui.home` 0.25 -> 0.25 ms.
- On the real `ks` path it is **0 ms**: `preflight_config` is imported and run at the entry seam before the shell opens, so `import kstrl.tui.session` hits `sys.modules` for `config_preflight`. The 0.9 ms only shows up in a test process that imports the screen without the CLI.

**7. Startup - no measurable cost from the extra banner widget or the 13 new tcss lines.**
Method: 9 full `App.run_test()` boots + `push_screen(InboxScreen)` + `pause()` per tree.
- HEAD~1: min 125.3 ms, median 135.5 ms (`styles.tcss` 13769 bytes / 751 lines).
- HEAD: min 122.9 ms, median 125.7 ms (14195 bytes / 764 lines).
HEAD measures marginally faster; the difference is noise.

## Bottom line

No efficiency finding in this diff rises above its own measurement noise. The one structural smell the brief flagged (`config_sections()` rebuilt per `load_or_report`) is 4.8 us warm and its 62 ms cold cost is already paid by the entry seam. The `toml_parse_scope` question resolves the other way from the way the brief framed it: it costs 1.9 us on the happy path and saves 37.5 ms on the env-fault path, so it is load-bearing, not overhead.

</details>

<details>
<summary>Altitude agent, verbatim</summary>

Two claims below are measured, not argued; the rest are structural.

### Where the depth is right

**A. The home shell must NOT pass `required={"evolution"}`.** `kstrl/cli.py:811`. `_PREFLIGHT_REQUIRED` maps a command to the section it is *about*. The shell is a container for ten screens, one of which is about `[evolution]`. Promoting it at shell entry would refuse to open the config screen and the init wizard, the two repair surfaces. Per-screen is the correct altitude for an about-ness decision on a multi-screen surface. The `config_guard` docstring argues this correctly.

**B. `env_scrub_is_safe` lifted out of `ConfigScreen.action_refresh`.** `kstrl/tui/config_guard.py:55`, `kstrl/tui/screens/config.py:211`. One process-wide hazard, one predicate, three askers. Correct generalization, and `blame_env` being a required keyword rather than a defaulted one forces each caller to answer it.

**C. `_section_for` passing the loader, and its cost.** `kstrl/config_preflight.py:283`. Passing the loader makes an unenrolled caller a `LookupError` (a kstrl defect) instead of a mislabeled message. Measured on this tree: `config_sections()` 0.005 ms warm, `load_or_report` 0.012 ms against 0.006 ms for a bare `InboxConfig.load`. The linear scan on every inbox refresh costs nothing; no case for caching.

### Findings

1. **`kstrl/tui/screens/config.py:226` - the imported tuple did not stop the next narrow guard, in a file this diff edits.** `except ValueError` around `build_config_report`. Measured: with `[run] max_iterations = ["3"]`, `build_config_report` raises `TypeError: int() argument must be a string... not 'list'`, which escapes. This is precisely the case `SURFACE_REJECTIONS` was invented for - a post-entry re-read (`build_config_report` scopes its parse per call so refresh sees the file as it is now), one keystroke away in the same shell the diff is fixing. The diff added an import to this file at line 26 and walked past the guard at 226. Deeper fix: route this through the same seam, or at minimum widen it and cover it in the survey.

2. **`kstrl/tui/home.py:26` - the same `except ValueError`, same call.** Latent today only because `preflight_config` at `cli.py:811` rejects the file first; it is one exemption or one refactor away from being live. The test file's header claims "the rest of the survey #289 asked for" and covers two of four sites.

3. **No mechanism enforces `SURFACE_REJECTIONS`; the house pattern is an AST walk.** This codebase already prevents exactly this class of drift mechanically: `tests/test_atomicio.py` walks for `mkstemp`, `tests/test_process_scoping.py` walks for `pgrep`, `tests/test_config_preflight.py` walks for unenrolled config dataclasses, `tests/test_prompt_versions.py` walks for unenrolled `*_PROMPT`. The new file has no walk, and findings 1 and 2 are the direct consequence. Deeper fix: walk `kstrl/tui/` for calls to any enrolled `*Config.load` (or `build_config_report`) not routed through `load_config`, and fail on a hand-written `except (ValueError, OSError)` around one. Per CLAUDE.md: if there is no mechanism, there is no plan.

4. **`kstrl/config_preflight.py:96` - `SURFACE_REJECTIONS` widens at the consumer for a normalization the reader owes.** `kstrl/config.py:509` `load_toml_document` documents "Raises ConfigError on malformed input" but lets `open()`'s `OSError` through raw, so `collect_config_problems` already compensates with an explicit `except OSError -> ConfigError`. The diff adds a second compensation and a third tuple name to remember. Deeper fix: wrap `OSError` in `ConfigError` inside `load_toml_document`; `SURFACE_REJECTIONS` then collapses back into `REJECTIONS`. Caveat that reinforces the point: `init_wizard.py:88`'s `OSError` is not from kstrl.toml at all, it is `resolve_verify_commands` reading `pyproject.toml` (`kstrl/verify.py:747`). One name is currently carrying two unrelated rationales, and its docstring documents only one.

5. **`kstrl/tui/screens/evolve.py:191`, `kstrl/tui/screens/inbox.py:87` - about-ness is remembered imperatively, which is what `_PREFLIGHT_REQUIRED` exists to stop.** That table's own comment: "Declared here, beside the exemptions, so a command does not carry its own remembered guard for a policy the seam already owns." The screens now carry exactly such a guard, in code, per call site. Deeper fix: a declarative `REQUIRES_CONFIG: tuple[Callable[[Path], Any], ...]` class attribute on the screen, resolved by one place, so the TUI's table reads like the CLI's rather than being scattered through `on_mount` paths.

6. **`kstrl/tui/config_guard.py:70` - `load_config` returns a string and leaves rendering to a two-step contract nothing enforces.** The caller must both compose a `ConfigProblemBanner` with `id="config-problem"` (the styling is id-keyed, so a wrong id yields an unstyled always-visible bar) and remember to call `.show(problem)`. A future screen that calls `load_config` without composing the banner raises `NoMatches` out of `on_mount` - #289's crash, reintroduced by someone using the fix. `inbox.py:64` also carries `self._unreadable` as a third copy of `problem is not None`. Deeper fix: a `ConfigGuardedScreen` base or mixin that yields the banner in `compose` and exposes one `self.guarded_load(loader)` doing both halves; that also answers the "should it live at the Screen base class" question - yes for the mount-and-render half, no for the policy half, which belongs in finding 5's table.

7. **`kstrl/tui/config_guard.py:84` - `ConfigProblemBanner` is in the wrong layer.** It is a near-clone of `kstrl/tui/widgets/safe_mode_chip.py:73` `SafeModeBanner`. Keeping it in `config_guard` drags `rich` and `textual.widgets` into a module that `screens/config.py` imports solely for the pure predicate `env_scrub_is_safe`. Deeper fix: `kstrl/tui/widgets/config_problem.py` next to `safe_mode_chip`, `config_guard.py` stays logic-only.

8. **The diff's stated principle is contradicted one layer below it, on the same screen.** `kstrl/tui/screens/evolve.py:203` refuses to show an empty trends table when the config will not load, because "no patterns yet" is a real state an operator cannot distinguish. `kstrl/evolution.py:1245` `get_experiment_trends` returns `[]` on `OSError` reading `experiments.tsv`, and `_read_journal_entries` behaves the same way. Same screen, same operator question, opposite answers. Pre-existing, but it means the fix sits one level too high to deliver the property it claims: chmod the journal instead of the config and the banner stays clean while the table goes empty.

9. **Minor, same class as 8: a fifth wording for one failure.** `kstrl/tui/app.py:225` renders a config failure during the safe-mode check as `SafeModeReason(source="control_dir", ...)` - `safemode.py:125/141/162` load `AutonomyConfig`, `PolicyConfig` and `QueueConfig` unguarded under that broad `except Exception`. It does not crash, so it is not #289, but the TUI now has five renderings of "kstrl.toml is unreadable" where the diff's own docstring claims the value is that the surfaces cannot drift.

### Summary judgement

The seam (`load_or_report` reusing `_detail`) is at the right altitude and the shell-level `required=` alternative would be wrong. The two things below it are not: the *policy* (which screen is about which section) is remembered per call site rather than declared once, and the *plumbing* (widen a tuple at each consumer) is a compensation for a missing normalization in `load_toml_document` with no mechanism to stop the next miss - which the diff already demonstrates by missing `screens/config.py:226` in a file it edits.

</details>


---

# Round 2: eleven review findings

All eleven reproduced on this branch before being touched. None was argued away, and one of them found a defect this PR introduced.

## The three serious ones

**2, the concurrency defect this PR introduced.** `env_scrub_is_safe` asked only whether a launched run was in flight. It ignored the app's own safe-mode worker, which `app.py` schedules every 5 seconds in *every* mode and which loads `AutonomyConfig`, `PolicyConfig` and `QueueConfig`, all reading `KSTRL_*`. Measured on my head with 84 variables set: a thread polling `KSTRL_AUTONOMY_LEVEL` across 50 blaming `load_or_report` calls saw it **missing for 95990 of 36.8M reads**. A tick landing in that window reports the default ladder, so a degraded factory reads nominal on the chip.

Fixed by reading all three: the launched-run handle, `app.orchestrator` (finding 3), and `_safe_mode_running`. The docstring now records *why a flag read is sufficient and no lock is needed*: every caller is on the Textual UI thread, the scrub is synchronous and never awaits, and a worker is only ever started from that same thread by a timer callback, so none can begin between the check and the scrub. `_safe_mode_running` is cleared in the worker's `finally` after its last config read, which makes True strictly wider than the danger window.

**4, the same crash class, still live on the same screen.** `get_experiment_trends` read `experiments.tsv` with no encoding behind `except OSError`. `UnicodeDecodeError` is a `ValueError`, so one bad byte raised out of `EvolveScreen.on_mount` two lines after the new banner. Verified:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 22
  File ".../kstrl/evolution.py", line 1256, in get_experiment_trends
    text = self.config.experiments_path.read_text()
```

Checking the rest of that `on_mount` rather than only the site reported found the identical shape **one line earlier**: `proposals.list_proposals` and `existing_proposal_titles`, both `read_text()` behind `except OSError`, both raising on the same input. All readers now name utf-8 and catch `ValueError`; the matching writers name it too, because the contract is two-sided.

**5, my own recurrence mechanism failing on the largest site it covers.** Confirmed: reverting only `kstrl/tui/session.py` left the walk **passing**. That site loads seven sections through `assemble_factory_configs`, a plain name the pattern could not see.

Naming it in a list would be the memory the walk exists to replace, so the helper set is now **derived**: a function that resolves a section *and does not guard it* can propagate, and a call to one counts as a config load. The "and does not guard it" half is what keeps the rule at the right depth; without it the walk flagged everyone who calls a helper that already converts. A test asserts the deriving code names no function.

Verified by reverting all seven guarded sites one at a time. Every one now fails the walk:

```
session.py _prepare_factory (assemble_factory_configs): covered
session.py _prepare_decompose (KstrlConfig.load):       covered
home.py run_home_shell (build_config_report):           covered
screens/config.py action_refresh (build_config_report): covered
init_wizard.py _detected_text (VerifyConfig.load):      covered
evolve.py (the original #289 defect):                   covered
inbox.py (the survey's second unguarded screen):        covered
```

## The rest

| # | Finding | Outcome |
|---|---|---|
| 1 | `ks config show` caught only `ValueError` around `build_config_report` | **Fixed.** Reproduced the raw traceback. `config` is preflight-exempt, which is exactly why its own guard has to be the shared tuple. It now prints `[run] int() argument must be a string ... not 'list'` and exits 1. |
| 3 | The predicate's docstring claimed a coverage it did not provide in `Mode.EMBEDDED` | **Fixed** with finding 2: `app.orchestrator` is read, and the docstring says why it is a different attribute from `run_context.handle`. |
| 6 | `_guarded_call_ids` walked the whole `Try`, counting a load in `except`/`finally` as guarded | **Fixed.** `Try.body` only, with a test on the exact fallback shape. |
| 7 | `_NOT_THE_BANNER` granted no exemption and was checked at file granularity | **Fixed.** Deleted. Its replacement is consulted by the walk, keyed by `(file, innermost function)`, and a second test re-checks both that the site is still one the walk would flag and that the mechanism it rests on (`start_command_thread`'s `except BaseException`) still exists. |
| 8 | The config screen reported a bare coercion message | **Fixed** on the live surface: the refresh notify now carries `collect_config_problems`' lines, so it names the section. |
| 9 | `_decide` discarded the `Inbox` it held and reloaded | **Fixed.** `self._redraw(box)`, which is what `_redraw` was split out for. |
| 10 | `load_or_report` caught `RuntimeError` for a loader whose own docstring argues it must not be | **Fixed.** A *bare* `RuntimeError` is re-raised. `REJECTIONS` names `RuntimeError` only for the domain errors deriving from it (`ServeError`, `QueueError`, `InboxError`, `IntakeError`), which are operator input and still reach the banner. Both sides tested. |
| 11 | `_section_for` ran before the `try`, so a clean mount paid for a lookup only failure needs | **Fixed.** Measured: first `config_sections()` costs 6.2 ms in a process that has imported `kstrl.tui.app`. First clean `load_or_report` is now **0.052 ms** against **6.180 ms** for the first failing one. |

## One thing to flag for the owner

Finding 8 is fixed on the config screen's refresh, which is the live surface. `tui/home.py`'s startup path still renders the generic "config could not be resolved - run `ks config show` for the error" rather than the seam's lines, because the report is built before `app.run()` and threading the problem lines through to the screen is plumbing across the app constructor and its tests. That guidance line is now *accurate and actionable*, which it was not before: finding 1 made `ks config show` name the section on the same file. Flagging it rather than burying it.

## Definition of done, round 2

- `uv run pytest tests/ -q`: **4218 passed, 28 skipped**.
- `uv run mypy kstrl/ --strict`: clean, 125 source files.
- `uv run ruff check kstrl/ tests/`: clean.
- Commit-time hooks: all pass. Two fired and were right, so I did what they said rather than working around them: codespell on a byte literal, and the file-length ratchet at 893 lines. The walk moved to `tests/test_tui_config_walk.py`, which is the correct split anyway: one file tests what the screens *do* with a broken config, the other a static property of the source.
- Coverage: **89.58%** against the 79.91% ratchet.
- CI: test, spine, coverage, lint and GitGuardian all pass.


---

# Round 2 review: all twelve fixed

Nothing filed, nothing pushed back on. Two of the twelve found a cost in my own round-1 fix, and one of them found a bug the old test could not have caught.

## The correction that matters: refusal is not the same tool as serialization

Findings 3 and 4 are right, and the measurement is worse than the finding says. Round 1 closed a real race by adding the app's own safe-mode worker to `env_scrub_is_safe`'s **refusal** condition. Reproduced on an EMPTY project with `run_context is None`, no run of any kind:

```
_safe_mode_running right after mount: True
env_scrub_is_safe(app):               False
run_context:                          None
notices on refresh at mount: ['config refresh is disabled while a run is
                              in flight (source detection scrubs the
                              environment)']
  flag held for 51.5 ms
  flag held for 82.0 ms
  flag held for 76.9 ms
  flag held for 82.0 ms
  flag held for 84.3 ms
```

So the config screen refused to refresh at random, with a message falsely blaming a launched run, and the evolve banner silently dropped the environment variable it exists to name. I closed a race by making two features intermittent, and I did not measure the cost before shipping it.

The two hazards are not the same hazard. A launched run spawns **subprocesses** that inherit the environment at `exec` and cannot be made to wait on a lock, so that one stays a refusal. The safe-mode worker is our own bounded thread, so it can simply wait. `config_report._ENVIRON_LOCK` (RLock) is now held for the whole of any scrub, for the whole of `_blamed_env_var`'s sweep including the per-variable pops outside `scrubbed_environ`, and by `safemode`'s config loads. `env_scrub_is_safe` reads two handles again, not three.

The race is still closed, and that is measured rather than argued:

```
50 blaming sweeps over 11.15 s
naive  reader (no lock): 496008 misses / 36223472 reads
locked reader (safemode):      0 misses / 10609176 reads
```

Cost of the lock: the scrub waits at most one safe-mode config read.

## The twelve

| # | Finding | Outcome |
|---|---|---|
| 1 | `observability.read_progress_events` opens with the locale encoding behind `except OSError`; the THIRD undecodable reader on `EvolveScreen.on_mount` | **Fixed.** Reproduced: `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9` out of `for line in f` at observability.py:418, through `evolution.py:1338`, into the Textual event loop. "Both" was three. **This reader is shared**: `ks status` (cli.py:3445) and the reducer (reducer.py:647) read the same log through the same function, so the fix lands on all three. The other agent's report of it from `ks status` is the same line of code. |
| 2 | `type(exc) is RuntimeError` misses `NotImplementedError` and `RecursionError` | **Fixed**, and generalised. The suggested fix was a tuple of the four domain errors named in `REJECTIONS`' docstring; kstrl defines **ten** `RuntimeError` subclasses, so that tuple was wrong the day it would have been written and staler with each new one. `config_preflight.raise_if_defect` asks a derivable question instead - did kstrl define this class - so there is no ledger to update. A test AST-walks `kstrl/` for every `RuntimeError` subclass and checks the predicate lets all of them through, then checks the three defects are re-raised. |
| 3 | Round 1's fix put the app's own safe-mode worker in the refusal condition, making the config screen's refresh intermittent | **Fixed** by serialization, above. Measured before and after. |
| 4 | Same for the banner's env blame | **Fixed** by the same lock. `blame_env` is `env_scrub_is_safe(self.app)` still, but that predicate no longer says False because our own thread is awake. |
| 5 | `evolution.save_proposals` writes prop-*.md with the locale encoding | **Fixed.** Measured: under a US-ASCII preferred encoding, `write_text('the agent’s note')` raises `UnicodeEncodeError`, which is a `ValueError` and escapes the adjacent `except OSError`. That write is explicitly non-fatal, so the defect turned a logged warning into a dead run. Tested in a child process under `LC_ALL=C PYTHONUTF8=0`, using the helper `test_atomicio` already has rather than a third copy of it. Test verified against the unfixed code: it fails, with that exception. |
| 6 | Four sites catch the widened tuple and swallow a bare `RuntimeError` | **Fixed** at all four (home.py, session.py x2, cli.py) plus `init_wizard._detected_text`, `config_report._resolve` and, in a follow-up commit, `collect_config_problems` itself - which is the seam all three reporting surfaces route through, so leaving it would have put the hole one call deep from each of them. |
| 7 | The walk cannot see a dotted owner, an aliased class, a module-attribute helper, an attribute-held loader, or a module-level load | **Fixed for four of the five, stated for the fifth.** The walk resolves names now instead of matching strings: `evolution.EvolutionConfig.load`, `IC.load` (through the importing file's own bindings), `config_report.build_config_report(...)` and a load at module scope are all seen, each with a test. `self._cfg_cls.load(root)` needs type inference rather than name resolution; matching every `.load(` instead would sweep in `Manifest.load` and `json.load`, which is a rule nobody keeps. It is now a documented limit with a test that fails if someone teaches the walk to resolve it without updating the docstring. |
| 8 | The helper set is matched by bare name and holds 30 generic ones | **Fixed.** Helpers are keyed `(module, name)` and restricted to module-level functions, which are the only ones another module can call by name; a call site resolves through its own imports. `run(...)` in a TUI file now counts only when `run` is the one kstrl defines and loads config in. A test asserts the collision names are still present in kstrl (otherwise it measures nothing) and that a file which did not import them is clean. |
| 9 | `build_config_report._resolve` catches `REJECTIONS`, not `SURFACE_REJECTIONS` | **Fixed.** This function has both kinds of caller: the entry check has a document read in front of it, the config screen's refresh does not. Test monkeypatches one phase loader to `PermissionError` and asserts the report still renders with that section in `unresolved` - which is #272's whole point, applied to the exception class #289 is about. |
| 10 | `ConfigScreen._problem_lines` duplicates `cli.config_show._problems` | **Fixed.** One `config_preflight.config_problem_lines`, callers supply only where warnings go. The copies had already drifted on the empty case. |
| 11 | The off-loop exemption is keyed on (file, bare function name) and session.py has two `def target()` | **Fixed, and it was hiding a real site.** With qualified keys the exemption's own test failed: `_prepare_factory.build.target` resolves no config at all (it calls `run_factory`; the loading is in `_run_factory_locked` below it). The closure actually being exempted was `_prepare_decompose.build.target`, which loads through `commandrun.open_command_run`. The old test passed throughout because it asked only whether SOME scope called `target` was flagged. The exemption now names the right one, and a test asserts the two closures are distinguishable. |
| 12 | `from pathlib import Path` at module scope in screens/config.py is annotation-only | **Fixed.** Finding 10 removed the only function that referenced it, so the import is gone rather than moved. |

## What the walk catches now, verified by reverting

Not asserted, measured. Each mutation applied to the real source and the walk re-run:

```
narrow the session.py guard to `except ValueError`:
  [(194, '_prepare_factory'), (256, '_prepare_decompose'),
   (281, '_prepare_decompose.build.target')]
revert evolve.py to the original #289 defect:
  [(191, 'EvolveScreen._load_patterns_and_trends')]
inbox.py as shipped:
  []
```

## One file split, because the ratchet was right again

`tests/test_tui_config_guard.py` hit 862 lines. The undecodable-DATA-file tests are a different contract from the broken-kstrl.toml tests - different failure, different write side, different fix - so they moved to `tests/test_evolve_screen_encoding.py`, with the screen helper they now share in `tests/helpers/tui_screens.py`. Same reasoning as the round-1 split, same ratchet, same answer.

## Definition of done, round 3

- `uv run pytest tests/ -q`: **4309 passed, 28 skipped**.
- `uv run mypy kstrl/ --strict`: clean, 126 source files.
- `uv run ruff check kstrl/ tests/`: clean.
- Commit-time hooks: all pass. complexipy fired once on a new 16-cognitive function and was right; I extracted the block rather than raising the ceiling.
- Coverage: **89.67%** (fast + spine combined) against the 79.91% ratchet.
- Rebased onto `origin/main` 4ee235c. The `atlas` check is gone from main (cba2b05), so CI is test / spine / coverage / lint / GitGuardian.

## Filed rather than fixed

`tui/home.py`'s startup path renders the generic "config could not be resolved" line rather than the seam's lines, because the report is built before `app.run()` and threading the problem lines through the app constructor is plumbing this PR does not do. It is accurate and actionable as it stands, and it is the only thing in the #289 survey I have not closed, so it is now **#313** rather than a paragraph in a PR body.
