### PR TITLE
fix(decompose): the convergence report names the history it excludes (#280)

### DIFF
--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -794,11 +794,13 @@ SPEC_ISSUES_REL_PATH = Path("scripts") / "kstrl" / "spec-issues.json"
 #
 # It is NOT the only copy: ``EvolutionJournal.get_spec_issue_runs``
 # hardcodes the same literal, and that file is under concurrent edit on
-# another branch, so it is not converted here. What keeps the two from
-# drifting is a mechanism rather than this comment -
-# ``test_the_journal_reader_agrees_with_the_event_name_written`` writes
-# an entry through this module and reads it back through the journal, so
-# changing this name alone fails that test (and fourteen others).
+# another branch, so it is not converted here. The constant belongs on
+# the storage layer rather than on this writer; filed as #314. What
+# keeps the two from drifting meanwhile is a mechanism rather than this
+# comment - ``test_the_journal_reader_agrees_with_the_event_name_written``
+# writes an entry through this module and reads it back through the
+# journal, so changing this name alone fails that test and fourteen
+# others.
 SPEC_ISSUES_EVENT = "spec_issues"
 
 
@@ -959,25 +961,40 @@ def _issue_identity(issue: SpecIssue) -> tuple[str, str]:
 def _stored_issues(entry: dict[str, Any]) -> list[SpecIssue] | None:
     """Rehydrate one journal entry's issue list into ``SpecIssue``.
 
-    Returns None when the entry carries no issue list at all, the one
-    shape that cannot be compared. Every other malformation (a non-dict
-    issue, a missing field, a non-string value) is normalized here, so
-    a journal written by an older version reads without crashing.
-    ``location`` and ``suggestion`` are not read back: the report
-    compares counts and issue text only.
+    Returns None for the two shapes that cannot be compared, so the
+    caller treats them alike and the accounting line reports them:
+
+    - no issue list at all, which is the legacy journal shape;
+    - an issue whose severity is not one of ``_SEVERITY_ORDER``.
+
+    The second is round 2 of review, and refusing it is the point.
+    ``_issue_counts`` buckets by severity, so an unrecognised one is
+    counted as nothing: seven issues stored with ``"severity": null``
+    rendered "Previous run raised 0 issue(s)" and put a 0 in the
+    blocker trend for a run that raised seven. Scoring part of an audit
+    is how a false number reaches the trend; declining to score it is
+    how the operator hears about it instead.
+
+    Everything else is still normalized rather than raised on, so a
+    journal written by an older version reads. ``location`` and
+    ``suggestion`` are not read back: the report compares counts and
+    issue text only.
     """
     raw = entry.get("issues")
     if not isinstance(raw, list):
         return None
-    return [
+    stored = [
         SpecIssue(
-            severity=str(i.get("severity", "")),
-            kind=str(i.get("kind", "")),
-            summary=str(i.get("summary", "")),
+            severity=_entry_str(i, "severity"),
+            kind=_entry_str(i, "kind"),
+            summary=_entry_str(i, "summary"),
         )
         for i in raw
         if isinstance(i, dict)
     ]
+    if any(i.severity not in _VALID_SEVERITIES for i in stored):
+        return None
+    return stored
 
 
 def _build_convergence(
@@ -995,7 +1012,7 @@ def _build_convergence(
     for entry in history:
         stored = _stored_issues(entry)
         if stored is not None:
-            audits.append((str(entry.get("spec_file", "")), stored))
+            audits.append((_entry_str(entry, "spec_file"), stored))
             trend.append(sum(1 for i in stored if i.severity == "blocker"))
     if not audits:
         return None
@@ -1015,11 +1032,12 @@ def _build_convergence(
 
 def _spec_convergence(
     issues: list[SpecIssue],
-    journal: EvolutionJournal | None,
+    entries: list[dict[str, Any]],
     project_name: str,
     spec_file: str,
+    lookback: int,
 ) -> SpecConvergence | None:
-    """Read this project's audit history and compare this run to it.
+    """Compare this run against this project's recorded audit history.
 
     Runs are matched by project name, not by spec path or content
     hash: the spec is edited between every round by construction (so a
@@ -1027,19 +1045,18 @@ def _spec_convergence(
     the file mid-loop (so the path does not either). A previous audit
     of a different file is still reported, with the file names named.
 
-    MUST be called before this run's own entry is appended to the
-    journal, or the "previous run" it compares against is this one.
+    ``lookback`` is how far back the trend reaches: the journal's own
+    knob rather than a number invented here, read as "the last N spec
+    audits" - decompose writes one audit per run, with or without a
+    factory run behind it.
+
+    MUST be called on entries read BEFORE this run's own is appended to
+    the journal, or the "previous run" it compares against is this one.
     """
-    if journal is None:
-        return None
     return _build_convergence(
         issues,
         spec_file,
-        # How far back the trend line reaches. The journal's existing
-        # lookback knob rather than a number invented here, read as
-        # "the last N spec audits" - decompose writes one audit per
-        # run, with or without a factory run behind it.
-        journal.get_spec_issue_runs(project_name, last_n=journal.config.lookback_runs),
+        _windowed_audits(_spec_audits(entries), project_name, lookback),
     )
 
 
@@ -1080,24 +1097,37 @@ class ExcludedProject:
 class ExcludedHistory:
     """Every spec audit in this journal the report does not count (#280).
 
-    Two axes, because there are two ways for the report to see less
-    than the journal holds, and #280 is that either one going unsaid is
-    the failure the report cannot afford:
+    Three buckets, because there are three ways for the report to see
+    less than the journal holds, and #280 is that any of them going
+    unsaid is the failure the report cannot afford. Each round of
+    review found another one being missed, so they are enumerated here
+    and every ``spec_issues`` entry falls into exactly one:
 
     - ``own_recorded`` counts THIS project's audits on disk. The trend
       may count fewer, because ``lookback_runs`` windows it and because
-      an entry with no readable issue list cannot be compared. Round 1
-      of review found the first version counting only the cross-project
-      axis while its wording claimed the whole journal, which is #280's
-      own defect on the other axis.
-    - ``projects`` covers every other project name in the journal.
+      an entry it cannot score is refused. Round 1 of review found the
+      first version counting only the cross-project axis while its
+      wording claimed the whole journal.
+    - ``projects`` covers every audit under some other project name.
+    - ``unattributed`` covers audits whose ``project`` field is absent,
+      null or not a string. Round 2 of review found these counted by
+      neither of the other two: three audits on disk reported as one.
 
-    Both are unwindowed by construction: a count of what the trend does
-    not cover that was itself windowed would omit history silently.
+    ``lookback`` is carried so the render can separate the two reasons
+    the trend counts fewer than ``own_recorded``. An audit outside the
+    window is the configured steady state and is a footnote on the
+    trend; an audit inside it that could not be scored is an anomaly
+    and gets a sentence.
+
+    The three counts are unwindowed by construction: a count of what
+    the trend does not cover that was itself windowed would omit
+    history silently, which is the bug this exists to fix.
     """
 
     own_recorded: int
     projects: tuple[ExcludedProject, ...]
+    unattributed: int = 0
+    lookback: int = 0
 
     @property
     def other_audits(self) -> int:
@@ -1105,7 +1135,23 @@ class ExcludedHistory:
 
     @property
     def is_empty(self) -> bool:
-        return self.own_recorded == 0 and not self.projects
+        return self.own_recorded == 0 and not self.projects and self.unattributed == 0
+
+    def unreadable(self, counted: int) -> int:
+        """This project's audits the trend was offered but could not score.
+
+        The window offers at most ``lookback`` of them, so anything
+        beyond that was never offered and is not an anomaly. A negative
+        result is impossible by construction but clamped anyway, since
+        a wrong number here would be the defect this class exists to
+        prevent.
+        """
+        offered = min(self.own_recorded, self.lookback) if self.lookback > 0 else 0
+        return max(0, offered - counted)
+
+    def windowed_out(self, counted: int) -> int:
+        """This project's audits the trend never saw, window included."""
+        return max(0, self.own_recorded - counted - self.unreadable(counted))
 
 
 def _entry_str(entry: dict[str, Any], key: str) -> str:
@@ -1145,68 +1191,116 @@ def _excluded_projects(
         if not project or project == project_name:
             continue
         by_project.setdefault(project, []).append(_entry_str(entry, "spec_file"))
-        last_seen[project] = _entry_str(entry, "timestamp")
+        # Only a timestamp that exists replaces one that exists. Round 2
+        # of review: assigning unconditionally let one trailing entry
+        # with no timestamp erase a good date every earlier entry for
+        # that project carried, losing evidence to a single bad row.
+        if timestamp := _entry_str(entry, "timestamp"):
+            last_seen[project] = timestamp
     excluded = [
         ExcludedProject(
             project=project,
             audits=len(files),
             spec_files=tuple(sorted({f for f in files if f})),
             read_this_spec=spec_file in files,
-            last_recorded=last_seen[project],
+            last_recorded=last_seen.get(project, ""),
         )
         for project, files in by_project.items()
     ]
     return tuple(sorted(excluded, key=lambda e: (not e.read_this_spec, -e.audits, e.project)))
 
 
+def _spec_audits(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Just the recorded spec audits, in file order."""
+    return [e for e in entries if e.get("event_type") == SPEC_ISSUES_EVENT]
+
+
+def _windowed_audits(
+    audits: list[dict[str, Any]],
+    project_name: str,
+    last_n: int,
+) -> list[dict[str, Any]]:
+    """The trend's history: the last ``last_n`` audits of one project.
+
+    The same rule as ``EvolutionJournal.get_spec_issue_runs``, applied
+    to entries already in memory so one read serves both the trend and
+    the accounting below it. Round 2 of review: the call site has both
+    results in scope, so the second parse of the same file bought
+    nothing. ``test_the_windowing_rule_matches_the_journals_own``
+    pins this against the journal's copy, because a duplicated rule
+    that drifts would make the trend and the accounting disagree.
+    Folding both into the journal is filed as #314, and doing so leaves
+    ``get_spec_issue_runs`` with no production caller today.
+    """
+    mine = [e for e in audits if _entry_str(e, "project") == project_name]
+    return mine[-last_n:] if last_n > 0 else []
+
+
 def _excluded_history(
-    journal: EvolutionJournal | None,
+    entries: list[dict[str, Any]],
     project_name: str,
     spec_file: str,
+    lookback: int,
 ) -> ExcludedHistory:
-    """Everything this journal records that the report will not count (#280).
+    """Everything the journal records that the report will not count (#280).
 
-    Empty for a first audit in a fresh repo, so the line it feeds never
-    fires on the common case.
+    Empty for a first audit in a fresh repo, so the lines it feeds
+    never fire on the common case.
 
-    Read through ``read_progress_events`` rather than
-    ``get_spec_issue_runs``, which filters to one project inside the
-    reader by design and so cannot answer either question this asks.
+    Takes ``entries`` rather than reading, so the caller reads once and
+    the trend and the accounting are computed over the same snapshot.
+    That also removes any chance of the two disagreeing because the
+    file changed between two reads.
 
-    That is a layering compromise and not a free one: it reaches past
-    ``EvolutionJournal`` to that journal's own storage path, and it
-    re-reads a file the trend has just read. A reader on
-    ``EvolutionJournal`` is the right home and would fold both into one
-    read. It is not done here because ``kstrl/evolution.py`` is under
-    concurrent edit on another branch, so this is a deferral for
-    contention, not a judgement that the layering is fine. The
-    mitigating fact is that it is the same tolerant read the journal
-    itself delegates to, over the same public path.
-
-    Growth, since the journal only ever grows: measured at 6.9 KB per
-    factory run in this repo, so 1 MB is about 150 runs and 10 MB about
-    1500. This read costs 4.4 ms at 1.9 MB, 53 ms at 19 MB and 229 ms
-    at 78 MB, against an architect call measured at 119 to 210 seconds.
-    Four other journal readers already parse the whole file per run, so
-    a journal large enough for this to matter is a compaction problem
-    for all of them rather than a reason to skip this one.
-
-    Deliberately NOT windowed by ``lookback_runs``. That knob bounds
-    how far back the *trend* reaches; a count of the history the trend
+    Deliberately NOT windowed by ``lookback_runs``; ``lookback`` is
+    carried only so the render can tell a windowed-out audit from one
+    the trend could not score. A count of the history the trend
     excludes that was itself windowed would omit history silently,
     which is the bug this exists to fix.
     """
-    if journal is None:
-        return ExcludedHistory(own_recorded=0, projects=())
-    entries = read_progress_events(journal.config.journal_path)
+    audits = _spec_audits(entries)
     return ExcludedHistory(
-        own_recorded=sum(
-            1
-            for e in entries
-            if e.get("event_type") == SPEC_ISSUES_EVENT and _entry_str(e, "project") == project_name
-        ),
-        projects=_excluded_projects(entries, project_name, spec_file),
+        own_recorded=sum(1 for e in audits if _entry_str(e, "project") == project_name),
+        projects=_excluded_projects(audits, project_name, spec_file),
+        unattributed=sum(1 for e in audits if not _entry_str(e, "project")),
+        lookback=lookback,
     )
+
+
+def _journal_snapshot(journal: EvolutionJournal | None) -> tuple[list[dict[str, Any]], int]:
+    """Every entry in the journal, and how far back the trend may reach.
+
+    Both together because both callers need both, and because a
+    journal that is absent has no entries AND no window: returning
+    the pair keeps that single fact in one place instead of a
+    conditional at the call site.
+
+    Read through ``read_progress_events`` rather than through
+    ``EvolutionJournal``, because no public reader on it returns the
+    whole entry set: ``get_spec_issue_runs`` filters to one project
+    inside the reader by design.
+
+    That is a layering compromise and not a free one. It reaches past
+    ``EvolutionJournal`` to that journal's own storage path, so a
+    journal that ever compacts, rotates or gains a second segment would
+    leave this reading less than the journal holds while the journal's
+    own reader kept working. Silent loss of the accounting is precisely
+    what #280 exists to fix, so the risk is pinned rather than trusted:
+    ``test_the_windowing_rule_matches_the_journals_own`` fails if the
+    two readers ever see different entries. A reader on
+    ``EvolutionJournal`` is the right home and would delete this
+    function; it is not added here because that file is under
+    concurrent edit on another branch. Filed as #314 rather than
+    raced.
+
+    One read per decompose, and the whole file: measured at 6.9 KB per
+    factory run in this repo, so 1 MB is about 150 runs and 10 MB about
+    1500. It costs 4.4 ms at 1.9 MB, 53 ms at 19 MB and 229 ms at
+    78 MB, against an architect call measured at 119 to 210 seconds.
+    """
+    if journal is None:
+        return [], 0
+    return read_progress_events(journal.config.journal_path), journal.config.lookback_runs
 
 
 def _surface_convergence(
@@ -1242,12 +1336,18 @@ def _surface_convergence(
     """
     if report is None and excluded.is_empty:
         return
+    counted = _counted_audits(report)
     ui.section("Spec Convergence")
     if report is not None:
-        _surface_trend(report, ui)
+        _surface_trend(report, ui, excluded.windowed_out(counted))
     elif excluded.own_recorded == 0:
         ui.info("No earlier audit of this project is recorded.")
-    for line in _excluded_lines(excluded, project_name, _counted_audits(report)):
+    else:
+        ui.info(
+            f"No earlier audit of '{project_name}' could be compared, though this "
+            f"journal records {excluded.own_recorded}."
+        )
+    for line in _excluded_lines(excluded, project_name, counted):
         ui.info(line)
 
 
@@ -1277,13 +1377,20 @@ def _join_capped(items: Sequence[str], noun: str) -> str:
 
 
 def _project_phrase(entry: ExcludedProject) -> str:
-    """One project named, with the files it read and when it last ran."""
-    parts = []
+    """One project named, with how much history it holds and when.
+
+    The audit count is rendered because it is the evidence the operator
+    judges a suspected rename on. Round 2 of review: it was carried on
+    the dataclass and dropped at the last step, so a project holding
+    100 audits printed identically to one holding 1, and the line
+    naming where the history lives could not say how much was there.
+    """
+    parts = [f"{entry.audits} audit(s)"]
     if entry.spec_files:
         parts.append(_join_capped(entry.spec_files, "file(s)"))
     if entry.last_recorded:
         parts.append(f"last {entry.last_recorded.split('T')[0]}")
-    return f"'{entry.project}' ({', '.join(parts)})" if parts else f"'{entry.project}'"
+    return f"'{entry.project}' ({', '.join(parts)})"
 
 
 def _excluded_lines(
@@ -1293,41 +1400,68 @@ def _excluded_lines(
 ) -> list[str]:
     """The lines naming audit history this report does not count (#280).
 
-    Up to two, one per axis, and between them they account for every
-    ``spec_issues`` entry in the journal. Each states a count it read
-    off disk against a count it read off the rendered trend, so neither
-    can claim more coverage than it has.
+    One per bucket that has something in it, and between the three of
+    them plus the trend footnote they account for every ``spec_issues``
+    entry in the journal. Each states a count read off disk against a
+    count read off the rendered trend, so none can claim more coverage
+    than it has.
 
-    Projects that audited this run's spec file are named in full and
-    only the rest are capped. Round 1 of review reproduced the previous
-    version dropping the strongest rename evidence: four other projects
-    that had all read ``spec.md``, which is a repo that split one spec
-    across several names and so #280's own shape, printed three of them
-    and "and 1 more project(s)".
+    An audit the window never offered the trend is NOT one of these
+    lines. That is the configured steady state, permanent from the
+    eleventh audit at the default lookback, and round 2 of review
+    measured the previous version printing a growing "40 recorded, 10
+    counted" note on every decompose forever. A warning that always
+    fires is noise, so that case is a footnote on the trend line it
+    qualifies (see ``_surface_trend``), and only an audit the trend was
+    OFFERED and could not score is an anomaly worth a sentence.
+
+    Projects that read this run's spec file are named ahead of the
+    rest, and both groups are capped: round 1 of review found the cap
+    dropping spec-file matches, and round 2 found the fix removing the
+    bound with it, rendering 971 characters for 25 such projects.
     """
     lines: list[str] = []
-    if excluded.own_recorded > counted:
+    unreadable = excluded.unreadable(counted)
+    if unreadable:
         lines.append(
-            f"Note: this journal records {excluded.own_recorded} earlier audit(s) of "
-            f"'{project_name}' and this report counts {counted}. The rest fall outside "
-            f"the lookback window, or carry no issue list to compare."
+            f"Note: {unreadable} earlier audit(s) of '{project_name}' fall inside the "
+            f"lookback window but could not be scored, so the trend does not count "
+            f"them. An audit is skipped when it records no issue list, or an issue "
+            f"whose severity is not blocker, major or minor."
         )
     if excluded.projects:
-        named = [_project_phrase(p) for p in excluded.projects if p.read_this_spec]
-        capped = _join_capped(
+        matched = _join_capped(
+            [_project_phrase(p) for p in excluded.projects if p.read_this_spec],
+            "project(s) that read this spec file",
+        )
+        rest = _join_capped(
             [_project_phrase(p) for p in excluded.projects if not p.read_this_spec],
             "project(s)",
         )
         lines.append(
             "Note: audits are matched by project name, and this report covers "
             f"'{project_name}'. This journal also records {excluded.other_audits} "
-            f"spec audit(s) under {', '.join(named + [capped] if capped else named)}."
+            f"spec audit(s) under {', '.join(p for p in (matched, rest) if p)}."
+        )
+    if excluded.unattributed:
+        lines.append(
+            f"Note: {excluded.unattributed} spec audit(s) in this journal record no "
+            f"project name, so neither the trend nor the line above counts them."
         )
     return lines
 
 
-def _surface_trend(report: SpecConvergence, ui: UI) -> None:
-    """The comparison itself: counts, deltas, trend and overlap."""
+def _surface_trend(report: SpecConvergence, ui: UI, windowed_out: int = 0) -> None:
+    """The comparison itself: counts, deltas, trend and overlap.
+
+    ``windowed_out`` is how many earlier audits of this project the
+    lookback window kept out of the trend. It is a footnote on the
+    trend line rather than a Note of its own: once a project has more
+    audits than ``lookback_runs`` the condition holds on every run
+    forever, so a separate warning would fire permanently and
+    round 2 of review measured exactly that. Qualifying the number in
+    place says the same thing where it is read and costs no line.
+    """
     for severity in _SEVERITY_ORDER:
         current = report.current_counts[severity]
         previous = report.previous_counts[severity]
@@ -1336,9 +1470,10 @@ def _surface_trend(report: SpecConvergence, ui: UI) -> None:
             severity.capitalize(),
             f"{current} (previous run: {previous}, {f'{delta:+d}' if delta else 'no change'})",
         )
+    scope = f"; {windowed_out} older audit(s) outside the lookback window" if windowed_out else ""
     ui.kv(
         "Trend",
-        ", ".join(str(n) for n in report.blocker_trend) + " (blockers, oldest run first)",
+        ", ".join(str(n) for n in report.blocker_trend) + f" (blockers, oldest run first{scope})",
     )
     ui.info(
         f"Previous run raised {report.previous_total} issue(s): {report.repeated} "
@@ -1712,15 +1847,18 @@ def _decompose_spec_impl(
     # this run is appended to the journal below - otherwise the
     # "previous run" the report compares against would be this one.
     journal = _spec_audit_journal(root_dir, ui)
+    # ONE read feeds both the trend and the accounting under it, so the
+    # two are computed over the same snapshot and cannot disagree
+    # because the file changed between two reads.
+    entries, lookback = _journal_snapshot(journal)
     # #280: the trend is keyed on the project name, so a rename starts a
     # fresh one and the runs before it drop out of view. Keying
     # differently would be worse (the spec is edited every round, so a
     # content hash never matches, and #260's own loop renamed the file
     # too), so what is fixed is the silence rather than the key.
-    excluded = _excluded_history(journal, project_name, spec_path.name)
     _surface_convergence(
-        _spec_convergence(spec_issues, journal, project_name, spec_path.name),
-        excluded,
+        _spec_convergence(spec_issues, entries, project_name, spec_path.name, lookback),
+        _excluded_history(entries, project_name, spec_path.name, lookback),
         project_name,
         ui,
     )

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -791,6 +791,14 @@ SPEC_ISSUES_REL_PATH = Path("scripts") / "kstrl" / "spec-issues.json"
 
 # The journal's discriminator for one recorded spec audit. Named because
 # this module both writes it and reads it back, and the two must agree.
+#
+# It is NOT the only copy: ``EvolutionJournal.get_spec_issue_runs``
+# hardcodes the same literal, and that file is under concurrent edit on
+# another branch, so it is not converted here. What keeps the two from
+# drifting is a mechanism rather than this comment -
+# ``test_the_journal_reader_agrees_with_the_event_name_written`` writes
+# an entry through this module and reads it back through the journal, so
+# changing this name alone fails that test (and fourteen others).
 SPEC_ISSUES_EVENT = "spec_issues"
 
 
@@ -1044,17 +1052,72 @@ class ExcludedProject:
     renamed a project and its spec file in the same moment, so neither
     half of the key survives to link the two histories. What this
     carries is the evidence the operator needs to judge it themselves -
-    the other project's name, how many audits it holds, and which spec
-    files those audits read.
+    the other project's name, how many audits it holds, which spec
+    files those audits read, and when the last of them was written.
 
     ``audits`` is not derivable from ``spec_files``: the files are
     deduplicated and the count is per audit, so one project auditing
     one file ten times is (10, one file).
+
+    ``read_this_spec`` is #280's first arm: this project audited the
+    same file the current run did. It is carried rather than recomputed
+    so the ordering rule and the display rule cannot drift apart.
+
+    ``last_recorded`` is the timestamp string on that project's most
+    recent entry, taken in file order because the journal is
+    append-only. It is whatever was written there, including "" for an
+    entry that recorded none, and never a value this code derives.
     """
 
     project: str
     audits: int
     spec_files: tuple[str, ...]
+    read_this_spec: bool
+    last_recorded: str
+
+
+@dataclass(frozen=True)
+class ExcludedHistory:
+    """Every spec audit in this journal the report does not count (#280).
+
+    Two axes, because there are two ways for the report to see less
+    than the journal holds, and #280 is that either one going unsaid is
+    the failure the report cannot afford:
+
+    - ``own_recorded`` counts THIS project's audits on disk. The trend
+      may count fewer, because ``lookback_runs`` windows it and because
+      an entry with no readable issue list cannot be compared. Round 1
+      of review found the first version counting only the cross-project
+      axis while its wording claimed the whole journal, which is #280's
+      own defect on the other axis.
+    - ``projects`` covers every other project name in the journal.
+
+    Both are unwindowed by construction: a count of what the trend does
+    not cover that was itself windowed would omit history silently.
+    """
+
+    own_recorded: int
+    projects: tuple[ExcludedProject, ...]
+
+    @property
+    def other_audits(self) -> int:
+        return sum(p.audits for p in self.projects)
+
+    @property
+    def is_empty(self) -> bool:
+        return self.own_recorded == 0 and not self.projects
+
+
+def _entry_str(entry: dict[str, Any], key: str) -> str:
+    """A string field of a journal entry, or "" for anything else.
+
+    NOT ``str(entry.get(key, ""))``: that renders a JSON ``null`` as
+    the literal ``"None"``, which round 1 of review reproduced as a
+    phantom project named 'None' passing the emptiness guard below and
+    a spec file printed as ``None``. A null field is an absent field.
+    """
+    value = entry.get(key)
+    return value if isinstance(value, str) else ""
 
 
 def _excluded_projects(
@@ -1064,81 +1127,99 @@ def _excluded_projects(
 ) -> tuple[ExcludedProject, ...]:
     """Spec audits in ``entries`` recorded under some other project.
 
-    Ordered so the display cap can only ever drop the weakest evidence.
-    A project that audited the file this run audited sorts first: that
-    is #280's first arm, the strongest hint of a plain project rename,
-    and it is a guarantee rather than a coincidence of the cap. The
-    rest follow by how much history they hold.
+    Ordered so the display cap drops only the weakest evidence: a
+    project that audited the file this run audited sorts first, then
+    the rest by how much history they hold. The cap itself never drops
+    a spec-file match; see ``_excluded_line``.
 
     Entries with no project name are skipped rather than grouped under
     "": an unnamed project is not somewhere the operator can go and
     look, so pointing at it is not evidence.
     """
     by_project: dict[str, list[str]] = {}
+    last_seen: dict[str, str] = {}
     for entry in entries:
         if entry.get("event_type") != SPEC_ISSUES_EVENT:
             continue
-        project = str(entry.get("project", ""))
+        project = _entry_str(entry, "project")
         if not project or project == project_name:
             continue
-        by_project.setdefault(project, []).append(str(entry.get("spec_file", "")))
+        by_project.setdefault(project, []).append(_entry_str(entry, "spec_file"))
+        last_seen[project] = _entry_str(entry, "timestamp")
     excluded = [
         ExcludedProject(
             project=project,
             audits=len(files),
             spec_files=tuple(sorted({f for f in files if f})),
+            read_this_spec=spec_file in files,
+            last_recorded=last_seen[project],
         )
         for project, files in by_project.items()
     ]
-    return tuple(
-        sorted(excluded, key=lambda e: (spec_file not in e.spec_files, -e.audits, e.project))
-    )
+    return tuple(sorted(excluded, key=lambda e: (not e.read_this_spec, -e.audits, e.project)))
 
 
 def _excluded_history(
     journal: EvolutionJournal | None,
     project_name: str,
     spec_file: str,
-) -> tuple[ExcludedProject, ...]:
-    """Every spec audit this journal holds under another project (#280).
+) -> ExcludedHistory:
+    """Everything this journal records that the report will not count (#280).
 
-    Empty for the ordinary single-project repo, so the line it feeds
-    never fires on the common case.
+    Empty for a first audit in a fresh repo, so the line it feeds never
+    fires on the common case.
 
     Read through ``read_progress_events`` rather than
     ``get_spec_issue_runs``, which filters to one project inside the
-    reader by design and so cannot see the entries this asks about. It
-    is the same tolerant read the journal itself delegates to, over the
-    same public path. A reader on ``EvolutionJournal`` would be the
-    better home and would collapse this into the read the trend already
-    does; measured at 0.099 ms on this repo's journal, so the second
-    read buys nothing worth a worse layering to avoid.
+    reader by design and so cannot answer either question this asks.
+
+    That is a layering compromise and not a free one: it reaches past
+    ``EvolutionJournal`` to that journal's own storage path, and it
+    re-reads a file the trend has just read. A reader on
+    ``EvolutionJournal`` is the right home and would fold both into one
+    read. It is not done here because ``kstrl/evolution.py`` is under
+    concurrent edit on another branch, so this is a deferral for
+    contention, not a judgement that the layering is fine. The
+    mitigating fact is that it is the same tolerant read the journal
+    itself delegates to, over the same public path.
+
+    Growth, since the journal only ever grows: measured at 6.9 KB per
+    factory run in this repo, so 1 MB is about 150 runs and 10 MB about
+    1500. This read costs 4.4 ms at 1.9 MB, 53 ms at 19 MB and 229 ms
+    at 78 MB, against an architect call measured at 119 to 210 seconds.
+    Four other journal readers already parse the whole file per run, so
+    a journal large enough for this to matter is a compaction problem
+    for all of them rather than a reason to skip this one.
 
     Deliberately NOT windowed by ``lookback_runs``. That knob bounds
     how far back the *trend* reaches; a count of the history the trend
     excludes that was itself windowed would omit history silently,
-    which is the bug it exists to fix.
+    which is the bug this exists to fix.
     """
     if journal is None:
-        return ()
-    return _excluded_projects(
-        read_progress_events(journal.config.journal_path),
-        project_name,
-        spec_file,
+        return ExcludedHistory(own_recorded=0, projects=())
+    entries = read_progress_events(journal.config.journal_path)
+    return ExcludedHistory(
+        own_recorded=sum(
+            1
+            for e in entries
+            if e.get("event_type") == SPEC_ISSUES_EVENT and _entry_str(e, "project") == project_name
+        ),
+        projects=_excluded_projects(entries, project_name, spec_file),
     )
 
 
 def _surface_convergence(
     report: SpecConvergence | None,
-    excluded: tuple[ExcludedProject, ...],
+    excluded: ExcludedHistory,
     project_name: str,
     ui: UI,
 ) -> None:
     """Render the convergence report, or nothing on the first run.
 
-    No report and nothing excluded (no journal, or a first audit in a
-    repo whose journal holds nothing else) renders silently, so the
-    common first-run case prints no noise.
+    No report and an empty ``excluded`` (no journal, or a first audit
+    in a repo whose journal holds nothing else) renders silently, so
+    the common first-run case prints no noise.
 
     Counts, deltas and the trend, with no "this spec is converging"
     verdict attached: no measured threshold separates converging from
@@ -1149,19 +1230,36 @@ def _surface_convergence(
 
     No report next to a non-empty ``excluded`` is #280's own shape: the
     audit that renamed the project starts a fresh trend, and the moment
-    the history is lost is the moment worth saying so. That case says
-    the absence out loud, because a note under a bare section header
-    would leave the operator to infer it from silence.
+    the history is lost is the moment worth saying so.
+
+    ``No earlier audit of this project is recorded`` is printed ONLY
+    when the journal records none. Round 1 of review reproduced it
+    firing over three audits of this very project that the report had
+    merely failed to read, under ``lookback_runs=0`` and again on a
+    legacy journal whose entries carry no issue list. A confident
+    statement over less data than the journal holds is the defect #280
+    is about, so what prints in that case is the accounting line below.
     """
-    if report is None and not excluded:
+    if report is None and excluded.is_empty:
         return
     ui.section("Spec Convergence")
-    if report is None:
-        ui.info("No earlier audit of this project is recorded.")
-    else:
+    if report is not None:
         _surface_trend(report, ui)
-    if excluded:
-        ui.info(_excluded_line(excluded, project_name))
+    elif excluded.own_recorded == 0:
+        ui.info("No earlier audit of this project is recorded.")
+    for line in _excluded_lines(excluded, project_name, _counted_audits(report)):
+        ui.info(line)
+
+
+def _counted_audits(report: SpecConvergence | None) -> int:
+    """How many EARLIER audits the rendered trend actually counted.
+
+    The trend carries one entry per readable prior audit plus this run,
+    so the earlier ones are its length minus one. Derived from the
+    rendered value rather than recomputed, so the accounting line can
+    never disagree with the trend printed directly above it.
+    """
+    return len(report.blocker_trend) - 1 if report is not None else 0
 
 
 # How many names one line spells out before summarising the rest. A
@@ -1178,18 +1276,54 @@ def _join_capped(items: Sequence[str], noun: str) -> str:
     return f"{joined} and {rest} more {noun}" if rest else joined
 
 
-def _excluded_line(excluded: tuple[ExcludedProject, ...], project_name: str) -> str:
-    """The one line naming the audit history this report does not cover."""
-    phrases: list[str] = []
-    for entry in excluded:
-        files = _join_capped(entry.spec_files, "file(s)")
-        phrases.append(f"'{entry.project}' ({files})" if files else f"'{entry.project}'")
-    return (
-        "Note: audits are matched by project name, and this report covers "
-        f"'{project_name}'. This journal holds {sum(e.audits for e in excluded)} "
-        f"more spec audit(s) that it does not count, under "
-        f"{_join_capped(phrases, 'project(s)')}."
-    )
+def _project_phrase(entry: ExcludedProject) -> str:
+    """One project named, with the files it read and when it last ran."""
+    parts = []
+    if entry.spec_files:
+        parts.append(_join_capped(entry.spec_files, "file(s)"))
+    if entry.last_recorded:
+        parts.append(f"last {entry.last_recorded.split('T')[0]}")
+    return f"'{entry.project}' ({', '.join(parts)})" if parts else f"'{entry.project}'"
+
+
+def _excluded_lines(
+    excluded: ExcludedHistory,
+    project_name: str,
+    counted: int,
+) -> list[str]:
+    """The lines naming audit history this report does not count (#280).
+
+    Up to two, one per axis, and between them they account for every
+    ``spec_issues`` entry in the journal. Each states a count it read
+    off disk against a count it read off the rendered trend, so neither
+    can claim more coverage than it has.
+
+    Projects that audited this run's spec file are named in full and
+    only the rest are capped. Round 1 of review reproduced the previous
+    version dropping the strongest rename evidence: four other projects
+    that had all read ``spec.md``, which is a repo that split one spec
+    across several names and so #280's own shape, printed three of them
+    and "and 1 more project(s)".
+    """
+    lines: list[str] = []
+    if excluded.own_recorded > counted:
+        lines.append(
+            f"Note: this journal records {excluded.own_recorded} earlier audit(s) of "
+            f"'{project_name}' and this report counts {counted}. The rest fall outside "
+            f"the lookback window, or carry no issue list to compare."
+        )
+    if excluded.projects:
+        named = [_project_phrase(p) for p in excluded.projects if p.read_this_spec]
+        capped = _join_capped(
+            [_project_phrase(p) for p in excluded.projects if not p.read_this_spec],
+            "project(s)",
+        )
+        lines.append(
+            "Note: audits are matched by project name, and this report covers "
+            f"'{project_name}'. This journal also records {excluded.other_audits} "
+            f"spec audit(s) under {', '.join(named + [capped] if capped else named)}."
+        )
+    return lines
 
 
 def _surface_trend(report: SpecConvergence, ui: UI) -> None:

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -6,7 +6,7 @@ import json
 import logging
 import re
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -49,6 +49,7 @@ from kstrl.manifest import (
     Manifest,
 )
 from kstrl.names import validate_branch_name, validate_component_id
+from kstrl.observability import read_progress_events
 from kstrl.prd import PRD
 
 logger = logging.getLogger(__name__)
@@ -788,6 +789,10 @@ def _surface_spec_issues(issues: list[SpecIssue], ui: UI) -> None:
 # next to manifest.json so one directory holds the decompose outputs.
 SPEC_ISSUES_REL_PATH = Path("scripts") / "kstrl" / "spec-issues.json"
 
+# The journal's discriminator for one recorded spec audit. Named because
+# this module both writes it and reads it back, and the two must agree.
+SPEC_ISSUES_EVENT = "spec_issues"
+
 
 def _issue_dicts(issues: list[SpecIssue]) -> list[dict[str, str]]:
     return [
@@ -886,7 +891,7 @@ def _record_spec_issues_event(
     entry: dict[str, Any] = {
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "project": project_name,
-        "event_type": "spec_issues",
+        "event_type": SPEC_ISSUES_EVENT,
         "spec_file": spec_file,
         "halted": halted,
         "counts": _issue_counts(issues),
@@ -1030,12 +1035,110 @@ def _spec_convergence(
     )
 
 
-def _surface_convergence(report: SpecConvergence | None, ui: UI) -> None:
+@dataclass(frozen=True)
+class ExcludedProject:
+    """Spec audits this journal holds under one OTHER project name (#280).
+
+    Not a claim that they are the same work. The report cannot know
+    that, and #280 is explicit that it should not try: the operator
+    renamed a project and its spec file in the same moment, so neither
+    half of the key survives to link the two histories. What this
+    carries is the evidence the operator needs to judge it themselves -
+    the other project's name, how many audits it holds, and which spec
+    files those audits read.
+
+    ``audits`` is not derivable from ``spec_files``: the files are
+    deduplicated and the count is per audit, so one project auditing
+    one file ten times is (10, one file).
+    """
+
+    project: str
+    audits: int
+    spec_files: tuple[str, ...]
+
+
+def _excluded_projects(
+    entries: list[dict[str, Any]],
+    project_name: str,
+    spec_file: str,
+) -> tuple[ExcludedProject, ...]:
+    """Spec audits in ``entries`` recorded under some other project.
+
+    Ordered so the display cap can only ever drop the weakest evidence.
+    A project that audited the file this run audited sorts first: that
+    is #280's first arm, the strongest hint of a plain project rename,
+    and it is a guarantee rather than a coincidence of the cap. The
+    rest follow by how much history they hold.
+
+    Entries with no project name are skipped rather than grouped under
+    "": an unnamed project is not somewhere the operator can go and
+    look, so pointing at it is not evidence.
+    """
+    by_project: dict[str, list[str]] = {}
+    for entry in entries:
+        if entry.get("event_type") != SPEC_ISSUES_EVENT:
+            continue
+        project = str(entry.get("project", ""))
+        if not project or project == project_name:
+            continue
+        by_project.setdefault(project, []).append(str(entry.get("spec_file", "")))
+    excluded = [
+        ExcludedProject(
+            project=project,
+            audits=len(files),
+            spec_files=tuple(sorted({f for f in files if f})),
+        )
+        for project, files in by_project.items()
+    ]
+    return tuple(
+        sorted(excluded, key=lambda e: (spec_file not in e.spec_files, -e.audits, e.project))
+    )
+
+
+def _excluded_history(
+    journal: EvolutionJournal | None,
+    project_name: str,
+    spec_file: str,
+) -> tuple[ExcludedProject, ...]:
+    """Every spec audit this journal holds under another project (#280).
+
+    Empty for the ordinary single-project repo, so the line it feeds
+    never fires on the common case.
+
+    Read through ``read_progress_events`` rather than
+    ``get_spec_issue_runs``, which filters to one project inside the
+    reader by design and so cannot see the entries this asks about. It
+    is the same tolerant read the journal itself delegates to, over the
+    same public path. A reader on ``EvolutionJournal`` would be the
+    better home and would collapse this into the read the trend already
+    does; measured at 0.099 ms on this repo's journal, so the second
+    read buys nothing worth a worse layering to avoid.
+
+    Deliberately NOT windowed by ``lookback_runs``. That knob bounds
+    how far back the *trend* reaches; a count of the history the trend
+    excludes that was itself windowed would omit history silently,
+    which is the bug it exists to fix.
+    """
+    if journal is None:
+        return ()
+    return _excluded_projects(
+        read_progress_events(journal.config.journal_path),
+        project_name,
+        spec_file,
+    )
+
+
+def _surface_convergence(
+    report: SpecConvergence | None,
+    excluded: tuple[ExcludedProject, ...],
+    project_name: str,
+    ui: UI,
+) -> None:
     """Render the convergence report, or nothing on the first run.
 
-    ``None`` (no journal, or no previous audit of this project) renders
-    silently, so the common first-run case prints no noise and the
-    caller has no branch to carry.
+    No report and nothing excluded (no journal, or a first audit in a
+    repo whose journal holds nothing else) renders silently, so the
+    common first-run case prints no noise.
 
     Counts, deltas and the trend, with no "this spec is converging"
     verdict attached: no measured threshold separates converging from
@@ -1043,10 +1146,54 @@ def _surface_convergence(report: SpecConvergence | None, ui: UI) -> None:
     and the rise from 1 to 3 happened while the operator was resolving
     real issues. The numbers are the evidence; the judgement about
     whether to pay for another round is the operator's.
+
+    No report next to a non-empty ``excluded`` is #280's own shape: the
+    audit that renamed the project starts a fresh trend, and the moment
+    the history is lost is the moment worth saying so. That case says
+    the absence out loud, because a note under a bare section header
+    would leave the operator to infer it from silence.
     """
-    if report is None:
+    if report is None and not excluded:
         return
     ui.section("Spec Convergence")
+    if report is None:
+        ui.info("No earlier audit of this project is recorded.")
+    else:
+        _surface_trend(report, ui)
+    if excluded:
+        ui.info(_excluded_line(excluded, project_name))
+
+
+# How many names one line spells out before summarising the rest. A
+# display cap on line length, not a threshold on meaning: nothing is
+# dropped from the counts, only from the list of names.
+_EXCLUDED_NAMES_SHOWN = 3
+
+
+def _join_capped(items: Sequence[str], noun: str) -> str:
+    """Join ``items``, naming at most ``_EXCLUDED_NAMES_SHOWN`` of them."""
+    shown = items[:_EXCLUDED_NAMES_SHOWN]
+    rest = len(items) - len(shown)
+    joined = ", ".join(shown)
+    return f"{joined} and {rest} more {noun}" if rest else joined
+
+
+def _excluded_line(excluded: tuple[ExcludedProject, ...], project_name: str) -> str:
+    """The one line naming the audit history this report does not cover."""
+    phrases: list[str] = []
+    for entry in excluded:
+        files = _join_capped(entry.spec_files, "file(s)")
+        phrases.append(f"'{entry.project}' ({files})" if files else f"'{entry.project}'")
+    return (
+        "Note: audits are matched by project name, and this report covers "
+        f"'{project_name}'. This journal holds {sum(e.audits for e in excluded)} "
+        f"more spec audit(s) that it does not count, under "
+        f"{_join_capped(phrases, 'project(s)')}."
+    )
+
+
+def _surface_trend(report: SpecConvergence, ui: UI) -> None:
+    """The comparison itself: counts, deltas, trend and overlap."""
     for severity in _SEVERITY_ORDER:
         current = report.current_counts[severity]
         previous = report.previous_counts[severity]
@@ -1431,8 +1578,16 @@ def _decompose_spec_impl(
     # this run is appended to the journal below - otherwise the
     # "previous run" the report compares against would be this one.
     journal = _spec_audit_journal(root_dir, ui)
+    # #280: the trend is keyed on the project name, so a rename starts a
+    # fresh one and the runs before it drop out of view. Keying
+    # differently would be worse (the spec is edited every round, so a
+    # content hash never matches, and #260's own loop renamed the file
+    # too), so what is fixed is the silence rather than the key.
+    excluded = _excluded_history(journal, project_name, spec_path.name)
     _surface_convergence(
         _spec_convergence(spec_issues, journal, project_name, spec_path.name),
+        excluded,
+        project_name,
         ui,
     )
     _record_spec_issues_event(

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -10,15 +10,20 @@ from pathlib import Path
 import pytest
 
 from kstrl.decompose import (
+    SPEC_ISSUES_EVENT,
     SpecBlockerError,
     SpecIssue,
     _build_convergence,
+    _excluded_history,
+    _excluded_line,
+    _excluded_projects,
     _extract_json,
     _issue_dicts,
     _parse_spec_issues,
     _validate_decompose_output,
     decompose_spec,
 )
+from kstrl.evolution import EvolutionConfig, EvolutionJournal
 from kstrl.prd import PRD
 from kstrl.ui.plain import PlainUI
 
@@ -773,6 +778,13 @@ def _run_decompose(
     return buffer.getvalue()
 
 
+def _journal_with(tmp_path: Path, entries: list[dict[str, object]]) -> EvolutionJournal:
+    """A real journal on disk holding ``entries``, written its own way."""
+    journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
+    journal.append_entries(entries)
+    return journal
+
+
 def _read_spec_issue_events(tmp_path: Path) -> list[dict[str, object]]:
     journal = tmp_path / ".kstrl" / "evolution.jsonl"
     assert journal.exists(), "journal event was not written"
@@ -1147,6 +1159,153 @@ class TestSpecConvergenceReport:
         assert report.repeated == 2
 
 
+class TestExcludedHistory:
+    """#280: the audit history the trend does not cover, named."""
+
+    def _entry(
+        self,
+        project: str,
+        spec_file: str = "spec.md",
+        event_type: str = SPEC_ISSUES_EVENT,
+    ) -> dict[str, object]:
+        return {"event_type": event_type, "project": project, "spec_file": spec_file}
+
+    def _line(self, journal: EvolutionJournal, project: str, spec_file: str = "mine.md") -> str:
+        """The rendered line for ``project``, or "" when nothing is excluded."""
+        excluded = _excluded_history(journal, project, spec_file)
+        return _excluded_line(excluded, project) if excluded else ""
+
+    def test_a_journal_of_one_project_excludes_nothing(self) -> None:
+        entries = [self._entry("writers-room"), self._entry("writers-room")]
+
+        assert _excluded_projects(entries, "writers-room", "spec.md") == ()
+
+    def test_another_project_is_counted_with_the_files_it_read(self) -> None:
+        entries = [
+            self._entry("writers-room", "spec.md"),
+            self._entry("writers-room", "spec.md"),
+            self._entry("writers-room-slice1", "spec-slice-1.md"),
+        ]
+
+        excluded = _excluded_projects(entries, "writers-room-slice1", "spec-slice-1.md")
+
+        assert len(excluded) == 1
+        assert excluded[0].project == "writers-room"
+        assert excluded[0].audits == 2
+        assert excluded[0].spec_files == ("spec.md",)
+
+    def test_only_spec_audits_count(self) -> None:
+        """The journal carries component results and experiments too.
+        Counting those would inflate the number the operator reads."""
+        entries = [
+            self._entry("other", event_type="component_result"),
+            self._entry("other", event_type=SPEC_ISSUES_EVENT),
+        ]
+
+        excluded = _excluded_projects(entries, "mine", "mine.md")
+
+        assert [(e.project, e.audits) for e in excluded] == [("other", 1)]
+
+    def test_an_entry_without_a_project_is_not_evidence(self) -> None:
+        """An unnamed project cannot be somewhere the operator can go
+        and look, so it is not history worth pointing at."""
+        entries: list[dict[str, object]] = [{"event_type": SPEC_ISSUES_EVENT}]
+
+        assert _excluded_projects(entries, "mine", "mine.md") == ()
+
+    def test_projects_are_ordered_by_how_much_history_they_hold(self) -> None:
+        entries = [
+            self._entry("a"),
+            self._entry("b"),
+            self._entry("b"),
+            self._entry("c"),
+        ]
+
+        excluded = _excluded_projects(entries, "mine", "mine.md")
+
+        assert [(e.project, e.audits) for e in excluded] == [("b", 2), ("a", 1), ("c", 1)]
+
+    def test_a_project_that_read_this_spec_file_sorts_first(self) -> None:
+        """#280's first arm, kept as a guarantee rather than a
+        coincidence of the display cap: the project that audited the
+        file this run audited is the strongest evidence of a plain
+        rename, so it survives however many projects the journal
+        holds - even though it holds the least history here."""
+        entries = [self._entry("busy") for _ in range(9)] + [self._entry("renamed", "mine.md")]
+
+        excluded = _excluded_projects(entries, "mine", "mine.md")
+
+        assert [e.project for e in excluded] == ["renamed", "busy"]
+
+    def test_distinct_spec_files_are_deduplicated_and_sorted(self) -> None:
+        entries = [
+            self._entry("other", "b.md"),
+            self._entry("other", "a.md"),
+            self._entry("other", "b.md"),
+            self._entry("other", ""),
+        ]
+
+        excluded = _excluded_projects(entries, "mine", "mine.md")
+
+        assert excluded[0].audits == 4
+        assert excluded[0].spec_files == ("a.md", "b.md")
+
+    def test_no_journal_excludes_nothing(self) -> None:
+        assert _excluded_history(None, "writers-room", "spec.md") == ()
+
+    def test_the_read_covers_the_whole_journal(self, tmp_path: Path) -> None:
+        journal = _journal_with(tmp_path, [self._entry("writers-room", "spec.md")] * 2)
+
+        assert self._line(journal, "writers-room-slice1", "spec-slice-1.md") == (
+            "Note: audits are matched by project name, and this report covers "
+            "'writers-room-slice1'. This journal holds 2 more spec audit(s) that "
+            "it does not count, under 'writers-room' (spec.md)."
+        )
+
+    def test_a_journal_holding_only_this_project_excludes_nothing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        journal = _journal_with(tmp_path, [self._entry("writers-room")] * 3)
+
+        assert _excluded_history(journal, "writers-room", "spec.md") == ()
+
+    def test_a_missing_journal_file_excludes_nothing(self, tmp_path: Path) -> None:
+        journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
+
+        assert _excluded_history(journal, "writers-room", "spec.md") == ()
+
+    def test_a_torn_line_does_not_cost_the_note(self, tmp_path: Path) -> None:
+        """The journal is append-only and a crash mid-write leaves a
+        torn tail; the rest of the history still has to be readable."""
+        journal = _journal_with(tmp_path, [self._entry("writers-room", "spec.md")])
+        with open(journal.config.journal_path, "a", encoding="utf-8") as handle:
+            handle.write('{"event_type": "spec_iss')
+
+        assert "1 more spec audit(s)" in self._line(journal, "writers-room-slice1")
+
+    def test_many_projects_are_summarised_rather_than_all_named(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A display cap on the names, never on the count: the total
+        still covers every audit the trend leaves out."""
+        journal = _journal_with(tmp_path, [self._entry(f"p{n}", f"s{n}.md") for n in range(6)])
+
+        line = self._line(journal, "mine")
+
+        assert "6 more spec audit(s)" in line
+        assert "'p0' (s0.md), 'p1' (s1.md), 'p2' (s2.md) and 3 more project(s)" in line
+
+    def test_many_spec_files_under_one_project_are_summarised_too(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        journal = _journal_with(tmp_path, [self._entry("other", f"s{n}.md") for n in range(5)])
+
+        assert "'other' (s0.md, s1.md, s2.md and 2 more file(s))" in self._line(journal, "mine")
+
+
 class TestSpecConvergenceThroughDecompose:
     """The report as the operator meets it, on the real code path."""
 
@@ -1227,10 +1386,120 @@ class TestSpecConvergenceThroughDecompose:
         assert "the previous audit read spec.md, this one read spec-slice-1.md" in output
 
     def test_a_different_project_has_its_own_history(self, tmp_path: Path) -> None:
+        """Still its own trend, but no longer its own silence (#280).
+
+        This test previously asserted the whole section was absent,
+        which is exactly the loss #280 reports: the operator was told
+        nothing at all about the audits the trend had just dropped.
+        """
         self._run(tmp_path, [BLOCKER_ISSUE], project_name="writers-room")
         output = self._run(tmp_path, [BLOCKER_ISSUE], project_name="deckgen")
 
+        assert "Trend:" not in output
+        assert "No earlier audit of this project is recorded." in output
+        assert "1 more spec audit(s)" in output
+        assert "'writers-room' (spec.md)" in output
+
+    def test_the_rename_that_lost_two_runs_now_says_so(self, tmp_path: Path) -> None:
+        """#280's own shape, end to end: five audits, a project AND
+        spec rename between runs 2 and 3, and a trend that covers only
+        the last three. The trend is unchanged; what is new is the line
+        that says the other two exist."""
+        for spec, project in [
+            ("spec.md", "writers-room"),
+            ("spec.md", "writers-room"),
+            ("spec-slice-1.md", "writers-room-slice1"),
+            ("spec-slice-1.md", "writers-room-slice1"),
+        ]:
+            self._run(tmp_path, [BLOCKER_ISSUE], spec_name=spec, project_name=project)
+        output = self._run(
+            tmp_path,
+            [BLOCKER_ISSUE],
+            spec_name="spec-slice-1.md",
+            project_name="writers-room-slice1",
+        )
+
+        assert "1, 1, 1 (blockers, oldest run first)" in output
+        assert (
+            "Note: audits are matched by project name, and this report covers "
+            "'writers-room-slice1'. This journal holds 2 more spec audit(s) that "
+            "it does not count, under 'writers-room' (spec.md)." in output
+        )
+
+    def test_an_ordinary_single_project_history_prints_no_note(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The false-positive check. A warning that always fires is
+        noise, and noise is how a report stops being read."""
+        for _ in range(4):
+            self._run(tmp_path, [BLOCKER_ISSUE])
+        output = self._run(tmp_path, [BLOCKER_ISSUE])
+
+        assert "1, 1, 1, 1, 1 (blockers, oldest run first)" in output
+        assert "more spec audit(s)" not in output
+
+    def test_a_genuine_two_project_repo_is_told_the_truth(self, tmp_path: Path) -> None:
+        """The measured cost of keying the note on "any other project"
+        rather than on a matching spec file: a repo holding two real
+        projects sees the line on every decompose of either.
+
+        Pinned rather than hidden, because it is the price of covering
+        #280's own session, where the spec file was renamed at the same
+        moment as the project and a spec-file match would have found
+        nothing. The line names the other project and the file it read,
+        so an operator on 'billing' dismisses 'auth' (auth.md) at a
+        glance instead of investigating.
+        """
+        self._run(tmp_path, [BLOCKER_ISSUE], spec_name="auth.md", project_name="auth")
+        self._run(tmp_path, [BLOCKER_ISSUE], spec_name="billing.md", project_name="billing")
+        output = self._run(
+            tmp_path,
+            [BLOCKER_ISSUE],
+            spec_name="billing.md",
+            project_name="billing",
+        )
+
+        assert "1, 1 (blockers, oldest run first)" in output
+        assert "this report covers 'billing'" in output
+        assert "1 more spec audit(s) that it does not count, under 'auth' (auth.md)" in output
+
+    def test_a_rename_within_one_project_prints_no_note(self, tmp_path: Path) -> None:
+        """The spec file moving is already reported by the rename line;
+        the note is about the OTHER half of the key and must stay out
+        of it."""
+        self._run(tmp_path, [BLOCKER_ISSUE], spec_name="spec.md")
+        output = self._run(tmp_path, [BLOCKER_ISSUE], spec_name="spec-slice-1.md")
+
+        assert "the previous audit read spec.md" in output
+        assert "more spec audit(s)" not in output
+
+    def test_no_note_when_the_journal_is_off(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A disabled journal reads nothing, so it can claim nothing."""
+        self._run(tmp_path, [BLOCKER_ISSUE], project_name="writers-room")
+        monkeypatch.setenv("KSTRL_EVOLUTION_ENABLED", "0")
+        output = self._run(tmp_path, [BLOCKER_ISSUE], project_name="deckgen")
+
         assert "Spec Convergence" not in output
+
+    def test_the_note_is_not_windowed_by_the_lookback(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``lookback_runs`` bounds how far back the trend reaches. A
+        note about history the trend excludes that were itself windowed
+        would omit history silently, which is the bug it fixes."""
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "2")
+        for _ in range(4):
+            self._run(tmp_path, [BLOCKER_ISSUE], project_name="writers-room")
+        output = self._run(tmp_path, [BLOCKER_ISSUE], project_name="deckgen")
+
+        assert "4 more spec audit(s)" in output
 
     def test_a_clean_audit_still_reports_the_drop(self, tmp_path: Path) -> None:
         self._run(tmp_path, [BLOCKER_ISSUE])

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -11,11 +11,14 @@ import pytest
 
 from kstrl.decompose import (
     SPEC_ISSUES_EVENT,
+    ExcludedHistory,
     SpecBlockerError,
+    SpecConvergence,
     SpecIssue,
     _build_convergence,
+    _counted_audits,
     _excluded_history,
-    _excluded_line,
+    _excluded_lines,
     _excluded_projects,
     _extract_json,
     _issue_dicts,
@@ -1160,22 +1163,34 @@ class TestSpecConvergenceReport:
 
 
 class TestExcludedHistory:
-    """#280: the audit history the trend does not cover, named."""
+    """#280: the audit history the report does not count, named."""
 
     def _entry(
         self,
         project: str,
         spec_file: str = "spec.md",
         event_type: str = SPEC_ISSUES_EVENT,
+        timestamp: str = "2026-08-20T00:00:00Z",
     ) -> dict[str, object]:
-        return {"event_type": event_type, "project": project, "spec_file": spec_file}
+        return {
+            "event_type": event_type,
+            "project": project,
+            "spec_file": spec_file,
+            "timestamp": timestamp,
+        }
 
-    def _line(self, journal: EvolutionJournal, project: str, spec_file: str = "mine.md") -> str:
-        """The rendered line for ``project``, or "" when nothing is excluded."""
+    def _lines(
+        self,
+        journal: EvolutionJournal,
+        project: str,
+        spec_file: str = "mine.md",
+        counted: int = 0,
+    ) -> str:
+        """The rendered note lines for ``project``, joined."""
         excluded = _excluded_history(journal, project, spec_file)
-        return _excluded_line(excluded, project) if excluded else ""
+        return "\n".join(_excluded_lines(excluded, project, counted))
 
-    def test_a_journal_of_one_project_excludes_nothing(self) -> None:
+    def test_a_journal_of_one_project_excludes_no_other_project(self) -> None:
         entries = [self._entry("writers-room"), self._entry("writers-room")]
 
         assert _excluded_projects(entries, "writers-room", "spec.md") == ()
@@ -1193,6 +1208,8 @@ class TestExcludedHistory:
         assert excluded[0].project == "writers-room"
         assert excluded[0].audits == 2
         assert excluded[0].spec_files == ("spec.md",)
+        assert excluded[0].read_this_spec is False
+        assert excluded[0].last_recorded == "2026-08-20T00:00:00Z"
 
     def test_only_spec_audits_count(self) -> None:
         """The journal carries component results and experiments too.
@@ -1213,6 +1230,43 @@ class TestExcludedHistory:
 
         assert _excluded_projects(entries, "mine", "mine.md") == ()
 
+    def test_a_json_null_project_is_not_a_project_named_none(self) -> None:
+        """Round 1 of review: ``str(entry.get("project", ""))`` renders
+        a JSON null as the literal "None", which then passes the
+        emptiness guard and prints a phantom project. A null field is
+        an absent field, and ``get_spec_issue_runs`` promises nothing
+        is assumed about an entry beyond it being a JSON object."""
+        entries: list[dict[str, object]] = [
+            {
+                "event_type": SPEC_ISSUES_EVENT,
+                "project": None,
+                "spec_file": None,
+                "timestamp": None,
+            }
+        ]
+
+        assert _excluded_projects(entries, "mine", "mine.md") == ()
+
+    def test_a_non_string_spec_file_and_timestamp_are_dropped_not_stringified(
+        self,
+    ) -> None:
+        """The same rule on the other two fields: a hand-edited journal
+        must not put a file literally named ``None`` or ``7`` in the
+        list, nor a date the operator cannot act on."""
+        entries: list[dict[str, object]] = [
+            {
+                "event_type": SPEC_ISSUES_EVENT,
+                "project": "other",
+                "spec_file": 7,
+                "timestamp": None,
+            }
+        ]
+
+        excluded = _excluded_projects(entries, "mine", "mine.md")
+
+        assert excluded[0].spec_files == ()
+        assert excluded[0].last_recorded == ""
+
     def test_projects_are_ordered_by_how_much_history_they_hold(self) -> None:
         entries = [
             self._entry("a"),
@@ -1226,16 +1280,30 @@ class TestExcludedHistory:
         assert [(e.project, e.audits) for e in excluded] == [("b", 2), ("a", 1), ("c", 1)]
 
     def test_a_project_that_read_this_spec_file_sorts_first(self) -> None:
-        """#280's first arm, kept as a guarantee rather than a
-        coincidence of the display cap: the project that audited the
-        file this run audited is the strongest evidence of a plain
-        rename, so it survives however many projects the journal
-        holds - even though it holds the least history here."""
+        """#280's first arm: the project that audited the file this run
+        audited is the strongest evidence of a plain rename, so it
+        leads even though it holds the least history here."""
         entries = [self._entry("busy") for _ in range(9)] + [self._entry("renamed", "mine.md")]
 
         excluded = _excluded_projects(entries, "mine", "mine.md")
 
         assert [e.project for e in excluded] == ["renamed", "busy"]
+        assert excluded[0].read_this_spec is True
+        assert excluded[1].read_this_spec is False
+
+    def test_the_last_recorded_timestamp_is_the_newest_entry_in_file_order(
+        self,
+    ) -> None:
+        """The journal is append-only, so the last entry for a project
+        is its most recent audit."""
+        entries = [
+            self._entry("other", timestamp="2026-01-01T00:00:00Z"),
+            self._entry("other", timestamp="2026-06-30T12:00:00Z"),
+        ]
+
+        excluded = _excluded_projects(entries, "mine", "mine.md")
+
+        assert excluded[0].last_recorded == "2026-06-30T12:00:00Z"
 
     def test_distinct_spec_files_are_deduplicated_and_sorted(self) -> None:
         entries = [
@@ -1251,29 +1319,42 @@ class TestExcludedHistory:
         assert excluded[0].spec_files == ("a.md", "b.md")
 
     def test_no_journal_excludes_nothing(self) -> None:
-        assert _excluded_history(None, "writers-room", "spec.md") == ()
+        assert _excluded_history(None, "writers-room", "spec.md").is_empty
 
     def test_the_read_covers_the_whole_journal(self, tmp_path: Path) -> None:
         journal = _journal_with(tmp_path, [self._entry("writers-room", "spec.md")] * 2)
 
-        assert self._line(journal, "writers-room-slice1", "spec-slice-1.md") == (
+        assert self._lines(journal, "writers-room-slice1", "spec-slice-1.md") == (
             "Note: audits are matched by project name, and this report covers "
-            "'writers-room-slice1'. This journal holds 2 more spec audit(s) that "
-            "it does not count, under 'writers-room' (spec.md)."
+            "'writers-room-slice1'. This journal also records 2 spec audit(s) under "
+            "'writers-room' (spec.md, last 2026-08-20)."
         )
 
-    def test_a_journal_holding_only_this_project_excludes_nothing(
+    def test_a_journal_holding_only_this_project_names_no_other(
         self,
         tmp_path: Path,
     ) -> None:
         journal = _journal_with(tmp_path, [self._entry("writers-room")] * 3)
 
-        assert _excluded_history(journal, "writers-room", "spec.md") == ()
+        assert _excluded_history(journal, "writers-room", "spec.md").projects == ()
+
+    def test_this_projects_own_audits_are_counted_unwindowed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The count the accounting line rests on. Not windowed by
+        ``lookback_runs``, because a count of what the trend does not
+        cover that was itself windowed would omit history silently."""
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "2")
+        journal = _journal_with(tmp_path, [self._entry("writers-room")] * 6)
+
+        assert _excluded_history(journal, "writers-room", "spec.md").own_recorded == 6
 
     def test_a_missing_journal_file_excludes_nothing(self, tmp_path: Path) -> None:
         journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
 
-        assert _excluded_history(journal, "writers-room", "spec.md") == ()
+        assert _excluded_history(journal, "writers-room", "spec.md").is_empty
 
     def test_a_torn_line_does_not_cost_the_note(self, tmp_path: Path) -> None:
         """The journal is append-only and a crash mid-write leaves a
@@ -1282,20 +1363,46 @@ class TestExcludedHistory:
         with open(journal.config.journal_path, "a", encoding="utf-8") as handle:
             handle.write('{"event_type": "spec_iss')
 
-        assert "1 more spec audit(s)" in self._line(journal, "writers-room-slice1")
+        assert "records 1 spec audit(s)" in self._lines(journal, "writers-room-slice1")
 
     def test_many_projects_are_summarised_rather_than_all_named(
         self,
         tmp_path: Path,
     ) -> None:
         """A display cap on the names, never on the count: the total
-        still covers every audit the trend leaves out."""
+        still covers every audit the report leaves out."""
         journal = _journal_with(tmp_path, [self._entry(f"p{n}", f"s{n}.md") for n in range(6)])
 
-        line = self._line(journal, "mine")
+        line = self._lines(journal, "mine")
 
-        assert "6 more spec audit(s)" in line
-        assert "'p0' (s0.md), 'p1' (s1.md), 'p2' (s2.md) and 3 more project(s)" in line
+        assert "records 6 spec audit(s)" in line
+        assert (
+            "'p0' (s0.md, last 2026-08-20), 'p1' (s1.md, last 2026-08-20), "
+            "'p2' (s2.md, last 2026-08-20) and 3 more project(s)" in line
+        )
+
+    def test_every_project_that_read_this_spec_file_survives_the_cap(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Round 1 of review: the sort put spec-file matches first but
+        the cap then truncated them, so four projects that had all read
+        the current spec file - a repo that split one spec across
+        several names, which is #280's own shape - printed three and
+        "and 1 more project(s)". The cap now applies only to projects
+        that did NOT read it."""
+        journal = _journal_with(
+            tmp_path,
+            [self._entry(f"p{n}", "mine.md") for n in range(4)]
+            + [self._entry(f"q{n}", "other.md") for n in range(4)],
+        )
+
+        line = self._lines(journal, "mine")
+
+        for name in ("p0", "p1", "p2", "p3"):
+            assert f"'{name}' (mine.md" in line
+        assert "and 1 more project(s)" in line
+        assert "'q3'" not in line
 
     def test_many_spec_files_under_one_project_are_summarised_too(
         self,
@@ -1303,7 +1410,49 @@ class TestExcludedHistory:
     ) -> None:
         journal = _journal_with(tmp_path, [self._entry("other", f"s{n}.md") for n in range(5)])
 
-        assert "'other' (s0.md, s1.md, s2.md and 2 more file(s))" in self._line(journal, "mine")
+        assert "'other' (s0.md, s1.md, s2.md and 2 more file(s)" in self._lines(journal, "mine")
+
+    def test_an_entry_with_no_timestamp_names_the_project_without_a_date(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        journal = _journal_with(tmp_path, [self._entry("other", "o.md", timestamp="")])
+
+        assert "'other' (o.md)." in self._lines(journal, "mine")
+
+
+class TestExcludedAccountingLine:
+    """#280 round 1, finding 2: the same-project half of the accounting."""
+
+    def _history(self, own: int) -> ExcludedHistory:
+        return ExcludedHistory(own_recorded=own, projects=())
+
+    def test_nothing_is_said_when_the_trend_counted_everything(self) -> None:
+        assert _excluded_lines(self._history(3), "mine", 3) == []
+
+    def test_the_gap_between_recorded_and_counted_is_named(self) -> None:
+        lines = _excluded_lines(self._history(6), "mine", 2)
+
+        assert lines == [
+            "Note: this journal records 6 earlier audit(s) of 'mine' and this report "
+            "counts 2. The rest fall outside the lookback window, or carry no issue "
+            "list to compare."
+        ]
+
+    def test_counted_audits_is_read_off_the_rendered_trend(self) -> None:
+        """So the accounting line can never disagree with the trend
+        printed directly above it."""
+        report = SpecConvergence(
+            current_counts={"blocker": 0, "major": 0, "minor": 0},
+            previous_counts={"blocker": 0, "major": 0, "minor": 0},
+            current_spec_file="spec.md",
+            previous_spec_file="spec.md",
+            repeated=0,
+            blocker_trend=(1, 1, 0),
+        )
+
+        assert _counted_audits(report) == 2
+        assert _counted_audits(None) == 0
 
 
 class TestSpecConvergenceThroughDecompose:
@@ -1397,8 +1546,8 @@ class TestSpecConvergenceThroughDecompose:
 
         assert "Trend:" not in output
         assert "No earlier audit of this project is recorded." in output
-        assert "1 more spec audit(s)" in output
-        assert "'writers-room' (spec.md)" in output
+        assert "also records 1 spec audit(s)" in output
+        assert "'writers-room' (spec.md, last " in output
 
     def test_the_rename_that_lost_two_runs_now_says_so(self, tmp_path: Path) -> None:
         """#280's own shape, end to end: five audits, a project AND
@@ -1422,9 +1571,12 @@ class TestSpecConvergenceThroughDecompose:
         assert "1, 1, 1 (blockers, oldest run first)" in output
         assert (
             "Note: audits are matched by project name, and this report covers "
-            "'writers-room-slice1'. This journal holds 2 more spec audit(s) that "
-            "it does not count, under 'writers-room' (spec.md)." in output
+            "'writers-room-slice1'. This journal also records 2 spec audit(s) under "
+            "'writers-room' (spec.md, last " in output
         )
+        # The trend counted every audit of this project, so the
+        # same-project accounting line has nothing to say.
+        assert "earlier audit(s) of 'writers-room-slice1'" not in output
 
     def test_an_ordinary_single_project_history_prints_no_note(
         self,
@@ -1437,7 +1589,7 @@ class TestSpecConvergenceThroughDecompose:
         output = self._run(tmp_path, [BLOCKER_ISSUE])
 
         assert "1, 1, 1, 1, 1 (blockers, oldest run first)" in output
-        assert "more spec audit(s)" not in output
+        assert "Note:" not in output
 
     def test_a_genuine_two_project_repo_is_told_the_truth(self, tmp_path: Path) -> None:
         """The measured cost of keying the note on "any other project"
@@ -1462,7 +1614,7 @@ class TestSpecConvergenceThroughDecompose:
 
         assert "1, 1 (blockers, oldest run first)" in output
         assert "this report covers 'billing'" in output
-        assert "1 more spec audit(s) that it does not count, under 'auth' (auth.md)" in output
+        assert "also records 1 spec audit(s) under 'auth' (auth.md, last " in output
 
     def test_a_rename_within_one_project_prints_no_note(self, tmp_path: Path) -> None:
         """The spec file moving is already reported by the rename line;
@@ -1472,7 +1624,7 @@ class TestSpecConvergenceThroughDecompose:
         output = self._run(tmp_path, [BLOCKER_ISSUE], spec_name="spec-slice-1.md")
 
         assert "the previous audit read spec.md" in output
-        assert "more spec audit(s)" not in output
+        assert "Note:" not in output
 
     def test_no_note_when_the_journal_is_off(
         self,
@@ -1499,7 +1651,98 @@ class TestSpecConvergenceThroughDecompose:
             self._run(tmp_path, [BLOCKER_ISSUE], project_name="writers-room")
         output = self._run(tmp_path, [BLOCKER_ISSUE], project_name="deckgen")
 
-        assert "4 more spec audit(s)" in output
+        assert "also records 4 spec audit(s)" in output
+
+    def test_a_windowed_out_run_is_counted_not_swallowed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Round 1 of review, finding 2: the note counted only
+        cross-project audits while its wording claimed everything the
+        journal holds, so same-project audits dropped by
+        ``lookback_runs`` went silently missing. That is #280's own
+        defect on the other axis. Reachable on the DEFAULT lookback of
+        10 after 11 audits, so not an exotic config.
+        """
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "2")
+        for _ in range(6):
+            self._run(tmp_path, [BLOCKER_ISSUE], project_name="mine")
+        output = self._run(tmp_path, [BLOCKER_ISSUE], project_name="mine")
+
+        assert "1, 1, 1 (blockers, oldest run first)" in output
+        assert (
+            "Note: this journal records 6 earlier audit(s) of 'mine' and this "
+            "report counts 2. The rest fall outside the lookback window, or carry "
+            "no issue list to compare." in output
+        )
+
+    def test_no_earlier_audit_is_claimed_only_when_none_is_recorded(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Round 1 of review, finding 1: with ``lookback_runs=0`` the
+        trend reads nothing, and the report announced that no earlier
+        audit of this project was recorded while three of them sat on
+        disk. A confident statement over less data than the journal
+        holds is the defect #280 is about.
+        """
+        for _ in range(3):
+            self._run(tmp_path, [BLOCKER_ISSUE], project_name="mine")
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "0")
+        output = self._run(tmp_path, [BLOCKER_ISSUE], project_name="mine")
+
+        assert "No earlier audit of this project is recorded." not in output
+        assert "records 3 earlier audit(s) of 'mine' and this report counts 0" in output
+
+    def test_a_legacy_entry_with_no_issue_list_is_counted_not_denied(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The second route to the same false line: entries the trend
+        cannot compare because they carry no issue list, which is the
+        legacy journal shape ``_stored_issues`` exists to tolerate."""
+        journal = tmp_path / ".kstrl" / "evolution.jsonl"
+        journal.parent.mkdir(parents=True)
+        journal.write_text(
+            "".join(
+                json.dumps(
+                    {
+                        "event_type": SPEC_ISSUES_EVENT,
+                        "project": "mine",
+                        "spec_file": "spec.md",
+                        "timestamp": "2026-08-20T00:00:00Z",
+                        "counts": {"blocker": 1, "major": 0, "minor": 0},
+                    }
+                )
+                + "\n"
+                for _ in range(3)
+            ),
+            encoding="utf-8",
+        )
+
+        output = self._run(tmp_path, [BLOCKER_ISSUE], project_name="mine")
+
+        assert "No earlier audit of this project is recorded." not in output
+        assert "records 3 earlier audit(s) of 'mine' and this report counts 0" in output
+
+    def test_the_journal_reader_agrees_with_the_event_name_written(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Round 1 of review, finding 5. ``SPEC_ISSUES_EVENT`` names the
+        discriminator this module writes and reads, but
+        ``EvolutionJournal.get_spec_issue_runs`` hardcodes the same
+        literal independently and that file is under concurrent edit on
+        another branch. This is the mechanism that makes the two
+        diverging impossible to ship quietly: change the constant alone
+        and the trend the journal reader feeds goes empty here.
+        """
+        self._run(tmp_path, [BLOCKER_ISSUE], project_name="writers-room")
+        runs = EvolutionJournal(EvolutionConfig.load(tmp_path)).get_spec_issue_runs("writers-room")
+
+        assert [r["event_type"] for r in runs] == [SPEC_ISSUES_EVENT]
 
     def test_a_clean_audit_still_reports_the_drop(self, tmp_path: Path) -> None:
         self._run(tmp_path, [BLOCKER_ISSUE])

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -22,8 +22,12 @@ from kstrl.decompose import (
     _excluded_projects,
     _extract_json,
     _issue_dicts,
+    _journal_snapshot,
     _parse_spec_issues,
+    _spec_audits,
+    _stored_issues,
     _validate_decompose_output,
+    _windowed_audits,
     decompose_spec,
 )
 from kstrl.evolution import EvolutionConfig, EvolutionJournal
@@ -1179,6 +1183,15 @@ class TestExcludedHistory:
             "timestamp": timestamp,
         }
 
+    def _history(
+        self,
+        journal: EvolutionJournal,
+        project: str,
+        spec_file: str = "mine.md",
+        lookback: int = 10,
+    ) -> ExcludedHistory:
+        return _excluded_history(_journal_snapshot(journal)[0], project, spec_file, lookback)
+
     def _lines(
         self,
         journal: EvolutionJournal,
@@ -1187,8 +1200,9 @@ class TestExcludedHistory:
         counted: int = 0,
     ) -> str:
         """The rendered note lines for ``project``, joined."""
-        excluded = _excluded_history(journal, project, spec_file)
-        return "\n".join(_excluded_lines(excluded, project, counted))
+        return "\n".join(
+            _excluded_lines(self._history(journal, project, spec_file), project, counted)
+        )
 
     def test_a_journal_of_one_project_excludes_no_other_project(self) -> None:
         entries = [self._entry("writers-room"), self._entry("writers-room")]
@@ -1319,7 +1333,7 @@ class TestExcludedHistory:
         assert excluded[0].spec_files == ("a.md", "b.md")
 
     def test_no_journal_excludes_nothing(self) -> None:
-        assert _excluded_history(None, "writers-room", "spec.md").is_empty
+        assert _excluded_history([], "writers-room", "spec.md", 10).is_empty
 
     def test_the_read_covers_the_whole_journal(self, tmp_path: Path) -> None:
         journal = _journal_with(tmp_path, [self._entry("writers-room", "spec.md")] * 2)
@@ -1327,7 +1341,7 @@ class TestExcludedHistory:
         assert self._lines(journal, "writers-room-slice1", "spec-slice-1.md") == (
             "Note: audits are matched by project name, and this report covers "
             "'writers-room-slice1'. This journal also records 2 spec audit(s) under "
-            "'writers-room' (spec.md, last 2026-08-20)."
+            "'writers-room' (2 audit(s), spec.md, last 2026-08-20)."
         )
 
     def test_a_journal_holding_only_this_project_names_no_other(
@@ -1336,7 +1350,7 @@ class TestExcludedHistory:
     ) -> None:
         journal = _journal_with(tmp_path, [self._entry("writers-room")] * 3)
 
-        assert _excluded_history(journal, "writers-room", "spec.md").projects == ()
+        assert self._history(journal, "writers-room", "spec.md").projects == ()
 
     def test_this_projects_own_audits_are_counted_unwindowed(
         self,
@@ -1349,12 +1363,12 @@ class TestExcludedHistory:
         monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "2")
         journal = _journal_with(tmp_path, [self._entry("writers-room")] * 6)
 
-        assert _excluded_history(journal, "writers-room", "spec.md").own_recorded == 6
+        assert self._history(journal, "writers-room", "spec.md", lookback=2).own_recorded == 6
 
     def test_a_missing_journal_file_excludes_nothing(self, tmp_path: Path) -> None:
         journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
 
-        assert _excluded_history(journal, "writers-room", "spec.md").is_empty
+        assert self._history(journal, "writers-room", "spec.md").is_empty
 
     def test_a_torn_line_does_not_cost_the_note(self, tmp_path: Path) -> None:
         """The journal is append-only and a crash mid-write leaves a
@@ -1377,8 +1391,9 @@ class TestExcludedHistory:
 
         assert "records 6 spec audit(s)" in line
         assert (
-            "'p0' (s0.md, last 2026-08-20), 'p1' (s1.md, last 2026-08-20), "
-            "'p2' (s2.md, last 2026-08-20) and 3 more project(s)" in line
+            "'p0' (1 audit(s), s0.md, last 2026-08-20), "
+            "'p1' (1 audit(s), s1.md, last 2026-08-20), "
+            "'p2' (1 audit(s), s2.md, last 2026-08-20) and 3 more project(s)" in line
         )
 
     def test_every_project_that_read_this_spec_file_survives_the_cap(
@@ -1399,9 +1414,10 @@ class TestExcludedHistory:
 
         line = self._lines(journal, "mine")
 
-        for name in ("p0", "p1", "p2", "p3"):
-            assert f"'{name}' (mine.md" in line
-        assert "and 1 more project(s)" in line
+        for name in ("p0", "p1", "p2"):
+            assert f"'{name}' (1 audit(s), mine.md" in line
+        assert "and 1 more project(s) that read this spec file" in line
+        assert "and 1 more project(s)." in line
         assert "'q3'" not in line
 
     def test_many_spec_files_under_one_project_are_summarised_too(
@@ -1410,7 +1426,9 @@ class TestExcludedHistory:
     ) -> None:
         journal = _journal_with(tmp_path, [self._entry("other", f"s{n}.md") for n in range(5)])
 
-        assert "'other' (s0.md, s1.md, s2.md and 2 more file(s)" in self._lines(journal, "mine")
+        assert "'other' (5 audit(s), s0.md, s1.md, s2.md and 2 more file(s), last " in (
+            self._lines(journal, "mine")
+        )
 
     def test_an_entry_with_no_timestamp_names_the_project_without_a_date(
         self,
@@ -1418,26 +1436,233 @@ class TestExcludedHistory:
     ) -> None:
         journal = _journal_with(tmp_path, [self._entry("other", "o.md", timestamp="")])
 
-        assert "'other' (o.md)." in self._lines(journal, "mine")
+        assert "'other' (1 audit(s), o.md)." in self._lines(journal, "mine")
+
+
+class TestJournalFieldsAreReadNotStringified:
+    """#280 round 2, finding 1: a null field is an absent field, on
+    every site that reads one, not just the site that was patched."""
+
+    def _run_with_history(self, tmp_path: Path, entry: dict[str, object]) -> str:
+        journal = tmp_path / ".kstrl" / "evolution.jsonl"
+        journal.parent.mkdir(parents=True)
+        journal.write_text(json.dumps(entry) + "\n", encoding="utf-8")
+        return _run_decompose(
+            tmp_path,
+            _single_component_output([_story()], spec_issues=[BLOCKER_ISSUE]),
+            spec_name="spec.md",
+            project_name="mine",
+        )
+
+    def test_a_null_spec_file_is_not_a_phantom_rename(self, tmp_path: Path) -> None:
+        """``str(entry.get("spec_file", ""))`` yields 'None' when the
+        key is PRESENT and null, so the rename line fired comparing
+        'None' with the real file: "the previous audit read None"."""
+        output = self._run_with_history(
+            tmp_path,
+            {
+                "event_type": SPEC_ISSUES_EVENT,
+                "project": "mine",
+                "spec_file": None,
+                "timestamp": "2026-08-20T00:00:00Z",
+                "issues": [{"severity": "blocker", "kind": "ambiguity", "summary": "old"}],
+            },
+        )
+
+        assert "previous audit read None" not in output
+        assert "Runs are matched by project name" not in output
+
+    def test_an_unscoreable_severity_does_not_put_a_false_zero_in_the_trend(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The worse half of the same class. ``_issue_counts`` buckets
+        by severity, so seven issues stored with a null severity were
+        counted as nothing: "Previous run raised 0 issue(s)" and a 0 in
+        the blocker trend for a run that raised seven. The audit is now
+        refused and reported instead of part-scored."""
+        output = self._run_with_history(
+            tmp_path,
+            {
+                "event_type": SPEC_ISSUES_EVENT,
+                "project": "mine",
+                "spec_file": "spec.md",
+                "timestamp": "2026-08-20T00:00:00Z",
+                "issues": [
+                    {"severity": None, "kind": "ambiguity", "summary": f"old-{n}"} for n in range(7)
+                ],
+            },
+        )
+
+        assert "Previous run raised 0 issue(s)" not in output
+        assert "0, 1 (blockers" not in output
+        assert "could not be scored" in output
+
+    def test_a_severity_outside_the_three_is_refused_by_the_rehydrator(self) -> None:
+        entry: dict[str, object] = {
+            "issues": [{"severity": "critical", "kind": "ambiguity", "summary": "x"}]
+        }
+
+        assert _stored_issues(entry) is None
+
+    def test_a_well_formed_issue_list_still_rehydrates(self) -> None:
+        entry: dict[str, object] = {
+            "issues": [{"severity": "minor", "kind": "ambiguity", "summary": "x"}]
+        }
+        stored = _stored_issues(entry)
+
+        assert stored is not None
+        assert [i.severity for i in stored] == ["minor"]
+
+
+class TestUnattributedAudits:
+    """#280 round 2, finding 2: audits belonging to no project name."""
+
+    def test_they_are_counted_by_a_third_bucket(self) -> None:
+        """They satisfy neither ``own_recorded`` nor ``_excluded_projects``,
+        so three audits on disk were reported as one."""
+        entries: list[dict[str, object]] = [
+            {"event_type": SPEC_ISSUES_EVENT, "project": None, "spec_file": "a.md"},
+            {"event_type": SPEC_ISSUES_EVENT, "spec_file": "b.md"},
+            {"event_type": SPEC_ISSUES_EVENT, "project": "other", "spec_file": "c.md"},
+        ]
+
+        history = _excluded_history(entries, "mine", "mine.md", 10)
+
+        assert history.own_recorded == 0
+        assert history.other_audits == 1
+        assert history.unattributed == 2
+
+    def test_every_spec_audit_lands_in_exactly_one_bucket(self) -> None:
+        """The property the accounting docstring claims, checked rather
+        than asserted in prose."""
+        entries: list[dict[str, object]] = [
+            {"event_type": SPEC_ISSUES_EVENT, "project": "mine"},
+            {"event_type": SPEC_ISSUES_EVENT, "project": "mine"},
+            {"event_type": SPEC_ISSUES_EVENT, "project": "other"},
+            {"event_type": SPEC_ISSUES_EVENT, "project": None},
+            {"event_type": "component_result", "project": "mine"},
+        ]
+
+        history = _excluded_history(entries, "mine", "mine.md", 10)
+        audits = sum(1 for e in entries if e.get("event_type") == SPEC_ISSUES_EVENT)
+
+        assert history.own_recorded + history.other_audits + history.unattributed == audits
+
+
+class TestOneJournalRead:
+    """#280 round 2, findings 6 and 7: one read, and a pin on the
+    layering shortcut that read takes."""
+
+    def _journal(self, tmp_path: Path, entries: list[dict[str, object]]) -> EvolutionJournal:
+        journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
+        journal.append_entries(entries)
+        return journal
+
+    def test_the_journal_is_parsed_once_per_report(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The trend and the accounting used to read the same file
+        twice. The call site has both in scope, so one read feeds both
+        and they cannot disagree because the file moved between them."""
+        import kstrl.decompose
+
+        reads: list[Path] = []
+        real = kstrl.decompose.read_progress_events
+
+        def counting(path: Path) -> list[dict[str, object]]:
+            reads.append(path)
+            return real(path)
+
+        monkeypatch.setattr(kstrl.decompose, "read_progress_events", counting)
+        _run_decompose(
+            tmp_path,
+            _single_component_output([_story()], spec_issues=[BLOCKER_ISSUE]),
+            project_name="mine",
+        )
+
+        assert len(reads) == 1
+
+    def test_the_windowing_rule_matches_the_journals_own(self, tmp_path: Path) -> None:
+        """``_journal_snapshot`` reaches past ``EvolutionJournal`` to its
+        storage path and ``_windowed_audits`` restates the window rule
+        that ``get_spec_issue_runs`` owns. Both are deferrals to
+        #314, and a deferral needs a mechanism: if the journal ever
+        compacts, rotates or gains a second segment, or if the window
+        rule changes, the two stop agreeing and this fails. Silent loss
+        of the accounting is the defect #280 exists to fix.
+        """
+        entries: list[dict[str, object]] = [
+            {
+                "event_type": SPEC_ISSUES_EVENT,
+                "project": "mine" if n % 2 else "other",
+                "spec_file": "spec.md",
+                "timestamp": f"2026-08-{n + 1:02d}T00:00:00Z",
+            }
+            for n in range(9)
+        ]
+        journal = self._journal(tmp_path, entries)
+
+        for last_n in (0, 1, 3, 10):
+            assert _windowed_audits(
+                _spec_audits(_journal_snapshot(journal)[0]), "mine", last_n
+            ) == journal.get_spec_issue_runs("mine", last_n=last_n)
+
+    def test_no_journal_reads_nothing_and_windows_nothing(self) -> None:
+        assert _journal_snapshot(None) == ([], 0)
 
 
 class TestExcludedAccountingLine:
     """#280 round 1, finding 2: the same-project half of the accounting."""
 
-    def _history(self, own: int) -> ExcludedHistory:
-        return ExcludedHistory(own_recorded=own, projects=())
+    def _history(self, own: int, lookback: int = 10) -> ExcludedHistory:
+        return ExcludedHistory(own_recorded=own, projects=(), lookback=lookback)
 
     def test_nothing_is_said_when_the_trend_counted_everything(self) -> None:
         assert _excluded_lines(self._history(3), "mine", 3) == []
 
-    def test_the_gap_between_recorded_and_counted_is_named(self) -> None:
-        lines = _excluded_lines(self._history(6), "mine", 2)
+    def test_a_windowed_out_audit_is_a_trend_footnote_not_a_warning(self) -> None:
+        """Round 2 of review: once a project has more audits than
+        ``lookback_runs`` this holds on every run forever, so a Note
+        would be permanent noise. It is a footnote on the trend line
+        instead; see ``_surface_trend``."""
+        history = self._history(40, lookback=10)
 
-        assert lines == [
-            "Note: this journal records 6 earlier audit(s) of 'mine' and this report "
-            "counts 2. The rest fall outside the lookback window, or carry no issue "
-            "list to compare."
+        assert _excluded_lines(history, "mine", 10) == []
+        assert history.windowed_out(10) == 30
+        assert history.unreadable(10) == 0
+
+    def test_an_audit_the_window_offered_but_could_not_be_scored_is_named(self) -> None:
+        """The anomaly half of the same gap, which does deserve a line."""
+        history = self._history(3, lookback=10)
+
+        assert history.unreadable(0) == 3
+        assert _excluded_lines(history, "mine", 0) == [
+            "Note: 3 earlier audit(s) of 'mine' fall inside the lookback window but "
+            "could not be scored, so the trend does not count them. An audit is "
+            "skipped when it records no issue list, or an issue whose severity is "
+            "not blocker, major or minor."
         ]
+
+    def test_the_two_causes_are_separated_when_both_apply(self) -> None:
+        history = self._history(40, lookback=10)
+
+        assert history.unreadable(7) == 3
+        assert history.windowed_out(7) == 30
+
+    def test_audits_with_no_project_name_are_their_own_line(self) -> None:
+        """Round 2 of review: an entry whose ``project`` is null or
+        absent was counted by neither axis, so three audits on disk
+        were reported as one."""
+        history = ExcludedHistory(own_recorded=0, projects=(), unattributed=2, lookback=10)
+
+        assert _excluded_lines(history, "mine", 0) == [
+            "Note: 2 spec audit(s) in this journal record no project name, so neither "
+            "the trend nor the line above counts them."
+        ]
+        assert not history.is_empty
 
     def test_counted_audits_is_read_off_the_rendered_trend(self) -> None:
         """So the accounting line can never disagree with the trend
@@ -1547,7 +1772,7 @@ class TestSpecConvergenceThroughDecompose:
         assert "Trend:" not in output
         assert "No earlier audit of this project is recorded." in output
         assert "also records 1 spec audit(s)" in output
-        assert "'writers-room' (spec.md, last " in output
+        assert "'writers-room' (1 audit(s), spec.md, last " in output
 
     def test_the_rename_that_lost_two_runs_now_says_so(self, tmp_path: Path) -> None:
         """#280's own shape, end to end: five audits, a project AND
@@ -1572,11 +1797,12 @@ class TestSpecConvergenceThroughDecompose:
         assert (
             "Note: audits are matched by project name, and this report covers "
             "'writers-room-slice1'. This journal also records 2 spec audit(s) under "
-            "'writers-room' (spec.md, last " in output
+            "'writers-room' (2 audit(s), spec.md, last " in output
         )
-        # The trend counted every audit of this project, so the
-        # same-project accounting line has nothing to say.
+        # The trend counted every audit of this project, so neither the
+        # anomaly line nor the trend footnote has anything to say.
         assert "earlier audit(s) of 'writers-room-slice1'" not in output
+        assert "outside the lookback window" not in output
 
     def test_an_ordinary_single_project_history_prints_no_note(
         self,
@@ -1614,7 +1840,7 @@ class TestSpecConvergenceThroughDecompose:
 
         assert "1, 1 (blockers, oldest run first)" in output
         assert "this report covers 'billing'" in output
-        assert "also records 1 spec audit(s) under 'auth' (auth.md, last " in output
+        assert "also records 1 spec audit(s) under 'auth' (1 audit(s), auth.md, last " in output
 
     def test_a_rename_within_one_project_prints_no_note(self, tmp_path: Path) -> None:
         """The spec file moving is already reported by the rename line;
@@ -1670,12 +1896,14 @@ class TestSpecConvergenceThroughDecompose:
             self._run(tmp_path, [BLOCKER_ISSUE], project_name="mine")
         output = self._run(tmp_path, [BLOCKER_ISSUE], project_name="mine")
 
-        assert "1, 1, 1 (blockers, oldest run first)" in output
         assert (
-            "Note: this journal records 6 earlier audit(s) of 'mine' and this "
-            "report counts 2. The rest fall outside the lookback window, or carry "
-            "no issue list to compare." in output
+            "1, 1, 1 (blockers, oldest run first; 4 older audit(s) outside the "
+            "lookback window)" in output
         )
+        # Round 2 of review: this is the configured steady state, so it
+        # qualifies the trend in place rather than firing a warning that
+        # would print on every run forever.
+        assert "could not be scored" not in output
 
     def test_no_earlier_audit_is_claimed_only_when_none_is_recorded(
         self,
@@ -1694,7 +1922,9 @@ class TestSpecConvergenceThroughDecompose:
         output = self._run(tmp_path, [BLOCKER_ISSUE], project_name="mine")
 
         assert "No earlier audit of this project is recorded." not in output
-        assert "records 3 earlier audit(s) of 'mine' and this report counts 0" in output
+        assert (
+            "No earlier audit of 'mine' could be compared, though this journal records 3." in output
+        )
 
     def test_a_legacy_entry_with_no_issue_list_is_counted_not_denied(
         self,
@@ -1725,7 +1955,13 @@ class TestSpecConvergenceThroughDecompose:
         output = self._run(tmp_path, [BLOCKER_ISSUE], project_name="mine")
 
         assert "No earlier audit of this project is recorded." not in output
-        assert "records 3 earlier audit(s) of 'mine' and this report counts 0" in output
+        assert (
+            "No earlier audit of 'mine' could be compared, though this journal records 3." in output
+        )
+        assert (
+            "Note: 3 earlier audit(s) of 'mine' fall inside the lookback window but "
+            "could not be scored" in output
+        )
 
     def test_the_journal_reader_agrees_with_the_event_name_written(
         self,
@@ -1762,7 +1998,10 @@ class TestSpecConvergenceThroughDecompose:
             self._run(tmp_path, [BLOCKER_ISSUE])
         output = self._run(tmp_path, [BLOCKER_ISSUE])
 
-        assert "1, 1, 1 (blockers, oldest run first)" in output
+        assert (
+            "1, 1, 1 (blockers, oldest run first; 1 older audit(s) outside the "
+            "lookback window)" in output
+        )
 
     def test_no_report_when_the_journal_is_off(
         self,


### PR DESCRIPTION
Fixes #280.

The convergence report shipped in #270 keys "the same spec" on the project
name. #280 reports that one documented failure mode of that choice is the
shape of a real session, and that the loss is silent. Verified before
changing anything, then fixed with a note line rather than a new keying
scheme, exactly as the issue argues for.

## The issue, verified first

Reconstructed #280's five-row journal on disk and replayed it through the
real code path: `EvolutionConfig.load` -> `EvolutionJournal` ->
`_spec_convergence` -> `_surface_convergence`, with `PlainUI`. Not
`_build_convergence` in isolation, so the journal reader and its project
filter are in the loop too.

```
1 spec.md            writers-room         {'blocker': 7,  'major': 11, 'minor': 3}
2 spec.md            writers-room         {'blocker': 11, 'major': 14, 'minor': 7}
3 spec-slice-1.md    writers-room-slice1  {'blocker': 1,  'major': 10, 'minor': 9}
4 spec-slice-1.md    writers-room-slice1  {'blocker': 3,  'major': 10, 'minor': 8}
5 spec-slice-1.md    writers-room-slice1  {'blocker': 4,  'major': 11, 'minor': 8}
```

Run 5, on `origin/main`:

```
== Spec Convergence ==
  Blocker:      4 (previous run: 3, +1)
  Major:        11 (previous run: 10, +1)
  Minor:        8 (previous run: 8, no change)
  Trend:        1, 3, 4 (blockers, oldest run first)
Previous run raised 21 issue(s): 0 reappear verbatim, 21 do not.
Matched on issue text, so a reworded issue counts as new: a floor on what carried over, not a count of what the architect resolved.
```

`1, 3, 4`, not `7, 11, 1, 3, 4`. The issue's diagnosis is correct as
written, including the mechanism: `get_spec_issue_runs` filters on
`entry.get("project") == project` inside the reader, so the two earlier
rows are never seen by anything downstream.

## One thing the issue does not mention, and it is worse

Run 3 is the moment the history is lost, and on `origin/main` run 3 prints
**nothing at all**. `_build_convergence` returns `None` when there is no
prior audit for the project, and `_surface_convergence(None, ui)` returns
immediately. So at the exact audit where two runs of history dropped out
of view, the report is not merely shorter: it is absent, and reads as an
ordinary first run.

There was a test pinning that silence.
`test_a_different_project_has_its_own_history` asserted
`"Spec Convergence" not in output` after a project rename. That assertion
is the bug, written down. It is updated here.

## What ships

One line, and only when it has something to say. No change to how runs are
matched, no content hash, no path key: the issue is right that both are
worse, and the trend numbers are byte-for-byte what they were.

Run 5, after:

```
== Spec Convergence ==
  Blocker:      4 (previous run: 3, +1)
  Major:        11 (previous run: 10, +1)
  Minor:        8 (previous run: 8, no change)
  Trend:        1, 3, 4 (blockers, oldest run first)
Previous run raised 21 issue(s): 0 reappear verbatim, 21 do not.
Matched on issue text, so a reworded issue counts as new: a floor on what carried over, not a count of what the architect resolved.
Note: audits are matched by project name, and this report covers 'writers-room-slice1'. This journal also records 2 spec audit(s) under 'writers-room' (spec.md, last 2026-08-22).
```

Run 3, the rename moment, after:

```
== Spec Convergence ==
No earlier audit of this project is recorded.
Note: audits are matched by project name, and this report covers 'writers-room-slice1'. This journal also records 2 spec audit(s) under 'writers-room' (spec.md, last 2026-08-22).
```

## Which arm, and why

#280 offers two. I shipped the second, with the first folded into its
wording rather than added as a separate line.

**Arm 1** (same `spec_file`, different project) does not fire on the
motivating case at all, because the spec file was renamed in the same
moment. Replayed: it covers the project-renamed-alone case and misses
#280's own. Shipping only arm 1 would close the issue without covering the
session that opened it.

**Arm 2** (the journal holds audits for other projects) fires on both. Its
cost is that it also fires in a repo that genuinely holds two projects.
That is a real cost and it is measured below, not waved away: the note
names the other project and the spec files it read, so a `billing` operator
seeing `'auth' (auth.md)` dismisses it at a glance rather than
investigating. It states a true fact about the journal and claims nothing
about whether the work is related, which is what the issue asked for.

Arm 1's information survives inside arm 2's line in two ways. The spec
files are named, so when they match the file this run audited, the operator
is looking straight at a project rename. And a project that audited this
run's spec file sorts first, so it is the one name the display cap can
never drop, however many projects the journal holds. That is arm 1's whole
signal as a guarantee, delivered without a second line or a second rule.
`test_a_project_that_read_this_spec_file_sorts_first` pins it.

## Replay of every shape, real output

All six from one script against the real code path. B is the
false-positive check.

| | shape | note fires |
|---|---|---|
| A | #280's own: project and spec both renamed | yes |
| B | ordinary single-project history, five runs | **no** |
| C | project renamed, spec file kept | yes |
| D | the rename moment itself (run 3) | yes |
| E | first audit ever, empty journal | **no** (nothing prints at all) |
| F | a genuine two-project repo | yes, and truthfully |

```
----- B. control: ordinary single-project history, no rename -----

== Spec Convergence ==
  Blocker:      4 (previous run: 3, +1)
  Major:        11 (previous run: 10, +1)
  Minor:        8 (previous run: 8, no change)
  Trend:        7, 11, 1, 3, 4 (blockers, oldest run first)
Previous run raised 21 issue(s): 0 reappear verbatim, 21 do not.
Matched on issue text, so a reworded issue counts as new: a floor on what carried over, not a count of what the architect resolved.

----- E. very first audit in a fresh repo -----

----- F. a genuine two-project repo (the note is a true statement, not an alarm) -----

== Spec Convergence ==
  Blocker:      1 (previous run: 3, -2)
  Major:        1 (previous run: 2, -1)
  Minor:        1 (previous run: 1, no change)
  Trend:        3, 1 (blockers, oldest run first)
Previous run raised 6 issue(s): 0 reappear verbatim, 6 do not.
Matched on issue text, so a reworded issue counts as new: a floor on what carried over, not a count of what the architect resolved.
Note: audits are matched by project name, and this report covers 'billing'. This journal also records 2 spec audit(s) under 'auth' (auth.md, last 2026-08-23).
```

B and E are the two that matter: a warning that always fires is noise, and
noise is how a report stops being read. Two tests pin them,
`test_an_ordinary_single_project_history_prints_no_note` and
`test_a_rename_within_one_project_prints_no_note`. F is pinned too, by
`test_a_genuine_two_project_repo_is_told_the_truth`, so the cost of arm 2
is recorded rather than discovered later.

It also fires on this repository's own `.kstrl/evolution.jsonl`, 18 lines,
which is the only real journal to hand:

```
Note: audits are matched by project name, and this report covers 'writers-room-slice1'. This journal holds 4 more spec audit(s) that it does not count, under 'slugify' (spec-slugify-run1.md, spec-slugify-run2.md).
```

## Two design points worth stating

**The note is not windowed by `lookback_runs`.** That knob bounds how far
back the trend reaches. A note about history the trend excludes that was
itself windowed would omit history silently, which is the bug it exists to
fix. `test_the_note_is_not_windowed_by_the_lookback` pins it: with the
lookback at 2 and four earlier audits, the note still says 4.

**The section header now prints when there is no trend.** #270 decided a
first run prints nothing, and that is still true when the journal has
nothing to say. What changed is that a first run whose journal holds other
projects' audits now prints the header, one line saying no earlier audit of
this project is recorded, and the note. The absence of a trend was the
information being lost; leaving the operator to infer it from silence is
what #280 is about.

## Cost of the extra read

The note needs entries `get_spec_issue_runs` filters out by design, so it
is a second read of the journal. Measured on this machine, not estimated,
`_excluded_history` end to end:

| journal | median | max |
|---|---|---|
| this repo's real journal, 18 lines, 35.0 KB | 0.098 ms | - |
| 5 audits, 19.5 KB | 0.056 ms | 0.096 ms |
| 50 audits, 196 KB | 0.432 ms | 0.501 ms |
| 500 audits, 2.0 MB | 4.374 ms | 6.128 ms |
| 5000 audits, 19.8 MB | 53.261 ms | 56.627 ms |

Once per `ks decompose`, next to an architect call #260 measured at 119 to
210 seconds.

## Testing

20 new tests, and one existing test corrected.

`TestExcludedHistory` (14) covers the pure grouping and the rendered line:
a single-project journal excludes nothing, another project is counted with
the files it read, only `spec_issues` entries count (the journal also
carries component results), an entry with no project name is not evidence,
projects order by how much history they hold, a project that read this
run's spec file sorts ahead of one holding nine times the history, spec
files dedupe and sort, no journal excludes nothing, a missing journal file
excludes nothing, a torn tail line does not cost the note, and both display
caps summarise rather than drop from the count.

`TestSpecConvergenceThroughDecompose` gains six running the real
`decompose_spec`: #280's five-run shape end to end, the single-project
false-positive check, the genuine two-project repo, the
rename-within-one-project false-positive check, the journal-disabled case,
and the lookback-independence check.
`test_a_different_project_has_its_own_history` is the corrected one.

Local gate:

- `uv run pytest tests/ -q`: 4202 passed, 28 skipped
- `uv run mypy kstrl/ --strict`: clean, 123 source files
- `uv run ruff check kstrl/ tests/`: clean
- coverage: 89.54% total against the 79.91% ratchet; `kstrl/decompose.py`
  91.95%, up from #270's 90.29%

No `*_PROMPT` constant is touched, so no version bump, snapshot or
calibration run is implicated.

## One thing deliberately not fixed

`kstrl/evolution.py` is being edited concurrently, so this change stays out
of it. The consequence is visible in the diff: `_excluded_history` composes
two public APIs, `EvolutionConfig.journal_path` and
`observability.read_progress_events`, rather than calling an
`EvolutionJournal` method, because there is no public reader for "every
spec audit in this journal" and `get_spec_issue_runs` filters to one
project inside the reader. Three of the four `/simplify` reviewers found
this independently and all three named the same right answer: a sibling of
`get_spec_issue_runs` on `EvolutionJournal`, which would also collapse the
two reads into one. It is a follow-up, not a blocker, and the reason is
written into `_excluded_history`'s docstring rather than left for the next
reader to rediscover.

## /simplify

Four reviewers, one per angle, run against the diff and the surrounding
`Convergence report (#260)` section. Findings verbatim below, each with
applied or declined and the reason. 13 applied, 9 declined.

### Reuse

> **1. `kstrl/decompose.py:1120` - re-implements `EvolutionJournal._read_all_entries()`. REQUIRES evolution.py.**
> `read_progress_events(journal.config.journal_path)` is byte-for-byte what `EvolutionJournal._read_all_entries()` already does (`kstrl/evolution.py:1302-1314`, same tolerant-read policy, same delegation). Cost: `decompose.py:1120` becomes the only site in `kstrl/` outside `evolution.py` that reaches into `config.journal_path` to *read* the journal (grep confirms: every other consumer goes through a journal method), and it adds a new module-level `from kstrl.observability import read_progress_events` at `decompose.py:52` for a dependency `evolution.py` deliberately keeps function-local. Call a public entry reader on `EvolutionJournal` instead (promote `_read_all_entries`, or add `get_spec_issue_runs`'s complement).

**Declined (deferred).** Correct, and the fix lives in `kstrl/evolution.py`,
which is under concurrent edit and out of bounds for this branch. Recorded
in `_excluded_history`'s docstring and in the section above.

> **2. `kstrl/decompose.py:1079` - duplicates `get_spec_issue_runs`' entry filter. REQUIRES evolution.py for the clean fix.**
> `entry.get("event_type") != "spec_issues"` plus the `project` / `spec_file` field reads re-state the schema knowledge that lives in `evolution.py:1277`. The `"spec_issues"` literal is now in three places (`decompose.py:890` writer, `decompose.py:1079` reader, `evolution.py:1277` reader). Minimum non-evolution fix: hoist one module constant in `decompose.py` and use it at both 890 and 1079.

**Applied**, in its minimum form. `SPEC_ISSUES_EVENT` is now a module
constant next to `SPEC_ISSUES_REL_PATH`, used by the writer and the reader.
The `evolution.py` copy stays until that file is free.

> **3. `kstrl/decompose.py:1563-1570` - the journal file is read and JSON-parsed twice per `ks decompose`.**
> `_spec_convergence` -> `get_spec_issue_runs` -> `_read_all_entries` -> `read_progress_events`, then `_excluded_note` -> `read_progress_events` on the same path. `_build_convergence` already takes a plain `history: list[dict]`, so one `entries` list could feed both. Cost: 2x full-file read + parse of an append-only journal that grows unboundedly. Cleanest form needs a public read (finding 1), hence REQUIRES evolution.py.

**Declined (deferred).** Same blocker as 1. Measured at 0.098 ms on the real
journal against a 119 to 210 s architect call, so the cost is real but not
worth a worse layering to avoid.

> **4. `kstrl/decompose.py:1058` - `_capped` is the fifth copy of "show first N, then say N more".**
> Existing inline siblings: `kstrl/verify.py:1094-1097`, `kstrl/factory.py:2244-2246`, `kstrl/parsers.py:117-119`, `kstrl/policy.py:483-485` - four different phrasings of the same three lines. There is no shared helper to call today, so this is not "call X instead"; the finding is that a fifth implementation was added private to `decompose.py`. If it is worth extracting, the home is a shared module (`kstrl/output.py`), not `decompose`.

**Declined.** The reviewer says there is nothing to call today, and the four
existing copies differ in cap and phrasing. Creating `kstrl/output.py` and
migrating five call sites is a separate change that would put four
unrelated files in a #280 diff.

> **5. `kstrl/decompose.py:1058` - `items: list[str]` forces a copy at the call site.**
> `decompose.py:1128` writes `_capped(list(e.spec_files), "file(s)")` purely to satisfy the annotation, converting a tuple that is already a sequence. `Sequence[str]` is the established convention here (`kstrl/policy.py:300`, `kstrl/review.py:828`, `kstrl/events.py:288`). Drops the `list(...)` wrapper.

**Applied.** `_join_capped(items: Sequence[str], ...)`, `list(...)` gone.

> **6. `tests/test_decompose.py:1163` - second `_entry` helper in the same file.**
> `TestSpecConvergenceReport._entry` (`tests/test_decompose.py:1006`) already builds "one prior journal entry, in the shape decompose writes". The new one builds the same `spec_issues` dict with a different parameter set (`project` / `event_type` vs `issues`), so neither is a superset and a reader has to track which class they are in. One module-level `_spec_entry(*, project=..., spec_file=..., event_type="spec_issues", issues=None)` serves both.

**Declined.** The merged helper takes four optional kwargs and every call
site passes a different subset, which is a worse read than two named
helpers. Merging also rewrites nine #270 tests that this change has no
other reason to touch.

> **7. `tests/test_decompose.py:1258` - redundant local import.**
> `from kstrl.evolution import EvolutionConfig, EvolutionJournal` inside `test_a_missing_journal_file_yields_no_note`, while this same diff added that exact import at module top (`tests/test_decompose.py:24`). Delete the local one.

**Applied.** Deleted.

> **8. `tests/test_decompose.py:779` - `_journal_with` duplicates `tests/test_evolution.py:1034`.**
> `TestSpecIssueRuns._journal` builds the same thing (a journal on disk holding given spec-audit entries), and `TestSpecIssueRuns._spec_entry` (`tests/test_evolution.py:1039`) overlaps finding 6's helper. Different serialisation route (`append_entries` vs `write_text`), same purpose. `tests/helpers/` has no journal helper today, so nothing to call yet; flagging because this is now the third journal-builder and `tests/helpers/` is where the codebase puts exactly this (see `procs.py`, `fake_run.py`).

**Declined.** Real, but the fix is a new `tests/helpers/` module plus edits
to `tests/test_evolution.py`, which another agent's branch also touches.
Worth doing when the journal-reader follow-up lands and both files are
being opened anyway.

> **9. `tests/test_decompose.py:1257` and `:1264` - re-test `read_progress_events`' contract through a fourth surface.**
> Missing file and torn tail are already asserted at `tests/test_observability.py:69` / `:120` (the owner) and again at `tests/test_evolution.py:1081` / `:1096` (the journal wrapper). These two add a third and fourth assertion of the same tolerant-read policy. Low cost individually; worth dropping if you want the new class tight.

**Declined.** These assert what `_excluded_history` does with a torn or
missing journal, which is a fail-quiet contract of this function, not of
`read_progress_events`. If the delegation were ever swapped they are the
tests that would notice.

### Simplification

> **1. `kstrl/decompose.py:1058` and `:1128` - `_capped` takes `list[str]`, so the one caller has to un-tuple.**
> `spec_files` is a `tuple[str, ...]` on the dataclass, so the call site writes `_capped(list(e.spec_files), 'file(s)')`. The body only slices, `len`s and joins. Cost: a copy plus a reader asking why a tuple needs converting. Simpler: `def _capped(items: Sequence[str], noun: str)` (`collections.abc` is already imported at line 9 for `Callable`) and drop `list(...)`.

**Applied.** Same as reuse 5.

> **2. `kstrl/decompose.py:1126-1134` - `_capped` nested inside a comprehension inside a `_capped` call, with a ternary in the middle.**
> Three constructions in one expression, and the ternary tests `e.spec_files` while the inner call re-derives the same emptiness. Cost: the densest four lines in the diff, and the two emptiness tests can drift apart. Simpler, flat, verified identical output:
> ```python
> phrases = []
> for e in excluded:
>     files = _capped(e.spec_files, "file(s)")
>     phrases.append(f"'{e.project}' ({files})" if files else f"'{e.project}'")
> named = _capped(phrases, "project(s)")
> ```
> `_capped([], ...)` already returns `""`, so `if files` replaces the separate condition.

**Applied** verbatim, in the new `_excluded_line`. One emptiness test, not
two.

> **3. `kstrl/decompose.py:1085-1095` - `tuple(genexp over sorted(dict.items(), key=lambda item: (-len(item[1]), item[0])))`.**
> The sort key indexes raw tuple slots (`item[1]`) to recompute a length the dataclass is about to store as `audits`. Cost: the ordering rule is written in a vocabulary (`item[0]`, `-len(item[1])`) that does not match the docstring's ("by audit count, most history first"). Simpler: build the list, then sort it by named fields.

**Applied.** Build the dataclasses, then sort by named fields. The key now
reads `(spec_file not in e.spec_files, -e.audits, e.project)`, which is the
ordering rule in the same words as the docstring.

> **4. `kstrl/decompose.py:1084, 1088-1089` - the name `spec_files` means two different things four lines apart.**
> The loop/genexp variable is the raw per-entry list (duplicates, empty strings included, one element per audit); the field of the same name is the deduplicated sorted tuple. That is why `audits=len(spec_files)` reads like "number of spec files" when it means "number of audits". Cost: the one line most likely to be misread on a later edit. Simpler: name the accumulated list `files` or `raw_files`.

**Applied.** The accumulator is `files`, and the dataclass docstring now
states that `audits` is not derivable from `spec_files`.

> **5. `kstrl/decompose.py:1120` - the journal file is now parsed twice per decompose, via a path that copies a private method from outside.** [...] Simpler: one public accessor on `EvolutionJournal` (e.g. `all_spec_issue_runs()`), or read the entries once in `_decompose_spec_impl` and hand the same list to both consumers.

**Declined (deferred).** Same as reuse 1 and 3.

> **6. `kstrl/decompose.py:1563-1571` - a five-line comment wedged between two positional arguments of one call.**
> Both arguments are unnamed nested calls, so the call reads `_surface_convergence(<expr>, <comment>, <expr>, ui)`. Cost: the comment attaches to an argument rather than a statement, and any future third argument makes it worse. Simpler: bind `excluded_note = _excluded_note(journal, project_name)` on its own line with the comment above it, then pass the name.

**Applied.** `excluded = _excluded_history(...)` is its own statement with
the comment above it.

> **7. `tests/test_decompose.py:1258` - dead local import.**

**Applied.** Same as reuse 7.

> **8. `tests/test_decompose.py:782` - `journal.append_entries([dict(entry) for entry in entries])`.**
> `append_entries` only `json.dumps` each entry and never mutates, so the defensive copy guards nothing. Simpler: pass `entries`.

**Applied.** Passes `entries`.

> **Verdict on the `_surface_trend` split:** Net win, keep it. It is a pure move, not new code: without it the ~28-line trend body would have been re-indented under an `else:`, producing a large no-op diff and a third nesting level. The split also gives `_surface_trend` a non-optional `SpecConvergence`, so the body loses the `| None` it never handled anyway, and it leaves `_surface_convergence` as a seven-line dispatcher whose two cases are readable at a glance. Single-use is fine here - the helper buys a nesting level and a narrower type.

Kept.

> **Not flagged:** `ExcludedAudits` earns its keep: `audits` is genuinely not derivable from `spec_files` [...] The one thing I would change is the name - the class holds one project, so `e.audits` on an `ExcludedAudits` stutters; `ExcludedProject` / `_excluded_projects` reads straight. `_EXCLUDED_NAMES_SHOWN` serving both the project cap and the file cap is right, not a conflation.

**Applied.** `ExcludedAudits` -> `ExcludedProject`, `_excluded_audits` ->
`_excluded_projects`, `_capped` -> `_join_capped`.

### Efficiency

> **1. `kstrl/decompose.py:1120` (with `:1030`) - the journal file is read, parsed and materialised twice per `ks decompose`.**
> Cost: 0.088 ms median on the repo's real 35 KB journal (matches the 0.099 ms you were given); 6.9 ms on a synthetic 949 KB / 10k-entry journal. Memory is *not* doubled - the first read's list is freed inside `get_spec_issue_runs`'s comprehension before the second read starts, so peak stays at one entries list (7.4 MB for that 10k-entry journal). Cheaper alternative A (**requires evolution.py**, so do not apply) [...] Cheaper alternative B (no evolution.py change): decompose does `entries = read_progress_events(journal.config.journal_path)` once and inlines the filter+slice that `get_spec_issue_runs` performs - it is two lines. Costs a duplicated copy of the windowing rule, which is a reuse regression traded for a saving that does not exist at this scale.

**Declined**, on the reviewer's own recommendation: "Leave finding 1 alone".
A is barred, B trades a documented windowing rule for 0.09 ms.

> **2. `kstrl/decompose.py:1126-1133` - every excluded project is fully formatted, then all but three are thrown away.**
> The inner list comprehension builds a display string (including a nested `_capped` join) for all N projects; the outer `_capped` keeps `[:3]`. Cheaper: slice `excluded[:_EXCLUDED_NAMES_SHOWN]` before formatting and pass `len(excluded)` for the "and N more" count. Cost: 0.056 ms for 200 projects vs 0.001 ms for 3. Real-world N is 1-2, where the waste is unmeasurable.

**Declined.** Slicing before formatting means `_join_capped` needs the true
total as a third parameter. A parameter for 0.055 ms at N=200, in a
function whose realistic N is 1, is a bad trade.

> **3. `kstrl/decompose.py:1128` - `list(e.spec_files)` copies a tuple that `_capped` never mutates.**
> `_capped` only does `items[:N]`, `len()` and `", ".join()`, all of which work on a tuple. Cheaper: type the parameter `Sequence[str]` (line 1058) and drop the `list()`. One list allocation per excluded project, saved for free.

**Applied.** Same as reuse 5.

> **4. `kstrl/decompose.py:1084` - `by_project` accumulates one string slot per matching entry, when only a count and a distinct set are ever used.**
> `spec_files` is immediately reduced to `len(...)` and `tuple(sorted(set(...)))` at 1088-1089. Cheaper: `dict[str, list]` -> a `Counter` plus a `defaultdict(set)`, or one dict of `[count, set]`. Cost: `_excluded_audits`'s own intermediates measured 225 KB against a 7.4 MB entries list on the 10k-entry journal - 3% on top of the read it is already paying for.

**Declined**, on the reviewer's own condition that it be taken only while
`_excluded_audits` is open for another reason. A `Counter` plus a
`defaultdict(set)` is two structures where one dict of lists reads plainly,
for 3% of a read already paid for.

> **5. Clean on the closure angle.** Nothing the diff introduces is long-lived. `ExcludedAudits` is a frozen dataclass of `str`/`int`/`tuple[str, ...]` - it holds no reference into the parsed entries beyond interned field strings, and dies with the note string. The only lambda (line 1093, the `sorted` key) is transient and captures nothing. No cache, no registry, no partial, no default-argument capture.

Noted, no action.

> **6. Not a finding, checked and cleared:** the new eager module-level `from kstrl.observability import read_progress_events` at line 52 departs from this module's deferred-import convention (`kstrl.evolution` is imported inside functions at line 860, `read_progress_events` lazily inside `evolution._read_all_entries`), but it costs 0.0 ms - `kstrl.observability` is already resident via decompose's existing eager `kstrl.events` / `kstrl.manifest` imports by the time line 52 runs.

Noted, no action.

> **Does any of it justify caring:** No. The whole extra pass sits next to an architect LLM call measured at 119-210 s. On the real 35 KB journal the second read is 0.088 ms, or 7x10^-7 of one `ks decompose`. Even the parent's 19.8 MB pathological journal at 57 ms is 0.05% of the cheapest LLM call, and a 19.8 MB journal has a compaction problem, not a reader problem. My recommendation: apply findings **2 and 3** only.

3 applied; 2 declined for the reason above.

### Altitude

> **1. `kstrl/decompose.py:52` and `:1120` - decompose reimplements `EvolutionJournal._read_all_entries` at the call site. REQUIRES evolution.py to fix properly.** [...] Right home for "which projects have spec audits in this journal": a sibling of `get_spec_issue_runs` in `evolution.py` - either `get_spec_issue_runs(project=None)` meaning "all", or a `spec_issue_projects() -> dict[str, list[str]]`. That is one read serving both callers and keeps `journal_path` private. **Deferred: requires evolution.py.**

**Declined (deferred).** Third independent report of the same thing, and
the reviewer's own verdict is deferred.

> **2. `kstrl/decompose.py:1098-1140` - the note is rendered in the data layer, so the structured value is built and discarded before the UI sees it.**
> The module's established split is `_spec_convergence` -> dataclass -> `_surface_convergence` renders. `_excluded_note` breaks it: `_capped` (a *line-length* cap, i.e. pure presentation) and the f-string sentence sit next to the journal read, and the renderer is handed a `str`. Cost: `_surface_convergence` can no longer choose its own rendering - `ui.warn` vs `ui.info` (the issue calls it a warning), a `kv` row, wrapping - and `kstrl/ui/bridge.py` receives prose where every other convergence datum arrives structured. The wording is pinned by string equality against a data function (`tests/test_decompose.py:1241`, `:1271`), so any rewording is a data-layer test failure. Fix: pass `tuple[ExcludedAudits, ...]`, move `_capped` and the sentence next to `_surface_trend`. Local, ~15 lines moved.

**Applied.** This is the largest change from the pass. `_excluded_history`
returns `tuple[ExcludedProject, ...]`; `_join_capped`, `_EXCLUDED_NAMES_SHOWN`
and the sentence moved next to `_surface_trend` in the render layer;
`_surface_convergence` takes the structured value. The replay output is
byte-identical before and after the move.

> **3. `kstrl/decompose.py:1142` and the call site at `:1563-1572` - two parallel nullable arguments where one boundary value belongs.**
> Both parameters are required positional (not optional), so all four callers/tests must pass both; four states, three meaningful. Putting the field on `SpecConvergence` genuinely does not work - it is `None` in exactly #280's case - but the answer to that is one struct at the boundary carrying `trend: SpecConvergence | None` plus `excluded: tuple[ExcludedAudits, ...]`, not two data-layer calls that each take `(journal, project_name)` and each read the same file. Cost as written: the call site needs a 5-line comment to explain why there are two arguments, and the next piece of convergence context becomes a third.

**Partly applied.** The nullability half is gone: `excluded` is a tuple,
empty for "nothing to say", so there are no longer two nullable arguments.
The wrapper struct is declined: a dataclass whose only job is to carry two
values into one render call, built once and destructured immediately, adds
a type without removing a decision.

> **4. `kstrl/decompose.py:1168-1170` - printing the header when `report is None` is correct; the extra sentence under it is not.**
> The section is the right home for the note, so the header branch is fine. But `"No earlier audit of this project is recorded."` is a fact about *this* run that prints only when some *other* project happens to have history - the identical run state renders two ways depending on unrelated journal contents. It is frame for the note masquerading as trend content. Cost: it belongs in the note's own text; left where it is, any later change to note placement leaves a bare unexplained line.

**Declined.** True as stated, but that is the section's existing rule, not a
new one: the whole block prints only when there is something to say, and
#270 chose that deliberately. When the only thing to say is the note, the
absence of a trend is exactly what the operator must not have to infer, so
the line earns its place. Folding it into the note's own text would give
the note two forms and a branch to pick between them.

> **5. `kstrl/decompose.py:1066` - only issue #280's cheap second arm shipped, so the note fires forever in any multi-project repo.**
> The issue's primary suggestion is "same `spec_file` under a *different* project name"; "any other project" is offered as a cheaper second arm. This implements only the second. Concrete cost: a repo holding N kstrl projects prints a note naming the other N-1 on every `ks decompose` of any of them, permanently, with no flag to silence it. `tests/test_decompose.py:1428` covers the single-project false-positive but there is no test for the multi-project steady state. Cheap fix at the right altitude, no new keying scheme: `ExcludedAudits.spec_files` is already collected, so ordering or flagging the entries whose `spec_files` contain the current spec file restores the arm-1 signal for one predicate.

**Applied, both halves.** Projects that read this run's spec file now sort
first, so arm 1's signal is a guarantee under the display cap rather than a
coincidence (`test_a_project_that_read_this_spec_file_sorts_first`). And the
missing multi-project steady-state test is now
`test_a_genuine_two_project_repo_is_told_the_truth`, which pins the cost
rather than leaving it to be discovered.

> **6. Minor.** `tests/test_decompose.py:1258` re-imports `EvolutionConfig, EvolutionJournal` inside a test body though `:24` already imports both at module scope. `_capped` is a very generic name for a private in a 1900-line module.

**Applied**, both. Local import deleted, `_capped` -> `_join_capped`.

> **Not a finding:** the `ExcludedAudits` shape, skipping unnamed projects, dedup/sort of `spec_files`, ordering by audit count, and the deliberate non-windowing by `lookback_runs` are all correctly reasoned and correctly placed.

Noted.

---

## Round 1 review: nine findings

> Superseded in places by round 2 below: the accounting wording, the
> note format and the two-read decision all changed. The reproductions
> and measurements here are what round 1 found, kept as the record.

Every one reproduced against the real code path before it was touched, and
re-run after. 6 fixed, 1 filed, 2 answered with measurement.

### 2. The note reproduced #280's own defect on the other axis. FIXED

The sharpest one, and it is correct. The note counted only cross-project
audits while its wording claimed everything the journal holds, so
same-project audits dropped by `lookback_runs` went silently missing.

Reproduced, `lookback_runs=2`, six audits of `mine` plus one of `other`:

```
  Trend:        1, 1, 0 (blockers, oldest run first)
Note: audits are matched by project name, and this report covers 'mine'. This journal holds 1 more spec audit(s) that it does not count, under 'other' (o.md).
```

It held five. Reachable on the default `lookback_runs=10` after eleven
audits of one project, so not an exotic config.

The accounting is now two-sided, and both sides come from measured values
rather than from what the code hoped was true:

```
  Trend:        1, 1, 0 (blockers, oldest run first)
Note: this journal records 6 earlier audit(s) of 'mine' and this report counts 2. The rest fall outside the lookback window, or carry no issue list to compare.
Note: audits are matched by project name, and this report covers 'mine'. This journal also records 1 spec audit(s) under 'other' (o.md, last 2026-08-20).
```

Between them the two lines account for every `spec_issues` entry in the
journal. `counted` is read off the rendered trend (`len(blocker_trend) - 1`)
rather than recomputed, so the accounting line cannot disagree with the
trend printed directly above it. `own_recorded` is deliberately unwindowed,
because a count of what the trend does not cover that was itself windowed
is the bug again.

Pinned by `test_a_windowed_out_run_is_counted_not_swallowed` end to end and
`TestExcludedAccountingLine` on the pure function.

### 1. A confident claim the code never checked. FIXED

Both routes reproduced. `lookback_runs=0` with three real audits of `mine`
on disk, and separately a legacy journal whose entries carry no `issues`
key, both printed:

```
== Spec Convergence ==
No earlier audit of this project is recorded.
```

That line now prints only when `own_recorded == 0`, which makes it true by
construction; the accounting line covers every other reason a trend could
not be built. Both routes are pinned:
`test_no_earlier_audit_is_claimed_only_when_none_is_recorded` and
`test_a_legacy_entry_with_no_issue_list_is_counted_not_denied`.

### 3. A JSON null became a project named 'None'. FIXED

Reproduced exactly:

```
>>> _excluded_projects([{"event_type":"spec_issues","project":None,"spec_file":None}], "mine", "mine.md")
(ExcludedProject(project='None', audits=1, spec_files=('None',)),)
```

`str(entry.get("project", ""))` renders a null as `"None"`, which then
passes the truthiness guard on the next line, defeating the rule the
docstring states. A new `_entry_str` returns `""` for anything that is not
a `str`, applied to `project`, `spec_file` and `timestamp`. Now returns
`()`. Two tests.

### 6. The "guarantee" was not one. FIXED

Reproduced with four other projects that had all audited `spec.md`, which
is a repo that split one spec across several names and therefore #280's own
shape:

```
under 'p0' (spec.md), 'p1' (spec.md), 'p2' (spec.md) and 1 more project(s).
```

The sort put all four first and the cap then dropped the fourth. The cap
now applies only to projects that did NOT read this run's spec file; every
match is named in full. `test_every_project_that_read_this_spec_file_survives_the_cap`.

### 7. No recency signal. FIXED

Each named project now carries `last_recorded`, the timestamp on its most
recent entry in file order (the journal is append-only), rendered as a date:

```
under 'auth' (auth.md, last 2026-08-20).
```

Taken from the journal, never derived, and `""` when the entry recorded
none, in which case the clause is omitted rather than guessed. This turns
the permanent-noise cost I flagged into evidence an operator can dismiss on
sight. Two tests.

### 4. Torn-tail writes eat the next entry. FILED AS #312

Reproduced through the real writer: append audit A, write the fragment
`{"event_type": "spec_iss`, append audit B, and the file becomes one
unparseable line. Two audits written, one readable, nothing warns.

`append_entries` never checks whether the file it appends to ends in a
newline. Not fixed here: `kstrl/evolution.py` is under concurrent edit.
Filed as **#312** with the reproduction and a suggested fix, and it affects
every journal writer, not just spec audits.

### 5. Two sources of truth for the event name. FIXED, with a correction

The finding is right that `evolution.py:1277` still hardcodes
`"spec_issues"` independently. The stated failure mode is half wrong, and
the difference matters: I changed `SPEC_ISSUES_EVENT` and ran the suite.

```
15 failed, 86 passed
```

Not a silent double failure. The trend does go empty, loudly, across
fifteen tests. The note does NOT "flip to counting every entry as another
project's history", because the reader that feeds it uses the same constant
and still filters out this project's own entries; both halves move together.

Since `kstrl/evolution.py` is under concurrent edit, the constant keeps its
second copy, but the agreement is now a mechanism rather than a comment:
`test_the_journal_reader_agrees_with_the_event_name_written` writes an entry
through this module and reads it back through `get_spec_issue_runs`, so the
two diverging fails a test named for exactly that. The constant's comment
now says where the other copy lives instead of implying there is only one.

### 8. Two journal reads per decompose. ANSWERED WITH THE GROWTH CURVE, THEN FIXED IN ROUND 2

The reviewer is right that a single 0.099 ms number does not answer a
question about a file that only grows. Measured, on this repo's real
journal and on synthetic ones:

| | |
|---|---|
| bytes per factory run | 6.9 KB (measured: 35.0 KB over 5 distinct `run_id`s, spec audits excluded) |
| 1 MB | about 150 factory runs |
| 10 MB | about 1,500 factory runs |
| 100 MB | about 15,200 factory runs |

| journal | median | max |
|---|---|---|
| 0.02 MB | 0.05 ms | 0.08 ms |
| 0.19 MB | 0.42 ms | 0.48 ms |
| 1.92 MB | 4.40 ms | 6.53 ms |
| 19.34 MB | 53.47 ms | 56.37 ms |
| 77.63 MB | 228.94 ms | 255.68 ms |

Roughly 2.9 ms per MB, linear. After 1,500 factory runs the extra read
costs about 27 ms, against an architect call measured at 119 to 210
seconds. Four other journal readers (`get_cross_run_patterns`,
`get_concern_hit_rate`, `get_fact_utilization`, `get_spec_issue_runs`)
already parse the whole file per run, so a journal large enough for this to
matter is a compaction problem for all five, not a reason to single this
one out.

Not fixed, for two reasons stated plainly rather than as a latency
argument. The right fix is a reader on `EvolutionJournal`, and that file is
under concurrent edit. The only fix available without it is to read once in
`decompose` and inline the window, which would leave `get_spec_issue_runs`
with no production caller at all: a dead public method on a file I cannot
clean up is worse than a second read of a file already read four times. The
docstring now says this in layering terms and carries the growth curve
rather than one number.

### 9. `read_progress_events` encoding. LEFT ALONE

Real, and already fixed on another branch. **PR #304** names
`encoding="utf-8"` and catches `ValueError` alongside `OSError` at
`observability.py:417`, for the same reason, reached from the TUI side
(#289). Verified in that PR's diff. No change here, so there is nothing to
collide.

### Gate after round 1

- `uv run pytest tests/ -q`: 4334 passed, 28 skipped
- `uv run mypy kstrl/ --strict`: clean, 124 source files
- `uv run ruff check kstrl/ tests/`: clean
- coverage: 89.62% against the 79.91% ratchet; `kstrl/decompose.py` 92.34%
- all pre-commit hooks pass at commit

Rebased onto `1580b00`.

---

## Round 2 review: nine live findings

Every one reproduced against the real code path before it was touched and
re-measured after. 6 fixed, 2 fixed that were "fix or answer", 1 filed.
Finding 10 was dropped as stale by the coordinator and confirmed so:
current `origin/main` `kstrl/observability.py` names `encoding="utf-8"` and
catches `(OSError, ValueError)`.

### 2. Audits belonging to no project were counted by neither bucket. FIXED

The one that matters, and it is #280's defect on a third axis. `own_recorded`
counts entries where the project matches; `_excluded_projects` skips entries
with no project. An entry whose `project` is null or absent satisfies
neither, so it existed on disk and in no count.

Reproduced, three `spec_issues` entries on disk:

```
own_recorded: 0  projects: ['other']
3 spec_issues entries on disk. The report says:
  Note: audits are matched by project name, and this report covers 'mine'. This journal also records 1 spec audit(s) under 'other' (c.md).
```

Two of three vanished, while the `_excluded_lines` docstring claimed the two
lines accounted for every entry.

Fixed with a third bucket and its own line:

```
Note: audits are matched by project name, and this report covers 'mine'. This journal also records 1 spec audit(s) under 'other' (1 audit(s), c.md).
Note: 2 spec audit(s) in this journal record no project name, so neither the trend nor the line above counts them.
```

The completeness claim is now a test rather than a docstring:
`test_every_spec_audit_lands_in_exactly_one_bucket` asserts
`own_recorded + other_audits + unattributed` equals the number of
`spec_issues` entries.

### 1. A present-but-null field became the string 'None'. FIXED

Both sites reproduced. The `spec_file` one printed a phantom rename:

```
Runs are matched by project name: the previous audit read None, this one read spec.md.
```

The severity one is worse, as the reviewer said, because it puts a false
number in the trend. Seven issues stored with `"severity": null`:

```
  Trend:        0, 1 (blockers, oldest run first)
Previous run raised 0 issue(s): 0 reappear verbatim, 0 do not.
```

`_entry_str` now covers both sites. That alone does not fix the second one:
an empty severity is still bucketed as nothing, so the false 0 would
survive. So `_stored_issues` now refuses an audit carrying a severity
outside `blocker`/`major`/`minor` instead of part-scoring it, and the
refusal surfaces through the anomaly line built for finding 4:

```
No earlier audit of 'mine' could be compared, though this journal records 1.
Note: 1 earlier audit(s) of 'mine' fall inside the lookback window but could not be scored, so the trend does not count them. An audit is skipped when it records no issue list, or an issue whose severity is not blocker, major or minor.
```

Declining to score is loud; part-scoring was silent. Four tests, two through
the real `decompose_spec`.

### 4. The accounting note became permanent noise. FIXED

`counted` is capped at `lookback_runs` while `own_recorded` is not, so
`own_recorded > counted` holds unconditionally from the 11th audit at the
default. Reproduced: a growing "40 recorded, 10 counted" note on every run
forever.

The two causes are now separated, because they are not the same event. An
audit the window never offered the trend is the configured steady state, so
it qualifies the number it applies to rather than firing a warning:

```
  Trend:        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 (blockers, oldest run first; 30 older audit(s) outside the lookback window)
```

No `Note:` at all in that case, measured at 40 audits and the default
lookback. An audit the trend was **offered** and could not score is an
anomaly and still gets a sentence, which is finding 1's surface above.
`ExcludedHistory.unreadable()` and `.windowed_out()` split them, and
`test_the_two_causes_are_separated_when_both_apply` pins that they do.

### 5. Removing the cap in round 1 removed the bound. FIXED

Round 1 exempted spec-file matches from the cap to make the guarantee real,
and took the length bound with it. Reproduced at 25 matching projects: 971
characters on one `ui.info`.

Both groups are capped now, matches first with their own summary. Measured:

| matching projects | rendered length |
|---|---|
| 1 | 167 chars |
| 4 | 308 chars |
| 25 | 310 chars |
| 200 | 312 chars |

```
Note: audits are matched by project name, and this report covers 'mine'. This journal also records 25 spec audit(s) under 'p000' (1 audit(s), mine.md, last 2026-08-20), 'p001' (1 audit(s), mine.md, last 2026-08-20), 'p002' (1 audit(s), mine.md, last 2026-08-20) and 22 more project(s) that read this spec file.
```

Bounded, and the summary still says these are spec-file matches rather than
lumping them with the rest.

### 3. The per-project audit count was carried and never rendered. FIXED

Reproduced: 1, 2 and 100 audits all printed
`'other' (o.md, last 2026-08-20)`. The count is the evidence the operator
judges a suspected rename on, so it is now the first part of the phrase:

```
    1 audits -> ...) under 'other' (1 audit(s), o.md, last 2026-08-20).
    2 audits -> ...) under 'other' (2 audit(s), o.md, last 2026-08-20).
  100 audits -> ...under 'other' (100 audit(s), o.md, last 2026-08-20).
```

### 8. One bad row erased a good date. FIXED

Reproduced: a good timestamp followed by an entry with none yielded
`last_recorded == ''`. `if timestamp := ...` keeps the newest date that
actually exists. Now returns `'2026-06-30T12:00:00Z'`. Same class as
finding 1, as the reviewer noted.

### 6. Two journal parses per decompose. FIXED, the reviewer's way

The reviewer's point that changes the answer is correct: the call site has
both results in scope. `_journal_snapshot` reads once and hands the entries
to both `_spec_convergence` and `_excluded_history`, so they are also
computed over the same snapshot and cannot disagree because the file moved
between two reads. Verified by counting calls:

```
read_progress_events called 1 time(s) for one report
```

`test_the_journal_is_parsed_once_per_report` pins it end to end.

The cost I flagged in round 1 is real and is now recorded rather than
argued: `EvolutionJournal.get_spec_issue_runs` has **no production caller
at all**, and `_windowed_audits` restates its window rule. Both are in
**#314**.

### 7. The deferral needed a mechanism. FIXED with the test

`test_the_windowing_rule_matches_the_journals_own` asserts that the entry
set reached through `journal.config.journal_path` and windowed by
`_windowed_audits` equals `journal.get_spec_issue_runs(...)`, across
`last_n` of 0, 1, 3 and 10. If the journal ever compacts, rotates or gains a
second segment, or if the window rule changes on either side, that test
fails rather than the accounting going quiet. That covers both halves of the
reviewer's concern in one test. The move itself is **#314**.

### 9. `SPEC_ISSUES_EVENT` is in the wrong module. FILED AS #314

The reviewer accepts that the guard test catches divergence, so this is
placement rather than correctness. Moving the constant onto `evolution.py`
means editing a file that PR #310 still has open, and it needs an
import-cycle check because `decompose` imports `kstrl.evolution` lazily
inside functions today, so it is more than an import plus a move. Filed as
part of **#314** with the other two `evolution.py` items, deliberately as
one issue: three separate issues would produce three PRs racing the same
file, which is what caused the deferral.

### 10. DROPPED, and confirmed stale

Checked `origin/main` at `4f1e165`: `read_progress_events` names
`encoding="utf-8"` and catches `(OSError, ValueError)`. PR #304's fix. No
action, no code touched.

### Issues filed across both rounds

- **#312** `append_entries` eats the next journal entry after a torn write
- **#314** fold the spec-audit reader, window rule and event constant into `EvolutionJournal`

### Gate after round 2

- `uv run pytest tests/ -q`: 4397 passed, 28 skipped
- `uv run mypy kstrl/ --strict`: clean, 126 source files
- `uv run ruff check kstrl/ tests/`: clean
- coverage: 89.72% against the 79.91% ratchet; `kstrl/decompose.py` 92.60%
- all pre-commit hooks pass at commit, complexipy included

Rebased onto `4f1e165`.
