### PR TITLE
fix(procgroup): bound the ps read against a child that will not die

### DIFF
--- a/kstrl/procgroup.py
+++ b/kstrl/procgroup.py
@@ -47,8 +47,8 @@ Anything else is "cannot see".
 
 TWO CONTROLS THAT DID NOT WORK, written down because each was claimed in
 this docstring before it was measured. The first checked that the
-caller's own process group appeared in the listing; ``subprocess.run``
-does not ``setpgid``, so the ``ps`` child runs in the caller's group and
+caller's own process group appeared in the listing; the read does not
+``setpgid``, so the ``ps`` child runs in the caller's group and
 ``ps -A`` always lists it - our own pgid appeared four times in every
 listing, the last row being ``ps`` itself. Satisfied by construction, it
 could never fire. The second was "every listed row is a zombie, so the
@@ -75,14 +75,46 @@ against a 246.5s suite, 0.11% of wall clock.
 
 POSIX only. ``ps`` group listings and ``killpg`` do not exist on Windows.
 
-WHAT THE ``ps`` TIMEOUT DOES NOT COVER, stated because an earlier version
-of this docstring claimed a bound it does not have. ``PS_TIMEOUT_SECONDS``
-bounds a ``ps`` that is slow but killable. It does NOT bound one wedged
-in an uninterruptible read (a hung NFS mount, a dead container runtime):
-CPython's ``subprocess.run`` handles its own timeout by calling
-``process.kill()`` and then ``process.wait()`` with NO timeout, and
-``Popen.__exit__`` waits again, so a D-state child that cannot be killed
-blocks the call indefinitely. Tracked as #309.
+WHY THE READ IS A ``Popen`` AND NOT ``subprocess.run`` (#309), because
+an earlier version of this docstring claimed a bound it did not have.
+``subprocess.run`` cannot give one. Read against the CPython 3.12.8 this
+tree runs: its timeout handler calls ``process.kill()`` and then
+``process.wait()`` with NO timeout, and the enclosing ``with Popen(...)``
+calls ``__exit__``, which calls ``self.wait()`` again, also unbounded. A
+``ps`` wedged in an uninterruptible read (a hung NFS mount, a dead
+container runtime) cannot be killed, so both waits block forever - and
+the one production caller is the daemon's reap path, which runs while
+``serve`` holds its singleton lock for the daemon's whole lifetime. The
+timeout named exactly the case it did not cover.
+
+So the read is a ``Popen`` driven by two BOUNDED ``communicate`` calls:
+``PS_TIMEOUT_SECONDS`` for the read itself, then a kill, then
+``PS_KILL_GRACE_SECONDS`` to collect a child the kill reached.
+``communicate(timeout=...)`` ends in ``wait(timeout=remaining)``, so
+every leg has a deadline and the call returns within the sum of the two.
+Nothing here uses ``with Popen(...)``: that is the second unbounded wait.
+
+WHAT THAT COSTS, since a bound bought with nothing would be suspicious. A
+child the kill did NOT reach is ABANDONED rather than waited on: we close
+our two pipe ends, which cannot block on a read end, and report "cannot
+see". It is not a permanent zombie. ``Popen.__del__`` hands an unreaped
+child to CPython's ``subprocess._active``, which the next ``Popen``
+constructed anywhere in the process polls, so it is collected once the
+kernel lets it die. The caller's fallback for "cannot see" is the signal
+probe, whose only error is over-reporting alive, so a bounded degraded
+answer is strictly better here than an unbounded exact one.
+
+THE COST IS PER READ, NOT PER RUN, and ``serve`` reads more than once.
+``_wait_out_grace`` waits out the direct child and then re-reads the
+group until its grace expires, and it checks the clock only at the top of
+that loop, so each read can overshoot by a whole 6.0s. Simulated over the
+two shapes that loop takes with a permanently wedged ``ps``: if the
+direct child outlives both graces, 2 reads and 37.00s; if it dies at once
+and a descendant holds on, 5 reads and 30.75s. So up to five abandoned
+children per terminated run, and a ``terminate_process_group`` worst case
+of 37s against the 25s an operator reads off ``GROUP_TERM_GRACE_SECONDS``
+plus the SIGKILL leg. Both numbers are finite, which is the change; the
+overshoot is worth knowing before anyone tunes either constant.
 
 This module is the only place in ``kstrl/`` or ``tests/`` that shells out
 to ``ps``, and ``tests/test_procgroup.py`` fails on a second one in
@@ -95,6 +127,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from contextlib import suppress
 from dataclasses import dataclass
 
 #: The three columns the question needs and no more. ``pid`` is there for
@@ -102,10 +135,21 @@ from dataclasses import dataclass
 #: docstring above for why each is load-bearing and what it costs.
 PS_ARGV = ("ps", "-A", "-o", "pid=,pgid=,stat=")
 
-#: A bound on how long a KILLABLE ``ps`` may stall the caller. 440x the
-#: 11.29ms measured for the call, so it cannot fire on a slow machine.
-#: It does not bound an unkillable one; see the docstring and #309.
+#: How long the ``ps`` read itself may take. 440x the 11.29ms measured
+#: for the call, so it cannot fire on a slow machine. Re-measured for
+#: #309 on a 914-process machine: median 11.47ms, max 13.35ms over 60
+#: samples.
 PS_TIMEOUT_SECONDS = 5.0
+
+#: How long a KILLED ``ps`` is given to be collected before it is
+#: abandoned. This buys the kill a scheduler round trip, not work, and
+#: measuring it says so: over 60 samples on the same machine, kill to
+#: reaped was max 0.236ms for ``ps`` and max 1.122ms for a ``sleep``
+#: child killed mid-run. 1.0s is ~890x the worse of the two. Raising it
+#: cannot rescue a D-state child, which is the only case that reaches
+#: the end of it; it would only lengthen the hang this bound exists to
+#: stop. The worst case for the whole read is the sum of the two: 6.0s.
+PS_KILL_GRACE_SECONDS = 1.0
 
 #: Said once, because several branches report it and reflowed copies of
 #: one sentence are how the two answers drift apart.
@@ -152,19 +196,7 @@ def read_group_liveness(pgid: int) -> GroupLiveness:
     earlier controls could not, are in the module docstring.
     """
     try:
-        out = subprocess.run(
-            PS_ARGV,
-            capture_output=True,
-            # Pinned rather than left to the locale, and non-decodable
-            # bytes are replaced rather than raised. A decode error here
-            # is a ValueError, which would escape a fail-closed
-            # ``except OSError`` and take the daemon down over a
-            # diagnostic (the repo's #291 lesson). Caught below as well,
-            # so a future edit cannot reintroduce it.
-            encoding="utf-8",
-            errors="replace",
-            timeout=PS_TIMEOUT_SECONDS,
-        )
+        out = _read_ps()
     except (OSError, ValueError, subprocess.TimeoutExpired) as exc:
         return GroupLiveness(None, f"ps failed to run ({exc!r}). {_UNMEASURABLE}")
     if out.returncode != 0:
@@ -173,6 +205,68 @@ def read_group_liveness(pgid: int) -> GroupLiveness:
             f"ps failed (rc={out.returncode}): {out.stderr.strip()!r}. {_UNMEASURABLE}",
         )
     return _interpret(_read_listing(out.stdout, pgid), pgid)
+
+
+def _read_ps() -> subprocess.CompletedProcess[str]:
+    """One ``ps`` read that returns within ``PS_TIMEOUT_SECONDS`` plus
+    ``PS_KILL_GRACE_SECONDS``, whatever the child does.
+
+    Why this is not ``subprocess.run``, and why no ``with`` block, is the
+    #309 section of the module docstring: both of those wait on the child
+    without a deadline, which is the hang.
+
+    No ``start_new_session``, matching what ``subprocess.run`` did: the
+    ``ps`` child stays in the caller's process group, which is what makes
+    the rejected "our own pgid is listed" control satisfied by
+    construction rather than merely usually true.
+    """
+    process = subprocess.Popen(
+        PS_ARGV,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        # Pinned rather than left to the locale, and non-decodable bytes
+        # are replaced rather than raised. A decode error here is a
+        # ValueError, which would escape a fail-closed ``except OSError``
+        # and take the daemon down over a diagnostic (the repo's #291
+        # lesson). Caught by the caller as well, so a future edit cannot
+        # reintroduce it.
+        encoding="utf-8",
+        errors="replace",
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=PS_TIMEOUT_SECONDS)
+    except BaseException:
+        # Every exit that is not a completed read leaves a child behind,
+        # so every one of them goes through the same disposal.
+        # ``BaseException`` because a KeyboardInterrupt out of the daemon
+        # must not be the one path that leaks the child.
+        _kill_or_abandon(process)
+        raise
+    return subprocess.CompletedProcess(PS_ARGV, process.returncode, stdout, stderr)
+
+
+def _kill_or_abandon(process: subprocess.Popen[str]) -> None:
+    """Kill the child, give the kill a bounded grace, then LET GO.
+
+    The second ``communicate`` is the wait ``subprocess.run`` does
+    without a deadline. Reaching ITS timeout means the kill did not land,
+    which on POSIX means an uninterruptible sleep, which no further
+    waiting can shorten - so this returns instead, and the module
+    docstring records what that abandoned child costs.
+    """
+    try:
+        process.kill()
+        process.communicate(timeout=PS_KILL_GRACE_SECONDS)
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        # One handler for both calls, because a kill that could not be
+        # sent leads to the same place as one that did not work: the
+        # child is not ours to collect, so let go of the pipes instead.
+        # Closing a pipe READ end cannot block, which is what makes this
+        # safe on a path whose whole contract is not to block.
+        for pipe in (process.stdout, process.stderr):
+            if pipe is not None:
+                with suppress(OSError):
+                    pipe.close()
 
 
 @dataclass(frozen=True)

--- a/kstrl/procgroup.py
+++ b/kstrl/procgroup.py
@@ -90,9 +90,21 @@ timeout named exactly the case it did not cover.
 So the read is a ``Popen`` driven by two BOUNDED ``communicate`` calls:
 ``PS_TIMEOUT_SECONDS`` for the read itself, then a kill, then
 ``PS_KILL_GRACE_SECONDS`` to collect a child the kill reached.
-``communicate(timeout=...)`` ends in ``wait(timeout=remaining)``, so
-every leg has a deadline and the call returns within the sum of the two.
-Nothing here uses ``with Popen(...)``: that is the second unbounded wait.
+``communicate(timeout=...)`` ends in ``wait(timeout=remaining)``, so both
+legs have a deadline. Nothing here uses ``with Popen(...)``: that is the
+second unbounded wait.
+
+WHAT THAT BOUND DOES NOT COVER, stated because the first version of this
+section promised a flat ceiling it does not have. The two deadlines cover
+the READ and the DISPOSAL, and nothing else. Process STARTUP is outside
+them: ``Popen.__init__`` forks and then blocks in ``_execute_child`` on
+``os.read(errpipe_read, 50000)`` until the child either execs or reports
+why it could not, and that read takes no timeout. A fork that never gets
+that far stalls there. This is not new and is not something this module
+can fix from the outside - ``subprocess.run`` builds its ``Popen`` through
+the identical path, so the residual is exactly what it was before #309.
+What changed is the part that WAS in this module's hands: once the child
+is running, no wait on it is unbounded any more.
 
 WHAT THAT COSTS, since a bound bought with nothing would be suspicious. A
 child the kill did NOT reach is ABANDONED rather than waited on: we close
@@ -101,8 +113,12 @@ see". It is not a permanent zombie. ``Popen.__del__`` hands an unreaped
 child to CPython's ``subprocess._active``, which the next ``Popen``
 constructed anywhere in the process polls, so it is collected once the
 kernel lets it die. The caller's fallback for "cannot see" is the signal
-probe, whose only error is over-reporting alive, so a bounded degraded
-answer is strictly better here than an unbounded exact one.
+probe, whose only error is over-reporting alive. That claim was written
+here before it was true: #309 round 1 found the probe reporting GONE for
+any error it could not explain, which is the dangerous direction this
+docstring opens with. This change is what made it routine rather than
+exotic, so ``signal_probe_alive`` was fixed with it and now reports alive
+for everything but ESRCH.
 
 THE COST IS PER READ, NOT PER RUN, and ``serve`` reads more than once.
 ``_wait_out_grace`` waits out the direct child and then re-reads the
@@ -260,9 +276,21 @@ def _kill_or_abandon(process: subprocess.Popen[str]) -> None:
     except (OSError, ValueError, subprocess.TimeoutExpired):
         # One handler for both calls, because a kill that could not be
         # sent leads to the same place as one that did not work: the
-        # child is not ours to collect, so let go of the pipes instead.
-        # Closing a pipe READ end cannot block, which is what makes this
-        # safe on a path whose whole contract is not to block.
+        # child is not ours to collect. SWALLOWED rather than raised,
+        # because the caller is already carrying the original failure and
+        # is about to re-raise it; letting a grace timeout out of here
+        # would displace the exception that says what actually went
+        # wrong. The pipes are released either way, below.
+        pass
+    finally:
+        # In a FINALLY rather than in the handler above, because the
+        # exceptions this names are not the only ones that get here. A
+        # KeyboardInterrupt landing in the grace escapes both calls with
+        # the pipe pair still held, which is the leak this whole path
+        # exists to avoid (#309 round 1, F3). Closing a pipe READ end
+        # cannot block, which is what makes this safe on a path whose
+        # contract is not to block, and a second close is a no-op, so the
+        # branch where ``communicate`` already closed them costs nothing.
         for pipe in (process.stdout, process.stderr):
             if pipe is not None:
                 with suppress(OSError):
@@ -355,7 +383,7 @@ def _kernel_says_group_is_empty(pgid: int) -> bool:
 def signal_probe_alive(pgid: int) -> bool:
     """Whether a signal to ``pgid`` would find a target. Zombies COUNT.
 
-    The pre-#298 reading, kept because it is the only thing left when
+    The signal reading, kept because it is the only thing left when
     ``ps`` gives no answer at all, and because a test needs it as the
     control that proves a zombie window was real rather than a group that
     quietly went away. ``PermissionError`` means something is there
@@ -365,17 +393,33 @@ def signal_probe_alive(pgid: int) -> bool:
     A pgid this module must not signal reads as ALIVE, which is the
     conservative direction: the caller then declines to call a run reaped.
 
+    ONLY ESRCH MEANS GONE (#309 round 1, F1), and that is why this is one
+    line rather than its own branch table. It used to have one, and its
+    generic ``OSError`` branch returned False - an error nobody could
+    explain read as "nothing is there", which ``serve`` turns into
+    "reaped" (the #186 F1 hazard the module docstring opens with). That
+    was the pre-#298 mapping carried forward, survivable only while this
+    function was nearly unreachable. #309 made "ps cannot see" a routine
+    outcome and this the routine fallback, so the fail-open moved onto the
+    normal path and had to go.
+
+    What replaced it is not a matching branch table but the SAME one.
+    ``_kernel_says_group_is_empty`` has always read ESRCH as the one
+    conclusive answer and every other ``OSError`` as "the question was not
+    answered", so once this function agrees with it on every branch,
+    writing the branches out twice is how they drift apart again. Two
+    readings of one ``killpg`` disagreeing about an unexplained error was
+    the defect underneath the defect; delegating is the only version of
+    the fix that cannot come undone.
+
+    This does NOT recreate the "every timed-out run is poisoned" hazard
+    ``serve._group_liveness_for_reap`` warns about. That one is about a
+    machine with no ``ps``, where this probe still answers ESRCH or EPERM
+    correctly and runs stay reapable. Only signal 0 failing for a reason
+    POSIX does not define reaches the changed branch, and refusing to
+    conclude from it is the whole point.
+
     Prefer ``read_group_liveness``. This answers the question #298 was
     about getting wrong.
     """
-    if not _may_signal_group(pgid):
-        return True
-    try:
-        os.killpg(pgid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    except OSError:
-        return False
-    return True
+    return not _kernel_says_group_is_empty(pgid)

--- a/kstrl/procgroup.py
+++ b/kstrl/procgroup.py
@@ -109,10 +109,42 @@ is running, no wait on it is unbounded any more.
 WHAT THAT COSTS, since a bound bought with nothing would be suspicious. A
 child the kill did NOT reach is ABANDONED rather than waited on: we close
 our two pipe ends, which cannot block on a read end, and report "cannot
-see". It is not a permanent zombie. ``Popen.__del__`` hands an unreaped
-child to CPython's ``subprocess._active``, which the next ``Popen``
-constructed anywhere in the process polls, so it is collected once the
-kernel lets it die. The caller's fallback for "cannot see" is the signal
+see".
+
+It is not a permanent zombie, and #309 round 2 is why that sentence now
+rests on code in this module rather than on CPython's. The claim used to
+be that ``Popen.__del__`` hands an unreaped child to
+``subprocess._active`` for a later ``Popen`` to poll. Read the order it
+does it in: it calls ``_warn(..., ResourceWarning)`` FIRST and appends to
+``_active`` after. Under warnings-as-errors that warn RAISES, ``__del__``
+aborts, the interpreter prints "Exception ignored in" and swallows it,
+and the registration never happens - so the object is freed with nobody
+left holding the pid, and the child stays a zombie for the life of the
+process. Measured on this tree: default warnings gives ``_active`` length
+1 and the child reaped; ``PYTHONWARNINGS=error`` gives length 0 and the
+child in state Z. That setting is not hypothetical here, and this file's
+own caller says so - ``serve._group_liveness_for_reap`` records that an
+earlier ``warnings.warn`` in the reap check took the daemon down under
+it, calling it "a common CI setting". A daemon that holds its lock for
+its whole life, abandoning up to five children per terminated run, is the
+worst place in the tree to rest on a ``__del__`` that may not finish.
+
+So ``_kill_or_abandon`` registers the child itself, on our own
+``_ABANDONED`` and on CPython's ``_active`` both; ``_register_abandoned``
+says why one of them is not enough. Holding the reference also means
+``__del__`` never runs, so the ResourceWarning that started this is not
+raised at all.
+
+THIS FIXES ONE SITE, NOT THE CLASS. ``verify.run_scrubbed``,
+``serve._wait_out_grace`` and ``agents.proc.DeadlineStreamer.kill`` each
+kill a child and give up on it the same way, and none of them registers
+what it drops. ``run_scrubbed`` is the wider window of the three by a
+long way - it needs no D-state child at all, only something outside the
+group holding the pipe write end, and it runs once per verification
+command rather than once per timed-out run. Tracked separately; said
+here so this section is not read as the class being handled.
+
+The caller's fallback for "cannot see" is the signal
 probe, whose only error is over-reporting alive. That claim was written
 here before it was true: #309 round 1 found the probe reporting GONE for
 any error it could not explain, which is the dangerous direction this
@@ -164,8 +196,18 @@ PS_TIMEOUT_SECONDS = 5.0
 #: child killed mid-run. 1.0s is ~890x the worse of the two. Raising it
 #: cannot rescue a D-state child, which is the only case that reaches
 #: the end of it; it would only lengthen the hang this bound exists to
-#: stop. The worst case for the whole read is the sum of the two: 6.0s.
+#: stop. The two together bound every WAIT on the child at 6.0s, which is
+#: not the same as bounding the call; see the docstring on ``_read_ps``.
 PS_KILL_GRACE_SECONDS = 1.0
+
+#: Children the kill did not reach, kept REFERENCED so they can still be
+#: reaped. The module docstring's #309 round 2 section is why this exists
+#: rather than ``Popen.__del__``. On a healthy machine it stays empty.
+#: Each entry can retain more than the object: measured at 18,833 bytes
+#: for a read that completed before the child was abandoned, almost all
+#: of it CPython's ``_fileobj2output`` holding the listing it had already
+#: buffered, against ~300 bytes for one abandoned before writing.
+_ABANDONED: list[subprocess.Popen[str]] = []
 
 #: Said once, because several branches report it and reflowed copies of
 #: one sentence are how the two answers drift apart.
@@ -224,8 +266,15 @@ def read_group_liveness(pgid: int) -> GroupLiveness:
 
 
 def _read_ps() -> subprocess.CompletedProcess[str]:
-    """One ``ps`` read that returns within ``PS_TIMEOUT_SECONDS`` plus
-    ``PS_KILL_GRACE_SECONDS``, whatever the child does.
+    """One ``ps`` read, with every wait on the child bounded.
+
+    ``PS_TIMEOUT_SECONDS`` for the read and ``PS_KILL_GRACE_SECONDS`` for
+    the disposal. NOT a flat ceiling on the call: process startup is
+    outside both, because ``Popen.__init__`` blocks on an ``os.read`` of
+    the exec error pipe that takes no timeout. Measured with a 3.0s stall
+    injected there and both constants at 0.05: 3.011s. The module
+    docstring's "WHAT THAT BOUND DOES NOT COVER" section has the rest,
+    including why that residual is not new.
 
     Why this is not ``subprocess.run``, and why no ``with`` block, is the
     #309 section of the module docstring: both of those wait on the child
@@ -236,6 +285,7 @@ def _read_ps() -> subprocess.CompletedProcess[str]:
     the rejected "our own pgid is listed" control satisfied by
     construction rather than merely usually true.
     """
+    _reap_abandoned()
     process = subprocess.Popen(
         PS_ARGV,
         stdout=subprocess.PIPE,
@@ -265,10 +315,19 @@ def _kill_or_abandon(process: subprocess.Popen[str]) -> None:
     """Kill the child, give the kill a bounded grace, then LET GO.
 
     The second ``communicate`` is the wait ``subprocess.run`` does
-    without a deadline. Reaching ITS timeout means the kill did not land,
-    which on POSIX means an uninterruptible sleep, which no further
-    waiting can shorten - so this returns instead, and the module
-    docstring records what that abandoned child costs.
+    without a deadline.
+
+    WHAT REACHING ITS TIMEOUT ACTUALLY MEANS, corrected in #309 round 2
+    because the first version stated a stronger thing as a POSIX fact.
+    ``communicate`` waits for EOF on both pipes and then for the process,
+    so the grace can expire with the direct child already dead and
+    reaped: anything that inherited the write ends still holds them open.
+    Demonstrated with a ``ps`` that forks - ``poll()`` returned 0 at kill
+    time and the full grace expired anyway, because a grandchild held the
+    pipes. It does not arise for ``PS_ARGV``, which forks nothing, but it
+    is why this says "let go" rather than "the kill did not land": what
+    is abandoned may be a descendant we never had a handle on, and no
+    amount of further waiting here is owed to it.
     """
     try:
         process.kill()
@@ -287,14 +346,81 @@ def _kill_or_abandon(process: subprocess.Popen[str]) -> None:
         # exceptions this names are not the only ones that get here. A
         # KeyboardInterrupt landing in the grace escapes both calls with
         # the pipe pair still held, which is the leak this whole path
-        # exists to avoid (#309 round 1, F3). Closing a pipe READ end
-        # cannot block, which is what makes this safe on a path whose
-        # contract is not to block, and a second close is a no-op, so the
-        # branch where ``communicate`` already closed them costs nothing.
-        for pipe in (process.stdout, process.stderr):
-            if pipe is not None:
-                with suppress(OSError):
-                    pipe.close()
+        # exists to avoid (#309 round 1, F3).
+        _release_pipes(process)
+        if process.returncode is None:
+            _register_abandoned(process)
+
+
+def _release_pipes(process: subprocess.Popen[str]) -> None:
+    """Close our ends of the pipes to a child we are done with.
+
+    Closing a pipe READ end cannot block, which is what makes this safe
+    on a path whose contract is not to block. A second close is a no-op,
+    so the branch where ``communicate`` already closed them costs
+    nothing.
+    """
+    for pipe in (process.stdout, process.stderr):
+        if pipe is not None:
+            with suppress(OSError):
+                pipe.close()
+
+
+def _register_abandoned(process: subprocess.Popen[str]) -> None:
+    """Keep an uncollected child reachable until something can reap it.
+
+    TWO registers, because they sweep at different rates and neither
+    rate alone is good enough (#309 round 2).
+
+    ``_ABANDONED`` is ours and is swept by the next read here. That is
+    the one this module can promise, and the one a test can see.
+
+    ``subprocess._active`` is CPython's, and every ``Popen`` constructed
+    anywhere in the process sweeps it in ``_cleanup``. This module's
+    reads are rare by design - the production caller asks once per
+    timed-out run - so ours alone would leave a corpse until the next
+    timeout, which may be days away. There are 70 spawn sites in
+    ``kstrl``, so ``_active`` collects it at the next git call or verify
+    command instead. That is what ``Popen.__del__`` would have done; we
+    do it up front precisely because ``__del__`` may not get there.
+    Guarded with ``getattr`` because it is CPython-private and is None on
+    Windows, which this module does not support anyway.
+
+    Registering also means ``__del__`` never runs, so the ResourceWarning
+    that made ``__del__`` unreliable is not raised at all.
+
+    ONLY SOMETHING ``_cleanup`` CAN POLL may go on ``_active``, which is
+    what the ``_internal_poll`` check is. ``_cleanup`` calls that method
+    on every entry, so anything else corrupts interpreter state for the
+    whole process: measured, a test double in there crashed the next real
+    spawn anywhere in the suite with ``AttributeError: '_FakePs' object
+    has no attribute '_internal_poll'``. That is a constraint of the
+    private list, not an accommodation for tests, and in production the
+    branch is always taken. Checked by attribute rather than by
+    ``isinstance``, because the name ``subprocess.Popen`` is itself
+    replaceable - the suite's own seam replaces it with a function, and
+    an ``isinstance`` against it then raises ``TypeError``.
+    """
+    _ABANDONED.append(process)
+    active = getattr(subprocess, "_active", None)
+    if active is not None and hasattr(process, "_internal_poll"):
+        active.append(process)
+
+
+def _reap_abandoned() -> None:
+    """Collect any abandoned child the kernel has since let die.
+
+    ``poll`` is ``waitpid(WNOHANG)``, so this cannot block - the only
+    reason it is safe to call on the path whose whole contract is not to
+    block. Swept before each fork because that is the moment the cost is
+    about to be paid again.
+
+    Rebuilt rather than removed from. ``list.remove`` is what CPython's
+    ``_cleanup`` does, and it has to guard the ``ValueError`` for an
+    entry another thread already dropped; a rebuild cannot raise that at
+    all, and walks the list once instead of once per corpse.
+    """
+    _ABANDONED[:] = [process for process in _ABANDONED if process.poll() is None]
 
 
 @dataclass(frozen=True)

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -1616,7 +1616,10 @@ def _group_liveness_for_reap(pgid: int) -> tuple[bool, str]:
     reasoning and the measurements are in ``kstrl.procgroup``).
 
     FAIL DIRECTION when ``ps`` cannot be trusted: fall back to the signal
-    probe, which is the pre-#298 behaviour. That is a deliberate choice
+    probe. That is nearly the pre-#298 behaviour: #309 round 1 fixed the
+    one branch of it that reported an unexplained error as GONE, so the
+    claim below about its error direction is now true rather than
+    aspirational. That is a deliberate choice
     between three options and not a default. Raising would take the
     daemon down over a diagnostic. Reporting "alive" unconditionally is
     the conservative direction for the one caller, but on a machine with

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -438,6 +438,31 @@ def with_observed_diffstat(raw_output: str, repo: ReviewRepo) -> str:
     return json.dumps(payload)
 
 
+@pytest.fixture(autouse=True)
+def isolate_abandoned_children() -> Generator[None, None, None]:
+    """A fresh ``procgroup._ABANDONED`` per test.
+
+    #309 round 2 added a module-level register of children a kill did not
+    reach, so that something can still reap them. Module-level means it
+    outlives any one test: a double left on it is swept by the next
+    test's read, and a test asserting the register is empty fails because
+    of what some earlier test abandoned. Both are the cross-test
+    contamination this conftest exists to prevent, so the reset lives
+    here once rather than in each of the three places that wanted it.
+
+    Only ours is reset. CPython's ``subprocess._active`` is process-wide
+    interpreter state that every ``Popen`` sweeps, and it drains itself.
+    """
+    from kstrl import procgroup
+
+    saved = procgroup._ABANDONED[:]
+    procgroup._ABANDONED.clear()
+    try:
+        yield
+    finally:
+        procgroup._ABANDONED[:] = saved
+
+
 @pytest.fixture
 def review_repo(tmp_path: Path) -> ReviewRepo:
     """The default one-file change, for tests that only need a repo."""

--- a/tests/helpers/procs.py
+++ b/tests/helpers/procs.py
@@ -33,7 +33,9 @@ import signal
 import subprocess
 import time
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import NoReturn
 
 import pytest
 
@@ -96,6 +98,27 @@ def group_has_live_member(pgid: int) -> bool:
     return liveness.live
 
 
+@dataclass
+class PsCall:
+    """One intercepted ``ps`` spawn, and everything a test asserts on it."""
+
+    #: What the ``Popen`` CONSTRUCTOR received. The deadlines are not here,
+    #: because ``Popen`` does not take one.
+    argv: list[str]
+    kwargs: dict[str, object]
+    #: One entry per ``communicate``, which IS where the bound lives.
+    timeouts: list[float | None] = field(default_factory=list)
+    #: How a test sees the abandoned-child path: the child was signalled,
+    #: and its pipe pair was released rather than left to the collector.
+    kills: int = 0
+    closed: list[str] = field(default_factory=list)
+
+
+#: What one ``communicate`` does with its deadline: answer with
+#: ``(returncode, stdout, stderr)``, or raise.
+Respond = Callable[[float | None], tuple[int, str, str]]
+
+
 def fake_ps(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -103,48 +126,171 @@ def fake_ps(
     stdout: str = "",
     stderr: str = "",
     raises: Callable[[], BaseException] | None = None,
-) -> list[dict[str, object]]:
+) -> list[PsCall]:
     """Answer ``kstrl.procgroup``'s ``ps`` with this. Returns the call log.
-
-    DELEGATES every other command to the real ``subprocess.run``. That is
-    load-bearing, not politeness: ``procgroup.subprocess`` IS the stdlib
-    module, so ``setattr`` on it replaces ``run`` for the whole process,
-    not for ``procgroup``. Measured before this guard existed: under
-    ``fake_ps(stdout="1 Ss\n")`` a plain
-    ``subprocess.run(["git", "rev-parse", "HEAD"])`` returned
-    ``stdout='1 Ss\n'`` and ``args=['ps','-A','-o','pgid=,stat=']``. Any
-    test that combined this helper with a git or fixture subprocess call
-    would have measured nothing and passed, which is the #292 class this
-    module exists to prevent.
 
     ``raises`` is a FACTORY rather than an instance. A module-level
     exception object re-raised by every parametrized case accumulates a
     traceback frame and an ``__context__`` per raise, so it retains every
     test frame and its locals until interpreter exit.
 
-    The returned list records the args and kwargs each intercepted ``ps``
-    call received, so a test can assert on what was passed - the
-    ``timeout=`` in particular, which is the only bound stopping a wedged
-    ``ps`` from hanging the daemon and which no test could otherwise see.
+    WHERE ``raises`` FIRES depends on what it is, because the two real
+    failures do not happen in the same place. A missing binary raises out
+    of the SPAWN; a timeout or a decode error raises out of the READ. The
+    handling under test is ``read_group_liveness``'s disposal of the
+    child, and it only has a child to dispose of in the second case, so
+    faking a spawn failure at the read would exercise a path that cannot
+    occur. ``OSError`` marks the first case; everything else is the
+    second.
     """
-    real_run = subprocess.run
-    calls: list[dict[str, object]] = []
+
+    def respond_for() -> Respond:
+        if raises is None:
+            return lambda _timeout: (returncode, stdout, stderr)
+        probe = raises()
+        if isinstance(probe, OSError):
+            raise probe
+
+        def fail(_timeout: float | None) -> tuple[int, str, str]:
+            # A FRESH instance per raise, which is the docstring's rule
+            # applied one level down. The read path raises TWICE - once
+            # from the read, once from the grace the kill is given - and
+            # capturing one instance here instead of the factory made the
+            # closure, the fake and the traceback a reference cycle:
+            # measured over 200 reads with gc off, 27 objects retained
+            # per read against 0 with this line.
+            raise raises()
+
+        return fail
+
+    return _patch_ps_popen(monkeypatch, respond_for)
+
+
+def unkillable_ps(monkeypatch: pytest.MonkeyPatch) -> list[PsCall]:
+    """Answer ``ps`` with a child that never dies. Returns the call log.
+
+    #309's fixture. A process in an uninterruptible sleep cannot be
+    produced on demand in CI, so this fakes the only property that
+    matters: every ``communicate`` burns its whole deadline and then
+    raises ``TimeoutExpired``, and ``kill`` does nothing. The deadline is
+    honoured rather than skipped so the test measures a real clock.
+    """
+    return _patch_ps_popen(monkeypatch, lambda: _wedge)
+
+
+#: What a wedged fake sleeps when handed no deadline. Long enough that a
+#: test asserting on a bound fails rather than hangs the suite, since
+#: pytest has no per-test timeout here.
+UNBOUNDED_WAIT_SECONDS = 30.0
+
+
+def _wedge(timeout: float | None) -> NoReturn:
+    """Spend the whole deadline, then report the call as never finishing.
+
+    Both halves of the wedged fake go through here: the ``communicate``
+    that has a deadline to burn, and the ``wait`` that has none and so
+    sleeps far past any bound a test allows.
+    """
+    time.sleep(UNBOUNDED_WAIT_SECONDS if timeout is None else timeout)
+    raise subprocess.TimeoutExpired(cmd=list(procgroup.PS_ARGV), timeout=timeout or 0.0)
+
+
+@dataclass
+class _FakePipe:
+    """A pipe end that records only whether it was closed."""
+
+    call: PsCall
+    name: str
+
+    def close(self) -> None:
+        self.call.closed.append(self.name)
+
+
+class _FakePs:
+    """A ``ps`` child that never really ran."""
+
+    def __init__(self, call: PsCall, respond: Respond) -> None:
+        self._call = call
+        self._respond = respond
+        self.returncode: int | None = None
+        self.stdout = _FakePipe(call, "stdout")
+        self.stderr = _FakePipe(call, "stderr")
+
+    def communicate(
+        self,
+        input: str | None = None,
+        timeout: float | None = None,
+    ) -> tuple[str, str]:
+        self._call.timeouts.append(timeout)
+        self.returncode, out, err = self._respond(timeout)
+        return out, err
+
+    def kill(self) -> None:
+        self._call.kills += 1
+
+    def wait(self, timeout: float | None = None) -> int:
+        """The unbounded wait #309 exists to keep production out of.
+
+        Sleeping rather than raising is deliberate: an exception here
+        could be swallowed by a fail-closed ``except``, and the defect
+        being tested is a hang, so the fake reproduces a hang.
+        """
+        _wedge(timeout)
+
+    def __enter__(self) -> _FakePs:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        """Faithful to ``Popen.__exit__``, which is half of the #309 hang.
+
+        It closes the pipes and then calls ``self.wait()`` with no
+        deadline. Reproducing that is what makes the bound test a
+        REGRESSION test: reinstating ``subprocess.run``, or wrapping the
+        read in ``with Popen(...)``, then costs the same unbounded sleep
+        here that it would cost the daemon, and the test fails on the
+        clock rather than on a missing method. Verified by running the
+        bound test against a reverted ``read_group_liveness``.
+        """
+        self.stdout.close()
+        self.stderr.close()
+        self.wait()
+
+
+def _patch_ps_popen(
+    monkeypatch: pytest.MonkeyPatch,
+    respond_for: Callable[[], Respond],
+) -> list[PsCall]:
+    """Route ``PS_ARGV`` to a fake child, everything else to the real ``Popen``.
+
+    The delegation is load-bearing, not politeness: ``procgroup.subprocess``
+    IS the stdlib module, so ``setattr`` on it replaces ``Popen`` for the
+    whole process, not for ``procgroup`` - and ``subprocess.run`` is built
+    on ``Popen``, so an undelegated fake would answer every ``run`` in the
+    suite too. Measured before this guard existed, when the seam was on
+    ``run``: under ``fake_ps(stdout="1 Ss\n")`` a plain
+    ``subprocess.run(["git", "rev-parse", "HEAD"])`` returned
+    ``stdout='1 Ss\n'`` and ``args=['ps','-A','-o','pgid=,stat=']``. A test
+    that combined the helper with a git or fixture subprocess call would
+    have measured nothing and passed, which is the #292 class this module
+    exists to prevent.
+
+    The seam is ``Popen`` rather than ``run`` because #309 moved the read
+    off ``run``; the module docstring of ``kstrl.procgroup`` says why.
+    """
+    real_popen = subprocess.Popen
+    calls: list[PsCall] = []
 
     def fake(*args: object, **kwargs: object) -> object:
         argv = list(args[0]) if args and isinstance(args[0], (list, tuple)) else []
         if argv != list(procgroup.PS_ARGV):
-            return real_run(*args, **kwargs)  # type: ignore[arg-type]
-        calls.append({"argv": argv, "kwargs": dict(kwargs)})
-        if raises is not None:
-            raise raises()
-        return subprocess.CompletedProcess(
-            args=argv,
-            returncode=returncode,
-            stdout=stdout,
-            stderr=stderr,
-        )
+            return real_popen(*args, **kwargs)  # type: ignore[arg-type]
+        call = PsCall(argv=argv, kwargs=dict(kwargs))
+        calls.append(call)
+        # Appended BEFORE the responder is built, so a fake that fails at
+        # the spawn is still a call the test can see.
+        return _FakePs(call, respond_for())
 
-    monkeypatch.setattr(procgroup.subprocess, "run", fake)
+    monkeypatch.setattr(procgroup.subprocess, "Popen", fake)
     return calls
 
 

--- a/tests/helpers/procs.py
+++ b/tests/helpers/procs.py
@@ -228,6 +228,15 @@ class _FakePs:
     def kill(self) -> None:
         self._call.kills += 1
 
+    def poll(self) -> int | None:
+        """Non-blocking status, which is how ``_reap_abandoned`` sweeps.
+
+        A fake that was abandoned reports None forever, so it stays on
+        the register for the life of the test - which is what lets a test
+        assert it got there at all.
+        """
+        return self.returncode
+
     def wait(self, timeout: float | None = None) -> int:
         """The unbounded wait #309 exists to keep production out of.
 

--- a/tests/test_procgroup.py
+++ b/tests/test_procgroup.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import ast
 import os
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -100,9 +101,10 @@ class TestAGoneIsOnlyReportedWhenItIsEvidence:
     """The safety argument, and the two controls that could not carry it.
 
     The first asked whether the caller's own group appeared in the
-    listing. Measured: `subprocess.run` does not setpgid, so the `ps`
-    child runs in the caller's group and `ps -A` always lists it. It was
-    satisfied by construction.
+    listing. Measured: the read does not setpgid, so the `ps` child runs
+    in the caller's group and `ps -A` always lists it. It was satisfied
+    by construction, and `_read_ps` keeps it that way by declining
+    `start_new_session`.
 
     The second was "every listed row for this group is a zombie, so the
     listing can see this group". Seeing SOME of a group is not seeing all
@@ -289,15 +291,18 @@ class TestTheTriStateWhenPsGivesNoAnswer:
 
 
 class TestThePsCallIsBounded:
-    """The timeout is the only thing stopping a wedged ps hanging the daemon.
+    """The bound is the only thing stopping a wedged ps hanging the daemon.
 
     Deleting ``timeout=PS_TIMEOUT_SECONDS`` from ``read_group_liveness``
     left the whole suite green before this class existed: the wedged-ps
     case raises a pre-built TimeoutExpired from the fake whether or not
-    the kwarg was ever passed, so it could not detect the loss. A ps
-    stalled on a D-state read (NFS, a hung container runtime) would then
-    block ``subprocess.run`` forever inside the daemon's reap path while
-    PS_TIMEOUT_SECONDS still read as a tested constant.
+    the kwarg was ever passed, so it could not detect the loss.
+
+    Then #309 showed that pinning the kwarg does not establish that the
+    kwarg BOUNDS anything: it was passed, and a ``ps`` that could not be
+    killed hung the call anyway, for the reasons the ``kstrl.procgroup``
+    module docstring sets out. So the class now measures the clock as
+    well as the kwargs, against a child that refuses to die.
     """
 
     def test_the_read_passes_its_timeout(
@@ -307,7 +312,64 @@ class TestThePsCallIsBounded:
         calls = procs.fake_ps(monkeypatch, stdout="50 4242 Ss\n")
         read_group_liveness(4242)
         assert calls, "the fake must have intercepted the ps call"
-        assert calls[0]["kwargs"]["timeout"] == PS_TIMEOUT_SECONDS
+        assert calls[0].timeouts == [PS_TIMEOUT_SECONDS]
+
+    def test_an_unkillable_ps_returns_within_the_bound(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The #309 case, measured on a clock rather than asserted.
+
+        Both constants are shrunk so the test costs its own bound rather
+        than six seconds; the fake burns whatever deadline it is handed,
+        so the reading is real at either size. The margin is 10x the
+        configured bound, which is loose enough for a loaded CI runner and
+        still 60x tighter than the counterfactual below.
+
+        MEASURED against the pre-#309 body restored under this same fake:
+        the read took 60.06s and this assertion failed with exactly this
+        message (two runs, 60.065s and 60.060s). That is the two unbounded
+        waits, 30s each - the one ``subprocess.run``'s timeout handler
+        does after ``kill()``, and the one ``Popen.__exit__`` does after
+        it. Both are gone; that is what the clock here is measuring.
+        """
+        monkeypatch.setattr("kstrl.procgroup.PS_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr("kstrl.procgroup.PS_KILL_GRACE_SECONDS", 0.05)
+        calls = procs.unkillable_ps(monkeypatch)
+
+        started = time.monotonic()
+        liveness = read_group_liveness(4242)
+        elapsed = time.monotonic() - started
+
+        # A real ps answers in ~11ms, so without this the assertion below
+        # would pass just as well on a fake that never intercepted.
+        assert len(calls) == 1, "the wedged fake must have answered the read"
+        assert elapsed < 1.0, f"the read took {elapsed:.3f}s, so nothing bounded it"
+        assert liveness.live is None, "an unmeasurable group must not read as gone"
+        assert "failed to run" in liveness.reason
+
+    def test_an_unkillable_ps_is_killed_and_let_go_of(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The bound above is only honest if the child was dealt with.
+
+        Two deadlines are spent, not one: the read, then the grace the
+        kill is given. The pipe pair is released rather than left to the
+        garbage collector, which is the leak half of #309; the child
+        itself is abandoned, and CPython's ``subprocess._active`` collects
+        it once the kernel lets it die.
+        """
+        monkeypatch.setattr("kstrl.procgroup.PS_TIMEOUT_SECONDS", 0.01)
+        monkeypatch.setattr("kstrl.procgroup.PS_KILL_GRACE_SECONDS", 0.02)
+        calls = procs.unkillable_ps(monkeypatch)
+
+        read_group_liveness(4242)
+
+        assert len(calls) == 1, "one read, not a retry loop"
+        assert calls[0].timeouts == [0.01, 0.02]
+        assert calls[0].kills == 1, "the child must be killed, not waited on"
+        assert calls[0].closed == ["stdout", "stderr"]
 
     def test_the_read_pins_its_encoding(
         self,
@@ -317,8 +379,8 @@ class TestThePsCallIsBounded:
         ValueError out of a function whose contract is not to raise."""
         calls = procs.fake_ps(monkeypatch, stdout="50 4242 Ss\n")
         read_group_liveness(4242)
-        assert calls[0]["kwargs"]["encoding"] == "utf-8"
-        assert calls[0]["kwargs"]["errors"] == "replace"
+        assert calls[0].kwargs["encoding"] == "utf-8"
+        assert calls[0].kwargs["errors"] == "replace"
 
 
 class TestTheFakeDoesNotAnswerForEveryCommand:

--- a/tests/test_procgroup.py
+++ b/tests/test_procgroup.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import pytest
 
+from kstrl import procgroup
 from kstrl.procgroup import (
     PS_ARGV,
     PS_KILL_GRACE_SECONDS,
@@ -357,9 +358,10 @@ class TestThePsCallIsBounded:
 
         Two deadlines are spent, not one: the read, then the grace the
         kill is given. The pipe pair is released rather than left to the
-        garbage collector, which is the leak half of #309; the child
-        itself is abandoned, and CPython's ``subprocess._active`` collects
-        it once the kernel lets it die.
+        garbage collector, which is the leak half of #309. What happens
+        to the child itself is `_register_abandoned`'s job and is tested
+        below; this used to claim `subprocess._active` collects it, which
+        round 2 measured false under warnings-as-errors.
         """
         monkeypatch.setattr("kstrl.procgroup.PS_TIMEOUT_SECONDS", 0.01)
         monkeypatch.setattr("kstrl.procgroup.PS_KILL_GRACE_SECONDS", 0.02)
@@ -388,13 +390,9 @@ class TestThePsCallIsBounded:
 
         The interrupt itself must still propagate: the caller asked to
         stop, and swallowing that would be a worse bug than the leak.
-        What must not happen is the leak on the way out.
-
         ``raises`` is the CLASS, so each raise is a fresh instance and the
-        interrupt arrives twice: once out of the read, and then again out
-        of the grace, which is the call that matters here. The two
-        deadlines in the log are the proof that it reached the disposal
-        rather than stopping at the read.
+        interrupt arrives twice; the two deadlines in the log are the
+        proof it reached the disposal rather than stopping at the read.
         """
         calls = procs.fake_ps(monkeypatch, raises=KeyboardInterrupt)
 
@@ -406,6 +404,73 @@ class TestThePsCallIsBounded:
         )
         assert calls[0].kills == 1, "the child is still killed before we let go"
         assert calls[0].closed == ["stdout", "stderr"]
+
+    def test_a_collected_child_is_not_registered(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The control. Without it the register could be growing on every
+        read, which is a leak wearing the costume of a fix."""
+        procs.fake_ps(monkeypatch, stdout="50 4242 Ss\n")
+        read_group_liveness(4242)
+        assert procgroup._ABANDONED == []
+
+    def test_the_register_drains_once_the_child_dies(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The register is only not-a-leak if something empties it.
+
+        A REAL child, because the sweep is ``poll()`` and a fake's poll is
+        whatever the fake says. This one is abandoned while alive, so it
+        lands on the register, and is then reaped by the next read.
+
+        Both halves of C1 are here: that an uncollected child is kept at
+        all, and that keeping it is not itself a leak. Why
+        ``Popen.__del__`` could not be trusted to do the keeping, with the
+        measurement, is in the ``kstrl.procgroup`` module docstring.
+        """
+        monkeypatch.setattr("kstrl.procgroup.PS_ARGV", ("sleep", "30"))
+        monkeypatch.setattr("kstrl.procgroup.PS_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr("kstrl.procgroup.PS_KILL_GRACE_SECONDS", 0.05)
+        # Nothing may be killed, so the child is genuinely abandoned alive.
+        monkeypatch.setattr("kstrl.procgroup.subprocess.Popen.kill", lambda self: None)
+        read_group_liveness(4242)
+        registered = list(procgroup._ABANDONED)
+        assert len(registered) == 1
+
+        child = registered[0]
+        child.terminate()
+        child.wait(timeout=10)
+        # The next read sweeps it, which is the whole contract.
+        monkeypatch.setattr("kstrl.procgroup.PS_ARGV", ("true",))
+        read_group_liveness(4242)
+        assert procgroup._ABANDONED == [], "a dead child must leave the register"
+
+    def test_a_real_child_is_disposed_of_without_leaking_a_descriptor(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The killable-but-slow case, against a REAL child.
+
+        Nothing else in the suite exercises the disposal against a real
+        ``Popen``: ``_FakePs`` stubs ``kill`` and ``communicate``, and its
+        ``close`` only appends to a list, so an fd leak or an unreaped
+        child would be invisible.
+        """
+        fd_dir = Path("/dev/fd")
+        if not fd_dir.is_dir():
+            pytest.skip("no /dev/fd on this platform")
+        monkeypatch.setattr("kstrl.procgroup.PS_ARGV", ("sleep", "30"))
+        monkeypatch.setattr("kstrl.procgroup.PS_TIMEOUT_SECONDS", 0.05)
+
+        before = len(os.listdir(fd_dir))
+        liveness = read_group_liveness(4242)
+        after = len(os.listdir(fd_dir))
+
+        assert liveness.live is None, "an unread group must not report as gone"
+        assert after == before, f"descriptors leaked: {before} -> {after}"
+        assert procgroup._ABANDONED == [], "a killable child must be reaped, not kept"
 
     def test_the_read_pins_its_encoding(
         self,
@@ -420,15 +485,22 @@ class TestThePsCallIsBounded:
 
 
 class TestTheFakeDoesNotAnswerForEveryCommand:
-    """`fake_ps` replaces the STDLIB `subprocess.run`, not procgroup's.
+    """`fake_ps` replaces the STDLIB `subprocess.Popen`, not procgroup's.
 
     `procgroup.subprocess` is the stdlib module object, so a setattr on
-    it is process-wide. Measured before the delegation guard existed: a
-    plain `subprocess.run(["git", "rev-parse", "HEAD"])` under
+    it is process-wide. Measured before the delegation guard existed,
+    when the seam was still on `run`: a plain
+    `subprocess.run(["git", "rev-parse", "HEAD"])` under
     `fake_ps(stdout="1 Ss\\n")` returned that stdout and
     `args=['ps','-A','-o','pgid=,stat=']`. A test that combined the
     helper with any other subprocess call would have measured nothing and
     passed, which is the #292 class the helper exists to prevent.
+
+    #309 moved the seam from `run` to `Popen`, which makes the guard
+    carry MORE: `subprocess.run` is itself built on `Popen`, so an
+    undelegated fake would now answer every `run` in the suite as well.
+    The test below calling `subprocess.run` is the proof it still does
+    not.
     """
 
     def test_another_command_reaches_the_real_subprocess(

--- a/tests/test_procgroup.py
+++ b/tests/test_procgroup.py
@@ -24,6 +24,7 @@ import pytest
 
 from kstrl.procgroup import (
     PS_ARGV,
+    PS_KILL_GRACE_SECONDS,
     PS_TIMEOUT_SECONDS,
     GroupLiveness,
     _kernel_says_group_is_empty,
@@ -371,6 +372,41 @@ class TestThePsCallIsBounded:
         assert calls[0].kills == 1, "the child must be killed, not waited on"
         assert calls[0].closed == ["stdout", "stderr"]
 
+    def test_an_interrupted_disposal_still_releases_the_pipes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """#309 round 1, F3.
+
+        The pipe close used to sit in the handler for
+        ``(OSError, ValueError, TimeoutExpired)``. A ``KeyboardInterrupt``
+        is none of those, so an operator stopping the daemon while it was
+        disposing of a wedged ``ps`` escaped with both fds still held -
+        the exact leak the disposal path exists to prevent, reached
+        through the one door it did not watch. The release is in a
+        ``finally`` now.
+
+        The interrupt itself must still propagate: the caller asked to
+        stop, and swallowing that would be a worse bug than the leak.
+        What must not happen is the leak on the way out.
+
+        ``raises`` is the CLASS, so each raise is a fresh instance and the
+        interrupt arrives twice: once out of the read, and then again out
+        of the grace, which is the call that matters here. The two
+        deadlines in the log are the proof that it reached the disposal
+        rather than stopping at the read.
+        """
+        calls = procs.fake_ps(monkeypatch, raises=KeyboardInterrupt)
+
+        with pytest.raises(KeyboardInterrupt):
+            read_group_liveness(4242)
+
+        assert calls[0].timeouts == [PS_TIMEOUT_SECONDS, PS_KILL_GRACE_SECONDS], (
+            "the interrupt must land in the disposal, not only in the read"
+        )
+        assert calls[0].kills == 1, "the child is still killed before we let go"
+        assert calls[0].closed == ["stdout", "stderr"]
+
     def test_the_read_pins_its_encoding(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -443,22 +479,52 @@ class TestTheSignalProbeIsKeptAsTheDegradedReading:
         monkeypatch.setattr("kstrl.procgroup.os.killpg", refuse)
         assert signal_probe_alive(4242) is True
 
-    def test_any_other_oserror_reads_as_gone(
+    @pytest.mark.parametrize(
+        "errno_and_text",
+        [
+            (22, "Invalid argument"),
+            # The errno #309 round 1 reproduced it with.
+            (5, "Input/output error"),
+        ],
+    )
+    def test_an_unexplained_error_reads_as_alive_not_gone(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        errno_and_text: tuple[int, str],
+    ) -> None:
+        """#309 round 1, F1, and the assertion that was inverted before it.
+
+        This used to assert False, pinning the pre-#298 mapping as
+        "endorsed by nobody but carried over unchanged". "Gone" is the
+        unsafe direction, for the reason the `kstrl.procgroup` module
+        docstring opens with. It survived while this function was nearly
+        unreachable; #309 made it the routine fallback for every read
+        `ps` cannot answer, so it had to be decided rather than deferred.
+
+        Flipping this assertion is the point of the test: it fails on the
+        other choice, which is what the old one could not do for the
+        choice it pinned.
+        """
+        number, text = errno_and_text
+
+        def broken(pgid: int, sig: int) -> None:
+            raise OSError(number, text)
+
+        monkeypatch.setattr("kstrl.procgroup.os.killpg", broken)
+        assert signal_probe_alive(4242) is True
+
+    def test_esrch_is_still_the_one_thing_that_means_gone(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Pinned rather than endorsed. This is the pre-#298 mapping,
-        carried over unchanged: "gone" is the UNSAFE direction here,
-        because `terminate_process_group` turns it into "reaped" and the
-        item is released for another attempt. #298 shrank its reach from
-        every call to only the calls where `ps` also gave no answer, and
-        changing the mapping is a separate decision with its own
-        reasoning."""
+        """The control for the test above. Without it, that one would
+        pass just as well on a function that had been made to return True
+        unconditionally, which measures nothing."""
 
-        def broken(pgid: int, sig: int) -> None:
-            raise OSError(22, "Invalid argument")
+        def absent(pgid: int, sig: int) -> None:
+            raise ProcessLookupError(3, "No such process")
 
-        monkeypatch.setattr("kstrl.procgroup.os.killpg", broken)
+        monkeypatch.setattr("kstrl.procgroup.os.killpg", absent)
         assert signal_probe_alive(4242) is False
 
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -2069,6 +2069,32 @@ class TestGroupLivenessDegradesRatherThanGuessing:
         procs.fake_ps(monkeypatch, returncode=127, stderr="boom")
         assert process_group_alive(pgid) is False
 
+    def test_a_blind_ps_and_an_unexplained_signal_error_is_not_reaped(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """#309 round 1, F1, at the level where it actually costs money.
+
+        Both readings fail at once: `ps` cannot be trusted, so the answer
+        falls back to the signal probe, and the probe's `killpg` fails
+        with an errno POSIX does not define for signal 0. Before F1 that
+        pair returned "nothing is running", which this function's own
+        docstring explains is the direction that releases the item. It
+        must report alive and carry a reason.
+
+        Written against a group that IS running - our own - so a False
+        here is the fail-open and never a true answer arrived at by luck.
+        """
+        procs.fake_ps(monkeypatch, returncode=127, stderr="ps: command not found")
+
+        def broken(pgid: int, sig: int) -> None:
+            raise OSError(5, "Input/output error")
+
+        monkeypatch.setattr("kstrl.procgroup.os.killpg", broken)
+        alive, degraded = _group_liveness_for_reap(os.getpgrp())
+        assert alive is True, "an unexplained error must never read as reaped"
+        assert degraded, "and the operator has to be told the answer was degraded"
+
     def test_the_degrade_reason_is_returned_not_warned(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_timeout_enforcement.py
+++ b/tests/test_timeout_enforcement.py
@@ -1126,25 +1126,54 @@ def _wait_calls(tree: ast.AST) -> list[tuple[ast.Call, str]]:
     ]
 
 
-def _popen_names(tree: ast.AST) -> set[str]:
-    """Every name in this module that means ``Popen``, aliases included.
+def _subprocess_aliases(tree: ast.AST) -> tuple[set[str], dict[str, str]]:
+    """Names bound to the subprocess module, and LOCAL name -> real name.
 
-    ``from subprocess import Popen as Spawn`` is a Popen, and a bare name
-    match does not know it - measured: without this the ``Spawn`` form
-    produced no finding at all, which is the under-reporting direction and
-    the one that matters. Same resolution ``_subprocess_aliases`` does for
-    the spawn functions in the audit below.
+    The mapping half is #309 round 2, C2. This used to return a SET of
+    local names and every caller then compared them against the ORIGINAL
+    names (``called == "Popen"``, ``called in SPAWN_FUNCS``), so an ``as``
+    rename walked straight through. Measured on a planted module:
+    ``from subprocess import run as _run`` followed by
+    ``_run(argv, capture_output=True)`` with no timeout at all passed
+    clean, as did the same trick for ``Popen``.
 
-    KNOWN over-report, deliberately left: any ``x.Popen(...)`` counts, so
-    a hypothetical ``mock.Popen()`` would be flagged. That direction costs
-    a comment on a line that is not really a child process; the other
-    direction costs a hang.
+    ONE resolver for both gates in this file. Round 2 also found the
+    ``with``-on-a-Popen gate carrying a second, weaker copy of this, with
+    a paragraph asserting the two agreed - which is the same shape as the
+    bug above: two readings held level by prose. They are one function
+    now, so the question cannot be asked again.
+
+    KNOWN MISSES, so the reach is not overstated. Only an ``import``
+    statement is resolved. ``_P = subprocess.Popen`` rebinds through an
+    assignment and ``getattr(subprocess, "Popen")`` through a string, and
+    following either needs dataflow this walk does not do.
     """
-    names = {"Popen"}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module == "subprocess":
-            names.update(a.asname or a.name for a in node.names if a.name == "Popen")
-    return names
+    imports = [n for n in ast.walk(tree) if isinstance(n, ast.Import)]
+    from_imports = [
+        n for n in ast.walk(tree) if isinstance(n, ast.ImportFrom) and n.module == "subprocess"
+    ]
+    module_aliases = {
+        alias.asname or alias.name
+        for node in imports
+        for alias in node.names
+        if alias.name == "subprocess"
+    }
+    direct_funcs = {
+        alias.asname or alias.name: alias.name for node in from_imports for alias in node.names
+    }
+    return module_aliases, direct_funcs
+
+
+def _popen_names(tree: ast.AST) -> set[str]:
+    """Every local name that means ``Popen``, derived not re-derived.
+
+    KNOWN over-report, deliberately left: ``_is_popen_call`` also accepts
+    any ``x.Popen(...)``, so a hypothetical ``mock.Popen()`` is flagged.
+    That direction costs a comment on a line that is not really a child
+    process; the other direction costs a hang.
+    """
+    _, direct = _subprocess_aliases(tree)
+    return {"Popen", *(local for local, real in direct.items() if real == "Popen")}
 
 
 def _is_popen_call(node: ast.expr, names: set[str]) -> bool:
@@ -1159,9 +1188,17 @@ def _is_popen_call(node: ast.expr, names: set[str]) -> bool:
 def _popen_bound_names(tree: ast.AST, names: set[str]) -> set[str]:
     """Names assigned a ``Popen(...)``, so ``with proc:`` is recognisable.
 
-    One level of resolution: the same depth ``tests/test_procgroup.py``
-    resolves argv constants at, and the same known miss - a Popen reached
-    through an attribute or out of a container is invisible here.
+    NAME COLLECTION, NOT SCOPE ANALYSIS, and the difference has teeth.
+    Every ``x = Popen(...)`` anywhere in the module contributes its name
+    to one flat set, so a ``with`` on a name bound in a different function
+    still matches, and a ``with`` on a PARAMETER matches only if the
+    parameter happens to share a name with some module-level binding.
+    Round 2 measured that: the planted mutation is caught today partly
+    because ``_kill_or_abandon``'s parameter is called ``process`` and so
+    is the binding in ``_read_ps``; renaming it to ``proc`` makes the
+    plant pass clean. A ``with`` on a Popen returned from a helper is
+    missed outright. Both want dataflow this walk does not do, and are
+    left for a follow-up rather than papered over here.
     """
     bound: set[str] = set()
     for node in ast.walk(tree):
@@ -1264,21 +1301,36 @@ class TestSubprocessTimeoutAudit:
         }
     )
 
-    @staticmethod
-    def _subprocess_aliases(tree: ast.Module) -> tuple[set[str], set[str]]:
-        """Names bound to the subprocess module / its spawn functions."""
-        module_aliases: set[str] = set()
-        direct_funcs: set[str] = set()
+    @classmethod
+    def _spawn_sites(cls, tree: ast.Module) -> list[tuple[ast.Call, str]]:
+        """``(call node, subprocess name)`` for every spawn call in the tree.
+
+        Split out of the test in #309 round 2 so it can be run over a
+        planted module. C2 was found by planting one by hand; a check
+        nobody can re-run is how the alias hole survived to be found by
+        hand in the first place.
+
+        ``called`` is always the name SUBPROCESS knows it by, never the
+        local alias, which is the C2 fix.
+        """
+        module_aliases, direct_funcs = _subprocess_aliases(tree)
+        sites: list[tuple[ast.Call, str]] = []
         for node in ast.walk(tree):
-            if isinstance(node, ast.Import):
-                for alias in node.names:
-                    if alias.name == "subprocess":
-                        module_aliases.add(alias.asname or alias.name)
-            elif isinstance(node, ast.ImportFrom):
-                if node.module == "subprocess":
-                    for alias in node.names:
-                        direct_funcs.add(alias.asname or alias.name)
-        return module_aliases, direct_funcs
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            called: str | None = None
+            if (
+                isinstance(fn, ast.Attribute)
+                and isinstance(fn.value, ast.Name)
+                and fn.value.id in module_aliases
+            ):
+                called = fn.attr
+            elif isinstance(fn, ast.Name) and fn.id in direct_funcs:
+                called = direct_funcs[fn.id]
+            if called == "Popen" or called in cls.SPAWN_FUNCS:
+                sites.append((node, called))
+        return sites
 
     def test_every_subprocess_call_has_timeout(self) -> None:
         package_root = Path(__file__).resolve().parent.parent / "kstrl"
@@ -1289,30 +1341,13 @@ class TestSubprocessTimeoutAudit:
         for py_file in sorted(package_root.rglob("*.py")):
             rel = py_file.relative_to(package_root.parent).as_posix()
             tree = ast.parse(py_file.read_text(encoding="utf-8"))
-            module_aliases, direct_funcs = self._subprocess_aliases(tree)
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.Call):
-                    continue
-                fn = node.func
-                called: str | None = None
-                if (
-                    isinstance(fn, ast.Attribute)
-                    and isinstance(fn.value, ast.Name)
-                    and fn.value.id in module_aliases
-                ):
-                    called = fn.attr
-                elif isinstance(fn, ast.Name) and fn.id in direct_funcs:
-                    called = fn.id
-                if called is None:
-                    continue
+            for node, called in self._spawn_sites(tree):
+                sites_seen += 1
                 if called == "Popen":
-                    sites_seen += 1
                     if rel not in self.POPEN_ALLOWLIST:
                         popen_violations.append(f"{rel}:{node.lineno}")
-                elif called in self.SPAWN_FUNCS:
-                    sites_seen += 1
-                    if not any(k.arg == "timeout" for k in node.keywords):
-                        violations.append(f"{rel}:{node.lineno} {called}")
+                elif not any(k.arg == "timeout" for k in node.keywords):
+                    violations.append(f"{rel}:{node.lineno} {called}")
 
         # If the walk ever finds nothing, the audit itself broke (import
         # style changed, package moved) - fail loudly, never vacuously.
@@ -1328,6 +1363,63 @@ class TestSubprocessTimeoutAudit:
             "Popen outside the deadline-managed allowlist (see class "
             "docstring):\n  " + "\n  ".join(popen_violations)
         )
+
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            # The plain forms, which always worked.
+            ("import subprocess\nsubprocess.run(argv)\n", [(2, "run")]),
+            ("import subprocess as sp\nsp.check_output(argv)\n", [(2, "check_output")]),
+            ("import subprocess\nsubprocess.Popen(argv)\n", [(2, "Popen")]),
+            # #309 round 2, C2. Every one of these passed the audit clean
+            # before the local-name mapping, including a brand new module
+            # calling run with no deadline at all.
+            ("from subprocess import run as _run\n_run(argv)\n", [(2, "run")]),
+            ("from subprocess import Popen as Spawn\nSpawn(argv)\n", [(2, "Popen")]),
+            (
+                "from subprocess import check_call as _cc\n_cc(argv)\n",
+                [(2, "check_call")],
+            ),
+            # The unrenamed from-import, which must keep working.
+            ("from subprocess import run\nrun(argv)\n", [(2, "run")]),
+        ],
+    )
+    def test_the_audit_resolves_a_renamed_import(
+        self,
+        body: str,
+        expected: list[tuple[int, str]],
+    ) -> None:
+        """C2's fix, as a mechanism instead of a sentence.
+
+        The audit compares against the name subprocess knows, so the
+        resolution has to hand it that name and not the local one. Planted
+        here because C2 was found by planting a module by hand, and a
+        check nobody can re-run is how the hole lasted.
+        """
+        sites = self._spawn_sites(ast.parse(body))
+        assert [(node.lineno, called) for node, called in sites] == expected, body
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            # Rebound through an assignment, not an import.
+            "import subprocess\n_P = subprocess.Popen\n_P(argv)\n",
+            # Reached through a string.
+            'import subprocess\ngetattr(subprocess, "Popen")(argv)\n',
+            # A different module's run.
+            "import other\nother.run(argv)\n",
+        ],
+    )
+    def test_the_audit_misses_these_and_says_so(self, body: str) -> None:
+        """The reach, executed rather than promised.
+
+        The first two are real holes, named in `_subprocess_aliases` and
+        left for a follow-up: closing them needs dataflow an AST walk does
+        not do. The third is not a hole, it is the scope. Pinned together
+        so the difference between "cannot see" and "does not care" stays
+        written down.
+        """
+        assert self._spawn_sites(ast.parse(body)) == [], body
 
     def test_no_allowlisted_module_waits_without_a_deadline(self) -> None:
         """#309's class: the allowlist admits a module, not a discipline.
@@ -1372,16 +1464,24 @@ class TestSubprocessTimeoutAudit:
         """
         package_root = Path(__file__).resolve().parent.parent / "kstrl"
         violations: list[str] = []
-        sites_seen = 0
+        blind: list[str] = []
 
         for rel in sorted(self.POPEN_ALLOWLIST):
             tree = ast.parse((package_root.parent / rel).read_text(encoding="utf-8"))
-            sites_seen += len(_wait_calls(tree))
+            if not _wait_calls(tree):
+                blind.append(rel)
             violations += [f"{rel}:{found}" for found in _unbounded_wait_findings(tree)]
 
-        assert sites_seen >= 10, (
-            f"audit only found {sites_seen} wait sites in the allowlisted "
-            "modules; the scan is broken, not the code clean"
+        # PER FILE, not a total. A global floor of 10 against an actual 11
+        # left one site of margin, so a legitimate refactor removing one
+        # wait failed CI with "the scan is broken" - a false diagnosis, and
+        # the kind of gate that gets deleted. A file on this allowlist is
+        # here because it manages a child process, so every one of them
+        # must show at least one wait; a file showing none means the walk
+        # stopped seeing that file, which is the thing worth failing on.
+        assert not blind, (
+            "these deadline-managed modules show no wait sites at all, so "
+            "the scan is broken rather than the code clean:\n  " + "\n  ".join(blind)
         )
         assert not violations, (
             "a deadline-managed module waits on a child without a "

--- a/tests/test_timeout_enforcement.py
+++ b/tests/test_timeout_enforcement.py
@@ -1108,6 +1108,119 @@ class TestCliTimeoutFlags:
 
 
 # ---------------------------------------------------------------------------
+# The #309 gate: a module on POPEN_ALLOWLIST must not wait without a deadline.
+# ---------------------------------------------------------------------------
+
+#: Methods that block on a child process. ``timeout=`` is optional on both.
+_WAIT_METHODS = frozenset({"wait", "communicate"})
+
+
+def _wait_calls(tree: ast.AST) -> list[tuple[ast.Call, str]]:
+    """Every ``.wait(...)`` / ``.communicate(...)`` call, with its method name."""
+    return [
+        (node, node.func.attr)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in _WAIT_METHODS
+    ]
+
+
+def _popen_names(tree: ast.AST) -> set[str]:
+    """Every name in this module that means ``Popen``, aliases included.
+
+    ``from subprocess import Popen as Spawn`` is a Popen, and a bare name
+    match does not know it - measured: without this the ``Spawn`` form
+    produced no finding at all, which is the under-reporting direction and
+    the one that matters. Same resolution ``_subprocess_aliases`` does for
+    the spawn functions in the audit below.
+
+    KNOWN over-report, deliberately left: any ``x.Popen(...)`` counts, so
+    a hypothetical ``mock.Popen()`` would be flagged. That direction costs
+    a comment on a line that is not really a child process; the other
+    direction costs a hang.
+    """
+    names = {"Popen"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            names.update(a.asname or a.name for a in node.names if a.name == "Popen")
+    return names
+
+
+def _is_popen_call(node: ast.expr, names: set[str]) -> bool:
+    """Whether this expression constructs a ``Popen``."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    called = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+    return called in names
+
+
+def _popen_bound_names(tree: ast.AST, names: set[str]) -> set[str]:
+    """Names assigned a ``Popen(...)``, so ``with proc:`` is recognisable.
+
+    One level of resolution: the same depth ``tests/test_procgroup.py``
+    resolves argv constants at, and the same known miss - a Popen reached
+    through an attribute or out of a container is invisible here.
+    """
+    bound: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and _is_popen_call(node.value, names):
+            bound.update(t.id for t in node.targets if isinstance(t, ast.Name))
+    return bound
+
+
+def _bare_wait_findings(tree: ast.AST) -> list[tuple[int, str]]:
+    """Waits on a child that name no deadline, or name one that is None."""
+    found: list[tuple[int, str]] = []
+    for node, method in _wait_calls(tree):
+        deadline = next((kw.value for kw in node.keywords if kw.arg == "timeout"), None)
+        if deadline is None:
+            found.append((node.lineno, f".{method}() names no timeout="))
+        elif isinstance(deadline, ast.Constant) and deadline.value is None:
+            found.append((node.lineno, f".{method}(timeout=None) is not a deadline"))
+    return found
+
+
+def _with_popen_findings(tree: ast.AST) -> list[tuple[int, str]]:
+    """``with`` blocks on a Popen, whose ``__exit__`` waits with no deadline."""
+    names = _popen_names(tree)
+    bound = _popen_bound_names(tree, names)
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.With | ast.AsyncWith):
+            continue
+        for item in node.items:
+            context = item.context_expr
+            named = isinstance(context, ast.Name) and context.id in bound
+            if _is_popen_call(context, names) or named:
+                found.append((node.lineno, "`with` on a Popen: __exit__ waits with no deadline"))
+    return found
+
+
+def _unbounded_wait_findings(tree: ast.AST) -> list[str]:
+    """Every way this module can wait on a child process forever.
+
+    Three forms, because #309 round 1 found the first version of this
+    check catching only one of them:
+
+    * ``.wait()`` / ``.communicate()`` with no ``timeout=`` at all.
+    * the same with ``timeout=None``, which READS as a deadline and is
+      not one. The first version passed this.
+    * ``with Popen(...)``, where the wait is ``__exit__`` and there is no
+      Call node anywhere in the tree to inspect. The first version passed
+      this too.
+
+    KNOWN MISS, stated so the gate is not trusted past its reach: only a
+    LITERAL ``None`` is visible here. A ``timeout=`` whose value is a name
+    that happens to hold None at run time reads exactly like a real
+    deadline, and following it needs dataflow an AST walk does not do.
+    """
+    found = _bare_wait_findings(tree) + _with_popen_findings(tree)
+    return [f"{line} {text}" for line, text in sorted(found)]
+
+
+# ---------------------------------------------------------------------------
 # Static audit: no subprocess call without a timeout (A+ orchestration gate)
 # ---------------------------------------------------------------------------
 
@@ -1216,10 +1329,6 @@ class TestSubprocessTimeoutAudit:
             "docstring):\n  " + "\n  ".join(popen_violations)
         )
 
-    #: Methods that block on a child. ``timeout=`` is optional on both, and
-    #: omitting it waits forever.
-    WAIT_METHODS = frozenset({"wait", "communicate"})
-
     def test_no_allowlisted_module_waits_without_a_deadline(self) -> None:
         """#309's class: the allowlist admits a module, not a discipline.
 
@@ -1248,11 +1357,18 @@ class TestSubprocessTimeoutAudit:
         ``kstrl/interaction.py``, ``kstrl/shutdown.py``). Inside them it
         is a child process, and there it must always name a deadline.
 
-        This is a receiver-name check, so it catches ``x.wait()`` on
-        anything, not only on a Popen. That is the conservative direction
-        for four files that exist to manage child processes; if one of
-        them ever needs an unbounded Event wait, that is a decision worth
-        writing down here rather than a false positive to widen around.
+        The wait half is a receiver-name check, so it catches ``x.wait()``
+        on anything, not only on a Popen. That is the conservative
+        direction for four files that exist to manage child processes; if
+        one of them ever needs an unbounded Event wait, that is a decision
+        worth writing down here rather than a false positive to widen
+        around.
+
+        The three forms it rejects, and the two that #309 round 1 found
+        the first version of this check passing, are in
+        ``_unbounded_wait_findings``. They are pinned as planted cases
+        below rather than by hand, because a gate verified once in a shell
+        session is a gate nobody can re-verify.
         """
         package_root = Path(__file__).resolve().parent.parent / "kstrl"
         violations: list[str] = []
@@ -1260,15 +1376,8 @@ class TestSubprocessTimeoutAudit:
 
         for rel in sorted(self.POPEN_ALLOWLIST):
             tree = ast.parse((package_root.parent / rel).read_text(encoding="utf-8"))
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.Call):
-                    continue
-                fn = node.func
-                if not isinstance(fn, ast.Attribute) or fn.attr not in self.WAIT_METHODS:
-                    continue
-                sites_seen += 1
-                if not any(k.arg == "timeout" for k in node.keywords):
-                    violations.append(f"{rel}:{node.lineno} .{fn.attr}()")
+            sites_seen += len(_wait_calls(tree))
+            violations += [f"{rel}:{found}" for found in _unbounded_wait_findings(tree)]
 
         assert sites_seen >= 10, (
             f"audit only found {sites_seen} wait sites in the allowlisted "
@@ -1278,3 +1387,84 @@ class TestSubprocessTimeoutAudit:
             "a deadline-managed module waits on a child without a "
             "deadline, which is #309:\n  " + "\n  ".join(violations)
         )
+
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            # The form the first version of this gate caught.
+            (
+                "proc.wait()\n",
+                ["1 .wait() names no timeout="],
+            ),
+            # #309 round 1, F4: a kwarg is present, so the first version
+            # reported clean. It waits forever all the same.
+            (
+                "proc.wait(timeout=None)\n",
+                ["1 .wait(timeout=None) is not a deadline"],
+            ),
+            (
+                "proc.communicate(timeout=None)\n",
+                ["1 .communicate(timeout=None) is not a deadline"],
+            ),
+            # F4 again: the wait is __exit__, so there is no Call node in
+            # the tree to inspect and the first version saw nothing.
+            (
+                "with subprocess.Popen(argv) as proc:\n    pass\n",
+                ["1 `with` on a Popen: __exit__ waits with no deadline"],
+            ),
+            (
+                "proc = subprocess.Popen(argv)\nwith proc:\n    pass\n",
+                ["2 `with` on a Popen: __exit__ waits with no deadline"],
+            ),
+            # Found in round 2: a bare name match reported this clean,
+            # which is the under-reporting direction.
+            (
+                "from subprocess import Popen as Spawn\nwith Spawn(argv) as p:\n    pass\n",
+                ["2 `with` on a Popen: __exit__ waits with no deadline"],
+            ),
+            (
+                "from subprocess import Popen as Spawn\np = Spawn(argv)\nwith p:\n    pass\n",
+                ["3 `with` on a Popen: __exit__ waits with no deadline"],
+            ),
+        ],
+    )
+    def test_the_gate_catches_each_planted_mutation(
+        self,
+        body: str,
+        expected: list[str],
+    ) -> None:
+        """The gate's own reach, measured rather than asserted.
+
+        #309 round 1 found the first version of this check passing two of
+        the three forms it exists to stop, and the manual verification
+        behind it had planted only the form it did catch. A guard that
+        reports clean on the bug it was written to prevent is the failure
+        this batch keeps repeating, so the planted forms live here as
+        cases rather than in a shell session nobody can re-run.
+        """
+        assert _unbounded_wait_findings(ast.parse(body)) == expected, body
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            # A real deadline, in each of the shapes the tree uses.
+            "proc.wait(timeout=5.0)\n",
+            "proc.communicate(timeout=self._remaining())\n",
+            "proc.wait(timeout=0)\n",
+            # Not a child process at all, and not a `with` on one.
+            "with open(path) as handle:\n    pass\n",
+            "with contextlib.suppress(OSError):\n    pass\n",
+            # A Popen that is never used as a context manager.
+            "proc = subprocess.Popen(argv)\nproc.wait(timeout=1)\n",
+        ],
+    )
+    def test_the_gate_stays_quiet_on_these(self, body: str) -> None:
+        assert _unbounded_wait_findings(ast.parse(body)) == [], body
+
+    def test_a_deadline_that_is_none_at_run_time_is_a_known_miss(self) -> None:
+        """The reach `_unbounded_wait_findings` claims, executed.
+
+        A docstring naming a limit is a claim; this is the measurement of
+        it, so the limit cannot quietly change into something else.
+        """
+        assert _unbounded_wait_findings(ast.parse("proc.wait(timeout=grace)\n")) == []

--- a/tests/test_timeout_enforcement.py
+++ b/tests/test_timeout_enforcement.py
@@ -1132,12 +1132,20 @@ class TestSubprocessTimeoutAudit:
       direct child, which on macOS is the caffeinate wrapper, so the
       factory itself outlived the timeout and the daemon requeued an
       item that was still executing.
+    - kstrl/procgroup.py: two bounded communicate(timeout) calls around a
+      kill, then the child is abandoned (#309). Popen is REQUIRED here
+      too, and for a different reason: subprocess.run's timeout handler
+      waits on the killed child with NO deadline and Popen.__exit__ waits
+      again, so `timeout=` cannot bound a ps that will not die. Measured
+      under a fake wedged child: 60.06s before, sub-second after
+      (tests/test_procgroup.py::TestThePsCallIsBounded).
     """
 
     SPAWN_FUNCS = frozenset({"run", "call", "check_call", "check_output"})
     POPEN_ALLOWLIST = frozenset(
         {
             "kstrl/agents/proc.py",
+            "kstrl/procgroup.py",
             "kstrl/serve.py",
             "kstrl/verify.py",
         }
@@ -1206,4 +1214,67 @@ class TestSubprocessTimeoutAudit:
         assert not popen_violations, (
             "Popen outside the deadline-managed allowlist (see class "
             "docstring):\n  " + "\n  ".join(popen_violations)
+        )
+
+    #: Methods that block on a child. ``timeout=`` is optional on both, and
+    #: omitting it waits forever.
+    WAIT_METHODS = frozenset({"wait", "communicate"})
+
+    def test_no_allowlisted_module_waits_without_a_deadline(self) -> None:
+        """#309's class: the allowlist admits a module, not a discipline.
+
+        Being on POPEN_ALLOWLIST said only that the module promised to
+        manage its own deadline, and nothing checked the promise. #309 is
+        what that costs: ``procgroup`` passed ``timeout=`` to
+        ``subprocess.run``, satisfied the audit above, and hung anyway,
+        because the wait ``run`` performs after killing the timed-out
+        child has no deadline. A pinned kwarg is not a bound.
+
+        WHAT THIS DOES NOT COVER, said plainly because a mechanism cited
+        for a claim it does not carry is worse than none. It would NOT
+        have caught #309: that unbounded wait was inside CPython, not in
+        this tree, so no walk of ``kstrl/`` could see it. The thing that
+        catches a revert to ``subprocess.run`` is the clock in
+        ``tests/test_procgroup.py::TestThePsCallIsBounded``, which
+        measured 60.06s against the old body. What this catches is the
+        sibling the allowlist invites and nobody was checking: a
+        hand-rolled ``Popen`` in one of these four files that waits on
+        its child with no deadline. All 11 current sites already pass one,
+        so this lands green and stays a ratchet rather than a cleanup.
+
+        Scoped to the allowlisted files because ``.wait(...)`` outside
+        them is overwhelmingly ``threading.Event.wait``, whose unbounded
+        form is legitimate and common (``kstrl/commandrun.py``,
+        ``kstrl/interaction.py``, ``kstrl/shutdown.py``). Inside them it
+        is a child process, and there it must always name a deadline.
+
+        This is a receiver-name check, so it catches ``x.wait()`` on
+        anything, not only on a Popen. That is the conservative direction
+        for four files that exist to manage child processes; if one of
+        them ever needs an unbounded Event wait, that is a decision worth
+        writing down here rather than a false positive to widen around.
+        """
+        package_root = Path(__file__).resolve().parent.parent / "kstrl"
+        violations: list[str] = []
+        sites_seen = 0
+
+        for rel in sorted(self.POPEN_ALLOWLIST):
+            tree = ast.parse((package_root.parent / rel).read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                if not isinstance(fn, ast.Attribute) or fn.attr not in self.WAIT_METHODS:
+                    continue
+                sites_seen += 1
+                if not any(k.arg == "timeout" for k in node.keywords):
+                    violations.append(f"{rel}:{node.lineno} .{fn.attr}()")
+
+        assert sites_seen >= 10, (
+            f"audit only found {sites_seen} wait sites in the allowlisted "
+            "modules; the scan is broken, not the code clean"
+        )
+        assert not violations, (
+            "a deadline-managed module waits on a child without a "
+            "deadline, which is #309:\n  " + "\n  ".join(violations)
         )


### PR DESCRIPTION
Closes #309.

## The defect, confirmed before anything was changed

`kstrl/procgroup.read_group_liveness` passed `timeout=PS_TIMEOUT_SECONDS` to
`subprocess.run` and claimed that bounded how long a wedged `ps` could stall the
caller. Read against the CPython 3.12.8 this tree runs, it does not:

- `subprocess.run`'s POSIX timeout handler calls `process.kill()` and then
  `process.wait()` with **no** timeout.
- The enclosing `with Popen(...)` then calls `__exit__`, which calls
  `self.wait()` again, also with no timeout.

A `ps` in an uninterruptible sleep cannot be killed, so both waits block
forever. The one production caller is `serve._group_liveness_for_reap`, reached
from `terminate_process_group` on the timed-out-run path, which runs while the
daemon holds `serve_lock` for its whole lifetime. So the case the timeout named
was the case it did not cover.

**Measured, not asserted.** Running the new bound test against the pre-#309 body
under a fake wedged child: the read took **60.06s** (two runs, 60.065s and
60.060s). That is exactly the two unbounded 30s waits the fake charges for. After
the fix the same test returns in under a second.

## What changed

`_read_ps` is now a `Popen` driven by two bounded `communicate` calls:
`PS_TIMEOUT_SECONDS` for the read, then a kill, then `PS_KILL_GRACE_SECONDS` to
collect a child the kill reached. `communicate(timeout=...)` ends in
`wait(timeout=remaining)`, so every leg has a deadline. Nothing uses
`with Popen(...)`, because that is the second unbounded wait.

A child the kill did **not** reach is abandoned rather than waited on: the two
pipe ends are closed (closing a read end cannot block) and the call reports
"cannot see".

**Correcting the issue text:** this is not a permanent zombie. `Popen.__del__`
hands an unreaped child to CPython's `subprocess._active`, which the next `Popen`
anywhere in the process polls, so it is collected once the kernel lets it die.
The standing cost is the outstanding child plus the pipe pair, and the pipe pair
is released immediately.

`PS_KILL_GRACE_SECONDS = 1.0` is measured, not picked. Over 60 samples on a
914-process machine, kill to reaped was max 0.236ms for `ps` and max 1.122ms for
a `sleep` child killed mid-run; 1.0s is about 890x the worse of the two. Raising
it cannot rescue a D-state child, which is the only thing that reaches the end
of it.

**Cost to the daemon, simulated over both shapes `serve._wait_out_grace` can
take with a permanently wedged `ps`:** if the direct child outlives both graces,
2 reads and 37.00s; if it dies at once and a descendant holds on, 5 reads and
30.75s. So up to five abandoned children per terminated run, and a
`terminate_process_group` worst case of 37s against the 25s an operator reads off
`GROUP_TERM_GRACE_SECONDS` plus the SIGKILL leg. Both numbers are finite, which
is the change. Recorded in the module docstring so nobody tunes either constant
without seeing the composition.

## Tests

`tests/helpers/procs.py` moves its monkeypatch seam from `subprocess.run` to
`Popen`, because the read no longer goes through `run`. The delegation guard that
sends every non-`ps` argv to the real thing moves with it and matters more now,
since `subprocess.run` is itself built on `Popen`.

- `TestThePsCallIsBounded::test_an_unkillable_ps_returns_within_the_bound` -
  injects a fake child whose every `communicate` burns its whole deadline then
  raises `TimeoutExpired`, whose `kill` does nothing, and whose `wait` sleeps 30s.
  Asserts on the clock. This is the test that measured 60.06s against the old
  body. The fake implements `__enter__`/`__exit__` faithfully so that reverting
  to `subprocess.run` fails on the clock rather than on a missing method, which
  is what makes it a regression test rather than a shape test.
- `TestThePsCallIsBounded::test_an_unkillable_ps_is_killed_and_let_go_of` - two
  deadlines are spent (0.01 then 0.02), the child is killed once, and both pipes
  are closed.
- `test_the_read_passes_its_timeout` now reads the `communicate` deadline rather
  than a `run` kwarg.
- `kstrl/procgroup.py` is added to `POPEN_ALLOWLIST` in
  `tests/test_timeout_enforcement.py`, with the reason recorded in the class
  docstring next to the other three entries.
- New: `test_no_allowlisted_module_waits_without_a_deadline` - the allowlist
  admitted a module, not a discipline. This walks the four allowlisted files and
  fails on any `.wait()`/`.communicate()` that names no `timeout=`. Verified by
  planting one: it failed with `kstrl/procgroup.py:259 .wait()`. All 11 current
  sites already pass a deadline, so it lands green. Its docstring says plainly
  that it would **not** have caught #309 (that wait was inside CPython, invisible
  to any walk of `kstrl/`) and that the clock test is what catches a revert.

Also verified outside the suite, against a **real** child (the killable-but-slow
case the fakes cannot cover): with `PS_ARGV` pointed at `sleep 5` and a 0.2s
deadline, the read returned in 0.202s, the child was killed and reaped,
`subprocess._active` was empty, and the process fd count was 4 before and 4
after.

Full suite: 4478 passed, 28 skipped. `mypy kstrl/ --strict` clean, `ruff check
kstrl/ tests/` clean, pre-commit clean on the staged files. Coverage combined
across both tiers is 89.83% against the 79.91% ratchet; `kstrl/procgroup.py`
itself is at 100% statement coverage.

---

## `/simplify` findings, verbatim

Four agents, one per angle. Findings are reproduced exactly as returned; my
disposition follows each block.

### Reuse

> ## Reuse review: findings
>
> **1. `_read_ps` + `_kill_or_abandon` is the fourth hand-rolled copy of the same bounded spawn/kill dance**
>
> - File: `/Users/wumpinihussein/Documents/code/ralph/.claude/worktrees/agent-a8c3765565938b314/kstrl/procgroup.py`, lines 199-258
> - The three existing copies of "Popen, bounded `communicate(timeout)`, kill, bounded second collect, give up on a child that will not die":
>   - `/Users/wumpinihussein/Documents/code/ralph/.claude/worktrees/agent-a8c3765565938b314/kstrl/verify.py:132` `run_scrubbed` (communicate at :163, `wait(term_grace)` at :167, second communicate at :175)
>   - `/Users/wumpinihussein/Documents/code/ralph/.claude/worktrees/agent-a8c3765565938b314/kstrl/serve.py:1393` `run_supervised` (communicate at :1433, second at :1443)
>   - `/Users/wumpinihussein/Documents/code/ralph/.claude/worktrees/agent-a8c3765565938b314/kstrl/agents/proc.py:148` `DeadlineStreamer.kill`, which already carries the identical policy in prose: "Unreapable child (e.g. stuck in uninterruptible IO). Do not hang the harness on it."
> - I checked whether there is a helper to call instead, and there is no clean one. `verify.run_scrubbed` is the only public function shaped right (same `CompletedProcess[str]` return, and it raises exactly the exception set the caller at `procgroup.py:189` already catches), but three things block a straight call-through, so I am not recommending it as-is: it passes `text=True` rather than a pinned `encoding="utf-8", errors="replace"`, so calling it would drop the #291 property `procgroup.py:222` deliberately keeps; it passes `start_new_session=True` and group-kills, which flips the property documented at `procgroup.py:207`; and its worst case is `timeout + 2 * term_grace` (default grace 5.0, so 15s) against the 6.0s the new docstring advertises. On top of that, `procgroup` is a leaf (os + subprocess only) imported by `serve.py:72`, and `verify` pulls in git, licensing, adequacy, config, findings, gateparse, guards, parsers, policy, prd, statedir. The dependency runs the wrong way.
> - Concrete cost of leaving four copies: four grace constants that nobody reconciles (`agents/proc.py:33` = 5.0, `verify.py:102` = 5.0, `serve.py:1443` literal 10 plus `serve.py:1468` = 15.0 plus `serve.py:1547` literal 10.0, `procgroup.py` `PS_KILL_GRACE_SECONDS` = 1.0), and four different answers to "what happens to a child the kill did not reach" (pass, raise `TimeoutExpired` with empty output, `RunOutcome(-9)`, abandon and close pipes). #309 is the cost realised rather than predicted: the audit "is the wait after the kill bounded?" had to be run once per copy, three copies already passed it, the fourth did not, and nothing in the code could have told you that without reading all four. The ledger at `tests/test_timeout_enforcement.py:1113-1141` is the tax made visible: the class docstring grows a hand-written bullet per copy, and this change adds the fourth bullet and the fourth allowlist entry.
> - What I would do instead: extract the mechanism downward into `procgroup` (the leaf, already the designated single place for process-state reads) as a public `bounded_read(argv, *, timeout, kill_grace)` returning `CompletedProcess`, and let `run_scrubbed` and `run_supervised` layer their group-kill policy on top of it. Honest caveat: only the mechanism is common, the kill policy genuinely differs per caller, so this is a real refactor and not a one-line substitution. As shipped, the fix lives in a private function in the leaf module, so copy five has nothing to call.
>
> **2. `unkillable_ps` re-implements `fake_ps`'s spawn closure**
>
> - File: `/Users/wumpinihussein/Documents/code/ralph/.claude/worktrees/agent-a8c3765565938b314/tests/helpers/procs.py`, lines 143-164 against 125-140
> - Lines 158-160 are byte-identical to 125-127; the only difference between the two fixtures is which `respond` the `_FakePs` is handed (`_wedge` versus the constant or `fail`).
> - Cost: two copies of the record-and-append protocol to keep in step with `_new_record` at :179 every time the record grows a field, and a reader has to diff two closures to discover that "unkillable" adds nothing but "burn the deadline before raising". One `_fake_ps(monkeypatch, respond)` with `fake_ps` and `unkillable_ps` as thin callers removes it.
>
> **3. `_wedge` and `_FakePs.wait` are the same two-line body twice**
>
> - File: `/Users/wumpinihussein/Documents/code/ralph/.claude/worktrees/agent-a8c3765565938b314/tests/helpers/procs.py`, lines 175-176 and 244-245
> - Both are `time.sleep(...)` then `raise subprocess.TimeoutExpired(cmd=list(procgroup.PS_ARGV), timeout=timeout or 0.0)`, differing only in the None default. `wait` can call `_wedge`.
> - Cost: small but exact, two sites hard-coding the `PS_ARGV` coupling and the sleep-then-raise contract, so a change to either has to be made twice or the fake's two halves diverge.
>
> **4. The call log re-implements recording that `MagicMock(spec=subprocess.Popen)` already gives this suite**
>
> - File: `/Users/wumpinihussein/Documents/code/ralph/.claude/worktrees/agent-a8c3765565938b314/tests/helpers/procs.py`, lines 179-235
> - The record is a `dict[str, object]` with hand-rolled counters, which forces three `assert isinstance(...)` narrowing casts inside the fake (lines 199, 227, 234) and untyped indexing at the assertion sites (`tests/test_procgroup.py:317, 372, 373, 374, 384, 385`). The suite already uses spec'd mocks for process doubles at `tests/test_serve.py:1793` and `tests/test_serve.py:2229`, where `communicate.call_args_list`, `kill.call_count` and `stdout.close.called` are exactly the three things being recorded here; and the repo's own container convention (CLAUDE.md, and `tests/helpers/fake_run.py:23`) says dataclass rather than `dict[str, object]`.
> - Honest caveat, and the reason I rank this weakest: the behavioural half (sleeping the deadline, an `__exit__` faithful enough to make the bound test a regression test) still needs custom `side_effect` functions, so a mock removes the recording code but not the fake. Cost is roughly 35 lines plus three casts that exist only because the record is untyped.
>
> ## Checked and clean
>
> - `kstrl/timeout.py:82` `run_with_timeout` is not a reuse target: it is built on `subprocess.run`, which is precisely what #309 shows cannot bound an unkillable child, and it has no callers outside `tests/test_timeout.py`.
> - `_patch_ps_popen` delegates non-`ps` argv to the real `Popen` rather than reimplementing a run path. That is correct and not duplication.
> - The new fixtures do not overlap the existing `dead_group` / `kill_group` / `wait_for_group_to_die` in the same helper module.
> - The bare `assert elapsed < 1.0` at `tests/test_procgroup.py:349` does not duplicate `KILL_BOUND_SECONDS` (`tests/test_timeout_enforcement.py:54`, 12.0): that constant is sized for a 1s deadline plus a 5s grace, while this test shrinks its constants to 0.05, so reusing it would be wrong rather than DRY.

**Disposition.** 2 and 3 applied. 4 applied as the dataclass rather than the
mock, for the caveat the agent itself names: the behavioural half still needs a
real fake. 1 **declined for this PR** - see the shared-disposal note below.

### Simplification

> I read the diff and all four files, plus the surrounding conventions (mypy scope, the Popen allowlist convention, the pre-commit hook set).
>
> ## Findings
>
> **1. `tests/helpers/procs.py:125-139, 156-163` (seam at `266-268`) - the `spawn` seam is one indirection too general, and both callers copy the same three-line record protocol.**
> `spawn(argv, kwargs)` is handed argv and kwargs, and both callers do exactly the same thing with them: `record = _new_record(argv, kwargs)`, `calls.append(record)`, `return _FakePs(record, X)`. The only thing that actually varies between `fake_ps` and `unkillable_ps` is `X`, the per-call `respond`. Simpler form: give `_patch_ps_popen` a `respond_for: Callable[[], Callable[...]]` parameter, let it own `calls`, build and append the record itself, and return the list. `unkillable_ps` collapses to `return _patch_ps_popen(monkeypatch, lambda: _wedge)` (one line instead of eight), `fake_ps` keeps only its `respond_for` closure, and the `argv`/`kwargs` parameters disappear from the seam entirely. The OSError-at-spawn case still works because `respond_for()` is called after the record is appended, preserving today's ordering. Cost of leaving it: roughly 12 lines, and two copies of the record-append protocol, so the record's shape has three edit sites and a third fixture would write it a third time.
>
> **2. `tests/helpers/procs.py:173-176` vs `237-245` - `_wedge` and `_FakePs.wait` are the same rule written twice, in mirror image.**
> Both sleep the deadline (`UNBOUNDED_WAIT_SECONDS` when it is None) and then raise `TimeoutExpired(cmd=list(procgroup.PS_ARGV), timeout=timeout or 0.0)`. The two conditionals are spelled in opposite order (`timeout if timeout is not None else UNBOUNDED` against `UNBOUNDED if timeout is None else timeout`), which invites the reader to hunt for a difference that is not there. Simpler form: one module-level `def _sleep_out(timeout: float | None) -> NoReturn`, used directly as the `respond` in `unkillable_ps` and called by `wait`. A `NoReturn` function satisfies the `Callable[[float | None], tuple[int, str, str]]` slot, so `_wedge` need not exist as a separate name. Cost of leaving it: two edit sites for one invariant, and the exception constructor duplicated.
>
> **3. `tests/helpers/procs.py:179-187, 190-200, 226-227, 233-234` - the call record is `dict[str, object]`, which buys three `assert isinstance` narrowings that nothing typechecks.**
> `_FakePipe.close`, `_FakePs.communicate` and `_FakePs.kill` each pull a field out of the record, assert its type, then mutate it. Those asserts are static-narrowing ceremony, not test assertions: at runtime `record["closed"].append(name)` works unaided. And nothing runs mypy over `tests/` - `pyproject.toml` sets `files = ["kstrl"]`, CI runs `uv run mypy kstrl/ --strict` (`.github/workflows/ci.yml:185`), and `.pre-commit-config.yaml` has no mypy hook at all. Simpler form: a small `@dataclass class _PsCall` with `argv`, `kwargs`, `timeouts: list[float | None]`, `kills: int`, `closed: list[str]`. That deletes `_new_record` (its docstring becomes field comments), deletes all three asserts and their intermediate locals, shrinks `_FakePipe` to a five-line dataclass, and turns `calls[0]["timeouts"]` into `calls[0].timeouts` at the four assertion sites in `tests/test_procgroup.py`. Cost of leaving it: six lines that assert something no checker reads, plus stringly-typed field access at every call site.
>
> **4. `tests/test_procgroup.py:301-307` and `tests/helpers/procs.py:284-286` - the `subprocess.run` hang mechanism is restated five times; two of the copies add no evidence.**
> The causal chain (run's timeout handler kills then waits with no deadline, `Popen.__exit__` waits again) now appears in `kstrl/procgroup.py:78-88`, `kstrl/procgroup.py:240-244`, `tests/test_procgroup.py:301-307`, `tests/test_procgroup.py:331-336` and `tests/helpers/procs.py:284-286`. Three of those earn it: the module docstring is canonical and is the only one that names the interpreter it was read against (CPython 3.12.8), the test method's copy carries the unique 60.065s counterfactual measurement, and the `test_timeout_enforcement.py` entry follows the established one-bullet-per-allowlisted-module convention that `serve.py` already sets. The test class docstring's second paragraph and `_patch_ps_popen`'s final paragraph restate the mechanism without adding evidence. `_read_ps`'s own docstring shows the cheaper form already in this diff: it points at the module docstring's #309 section instead of repeating it. Cost of leaving it: five prose copies of one version-specific claim about CPython internals, four of which name no version, with no mechanism anywhere that fails when a copy goes stale.
>
> ## Checked and judged fine
>
> - The production side is close to minimal. `_read_ps` plus `_kill_or_abandon` is two small functions with one caller each, but splitting is right here: the disposal is reached from a `BaseException` handler and reads better named than inlined. Rebuilding a `CompletedProcess` keeps `read_group_liveness` untouched and is self-documenting, so it is not gratuitous. The `if pipe is not None` guard is load-bearing for the strict mypy that does run on `kstrl/`.
> - `_FakePs.wait`, `__enter__`/`__exit__`, and `communicate`'s unused leading `input` parameter all look like dead weight in the current tree but are not. `subprocess.run` calls `process.communicate(input, timeout=timeout)` positionally inside `with Popen(...) as process`, then `process.wait()` on the POSIX timeout path (verified against the stdlib source here), so those three are exactly what makes a revert to `subprocess.run` fail on the clock instead of on a missing attribute.
> - Moving the "delegates every other command" paragraph out of `fake_ps` and into `_patch_ps_popen` is a deduplication in the right direction: it now sits with the code that does the delegating, for both fixtures.

**Disposition.** All four applied. 1 applied exactly as described. 2 applied by
making `_wedge` `-> NoReturn` and having `wait` call it. 3 applied as a public
`PsCall` dataclass. 4 applied to the two copies it names, keeping the three it
says earn their place.

### Efficiency

> Measurements done. Here is the review.
>
> ## Finding
>
> **1. `tests/helpers/procs.py:130-137` - `fake_ps` captures an exception INSTANCE in the `fail` closure, which is the exact pattern the same function's docstring forbids.**
>
> ```python
> exc = raises()                 # line 130, one instance per spawn
> if isinstance(exc, OSError):
>     raise exc
>
> def fail(_timeout: float | None) -> tuple[int, str, str]:
>     raise exc                  # line 135, raises that same instance every time
> ```
>
> The docstring three lines above (procs.py:109-112) says `raises` is a FACTORY rather than an instance because "a module-level exception object re-raised by every parametrized case accumulates a traceback frame and an `__context__` per raise, so it retains every test frame and its locals". The new code re-establishes that inside the helper: the factory is called once at spawn, and the instance it returns is then raised repeatedly.
>
> Concrete cost, measured on this tree (`ps` fake, `read_group_liveness(4242)`, CPython 3.12):
>
> - The one instance is raised **twice per read**, not once. `_read_ps` (procgroup.py:226) gets it from the first `communicate`, then `_kill_or_abandon` (procgroup.py:248) calls `communicate` again on the same fake, which raises the same object again.
> - Its traceback grows to **7 entries** for a single `read_group_liveness` call, spanning `read_group_liveness`, `_kill_or_abandon`, `_read_ps` and both fake frames.
> - Through that traceback the retained exception reaches the `_FakePs`, its `_respond` closure and its cell back to itself, so it is a **reference cycle**: refcounting cannot free it. A/B over 200 reads with `gc` disabled: **27 objects per read** survive with the instance in the closure, **0 per read** with the factory in the closure. `gc.collect()` freed exactly those 5400 objects, so it is cyclic garbage rather than a permanent leak, but it is garbage refcounting would otherwise never have made.
> - `__context__` does not accumulate (CPython skips self-context), so that half of the docstring's warning does not apply here. The traceback half does.
>
> Cheaper alternative, one line, same behaviour: keep the probe for the `isinstance` branch, then raise a fresh instance inside the closure so only the FACTORY is captured.
>
> ```python
> exc = raises()
> if isinstance(exc, OSError):
>     raise exc
>
> def fail(_timeout: float | None) -> tuple[int, str, str]:
>     raise raises()
> ```
>
> Measured at 0 retained objects per read. Safe for the three call sites that use `raises` (test_procgroup.py:254, 265, 284): they assert on `liveness.live` and on a substring of `liveness.reason`, never on exception identity, so a fresh instance of the same type is indistinguishable to them.
>
> ## Considered, measured, and NOT findings
>
> - **The reap-loop latency question.** Not a real cost, in either direction I could measure. Healthy path A/B on a 927-process machine, n=60: old `subprocess.run` form median 12.24ms / max 14.62ms, new `_read_ps` median 12.22ms / max 14.44ms. Identical inside noise, and `PS_KILL_GRACE_SECONDS` is only reached when the read already timed out or raised, so a healthy poll pays nothing new. The "6.0s per poll instead of 5.0s" framing compares against a bound that did not exist: the old worst case on a wedged `ps` was unbounded (the diff's own test measured 60.065s under a fake, and a real D-state child never returns at all). Trading unbounded for 6.0s is the whole point of the change, and 1.0s of it buys the kill a round trip that measured 0.236ms.
> - **One abandoned child per POLL, not per call.** `serve._wait_out_grace` polls `_confirm_group_gone` every `GROUP_POLL_SECONDS = 0.25` for `GROUP_TERM_GRACE_SECONDS = 15.0` then 10.0, so a permanently wedged `ps` abandons roughly 5 children per terminated run, not the "one outstanding child" the module docstring (procgroup.py:97-106) accounts for. I chased the second-order cost because every `Popen` in the process sweeps `subprocess._active`, and it does not matter: `os.waitpid(pid, WNOHANG)` measured 0.16us, so even 1000 accumulated children add 0.16ms to a `Popen` that already costs 12ms, about 1.3%. Worth a word in the docstring if anyone touches it; not worth code.
> - **Suite cost of the two new tests.** `_wedge` sleeps its whole deadline deliberately so the clock assertion is real. The constants are shrunk to 0.05/0.05 and 0.01/0.02, and the measured cost is 0.11s + 0.04s against a 246.5s suite. `tests/test_procgroup.py` runs 56 tests in 0.69s.
> - **The seam moving from `run` to `Popen`** (procs.py:290-294) means the fake now intercepts every `Popen` in the process rather than every `run`, and rebuilds `list(procgroup.PS_ARGV)` on each. Two small list allocations against a fork that costs 12ms. Below the noise floor of anything I can measure.
> - **`_read_ps` building a `subprocess.CompletedProcess`** purely so the caller can read three attributes: one allocation per fork. Not worth trading the readable call site for a tuple.

**Disposition.** Applied exactly as written, with the measurement recorded in the
comment. Its second "not a finding" note is applied too, and refined: the
docstring's "one outstanding child" claim was wrong, so I simulated both shapes
the loop takes and recorded 2-to-5 reads and 30.75-to-37.00s. The simulation
corrects the agent's own "roughly 5 per run", which assumed the poll loop always
runs; when the direct child outlives the grace, `process.wait(timeout=grace)`
consumes the whole grace first and only 2 reads happen.

### Altitude

> Read the diff, all four current files, and the three other Popen sites. Ran the checks and measured the one claim the diff rests on.
>
> ## Verdict on the altitude question first
>
> **The narrow fix is the right scope for the hang, and the "same defect elsewhere" hypothesis is false.** I read all three other sites. Every `.wait(` and `.communicate(` in `kstrl/` already carries a `timeout=`: `kstrl/verify.py:163,167,175`, `kstrl/agents/proc.py:141,152,156`, `kstrl/serve.py:1433,1443,1575`. `procgroup` was the only site still on `subprocess.run`, and it is a leaf library (imports only `os`, `subprocess`, `contextlib`) whose caller cannot impose a deadline on a synchronous call without a thread. So the bound must live inside it, not in `serve`. A shared *runner* is the wrong unit: the four sites differ on session-or-not, group-or-direct-child, TERM-then-KILL or KILL-only, drain or re-raise. Four knobs for four callers is not a generalization.
>
> There is still a real generalization the diff missed, and it is the *disposal*, not the runner.
>
> ## Findings
>
> **1. `tests/test_timeout_enforcement.py:1147-1152` - the static gate this diff extends still cannot see the defect class it was extended for.**
> The audit checks `Popen` (file allowlist) and `run/call/check_call/check_output` (must pass `timeout=`). It has no check on `.wait()` or `.communicate()`. #309 *is* an unbounded `.wait()`. Cost: a new `proc.wait()` with no timeout in any of the now-four allowlisted files lands green, and the allowlist is file-granular so it cannot distinguish `_read_ps`'s two bounded communicates from a future bare `Popen` + `.wait()` in the same file. The remedy can be added **green today**: all 11 such call sites already pass a timeout. Scope the new check to `POPEN_ALLOWLIST` files to avoid the `threading.Event` false positives at `kstrl/commandrun.py:66`, `kstrl/interaction.py:176`, `kstrl/shutdown.py:45`.
>
> **2. `kstrl/verify.py:177`, `kstrl/serve.py:1445`, `kstrl/agents/proc.py:157-160` - the pipe-release invariant is established at one site and left broken at three.**
> Measured rather than assumed: `Popen.__del__` resurrects an unreaped child into `subprocess._active`, which holds the Popen, which holds its pipe objects, so the fds stay open until the child dies. My script: abandoned without close gives `_active=1` with both fds open; with the explicit close both are closed. So the close in `_kill_or_abandon` is load-bearing, and the three sibling abandon paths retain 2 fds per abandoned child, permanently for exactly the D-state child #309 is about. Cost is inverted against frequency: `procgroup` (now fixed) runs once per timed-out run, while `run_scrubbed` has 15 call sites and runs once per verification command per iteration. Right-sized remedy: a shared `dispose(process, grace)` in `procgroup` carrying only kill, bounded collect, release pipes. `procgroup` is a leaf, so `verify`, `serve` and `agents.proc` can import it with no cycle.
>
> **3. `kstrl/serve.py:1573-1582` - serve's grace is a floor, not a ceiling, and the new constant moves it with nothing recording that.**
> `_wait_out_grace` sets `deadline = grace`, then calls `_confirm_group_gone` once unconditionally and re-checks the clock only at the top of the loop, so each read overshoots by the full `PS_TIMEOUT_SECONDS + PS_KILL_GRACE_SECONDS`. Cost: `terminate_process_group`'s worst case moves from 15+5 + 10+5 = 35s to 15+6 + 10+6 = 37s, against the 25s an operator reads off `GROUP_TERM_GRACE_SECONDS` and the SIGKILL leg. The direction is a large improvement (it was unbounded), but one comment at 1573, or threading the remaining budget into the read, would make the composition visible.
>
> **4. `kstrl/procgroup.py:80-84`, `tests/test_procgroup.py:301-306`, `tests/test_timeout_enforcement.py:1136-1141`, `tests/helpers/procs.py:251-259` - the CPython implementation claim is restated in full four times.**
> `subprocess.run`'s timeout handler is an implementation detail pinned to "the CPython 3.12.8 this tree runs" (confirmed, `uv run python -V` is 3.12.8). Cost: when it changes, four copies go stale and nothing catches it. This is the exact argument `procgroup.py:110-112` makes about the `ps` parse, applied to prose. The two in-module docstrings at `procgroup.py:205` and `241` already do the right thing and point back to the module docstring; the other three could too.
>
> ## Checked and found sound (not findings)
>
> - **`PS_KILL_GRACE_SECONDS` belongs where it is.** It sits next to `PS_TIMEOUT_SECONDS` with its measurement attached. The repo already carries three other grace constants at genuinely different values for genuinely different policies (`verify._SCRUB_TERM_GRACE_SECONDS` 5.0, `agents.proc.DEFAULT_TERM_GRACE_SECONDS` 5.0, `serve.GROUP_TERM_GRACE_SECONDS` 15.0). 1.0 measured against a `ps` that returns in 0.2ms is not the same policy. It also survives finding 2's remedy unchanged, as this caller's default for a shared `grace` parameter, which is how `verify` and `agents.proc` already parameterize theirs.
> - **Adding `kstrl/procgroup.py` to `POPEN_ALLOWLIST` is correct use of the gate**, with the required justification written into the class docstring. The weakness is the gate's granularity (finding 1), not this entry.
> - **Moving the test seam from `subprocess.run` to `subprocess.Popen` is the right call.** Patching `procgroup._read_ps` would be narrower but would stop measuring the bound, which is the point of the regression test. The non-`ps` delegation keeps it transparent, and it degrades safely for keyword-`args` and shell-string spawns (argv becomes `[]`, so it delegates).
>
> ## Verification run
>
> `uv run mypy kstrl/ --strict` clean (127 files); `uv run ruff check kstrl/ tests/` clean; `tests/test_procgroup.py tests/test_timeout_enforcement.py tests/test_process_scoping.py` 107 passed in 24.15s. Measurement script for finding 2 left at `/private/tmp/.../scratchpad/fdcheck.py`. No files edited.

**Disposition.** 1 applied, after I re-ran the audit myself and confirmed all 11
sites pass a deadline and the three unbounded ones are `threading.Event.wait`.
I did **not** accept its framing that "#309 *is* an unbounded `.wait()`" that this
gate would catch: #309's unbounded wait was inside CPython, invisible to any walk
of `kstrl/`, and the new test's docstring says so explicitly rather than claiming
a reach it lacks. 3 applied, in the module docstring, with the numbers simulated
rather than added by hand. 4 applied jointly with the simplification agent's
finding 4. 2 **declined for this PR** - see below.

### Declined, and why

**A shared `dispose(process, grace)` used by `verify`, `serve` and `agents.proc`
(reuse 1, altitude 2).** Both agents are right that the pipe-release invariant is
now established at one site and absent at three, and altitude 2 measured the fd
retention rather than assuming it. I am not doing it here because it changes the
behaviour of three modules outside #309's diff, each with its own kill policy and
its own tests, and it would turn a bounded bug fix into a cross-module refactor
reviewed as a side effect of a `ps` timeout. It wants its own issue, its own
before/after fd measurements at `run_scrubbed`'s 15 call sites, and its own
review. Flagging it here so it is not lost.

**Narrowing `serve_lock` around the reap.** Considered and rejected on the
merits, not deferred. `serve_lock` is the daemon singleton lock, held for the
process lifetime precisely so two `ks serve` cannot double-lease the queue.
Releasing it around a reap would let a second daemon start and lease the same
repo, which is the #186 F1 hazard the reap check exists to prevent. The hang was
never caused by the lock's scope; it was caused by an unbounded wait inside the
work the lock protects. Bounding the wait is the fix. The lock stays.


---

# Round 2: the four review findings

Two of the four were overclaims in prose rather than regressions in code, and
the framing below says which.

## F1 (fix). The probe's failure direction was the dangerous one, and the new docstring claimed the opposite.

`signal_probe_alive` ended `except OSError: return False`. An errno nobody could
explain therefore read as NOT ALIVE, `terminate_process_group` turns that into
`reaped`, the item is released, and a second factory can start on a repo the
first is still writing to. Byte-identical on `origin/main`, so this PR did not
introduce it. It is still this PR's to deal with, for the reason the review
gave: this change makes "ps cannot see" a routine outcome, so a nearly
unreachable fail-open moved onto the normal path. And the claim that the
fallback's "only error is over-reporting alive" was new text here and false.

**Decision: make the code conservative.** `except OSError: return True`, so only
ESRCH means gone.

**Why that and not the caller-side alternative.** `signal_probe_alive` returns a
plain `bool`, which cannot carry the difference between "the kernel said the
group is empty" and "the question was not answered". Teaching
`serve._group_liveness_for_reap` to refuse would first require the probe to
report three states, which is the leaf change with more machinery on top. The
review agent reached the same conclusion independently and checked the other
caller: `tests/test_shutdown.py:657` asserts `is True` as a positive control, and
the branches reachable there on a real machine (success, EPERM, ESRCH) are
unchanged.

**Checked nothing depended on the old direction** before changing it: the only
test pinning it was `test_any_other_oserror_reads_as_gone`, whose own docstring
said it was "pinned rather than endorsed" and that changing the mapping was a
separate decision. Full suite green afterwards.

**The fix is one line, not a second branch table.** The round-2 review verified
on all six branches that `signal_probe_alive` had become the exact boolean
complement of `_kernel_says_group_is_empty`, which has always read ESRCH as the
one conclusive answer. Two readings of one `killpg` agreeing only by paragraph is
how they disagreed in the first place, so `signal_probe_alive` is now
`return not _kernel_says_group_is_empty(pgid)`. Both test classes still pass
unchanged, through one implementation.

**Pinned so it fails on the other choice** (verified by restoring the old
mapping; 3 tests fail, and pass on the chosen one):

- `tests/test_procgroup.py::TestTheSignalProbeIsKeptAsTheDegradedReading::test_an_unexplained_error_reads_as_alive_not_gone`, parametrized over EINVAL and the EIO the reviewer reproduced with. Old mapping: `E assert False is True where False = signal_probe_alive(4242)`.
- `...::test_esrch_is_still_the_one_thing_that_means_gone` - the control, so the test above cannot pass on a function stubbed to return True.
- `tests/test_serve.py::TestGroupLivenessDegradesRatherThanGuessing::test_a_blind_ps_and_an_unexplained_signal_error_is_not_reaped` - the daemon-level consequence, both readings failing at once against a group that is genuinely running. Old mapping: `E AssertionError: an unexplained error must never read as reaped`.

## F2 (claim only). Popen startup was never bounded, and was not bounded before.

Confirmed against the installed CPython 3.12.8: `Popen.__init__` blocks in
`_execute_child` on `part = os.read(errpipe_read, 50000)`, which takes no
timeout. `subprocess.run` constructs its `Popen` through the identical path, so
the hazard is unchanged by this PR. No re-engineering of process spawning.

The hard guarantee is gone. The module docstring now carries a "WHAT THAT BOUND
DOES NOT COVER" section saying the two deadlines cover the read and the
disposal, that startup is outside them, that the residual is exactly what it was
before #309, and what did change: once the child is running, no wait on it is
unbounded.

## F3 (fix). Cleanup could skip closing the pipes.

The release sat inside `except (OSError, ValueError, TimeoutExpired)`. A
`KeyboardInterrupt` in the grace `communicate` is none of those and escaped with
both fds held. It is in a `finally` now.

Test: `tests/test_procgroup.py::TestThePsCallIsBounded::test_an_interrupted_disposal_still_releases_the_pipes`.
Verified against the pre-F3 body: `E AssertionError: assert [] == ['stdout', 'stderr']`,
which is the reviewer's measured "both close counts at zero".

The test uses the existing `fake_ps(raises=KeyboardInterrupt)` rather than a new
fixture, on the round-2 review's measured finding that it drives the path end to
end; it asserts `timeouts == [PS_TIMEOUT_SECONDS, PS_KILL_GRACE_SECONDS]` so the
interrupt is proved to reach the disposal and not just the read.

## F4 (fix). The gate passed the mutations it exists to catch.

Correct, and measured rather than accepted on report. Applying the round-1
predicate to the three forms:

```
round-1 gate on 1 bare wait():        CAUGHT ['1 .wait()']
round-1 gate on 2 wait(timeout=None): PASSED CLEAN []
round-1 gate on 3 with Popen(...):    PASSED CLEAN []
```

The check now rejects all three. **Each planted separately into
`kstrl/procgroup.py`, exact failure text:**

```
=== MUTATION 1: bare process.wait() ===
E       AssertionError: a deadline-managed module waits on a child without a deadline, which is #309:
E           kstrl/procgroup.py:275 .wait() names no timeout=
E       assert not ['kstrl/procgroup.py:275 .wait() names no timeout=']

=== MUTATION 2: process.wait(timeout=None) ===
E       AssertionError: a deadline-managed module waits on a child without a deadline, which is #309:
E           kstrl/procgroup.py:275 .wait(timeout=None) is not a deadline
E       assert not ['kstrl/procgroup.py:275 .wait(timeout=None) is not a deadline']

=== MUTATION 3: with subprocess.Popen(...) ===
E       AssertionError: a deadline-managed module waits on a child without a deadline, which is #309:
E           kstrl/procgroup.py:239 `with` on a Popen: __exit__ waits with no deadline
E       assert not ['kstrl/procgroup.py:239 `with` on a Popen: __exit__ waits with no deadline']
```

`sites_seen >= 10` is kept. Two things were added beyond the ask, because
verifying a gate once in a shell session is the failure mode this finding is
about:

- The planted forms are now parametrized cases
  (`test_the_gate_catches_each_planted_mutation`), with a negative set
  (`test_the_gate_stays_quiet_on_these`) and an executed statement of the one
  known miss (`test_a_deadline_that_is_none_at_run_time_is_a_known_miss`). The
  gate is re-verifiable by anyone, forever, instead of by me, once.
- The round-2 review then found a fourth hole in my fix: `_is_popen_call` was a
  bare name match, so `from subprocess import Popen as Spawn` followed by
  `with Spawn(argv)` produced no finding. That is the under-reporting direction.
  It is alias-aware now, with both alias forms as planted cases.

## Not findings

The reviewer cleared the pipe-buffer deadlock question, confirmed the grace is
applied where claimed, and confirmed normal timeout cleanup closes both pipes.

## Verification

Full suite 4496 passed / 28 skipped. `mypy kstrl/ --strict` clean, `ruff check
kstrl/ tests/` clean, staged pre-commit clean. Coverage 89.83% against the 79.91%
ratchet; `kstrl/procgroup.py` at 100% statement coverage.

---

## `/simplify` round 2, verbatim

Two agents over the round-2 diff only, one per pair of angles.

### Reuse and simplification

> I verified the central reuse claim empirically rather than asserting it. Findings below.
>
> ## Findings
>
> **1. `tests/helpers/procs.py:182-203` (and `tests/test_procgroup.py:374-385`) - `interrupted_ps` re-implements coverage the existing `fake_ps(raises=...)` already gives.**
> Measured, not argued. `procs.fake_ps(monkeypatch, raises=KeyboardInterrupt)` drives F3 end to end: the read raises `KeyboardInterrupt`, `_read_ps`'s `except BaseException` routes to `_kill_or_abandon`, the grace `communicate` raises it again (call log shows `timeouts=[5.0, 1.0]`, so the interrupt does land in the disposal), the interrupt propagates, and `kills == 1`, `closed == ["stdout", "stderr"]`. I planted the pre-F3 body (release inside the `except` clause) and that fixture catches it: `closed == []`. It also needs no `PS_TIMEOUT_SECONDS` monkeypatch and mypy accepts the class object against `Callable[[], BaseException]` (checked under `--strict`). Cost: 23 lines of second fixture plus a new `itertools` import, in the one module whose stated thesis is that two fixtures for one behaviour drift apart. The only thing the new fixture expresses that `fake_ps` cannot is the narrative "wedge first, interrupt the grace second" - if that distinction is judged load-bearing, a `raises_after: int = 0` argument on `fake_ps` says it without a second fixture.
> Secondary nit in the same block: `itertools.count()` plus `if next(disposals):` is a general counter used only to answer "have I been called before", and it leans on 0 being falsy to mean "first call".
>
> **2. `tests/test_timeout_enforcement.py:1176` - `_popen_bound_names(tree)` is called inside the with-item loop, so the whole-tree walk is redone per item.**
> Measured before flagging, and the measurement lowers the severity: the four allowlisted files today hold 18 with-items and **zero** with a `Name` context expression, so the short-circuit means the recompute never fires in the real gate. It is latent, not current. What it costs when it fires: `kstrl/serve.py` is 10,102 AST nodes, so the first `with lock:` added to that file makes the gate re-walk 10k nodes per such statement. Hoisting the call above the outer loop is one line and removes the latent quadratic outright.
>
> **3. `tests/test_timeout_enforcement.py:1160, 1163, 1177, 1201` - the `(int, str)` tuple carries a line number that is also baked into the string it travels with.**
> `f"{node.lineno} .{method}() names no timeout="` embeds the lineno, and the tuple's first element repeats it purely so `sorted` orders numerically. The sort is justified (two lists concatenated in `ast.walk` order are not source-ordered), the double encoding is not: the number is written twice at each of the three append sites, and the planted-case expectations then read as bare-prefixed strings (`"1 .wait() names no timeout="`) that mean nothing without knowing the convention. Dropping the prefix from the message and formatting `f"{line} {text}"` once in `_unbounded_wait_findings` removes the duplication and leaves the sort intact.
>
> **4. `tests/test_timeout_enforcement.py:1361-1362` - each allowlisted file is parsed twice per gate run.**
> `ast.parse(source)` for `_wait_calls`, then `_unbounded_wait_findings(source)` parses the same text again internally. Measured: one parse of the four files is 9.0 ms against a ~29 ms gate, so the redundant parse is about a third of the test's runtime. The underlying cause is an API asymmetry the diff introduced: `_wait_calls`, `_bare_wait_findings` and `_with_popen_findings` all take a tree, while `_unbounded_wait_findings` alone takes a source string. Taking a tree there (with the planted-case tests passing `ast.parse(body)`) makes the family consistent and the double parse impossible.
>
> **5. `kstrl/procgroup.py:277-281` - the `except (...): pass` now reads as dead code, because the comment that justified it moved into the `finally`.**
> The clause is load-bearing: without the swallow, a `TimeoutExpired` from the grace would propagate out of `_kill_or_abandon` and displace the original exception that `_read_ps` is about to re-raise. But the surviving comment stops at "the child is not ours to collect." - the old payoff clause ("so let go of the pipes instead") went to the `finally`, and nothing left on the `except` says why swallowing is right. The next reader with a linter is going to try to delete a bare `pass` whose reason is stated nowhere. One clause restores it.
>
> **6. `kstrl/procgroup.py:118-119` - the hazard sentence is re-derived where the module docstring already established it 95 lines earlier.**
> "lets a second factory start on a repo the first is still writing to" is already the module docstring's opening safety argument at line 24-26, under a heading whose whole subject is when a "gone" is trustworthy. This diff restates the same causal chain at line 118-119, again at line 396-398 in `signal_probe_alive`, again at `tests/test_procgroup.py:490-493`, and again at `tests/test_serve.py:2081-2084`. Five statements of one claim, four of them added or rewritten here. Cost: the mapping is one decision, and a future change to it has to be found and re-argued in five places, four of which no mechanism checks. `signal_probe_alive`'s version is the one that sits on the code it describes; the other three can cite it in a clause.
>
> **7. `tests/test_timeout_enforcement.py:1134` vs `tests/test_procgroup.py:593-595` - verbatim duplicate of the callee-name idiom.**
> `name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")` is `_callee_name`'s body, character for character.
> My honest judgment, since you asked for it: **do not share a helper here.** The shared surface is exactly this one line. The two functions you flagged as similar in shape are not similar in substance - `_module_argv_constants` walks `tree.body` only, keys names to a first string token, and exists to resolve module-level argv constants; `_popen_bound_names` walks the entire tree, returns a bare name set, and exists to resolve a `with` target. Extracting a `tests/helpers/astnet.py` would couple two independent gates so that a future widening of one has to be argued against the other, and it would buy back one line. Flagging the duplicate for the record, recommending it be left alone.
>
> **8. `tests/test_timeout_enforcement.py:1156` - `assert isinstance(node.func, ast.Attribute)` re-proves what `_wait_calls` just guaranteed.**
> Runtime-dead; it exists only to re-narrow the type for mypy after `_wait_calls` returns the widened `list[ast.Call]`. Minor, and the fix is cheap: having `_wait_calls` yield `(node, node.func.attr)` pairs removes the assert and the re-lookup, and `sites_seen += len(...)` still works unchanged.
>
> ## Considered and not flagged
>
> The six-helper split itself. `_wait_calls` and `_is_popen_call` have two callers each, and `_bare_wait_findings` / `_with_popen_findings` name the two forms the `_unbounded_wait_findings` docstring taxonomy and the planted cases both refer to. Collapsing them into one 25-line function with two loops would cost that naming and save nothing. The count is fine; findings 2, 3 and 4 are about how they talk to each other, not how many there are.
>
> Also not flagged: `package_root.parent / rel` at line 1360-1361 appends `"kstrl"` and immediately strips it again. It reads badly, but it is pre-existing rather than added here.

**Disposition.** 1 through 6 and 8 applied. 1 applied as recommended: the second
fixture and the `itertools` import are gone, and the F3 counterfactual was re-run
against the simpler fixture to confirm it still bites. 7 left alone on the
agent's own recommendation. The final note about `package_root.parent / rel` is
pre-existing and out of scope.

### Efficiency and altitude

> I have measured everything I claim below. Findings, highest value first.
>
> ## Findings
>
> **1. `kstrl/procgroup.py:380-429` and `:360-377` - after F1, `signal_probe_alive` is the exact boolean complement of `_kernel_says_group_is_empty`, and nothing enforces that.**
> Verified on all six branches (success, ESRCH, EPERM, EINVAL, EIO, and the `pgid <= 1` refusal): `signal_probe_alive(p) == not _kernel_says_group_is_empty(p)` in every one. Before F1 they disagreed on the generic `OSError` branch, which is the defect F1 fixed. Cost: F1's own stated argument is "two functions in one module disagreeing about what an unexplained error means was the defect underneath the defect", and the thing now holding them in agreement is a paragraph. The duplication is doubled in the tests: `tests/test_procgroup.py:205` `TestTheKernelControl` (4 cases) and `:449` `TestTheSignalProbeIsKeptAsTheDegradedReading` (6 cases, 2 of them added by this diff) pin one 5-row table twice at opposite polarity, and editing one class fails nothing in the other. Available mechanism: `return not _kernel_says_group_is_empty(pgid)`, one line, which turns the docstring's "the rule now matches" into structure. Honest cost of that collapse: one docstring then carries both framings. A cheaper alternative that still gets a mechanism is one parametrized test asserting the complement across the branch table.
>
> **2. `kstrl/procgroup.py:383` contradicted by `:393-401` - the F1 paragraph was appended, not integrated.**
> The docstring opens "The pre-#298 reading, kept because it is the only thing left when `ps` gives no answer at all" and ten lines later says "That was the pre-#298 mapping carried forward ... and had to go". Cost: the summary line of the function this whole fix is about now states the thing the same docstring later reverses, so a reader who stops at the first sentence gets the pre-F1 answer.
>
> **3. `kstrl/serve.py:1619` - the one production caller still describes the leaf as "the pre-#298 behaviour".**
> F1 landed at the leaf and the caller's description of the leaf was not revisited. That sentence is now false for exactly the branch #309 round 1 was about, and it sits in the docstring a reader chasing the fail direction reads next. Cost: one stale sentence in the highest-traffic place. Worth noting the counterweight in the same docstring at `:1625-1626`, "its only error is over-reporting alive": that claim was false before F1 and F1 makes it true without touching serve.py, which is the strongest evidence the leaf was the right altitude.
>
> **4. `tests/test_timeout_enforcement.py:1129-1136` - `_is_popen_call` re-derives, more weakly, the Popen detection the same class already computes at `:1250-1263`.**
> `_subprocess_aliases` resolves `import subprocess as sp` and `from subprocess import Popen as Spawn`; `_is_popen_call` is a bare name match. Measured: `from subprocess import Popen as Spawn` then `with Spawn(argv) as p:` produces no finding, while `with mock.Popen():` produces one. Cost: two definitions of "this constructs a Popen" 120 lines apart in one class, the newer being the weaker, with the older machinery already in scope as a `@staticmethod`.
>
> **5. Prose repetition of the #186 F1 rationale, against a rule the module states itself.**
> "releases the item and a second factory starts on a repo the first is still writing to" is stated canonically at `kstrl/procgroup.py:25`. This diff adds four more copies of the argument: `kstrl/procgroup.py:119`, `kstrl/procgroup.py:396`, `tests/test_procgroup.py:491`, `tests/test_serve.py:2083`. Cost: a future change to the fail direction has to move five texts and a reviewer has to check five. `kstrl/procgroup.py:171-172` names this exact anti-pattern for a runtime string ("Said once, because ... reflowed copies of one sentence are how the two answers drift apart"), and `:271` shows the reference-style alternative ("the module docstring records what that abandoned child costs"). On volume alone the module is defensible: measured across the 98 kstrl modules over 100 lines, procgroup.py is 66% prose against a 26% median, in line with atomicio.py at 74% and scope.py at 67% for this class of module. The repetition is the cost, not the length.
>
> **6. `tests/test_timeout_enforcement.py:1361-1362` - each allowlisted file is parsed twice per gate run. Measured: does not matter.**
> 9.1 ms per gate run for the redundant parse pass. The whole test measures 0.04 s in-suite (`pytest --durations`), which is 0.004% of the 246.5 s suite the repo records. Parsing once and passing the tree is a two-line change that buys legibility, not time. Reporting it as cost would be dishonest.
>
> **7. `tests/test_timeout_enforcement.py:1176` - the per-with-item `_popen_bound_names(tree)` call fires zero times today. Measured: does not matter.**
> The premise that it is recomputed per item is currently false in practice: `and` short-circuits, and none of the 18 with-items across the four allowlisted files has a bare `Name` context expression (they are all calls, `open(...)`, `suppress(...)`). Worst plausible case, all 15 of serve.py's with-items becoming `with proc:`, is 35.2 ms against 2.34 ms hoisted. Apples to apples over three runs the shipped gate body is 32.8 ms and a single-parse, hoisted equivalent is 28.0 ms: 4.8 ms of waste, 0.002% of the suite. Still worth hoisting, because a per-tree fact computed inside a per-item loop reads as if it depended on the item.
>
> **8. `tests/helpers/procs.py:193-201` - checked for closure retention, found none.**
> Measured 4 objects retained per read with gc disabled over 50 reads, and those four are the `PsCall` log entry the test asserts on, which is the fixture's product. Compare the 27-per-read cycle `fake_ps` documents at `:155-163`. The `itertools.count` is built inside `respond_for`, so it is per fake child (56 bytes) and dies with it, and `raise KeyboardInterrupt` raises the class, so no instance, traceback or test frame is captured. No finding. One naming nit at `:194`: `disposals` counts every `communicate`, the read included, so `if next(disposals)` actually means "this is not the first call".
>
> ## The three altitude questions, answered
>
> **(a) Was the leaf the right depth?** Yes. `serve._group_liveness_for_reap` could not have been taught the distinction: `signal_probe_alive` returns a plain bool, so the caller has nothing to branch on, and the alternative at the caller is to stop using the probe, which reinstates the "every timed-out run is poisoned" trade the docstring at `serve.py:1618-1629` already rejected with reasons. No other caller wanted the old direction. `tests/test_shutdown.py:657` is the only one, and it asserts `is True` as a positive control that the zombie window is real; F1 widens the set of conditions satisfying it, so it can now pass vacuously on an unexplained errno rather than failing loudly, but the branches reachable on a real machine there (success, EPERM, ESRCH) are unchanged. The missed opportunity at the leaf is finding 1, not the choice of altitude.
>
> **(b) Should the gate cover all of `kstrl/`?** No, the POPEN_ALLOWLIST scope is right. Widening produces exactly three false positives, all `threading.Event` waits, and all three pass their deadline positionally, so even a "must name `timeout=`" reading flags them: `kstrl/commandrun.py:66` `stop_event.wait(period)`, `kstrl/interaction.py:176` `pending.event.wait()`, `kstrl/shutdown.py:45` `self._event.wait(timeout)`. The four allowlisted files contain no Event waits at all: all 11 wait/communicate sites in them are on a Popen, so the receiver-name shortcut costs nothing where it is applied.
>
> **(c) Does the gate belong in a test file?** Yes. Eleven test modules in this repo already AST-walk as gates (`test_atomicio`, `test_process_scoping`, `test_prompt_enrollment_walk`, `test_state_dir_scope`, `test_procgroup` itself, and six more), and ruff is configured with stock rules only, `select = ["E", "F", "I", "UP", "B"]`, with no custom-plugin infrastructure anywhere in `pyproject.toml`. There is no lint surface to move it to without introducing a toolchain, and doing so would break with the repo's established mechanism.

**Disposition.** 1 applied as the collapse rather than the complement test: the
agent offered both and named the collapse the one that "turns the docstring into
structure", which is the whole argument F1 rests on. Its stated cost (one
docstring carrying both framings) is paid in `signal_probe_alive`'s rewritten
body. 2, 3, 4, 5 and 7 applied. 4 in particular closed a real under-reporting
hole in my own F4 fix. 6 not applied for speed, which the agent correctly says
would be dishonest, but applied for the API consistency the other agent's finding
4 identified as its cause. 8 is moot: the fixture it measured was deleted under
the other agent's finding 1.


---

# Round 3: the two false mechanism claims

## C1 (fixed in code). The abandoned child WAS a permanent zombie under warnings-as-errors.

Verified against the installed CPython 3.12.8 rather than taken on report. `Popen.__del__` calls `_warn(..., ResourceWarning)` before `_active.append(self)`, so under `-W error` the warn raises, `__del__` aborts, and the registration never happens.

```
--- default warnings ---
  _active length after drop: 1
  child 38654 state: '(not listed)'
--- PYTHONWARNINGS=error ---
  _active length after drop: 0
  child 39789 state: 'Z'
```

**Fix:** `_kill_or_abandon` now registers the child itself, via `_register_abandoned`.

**It registers in two places, and the second one is a regression the round-3 `/simplify` pass caught in my own fix.** My first version put the child only on a module-level `_ABANDONED` swept at the top of `_read_ps`. That is strictly better under `-W error` and strictly worse under default warnings, which is what CI and most operators actually run: CPython's `_active` is swept by `_cleanup()` on every `Popen.__init__`, and there are 70 spawn sites in `kstrl`, so the old path reaped an abandoned `ps` at the next git call. Mine would have waited for the next timed-out read, which may be days away. So it registers on both: ours for the promise this module can make and a test can see, CPython's for the frequency.

**Only something `_cleanup` can poll may go on `_active`.** Measured, not anticipated: putting a test double there crashed the next real spawn anywhere in the suite with `AttributeError: '_FakePs' object has no attribute '_internal_poll'`. The guard checks for that attribute rather than `isinstance(process, subprocess.Popen)`, because the suite's own seam replaces the name `subprocess.Popen` with a function and an `isinstance` against it then raises `TypeError` - also measured, from four failing tests.

**End to end, through the real module, under the setting that broke it:**

```
registered after abandoning: 1
child 73655 before the sweep: 'Z'
register after the next read: 0
child 73655 after the sweep:  '(gone)'
```

Tests: `test_the_register_drains_once_the_child_dies` (a real child, abandoned alive, then reaped by the next read), `test_a_collected_child_is_not_registered` (the control, so the register cannot be growing on healthy reads), `test_a_real_child_is_disposed_of_without_leaking_a_descriptor` (the round-1 hand check, made repeatable). Verified by removing the registration: `E AssertionError: an uncollected child must be kept, or nothing can ever reap it`.

**The docstring no longer reads as if the class were handled.** A new "THIS FIXES ONE SITE, NOT THE CLASS" paragraph names `verify.run_scrubbed`, `serve._wait_out_grace` and `agents.proc.DeadlineStreamer.kill`. See the follow-ups below: one of them is materially worse than `procgroup` ever was.

## C2 (fixed). `_popen_names` claimed a resolution `_subprocess_aliases` did not have.

Took the one-liner: `direct_funcs` is now `dict[local, original]` and the caller compares against the original.

**What it broke: nothing.** Full suite green, and the only call site was inside this class.

**Verified by planting, as parametrized cases rather than by hand** (`test_the_audit_resolves_a_renamed_import`), covering `from subprocess import run as _run`, `Popen as Spawn`, `check_call as _cc`, plus the unrenamed forms as controls. Against the old mapping: `E assert [] == [(2, 'run')]`, `E assert [] == [(2, 'Popen')]`, `E assert [] == [(2, 'check_call')]`. So the case the review cared about, a brand new module calling `subprocess.run` with no timeout at all, now fails the audit.

The audit body was extracted into `_spawn_sites` to make that possible. `test_the_audit_misses_these_and_says_so` executes the two remaining holes (`_P = subprocess.Popen`, `getattr(subprocess, "Popen")`), which need dataflow an AST walk does not do.

**And the paragraph is gone rather than repaired.** The round-3 pass measured that `_popen_names` agreed with `_subprocess_aliases` on all 283 files plus 5 synthetic forms, and pointed out that prose asserting two resolvers agree is the same shape as the bug C2 was. `_popen_names` now derives from `_subprocess_aliases` instead, so the claim cannot be wrong.

## C3 (fixed). `_read_ps` kept the promise the module docstring withdrew.

Opening line is now "One `ps` read, with every wait on the child bounded", with the startup residual and the measured 3.011s stated, pointing at the module docstring section that qualifies it. The `PS_KILL_GRACE_SECONDS` comment had the same flat-ceiling claim and got the same treatment.

## Non-blockers folded in

All five.

- **The grace bounds an EOF wait on the pipes, not a wait on the process.** `_kill_or_abandon`'s docstring stated the old version as a POSIX fact and used it to justify "no further waiting can shorten it". Rewritten, including that what is abandoned may be a descendant we never had a handle on.
- **`tests/test_procgroup.py`'s stale "replaces `subprocess.run`"** now says `Popen`, and says why the guard carries more since the move.
- **`sites_seen >= 10`** replaced with a per-file check: every allowlisted file must show at least one wait site. A global floor of 10 against an actual 11 would have failed a legitimate refactor with "the scan is broken", which is a false diagnosis.
- **`_popen_bound_names` is name collection, not scope analysis**, and now says so, including the measured detail that the planted `with` mutation is caught partly because the parameter happens to be called `process`.
- **No test exercised the disposal against a real `Popen`.** `test_a_real_child_is_disposed_of_without_leaking_a_descriptor` now does, asserting the fd count is unchanged and the child reaped.

## Verification

Full suite 4509 passed, 28 skipped. `mypy kstrl/ --strict` clean, `ruff check` and `ruff format --check` clean, staged pre-commit clean. Coverage 89.84% against the 79.91% ratchet; `kstrl/procgroup.py` at 100% statement coverage.

## Follow-ups this round surfaced, not fixed here

- **`verify.run_scrubbed` has the same zombie exposure and a much wider window.** Reproduced by the review pass: it needs no D-state child, only something outside the group holding the pipe write end, and it runs once per verification command rather than once per timed-out read. Under `warnings.simplefilter("error")` the measurement was `_active` length 0 and `ps` reporting `95800 Z <defunct>`. It also never closes its two pipe ends, which is the round-1 F3 leak, fixed in `procgroup` and not there. `serve._wait_out_grace` and `agents.proc.DeadlineStreamer.kill` are the same class at `procgroup`'s original narrower width.
- **`tests/test_procgroup.py`'s `ps`-owner net has the C2 hole.** Measured: `from subprocess import run as _run; _run(["ps","-A"])` returns `[]`, so a second `ps` parse can land behind an `as` rename and `test_no_second_ps_call_exists` stays green. Same defect class, different gate, pre-existing.
- **Two `with`-on-a-Popen gaps with real reach:** a `Popen` returned from a helper, and a `Popen` parameter whose name matches no module-level binding.

---

## `/simplify` round 3, verbatim

Two agents over the round-3 diff only.

### Reuse and simplification

> ## Findings
>
> **1. `tests/test_procgroup.py:459-461` is not ruff-formatted.**
> `ruff format --check` collapses the `monkeypatch.setattr("kstrl.procgroup.subprocess.Popen.kill", lambda self: None)` call to one line. Cost: the `ruff-format` pre-commit hook (`.pre-commit-config.yaml:69`) fails, on a branch whose stated purpose is fixing pre-commit findings, and commit `745343f` just reformatted the tree. `ruff check` is clean; this is the only formatting regression in the diff.
>
> **2. `tests/test_procgroup.py:362` still carries the claim C1 withdrew.**
> `test_an_unkillable_ps_is_killed_and_let_go_of`'s docstring says "the child itself is abandoned, and CPython's `subprocess._active` collects it once the kernel lets it die", the exact sentence the diff deleted from `kstrl/procgroup.py` and measured false. Cost: the file now says both things 50 lines apart, and the false copy sits on the test a reader reaches first.
>
> **3. `tests/test_timeout_enforcement.py:1129` `_popen_names` re-implements the Popen half of `_subprocess_aliases` (1284).**
> Both walk `ImportFrom` where `module == "subprocess"` and take `asname or name`. Measured: `{"Popen"} | {loc for loc, orig in direct.items() if orig == "Popen"}` agrees with `_popen_names` on all 283 `.py` files in the repo plus 5 synthetic import forms, 0 disagreements. Cost: the diff spends a new 9-line paragraph (1137-1144) explaining that the two "resolve the same import forms" and "share their misses", prose holding two copies in sync, which is precisely the failure C2 was (the previous version of that same sentence claimed a guarantee the other function did not have). Deriving one from the other deletes both the copy and the paragraph.
>
> **4. `tests/test_procgroup.py:411-434` `test_an_abandoned_child_is_registered_for_a_later_reap` is subsumed.**
> `test_the_register_drains_once_the_child_dies:464` asserts the identical claim (`len(...) == 1` after abandonment) against a real `Popen` instead of a fake whose `poll()` is a stubbed attribute, through the same `_kill_or_abandon` branch. Its arrangement is a copy of `test_an_unkillable_ps_is_killed_and_let_go_of:353`, differing only in the two constants. Cost: 24 lines plus a 12-line docstring that restates the whole `_active` measurement already written at `kstrl/procgroup.py:116-130`, for one assertion that could be line 375 of the existing test.
>
> **5. `tests/test_procgroup.py:446` leaves `PS_KILL_GRACE_SECONDS` at 1.0 while shrinking `PS_TIMEOUT_SECONDS` to 0.05.**
> The abandoned `sleep 30` is alive, so the grace `communicate` burns the full real second. Measured: 1.06s for this test against 0.03s and 0.05s for its two neighbours; adding the one `setattr` line both neighbours already have takes it to 0.11s. Cost: 0.95s of deterministic dead wall clock per run.
>
> **6. Three different isolation strategies for `_ABANDONED` across four tests.**
> `tests/helpers/procs.py:294` resets it inside `_patch_ps_popen`; `tests/test_procgroup.py:456` hand-rolls the same reset; `tests/test_procgroup.py:500` asserts against the real module list with no reset at all. Cost: (a) `_patch_ps_popen`, whose one job is routing `PS_ARGV` to a fake, silently acquires a second unrelated job for every `fake_ps` caller in the suite; (b) line 500's assertion is about unowned global state, so the first test anywhere that abandons a real child fails it with "a killable child must be reaped, not kept", a false diagnosis of exactly the kind this same diff removed from the `sites_seen >= 10` gate in `test_timeout_enforcement.py`. One autouse fixture covers all four and lets the helper keep one job.
>
> **7. `kstrl/procgroup.py:193-195` restates the module docstring instead of pointing at it.**
> The comment already says "the module docstring's #309 round 2 section measures why", then repeats "holding the reference here is also what stops `__del__` running at all", which is line 134-135 verbatim in substance. Cost: two copies of one sentence, against the rule the very next constant states (`_UNMEASURABLE:199-200`, "Said once, because ... reflowed copies of one sentence are how the two answers drift apart").
>
> **8. `tests/test_timeout_enforcement.py:1314` `_spawn_sites` docstring describes a return shape it does not have.**
> First line promises `(lineno, subprocess name)`; the signature and body return `list[tuple[ast.Call, str]]`. Cost: a caller trusting it writes `for lineno, name in sites` and binds an `ast.Call` to `lineno`; the diff's own new test at 1413 has to convert with `[(node.lineno, called) for node, called in sites]`.
>
> **9. `tests/test_timeout_enforcement.py:1344-1348` `_names_a_timeout` is a one-expression static method with one caller.**
> Called only at 1363, and it deduplicates nothing: `_bare_wait_findings:1189` still scans `node.keywords` for `timeout` inline. Cost: minor, an indirection to a static method to learn what "names a timeout" means. Unlike `_spawn_sites` it enables no test.
>
> **10. `kstrl/procgroup.py:132-142` merges two topics into one paragraph.**
> The new `_ABANDONED` material was appended to the front of the pre-existing signal-probe paragraph with no break, leaving the ragged "is the signal / probe" wrap at 136-137 and one paragraph carrying both the reap register and the round-1 probe fix. Cost: one blank line; minor.
>
> ## Considered and not flagged
>
> - **`_release_pipes` (`kstrl/procgroup.py:344`)** earns the extraction despite its single caller. C1 grew the `finally` block, and hoisting the older four-line loop keeps it two readable statements. The split of the explanation (why-in-a-finally stays at the call site, why-a-read-end-cannot-block moves to the function) is clean rather than duplicated.
> - **`_reap_abandoned`** is the counterpart to the append and has its own contract; single caller is not a smell here.
> - **`_spawn_sites`** did more than move the audit: it enabled 10 new planted-module cases that could not otherwise exist, and hoisting `sites_seen += 1` out of the two branches genuinely simplified the loop.
> - **`_ABANDONED` as module-level state** is the simplest thing that works. It needs a strong reference (that is the mechanism), `_read_ps` is a module function with no object to hang state on, and the alternatives are worse (`waitpid(-1, WNOHANG)` reaps other people's children; a reaper thread is more machinery). The smell is in the test isolation, not the register, finding 6.
> - **Module docstring internal redundancy**: none. Neither of the two newly added paragraphs (114-130, 132-136) repeats the other; they are the evidence and the consequence. The duplication is docstring-to-comment (finding 7) and docstring-to-test-docstring (folded into finding 4).
>
> ## Reuse verdict on the register
>
> Nothing existed to reuse. `agents/proc.py:45` `_ACTIVE` is a `WeakSet` of `DeadlineStreamer` for shutdown-time group kill, the opposite lifetime and purpose; `serve.py` and `verify.py` hold no child registry. Worth telling the caller: `agents/proc.py:155-161` swallows the identical unreapable-child case with a bare `pass` and no register, so it has the shape C1 just measured. Out of scope for this PR, but it is the one natural consumer if `_reap_abandoned` is ever shared.

**Disposition.** All ten applied. 3 applied as the derivation, which deleted the duplicate resolver and the paragraph. 4 applied by deleting the fake-based test and folding its claim into the real-child one, which proves more. 6 applied as a single autouse fixture in `tests/conftest.py`, which also let `_patch_ps_popen` go back to one job. 9 inlined. The `agents/proc.py` note is carried into the follow-up list above.

### Efficiency and altitude

> ## EFFICIENCY
>
> **E1. `_reap_abandoned`'s O(n) `list.remove` does not matter. Not a finding.** `kstrl/procgroup.py:367-369`.
>
> Measured on this machine (`.venv` CPython 3.12.8, 949-process box), median over 2000 sweeps:
>
> | n | all entries still alive | all entries dead (the `remove` path) |
> |---|---|---|
> | 5 | 0.167 us | 0.292 us |
> | 100 | 1.375 us | 4.041 us |
> | 1000 | 12.208 us | 67.416 us |
>
> One real `ps -A -o pid=,pgid=,stat=` read on the same box: 13.968 ms median. So at the realistic size the docstring names (up to 5 abandoned per terminated run) the whole sweep is 0.002% of the read it precedes; even at a fabricated n=1000 it is 0.48%. A real `Popen.poll()` (`waitpid(WNOHANG)`) costs 0.292 us median, so the syscalls dominate the list work and both are noise. Do not change this.
>
> **E2. Each register entry retains up to 18.8 KB, not "the object itself", and `_release_pipes` does not free it.** `kstrl/procgroup.py:344-355` and `kstrl/procgroup.py:191-197`.
>
> The `_ABANDONED` comment says growth is "bounded by how many reads are abandoned", which frames the entry as cheap. Measured deep size of a real abandoned `Popen` graph after running procgroup's exact disposal (both communicates, then the pipe closes):
>
> - `sys.getsizeof(Popen)` alone: 48 bytes, plus 296 for `__dict__`
> - CPython's `Popen._fileobj2output`, the partial-read accumulator `_communicate` leaves behind when it raises `TimeoutExpired`: 16,133 bytes in 1 chunk
> - total retained graph: **18,833 bytes**, i.e. 390x the object
>
> 16,133 bytes is exactly the full `ps` listing on this box (949 rows). Closing the pipe objects does not touch `_fileobj2output` (the measurement ran after the closes). So the range per entry is roughly 0.3 KB (a `ps` wedged in D-state before writing anything) to 18.8 KB (the grandchild-holds-the-pipes case `_kill_or_abandon`'s own docstring describes, where the listing was fully read). At the docstring's worst case of 5 abandoned per terminated run that is ~94 KB per run, held for the daemon's life. Concrete cost: small, but the comment's "growth is bounded by how many reads are abandoned" understates the per-entry constant by two orders of magnitude. A one-line `process._fileobj2output = {}` before appending would drop it to ~300 bytes; or say the number in the comment.
>
> **E3. Sweeping only inside `_read_ps` is a regression against the default-warnings case the old code handled well.** `kstrl/procgroup.py:275`.
>
> `subprocess._active` is swept by `_cleanup()` at the top of every `Popen.__init__` (`subprocess.py:822`), and `kstrl/` has 70 spawn sites across 16 modules. So under default warnings the old path reaped an abandoned `ps` at the next git call, verification command or agent spawn: milliseconds to seconds. `_ABANDONED` is swept only by the next `_read_ps`, and the module docstring itself says the production caller "asks once per timed-out run, on the way out" (line 71) and measured "every `wait_for_group_to_die` call converged on its first poll" (line 73), so on a healthy daemon that is one read per terminated run and the register drains at the next timeout, which may be days away or never.
>
> The honest summary of the trade the PR makes: strictly better under `PYTHONWARNINGS=error` (where the old path leaked forever), strictly worse under default warnings (zombie lifetime goes from "next spawn anywhere" to "next timed-out run"). Nothing in `pyproject.toml` or `.github/` sets warnings-as-errors in this repo today, so the default case is the one CI and most operators are actually in. The module docstring's unconditional "It is not a permanent zombie" (line 114) is now conditional on another `ps` read happening, and that condition is not stated where the claim is.
>
> Answering the frequency question directly: sweeping after abandoning would be useless (the child was abandoned precisely because it would not die). The frequency that is better on both axes is `_active`'s, see A2.
>
> ## ALTITUDE
>
> **A1. `_ABANDONED` is at the right altitude as module-level state, and the module already argues why.** `kstrl/procgroup.py:191-197`.
>
> Not a finding, stated so the question is closed. `_may_signal_group`'s docstring (lines 218-232) makes exactly the argument that applies here: "nothing enforces that its callers came through one of them, and a docstring saying they do is a convention, not a mechanism". A caller-owned register would be that convention, and `tests/helpers/procs.py` is a second caller that would not have one. Module-level is consistent.
>
> Thread-safety, checked rather than assumed: `read_group_liveness` has exactly one production caller, `serve._group_liveness_for_reap` (`kstrl/serve.py:1650`), reached from `_wait_out_grace`/`process_group_alive` on the daemon's single thread; `serve` imports no threading; `ks serve` is called directly from `cli.py:5157`, never through `tui/bridge.start_command_thread`. Every test caller (`test_shutdown.py`, `test_serve.py`, `test_process_scoping.py`) is on the main thread, and there is no pytest-xdist. So it is single-threaded today.
>
> **A2. The sweep reimplements CPython's `_cleanup` one guard short, and appending to `subprocess._active` would be better on frequency at equal cost.** `kstrl/procgroup.py:358-369`.
>
> CPython's `_cleanup` (`subprocess.py:268-279`) is the same three lines plus a guard the PR dropped:
>
> ```python
> try:
>     _active.remove(inst)
> except ValueError:
>     # This can happen if two threads create a new Popen instance.
>     # It's harmless that it was already removed, so ignore.
>     pass
> ```
>
> Concrete cost if that race ever becomes reachable: `ValueError` escapes `_reap_abandoned` and `_read_ps`, is caught by `read_group_liveness`'s `except (OSError, ValueError, TimeoutExpired)` at line 245, and reports "ps failed to run" plus a signal-probe fallback. That is the safe direction (over-reports alive), but it is a silent semantic substitution triggered by a sweep, not by `ps`. Three lines to match the upstream it copies.
>
> The stronger option the review asks about: append to `subprocess._active` in `_kill_or_abandon` rather than waiting for `__del__` to do it. That is what `__del__` would have done, so it is not new coupling, and it fixes E3 outright since all 70 spawn sites then sweep it. It also removes the ResourceWarning by itself (`_active` holds the strong reference, so `__del__` does not run; when `_cleanup` removes it the returncode is already set). Keeping `_ABANDONED` as well costs nothing and keeps the tests' handle. Hedge for the private API is one `getattr(subprocess, "_active", None) is not None` check, which the module needs anyway since `_active is None` on Windows.
>
> **A3. The class is alive, and the widest window in it was not the one fixed.** Fixing only `procgroup` leaves three siblings exposed, and one of them is worse than `procgroup` ever was.
>
> - `kstrl/verify.py:175-177` (`run_scrubbed`): **measured, reproduced.** This one does not need a D-state child. `proc.wait(timeout=term_grace)` at line 167 expires if the child traps SIGTERM, the group SIGKILL lands, and then `proc.communicate(timeout=term_grace)` at 175 still expires because anything outside the group holds the pipe write end. The direct child is then dead-but-unreaped and dropped. Reproduced with a shell that traps TERM and backgrounds a `setsid` helper holding stdout: under default warnings the pid is reaped and gone; under `warnings.simplefilter("error")` `subprocess._active` is length 0 and `ps -o pid=,stat=` on that pid returns `95800 Z <defunct>` with `os.waitpid` still returning `(95800, 9)`. Concrete cost: `run_scrubbed` runs the project's test, typecheck and lint commands on every verification pass, so this fires far more often than `procgroup`'s once-per-timed-out-run. The same path also never closes its two pipe ends, which is the #309 round 1 F3 leak the PR fixed in `procgroup` (`_release_pipes`) and not here; the `-W error` run printed a second `ResourceWarning: unclosed file <_io.TextIOWrapper name=5>` on top of the zombie.
> - `kstrl/serve.py:1441-1445` plus `kstrl/serve.py:1575-1577`: same class, narrower window. `_wait_out_grace` uses `process.wait(timeout=grace)`, which does not care about pipes, so only a child surviving SIGTERM+15s and SIGKILL+10s (D-state) is left unreaped. Identical width to `procgroup`'s, in the same daemon holding the same lock, unfixed.
> - `kstrl/agents/proc.py:151-161`: same class, same D-state-only width, in `kill()`'s final `except subprocess.TimeoutExpired: pass`. The `Popen` dies with the `ProcStreamer` once `_ACTIVE.discard(self)` runs.
>
> Judgement on scope: the argument the PR's own module docstring makes ("a daemon that holds its lock for its whole life ... is the worst place in the tree to rest on a `__del__` that may not finish") applies verbatim to `verify.run_scrubbed`, which runs inside the same daemon far more often and has a window that needs no exotic kernel state. Shipping `procgroup` alone is defensible only if the follow-up is named; as written, the PR closes the narrowest of four instances and the docstring reads as if the class were handled.
>
> **A4. `_spawn_sites` was extracted at the right depth, but the alias resolution wants to be shared: the identical C2 hole is open one file over.** `tests/test_procgroup.py:637-648`, `:699-701`, `:722-731`.
>
> `test_procgroup.py`'s `ps`-owner net matches `_callee_name(node) in _SUBPROCESS_CALLS`, with no import resolution at all. Ran the real `_ps_call_lines` over planted modules:
>
> | plant | finding |
> |---|---|
> | `import subprocess; subprocess.run(["ps","-A"])` | `[2]` |
> | `import subprocess as sp; sp.run(["ps","-A"])` | `[2]` |
> | `from subprocess import run; run(["ps","-A"])` | `[2]` |
> | `from subprocess import run as _run; _run(["ps","-A"])` | **`[]`** |
> | `from subprocess import Popen as Spawn; Spawn(["ps","-A"])` | **`[]`** |
> | `from subprocess import run as _r; ARGV=("ps","-A"); _r(ARGV)` | **`[]`** |
>
> Concrete cost: a second `ps` parse can land anywhere in `kstrl/` or `tests/` behind an `as` rename and `test_no_second_ps_call_exists` stays green, so `procgroup.py:156-160`'s claim that "this module is the only place in `kstrl/` or `tests/` that shells out to `ps`, and `tests/test_procgroup.py` fails on a second one" is enforced only against unrenamed imports. That is the same under-reporting direction C2 was raised about, in the net that backs the module's own closing claim.
>
> There are now four separate resolvers of "what name means subprocess here": `test_timeout_enforcement.py:1118` (`_wait_calls`, none), `:1129` (`_popen_names`, from-imports of `Popen` only), `:1284` (`_subprocess_aliases`, both forms, now local to original), and `test_procgroup.py:699` (`_callee_name`, none). Three of the four are one function's worth of duplication. A shared `tests/helpers/astnets.py` exporting the alias map is the right depth; extracting `_spawn_sites` inside one file was the right first move but stops at the file boundary, and the measurement above is what that boundary costs.
>
> ## Positive, worth keeping
>
> `tests/test_timeout_enforcement.py:1481-1499`: replacing `sites_seen >= 10` with a per-file `blind` check is a real altitude improvement. A global floor of 10 against an actual 11 gave one site of margin and would have failed CI with "the scan is broken" for a legitimate refactor, which is a false diagnosis and the kind of gate that gets deleted. Per-file is the invariant that was actually meant.
>
> ## Checked, nothing found
>
> - `_reap_abandoned` runs before the `Popen` on every path including the spawn-failure path, so no read escapes it.
> - No `fork`-without-`exec` anywhere in `kstrl/` (no `multiprocessing`), so an inherited `_ABANDONED` across a fork is not reachable; `Popen._try_wait` swallows `ChildProcessError` anyway.
> - `tests/helpers/procs.py:289-294` resetting `_ABANDONED` per test through `monkeypatch` is the right seam and restores the real list.
> - `_release_pipes` extraction from the `finally` block is a clean split with no behaviour change.

**Disposition.** E3 and A2 applied together as the dual registration, which is the single most important change in this round: my own C1 fix had made the default-warnings case worse, and neither the review nor I had spotted it. A2's `ValueError` guard is addressed by rebuilding the list rather than removing from it, which cannot raise it at all and walks once instead of once per corpse. E2's number is now in the `_ABANDONED` comment rather than the vaguer "bounded by how many reads are abandoned"; I did not add the `_fileobj2output` reset, because the retention is what CPython's own `__del__` path would have held and a second private-attribute write is not worth ~94 KB. E1 and A1 confirmed and not changed. A3 is named in the module docstring and in the follow-ups above. A4 is left for a follow-up, per the scoping in the review message; the one part of it inside this file's boundary, the duplicate `_popen_names` resolver, is fixed under the other agent's finding 3.
