### PR TITLE
fix(evolution): a torn journal line no longer eats the entry after it (#312)

### DIFF
--- a/docs/evolution-metrics.md
+++ b/docs/evolution-metrics.md
@@ -20,8 +20,41 @@ migrations are detectable.
 | `event_type` | Written by | When |
 |---|---|---|
 | `component_result` | `EvolutionJournal.record_run` | Once per component at the end of every factory run |
-| `findings_superseded` | factory `_journal_superseded_findings` | When a retry supersedes an attempt's findings (R3.3) |
+| `findings_superseded` | pipeline `AttemptRecorder.journal_superseded_findings` | When a retry supersedes an attempt's findings (R3.3) |
 | `contract_result` | factory `_record_contract_event` | After every contract-test tier, pass or fail (R0.3) |
+| `role_usage` | `EvolutionJournal.record_run` | Once per role that spent tokens outside any manifest component (#257) |
+| `autonomy_transition` | `autonomy.commit_transition` | Every promotion or demotion of the autonomy ladder |
+| `spec_issues` | `decompose._record_spec_issues_event` | Once per spec audit (#280); carries no `run_id` |
+| `journal_repair` | `EvolutionJournal.append_entries` | When an append finds the file not newline-terminated, i.e. a previous write was interrupted (#312) |
+
+### `journal_repair`
+
+The journal is append-only, so a crash mid-write leaves an unterminated
+tail and the next append would concatenate onto it, making both lines
+unparseable. `append_entries` writes a newline first and records that it
+did. Reading one of these rows:
+
+| Field | Definition |
+|---|---|
+| `schema_version` | As above. |
+| `timestamp` | UTC ISO-8601 at repair time, NOT at crash time. |
+| `event_type` | `journal_repair`. |
+| `detail` | Fixed prose describing what was found. |
+
+- **Deliberately carries no `run_id` and no `project`.** Every run
+  aggregate windows by the last N distinct `run_id`s, so a repair row
+  with one would be one of the N and a single tear would shorten the
+  history the metrics above are computed over. It counts towards
+  nothing, by construction.
+- **What was lost.** The line IMMEDIATELY ABOVE the row is the
+  interrupted write. If it is a complete JSON object it was a whole
+  record that lost only its newline, and it is readable again. If it is
+  a fragment, that record was never written and is unrecoverable. The
+  row exists so the difference is visible rather than guessed at.
+- **Counting.** `ks evolve --status` prints the count when it is
+  non-zero (`EvolutionJournal.get_repair_count`). Two processes
+  repairing the same tear write two rows, so the count is of rows, not
+  of incidents.
 
 ### `component_result` fields
 

--- a/docs/evolution-metrics.md
+++ b/docs/evolution-metrics.md
@@ -46,15 +46,21 @@ did. Reading one of these rows:
   with one would be one of the N and a single tear would shorten the
   history the metrics above are computed over. It counts towards
   nothing, by construction.
-- **What was lost.** The line IMMEDIATELY ABOVE the row is the
+- **What the line above the row is.** POSSIBLE loss, not confirmed
+  loss: the line IMMEDIATELY ABOVE the row is the
   interrupted write. If it is a complete JSON object it was a whole
   record that lost only its newline, and it is readable again. If it is
   a fragment, that record was never written and is unrecoverable. The
   row exists so the difference is visible rather than guessed at.
 - **Counting.** `ks evolve --status` prints the count when it is
-  non-zero (`EvolutionJournal.get_repair_count`). Two processes
+  non-zero (`EvolutionJournal.get_repair_count`), before the
+  no-experiments exit, because a journal can hold a repair long before
+  any factory run has written `experiments.tsv`. Two processes
   repairing the same tear write two rows, so the count is of rows, not
-  of incidents.
+  of incidents. It is also a LOWER bound: a write split part-way
+  through (residual 4 on `append_entries`) can land the newline that
+  isolates the fragment without landing the row, and the next append
+  then sees a terminated file and adds none.
 
 ### `component_result` fields
 

--- a/kstrl/autonomy.py
+++ b/kstrl/autonomy.py
@@ -778,7 +778,7 @@ def commit_transition(
     """
     state.save(root_dir)
 
-    from kstrl.evolution import JOURNAL_SCHEMA_VERSION, EvolutionConfig
+    from kstrl.evolution import JOURNAL_SCHEMA_VERSION, EvolutionConfig, EvolutionJournal
 
     entry = {
         "schema_version": JOURNAL_SCHEMA_VERSION,
@@ -801,12 +801,14 @@ def commit_transition(
         root_dir,
         warn=lambda message: warnings.warn(message, RuntimeWarning, stacklevel=2),
     )
+    # Through append_entries (the one writer of the line format, #312)
+    # rather than a second raw open. EvolutionJournal is constructed
+    # directly rather than through .open(), which would also gate on
+    # config.enabled and stop recording transitions this function
+    # records today.
     try:
         if config is not None:
-            journal_path = config.journal_path
-            journal_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(journal_path, "a") as handle:
-                handle.write(json.dumps(entry, separators=(",", ":")) + "\n")
+            EvolutionJournal(config).append_entries([entry])
     except OSError as exc:
         warnings.warn(
             f"autonomy: journal append failed (non-fatal): {exc}",

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -653,6 +653,9 @@ def _echo_journal_repairs(journal: EvolutionJournal, ui_impl: UI) -> None:
     ERROR in red would make a repaired journal indistinguishable from
     "Evolution is disabled in config".
 
+    POSSIBLE loss, not confirmed loss (#327 round 2, F8): the line
+    names both outcomes and points at the one line that decides which.
+
     Silent at zero, which is the whole reason this is worth a line at
     all: a healthy journal that prints "0 repairs" every time teaches an
     operator to skip the line that matters.
@@ -675,8 +678,10 @@ def _echo_journal_repairs(journal: EvolutionJournal, ui_impl: UI) -> None:
     if repairs:
         ui_impl.warn(
             f"  journal: {repairs} interrupted write(s) repaired. A crash left "
-            f"{journal.config.journal_path} without a trailing newline; the fragment "
-            "above each journal_repair row was lost."
+            f"{journal.config.journal_path} without a trailing newline. The line above "
+            "each journal_repair row is what that write left behind: either a torn "
+            "fragment, which is lost, or a whole record that lost only its newline, "
+            "which is readable again. Read it to tell which."
         )
 
 
@@ -3983,6 +3988,12 @@ def evolve(
     if show_status:
         ui_impl.section("Experiment Trends")
         trends = journal.get_experiment_trends(last_n=10)
+        # Before the empty-trends exit, not after (#327 round 2, F7).
+        # decompose and autonomy both write to the journal before any
+        # factory run has written experiments.tsv, so a repair with no
+        # trends is not an edge case: it is the state the operator most
+        # likely to HAVE a repair is in, and the exit below skipped it.
+        _echo_journal_repairs(journal, ui_impl)
         if not trends:
             ui_impl.info("No experiments recorded yet. Run `ks factory` first.")
             sys.exit(0)
@@ -3994,7 +4005,6 @@ def evolve(
                 f"failed={entry.get('failed', '?')} "
                 f"retry_rate={entry.get('retry_rate', '?')}"
             )
-        _echo_journal_repairs(journal, ui_impl)
         sys.exit(0)
 
     if apply_id:

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn
 
 if TYPE_CHECKING:
-    from kstrl.evolution import EvolutionConfig
+    from kstrl.evolution import EvolutionConfig, EvolutionJournal
     from kstrl.interaction import InteractionChannel
 
 from dataclasses import replace
@@ -640,6 +640,44 @@ def _echo_config_problems(problems: list[str]) -> None:
         click.echo(f"  {problem}")
     click.echo("")
     click.echo(f"error: {len(problems)} unusable config section(s)", err=True)
+
+
+def _echo_journal_repairs(journal: EvolutionJournal, ui_impl: UI) -> None:
+    """`ks evolve --status`'s report of interrupted journal writes (#312).
+
+    Why the count exists at all is argued once, on
+    ``EvolutionJournal.get_repair_count``. What is decided HERE:
+
+    ``warn``, not ``err``: this command exits 0, and every other
+    ``ui_impl.err`` in this module precedes a non-zero exit, so printing
+    ERROR in red would make a repaired journal indistinguishable from
+    "Evolution is disabled in config".
+
+    Silent at zero, which is the whole reason this is worth a line at
+    all: a healthy journal that prints "0 repairs" every time teaches an
+    operator to skip the line that matters.
+
+    Only ``ks evolve --status`` calls it. The evolve TUI screen renders
+    the same trends and stays silent about repairs, which is #333:
+    ``get_repair_count`` is click-free and on the journal, so that
+    screen can ask for itself, but claiming this helper serves the TUI
+    would be false. It lives in the click module.
+
+    Takes the journal and asks IT for the path, rather than being handed
+    both: a count from one journal printed beside another one's path is
+    a report that cannot be wrong today and could be after any edit. A
+    helper rather than four lines inline because ``evolve`` is already
+    over the cognitive gate at 23, so a branch added there would fail
+    the staged complexity ratchet on a function this change is not
+    otherwise touching.
+    """
+    repairs = journal.get_repair_count()
+    if repairs:
+        ui_impl.warn(
+            f"  journal: {repairs} interrupted write(s) repaired. A crash left "
+            f"{journal.config.journal_path} without a trailing newline; the fragment "
+            "above each journal_repair row was lost."
+        )
 
 
 def _preflight_root(ctx: click.Context) -> Path:
@@ -3956,6 +3994,7 @@ def evolve(
                 f"failed={entry.get('failed', '?')} "
                 f"retry_rate={entry.get('retry_rate', '?')}"
             )
+        _echo_journal_repairs(journal, ui_impl)
         sys.exit(0)
 
     if apply_id:

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from kstrl.observability import ends_without_newline
 from kstrl.verify import SCOPE_UNREADABLE_CHECK, SCOPE_UNREADABLE_ERROR_PREFIX
 
 if TYPE_CHECKING:
@@ -34,6 +35,14 @@ logger = logging.getLogger("kstrl.evolution")
 # pre-R6 shape); wave 1 (R4.1) archived the polluted v1 journals to
 # .kstrl/archive/, so fresh journals contain v2 entries only.
 JOURNAL_SCHEMA_VERSION = 2
+
+# #312: the event_type of the row append_entries writes when it finds the
+# journal not newline-terminated. Its own type rather than a synthetic
+# component_result, for the reason _role_usage_entries gives: every
+# aggregate in this module selects on event_type, so a row of this type
+# counts towards nothing and cannot invent an outcome. It exists to be
+# grepped: it is the only durable trace that a crash tore the file.
+JOURNAL_REPAIR_EVENT = "journal_repair"
 
 # #191: what a component_result entry records when no fact-utilization
 # measurement reached the journal - the component never got past the
@@ -460,6 +469,33 @@ def signatures_from_findings(phase: str, findings: Iterable[Finding]) -> list[st
 
 def _timestamp_now() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _journal_line(entry: dict[str, Any]) -> str:
+    """One JSONL line, terminator included. The journal's line format."""
+    return json.dumps(entry, separators=(",", ":")) + "\n"
+
+
+def _repair_entry() -> dict[str, Any]:
+    """The row :meth:`EvolutionJournal.append_entries` writes on finding
+    an unterminated tail.
+
+    Carries no ``run_id`` on purpose: ``_read_journal_entries`` keeps the
+    last N distinct run_ids, so a repair row with one of its own would be
+    one of the N and a single tear would shorten the history every
+    aggregate reads by a whole run.
+    """
+    return {
+        "schema_version": JOURNAL_SCHEMA_VERSION,
+        "timestamp": _timestamp_now(),
+        "event_type": JOURNAL_REPAIR_EVENT,
+        "detail": (
+            "the preceding line was not newline-terminated when this append "
+            "ran, so a write was interrupted. It is either a torn fragment "
+            "that was never readable, or a complete record that lost only its "
+            "newline; both are on their own line now."
+        ),
+    }
 
 
 def _summarize_findings(findings: list[Finding]) -> dict[str, Any]:
@@ -1401,15 +1437,59 @@ class EvolutionJournal:
     def append_entries(self, entries: list[dict[str, Any]]) -> None:
         """Append entries to the journal in JSONL form.
 
-        The one writer of the journal's line format. Raises ``OSError``
-        rather than handling it, because the two callers surface a
-        failed write differently: :meth:`record_run` logs it, while
-        decompose warns through the run's UI.
+        The one writer of the journal's line format, enforced by
+        ``tests/test_journal_torn_tail.py``. Raises ``OSError`` rather
+        than handling it, because the two callers surface a failed write
+        differently: :meth:`record_run` logs it, while decompose warns
+        through the run's UI.
+
+        #312: a crash mid-write leaves a tail with no newline, and an
+        append onto that tail concatenates the two into one unparseable
+        line, so the tolerant reader drops the NEW entry as well. The
+        cost is measured, not assumed, and it is not always one entry: a
+        tail that lost only its newline is a COMPLETE record, and
+        concatenating onto it destroys that record too. Writing a
+        newline first repairs the tail into a line of its own, which
+        drops a genuine fragment (unavoidable, it was never written) and
+        RECOVERS a record that lost only its terminator.
+
+        Healing forward rather than raising, because the caller is a
+        record-keeper: refusing to append would answer the loss of one
+        record by losing every later one. So the repair is recorded
+        instead, twice, per "if it's worth deciding, it's worth
+        recording" - a ``JOURNAL_REPAIR_EVENT`` row in the file itself,
+        which is what an operator greps months later, and a warning on
+        this module's logger for whoever is watching now. The row is
+        durable where the log line is not: the process that tore the
+        file is exactly the process whose stderr nobody kept.
+
+        An empty append writes nothing, so it repairs nothing: there is
+        no entry to protect and the next real append will do it.
+
+        Probe-then-append is a read-modify-write, and this file takes no
+        lock. Two appenders racing onto a torn file both see the tear and
+        both repair it, which costs a blank line and a second repair row,
+        and the reader skips both. The window where a probe goes stale
+        needs another writer to crash mid-write inside it, and that is
+        the case this method already loses to today, so the probe makes
+        an unlocked append no less safe than it was.
         """
-        self.config.journal_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.config.journal_path, "a") as f:
+        path = self.config.journal_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        repairing = bool(entries) and ends_without_newline(path)
+        with open(path, "a", encoding="utf-8") as f:
+            if repairing:
+                f.write("\n" + _journal_line(_repair_entry()))
             for entry in entries:
-                f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+                f.write(_journal_line(entry))
+        if repairing:
+            logger.warning(
+                "evolution journal did not end in a newline, so a crash tore it: "
+                "%s. A newline and a %s row were written before this append, so "
+                "the unterminated tail cannot swallow the entries after it.",
+                path,
+                JOURNAL_REPAIR_EVENT,
+            )
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -1422,9 +1422,14 @@ class EvolutionJournal:
         evolve --status`` prints this when it is non-zero.
 
         Counts rows, not incidents: :meth:`append_entries` residual 2
-        is how one tear can produce two. A non-zero count means at
-        least one crash left an unterminated tail, and the fragment
-        above each row is what was lost.
+        is how one tear can produce two, and residual 4 is how a repair
+        can happen and not be counted, so this is a lower bound. A
+        non-zero count means at least one crash left an unterminated
+        tail. It does NOT mean a record was lost: the line above each
+        row is either a fragment that was never readable or a whole
+        record that lost only its newline and is readable again, which
+        is the distinction ``docs/evolution-metrics.md`` and the status
+        line both draw.
         """
         return sum(
             1 for e in self._read_all_entries() if e.get("event_type") == JOURNAL_REPAIR_EVENT
@@ -1497,14 +1502,28 @@ class EvolutionJournal:
         no entry to protect and the next real append will do it.
 
         ONE file description does the probe and the append, in
-        ``"a+b"``. That is not an optimisation, it is what removes the
-        window in which the path could be replaced or a symlink
-        retargeted between the two, and what makes a journal this
-        process cannot READ raise out of the open rather than being
-        probed as "not torn" and appended to blind. It costs the
-        text-mode ``encoding="utf-8"``, so the bytes are encoded
-        explicitly instead, which is the same two-sided contract stated
-        at the other end.
+        ``"a+b"``, and the repair row plus the whole batch go in ONE
+        ``write``. Neither is an optimisation. The single description is
+        what removes the window in which the path could be replaced or a
+        symlink retargeted between the two, and what makes a journal
+        this process cannot READ raise out of the open rather than being
+        probed as "not torn" and appended to blind; the single write is
+        what stops another appender landing between the newline that
+        isolates a torn fragment and the entries the repair was for. It
+        costs the text-mode ``encoding="utf-8"``, so the bytes are
+        encoded explicitly instead, which is the same two-sided contract
+        stated at the other end.
+
+        Both are enforced by ``tests/test_journal_write_boundary.py``,
+        which counts descriptors and writes. Round 2 of review on #327
+        found that neither was, and the measurement here agrees: a
+        version that reopens the file for the append, and a version
+        that writes the newline, the marker and the batch separately,
+        each pass 284 tests and 1 xfail across
+        ``test_journal_torn_tail``, ``test_journal_one_writer``,
+        ``test_decompose``, ``test_autonomy_ladder`` and
+        ``test_config_control_plane``. An argument in a docstring is
+        not a mechanism.
 
         WHAT IS STILL NOT ATOMIC, precisely, because a docstring that
         implied otherwise would be worse than no docstring. This takes
@@ -1521,12 +1540,31 @@ class EvolutionJournal:
            and counted by none.
         3. O_APPEND makes each ``write`` land at the end, and the repair
            row plus the whole batch go in ONE ``write`` so that another
-           appender cannot land between them. That is not a guarantee:
-           ``BufferedWriter.write`` flushes and loops for a payload
-           larger than its buffer (``io.DEFAULT_BUFFER_SIZE``, 8192
-           here), so a large batch can still be split into several raw
-           writes and interleaved. Splitting predates this change; the
-           single call narrows it, it does not close it.
+           appender cannot land between them. That is not a guarantee,
+           but not for the reason it is tempting to write down. Measured
+           on this interpreter: ``BufferedWriter`` hands a payload of
+           ANY size to the raw layer in one ``write(2)`` (100 bytes to
+           5 MB, one raw call each), so the split is not size-driven and
+           ``io.DEFAULT_BUFFER_SIZE`` is not the threshold. It loops
+           only when the OS returns a SHORT write, which on a regular
+           file means a signal or ENOSPC. Rare, not impossible, and it
+           predates this change.
+        4. The repair is not two-phase-safe either. There is no gap
+           BETWEEN two calls, because there is only one call: the
+           newline that isolates the fragment, the marker and the batch
+           are one ``write``. What is left is a partial write INSIDE it,
+           which is residual 3's short write, landing the newline and
+           not the marker. That leaves a file that is terminated,
+           malformed one line up and carrying no repair row, and the
+           next append reads the last BYTE, finds a newline and adds
+           none. Nothing is at risk by then - the fragment is isolated,
+           which was the point - so this is an audit gap, not data loss,
+           and the isolated fragment line is still on disk to be read.
+           Closing it means parsing the last LINE on every append, which
+           would fire on any malformed tail rather than a torn one: a
+           different contract, not a bug fix.
+           ``test_a_terminated_but_malformed_tail_is_not_a_tear`` pins
+           it, so it cannot quietly stop being true.
 
         Neither 1 nor 3 is made worse by the probe: at cbdff7c the same
         two writers produced the same interleaving with no probe at all.

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -18,7 +18,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from kstrl.observability import ends_without_newline
+from kstrl.observability import handle_ends_without_newline, read_progress_events
 from kstrl.verify import SCOPE_UNREADABLE_CHECK, SCOPE_UNREADABLE_ERROR_PREFIX
 
 if TYPE_CHECKING:
@@ -43,6 +43,17 @@ JOURNAL_SCHEMA_VERSION = 2
 # counts towards nothing and cannot invent an outcome. It exists to be
 # grepped: it is the only durable trace that a crash tore the file.
 JOURNAL_REPAIR_EVENT = "journal_repair"
+
+
+# The header row record_run writes to experiments.tsv, at module scope so
+# that a test can assert against the columns the writer actually emits
+# rather than a shorter hand-typed row that csv.DictReader happens to
+# tolerate. Files written before R3.1 keep their shorter header.
+EXPERIMENTS_HEADER = (
+    "run_id\ttimestamp\tproject\tcomponents_total\tcompleted\tfailed\t"
+    "skipped\tavg_iterations\tavg_duration_s\tretry_rate\tcommon_failure\t"
+    "total_tokens\ttotal_cost_usd\tunreported_calls"
+)
 
 # #191: what a component_result entry records when no fact-utilization
 # measurement reached the journal - the component never got past the
@@ -771,11 +782,6 @@ class EvolutionJournal:
         else:
             total_tokens_col = total_cost_col = unreported_col = ""
 
-        header = (
-            "run_id\ttimestamp\tproject\tcomponents_total\tcompleted\tfailed\t"
-            "skipped\tavg_iterations\tavg_duration_s\tretry_rate\tcommon_failure\t"
-            "total_tokens\ttotal_cost_usd\tunreported_calls"
-        )
         row = (
             f"{run_id}\t{timestamp}\t{manifest.project_name}\t{total}\t"
             f"{completed}\t{failed}\t{skipped}\t{avg_iterations:.2f}\t"
@@ -793,7 +799,7 @@ class EvolutionJournal:
             # file get_experiment_trends decodes as utf-8.
             with open(self.config.experiments_path, "a", encoding="utf-8") as f:
                 if needs_header:
-                    f.write(header + "\n")
+                    f.write(EXPERIMENTS_HEADER + "\n")
                 f.write(row + "\n")
         except OSError as exc:
             logger.warning(
@@ -1402,6 +1408,29 @@ class EvolutionJournal:
         return rows[-last_n:]
 
     # ------------------------------------------------------------------
+    # get_repair_count
+    # ------------------------------------------------------------------
+
+    def get_repair_count(self) -> int:
+        """How many interrupted writes this journal has been repaired from.
+
+        The read surface for ``JOURNAL_REPAIR_EVENT`` (#327 round 1,
+        F5). Writing the row was only half of "if it's worth deciding,
+        it's worth recording": a row no command reports is reachable
+        only by an operator who already suspects the problem, and the
+        logger warning goes to orchestrator.log under the TUI. ``ks
+        evolve --status`` prints this when it is non-zero.
+
+        Counts rows, not incidents: :meth:`append_entries` residual 2
+        is how one tear can produce two. A non-zero count means at
+        least one crash left an unterminated tail, and the fragment
+        above each row is what was lost.
+        """
+        return sum(
+            1 for e in self._read_all_entries() if e.get("event_type") == JOURNAL_REPAIR_EVENT
+        )
+
+    # ------------------------------------------------------------------
     # get_spec_issue_runs
     # ------------------------------------------------------------------
 
@@ -1438,10 +1467,10 @@ class EvolutionJournal:
         """Append entries to the journal in JSONL form.
 
         The one writer of the journal's line format, enforced by
-        ``tests/test_journal_torn_tail.py``. Raises ``OSError`` rather
-        than handling it, because the two callers surface a failed write
-        differently: :meth:`record_run` logs it, while decompose warns
-        through the run's UI.
+        ``tests/test_journal_one_writer.py``. Raises ``OSError`` rather
+        than handling it, because the three callers surface a failed
+        write differently: :meth:`record_run` logs it, decompose warns
+        through the run's UI, and ``autonomy.commit_transition`` warns.
 
         #312: a crash mid-write leaves a tail with no newline, and an
         append onto that tail concatenates the two into one unparseable
@@ -1458,30 +1487,58 @@ class EvolutionJournal:
         record by losing every later one. So the repair is recorded
         instead, twice, per "if it's worth deciding, it's worth
         recording" - a ``JOURNAL_REPAIR_EVENT`` row in the file itself,
-        which is what an operator greps months later, and a warning on
-        this module's logger for whoever is watching now. The row is
-        durable where the log line is not: the process that tore the
-        file is exactly the process whose stderr nobody kept.
+        which is what ``ks evolve --status`` counts and an operator
+        greps months later, and a warning on this module's logger for
+        whoever is watching now. The row is durable where the log line
+        is not: the process that tore the file is exactly the process
+        whose stderr nobody kept.
 
         An empty append writes nothing, so it repairs nothing: there is
         no entry to protect and the next real append will do it.
 
-        Probe-then-append is a read-modify-write, and this file takes no
-        lock. Two appenders racing onto a torn file both see the tear and
-        both repair it, which costs a blank line and a second repair row,
-        and the reader skips both. The window where a probe goes stale
-        needs another writer to crash mid-write inside it, and that is
-        the case this method already loses to today, so the probe makes
-        an unlocked append no less safe than it was.
+        ONE file description does the probe and the append, in
+        ``"a+b"``. That is not an optimisation, it is what removes the
+        window in which the path could be replaced or a symlink
+        retargeted between the two, and what makes a journal this
+        process cannot READ raise out of the open rather than being
+        probed as "not torn" and appended to blind. It costs the
+        text-mode ``encoding="utf-8"``, so the bytes are encoded
+        explicitly instead, which is the same two-sided contract stated
+        at the other end.
+
+        WHAT IS STILL NOT ATOMIC, precisely, because a docstring that
+        implied otherwise would be worse than no docstring. This takes
+        no lock, and #330 tracks that:
+
+        1. Between this process's tail read and its write, another
+           process can append. If that other write is a complete line,
+           nothing is lost. If it crashed mid-line inside that window,
+           this append lands on the fragment and the pair is unreadable
+           - the #312 outcome, in the narrower window.
+        2. Two processes repairing one tear each write a newline and a
+           repair row, so a single incident can be recorded twice. Both
+           the blank line and the extra row are skipped by every reader
+           and counted by none.
+        3. O_APPEND makes each ``write`` land at the end, and the repair
+           row plus the whole batch go in ONE ``write`` so that another
+           appender cannot land between them. That is not a guarantee:
+           ``BufferedWriter.write`` flushes and loops for a payload
+           larger than its buffer (``io.DEFAULT_BUFFER_SIZE``, 8192
+           here), so a large batch can still be split into several raw
+           writes and interleaved. Splitting predates this change; the
+           single call narrows it, it does not close it.
+
+        Neither 1 nor 3 is made worse by the probe: at cbdff7c the same
+        two writers produced the same interleaving with no probe at all.
         """
         path = self.config.journal_path
         path.parent.mkdir(parents=True, exist_ok=True)
-        repairing = bool(entries) and ends_without_newline(path)
-        with open(path, "a", encoding="utf-8") as f:
+        with open(path, "a+b") as handle:
+            repairing = bool(entries) and handle_ends_without_newline(handle)
+            payload = "".join(_journal_line(entry) for entry in entries)
             if repairing:
-                f.write("\n" + _journal_line(_repair_entry()))
-            for entry in entries:
-                f.write(_journal_line(entry))
+                payload = "\n" + _journal_line(_repair_entry()) + payload
+            handle.write(payload.encode("utf-8"))
         if repairing:
             logger.warning(
                 "evolution journal did not end in a newline, so a crash tore it: "
@@ -1505,8 +1562,6 @@ class EvolutionJournal:
         policy rather than two. One unreadable line must not cost the
         reader the rest of the history.
         """
-        from kstrl.observability import read_progress_events
-
         return read_progress_events(self.config.journal_path)
 
     def _read_journal_entries(self, lookback_runs: int = 10) -> list[dict[str, Any]]:

--- a/kstrl/observability.py
+++ b/kstrl/observability.py
@@ -403,6 +403,42 @@ class NullProgressLog(ProgressLog):
         pass
 
 
+def ends_without_newline(path: Path) -> bool:
+    """True when ``path`` exists, holds bytes, and its last one is not ``\\n``.
+
+    The write-side companion to :func:`read_progress_events`, and here
+    rather than in the one module that calls it today because it is the
+    generic half of #312 with no policy in it. That defect is one an
+    appender to any JSONL file in this package can have: a crash leaves
+    an unterminated tail, the next append concatenates onto it, and the
+    tolerant reader above drops BOTH lines. Measured on this tree, four
+    other appenders still can (``ProgressLog.emit``, ``JsonlSink``,
+    ``workqueue``, ``inbox``); what each of them should WRITE on finding
+    a tear differs per file, so only the predicate is shared. #291 is
+    the argument for hoisting it before the second copy rather than
+    after the tenth.
+
+    Read in BINARY, which is the point: the last byte of a file torn
+    mid-utf-8-sequence cannot be decoded, and a text-mode probe would
+    raise ``UnicodeDecodeError`` on exactly the file that most needs the
+    repair.
+
+    An unreadable file answers False: it is not evidence of a tear, and
+    a caller about to write will raise the same ``OSError`` itself. A
+    missing file answers False through the same path, since
+    ``FileNotFoundError`` is an ``OSError``.
+    """
+    try:
+        with open(path, "rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            if handle.tell() == 0:
+                return False
+            handle.seek(-1, os.SEEK_END)
+            return handle.read(1) != b"\n"
+    except OSError:
+        return False
+
+
 def read_progress_events(path: Path) -> list[dict[str, Any]]:
     """Read all events from a JSONL progress log.
 

--- a/kstrl/observability.py
+++ b/kstrl/observability.py
@@ -10,7 +10,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Protocol
+from typing import IO, Any, Protocol
 
 
 class ProgressSink(Protocol):
@@ -403,40 +403,46 @@ class NullProgressLog(ProgressLog):
         pass
 
 
-def ends_without_newline(path: Path) -> bool:
-    """True when ``path`` exists, holds bytes, and its last one is not ``\\n``.
+def handle_ends_without_newline(handle: IO[bytes]) -> bool:
+    """True when the open binary file holds bytes and the last is not ``\\n``.
 
     The write-side companion to :func:`read_progress_events`, and here
     rather than in the one module that calls it today because it is the
     generic half of #312 with no policy in it. That defect is one an
     appender to any JSONL file in this package can have: a crash leaves
     an unterminated tail, the next append concatenates onto it, and the
-    tolerant reader above drops BOTH lines. Measured on this tree, four
+    tolerant reader below drops BOTH lines. Measured on this tree, four
     other appenders still can (``ProgressLog.emit``, ``JsonlSink``,
-    ``workqueue``, ``inbox``); what each of them should WRITE on finding
-    a tear differs per file, so only the predicate is shared. #291 is
-    the argument for hoisting it before the second copy rather than
-    after the tenth.
+    ``workqueue``, ``inbox``), which is #331; what each of them should
+    WRITE on finding a tear differs per file, so only the predicate is
+    shared. #291 is the argument for hoisting it before the second copy
+    rather than after the tenth.
 
-    Read in BINARY, which is the point: the last byte of a file torn
+    Takes an OPEN HANDLE rather than a path, which is the whole design:
+
+    - the caller opens once, in ``"a+b"``, and probes and appends
+      through one file description, so there is no window between the
+      two in which the path can be replaced, retargeted or deleted;
+    - a file this process cannot read cannot be opened ``"a+b"`` at all,
+      so an unreadable journal raises ``PermissionError`` out of the
+      open instead of being reported as "not torn" and appended to
+      blind (#327 round 1, F3: a path-taking probe that answered False
+      on every ``OSError`` was fail-OPEN on a mode-0200 journal);
+    - a long-lived appender such as ``JsonlSink`` can ask this once when
+      it opens, which a path-taking predicate cannot serve.
+
+    Binary, which is the point: the last byte of a file torn
     mid-utf-8-sequence cannot be decoded, and a text-mode probe would
     raise ``UnicodeDecodeError`` on exactly the file that most needs the
-    repair.
-
-    An unreadable file answers False: it is not evidence of a tear, and
-    a caller about to write will raise the same ``OSError`` itself. A
-    missing file answers False through the same path, since
-    ``FileNotFoundError`` is an ``OSError``.
+    repair. Seeks are reads; in append mode the write position is the
+    end regardless, so this does not disturb where the caller's next
+    write lands. Raises nothing of its own: an IO error belongs to the
+    caller that owns the handle.
     """
-    try:
-        with open(path, "rb") as handle:
-            handle.seek(0, os.SEEK_END)
-            if handle.tell() == 0:
-                return False
-            handle.seek(-1, os.SEEK_END)
-            return handle.read(1) != b"\n"
-    except OSError:
+    if handle.seek(0, os.SEEK_END) == 0:
         return False
+    handle.seek(-1, os.SEEK_END)
+    return handle.read(1) != b"\n"
 
 
 def read_progress_events(path: Path) -> list[dict[str, Any]]:

--- a/tests/helpers/journal.py
+++ b/tests/helpers/journal.py
@@ -1,16 +1,33 @@
-"""The interrupted journal write, spelled once.
+"""The interrupted journal write, spelled once, and the records to test it with.
 
-Two test files assert about the same crash from opposite sides:
+Three test files assert about the same crash from different sides:
 ``test_decompose.py`` that a torn tail does not cost the convergence
-note (the read side), and ``test_journal_torn_tail.py`` that it does not
-cost the entry written after it (the write side, #312). Both used to
-carry their own copy of the fragment, so the claim that they pin the
-same interrupted write was prose. It is an import now.
+note (the read side), ``test_journal_torn_tail.py`` that it does not
+cost the entry written after it (the write side, #312), and
+``test_journal_write_boundary.py`` that the repair is one descriptor
+and one write. The first two used to carry their own copy of the
+fragment, so the claim that they pin the same interrupted write was
+prose. It is an import now.
+
+Two kinds of thing live here, and the reason differs. The CRASH SHAPES
+(``TORN_FRAGMENT``, ``DANGLING_UTF8``, ``tear``, ``lose_the_newline``,
+``terminate``) are here because a crash spelled two ways in two files
+is two different claims; that is the rule, and it holds even for the
+ones with a single caller today. The RECORD BUILDERS and READERS
+(``audit``, ``component_result``, ``journal_at``, ``audits_in``,
+``repair_rows_in``) are here because the boundary file needs the same
+entries as the cost file; ``component_result``, ``audits_in`` and
+``repair_rows_in`` have one caller each at the moment, which is the
+weakest case for this module and worth revisiting if it stays that way.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+
+from kstrl.evolution import JOURNAL_REPAIR_EVENT, EvolutionConfig, EvolutionJournal
+from kstrl.observability import read_progress_events
 
 #: A partial JSONL line: valid JSON up to the point the process died,
 #: with no closing brace and no newline. Short enough to read, and it is
@@ -29,3 +46,64 @@ def tear(path: Path, fragment: str = TORN_FRAGMENT) -> None:
     """Leave ``path`` mid-line the way a crash does: no trailing newline."""
     with open(path, "a", encoding="utf-8") as handle:
         handle.write(fragment)
+
+
+def lose_the_newline(path: Path) -> None:
+    """The other crash: a COMPLETE record whose terminator never landed.
+
+    Costlier than a torn fragment, which is why it is spelled here
+    rather than as a one-liner in whichever test needs it: appending
+    onto this destroys a whole readable record as well as the new one,
+    so it is the case the repair RECOVERS.
+    """
+    path.write_bytes(path.read_bytes()[:-1])
+
+
+def terminate(path: Path) -> None:
+    """The third shape: a repair that landed its newline and nothing else.
+
+    Residual 4 of ``EvolutionJournal.append_entries``. The fragment is
+    isolated, so nothing is at risk, and the file now ends in a newline,
+    so the next append writes no repair row and the incident is
+    invisible to ``get_repair_count``.
+    """
+    path.write_bytes(path.read_bytes() + b"\n")
+
+
+def audit(project: str) -> dict[str, Any]:
+    return {
+        "timestamp": "2026-08-20T00:00:00Z",
+        "project": project,
+        "event_type": "spec_issues",
+        "spec_file": f"{project}.md",
+    }
+
+
+def component_result(run_id: str, component_id: str) -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "timestamp": "2026-08-20T00:00:00Z",
+        "run_id": run_id,
+        "project": "p",
+        "component_id": component_id,
+        "event_type": "component_result",
+        "failure_signatures": ["tests:assertion"],
+        "findings_summary": {"by_category": {"scope_creep": 1}},
+        "knowledge_utilization": {"measured": True, "injected": 3, "referenced": 2},
+    }
+
+
+def journal_at(tmp_path: Path) -> EvolutionJournal:
+    return EvolutionJournal(EvolutionConfig.load(tmp_path))
+
+
+def audits_in(path: Path) -> list[str]:
+    return [
+        str(entry.get("project"))
+        for entry in read_progress_events(path)
+        if entry.get("event_type") == "spec_issues"
+    ]
+
+
+def repair_rows_in(path: Path) -> list[dict[str, Any]]:
+    return [e for e in read_progress_events(path) if e.get("event_type") == JOURNAL_REPAIR_EVENT]

--- a/tests/helpers/journal.py
+++ b/tests/helpers/journal.py
@@ -1,0 +1,31 @@
+"""The interrupted journal write, spelled once.
+
+Two test files assert about the same crash from opposite sides:
+``test_decompose.py`` that a torn tail does not cost the convergence
+note (the read side), and ``test_journal_torn_tail.py`` that it does not
+cost the entry written after it (the write side, #312). Both used to
+carry their own copy of the fragment, so the claim that they pin the
+same interrupted write was prose. It is an import now.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: A partial JSONL line: valid JSON up to the point the process died,
+#: with no closing brace and no newline. Short enough to read, and it is
+#: the shape a crash actually leaves.
+TORN_FRAGMENT = '{"event_type": "spec_iss'
+
+#: Bytes that stop mid-utf-8-sequence: the last byte of "café" removed,
+#: leaving a dangling 0xc3 that no decoder will accept. kstrl's own
+#: writer emits pure ASCII (``json.dumps`` escapes), so bytes like these
+#: reach a journal the way an operator's editor or a foreign writer puts
+#: them there.
+DANGLING_UTF8 = '{"project": "café'.encode()[:-1]
+
+
+def tear(path: Path, fragment: str = TORN_FRAGMENT) -> None:
+    """Leave ``path`` mid-line the way a crash does: no trailing newline."""
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(fragment)

--- a/tests/test_autonomy_ladder.py
+++ b/tests/test_autonomy_ladder.py
@@ -851,18 +851,24 @@ class TestTransitionAudit:
         assert any(isinstance(e, AutonomyTransition) for e in seen)
 
     def test_journal_failure_is_not_fatal(self, tmp_path: Path) -> None:
-        # Losing the log must never strand the ladder unsaved.
+        """Losing the log must never strand the ladder unsaved.
+
+        A real failure on a real path (a directory where the journal
+        file should be) rather than a patched ``kstrl.autonomy.open``,
+        which stopped intercepting anything when #312 moved the write
+        into ``EvolutionJournal.append_entries``. A patched builtin pins
+        WHERE the code writes, which is not what this test is about.
+        """
         from kstrl.autonomy import commit_transition
+        from kstrl.evolution import EvolutionConfig
+
+        journal_path = EvolutionConfig.load(tmp_path).journal_path
+        journal_path.parent.mkdir(parents=True, exist_ok=True)
+        journal_path.mkdir()
 
         state = _eligible_state()
         record = state.promote(actor="human", ack="ok")
-        with (
-            patch(
-                "kstrl.autonomy.open",
-                side_effect=OSError("disk full"),
-            ),
-            pytest.warns(RuntimeWarning, match="journal append failed"),
-        ):
+        with pytest.warns(RuntimeWarning, match="journal append failed"):
             commit_transition(state, record, tmp_path)
         assert AutonomyState.load(tmp_path).level == int(AutonomyLevel.L2_GATED_MERGE)
 

--- a/tests/test_config_control_plane.py
+++ b/tests/test_config_control_plane.py
@@ -338,12 +338,11 @@ class TestEvolveCommandTomlRoundTrip:
         (tmp_path / "kstrl.toml").write_text('[evolution]\njournal_path = "custom/evo.jsonl"\n')
         box: dict[str, Any] = {}
 
-        class FakeJournal:
+        # Subclasses the real journal so a second call does not AttributeError (#327 F7).
+        class FakeJournal(evolution_mod.EvolutionJournal):
             def __init__(self, config: EvolutionConfig) -> None:
+                super().__init__(config)
                 box["config"] = config
-
-            def get_experiment_trends(self, last_n: int = 10) -> list[Any]:
-                return []
 
         monkeypatch.setattr(evolution_mod, "EvolutionJournal", FakeJournal)
         runner = CliRunner()

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -33,6 +33,7 @@ from kstrl.decompose import (
 from kstrl.evolution import EvolutionConfig, EvolutionJournal
 from kstrl.prd import PRD
 from kstrl.ui.plain import PlainUI
+from tests.helpers.journal import tear
 
 
 class MockDecomposeAgent:
@@ -1382,10 +1383,14 @@ class TestExcludedHistory:
 
     def test_a_torn_line_does_not_cost_the_note(self, tmp_path: Path) -> None:
         """The journal is append-only and a crash mid-write leaves a
-        torn tail; the rest of the history still has to be readable."""
+        torn tail; the rest of the history still has to be readable.
+
+        The write side of the same tear is
+        ``tests/test_journal_torn_tail.py`` (#312), and the fragment is
+        shared rather than copied so the two cannot drift apart.
+        """
         journal = _journal_with(tmp_path, [self._entry("writers-room", "spec.md")])
-        with open(journal.config.journal_path, "a", encoding="utf-8") as handle:
-            handle.write('{"event_type": "spec_iss')
+        tear(journal.config.journal_path)
 
         assert "records 1 spec audit(s)" in self._lines(journal, "writers-room-slice1")
 

--- a/tests/test_journal_guard_detects.py
+++ b/tests/test_journal_guard_detects.py
@@ -1,0 +1,265 @@
+"""Positive controls for the one-writer guard: source it MUST flag.
+
+The guard lives in ``tests/test_journal_one_writer.py`` and its three
+pinned inventories assert that a list is empty or that a dict is
+unchanged. An empty list is also what a switched-off detector returns,
+so without this file the whole of layer 2 could be replaced by
+``return []`` and that file would stay green. Measured before these
+existed: stubbing ``is_write_mode``, ``mentions_journal``,
+``write_target``, ``journal_aliases``, ``open_aliases`` or
+``journal_writes_outside_append_entries`` itself to a constant left it
+all passing.
+
+Separate from the guard because the 800-line ratchet fired, and the
+seam is the right one: that file walks the package and pins what is
+there, this one feeds the detector snippets and pins what it says.
+Importing the walkers across test modules is the house pattern here
+(``test_decompose_run``, ``test_feature_run``, ``test_prd_tamper`` and
+seven others do the same).
+
+Every shape round 1 of review on #327 listed has a case here, and so
+does every shape round 2 added.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.test_journal_one_writer import (
+    JOURNAL_ATTRIBUTE,
+    KSTRL_PACKAGE,
+    journal_path_escapes,
+    journal_writes_outside_append_entries,
+    label,
+)
+
+
+class TestTheGuardDetects:
+    """Layer 2 fed source it is SUPPOSED to flag, snippet by snippet.
+
+    On a snippet rather than on the package, which is what makes the
+    detector's own failure reachable. Only layer 1 could ever notice a
+    switched-off detector on its own, and only because it asserts a
+    NON-empty expected set.
+    """
+
+    def offenders(self, tmp_path: Path, source: str, name: str = "other.py") -> list[str]:
+        path = tmp_path / name
+        path.write_text(source, encoding="utf-8")
+        return journal_writes_outside_append_entries(path)
+
+    def test_the_seed_tracks_the_attribute_name(self, tmp_path: Path) -> None:
+        """Layer 2 has one seed, and it used to be a literal.
+
+        ``mentions_journal`` is the only thing that binds the first
+        alias, so if its spelling drifts from ``JOURNAL_ATTRIBUTE`` the
+        alias set stays empty and layer 2 reports nothing at all, with
+        every test in this class still green because their snippets
+        carry the old spelling too. Built out of the constant here, so
+        the two cannot drift apart in silence.
+        """
+        source = f'open(config.{JOURNAL_ATTRIBUTE}, "a")\n'
+        assert self.offenders(tmp_path, source) == [
+            f"other.py:1: writes to config.{JOURNAL_ATTRIBUTE}"
+        ]
+
+    def test_a_positional_mode_is_a_write(self, tmp_path: Path) -> None:
+        found = self.offenders(tmp_path, 'open(config.journal_path, "a")\n')
+        assert found == ["other.py:1: writes to config.journal_path"]
+
+    def test_a_keyword_mode_is_a_write(self, tmp_path: Path) -> None:
+        """The hole round 1 found: ``mode=`` was never read."""
+        found = self.offenders(tmp_path, 'open(config.journal_path, mode="a")\n')
+        assert found == ["other.py:1: writes to config.journal_path"]
+
+    def test_r_plus_is_a_write(self, tmp_path: Path) -> None:
+        """Every letter that can write, not just the first one."""
+        found = self.offenders(tmp_path, 'open(config.journal_path, "r+")\n')
+        assert found == ["other.py:1: writes to config.journal_path"]
+
+    def test_a_plain_read_is_not_a_write(self, tmp_path: Path) -> None:
+        """The distinction the mode test buys, pinned so it can fail.
+
+        The journal has a legitimate reader; flagging it would make this
+        guard about touching the file rather than writing it.
+        """
+        assert self.offenders(tmp_path, 'open(config.journal_path, "r")\n') == []
+        assert self.offenders(tmp_path, "open(config.journal_path)\n") == []
+
+    def test_an_alias_chain_of_any_length_is_followed(self, tmp_path: Path) -> None:
+        """Single-hop resolution let ``target = journal_path`` through."""
+        source = 'journal_path = config.journal_path\ntarget = journal_path\nopen(target, "a")\n'
+        assert self.offenders(tmp_path, source) == ["other.py:3: writes to target"]
+
+    def test_an_annotated_assignment_binds_too(self, tmp_path: Path) -> None:
+        source = 'journal_path: Path = config.journal_path\nopen(journal_path, "a")\n'
+        assert self.offenders(tmp_path, source) == ["other.py:2: writes to journal_path"]
+
+    def test_an_alias_of_open_itself_is_followed(self, tmp_path: Path) -> None:
+        source = 'open_file = open\nopen_file(config.journal_path, "a")\n'
+        assert self.offenders(tmp_path, source) == ["other.py:2: writes to config.journal_path"]
+
+    def test_the_dotted_opens_are_covered(self, tmp_path: Path) -> None:
+        for owner in ("builtins", "io", "os"):
+            found = self.offenders(tmp_path, f'{owner}.open(config.journal_path, "a")\n')
+            assert found == ["other.py:1: writes to config.journal_path"], owner
+
+    def test_a_call_on_the_path_still_counts(self, tmp_path: Path) -> None:
+        source = 'journal_path = config.journal_path\nopen(journal_path.resolve(), "a")\n'
+        assert self.offenders(tmp_path, source) == ["other.py:2: writes to journal_path.resolve()"]
+
+    def test_the_path_write_methods_are_covered(self, tmp_path: Path) -> None:
+        for method in ("write_text", "write_bytes"):
+            found = self.offenders(tmp_path, f"config.journal_path.{method}(row)\n")
+            assert found == ["other.py:1: writes to config.journal_path"], method
+
+    def test_path_dot_open_is_covered(self, tmp_path: Path) -> None:
+        found = self.offenders(tmp_path, 'config.journal_path.open("a")\n')
+        assert found == ["other.py:1: writes to config.journal_path"]
+
+    def test_a_getattr_of_the_attribute_is_a_write(self, tmp_path: Path) -> None:
+        """#327 round 2, F9, shape one. Both layers were blind to it."""
+        source = 'target = getattr(config, "journal_" + "path")\nopen(target, "a")\n'
+        assert self.offenders(tmp_path, source) == ["other.py:2: writes to target"]
+
+        direct = 'open(getattr(config, "journal_" + "path"), "a")\n'
+        assert self.offenders(tmp_path, direct) == [
+            "other.py:1: writes to getattr(config, 'journal_' + 'path')"
+        ]
+
+    def test_a_filename_built_out_of_pieces_is_a_write(self, tmp_path: Path) -> None:
+        """#327 round 2, F9, shape two: no substring to search for."""
+        source = 'target = root / ".kstrl" / ("evolution" + ".jsonl")\nopen(target, "a")\n'
+        assert "evolution.jsonl" not in source
+        assert self.offenders(tmp_path, source) == ["other.py:2: writes to target"]
+
+    def test_the_directory_can_move_into_the_literal(self, tmp_path: Path) -> None:
+        """The F9 shape with the split one literal to the left.
+
+        Decidable, and layer 2 used to discard it: with an equality
+        test the folded value was ``".kstrl/evolution.jsonl"``, which is
+        not the filename, so the offender list came back empty and only
+        a module COUNT moved.
+        """
+        source = 'open(root / (".kstrl/evolution" + ".jsonl"), "a")\n'
+        assert self.offenders(tmp_path, source) == [
+            "other.py:1: writes to root / ('.kstrl/evolution' + '.jsonl')"
+        ]
+
+    def test_the_namespace_spellings_of_the_attribute_are_writes(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``__dict__`` and ``vars``: the same read, without a dot."""
+        via_dict = 'target = config.__dict__["journal_path"]\nopen(target, "a")\n'
+        assert self.offenders(tmp_path, via_dict) == ["other.py:2: writes to target"]
+
+        via_vars = 'target = vars(config)["journal_path"]\nopen(target, "a")\n'
+        assert self.offenders(tmp_path, via_vars) == ["other.py:2: writes to target"]
+
+    def test_an_f_string_of_constants_folds_too(self, tmp_path: Path) -> None:
+        """CPython folds ``f"a{'b'}"`` only sometimes, so this is
+        checked rather than assumed."""
+        source = 'open(root / f"evolution{\'.jsonl\'}", "a")\n'
+        assert self.offenders(tmp_path, source) != []
+
+    def test_a_converted_or_formatted_placeholder_does_not_fold(self, tmp_path: Path) -> None:
+        """The two guards on ``folded_placeholder``, one control each.
+
+        ``!r`` adds quotes and a format spec pads, so neither value is
+        the one in the source. Both were measured removable with this
+        file green before these existed.
+        """
+        source = 'open(root / f"evolution{\'.jsonl\'!r}", "a")\n'
+        assert self.offenders(tmp_path, source) == []
+
+        padded = 'open(root / f"evolution{\'.jsonl\':>10}", "a")\n'
+        assert self.offenders(tmp_path, padded) == []
+
+    def test_a_filename_the_interpreter_has_to_build_is_missed(self, tmp_path: Path) -> None:
+        """The disclosed residual, pinned so the disclosure stays true.
+
+        ``"".join`` needs the interpreter, so folding answers None and
+        this write is NOT reported. Asserting it records the boundary of
+        what the guard claims; if somebody widens the folder, this test
+        is where they find out the docstring above has to change.
+        """
+        source = 'target = root / "".join(("evolution", ".jsonl"))\nopen(target, "a")\n'
+        assert self.offenders(tmp_path, source) == []
+
+    def test_layer_one_sees_a_getattr_acquisition(self, tmp_path: Path) -> None:
+        """The clause at the other layer, which had no control of its own.
+
+        Every other case in this class feeds
+        ``journal_writes_outside_append_entries``. Measured while this
+        was missing: deleting ``or dynamic_attribute_read(node)`` from
+        ``journal_path_escapes`` left the whole file green, because
+        layer 1's expected dict holds no getattr row to move. Layer 1 is
+        the half that catches a path handed to a helper and opened
+        there, and a getattr-obtained path handed to a helper is exactly
+        the residual layer 2 discloses.
+        """
+        path = tmp_path / "other.py"
+        path.write_text('target = getattr(config, "journal_" + "path")\n', encoding="utf-8")
+        assert journal_path_escapes(path) == ["other.py: getattr(config, 'journal_' + 'path')"]
+
+    def test_a_duplicate_basename_is_named_by_its_package_path(self) -> None:
+        """A key and a message that send the reader to the right file.
+
+        Measured on this tree: ten basenames occur twice under
+        ``kstrl/``, ``decompose.py`` among them. Both halves asserted,
+        because a ``label`` that returned the full absolute path would
+        satisfy the second line alone and break every pinned key.
+        """
+        assert label(KSTRL_PACKAGE / "decompose.py") == "decompose.py"
+        assert label(KSTRL_PACKAGE / "tui" / "screens" / "decompose.py") == str(
+            Path("tui") / "screens" / "decompose.py"
+        )
+
+    def test_an_unrelated_file_is_left_alone(self, tmp_path: Path) -> None:
+        """The false-positive side. Without this, "flag everything" passes."""
+        source = 'other_path = config.experiments_path\nopen(other_path, "a")\n'
+        assert self.offenders(tmp_path, source) == []
+
+    def test_the_sanctioned_writer_is_exempt(self, tmp_path: Path) -> None:
+        source = (
+            "class EvolutionJournal:\n"
+            "    def append_entries(self, entries):\n"
+            "        path = self.config.journal_path\n"
+            '        with open(path, "a+b") as handle:\n'
+            "            handle.write(b'{}')\n"
+        )
+        assert self.offenders(tmp_path, source, name="evolution.py") == []
+
+    def test_the_exemption_is_the_class_method_and_nothing_else(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Round 1 exempted anything anywhere named ``append_entries``."""
+        nested = (
+            "def record_run(self):\n"
+            "    def append_entries(rows):\n"
+            '        open(self.config.journal_path, "a")\n'
+        )
+        assert self.offenders(tmp_path, nested, name="evolution.py") == [
+            "evolution.py:3: writes to self.config.journal_path"
+        ]
+
+        elsewhere = (
+            "class Sneaky:\n"
+            "    def append_entries(self, config):\n"
+            '        open(config.journal_path, "a")\n'
+        )
+        assert self.offenders(tmp_path, elsewhere, name="evolution.py") == [
+            "evolution.py:3: writes to config.journal_path"
+        ]
+
+    def test_the_exemption_does_not_apply_in_another_module(self, tmp_path: Path) -> None:
+        source = (
+            "class EvolutionJournal:\n"
+            "    def append_entries(self, entries):\n"
+            '        open(self.config.journal_path, "a")\n'
+        )
+        assert self.offenders(tmp_path, source, name="autonomy.py") == [
+            "autonomy.py:3: writes to self.config.journal_path"
+        ]

--- a/tests/test_journal_one_writer.py
+++ b/tests/test_journal_one_writer.py
@@ -47,6 +47,32 @@ def package_sources() -> list[Path]:
     return sorted(KSTRL_PACKAGE.rglob("*.py"))
 
 
+#: Source text -> its parsed tree. Three walkers in this file cross the
+#: whole package, and each used to parse it for itself.
+_PARSED: dict[str, ast.Module] = {}
+
+
+def parsed(source_file: Path) -> ast.Module:
+    """The module's AST, parsed once and shared by the three walkers.
+
+    ``tests/test_state_dir_scope.py`` already carries this pattern with
+    its own measurement (85 ms a pass, two walkers). Measured here: 127
+    modules, 65,366 lines, 236,779 nodes, 162 ms a pass, and this file
+    made three of them, which was 0.20 s of the file's 0.71 s.
+
+    Keyed on the TEXT rather than the path, because the positive
+    controls below rewrite one ``other.py`` several times within a
+    single test, and a path-keyed cache would hand the second call the
+    first snippet's tree.
+    """
+    text = source_file.read_text(encoding="utf-8")
+    tree = _PARSED.get(text)
+    if tree is None:
+        tree = ast.parse(text)
+        _PARSED[text] = tree
+    return tree
+
+
 # --- the one-writer guard, in pieces small enough to read -----------------
 #
 # Two layers, because one of them is a net and the other is a message.
@@ -78,8 +104,130 @@ def package_sources() -> list[Path]:
 #: Names that resolve to the builtin ``open`` when they own the call.
 _OPEN_MODULES = frozenset({"builtins", "io", "os"})
 
+#: The two things a writer has to reach: the attribute that holds the
+#: path, and the filename it points at.
+JOURNAL_ATTRIBUTE = "journal_path"
+JOURNAL_FILENAME = "evolution.jsonl"
+
 #: Path methods that write without going through ``open``.
 _PATH_WRITE_METHODS = frozenset({"write_text", "write_bytes"})
+
+
+def folded_str(node: ast.AST) -> str | None:
+    """The string this expression is KNOWN to evaluate to, or None.
+
+    Round 2 of review on #327, F9: two writers defeated all three
+    layers by never spelling in one piece what they reach.
+
+        target = getattr(config, "journal_" + "path")
+        target = root / ".kstrl" / ("evolution" + ".jsonl")
+
+    Neither is exotic; both are what somebody writes to get past a
+    string search, and either reintroduces #312 with CI green. Constant
+    folding is the answer to both. CPython folds adjacent literals
+    (``"a" "b"``) into one ``Constant`` at parse time, so that case
+    needs nothing here; an f-string does NOT fold, measured on this
+    interpreter, so ``JoinedStr`` and ``FormattedValue`` are handled
+    explicitly alongside the ``+``.
+
+    Decidable cases only. Anything whose value needs the interpreter
+    (``"".join(parts)``, ``%``-formatting, ``str.replace``, a name, an
+    env var) returns None, and the docstring on the test says so
+    rather than the guard pretending otherwise.
+
+    Split across four functions because the recursion costs 23 on the
+    cognitive gate in one, and that hook fails rather than advises.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value if isinstance(node.value, str) else None
+    if isinstance(node, ast.BinOp):
+        return folded_concat(node)
+    if isinstance(node, ast.FormattedValue):
+        return folded_placeholder(node)
+    if isinstance(node, ast.JoinedStr):
+        return folded_parts(node.values)
+    return None
+
+
+def folded_concat(node: ast.BinOp) -> str | None:
+    """``"journal_" + "path"``, and nothing else that uses ``+``."""
+    if not isinstance(node.op, ast.Add):
+        return None
+    return folded_parts([node.left, node.right])
+
+
+def folded_placeholder(node: ast.FormattedValue) -> str | None:
+    """The ``{...}`` of an f-string, when it is decidable.
+
+    ``!r`` and a format spec both change the result, so only the plain
+    case folds. Measured on this interpreter: ``ast.parse`` gives
+    ``conversion == -1`` for a plain placeholder and for one with a
+    format spec, and 114 for ``!r``; ``None`` never appears on the parse
+    path, so it is not tested for. Both halves have a control below,
+    because each was measured to be removable with the file green.
+    """
+    if node.conversion == -1 and node.format_spec is None:
+        return folded_str(node.value)
+    return None
+
+
+def folded_parts(nodes: list[ast.expr]) -> str | None:
+    """Every piece folded and joined, or None if any piece is unknown."""
+    parts: list[str] = []
+    for node in nodes:
+        folded = folded_str(node)
+        if folded is None:
+            return None
+        parts.append(folded)
+    return "".join(parts)
+
+
+def dynamic_attribute_read(node: ast.AST) -> bool:
+    """The attribute, reached without an ``ast.Attribute`` node.
+
+    ``getattr(x, "journal_path")`` however the name is assembled, and
+    the two subscript spellings of the same thing,
+    ``x.__dict__["journal_path"]`` and ``vars(x)["journal_path"]``. All
+    three are DECIDABLE, and round 2 of review on #327 is the record of
+    what it costs to leave a decidable shape undecided: the disclosure
+    below says only the undecidable half remains, so anything decidable
+    that is missed makes that disclosure false.
+    """
+    if isinstance(node, ast.Subscript):
+        return folded_str(node.slice) == JOURNAL_ATTRIBUTE and reads_a_namespace(node.value)
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "getattr"
+        and len(node.args) >= 2
+        and folded_str(node.args[1]) == JOURNAL_ATTRIBUTE
+    )
+
+
+def reads_a_namespace(node: ast.expr) -> bool:
+    """``x.__dict__`` or ``vars(x)``: an object's attribute table."""
+    if isinstance(node, ast.Attribute):
+        return node.attr == "__dict__"
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "vars"
+
+
+def reaches_journal_dynamically(node: ast.expr) -> bool:
+    """Does this expression reach the journal without naming it plainly?
+
+    True for a ``getattr`` of the attribute and for any subexpression
+    whose folded value CONTAINS the journal's filename, at any depth, so
+    that ``root / ".kstrl" / ("evolution" + ".jsonl")`` counts. Contains
+    rather than equals, and the difference is not academic: with
+    equality, ``root / (".kstrl/evolution" + ".jsonl")`` folded fine,
+    the inventory counted it, and layer 2 threw the answer away and
+    reported nothing, so the author got a changed module count instead
+    of "this line writes to the journal". Same predicate as
+    :func:`folded_filename_sites` now.
+    """
+    return any(
+        dynamic_attribute_read(child) or JOURNAL_FILENAME in (folded_str(child) or "")
+        for child in ast.walk(node)
+    )
 
 
 def mode_argument(node: ast.Call, index: int) -> ast.expr | None:
@@ -164,7 +312,7 @@ def mentions_journal(rendered: str, names: set[str]) -> bool:
     the path counts: ``open(journal_path.resolve(), "a")`` was another
     round-1 miss.
     """
-    if "config.journal_path" in rendered:
+    if f"config.{JOURNAL_ATTRIBUTE}" in rendered:
         return True
     return any(re.search(rf"\b{re.escape(name)}\b", rendered) for name in names)
 
@@ -201,7 +349,7 @@ def alias_sweep(nodes: list[ast.AST], exempt: set[int], names: set[str]) -> set[
         targets, value = assignment_parts(node)
         if value is None or getattr(node, "lineno", -1) in exempt:
             continue
-        if mentions_journal(ast.unparse(value), names):
+        if mentions_journal(ast.unparse(value), names) or reaches_journal_dynamically(value):
             found.update(targets)
     return found
 
@@ -229,7 +377,7 @@ def append_entries_lines(nodes: list[ast.AST], source_file: Path) -> set[int]:
 
 def journal_writes_outside_append_entries(source_file: Path) -> list[str]:
     """Every write to the evolution journal in one file, bar the sanctioned one."""
-    nodes = list(ast.walk(ast.parse(source_file.read_text(encoding="utf-8"))))
+    nodes = list(ast.walk(parsed(source_file)))
     exempt = append_entries_lines(nodes, source_file)
     names = journal_aliases(nodes, exempt)
     opens = open_aliases(nodes)
@@ -238,8 +386,10 @@ def journal_writes_outside_append_entries(source_file: Path) -> list[str]:
         if not isinstance(node, ast.Call) or node.lineno in exempt:
             continue
         target = write_target(node, opens)
-        rendered = ast.unparse(target) if target is not None else ""
-        if rendered and mentions_journal(rendered, names):
+        if target is None:
+            continue
+        rendered = ast.unparse(target)
+        if mentions_journal(rendered, names) or reaches_journal_dynamically(target):
             found.append(f"{label(source_file)}:{node.lineno}: writes to {rendered}")
     return found
 
@@ -253,151 +403,30 @@ def journal_path_escapes(source_file: Path) -> list[str]:
     about, and pinning six extra sites costs one line each in the
     expected set while guessing costs a hole.
     """
-    tree = ast.parse(source_file.read_text(encoding="utf-8"))
+    tree = parsed(source_file)
     return [
         f"{label(source_file)}: {ast.unparse(node)}"
         for node in ast.walk(tree)
-        if isinstance(node, ast.Attribute) and node.attr == "journal_path"
+        if (isinstance(node, ast.Attribute) and node.attr == JOURNAL_ATTRIBUTE)
+        or dynamic_attribute_read(node)
     ]
 
 
-class TestTheGuardDetects:
-    """Positive controls: layer 2 fed source it is SUPPOSED to flag.
+def folded_filename_sites(source_file: Path) -> int:
+    """How many expressions in one module reduce to the journal's name.
 
-    Without these the whole of layer 2 could be replaced by ``return []``
-    and the three tests below would stay green, because their only
-    assertion is that the offender list is empty, and an empty list is
-    what a switched-off detector returns. Measured, before these existed:
-    stubbing ``is_write_mode``, ``mentions_journal``, ``write_target``,
-    ``journal_aliases``, ``open_aliases`` or
-    ``journal_writes_outside_append_entries`` itself to a constant left
-    all three passing. Only layer 1 noticed, and only because it asserts
-    a NON-empty expected set.
-
-    So each shape round 1 of review on #327 listed gets a case here, on
-    a snippet rather than on the package, which is what makes the
-    detector's own failure reachable.
+    Substring of the folded value, not equality, which is what lets
+    ONE inventory replace two: the ``EvolutionConfig`` default folds to
+    ``".kstrl/evolution.jsonl"`` and every prose mention folds to a
+    whole docstring, so an exact match saw one site where a text search
+    saw seven. Measured: substring-of-folded reproduces the text
+    search's seven modules exactly, and unlike the text search it also
+    sees ``("evolution" + ".jsonl")`` and cannot be fooled by a comment.
+    Counted per module so an unrelated edit does not fail it.
     """
-
-    def offenders(self, tmp_path: Path, source: str, name: str = "other.py") -> list[str]:
-        path = tmp_path / name
-        path.write_text(source, encoding="utf-8")
-        return journal_writes_outside_append_entries(path)
-
-    def test_a_positional_mode_is_a_write(self, tmp_path: Path) -> None:
-        found = self.offenders(tmp_path, 'open(config.journal_path, "a")\n')
-        assert found == ["other.py:1: writes to config.journal_path"]
-
-    def test_a_keyword_mode_is_a_write(self, tmp_path: Path) -> None:
-        """The hole round 1 found: ``mode=`` was never read."""
-        found = self.offenders(tmp_path, 'open(config.journal_path, mode="a")\n')
-        assert found == ["other.py:1: writes to config.journal_path"]
-
-    def test_r_plus_is_a_write(self, tmp_path: Path) -> None:
-        """Every letter that can write, not just the first one."""
-        found = self.offenders(tmp_path, 'open(config.journal_path, "r+")\n')
-        assert found == ["other.py:1: writes to config.journal_path"]
-
-    def test_a_plain_read_is_not_a_write(self, tmp_path: Path) -> None:
-        """The distinction the mode test buys, pinned so it can fail.
-
-        The journal has a legitimate reader; flagging it would make this
-        guard about touching the file rather than writing it.
-        """
-        assert self.offenders(tmp_path, 'open(config.journal_path, "r")\n') == []
-        assert self.offenders(tmp_path, "open(config.journal_path)\n") == []
-
-    def test_an_alias_chain_of_any_length_is_followed(self, tmp_path: Path) -> None:
-        """Single-hop resolution let ``target = journal_path`` through."""
-        source = 'journal_path = config.journal_path\ntarget = journal_path\nopen(target, "a")\n'
-        assert self.offenders(tmp_path, source) == ["other.py:3: writes to target"]
-
-    def test_an_annotated_assignment_binds_too(self, tmp_path: Path) -> None:
-        source = 'journal_path: Path = config.journal_path\nopen(journal_path, "a")\n'
-        assert self.offenders(tmp_path, source) == ["other.py:2: writes to journal_path"]
-
-    def test_an_alias_of_open_itself_is_followed(self, tmp_path: Path) -> None:
-        source = 'open_file = open\nopen_file(config.journal_path, "a")\n'
-        assert self.offenders(tmp_path, source) == ["other.py:2: writes to config.journal_path"]
-
-    def test_the_dotted_opens_are_covered(self, tmp_path: Path) -> None:
-        for owner in ("builtins", "io", "os"):
-            found = self.offenders(tmp_path, f'{owner}.open(config.journal_path, "a")\n')
-            assert found == ["other.py:1: writes to config.journal_path"], owner
-
-    def test_a_call_on_the_path_still_counts(self, tmp_path: Path) -> None:
-        source = 'journal_path = config.journal_path\nopen(journal_path.resolve(), "a")\n'
-        assert self.offenders(tmp_path, source) == ["other.py:2: writes to journal_path.resolve()"]
-
-    def test_the_path_write_methods_are_covered(self, tmp_path: Path) -> None:
-        for method in ("write_text", "write_bytes"):
-            found = self.offenders(tmp_path, f"config.journal_path.{method}(row)\n")
-            assert found == ["other.py:1: writes to config.journal_path"], method
-
-    def test_path_dot_open_is_covered(self, tmp_path: Path) -> None:
-        found = self.offenders(tmp_path, 'config.journal_path.open("a")\n')
-        assert found == ["other.py:1: writes to config.journal_path"]
-
-    def test_a_duplicate_basename_is_named_by_its_package_path(self) -> None:
-        """A key and a message that send the reader to the right file.
-
-        Measured on this tree: ten basenames occur twice under
-        ``kstrl/``, ``decompose.py`` among them. Both halves asserted,
-        because a ``label`` that returned the full absolute path would
-        satisfy the second line alone and break every pinned key.
-        """
-        assert label(KSTRL_PACKAGE / "decompose.py") == "decompose.py"
-        assert label(KSTRL_PACKAGE / "tui" / "screens" / "decompose.py") == str(
-            Path("tui") / "screens" / "decompose.py"
-        )
-
-    def test_an_unrelated_file_is_left_alone(self, tmp_path: Path) -> None:
-        """The false-positive side. Without this, "flag everything" passes."""
-        source = 'other_path = config.experiments_path\nopen(other_path, "a")\n'
-        assert self.offenders(tmp_path, source) == []
-
-    def test_the_sanctioned_writer_is_exempt(self, tmp_path: Path) -> None:
-        source = (
-            "class EvolutionJournal:\n"
-            "    def append_entries(self, entries):\n"
-            "        path = self.config.journal_path\n"
-            '        with open(path, "a+b") as handle:\n'
-            "            handle.write(b'{}')\n"
-        )
-        assert self.offenders(tmp_path, source, name="evolution.py") == []
-
-    def test_the_exemption_is_the_class_method_and_nothing_else(
-        self,
-        tmp_path: Path,
-    ) -> None:
-        """Round 1 exempted anything anywhere named ``append_entries``."""
-        nested = (
-            "def record_run(self):\n"
-            "    def append_entries(rows):\n"
-            '        open(self.config.journal_path, "a")\n'
-        )
-        assert self.offenders(tmp_path, nested, name="evolution.py") == [
-            "evolution.py:3: writes to self.config.journal_path"
-        ]
-
-        elsewhere = (
-            "class Sneaky:\n"
-            "    def append_entries(self, config):\n"
-            '        open(config.journal_path, "a")\n'
-        )
-        assert self.offenders(tmp_path, elsewhere, name="evolution.py") == [
-            "evolution.py:3: writes to config.journal_path"
-        ]
-
-    def test_the_exemption_does_not_apply_in_another_module(self, tmp_path: Path) -> None:
-        source = (
-            "class EvolutionJournal:\n"
-            "    def append_entries(self, entries):\n"
-            '        open(self.config.journal_path, "a")\n'
-        )
-        assert self.offenders(tmp_path, source, name="autonomy.py") == [
-            "autonomy.py:3: writes to self.config.journal_path"
-        ]
+    return sum(
+        1 for node in ast.walk(parsed(source_file)) if JOURNAL_FILENAME in (folded_str(node) or "")
+    )
 
 
 #: Every place in ``kstrl/`` that reads or writes an attribute named
@@ -467,18 +496,30 @@ class TestOneWriter:
 
         ``EXPECTED_JOURNAL_PATH_SITES`` cannot see
         ``open(root / ".kstrl" / "evolution.jsonl", "a")``, because that
-        never touches the attribute. Counted per module rather than per
-        line, so an edit elsewhere in a file does not fail this, and
-        every module that names the file at all is accounted for: two
-        defaults, one inventory, and four mentions in prose.
-        """
-        spellings: dict[str, int] = {}
-        for source_file in package_sources():
-            hits = source_file.read_text(encoding="utf-8").count("evolution.jsonl")
-            if hits:
-                spellings[label(source_file)] = hits
+        never touches the attribute. Nor can a text search see
+        ``("evolution" + ".jsonl")``, which is how round 2 of review
+        defeated this half (F9). One inventory covers both: every
+        expression whose folded value CONTAINS the filename, counted
+        per module so an unrelated edit does not fail it.
 
-        assert spellings == {
+        Seven modules, and only one of them is a path: the
+        ``EvolutionConfig`` default, which folds to the whole relative
+        path, and the state-dir inventory, which is the bare name. The
+        other five are prose, and they fold to a whole docstring that
+        happens to contain the name.
+
+        What folding cannot decide, stated rather than implied:
+        ``"".join(("evolution", ".jsonl"))``, ``"%s.jsonl" % stem``, or
+        any name resolved at run time. The test below asserts that miss,
+        so this disclosure fails if it stops being true.
+        """
+        built: dict[str, int] = {}
+        for source_file in package_sources():
+            hits = folded_filename_sites(source_file)
+            if hits:
+                built[label(source_file)] = hits
+
+        assert built == {
             "atomicio.py": 1,  # prose in the module docstring
             "events.py": 1,  # prose in a docstring
             "evolution.py": 1,  # the EvolutionConfig default
@@ -487,8 +528,8 @@ class TestOneWriter:
             "pipeline.py": 1,  # prose in a docstring
             "statedir.py": 1,  # the state-dir inventory, by name
         }, (
-            "Somebody spelled the journal's filename instead of asking "
-            f"EvolutionConfig for it. Sites: {spellings}"
+            "Somebody spelled or assembled the journal's filename instead of "
+            f"asking EvolutionConfig for it. Sites: {built}"
         )
 
     def test_append_entries_is_the_only_writer_of_the_journal(self) -> None:
@@ -516,6 +557,17 @@ class TestOneWriter:
           file (layer 1 is what makes that true), so the write has to be
           added inside the exempt method itself, which is the one place
           a reviewer of this invariant is already reading.
+        - a path or a filename the INTERPRETER has to build. Round 2 of
+          review, F9, defeated every layer with two constant-foldable
+          shapes; those are folded now, positive controls and all, as
+          are the two subscript spellings of an attribute read. What
+          remains is the undecidable half, ``"".join(...)``,
+          ``%``-formatting, a name resolved at run time. Pinned by
+          ``test_a_filename_the_interpreter_has_to_build_is_missed``, so
+          the disclosure fails if it stops being true. The rule this
+          leaves behind: a shape a reader can decide by looking at it is
+          a shape this guard must decide, and anything else is disclosed
+          here.
         """
         offenders = [
             offender

--- a/tests/test_journal_one_writer.py
+++ b/tests/test_journal_one_writer.py
@@ -1,0 +1,530 @@
+"""``append_entries`` is the only writer of the evolution journal's lines.
+
+Split out of ``tests/test_journal_torn_tail.py`` when the file-length
+ratchet fired, and it was right: that file is about what an interrupted
+write COSTS, measured against real bytes on a real file, and this one is
+a static guard over the whole package with no journal in it at all.
+Different subject, different failure message, different reason to fail.
+
+#312 is why the invariant is worth a guard: there were two writers of
+this file, the second one had its own copy of the defect, and the
+docstring on the first one claimed to be the only one. Round 1 of review
+on #327 then found the first version of this guard passing an ordinary
+``open(config.journal_path, mode="a")``, which is what produced the two
+layers below.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+#: The package under test, located the way every other AST-walking test
+#: in this suite locates it (test_atomicio, test_prompt_versions).
+KSTRL_PACKAGE = Path(__file__).resolve().parent.parent / "kstrl"
+
+
+def label(source_file: Path) -> str:
+    """How a file is named in a key and in a failure message.
+
+    Not ``source_file.name``: ten basenames occur twice in ``kstrl/``
+    (``config.py``, ``decompose.py``, ``inbox.py`` and seven more, once
+    at the top level and once under ``tui/screens/``). Nothing collides
+    in the pinned sets today, and the counts would still move if it did,
+    but the message would name a file the reader cannot then find.
+    Falls back to the basename outside the package, which is what the
+    snippets in ``TestTheGuardDetects`` are.
+    """
+    try:
+        return str(source_file.relative_to(KSTRL_PACKAGE))
+    except ValueError:
+        return source_file.name
+
+
+def package_sources() -> list[Path]:
+    """Every module in ``kstrl/``, in a stable order."""
+    return sorted(KSTRL_PACKAGE.rglob("*.py"))
+
+
+# --- the one-writer guard, in pieces small enough to read -----------------
+#
+# Two layers, because one of them is a net and the other is a message.
+#
+# LAYER 1, ``journal_path_escapes``, pins every expression in ``kstrl/``
+# that reads an attribute named ``journal_path``. It is the net: code
+# cannot write to a file whose path it never obtained, so a second
+# writer in any shape has to appear here first, whatever it does with
+# the path afterwards. It needs no alias resolution at all, which is the
+# point. #324 records that this repo has about eleven AST guards each
+# re-implementing that resolution and each holed independently, and this
+# one deliberately does not make resolution load-bearing.
+#
+# LAYER 2, ``journal_writes_outside_append_entries``, does resolve
+# aliases, and says what it cannot see rather than claiming to be
+# exhaustive. It is not merely a nicer error message for layer 1: it
+# catches one thing layer 1 provably cannot, an EXISTING attribute read
+# rebound to a local that is then written through, which leaves layer
+# 1's counts untouched. Layer 1 in turn catches what layer 2 cannot, a
+# path handed to a helper and opened there. Both were planted and
+# measured; neither is redundant.
+#
+# Round 1 of review on #327 found layer 2 passing an ordinary
+# ``open(config.journal_path, mode="a")``, which is why layer 1 exists
+# at all, and why ``TestTheGuardDetects`` below feeds this layer source
+# it is supposed to flag: a guard whose only assertion is that a list is
+# empty cannot notice its own detector being switched off.
+
+#: Names that resolve to the builtin ``open`` when they own the call.
+_OPEN_MODULES = frozenset({"builtins", "io", "os"})
+
+#: Path methods that write without going through ``open``.
+_PATH_WRITE_METHODS = frozenset({"write_text", "write_bytes"})
+
+
+def mode_argument(node: ast.Call, index: int) -> ast.expr | None:
+    """The mode/flags argument of an open-like call, positional or keyword.
+
+    ``mode=`` was the hole round 1 found: only positional arguments were
+    read, so ``open(p, mode="a")`` was classified as a read. ``flags`` is
+    here for ``os.open``.
+    """
+    for keyword in node.keywords:
+        if keyword.arg in ("mode", "flags"):
+            return keyword.value
+    return node.args[index] if len(node.args) > index else None
+
+
+def is_write_mode(mode: ast.expr | None) -> bool:
+    """Does this mode argument write? An absent mode reads.
+
+    Every letter that can write, not just the first character: ``"r+"``
+    and ``"rb+"`` write. Anything that is not a literal string counts as
+    a write, including ``os.O_APPEND``, because a guard must not be
+    argued out of by indirection.
+    """
+    if mode is None:
+        return False
+    if isinstance(mode, ast.Constant) and isinstance(mode.value, str):
+        return any(letter in mode.value for letter in "awx+")
+    return True
+
+
+def write_target(node: ast.Call, open_names: set[str]) -> ast.expr | None:
+    """The path expression a call writes to, or None if it writes none.
+
+    Covers ``open(p, "a")`` and any alias of ``open``; ``builtins.open``,
+    ``io.open`` and ``os.open``; ``p.open("a")``; and ``p.write_text`` /
+    ``p.write_bytes``.
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        if func.id not in open_names or not node.args:
+            return None
+        return node.args[0] if is_write_mode(mode_argument(node, 1)) else None
+    if not isinstance(func, ast.Attribute):
+        return None
+    if func.attr in _PATH_WRITE_METHODS:
+        return func.value
+    if func.attr != "open":
+        return None
+    if ast.unparse(func.value).split(".")[-1] in _OPEN_MODULES:
+        return node.args[0] if node.args and is_write_mode(mode_argument(node, 1)) else None
+    return func.value if is_write_mode(mode_argument(node, 0)) else None
+
+
+def assignment_parts(node: ast.AST) -> tuple[list[str], ast.expr | None]:
+    """The plain names an assignment binds, and what it binds them to.
+
+    Handles ``AnnAssign`` as well as ``Assign``: an annotated
+    ``journal_path: Path = config.journal_path`` was invisible to round
+    1's walk, which looked only at ``Assign``.
+    """
+    if isinstance(node, ast.Assign):
+        return [t.id for t in node.targets if isinstance(t, ast.Name)], node.value
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return [node.target.id], node.value
+    return [], None
+
+
+def open_aliases(nodes: list[ast.AST]) -> set[str]:
+    """``{"open"}`` plus any name bound to it, e.g. ``open_file = open``."""
+    names = {"open"}
+    for node in nodes:
+        targets, value = assignment_parts(node)
+        if isinstance(value, ast.Name) and value.id in names:
+            names.update(targets)
+    return names
+
+
+def mentions_journal(rendered: str, names: set[str]) -> bool:
+    """Does this expression reach the evolution journal's path?
+
+    Substring and word-boundary rather than equality, so that a call ON
+    the path counts: ``open(journal_path.resolve(), "a")`` was another
+    round-1 miss.
+    """
+    if "config.journal_path" in rendered:
+        return True
+    return any(re.search(rf"\b{re.escape(name)}\b", rendered) for name in names)
+
+
+def journal_aliases(nodes: list[ast.AST], exempt: set[int]) -> set[str]:
+    """Local names holding the journal path, to a FIXED POINT.
+
+    ``journal_path = config.journal_path`` is how the old
+    ``commit_transition`` reached it, and ``target = journal_path`` after
+    that is how round 1's single-hop walk was escaped. Iterating until
+    nothing new is bound closes the chain at any length.
+
+    Assignments inside the exempt method are skipped because aliases are
+    collected per module rather than per scope, and that method binds the
+    journal to ``path``: without the skip the commonest local name in
+    ``evolution.py`` would mean "the journal" everywhere in the file.
+    """
+    names: set[str] = set()
+    while True:
+        found = alias_sweep(nodes, exempt, names)
+        if found <= names:
+            return names
+        names |= found
+
+
+def alias_sweep(nodes: list[ast.AST], exempt: set[int], names: set[str]) -> set[str]:
+    """The names ONE pass binds to the journal, given what is known so far.
+
+    Split from the loop above because the nesting cost 17 on the
+    cognitive gate, which is a hook that fails rather than advises.
+    """
+    found: set[str] = set()
+    for node in nodes:
+        targets, value = assignment_parts(node)
+        if value is None or getattr(node, "lineno", -1) in exempt:
+            continue
+        if mentions_journal(ast.unparse(value), names):
+            found.update(targets)
+    return found
+
+
+def append_entries_lines(nodes: list[ast.AST], source_file: Path) -> set[int]:
+    """The lines of ``EvolutionJournal.append_entries``: the one writer.
+
+    Resolved through the CLASS, in the one module that may define it,
+    rather than by function name: round 1 exempted anything anywhere
+    called ``append_entries``, so an unrelated method or a nested
+    function of that name was a free pass. Located by walking rather
+    than by pinning a line number, so editing the file above it does not
+    fail the guard.
+    """
+    if label(source_file) != "evolution.py":
+        return set()
+    for node in nodes:
+        if not isinstance(node, ast.ClassDef) or node.name != "EvolutionJournal":
+            continue
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef) and item.name == "append_entries":
+                return set(range(item.lineno, (item.end_lineno or item.lineno) + 1))
+    return set()
+
+
+def journal_writes_outside_append_entries(source_file: Path) -> list[str]:
+    """Every write to the evolution journal in one file, bar the sanctioned one."""
+    nodes = list(ast.walk(ast.parse(source_file.read_text(encoding="utf-8"))))
+    exempt = append_entries_lines(nodes, source_file)
+    names = journal_aliases(nodes, exempt)
+    opens = open_aliases(nodes)
+    found: list[str] = []
+    for node in nodes:
+        if not isinstance(node, ast.Call) or node.lineno in exempt:
+            continue
+        target = write_target(node, opens)
+        rendered = ast.unparse(target) if target is not None else ""
+        if rendered and mentions_journal(rendered, names):
+            found.append(f"{label(source_file)}:{node.lineno}: writes to {rendered}")
+    return found
+
+
+def journal_path_escapes(source_file: Path) -> list[str]:
+    """Every read or write of an attribute named ``journal_path``.
+
+    Layer 1. Deliberately NOT filtered down to the evolution journal:
+    telling ``self.config.journal_path`` from ``pipeline``'s
+    progress-log ``self.journal_path`` needs the type resolution #324 is
+    about, and pinning six extra sites costs one line each in the
+    expected set while guessing costs a hole.
+    """
+    tree = ast.parse(source_file.read_text(encoding="utf-8"))
+    return [
+        f"{label(source_file)}: {ast.unparse(node)}"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr == "journal_path"
+    ]
+
+
+class TestTheGuardDetects:
+    """Positive controls: layer 2 fed source it is SUPPOSED to flag.
+
+    Without these the whole of layer 2 could be replaced by ``return []``
+    and the three tests below would stay green, because their only
+    assertion is that the offender list is empty, and an empty list is
+    what a switched-off detector returns. Measured, before these existed:
+    stubbing ``is_write_mode``, ``mentions_journal``, ``write_target``,
+    ``journal_aliases``, ``open_aliases`` or
+    ``journal_writes_outside_append_entries`` itself to a constant left
+    all three passing. Only layer 1 noticed, and only because it asserts
+    a NON-empty expected set.
+
+    So each shape round 1 of review on #327 listed gets a case here, on
+    a snippet rather than on the package, which is what makes the
+    detector's own failure reachable.
+    """
+
+    def offenders(self, tmp_path: Path, source: str, name: str = "other.py") -> list[str]:
+        path = tmp_path / name
+        path.write_text(source, encoding="utf-8")
+        return journal_writes_outside_append_entries(path)
+
+    def test_a_positional_mode_is_a_write(self, tmp_path: Path) -> None:
+        found = self.offenders(tmp_path, 'open(config.journal_path, "a")\n')
+        assert found == ["other.py:1: writes to config.journal_path"]
+
+    def test_a_keyword_mode_is_a_write(self, tmp_path: Path) -> None:
+        """The hole round 1 found: ``mode=`` was never read."""
+        found = self.offenders(tmp_path, 'open(config.journal_path, mode="a")\n')
+        assert found == ["other.py:1: writes to config.journal_path"]
+
+    def test_r_plus_is_a_write(self, tmp_path: Path) -> None:
+        """Every letter that can write, not just the first one."""
+        found = self.offenders(tmp_path, 'open(config.journal_path, "r+")\n')
+        assert found == ["other.py:1: writes to config.journal_path"]
+
+    def test_a_plain_read_is_not_a_write(self, tmp_path: Path) -> None:
+        """The distinction the mode test buys, pinned so it can fail.
+
+        The journal has a legitimate reader; flagging it would make this
+        guard about touching the file rather than writing it.
+        """
+        assert self.offenders(tmp_path, 'open(config.journal_path, "r")\n') == []
+        assert self.offenders(tmp_path, "open(config.journal_path)\n") == []
+
+    def test_an_alias_chain_of_any_length_is_followed(self, tmp_path: Path) -> None:
+        """Single-hop resolution let ``target = journal_path`` through."""
+        source = 'journal_path = config.journal_path\ntarget = journal_path\nopen(target, "a")\n'
+        assert self.offenders(tmp_path, source) == ["other.py:3: writes to target"]
+
+    def test_an_annotated_assignment_binds_too(self, tmp_path: Path) -> None:
+        source = 'journal_path: Path = config.journal_path\nopen(journal_path, "a")\n'
+        assert self.offenders(tmp_path, source) == ["other.py:2: writes to journal_path"]
+
+    def test_an_alias_of_open_itself_is_followed(self, tmp_path: Path) -> None:
+        source = 'open_file = open\nopen_file(config.journal_path, "a")\n'
+        assert self.offenders(tmp_path, source) == ["other.py:2: writes to config.journal_path"]
+
+    def test_the_dotted_opens_are_covered(self, tmp_path: Path) -> None:
+        for owner in ("builtins", "io", "os"):
+            found = self.offenders(tmp_path, f'{owner}.open(config.journal_path, "a")\n')
+            assert found == ["other.py:1: writes to config.journal_path"], owner
+
+    def test_a_call_on_the_path_still_counts(self, tmp_path: Path) -> None:
+        source = 'journal_path = config.journal_path\nopen(journal_path.resolve(), "a")\n'
+        assert self.offenders(tmp_path, source) == ["other.py:2: writes to journal_path.resolve()"]
+
+    def test_the_path_write_methods_are_covered(self, tmp_path: Path) -> None:
+        for method in ("write_text", "write_bytes"):
+            found = self.offenders(tmp_path, f"config.journal_path.{method}(row)\n")
+            assert found == ["other.py:1: writes to config.journal_path"], method
+
+    def test_path_dot_open_is_covered(self, tmp_path: Path) -> None:
+        found = self.offenders(tmp_path, 'config.journal_path.open("a")\n')
+        assert found == ["other.py:1: writes to config.journal_path"]
+
+    def test_a_duplicate_basename_is_named_by_its_package_path(self) -> None:
+        """A key and a message that send the reader to the right file.
+
+        Measured on this tree: ten basenames occur twice under
+        ``kstrl/``, ``decompose.py`` among them. Both halves asserted,
+        because a ``label`` that returned the full absolute path would
+        satisfy the second line alone and break every pinned key.
+        """
+        assert label(KSTRL_PACKAGE / "decompose.py") == "decompose.py"
+        assert label(KSTRL_PACKAGE / "tui" / "screens" / "decompose.py") == str(
+            Path("tui") / "screens" / "decompose.py"
+        )
+
+    def test_an_unrelated_file_is_left_alone(self, tmp_path: Path) -> None:
+        """The false-positive side. Without this, "flag everything" passes."""
+        source = 'other_path = config.experiments_path\nopen(other_path, "a")\n'
+        assert self.offenders(tmp_path, source) == []
+
+    def test_the_sanctioned_writer_is_exempt(self, tmp_path: Path) -> None:
+        source = (
+            "class EvolutionJournal:\n"
+            "    def append_entries(self, entries):\n"
+            "        path = self.config.journal_path\n"
+            '        with open(path, "a+b") as handle:\n'
+            "            handle.write(b'{}')\n"
+        )
+        assert self.offenders(tmp_path, source, name="evolution.py") == []
+
+    def test_the_exemption_is_the_class_method_and_nothing_else(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Round 1 exempted anything anywhere named ``append_entries``."""
+        nested = (
+            "def record_run(self):\n"
+            "    def append_entries(rows):\n"
+            '        open(self.config.journal_path, "a")\n'
+        )
+        assert self.offenders(tmp_path, nested, name="evolution.py") == [
+            "evolution.py:3: writes to self.config.journal_path"
+        ]
+
+        elsewhere = (
+            "class Sneaky:\n"
+            "    def append_entries(self, config):\n"
+            '        open(config.journal_path, "a")\n'
+        )
+        assert self.offenders(tmp_path, elsewhere, name="evolution.py") == [
+            "evolution.py:3: writes to config.journal_path"
+        ]
+
+    def test_the_exemption_does_not_apply_in_another_module(self, tmp_path: Path) -> None:
+        source = (
+            "class EvolutionJournal:\n"
+            "    def append_entries(self, entries):\n"
+            '        open(self.config.journal_path, "a")\n'
+        )
+        assert self.offenders(tmp_path, source, name="autonomy.py") == [
+            "autonomy.py:3: writes to self.config.journal_path"
+        ]
+
+
+#: Every place in ``kstrl/`` that reads or writes an attribute named
+#: ``journal_path``, with how many times each expression appears in that
+#: module. A second writer of the evolution journal has to obtain the
+#: path, so it has to change this list, whatever shape the write takes.
+#:
+#: Adding a row is not forbidden, it is the point: the diff that adds
+#: one is where somebody says why new code needs the journal's path and
+#: why it is not going through ``append_entries``.
+#:
+#: The ``pipeline`` and ``workqueue`` rows are a DIFFERENT file (the
+#: progress log and the queue journal). They are pinned anyway, because
+#: separating them from the evolution journal by name alone is a guess
+#: and #324 is the record of what guessing costs.
+EXPECTED_JOURNAL_PATH_SITES: dict[str, int] = {
+    "cli.py: journal.config.journal_path": 1,
+    "decompose.py: journal.config.journal_path": 1,
+    "evolution.py: config.journal_path": 5,
+    "evolution.py: self.config.journal_path": 3,
+    "pipeline.py: self.journal_path": 4,
+    "workqueue.py: self.journal_path": 2,
+}
+
+
+class TestOneWriter:
+    """``append_entries`` is the only writer of the journal's lines, and
+    #312 is what the second one cost. This is the mechanism behind that
+    sentence in its docstring."""
+
+    def test_no_new_code_gets_hold_of_the_journal_path(self) -> None:
+        """Layer 1, the net: pin every escape point of the path itself.
+
+        Code cannot write to a file whose path it never obtained, so
+        NEW code that gets hold of it has to change this list, whatever
+        shape the write takes afterwards. That is why this layer
+        resolves nothing: an exact set of expressions has no aliasing to
+        be wrong about. Measured: of the eleven shapes round 1 of review
+        listed, this layer catches ten.
+
+        Two things it cannot see, both covered elsewhere rather than
+        implied away:
+
+        - an EXISTING acquisition re-spelled into a local that is then
+          written through. The attribute is still read once, so these
+          counts do not move. Layer 2 is what sees that, which is why
+          both exist.
+        - a path spelled out rather than asked for. The test below
+          covers that half.
+        """
+        found: dict[str, int] = {}
+        for source_file in package_sources():
+            for site in journal_path_escapes(source_file):
+                found[site] = found.get(site, 0) + 1
+
+        assert found == EXPECTED_JOURNAL_PATH_SITES, (
+            "The set of places that get hold of a journal path changed. If this is "
+            "a new writer of the evolution journal, route it through "
+            "EvolutionJournal.append_entries: an unguarded append concatenates onto "
+            "an unterminated tail and eats the entry after it (#312). If it is a "
+            "read, or another file's journal, add it to EXPECTED_JOURNAL_PATH_SITES "
+            f"with a reason. Found: {found}"
+        )
+
+    def test_nobody_spells_the_journal_filename_for_themselves(self) -> None:
+        """The other half of layer 1: the path obtained by construction.
+
+        ``EXPECTED_JOURNAL_PATH_SITES`` cannot see
+        ``open(root / ".kstrl" / "evolution.jsonl", "a")``, because that
+        never touches the attribute. Counted per module rather than per
+        line, so an edit elsewhere in a file does not fail this, and
+        every module that names the file at all is accounted for: two
+        defaults, one inventory, and four mentions in prose.
+        """
+        spellings: dict[str, int] = {}
+        for source_file in package_sources():
+            hits = source_file.read_text(encoding="utf-8").count("evolution.jsonl")
+            if hits:
+                spellings[label(source_file)] = hits
+
+        assert spellings == {
+            "atomicio.py": 1,  # prose in the module docstring
+            "events.py": 1,  # prose in a docstring
+            "evolution.py": 1,  # the EvolutionConfig default
+            "init_cmd.py": 1,  # a commented example in the scaffolded kstrl.toml
+            "knowledge.py": 1,  # prose in the module docstring
+            "pipeline.py": 1,  # prose in a docstring
+            "statedir.py": 1,  # the state-dir inventory, by name
+        }, (
+            "Somebody spelled the journal's filename instead of asking "
+            f"EvolutionConfig for it. Sites: {spellings}"
+        )
+
+    def test_append_entries_is_the_only_writer_of_the_journal(self) -> None:
+        """Layer 2, the message: name the offending write and the fix.
+
+        Resolves aliases to a fixed point through ``Assign`` and
+        ``AnnAssign``, reads ``mode=`` as well as positional modes,
+        follows aliases of ``open`` itself, and knows ``builtins.open``,
+        ``io.open``, ``os.open``, ``Path.open``, ``write_text`` and
+        ``write_bytes``. The exemption is resolved through the
+        ``EvolutionJournal`` class in ``evolution.py``, so an unrelated
+        method or a nested function called ``append_entries`` is not
+        exempt.
+
+        What it still CANNOT see, stated rather than implied, because a
+        guard that overstates its reach is worse than one that does not
+        exist:
+
+        - a path handed to a helper as a parameter and opened there.
+          Planted and measured: layer 1 catches it, because the caller
+          had to read the attribute to pass it on.
+        - a write through a handle somebody else opened. Planted and
+          measured: NEITHER layer catches it. The bound on that residual
+          is that only ``append_entries`` ever holds a handle to this
+          file (layer 1 is what makes that true), so the write has to be
+          added inside the exempt method itself, which is the one place
+          a reviewer of this invariant is already reading.
+        """
+        offenders = [
+            offender
+            for source_file in package_sources()
+            for offender in journal_writes_outside_append_entries(source_file)
+        ]
+
+        assert offenders == [], (
+            "A journal write outside append_entries: it will concatenate onto an "
+            "unterminated tail and eat the entry after it (#312). Route it through "
+            f"EvolutionJournal.append_entries. Offenders: {offenders}"
+        )

--- a/tests/test_journal_torn_tail.py
+++ b/tests/test_journal_torn_tail.py
@@ -19,25 +19,32 @@ and it is not uniform: ``test_a_tail_that_lost_only_its_newline_keeps_
 its_record`` is the case where the interrupted write cost TWO records
 rather than one, because a tail that lost only its terminator is a
 complete record that the concatenation then destroys as well.
+
+The static half of #312 - that ``append_entries`` is the only writer of
+this file, which is what a second copy of the defect cost - lives in
+``tests/test_journal_one_writer.py``. It was split out when the
+file-length ratchet fired, and the split is along the seam: nothing in
+that file opens a journal.
 """
 
 from __future__ import annotations
 
-import ast
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from kstrl.evolution import JOURNAL_REPAIR_EVENT, EvolutionConfig, EvolutionJournal
-from kstrl.observability import ends_without_newline, read_progress_events
+from kstrl.evolution import (
+    EXPERIMENTS_HEADER,
+    JOURNAL_REPAIR_EVENT,
+    EvolutionConfig,
+    EvolutionJournal,
+)
+from kstrl.observability import handle_ends_without_newline, read_progress_events
 from tests.helpers.journal import DANGLING_UTF8, TORN_FRAGMENT, tear
-
-#: The package under test, located the way every other AST-walking test
-#: in this suite locates it (test_atomicio, test_prompt_versions).
-KSTRL_PACKAGE = Path(__file__).resolve().parent.parent / "kstrl"
 
 
 def audit(project: str) -> dict[str, Any]:
@@ -77,103 +84,6 @@ def audits_in(path: Path) -> list[str]:
 
 def repair_rows_in(path: Path) -> list[dict[str, Any]]:
     return [e for e in read_progress_events(path) if e.get("event_type") == JOURNAL_REPAIR_EVENT]
-
-
-# --- the one-writer guard, in pieces small enough to read -----------------
-
-
-def is_write_mode(mode_args: list[ast.expr]) -> bool:
-    """Does this open() mode argument write? An absent mode reads.
-
-    Every mode letter that can write, not just the first character: an
-    earlier draft tested ``mode[0] in "aw"`` and so read ``"r+"`` and
-    ``"rb+"`` as reads, which is a hole in a guard whose docstring
-    claims it cannot be argued out of by indirection. A mode that is not
-    a literal string counts as a write for the same reason.
-    """
-    if not mode_args:
-        return False
-    mode = mode_args[0]
-    if isinstance(mode, ast.Constant) and isinstance(mode.value, str):
-        return any(letter in mode.value for letter in "awx+")
-    return True
-
-
-def write_target(node: ast.Call) -> ast.expr | None:
-    """The path expression a call writes to, or None if it writes none.
-
-    Covers the builtin ``open(path, "a")``, the method ``path.open("a")``
-    and ``path.write_text`` / ``path.write_bytes``.
-    """
-    func = node.func
-    if isinstance(func, ast.Attribute):
-        if func.attr in ("write_text", "write_bytes"):
-            return func.value
-        return func.value if func.attr == "open" and is_write_mode(node.args[:1]) else None
-    if isinstance(func, ast.Name) and func.id == "open" and node.args:
-        return node.args[0] if is_write_mode(node.args[1:2]) else None
-    return None
-
-
-def journal_aliases(nodes: list[ast.AST], permitted: set[int]) -> set[str]:
-    """Local names assigned from an expression naming the journal.
-
-    The old ``commit_transition`` reached it exactly this way:
-    ``journal_path = config.journal_path`` and then a raw open of the
-    local. Assignments inside ``append_entries`` are skipped because
-    aliases are collected per module rather than per scope, and that
-    method binds the journal to ``path``: without the skip, the
-    commonest local name in ``evolution.py`` would mean "the journal"
-    everywhere in the file, and the next unrelated ``open(path, "w")``
-    in it would be a false offender. Measured on this tree, honestly:
-    the skip changes nothing today (both ways report zero), because the
-    one other write through a local ``path`` in that module moved to
-    ``observability.ends_without_newline``. An earlier draft of this
-    change, with the probe still in ``evolution.py``, DID report it.
-    """
-    names: set[str] = set()
-    for node in nodes:
-        if not isinstance(node, ast.Assign) or node.lineno in permitted:
-            continue
-        if not isinstance(node.value, ast.Attribute):
-            continue
-        if "config.journal_path" in ast.unparse(node.value):
-            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
-    return names
-
-
-def append_entries_lines(nodes: list[ast.AST]) -> set[int]:
-    """Every line of ``append_entries``: the one permitted writer.
-
-    Located by walking to the def rather than by pinning a line number,
-    so editing the file above it does not fail the guard. A file with no
-    such def gets an empty set, which is why this needs no exemption
-    list naming ``evolution.py``.
-    """
-    for node in nodes:
-        if isinstance(node, ast.FunctionDef) and node.name == "append_entries":
-            return set(range(node.lineno, (node.end_lineno or node.lineno) + 1))
-    return set()
-
-
-def journal_writes_outside_append_entries(source_file: Path) -> list[str]:
-    """Every write to the evolution journal in one file, bar the sanctioned one.
-
-    One ``ast.walk`` feeds all three passes. Measured over kstrl's 127
-    files: walking per pass costs 232 ms, walking once costs 182 ms.
-    """
-    nodes = list(ast.walk(ast.parse(source_file.read_text(encoding="utf-8"))))
-    permitted = append_entries_lines(nodes)
-    aliases = journal_aliases(nodes, permitted)
-    found: list[str] = []
-    for node in nodes:
-        if not isinstance(node, ast.Call) or node.lineno in permitted:
-            continue
-        target = write_target(node)
-        rendered = ast.unparse(target) if target is not None else ""
-        if "config.journal_path" in rendered or (rendered and rendered in aliases):
-            found.append(f"{source_file.name}:{node.lineno}: writes to {rendered}")
-    return found
 
 
 class TestTheEntryAfterATear:
@@ -300,7 +210,9 @@ class TestWhatIsNotATear:
         assert repair_rows_in(journal.config.journal_path) == []
 
     def test_a_missing_journal_file_is_not_a_tear(self, tmp_path: Path) -> None:
-        """FileNotFoundError is an OSError, and answers "not torn"."""
+        """``"a+b"`` creates it, and a zero-length file has no
+        unterminated line in it. Distinct from the empty-file case above
+        in what it exercises: there the file is already there."""
         journal = journal_at(tmp_path)
         assert not journal.config.journal_path.exists()
 
@@ -324,20 +236,182 @@ class TestWhatIsNotATear:
 
         assert journal.config.journal_path.read_bytes() == before
 
-    def test_a_directory_where_the_journal_should_be_is_not_a_tear(self, tmp_path: Path) -> None:
-        """An unreadable path is not evidence of an interrupted write.
-
-        ``ends_without_newline`` answers False and lets the append
-        raise the real ``OSError`` for the caller to surface, rather
-        than inventing a repair for a file it could not read.
-        """
+    def test_a_directory_where_the_journal_should_be_raises(self, tmp_path: Path) -> None:
+        """An unopenable path raises for the caller to surface, and the
+        three callers each already handle ``OSError`` their own way."""
         journal = journal_at(tmp_path)
         journal.config.journal_path.parent.mkdir(parents=True, exist_ok=True)
         journal.config.journal_path.mkdir()
 
-        assert ends_without_newline(journal.config.journal_path) is False
         with pytest.raises(OSError):
             journal.append_entries([audit("alpha")])
+
+
+class TestTheRepairIsReportable:
+    """#327 round 1, F5: a durable row nothing reports is reachable only
+    by an operator who already suspects the problem."""
+
+    def status_output(self, tmp_path: Path) -> str:
+        """`ks evolve --status` against a real root, through the real CLI."""
+        from click.testing import CliRunner
+
+        import kstrl.cli as cli_mod
+
+        result = CliRunner().invoke(
+            cli_mod.cli,
+            ["evolve", "--status", "--root", str(tmp_path), "--ui", "plain", "--no-color"],
+        )
+        assert result.exit_code == 0, result.output
+        return str(result.output)
+
+    def experiments_row(self, tmp_path: Path) -> None:
+        """--status prints trends from experiments.tsv and exits early
+        when there are none, so the repair line needs a row to reach.
+
+        The header is the one ``record_run`` writes, read out of the
+        source rather than retyped: a shorter hand-written header passes
+        only because ``csv.DictReader`` tolerates it, which is not
+        evidence that --status reaches the repair line on a real file.
+        """
+        path = tmp_path / ".kstrl" / "experiments.tsv"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        columns = EXPERIMENTS_HEADER.split("\t")
+        row = ["r1", "2026-08-20T00:00:00Z"] + ["0"] * (len(columns) - 2)
+        path.write_text(
+            EXPERIMENTS_HEADER + "\n" + "\t".join(row) + "\n",
+            encoding="utf-8",
+        )
+
+    def test_a_repaired_journal_says_so_in_ks_evolve_status(self, tmp_path: Path) -> None:
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        tear(journal.config.journal_path)
+        journal.append_entries([audit("beta")])
+        self.experiments_row(tmp_path)
+
+        output = self.status_output(tmp_path)
+
+        assert "1 interrupted write(s) repaired" in output
+        assert "journal_repair" in output
+
+    def test_a_healthy_journal_says_nothing(self, tmp_path: Path) -> None:
+        """Silence at zero is the point: a line that prints on every
+        healthy journal is a line an operator learns to skip."""
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        self.experiments_row(tmp_path)
+
+        output = self.status_output(tmp_path)
+
+        assert "interrupted write" not in output
+
+    def test_the_count_is_of_rows_not_of_incidents(self, tmp_path: Path) -> None:
+        """What ``get_repair_count`` promises, and no more. Two tears
+        are two rows; #330 is the case where one tear becomes two."""
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        tear(journal.config.journal_path)
+        journal.append_entries([audit("beta")])
+        tear(journal.config.journal_path)
+        journal.append_entries([audit("gamma")])
+
+        assert journal.get_repair_count() == 2
+
+    def test_the_count_survives_an_unreadable_journal(self, tmp_path: Path) -> None:
+        """It reads through ``read_progress_events``, which answers []
+        rather than raising, so a status command cannot be taken down by
+        the very file it is reporting on."""
+        journal = journal_at(tmp_path)
+        journal.config.journal_path.parent.mkdir(parents=True, exist_ok=True)
+        journal.config.journal_path.write_bytes(b"\xff\xfe not utf-8 at all\n")
+
+        assert journal.get_repair_count() == 0
+
+
+class TestTheSharedPredicate:
+    """``handle_ends_without_newline`` is public and #331 is four other
+    appenders that need it, so its contract is tested on its own rather
+    than only through the journal."""
+
+    def probe(self, tmp_path: Path, payload: bytes) -> bool:
+        path = tmp_path / "sample.jsonl"
+        path.write_bytes(payload)
+        with open(path, "a+b") as handle:
+            return handle_ends_without_newline(handle)
+
+    def test_a_terminated_file_is_not_torn(self, tmp_path: Path) -> None:
+        assert self.probe(tmp_path, b'{"a":1}\n') is False
+
+    def test_an_unterminated_file_is_torn(self, tmp_path: Path) -> None:
+        assert self.probe(tmp_path, b'{"a":1}') is True
+
+    def test_an_empty_file_is_not_torn(self, tmp_path: Path) -> None:
+        assert self.probe(tmp_path, b"") is False
+
+    def test_an_undecodable_last_byte_is_answered_not_raised(self, tmp_path: Path) -> None:
+        """The case a text-mode probe cannot serve at all: the last byte
+        is the lead of a multi-byte sequence that was never finished."""
+        assert self.probe(tmp_path, b'{"a":1}\xc3') is True
+
+    def test_the_probe_does_not_move_where_the_next_write_lands(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """It seeks in order to read. In append mode the write position
+        is the end regardless, and a caller that lost bytes to a stray
+        seek would be a worse defect than the one this exists for."""
+        path = tmp_path / "sample.jsonl"
+        path.write_bytes(b'{"a":1}')
+        with open(path, "a+b") as handle:
+            handle_ends_without_newline(handle)
+            handle.write(b'\n{"b":2}\n')
+
+        assert path.read_bytes() == b'{"a":1}\n{"b":2}\n'
+
+
+class TestAnUnreadableJournal:
+    """#327 round 1, F3: a probe that could not read must never be taken
+    for "not torn"."""
+
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root ignores the mode bits this test sets",
+    )
+    def test_a_write_only_journal_refuses_rather_than_appending_blind(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The fail-open path this fix closes, on a real file.
+
+        Mode 0200 is the reachable case where the read fails and the
+        write would succeed. The earlier shape probed the tail through a
+        separate ``open(path, "rb")`` and answered False on every
+        ``OSError``, which means "not torn, go ahead": the append then
+        joined the new entry to the fragment and lost it, exactly the
+        defect #312 is about, arrived at from the other direction.
+
+        Opening ``"a+b"`` once is what closes it. The permission needed
+        to check the tail IS the permission the write demands, so an
+        unreadable journal raises instead of being appended to blind.
+        The cost is stated rather than hidden: on a write-only journal
+        this now refuses, and the entry is not written at all. That is
+        the fail-closed direction, and the caller warns.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        path = journal.config.journal_path
+        tear(path)
+        before = path.read_bytes()
+        path.chmod(0o200)
+
+        try:
+            with pytest.raises(PermissionError):
+                journal.append_entries([audit("beta")])
+        finally:
+            path.chmod(0o600)
+
+        assert path.read_bytes() == before
+        assert b"beta" not in before
 
 
 class TestTheTearIsVisible:
@@ -393,16 +467,18 @@ class TestTheTearIsVisible:
         Every aggregate in ``evolution`` selects on ``event_type`` or
         windows by ``run_id``, and the row has its own type and no
         ``run_id``. This compares a torn journal against a clean one
-        holding the same records, and pins that the clean answers are
-        non-trivial so the comparison is not two empty dicts agreeing.
+        holding the same records, and pins that every clean answer is
+        non-trivial so no comparison here is two empty results agreeing.
         """
+        records = [component_result("r1", "c1"), component_result("r2", "c2"), audit("p")]
+
         clean = journal_at(tmp_path / "clean")
-        clean.append_entries([component_result("r1", "c1"), component_result("r2", "c2")])
+        clean.append_entries(records)
 
         torn = journal_at(tmp_path / "torn")
-        torn.append_entries([component_result("r1", "c1")])
+        torn.append_entries(records[:1])
         tear(torn.config.journal_path)
-        torn.append_entries([component_result("r2", "c2")])
+        torn.append_entries(records[1:])
         assert len(repair_rows_in(torn.config.journal_path)) == 1
 
         assert clean.get_concern_hit_rate()["components"] == 2
@@ -413,6 +489,11 @@ class TestTheTearIsVisible:
         assert [p.description for p in torn.get_cross_run_patterns()] == [
             p.description for p in clean.get_cross_run_patterns()
         ]
+        # The spec-audit reader takes a different route to the file
+        # (_read_all_entries, no run window), so it gets a record of its
+        # own to find. Round 1 of review, F6: comparing two EMPTY
+        # results is an assertion that cannot fail.
+        assert len(clean.get_spec_issue_runs("p")) == 1
         assert clean.get_spec_issue_runs("p") == torn.get_spec_issue_runs("p")
 
     def test_the_repair_row_cannot_push_a_run_out_of_the_lookback_window(
@@ -458,24 +539,45 @@ class TestTheUndecodableTail:
         assert DANGLING_UTF8 in lines
         assert any(b'"project":"beta"' in line for line in lines)
 
-    def test_but_the_reader_still_loses_the_whole_file_to_it(self, tmp_path: Path) -> None:
-        """Measured, and NOT fixed here: one undecodable byte anywhere
-        costs every entry in the journal, not one line.
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "read_progress_events answers [] to a decode error instead of "
+            "skipping the one line, so an undecodable tail costs the whole "
+            "journal. Deferred from #312, not fixed here. Delete this marker "
+            "when the reader is fixed: strict=True makes an unexpected PASS "
+            "a failure, so this test cannot be left claiming a gap that has "
+            "been closed."
+        ),
+    )
+    def test_an_undecodable_tail_should_cost_one_line_not_the_file(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Asserts the DESIRED behaviour, and currently fails.
 
-        ``read_progress_events`` names utf-8 and catches ``ValueError``,
-        so it satisfies both halves of the CLAUDE.md encoding rule and is
-        not one of the #320 sites. What it does with the failure is the
-        gap: ``UnicodeDecodeError`` is raised by the ITERATION, outside
-        the per-line ``JSONDecodeError`` handler, so the whole read
-        returns []. That contradicts ``_read_all_entries``'s own stated
-        policy that "one unreadable line must not cost the reader the
-        rest of the history". It is a read-side change to a function
-        three callers share, and
-        ``test_evolve_screen_encoding.py::
-        test_the_journal_reader_is_shared_with_ks_status`` pins its
-        current source text, so it belongs in its own change rather than
-        riding along with the write-side fix. This test exists so the
-        gap is recorded rather than implied.
+        Round 1 of review on #327, F4: the earlier version of this
+        asserted ``read_progress_events(path) == []``, which is a
+        passing test that requires the defect to stay. Whoever fixed the
+        reader would have seen it go red and reasonably concluded they
+        had broken something.
+
+        The gap itself: ``read_progress_events`` names utf-8 and catches
+        ``ValueError``, so it satisfies both halves of the CLAUDE.md
+        encoding rule and is not one of the #320 sites. What it does
+        with the failure is the problem. ``UnicodeDecodeError`` comes
+        out of the line ITERATION, outside the per-line
+        ``JSONDecodeError`` handler, so one bad byte anywhere returns
+        nothing at all. That contradicts ``_read_all_entries``'s own
+        stated policy that "one unreadable line must not cost the reader
+        the rest of the history", and the write side above already
+        survives this exact file.
+
+        Deferred rather than fixed because it is a read-side change to a
+        function three callers share, which deserves its own change and
+        its own measurement. The deferral is defensible because kstrl's
+        own writer emits pure ASCII; these bytes arrive from an
+        operator's editor or a foreign writer.
         """
         journal = journal_at(tmp_path)
         journal.append_entries([audit("alpha")])
@@ -484,30 +586,4 @@ class TestTheUndecodableTail:
 
         journal.append_entries([audit("beta")])
 
-        assert read_progress_events(path) == []
-
-
-class TestOneWriter:
-    """``append_entries`` is the only writer of the journal's lines, and
-    #312 is what the second one cost. This is the mechanism behind that
-    sentence in its docstring."""
-
-    def test_append_entries_is_the_only_writer_of_the_journal(self) -> None:
-        """Fails on a second raw appender anywhere in ``kstrl/``.
-
-        What it CANNOT see, stated rather than implied: a write through
-        a name that never mentions ``config.journal_path``, and a path
-        handed to a helper as an argument. It sees the shape the defect
-        actually had, in ``kstrl/autonomy.py``.
-        """
-        offenders = [
-            offender
-            for source_file in sorted(KSTRL_PACKAGE.rglob("*.py"))
-            for offender in journal_writes_outside_append_entries(source_file)
-        ]
-
-        assert offenders == [], (
-            "A journal write outside append_entries: it will concatenate onto an "
-            "unterminated tail and eat the entry after it (#312). Route it through "
-            f"EvolutionJournal.append_entries. Offenders: {offenders}"
-        )
+        assert audits_in(path) == ["alpha", "beta"]

--- a/tests/test_journal_torn_tail.py
+++ b/tests/test_journal_torn_tail.py
@@ -1,0 +1,513 @@
+"""#312: what an interrupted journal write costs the entries after it.
+
+The read side of this was already covered, by
+``tests/test_decompose.py::TestExcludedHistory::
+test_a_torn_line_does_not_cost_the_note``: a torn tail must not make the
+rest of the history unreadable. This file is the WRITE side, which the
+read-side test cannot see. ``append_entries`` opened the file in append
+mode and wrote, without ever asking whether the file ended in a newline,
+so the next entry was concatenated onto the fragment and the pair became
+one unparseable line. The fragment was already lost; the entry after it
+was not, until the append destroyed it too.
+
+Every assertion here runs against real bytes on a real file, torn by
+truncating or by writing a partial line. A mock append cannot see the
+defect, because the defect IS the bytes.
+
+The blast radius is measured rather than asserted from the issue text,
+and it is not uniform: ``test_a_tail_that_lost_only_its_newline_keeps_
+its_record`` is the case where the interrupted write cost TWO records
+rather than one, because a tail that lost only its terminator is a
+complete record that the concatenation then destroys as well.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kstrl.evolution import JOURNAL_REPAIR_EVENT, EvolutionConfig, EvolutionJournal
+from kstrl.observability import ends_without_newline, read_progress_events
+from tests.helpers.journal import DANGLING_UTF8, TORN_FRAGMENT, tear
+
+#: The package under test, located the way every other AST-walking test
+#: in this suite locates it (test_atomicio, test_prompt_versions).
+KSTRL_PACKAGE = Path(__file__).resolve().parent.parent / "kstrl"
+
+
+def audit(project: str) -> dict[str, Any]:
+    return {
+        "timestamp": "2026-08-20T00:00:00Z",
+        "project": project,
+        "event_type": "spec_issues",
+        "spec_file": f"{project}.md",
+    }
+
+
+def component_result(run_id: str, component_id: str) -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "timestamp": "2026-08-20T00:00:00Z",
+        "run_id": run_id,
+        "project": "p",
+        "component_id": component_id,
+        "event_type": "component_result",
+        "failure_signatures": ["tests:assertion"],
+        "findings_summary": {"by_category": {"scope_creep": 1}},
+        "knowledge_utilization": {"measured": True, "injected": 3, "referenced": 2},
+    }
+
+
+def journal_at(tmp_path: Path) -> EvolutionJournal:
+    return EvolutionJournal(EvolutionConfig.load(tmp_path))
+
+
+def audits_in(path: Path) -> list[str]:
+    return [
+        str(entry.get("project"))
+        for entry in read_progress_events(path)
+        if entry.get("event_type") == "spec_issues"
+    ]
+
+
+def repair_rows_in(path: Path) -> list[dict[str, Any]]:
+    return [e for e in read_progress_events(path) if e.get("event_type") == JOURNAL_REPAIR_EVENT]
+
+
+# --- the one-writer guard, in pieces small enough to read -----------------
+
+
+def is_write_mode(mode_args: list[ast.expr]) -> bool:
+    """Does this open() mode argument write? An absent mode reads.
+
+    Every mode letter that can write, not just the first character: an
+    earlier draft tested ``mode[0] in "aw"`` and so read ``"r+"`` and
+    ``"rb+"`` as reads, which is a hole in a guard whose docstring
+    claims it cannot be argued out of by indirection. A mode that is not
+    a literal string counts as a write for the same reason.
+    """
+    if not mode_args:
+        return False
+    mode = mode_args[0]
+    if isinstance(mode, ast.Constant) and isinstance(mode.value, str):
+        return any(letter in mode.value for letter in "awx+")
+    return True
+
+
+def write_target(node: ast.Call) -> ast.expr | None:
+    """The path expression a call writes to, or None if it writes none.
+
+    Covers the builtin ``open(path, "a")``, the method ``path.open("a")``
+    and ``path.write_text`` / ``path.write_bytes``.
+    """
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        if func.attr in ("write_text", "write_bytes"):
+            return func.value
+        return func.value if func.attr == "open" and is_write_mode(node.args[:1]) else None
+    if isinstance(func, ast.Name) and func.id == "open" and node.args:
+        return node.args[0] if is_write_mode(node.args[1:2]) else None
+    return None
+
+
+def journal_aliases(nodes: list[ast.AST], permitted: set[int]) -> set[str]:
+    """Local names assigned from an expression naming the journal.
+
+    The old ``commit_transition`` reached it exactly this way:
+    ``journal_path = config.journal_path`` and then a raw open of the
+    local. Assignments inside ``append_entries`` are skipped because
+    aliases are collected per module rather than per scope, and that
+    method binds the journal to ``path``: without the skip, the
+    commonest local name in ``evolution.py`` would mean "the journal"
+    everywhere in the file, and the next unrelated ``open(path, "w")``
+    in it would be a false offender. Measured on this tree, honestly:
+    the skip changes nothing today (both ways report zero), because the
+    one other write through a local ``path`` in that module moved to
+    ``observability.ends_without_newline``. An earlier draft of this
+    change, with the probe still in ``evolution.py``, DID report it.
+    """
+    names: set[str] = set()
+    for node in nodes:
+        if not isinstance(node, ast.Assign) or node.lineno in permitted:
+            continue
+        if not isinstance(node.value, ast.Attribute):
+            continue
+        if "config.journal_path" in ast.unparse(node.value):
+            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+    return names
+
+
+def append_entries_lines(nodes: list[ast.AST]) -> set[int]:
+    """Every line of ``append_entries``: the one permitted writer.
+
+    Located by walking to the def rather than by pinning a line number,
+    so editing the file above it does not fail the guard. A file with no
+    such def gets an empty set, which is why this needs no exemption
+    list naming ``evolution.py``.
+    """
+    for node in nodes:
+        if isinstance(node, ast.FunctionDef) and node.name == "append_entries":
+            return set(range(node.lineno, (node.end_lineno or node.lineno) + 1))
+    return set()
+
+
+def journal_writes_outside_append_entries(source_file: Path) -> list[str]:
+    """Every write to the evolution journal in one file, bar the sanctioned one.
+
+    One ``ast.walk`` feeds all three passes. Measured over kstrl's 127
+    files: walking per pass costs 232 ms, walking once costs 182 ms.
+    """
+    nodes = list(ast.walk(ast.parse(source_file.read_text(encoding="utf-8"))))
+    permitted = append_entries_lines(nodes)
+    aliases = journal_aliases(nodes, permitted)
+    found: list[str] = []
+    for node in nodes:
+        if not isinstance(node, ast.Call) or node.lineno in permitted:
+            continue
+        target = write_target(node)
+        rendered = ast.unparse(target) if target is not None else ""
+        if "config.journal_path" in rendered or (rendered and rendered in aliases):
+            found.append(f"{source_file.name}:{node.lineno}: writes to {rendered}")
+    return found
+
+
+class TestTheEntryAfterATear:
+    def test_the_entry_after_a_torn_line_survives(self, tmp_path: Path) -> None:
+        """The issue, reproduced: two audits written, one readable.
+
+        Measured on cbdff7c before the fix: ``['alpha']``. The torn
+        fragment ate 'beta', which was written after the crash and had
+        nothing to do with it.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        tear(journal.config.journal_path)
+
+        journal.append_entries([audit("beta")])
+
+        assert audits_in(journal.config.journal_path) == ["alpha", "beta"]
+
+    def test_the_torn_fragment_is_not_resurrected(self, tmp_path: Path) -> None:
+        """The repair isolates the fragment, it does not repair it.
+
+        A partial JSON object was never a record and cannot become one.
+        What the fix owes is that it stops costing its successor, and
+        claiming more than that in a docstring would be the defect this
+        suite exists to catch.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        tear(journal.config.journal_path)
+
+        journal.append_entries([audit("beta")])
+
+        path = journal.config.journal_path
+        assert TORN_FRAGMENT in path.read_text(encoding="utf-8")
+        parsed_types = [e.get("event_type") for e in read_progress_events(path)]
+        assert parsed_types == ["spec_issues", JOURNAL_REPAIR_EVENT, "spec_issues"]
+
+    def test_a_tail_that_lost_only_its_newline_keeps_its_record(self, tmp_path: Path) -> None:
+        """The tear that costs TWO records, not one.
+
+        When the interruption lands between the last byte of a record
+        and its newline, the record on disk is complete and readable.
+        Appending onto it concatenates two whole objects into
+        ``{...}{...}``, which ``json.loads`` rejects as "Extra data", so
+        the reader loses the old record AND the new one. Measured
+        before the fix: ``['a1', 'a2']`` from a file that held three
+        audits and had just been handed a fourth.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("a1"), audit("a2"), audit("a3")])
+        path = journal.config.journal_path
+        path.write_bytes(path.read_bytes()[:-1])
+        assert audits_in(path) == ["a1", "a2", "a3"]
+
+        journal.append_entries([audit("a4")])
+
+        assert audits_in(path) == ["a1", "a2", "a3", "a4"]
+
+    def test_an_autonomy_transition_after_a_tear_survives(self, tmp_path: Path) -> None:
+        """The second writer, which the fix to the first would not reach.
+
+        ``commit_transition`` had its own raw ``open(journal_path, "a")``
+        and so had its own copy of #312. It now goes through
+        ``append_entries``, which is what makes "the one writer of the
+        journal's line format" true rather than asserted.
+        """
+        from kstrl.autonomy import AutonomyState, Transition, commit_transition
+
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        tear(journal.config.journal_path)
+
+        commit_transition(
+            AutonomyState(level=1),
+            Transition(
+                at="2026-08-20T00:00:00Z",
+                direction="promote",
+                from_level=0,
+                to_level=1,
+                actor="tester",
+                trigger="manual",
+                reason="test",
+                evidence={},
+            ),
+            tmp_path,
+        )
+
+        events = read_progress_events(journal.config.journal_path)
+        assert [e.get("event_type") for e in events] == [
+            "spec_issues",
+            JOURNAL_REPAIR_EVENT,
+            "autonomy_transition",
+        ]
+
+
+class TestWhatIsNotATear:
+    def test_an_intact_journal_is_appended_to_unchanged(self, tmp_path: Path) -> None:
+        """No blank line, no repair row, byte for byte what it was.
+
+        The guard has to be silent on the overwhelmingly common path or
+        it becomes noise that an operator learns to ignore.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        path = journal.config.journal_path
+        before = path.read_bytes()
+
+        journal.append_entries([audit("beta")])
+
+        after = path.read_bytes()
+        assert after.startswith(before)
+        assert after == before + json.dumps(audit("beta"), separators=(",", ":")).encode() + b"\n"
+        assert repair_rows_in(path) == []
+
+    def test_an_empty_journal_file_is_not_a_tear(self, tmp_path: Path) -> None:
+        """Zero bytes has no unterminated line in it."""
+        journal = journal_at(tmp_path)
+        journal.config.journal_path.parent.mkdir(parents=True, exist_ok=True)
+        journal.config.journal_path.write_bytes(b"")
+
+        journal.append_entries([audit("alpha")])
+
+        assert audits_in(journal.config.journal_path) == ["alpha"]
+        assert repair_rows_in(journal.config.journal_path) == []
+
+    def test_a_missing_journal_file_is_not_a_tear(self, tmp_path: Path) -> None:
+        """FileNotFoundError is an OSError, and answers "not torn"."""
+        journal = journal_at(tmp_path)
+        assert not journal.config.journal_path.exists()
+
+        journal.append_entries([audit("alpha")])
+
+        assert audits_in(journal.config.journal_path) == ["alpha"]
+        assert repair_rows_in(journal.config.journal_path) == []
+
+    def test_an_empty_append_repairs_nothing(self, tmp_path: Path) -> None:
+        """Nothing to protect, so nothing is written.
+
+        Repairing here would mutate the file on a call that was asked to
+        add no records, and the next real append repairs it anyway.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        tear(journal.config.journal_path)
+        before = journal.config.journal_path.read_bytes()
+
+        journal.append_entries([])
+
+        assert journal.config.journal_path.read_bytes() == before
+
+    def test_a_directory_where_the_journal_should_be_is_not_a_tear(self, tmp_path: Path) -> None:
+        """An unreadable path is not evidence of an interrupted write.
+
+        ``ends_without_newline`` answers False and lets the append
+        raise the real ``OSError`` for the caller to surface, rather
+        than inventing a repair for a file it could not read.
+        """
+        journal = journal_at(tmp_path)
+        journal.config.journal_path.parent.mkdir(parents=True, exist_ok=True)
+        journal.config.journal_path.mkdir()
+
+        assert ends_without_newline(journal.config.journal_path) is False
+        with pytest.raises(OSError):
+            journal.append_entries([audit("alpha")])
+
+
+class TestTheTearIsVisible:
+    def test_the_repair_is_recorded_in_the_journal(self, tmp_path: Path) -> None:
+        """Healing forward is a judgement call, so it leaves a record.
+
+        The row is the durable half: the process that tore the file is
+        the process whose stderr nobody kept, and this is what an
+        operator can grep months later.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        tear(journal.config.journal_path)
+
+        journal.append_entries([audit("beta")])
+
+        rows = repair_rows_in(journal.config.journal_path)
+        assert len(rows) == 1
+        assert rows[0]["timestamp"]
+        assert "not newline-terminated" in rows[0]["detail"]
+
+    def test_the_repair_is_logged(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The live half, for whoever is watching the run it happened in."""
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        tear(journal.config.journal_path)
+
+        with caplog.at_level(logging.WARNING, "kstrl.evolution"):
+            journal.append_entries([audit("beta")])
+
+        assert any("did not end in a newline" in record.message for record in caplog.records)
+
+    def test_one_tear_records_one_repair(self, tmp_path: Path) -> None:
+        """The file ends in a newline once repaired, so later appends
+        are ordinary appends. A repeated row would be a loop that
+        reported a fresh incident on every write."""
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        tear(journal.config.journal_path)
+
+        journal.append_entries([audit("beta")])
+        journal.append_entries([audit("gamma")])
+
+        assert len(repair_rows_in(journal.config.journal_path)) == 1
+
+    def test_the_repair_row_counts_towards_no_aggregate(self, tmp_path: Path) -> None:
+        """A repair row must not move a number anyone reads.
+
+        Every aggregate in ``evolution`` selects on ``event_type`` or
+        windows by ``run_id``, and the row has its own type and no
+        ``run_id``. This compares a torn journal against a clean one
+        holding the same records, and pins that the clean answers are
+        non-trivial so the comparison is not two empty dicts agreeing.
+        """
+        clean = journal_at(tmp_path / "clean")
+        clean.append_entries([component_result("r1", "c1"), component_result("r2", "c2")])
+
+        torn = journal_at(tmp_path / "torn")
+        torn.append_entries([component_result("r1", "c1")])
+        tear(torn.config.journal_path)
+        torn.append_entries([component_result("r2", "c2")])
+        assert len(repair_rows_in(torn.config.journal_path)) == 1
+
+        assert clean.get_concern_hit_rate()["components"] == 2
+        assert torn.get_concern_hit_rate() == clean.get_concern_hit_rate()
+        assert clean.get_fact_utilization()["measured"] == 2
+        assert torn.get_fact_utilization() == clean.get_fact_utilization()
+        assert len(clean.get_cross_run_patterns()) == 1
+        assert [p.description for p in torn.get_cross_run_patterns()] == [
+            p.description for p in clean.get_cross_run_patterns()
+        ]
+        assert clean.get_spec_issue_runs("p") == torn.get_spec_issue_runs("p")
+
+    def test_the_repair_row_cannot_push_a_run_out_of_the_lookback_window(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The second reason the row is invisible, and the reason it
+        carries no ``run_id``.
+
+        ``_read_journal_entries`` keeps the last N DISTINCT run_ids. A
+        repair row with a run_id of its own would be one of those N, so
+        a tear would silently shorten the history every aggregate reads
+        by one run. Sized so that is exactly what would happen: lookback
+        2, two real runs, one tear between them.
+        """
+        journal = journal_at(tmp_path)
+        journal.config.lookback_runs = 2
+        journal.append_entries([component_result("r1", "c1")])
+        tear(journal.config.journal_path)
+        journal.append_entries([component_result("r2", "c2")])
+
+        assert journal.get_concern_hit_rate(lookback_runs=2)["runs"] == 2
+
+
+class TestTheUndecodableTail:
+    """A tear inside a multi-byte character, which is the case the write
+    side survives and the read side does not."""
+
+    def test_a_tail_torn_mid_utf8_sequence_is_still_repaired_on_disk(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The probe reads bytes, so it works where a decode cannot."""
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        path = journal.config.journal_path
+        assert DANGLING_UTF8.endswith(b"\xc3")
+        path.write_bytes(path.read_bytes() + DANGLING_UTF8)
+
+        journal.append_entries([audit("beta")])
+
+        lines = path.read_bytes().split(b"\n")
+        assert DANGLING_UTF8 in lines
+        assert any(b'"project":"beta"' in line for line in lines)
+
+    def test_but_the_reader_still_loses_the_whole_file_to_it(self, tmp_path: Path) -> None:
+        """Measured, and NOT fixed here: one undecodable byte anywhere
+        costs every entry in the journal, not one line.
+
+        ``read_progress_events`` names utf-8 and catches ``ValueError``,
+        so it satisfies both halves of the CLAUDE.md encoding rule and is
+        not one of the #320 sites. What it does with the failure is the
+        gap: ``UnicodeDecodeError`` is raised by the ITERATION, outside
+        the per-line ``JSONDecodeError`` handler, so the whole read
+        returns []. That contradicts ``_read_all_entries``'s own stated
+        policy that "one unreadable line must not cost the reader the
+        rest of the history". It is a read-side change to a function
+        three callers share, and
+        ``test_evolve_screen_encoding.py::
+        test_the_journal_reader_is_shared_with_ks_status`` pins its
+        current source text, so it belongs in its own change rather than
+        riding along with the write-side fix. This test exists so the
+        gap is recorded rather than implied.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        path = journal.config.journal_path
+        path.write_bytes(path.read_bytes() + DANGLING_UTF8)
+
+        journal.append_entries([audit("beta")])
+
+        assert read_progress_events(path) == []
+
+
+class TestOneWriter:
+    """``append_entries`` is the only writer of the journal's lines, and
+    #312 is what the second one cost. This is the mechanism behind that
+    sentence in its docstring."""
+
+    def test_append_entries_is_the_only_writer_of_the_journal(self) -> None:
+        """Fails on a second raw appender anywhere in ``kstrl/``.
+
+        What it CANNOT see, stated rather than implied: a write through
+        a name that never mentions ``config.journal_path``, and a path
+        handed to a helper as an argument. It sees the shape the defect
+        actually had, in ``kstrl/autonomy.py``.
+        """
+        offenders = [
+            offender
+            for source_file in sorted(KSTRL_PACKAGE.rglob("*.py"))
+            for offender in journal_writes_outside_append_entries(source_file)
+        ]
+
+        assert offenders == [], (
+            "A journal write outside append_entries: it will concatenate onto an "
+            "unterminated tail and eat the entry after it (#312). Route it through "
+            f"EvolutionJournal.append_entries. Offenders: {offenders}"
+        )

--- a/tests/test_journal_torn_tail.py
+++ b/tests/test_journal_torn_tail.py
@@ -33,57 +33,23 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any
 
 import pytest
 
-from kstrl.evolution import (
-    EXPERIMENTS_HEADER,
-    JOURNAL_REPAIR_EVENT,
-    EvolutionConfig,
-    EvolutionJournal,
-)
+from kstrl.evolution import EXPERIMENTS_HEADER, JOURNAL_REPAIR_EVENT
 from kstrl.observability import handle_ends_without_newline, read_progress_events
-from tests.helpers.journal import DANGLING_UTF8, TORN_FRAGMENT, tear
-
-
-def audit(project: str) -> dict[str, Any]:
-    return {
-        "timestamp": "2026-08-20T00:00:00Z",
-        "project": project,
-        "event_type": "spec_issues",
-        "spec_file": f"{project}.md",
-    }
-
-
-def component_result(run_id: str, component_id: str) -> dict[str, Any]:
-    return {
-        "schema_version": 2,
-        "timestamp": "2026-08-20T00:00:00Z",
-        "run_id": run_id,
-        "project": "p",
-        "component_id": component_id,
-        "event_type": "component_result",
-        "failure_signatures": ["tests:assertion"],
-        "findings_summary": {"by_category": {"scope_creep": 1}},
-        "knowledge_utilization": {"measured": True, "injected": 3, "referenced": 2},
-    }
-
-
-def journal_at(tmp_path: Path) -> EvolutionJournal:
-    return EvolutionJournal(EvolutionConfig.load(tmp_path))
-
-
-def audits_in(path: Path) -> list[str]:
-    return [
-        str(entry.get("project"))
-        for entry in read_progress_events(path)
-        if entry.get("event_type") == "spec_issues"
-    ]
-
-
-def repair_rows_in(path: Path) -> list[dict[str, Any]]:
-    return [e for e in read_progress_events(path) if e.get("event_type") == JOURNAL_REPAIR_EVENT]
+from tests.helpers.journal import (
+    DANGLING_UTF8,
+    TORN_FRAGMENT,
+    audit,
+    audits_in,
+    component_result,
+    journal_at,
+    lose_the_newline,
+    repair_rows_in,
+    tear,
+    terminate,
+)
 
 
 class TestTheEntryAfterATear:
@@ -135,7 +101,7 @@ class TestTheEntryAfterATear:
         journal = journal_at(tmp_path)
         journal.append_entries([audit("a1"), audit("a2"), audit("a3")])
         path = journal.config.journal_path
-        path.write_bytes(path.read_bytes()[:-1])
+        lose_the_newline(path)
         assert audits_in(path) == ["a1", "a2", "a3"]
 
         journal.append_entries([audit("a4")])
@@ -209,6 +175,31 @@ class TestWhatIsNotATear:
         assert audits_in(journal.config.journal_path) == ["alpha"]
         assert repair_rows_in(journal.config.journal_path) == []
 
+    def test_a_terminated_but_malformed_tail_is_not_a_tear(self, tmp_path: Path) -> None:
+        """Residual 4 of ``append_entries``, pinned rather than implied.
+
+        The mechanism is argued there and summarised for operators in
+        ``docs/evolution-metrics.md``; this is the file it describes,
+        and the two assertions are what that argument claims: every
+        record survives, and the incident is invisible to the count.
+
+        Asserting 0 records an ACCEPTED residual, not a wish. Whoever
+        closes it has three things to change together and this is the
+        list: residual 4 on ``append_entries``, the "It is also a LOWER
+        bound" sentence in ``docs/evolution-metrics.md``, and the 0
+        below, which becomes 1.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        path = journal.config.journal_path
+        tear(path)
+        terminate(path)
+
+        journal.append_entries([audit("beta")])
+
+        assert audits_in(path) == ["alpha", "beta"]
+        assert journal.get_repair_count() == 0
+
     def test_a_missing_journal_file_is_not_a_tear(self, tmp_path: Path) -> None:
         """``"a+b"`` creates it, and a zero-length file has no
         unterminated line in it. Distinct from the empty-file case above
@@ -273,7 +264,7 @@ class TestTheRepairIsReportable:
         only because ``csv.DictReader`` tolerates it, which is not
         evidence that --status reaches the repair line on a real file.
         """
-        path = tmp_path / ".kstrl" / "experiments.tsv"
+        path = journal_at(tmp_path).config.experiments_path
         path.parent.mkdir(parents=True, exist_ok=True)
         columns = EXPERIMENTS_HEADER.split("\t")
         row = ["r1", "2026-08-20T00:00:00Z"] + ["0"] * (len(columns) - 2)
@@ -293,6 +284,55 @@ class TestTheRepairIsReportable:
 
         assert "1 interrupted write(s) repaired" in output
         assert "journal_repair" in output
+
+    def test_a_repair_is_reported_when_there_are_no_experiments_yet(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """#327 round 2, F7: the state that PRODUCES repairs reported none.
+
+        Only ``ks factory`` writes experiments.tsv; decompose and
+        autonomy write to the journal. So "a repaired journal and no
+        experiments" is the ordinary state of a project that ran
+        ``ks decompose`` and crashed, and --status used to exit on the
+        empty trends before it reached the repair line. No
+        experiments.tsv is created here, deliberately: the pair of this
+        test and the one above it is what pins the ORDER of those two
+        lines in ``cli.evolve``.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        tear(journal.config.journal_path)
+        journal.append_entries([audit("beta")])
+        assert not journal.config.experiments_path.exists()
+
+        output = self.status_output(tmp_path)
+
+        assert "1 interrupted write(s) repaired" in output
+        assert "No experiments recorded yet" in output
+
+    def test_a_recovered_record_is_not_reported_as_lost(self, tmp_path: Path) -> None:
+        """#327 round 2, F8: possible loss reported as certain loss.
+
+        A tail that lost only its newline is a COMPLETE record, and the
+        repair is exactly what makes it readable again. Both audits are
+        readable below, so a status line saying the line above the
+        marker "was lost" reports data loss on the case this fix
+        RECOVERS. ``docs/evolution-metrics.md`` always described it
+        correctly; only the status wording was wrong.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        path = journal.config.journal_path
+        lose_the_newline(path)
+        journal.append_entries([audit("beta")])
+        assert audits_in(path) == ["alpha", "beta"]
+
+        output = self.status_output(tmp_path)
+
+        assert "1 interrupted write(s) repaired" in output
+        assert "readable again" in output
+        assert "was lost" not in output
 
     def test_a_healthy_journal_says_nothing(self, tmp_path: Path) -> None:
         """Silence at zero is the point: a line that prints on every
@@ -447,6 +487,27 @@ class TestTheTearIsVisible:
             journal.append_entries([audit("beta")])
 
         assert any("did not end in a newline" in record.message for record in caplog.records)
+
+    def test_the_repair_row_says_what_was_and_was_not_lost(self, tmp_path: Path) -> None:
+        """The durable half of the F8 distinction, which nothing pinned.
+
+        ``ks evolve --status`` says the line above the marker is either
+        a lost fragment or a recovered record, and a test pins that. The
+        ROW says the same thing to whoever greps the file months later,
+        and until now only its first clause was pinned, so an edit to
+        the either/or half was caught by nothing. Not shared as one
+        constant with the CLI on purpose: this is data written into a
+        file, that is a line printed by a command, and they are read by
+        different people at different times.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        tear(journal.config.journal_path)
+        journal.append_entries([audit("beta")])
+
+        detail = str(repair_rows_in(journal.config.journal_path)[0]["detail"])
+        assert "torn fragment that was never readable" in detail
+        assert "lost only its newline" in detail
 
     def test_one_tear_records_one_repair(self, tmp_path: Path) -> None:
         """The file ends in a newline once repaired, so later appends

--- a/tests/test_journal_write_boundary.py
+++ b/tests/test_journal_write_boundary.py
@@ -1,0 +1,259 @@
+"""The transaction boundary ``append_entries`` rests on (#312, #327).
+
+Round 2 of review on #327, F10. ``append_entries`` declines a lock, and
+the argument for that decision is entirely in two properties: the probe
+and the append go through ONE file description, so the path cannot be
+replaced or a symlink retargeted between them, and the repair row plus
+the batch go in ONE write, so nothing lands between the newline that
+isolates a torn fragment and the entries the repair was for.
+
+Both were argued in a docstring and neither was pinned. Measured, in a
+copy of the tree with ``__pycache__`` cleared and
+``PYTHONDONTWRITEBYTECODE=1``: two broken versions of
+``append_entries``, one that reopens the file for the append and one
+that writes the newline, the marker and the batch separately, each
+pass 284 tests and 1 xfail across ``test_journal_torn_tail``,
+``test_journal_one_writer``, ``test_decompose``,
+``test_autonomy_ladder`` and ``test_config_control_plane``. A
+mechanism nothing holds in place is the defect this PR has now hit
+twice: round 1 of review found every helper of the AST guard stubbable
+to a constant with that guard green.
+
+Separate from ``test_journal_torn_tail.py`` because the subject is
+different and the file-length ratchet is real: that file is what a tear
+COSTS, measured in bytes on disk, and this one is HOW the write is
+performed, measured in descriptors and syscalls, neither of which
+leaves a trace on disk.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import IO, Any
+
+import pytest
+
+import kstrl.evolution as evolution_mod
+from kstrl.evolution import JOURNAL_REPAIR_EVENT
+from kstrl.observability import read_progress_events
+from tests.helpers.journal import TORN_FRAGMENT, audit, journal_at, tear
+
+
+@dataclass
+class JournalIO:
+    """What one call did to the journal file, as opposed to with it."""
+
+    #: The mode of every ``open`` of the journal, in order.
+    opens: list[str] = field(default_factory=list)
+    #: The payload of every ``write``, in order, across all of them.
+    writes: list[bytes] = field(default_factory=list)
+
+
+class CountingHandle:
+    """A REAL handle that records what it was asked to do.
+
+    Not a fake and not a stub: every call is delegated to the object
+    ``open`` returned, so the bytes that reach the disk are the bytes
+    the code under test wrote. That is asserted rather than claimed, by
+    ``test_the_recorder_does_not_change_what_lands_on_disk``, because a
+    recorder that swallowed a write would make the two tests above it
+    pass by breaking the thing they measure.
+
+    It exists because the property under test leaves NO trace on disk:
+    a file written through two descriptors, or in three writes, is
+    byte-for-byte the file written through one descriptor in one write.
+    """
+
+    def __init__(self, handle: IO[bytes], record: JournalIO) -> None:
+        self._handle = handle
+        self._record = record
+
+    def write(self, data: bytes) -> int:
+        self._record.writes.append(data)
+        return self._handle.write(data)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._handle, name)
+
+    def __enter__(self) -> CountingHandle:
+        self._handle.__enter__()
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self._handle.__exit__(*exc_info)
+
+
+def without_timestamps(path: Path) -> list[dict[str, Any]]:
+    """Every readable entry in the journal, minus its wall clock.
+
+    Through ``read_progress_events``, not a private copy of it: these
+    bytes are a REPAIRED journal, so one line is a torn fragment that
+    is not supposed to parse, and the tolerance that skips it is the
+    production reader's policy. A second copy would keep the old
+    behaviour when the strict xfail in ``test_journal_torn_tail`` is
+    closed, and this comparison would stop being a comparison of what
+    readers see.
+    """
+    return [
+        {key: value for key, value in entry.items() if key != "timestamp"}
+        for entry in read_progress_events(path)
+    ]
+
+
+@contextlib.contextmanager
+def recording(
+    monkeypatch: pytest.MonkeyPatch,
+    path: Path,
+) -> Iterator[JournalIO]:
+    """Count opens of ``path`` and writes through them, in ``evolution``.
+
+    Shadows the module's global ``open`` rather than the builtin, so
+    nothing outside ``kstrl.evolution`` is affected, and calls the real
+    ``open`` for every other path so ``record_run``'s experiments.tsv
+    behaves normally.
+
+    Through ``monkeypatch.context()`` rather than ``monkeypatch.undo()``
+    in a ``finally``: ``undo`` empties the whole stack of the
+    function-scoped fixture, which ``tests/conftest.py``'s two autouse
+    guards share. Leaving this block would have taken the chdir into
+    ``tmp_path``, the cleared ``KSTRL_*`` env and the agent-spend guard
+    with it, so a bare ``EvolutionConfig()`` afterwards would resolve
+    against the real checkout. Nothing does that today; a helper that
+    invites it is worse than a test that does it once.
+    """
+    record = JournalIO()
+    real_open = open
+
+    def counting_open(file: Any, mode: str = "r", *args: Any, **kwargs: Any) -> Any:
+        handle = real_open(file, mode, *args, **kwargs)
+        if isinstance(file, (str, Path)) and Path(file) == path:
+            record.opens.append(mode)
+            return CountingHandle(handle, record)
+        return handle
+
+    with monkeypatch.context() as patched:
+        patched.setattr(evolution_mod, "open", counting_open, raising=False)
+        yield record
+
+
+class TestTheTransactionBoundary:
+    """#327 round 2, F10: the two properties the F1 decision RESTS on.
+
+    F1 declined a lock and argued instead that ONE file description
+    makes the probe and the append one transaction, and that ONE write
+    keeps the repair and the entries it protects together. Both were
+    argued in a docstring and neither was pinned; the module docstring
+    above carries the measurement.
+
+    Counting descriptors and writes rather than reading the source,
+    because the property is about what the process does: a second open
+    moved into a helper is the same defect, and an AST test would call
+    it clean.
+    """
+
+    def test_the_probe_and_the_append_share_one_file_description(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """One open, in the mode that makes it both readable and an append.
+
+        Two opens is the shape this fix exists to remove: between the
+        probe's close and the append's open, the path can be replaced or
+        a symlink retargeted, and the append then lands somewhere the
+        probe never looked. The mode is asserted too, because ``"a+b"``
+        is what makes an unreadable journal raise here rather than be
+        reported as "not torn" (round 1, F3).
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        path = journal.config.journal_path
+        tear(path)
+
+        with recording(monkeypatch, path) as io:
+            journal.append_entries([audit("beta")])
+
+        assert io.opens == ["a+b"]
+
+    def test_a_repair_and_the_entries_it_protects_are_one_write(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The newline, the marker and the batch go in a single write.
+
+        Three writes is the shape that lets another appender land
+        between the newline that isolates the fragment and the entries
+        the repair was for. One write does not make that impossible
+        (residual 3: a payload above the buffer is split), which is why
+        the docstring says so, but it removes the two gaps that are
+        certain.
+        """
+        journal = journal_at(tmp_path)
+        journal.append_entries([audit("alpha")])
+        path = journal.config.journal_path
+        tear(path)
+
+        with recording(monkeypatch, path) as io:
+            journal.append_entries([audit("beta")])
+
+        assert len(io.writes) == 1
+        payload = io.writes[0]
+        assert payload.startswith(b"\n")
+        assert payload.count(b"\n") == 3
+        assert JOURNAL_REPAIR_EVENT.encode() in payload
+        assert b'"beta"' in payload
+
+    def test_an_ordinary_append_is_one_open_and_one_write_too(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The un-torn path, so "one write" is not a repair-only property.
+
+        Three entries, one write: a per-entry write would interleave a
+        concurrent appender's line into the middle of this batch.
+        """
+        journal = journal_at(tmp_path)
+
+        with recording(monkeypatch, journal.config.journal_path) as io:
+            journal.append_entries([audit("a"), audit("b"), audit("c")])
+
+        assert io.opens == ["a+b"]
+        assert len(io.writes) == 1
+        assert io.writes[0].count(b"\n") == 3
+
+    def test_the_recorder_does_not_change_what_lands_on_disk(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The control for the two tests above.
+
+        A recorder that swallowed a write would make both of them pass
+        by breaking the thing they measure. The same sequence is run
+        with the instrument and without it, and the two files are
+        compared entry for entry and line for line. Timestamps are
+        dropped from the comparison and nothing else is: the repair row
+        carries a wall clock, so the two runs differ there by
+        construction.
+        """
+        plain = journal_at(tmp_path / "plain")
+        plain.append_entries([audit("alpha")])
+        tear(plain.config.journal_path)
+        plain.append_entries([audit("beta")])
+
+        watched = journal_at(tmp_path / "watched")
+        watched.append_entries([audit("alpha")])
+        tear(watched.config.journal_path)
+        with recording(monkeypatch, watched.config.journal_path):
+            watched.append_entries([audit("beta")])
+
+        expected = plain.config.journal_path
+        actual = watched.config.journal_path
+        assert without_timestamps(actual) == without_timestamps(expected)
+        assert actual.read_bytes().count(b"\n") == expected.read_bytes().count(b"\n")
+        assert TORN_FRAGMENT in actual.read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes #312.

## The defect, reproduced against real bytes

`append_entries` opened the journal in append mode and wrote, without ever
asking whether the file already ended in a newline. A crash mid-write leaves an
unterminated tail, so the next entry was concatenated onto the fragment and the
pair became one unparseable line. The tolerant reader skipped it, and the entry
written after the crash was gone.

Run on cbdff7c, real journal, real bytes, no mocks:

```
after audit A: 1 line(s)
after the crash: file ends with newline? False

--- journal on disk ---
{"timestamp":"2026-08-20T00:00:00","project":"alpha","event_type":"spec_issues","spec_file":"alpha.md"}
{"event_type": "spec_iss{"timestamp":"2026-08-20T00:00:00","project":"beta","event_type":"spec_issues","spec_file":"beta.md"}

--- what any reader sees ---
1 line(s) parsed: ['spec_issues']

audits written: 2 (alpha, beta)
audits readable: 1 ['alpha']
```

Same script after this change:

```
--- journal on disk ---
{"timestamp":"2026-08-20T00:00:00","project":"alpha","event_type":"spec_issues","spec_file":"alpha.md"}
{"event_type": "spec_iss
{"schema_version":2,"timestamp":"2026-09-01T09:23:40Z","event_type":"journal_repair","detail":"the preceding line was not newline-terminated when this append ran, ..."}
{"timestamp":"2026-08-20T00:00:00","project":"beta","event_type":"spec_issues","spec_file":"beta.md"}

--- what any reader sees ---
3 line(s) parsed: ['spec_issues', 'journal_repair', 'spec_issues']

audits written: 2 (alpha, beta)
audits readable: 2 ['alpha', 'beta']
journal_repair rows: 1
```

## Blast radius, measured rather than repeated

The issue says the cost is one entry. Measured, it is not uniform. Six tear
offsets, each on a journal holding three audits, then one more audit appended
through the real writer:

| tear | last byte | audits before | audits after, cbdff7c | audits after, this PR | repair row |
|---|---|---|---|---|---|
| mid-line (torn JSON) | `t` | 2 | 2, new entry eaten | 3 | 1 |
| at a line boundary (intact) | `\n` | 3 | 4 | 4 | 0 |
| trailing newline lost only | `}` | 3 | **2, TWO records eaten** | 4 | 1 |
| mid-utf-8 sequence | `\xc3` | 0 | 0 | 0, but the entry IS on disk | 0 |
| empty file, 0 bytes | none | 0 | 1 | 1 | 0 |
| missing file | none | 0 | 1 | 1 | 0 |

Two corrections to the issue's account:

1. **A tear that loses only the trailing newline costs TWO records, not one.**
   The tail is a complete record that reads back fine; concatenating onto it
   turns `{...}` into `{...}{...}`, which `json.loads` rejects as "Extra data",
   so the reader loses the old record as well as the new one. Repairing the
   newline RECOVERS that record rather than merely protecting its successor.
   Pinned by `test_a_tail_that_lost_only_its_newline_keeps_its_record`.

2. **A tear inside a multi-byte character costs the whole file, and this PR
   does not fix that.** The write side survives it: the newline probe reads
   the last byte in BINARY, so it works on a file no decoder will touch, and
   the new entry lands on its own line (verified at byte level). The read side
   does not: `read_progress_events` raises `UnicodeDecodeError` from the line
   iteration, outside its per-line `JSONDecodeError` handler, so the outer
   `except (OSError, ValueError)` returns `[]` and every entry in the journal
   is lost, not one line. That contradicts `_read_all_entries`'s own stated
   policy that "one unreadable line must not cost the reader the rest of the
   history".

   That reader is NOT one of the ~15 sites in #320: it already names
   `encoding="utf-8"` AND catches `ValueError` alongside `OSError`, which is
   both halves of the CLAUDE.md rule. Its gap is what it does after catching.
   Fixing it means changing a function three callers share, and
   `test_evolve_screen_encoding.py::test_the_journal_reader_is_shared_with_ks_status`
   pins its current source text, so it belongs in its own change rather than
   riding along with a write-side fix. `test_but_the_reader_still_loses_the_whole_file_to_it`
   records the gap as a passing test so it cannot be forgotten or overclaimed.

## Silent heal, or visible?

Healed forward, and recorded twice. The reasoning:

Raising would be the wrong reading of "halt over heroics" here. The caller is a
record-keeper: `record_run`, the spec-audit writer and the autonomy ladder all
append AFTER the work they describe is already done. Refusing to append would
answer the loss of one record by losing every record after it, and the ladder's
own comment says losing the log must never strand a transition unsaved.

But a silent heal would be a data-loss event that nothing records, which is the
other half of the doctrine ("if it's worth deciding, it's worth recording"). So
the repair writes:

- a `journal_repair` row into the journal itself, immediately after the newline.
  This is the durable half and the answer to "what could an operator ever use
  to know it happened": `grep journal_repair .kstrl/evolution.jsonl`. It is
  durable where a log line is not, because the process that tore the file is
  exactly the process whose stderr nobody kept.
- a `logger.warning` on `kstrl.evolution`, the live half, alongside the other
  degrade warnings that module already emits.

The row is invisible to every number anyone reads, for three independent
reasons: its own `event_type` (all six aggregates select on that), no `run_id`
(the lookback window drops rows without one) and no `project`. The middle one
matters most and is its own test: a repair row carrying a `run_id` would be one
of the last N distinct runs, so a single tear would silently shorten the
history every aggregate reads by a whole run.

A limit worth naming rather than leaving to be found: probe-then-append is a
read-modify-write and this file takes no lock. Two appenders racing onto a torn
file both repair it, which costs a blank line and a second repair row, and the
reader skips both. For a probe to go stale another writer has to crash
mid-write inside the window, which is the case this method already loses to
today, so the probe makes an unlocked append no less safe than it was. Stated
in the docstring.

## Every writer, not just the spec audits

The issue notes that every writer is affected. There were two:
`EvolutionJournal.append_entries` and a second raw `open(journal_path, "a")` in
`autonomy.commit_transition`, which had its own copy of the defect. It now goes
through `append_entries`, which is what makes that method's "the one writer of
the journal's line format" true rather than asserted, and
`test_append_entries_is_the_only_writer_of_the_journal` is the mechanism behind
the sentence: it AST-walks `kstrl/` for a write to the evolution journal outside
`append_entries` and lands at zero offenders. It states what it cannot see: a
write through a name that never mentions `config.journal_path`.

`EvolutionJournal(config)` is constructed directly rather than through `.open()`,
which would also gate on `config.enabled` and stop recording transitions that
this function records today. That divergence is pre-existing and deliberate, but
this change is the moment it became load-bearing, so it is raised rather than
left implicit: with `enabled = false`, `commit_transition` still writes, and can
now also write a blank line and a `journal_repair` row.

## Where the newline predicate lives

`ends_without_newline` is public in `kstrl/observability.py`, next to
`read_progress_events`, rather than private in `evolution.py`. It is the generic
half of the fix with no policy in it, and the four other JSONL appenders
measurably have the same defect: a review agent reproduced each with a real tear
and a real append and lost the following record every time.

| appender | after a tear |
|---|---|
| `observability.py:127` (progress.jsonl) | `['alpha']`, beta lost |
| `events.py:847` (JsonlSink, events.jsonl) | `['r1']`, r2 lost |
| `workqueue.py:854` (queue journal) | `['a']`, b lost |
| `inbox.py:504` (inbox log) | `['first']`, second lost |

Those four are NOT fixed here, deliberately: what each should WRITE on finding
a tear differs per file (`JsonlSink` holds a long-lived handle and would need
the probe at open time, `inbox` appends under `control_lock` and the others
under nothing, and each file's repair marker would need a different schema), so
only the predicate is shared. They deserve their own issue. Hoisting the
mechanism before the second copy rather than after the tenth is #291's lesson.
`kstrl/proposals.py:160` is not one of them: it appends Markdown and already
pads a missing newline, which is the same idiom arrived at independently.

## Planted mutations

No test here is trusted until it has been seen to fail. Every run below cleared
`__pycache__` first and ran with `PYTHONDONTWRITEBYTECODE=1`, because CPython
invalidates bytecode on mtime-seconds plus size and two same-size edits within
one second reuse the stale `.pyc`.

Counts are from re-running every mutation against the final tree, after the
/simplify pass moved code around.

| mutation | result |
|---|---|
| M1 remove the repair (`repairing = False`) | 10 failed. Headline: `AssertionError: assert ['alpha'] == ['alpha', 'beta']` and `assert ['a1', 'a2'] == ['a1', 'a2', 'a3', 'a4']` |
| M2 restore the second raw writer in autonomy.py | 2 failed, including `Offenders: ['autonomy.py:816: writes to journal_path']` |
| M3 heal silently (newline, no row) | 5 failed |
| M4a repair row typed as `component_result` | 5 failed |
| M4b an aggregate stops filtering on `event_type` | **passed, and correctly so**: the row has no `run_id`, so the lookback window drops it regardless. Reported rather than quietly dropped, because a mutation that does not fail is evidence about the guard's shape. |
| M4c give the repair row a `run_id` | 1 failed: `assert 1 == 2`, one whole run of history gone from every aggregate |
| M5 probe the tail by decoding instead of in binary | 2 failed with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in position 121` |
| M6 repair unconditionally, no probe | 8 failed |

## One existing test moved with the seam

`test_autonomy_ladder.py::TestTransitionAudit::test_journal_failure_is_not_fatal`
patched `kstrl.autonomy.open`, which intercepts nothing once the write lives in
`append_entries`. It failed honestly when that happened. It is rewritten to
cause a real failure on a real path (a directory where the journal file should
be, so `open` raises `IsADirectoryError` wherever the write lives) rather than
re-pointing the patch at the new seam, because a patched builtin pins WHERE the
code writes and that is not what the test is about.

## Verification

- `uv run pytest tests/ -q`: 4665 passed, 28 skipped, 0 failed
- `uv run mypy kstrl/ --strict`: Success, no issues found in 127 source files
- `uv run ruff check kstrl/ tests/`: All checks passed
- `uv run ruff format --check kstrl/ tests/`: clean
- `uv run python scripts/gen_docs.py --check`: README generated sections are current
- coverage: `TOTAL 23241 2350 89.89%`, against the 79.91 baseline
- `uvx vulture@2.16 --min-confidence 80 kstrl`: no findings
- `pre-commit run --files <the seven touched files>`: every hook Passed or
  Skipped, including complexipy, the cyclomatic ratchet, the 800-line ratchet,
  the em-dash hook and gitleaks

New tests, by name, all in `tests/test_journal_torn_tail.py` unless stated:

- `TestTheEntryAfterATear::test_the_entry_after_a_torn_line_survives`
- `TestTheEntryAfterATear::test_the_torn_fragment_is_not_resurrected`
- `TestTheEntryAfterATear::test_a_tail_that_lost_only_its_newline_keeps_its_record`
- `TestTheEntryAfterATear::test_an_autonomy_transition_after_a_tear_survives`
- `TestWhatIsNotATear::test_an_intact_journal_is_appended_to_unchanged`
- `TestWhatIsNotATear::test_an_empty_journal_file_is_not_a_tear`
- `TestWhatIsNotATear::test_a_missing_journal_file_is_not_a_tear`
- `TestWhatIsNotATear::test_an_empty_append_repairs_nothing`
- `TestWhatIsNotATear::test_a_directory_where_the_journal_should_be_is_not_a_tear`
- `TestTheTearIsVisible::test_the_repair_is_recorded_in_the_journal`
- `TestTheTearIsVisible::test_the_repair_is_logged`
- `TestTheTearIsVisible::test_one_tear_records_one_repair`
- `TestTheTearIsVisible::test_the_repair_row_counts_towards_no_aggregate`
- `TestTheTearIsVisible::test_the_repair_row_cannot_push_a_run_out_of_the_lookback_window`
- `TestTheUndecodableTail::test_a_tail_torn_mid_utf8_sequence_is_still_repaired_on_disk`
- `TestTheUndecodableTail::test_but_the_reader_still_loses_the_whole_file_to_it`
- `TestOneWriter::test_append_entries_is_the_only_writer_of_the_journal`

Rewritten: `tests/test_autonomy_ladder.py::TestTransitionAudit::test_journal_failure_is_not_fatal`.

## /simplify

Four agents, four angles. What was applied and what was declined, then all four
reports verbatim below so the declines can be checked rather than taken on
trust.

**Applied**

- Hoisted the newline predicate out of `evolution.py` into
  `observability.ends_without_newline`, public, next to the reader whose
  tolerance it protects (altitude 1, reuse 4). Not into `atomicio`: that module
  is emphatically "the one atomic file write", and an append-tail predicate is
  not an atomic write.
- Single `ast.walk` per file in the guard, reused across all three passes
  (efficiency 2). Measured by the reviewer at 232 ms to 182 ms.
- Dropped the `source_file.name == "evolution.py"` special case: a file with no
  `append_entries` already yields an empty permitted set (simplification 2).
- Aliases are no longer collected inside `append_entries` (simplification 1's
  false positive, fixed at its root rather than by deleting the alias walker).
- `is_write_mode` now tests every mode letter that can write, so `"r+"` and
  `"rb+"` are writes (simplification 3).
- `_repair_entry` is a module-level function: it never touched `self`
  (simplification 7).
- `TORN_FRAGMENT`, `DANGLING_UTF8` and `tear()` moved to
  `tests/helpers/journal.py` and are imported by both the read-side test in
  `test_decompose.py` and the write-side tests, so "both sides pin the same
  interrupted write" is an import rather than a comment (reuse 1).
- `test_journal_failure_is_not_fatal` asks `EvolutionConfig` where the journal
  lives instead of hardcoding `.kstrl/evolution.jsonl` (reuse 2,
  simplification 9), and its docstring is cut to the one durable sentence.
- Trimmed the comment in `commit_transition` to the part the callee's docstring
  does not already carry (simplification 8).

**Declined, with reasons**

- *Delete the alias walker and the mode test entirely (simplification 1).* The
  measured false positive it identified is real and is fixed above. Deleting
  the walker would leave the guard matching a hardcoded name, so
  `jp = journal.config.journal_path` then `open(jp, "a")` would walk straight
  past it. The shape the defect had is worth more than 35 lines.
- *A `torn_journal` fixture for the seven repeated preludes (simplification 4).*
  The three lines are the subject of these tests. Hiding the tear in a fixture
  makes the reader take on trust the one thing each test is about.
- *Merge the two `TestTheUndecodableTail` tests (simplification 5).* They assert
  two different contracts: the write side survives an undecodable tail, the read
  side does not. One failure message should not cover both. The duplicated
  literal they shared IS removed, into `DANGLING_UTF8`.
- *xfail the test that pins the reader's known-wrong behaviour
  (simplification 6).* It asserts what the code does today, measured. When
  somebody fixes the reader it fails, they read the docstring and delete it,
  which is the outcome I want. An xfail turning into an xpass says less.
- *Give the repair row a read surface in `ks status` or a doctor check
  (altitude 7).* Fair, and it lands in CLI and TUI surfaces #312 does not
  touch. The log line is the live surface; the row is the durable one. Worth
  its own issue.
- *Fix the four other JSONL appenders (reuse 4, altitude 2).* The reviewer that
  raised it also measured why a shared `append_jsonl` does not fit them. Only
  the mechanism is shared here. Recorded above with the measurements.
- *Share the `audits_in` / `repair_rows_in` journal readers with the three
  other copies in `tests/` (reuse 3), fold the six copies of
  `EvolutionJournal(EvolutionConfig.load(tmp_path))` (reuse 5), unify the five
  journal-row builders (reuse 6), share `KSTRL_PACKAGE` and the ten AST parses
  across the suite (reuse 7, efficiency 3).* All pre-existing duplication this
  change adds one instance to. Each is a refactor across three to ten test
  files, which is a different PR.
- *Bind the repeated aggregate calls to locals (efficiency 4).* The reviewer
  measured it below the 5 ms cutoff.
- *Merge probe and append into one `a+b` handle (efficiency 1).* The reviewer
  measured it: 28.2 us against 30.0 us, inside the noise, and it would cost the
  named utf-8 text-mode write. Their own recommendation was to leave it.
- *State the repair rationale once instead of four times (simplification 8,
  altitude 9).* Partly done (the `commit_transition` comment). The remaining
  three say different things: the constant's comment is about `event_type`,
  `_repair_entry`'s is about `run_id`, and a test docstring saying what it pins
  is what tests are for.

<details>
<summary>Reuse agent, verbatim</summary>

Reviewed the staged diff, both touched source files, both touched test files, and the shared modules (`kstrl/atomicio.py`, `kstrl/observability.py`, `tests/helpers/`) plus the adjacent journal tests (`tests/test_evolution.py`, `tests/test_decompose.py`, `tests/test_usage_meter.py`, `tests/test_contract_safety.py`, `tests/test_atomicio.py`).

Findings, highest cost first.

1. `tests/test_journal_torn_tail.py:44` (and the `tear()` helper at :78) - `TORN_FRAGMENT` is a copy of a literal, not a shared constant, so the contract its comment claims does not exist.
   The comment says "Byte for byte the fragment the read-side test uses, so both sides of the contract are pinned against the same interrupted write." The read-side test hardcodes the same literal inline at `tests/test_decompose.py:1387` (`handle.write('{"event_type": "spec_iss')`), and nothing connects the two. Cost: the pin is prose. Editing either literal silently un-pins the pair, and the file's own stated reason for existing ("both sides of the contract") degrades without any test failing. `tear()` is also a duplicate of the two-line body at `tests/test_decompose.py:1386-1387`. Concrete fix: one `tests/helpers/journal.py` exporting `TORN_FRAGMENT` and `tear(path, fragment=...)`, imported by both files. Worth doing, because the whole argument for the new file is that it is the write-side twin of that specific read-side test.

2. `tests/test_autonomy_ladder.py:868-869` - the rewritten failure injection hardcodes `.kstrl/evolution.jsonl` instead of asking the config that owns that default.
   The new test file does the same setup correctly at `tests/test_journal_torn_tail.py:293-294`, via `journal.config.journal_path`. `EvolutionConfig.journal_path` is the existing owner of the default (`kstrl/evolution.py:77`, resolved against `root_dir` by `_resolve_relative_paths`), and `tests/test_contract_safety.py:205` documents that anchoring explicitly. Cost: the test's OSError injection is coupled to a path constant it does not own, one release before that path plausibly moves (`kstrl/inbox.py` shows the R8.9 XDG control-dir migration already under way for a sibling file). If the default moves, the `mkdir` lands somewhere harmless, `open` succeeds, and the test fails as "DID NOT WARN" with nothing pointing at the moved path. One-line fix: `EvolutionConfig.load(tmp_path).journal_path`.

3. `tests/test_journal_torn_tail.py:84` and `:92` - `audits_in` / `repair_rows_in` are the fourth and fifth "read the journal, filter by event_type" helper in `tests/`.
   The existing ones are `tests/test_contract_safety.py:205` `_read_journal_events(root, event_type)` (the closest match, same signature shape), `tests/test_usage_meter.py:844` `_read_journal(tmp_path)`, and `tests/test_decompose.py:795` `_read_spec_issue_events(tmp_path)`. The new pair is the best implementation of the five, because it is the only one that goes through `observability.read_progress_events` instead of hand-splitting lines, which is exactly the argument for making it the shared one rather than the fifth copy. Cost: three of the existing copies parse lines themselves, so the tolerant-read behaviour the journal now depends on is asserted by tests that do not use it; any future change to how the journal is read has to be repeated in four places or the tests quietly stop testing the real reader.

4. `kstrl/evolution.py:473-499` - `_journal_line` and `_ends_without_newline` are private to `evolution.py`, and the package has three other JSONL appenders that carry the same #312 defect.
   `kstrl/observability.py:127-128` (progress log), `kstrl/inbox.py:502-505` (inbox log), `kstrl/knowledge.py:781-783` (dependency-scope telemetry) all do `open(path, "a")` then `json.dumps(...) + "\n"` with no newline probe. The read half of exactly this convention was deliberately unified: `EvolutionJournal._read_all_entries` (`kstrl/evolution.py:1510-1522`) delegates to `observability.read_progress_events` and says why, "the tolerant-read policy ... should be one policy rather than two". After this diff the write half is the asymmetric one, which reads as a decision the diff makes without stating it. Cost: naming the format here fixes one appender out of four; putting the pair next to `read_progress_events` as an `append_jsonl(path, entries)` would carry the repair to `inbox.jsonl` and the knowledge telemetry log for free. Not a bug, a placement call worth making explicitly.

5. `tests/test_journal_torn_tail.py:74` - `journal_at` is the sixth copy of `EvolutionJournal(EvolutionConfig.load(tmp_path))`.
   Existing copies: `tests/test_decompose.py:790` (`_journal_with`), `:1379`, `:1568` (`TestOneJournalRead._journal`), `:1989`, `tests/test_evolve_screen_encoding.py:42` and `:77`. Cost is low (one line each) and the duplication is pre-existing, so I read this as defensible test isolation rather than something to remove now. Flagging only because item 1's shared helper module would naturally absorb it, making the count 6-to-1 rather than 6-to-7.

6. `tests/test_journal_torn_tail.py:51` and `:60` - `audit()` / `component_result()` add two more journal-row builders to a suite that has three.
   Existing: `tests/test_decompose.py:1025` `_entry`, `tests/test_decompose.py:1182` `_entry`, `tests/test_evolution.py:1039` `_spec_entry`, all building a `spec_issues` row with a different subset of fields. Cost: if the row shape gains a required field, five builders disagree about what a valid row looks like, and each one's tests keep passing on the old shape. Low priority, and each builder is genuinely minimal for its own test, so this is the weakest item here.

7. `tests/test_journal_torn_tail.py:48` - `KSTRL_PACKAGE = Path(__file__).resolve().parent.parent / "kstrl"` is the eighth file to spell the package root this way (10 sites total: `test_atomicio.py`, `test_tui_config_guard.py`, `test_prompt_enrollment_walk.py`, `test_check_name_enrolment.py`, `test_timeout_enforcement.py`, `test_evolve_screen_encoding.py`, `test_config_preflight.py` via `REPO_ROOT`, plus this one), each paired with its own `rglob("*.py")` + `ast.parse(read_text(encoding="utf-8"))` loop. The new file names this as deliberate ("the way every other AST-walking test in this suite locates it"), and `tests/conftest.py` already exports `REPO_ROOT` that six of them could use. Cost is a repo-layout change touching eight files. Genuinely low, listed once for completeness.

What I checked and found clean: the AST write-classifiers `is_write_mode` / `write_target` / `journal_aliases` have no existing equivalent (`tests/test_atomicio.py:_called_names` only collects callee names, `tests/test_state_dir_scope.py:_import_closure` walks imports, neither classifies an open mode or a write target); `_ends_without_newline` has no prior art anywhere in `kstrl/` or `tests/` (no other `SEEK_END` or newline probe exists); `_repair_entry` correctly reuses `_timestamp_now` and `JOURNAL_SCHEMA_VERSION`; `kstrl/autonomy.py:809` replacing its raw `open` with `EvolutionJournal.append_entries` is the main reuse win of the diff, and the tests correctly reuse `observability.read_progress_events` rather than re-parsing lines. No `atomicio` violation: `append_entries` is an append, not a whole-file rewrite, so `atomic_write_text` is the wrong helper here and not calling it is right.

</details>

<details>
<summary>Simplification agent, verbatim</summary>

## Simplification review: #312 torn-journal-tail change

I ran the guard and three cut-down variants of it over `kstrl/` and over the pre-fix `autonomy.py` rather than reasoning about them, so the numbers below are measured.

### 1. `tests/test_journal_torn_tail.py:99-156` - two of the guard's helpers exist only to cancel each other out

`journal_aliases` returns exactly one name across the whole of `kstrl/`: `path`, and it comes from `path = self.config.journal_path` on line 1470 of `evolution.py`, which is inside `append_entries` itself. Because aliases are collected per module rather than per scope, the commonest local name in `evolution.py` now means "the journal" everywhere in the file. The only thing stopping `_ends_without_newline`'s `open(path, "rb")` at `/Users/wumpinihussein/.../kstrl/evolution.py:492` from being reported as an offender is `is_write_mode`.

Measured, on the current tree:
- shipped guard: `[]`
- drop `is_write_mode` only: `['evolution.py:492: path']` (false positive on its own module)
- drop BOTH helpers, match `"config.journal_path" in rendered or rendered == "journal_path"`: `[]`

And against `git show HEAD:kstrl/autonomy.py`, that same minimal rule still catches the real #312 defect: `old autonomy.py:808: journal_path`. The historical alias was literally named `journal_path`, so a substring/equality test sees it without an alias walker.

Cost: about 35 of the guard's 77 lines, a second full `ast.walk` per file, and a latent false positive the day anyone in `evolution.py` writes any other file through a local called `path`.

### 2. `tests/test_journal_torn_tail.py:163` - the filename special case is redundant

`permitted = append_entries_lines(tree) if source_file.name == "evolution.py" else set()`. `append_entries_lines` already returns `set()` for any file with no such def, so the conditional only matters for a hypothetical second `append_entries` elsewhere. Verified: with the condition removed the guard still reports zero offenders. Simpler: `permitted = append_entries_lines(tree)`, and one less hard-coded module name to un-exempt on a rename.

### 3. `tests/test_journal_torn_tail.py:99-110` - the mode classifier does not buy what its docstring claims

`mode.value[:1] in ("a", "w")` treats `"r+"` and `"rb+"` as reads, while the docstring argues "a guard must not be argued out of by indirection". If the guard keeps a mode test it needs to grow; per finding 1 the cheaper move is to delete the mode test rather than complete it.

### 4. `tests/test_journal_torn_tail.py` - seven tests repeat the same three-line prelude

Lines 183-185, 199-201, 241-243, 314-316, 347-349, 364-366, 377-379 are byte-identical: construct journal, append `alpha`, tear. A `torn_journal` fixture yielding `(journal, path)` turns 21 lines into 7 and gives one place to change when the fixture shape moves.

### 5. `tests/test_journal_torn_tail.py:440-489` - `TestTheUndecodableTail` is one test written twice

Both tests build the same file (append `alpha`, splice `'{"project": "café'.encode()[:-1]`, append `beta`) and differ only in the assertion, and the dangling-bytes expression is spelled out twice rather than sitting beside `TORN_FRAGMENT` as a constant. One test with both assertions covers it.

### 6. `tests/test_journal_torn_tail.py:463-489` - a green test that pins a known-wrong behaviour

`assert read_progress_events(path) == []` asserts that one undecodable byte costs the reader the entire journal, with a 19-line docstring saying that this is wrong and deliberately not fixed here. Cost: the read-side fix cannot land without editing this file, and the assertion tells a future reader nothing about the change under review. An `xfail` or a line in the issue records the gap without a passing test defending it.

### 7. `kstrl/evolution.py:1487` - `_repair_entry` is a method that never touches `self`

Confirmed by AST: no `self.` in the body. It reads `JOURNAL_SCHEMA_VERSION` and `_timestamp_now()`, both module-level, and has exactly one call site. A module-level function beside `_journal_line`, or inlining it, is the same behaviour without implying instance state. Related and minor: `_journal_line` (line 473) also has exactly one calling function and two call sites, both inside `append_entries`; the constant, the two module-level helpers and the method are four names for what is one 12-line method.

### 8. The same WHY is written five times

"Its own `event_type`, no `run_id`, therefore it counts towards no aggregate" appears at `kstrl/evolution.py:38-43` (the constant's comment), in `_repair_entry`'s docstring, and in both docstrings of `TestTheTearIsVisible` (`tests/test_journal_torn_tail.py:386-433`). Separately, `kstrl/autonomy.py:804-811` spends 8 comment lines restating `append_entries`' own docstring above a one-line call; only the last sentence (why `EvolutionJournal(config)` rather than `.open()`, which would gate on `config.enabled`) is information the callee does not already carry. Cost: five copies that drift apart, against a rule that wants the reason recorded once where it belongs.

### 9. `tests/test_autonomy_ladder.py:854-866` - 13-line docstring, 6-line test

Most of it narrates the test's own edit history ("This test used to patch `kstrl.autonomy.open`..."). The one durable sentence is why the patch was not re-pointed. The setup also hard-codes `.kstrl/evolution.jsonl` instead of asking `EvolutionConfig` where the journal lives, duplicating the trick already used by `test_a_directory_where_the_journal_should_be_is_not_a_tear`.

### Not a finding, but worth naming

The repair ROW (as opposed to the newline plus the log line) is the single largest source of added surface in this change: the constant, `_repair_entry`, and four of the seventeen tests exist to write it and then prove it moves no number anyone reads. That is a deliberate call, argued in the docstring and backed by the "if it is worth deciding, it is worth recording" rule, so deleting it would lose behaviour rather than complexity. Flagging only so the price is visible.

No dead code was left behind: `import json` in `kstrl/autonomy.py` is still used at line 362, and `patch` in `tests/test_autonomy_ladder.py` is still used at lines 573-578 and 906-922.

</details>

<details>
<summary>Efficiency agent, verbatim</summary>

Measurements taken on macOS arm64 / APFS / CPython 3.12.8, warm page cache, against the staged blobs. Note: the working tree diverged mid-review (another agent is editing `kstrl/evolution.py` and `kstrl/observability.py` right now, and `_ends_without_newline` is gone from the unstaged copy). Everything below was measured against the staged content, which still matches the patch.

## Findings

**1. `kstrl/evolution.py:1472` - the extra binary probe before every non-empty append. Real, measured, and not worth removing.**

- Cost: `_ends_without_newline` measured at **10.4 us/call** on a 1.1 MB journal. The append it guards (`open("a", encoding="utf-8")` + write + close) is **19.7 us**, and the `path.parent.mkdir(exist_ok=True)` already on the line above is **3.0 us**. So the probe adds roughly 35% to a per-call cost that was already ~23 us.
- Frequency: five call sites, all coarse-grained. `kstrl/evolution.py:722` (`record_run` - **once per factory run**, because it batches every component entry into one `append_entries` call), `kstrl/factory.py:3843` (once per contract tier result), `kstrl/pipeline.py:1251` (once per superseded retry), `kstrl/decompose.py:1051` (once per decompose), `kstrl/autonomy.py:814` (once per ladder transition). Order 10 to 40 calls per run. Total added cost per factory run: **0.1 to 0.4 ms**, against a run measured in minutes and dollars. This is not a hot path.
- The suggested fix does not pay. I measured the merged single-open form (`open(path, "a+b")`, seek to end, tell, seek(-1), read(1), then write): **28.2 us** versus **30.0 us** for the current probe-then-append pair. That is a ~1.8 us saving, inside the noise, and it would cost the utf-8 text-mode write that the module pins deliberately (the two-sided encoding contract in CLAUDE.md). **Recommendation: leave it alone.** The syscall pair is avoidable in principle and worth nothing in practice.

**2. `tests/test_journal_torn_tail.py:372-386` - `journal_writes_outside_append_entries` walks each parsed tree twice. The only measurable waste I found.**

`journal_aliases(tree)` does a full `ast.walk`, then the function does a second full `ast.walk` for the call nodes. Measured over `kstrl/`'s 127 files / 65,207 lines / 236,703 AST nodes:

- as written: **232.2 ms**
- with `nodes = list(ast.walk(tree))` reused across both passes: **182.4 ms**
- saving: **~50 ms, 21% of the guard**

Breakdown: read + `ast.parse` of the 127 files is **128 ms**, and one bare `ast.walk` over every tree is **64 ms**. The `ast.unparse` calls are *not* the cost, contrary to what the shape suggests: there are only 236 of them in `journal_aliases` and 54 in `write_target`. I tested a `node.value.attr == "journal_path"` pre-filter that cuts the unparses from 236 to 1, and it measured **64.8 ms vs 66.2 ms**, i.e. nothing. Do not bother with that one.

**3. `tests/test_journal_torn_tail.py:507` - the AST guard's absolute runtime is fine for a unit suite.**

Measured with `--durations`: the guard test is **0.25 s**, the whole new file is **0.37 s** for 17 tests. Full suite is **266.6 s** (4127 passed, 28 skipped). So the guard is **0.09%** of the suite and the file is **0.14%**. Acceptable, clearly.

The context worth naming: `grep` for `rglob("*.py")` in `tests/` shows this is now roughly the tenth test file that independently reads and parses the entire `kstrl/` package (`test_atomicio`, `test_check_name_enrolment`, `test_config_preflight`, `test_prompt_enrollment_walk`, `test_timeout_enforcement`, `test_toml_readers`, `test_tui_config_guard`, `test_tui_config_walk`, `test_state_dir_scope`, plus this one). At **128 ms** of read+parse each, that is roughly **1.3 s** of the suite spent re-parsing the same 65,207 lines. A shared `lru_cache`d parse in `tests/helpers/` would collapse it. This diff did not create that pattern, it adds one more instance of it.

**4. `tests/test_journal_torn_tail.py:617-625` - repeated aggregate calls, each one a fresh file read. Nit, below the measurement floor.**

`test_the_repair_row_counts_towards_no_aggregate` calls `clean.get_concern_hit_rate()`, `clean.get_fact_utilization()` and `clean.get_cross_run_patterns()` twice each (once for the non-triviality assert, once inside the equality against `torn`). Every one of those calls goes through `_read_all_entries` -&gt; `read_progress_events`, which re-opens and re-parses the journal from disk. That is 11 file reads where 7 would do. The files hold two entries, so the whole test came in under the 5 ms `--durations` cutoff. Binding each clean result to a local would be tidier but buys nothing measurable.

## What I did not find

No blocking work added to any hot path, no independent operations serialised that could have been concurrent, no redundant computation in `append_entries` itself. `_repair_entry()` and the `logger.warning` are both behind `if repairing`, so the common path pays nothing for them, and `bool(entries)` short-circuits the probe on an empty append. Hoisting the line format into `_journal_line` adds one Python call per entry (~0.1 us) against a `json.dumps` that dominates it.

One aside, not an efficiency finding and not from this diff: the full-suite run hit a pre-existing failure at `tests/test_tui_embed.py::TestNotifyCapture::test_subprocess_module_is_what_fire_uses`, unrelated to the journal.

</details>

<details>
<summary>Altitude agent, verbatim</summary>

## Verdict

The depth is largely right. The two structural choices - one writer of the line format, and healing forward with a record rather than raising - are the correct altitude for this file. One generic piece is in the wrong place, and one claim ("the one writer") is enforced more narrowly than it reads.

## Findings

**1. `kstrl/evolution.py:478` - the only reusable piece of the fix is a private in a leaf module.**
`_ends_without_newline` is a zero-policy, twelve-line byte predicate with nothing journal-specific in it. It sits next to journal-specific code, underscore-private, in a module about the evolution journal. The four other JSONL appenders cannot reuse it without `kstrl.inbox` importing a private from `kstrl.evolution`, which is a dependency nobody will write. Cost: the next fixer of the same defect at another site copies the predicate, which is the #291 shape (ten hand-rolled `mkstemp` copies) starting over. `kstrl/atomicio.py` is the established home for shared file-write mechanics and already carries an AST guard convention.

**2. The other four sites measurably have the identical defect, but generalising the policy now would be premature.**
I reproduced each with a real tear and a real append (`progress.jsonl` -&gt; `['alpha']`, beta lost; `events.jsonl` -&gt; `['r1']`, r2 lost; queue journal -&gt; `['a']`, b lost; inbox -&gt; `['first']`, second lost). Sites: `kstrl/observability.py:127`, `kstrl/events.py:847`, `kstrl/workqueue.py:854`, `kstrl/inbox.py:504`. All four readers are per-line tolerant, so the concatenation costs the new record exactly as #312 describes. But a shared "append a JSONL line" helper does not fit them: `JsonlSink` holds a long-lived handle and would need the probe at open time, not per emit; `inbox._append` writes under `control_lock` and the others under nothing; and each file's repair marker would need a different schema (`ts`/`event`, a typed `Event` subclass, a folded `InboxItem`). Splitting mechanism from policy is the right call. Hoist the predicate only.

**3. `kstrl/proposals.py:160` is not a case, and already has the idiom.**
`mark_applied` appends Markdown, not JSONL, and writes a leading `"\n"` by construction; `append_to_agent_learnings` at line 148 explicitly pads `head` when it does not end in a newline. Worth naming because the codebase already solved this shape in one place - the fix is a second, unlinked instance of an idiom that exists.

**4. `tests/test_journal_torn_tail.py:492` - the guard's protection is narrower than the invariant it names.**
`TestOneWriter` plus its four helpers (lines 99-172) is about 75 lines of bespoke AST machinery. It matches on the literal string `config.journal_path` inside `ast.unparse` output, so it enforces "no second writer of `evolution.jsonl`" rather than "no unguarded JSONL append". Cost: the four sites in finding 2 will never trip it, and a reader of `append_entries`'s docstring ("enforced by `tests/test_journal_torn_tail.py`") gets a stronger impression of coverage than the guard delivers. The docstring at line 495 does state the limits honestly, so this is scope, not concealment. Mitigating: this is the ninth hand-rolled AST walker in `tests/` (test_atomicio, test_process_scoping, test_prompt_enrollment_walk, test_check_name_enrolment and others), so hand-rolling is settled house style and the absence of a shared walker is pre-existing debt this change adds to rather than creates.

**5. `kstrl/autonomy.py:814` - routing through `append_entries` is the right depth, unambiguously.**
The old code duplicated the line format verbatim (`json.dumps(entry, separators=(",", ":")) + "\n"`) and its own `mkdir`, which made the existing "one writer" docstring false. Leaving it alone would have required fixing #312 twice and left the format forked. No cost identified.

**6. `kstrl/autonomy.py:804-811` - it routes through the line-format seam while deliberately staying outside the writer seam.**
`EvolutionJournal.open()` at `evolution.py:583` exists, per its own docstring, because "the four writers that existed before #257 disagreed" on the parse-and-enabled pair. `commit_transition` now duplicates half of it (`load_or_none`) and skips the other half (`config.enabled`). Cost: `enabled = false` in `kstrl.toml` silences four writers and not this one, and the fix widens that slightly - a disabled journal can now also receive a `journal_repair` row and a blank line. The behaviour is pre-existing and the divergence is commented, so this is a preserved choice rather than a new one, but the change is the moment it became load-bearing and it was not raised as a question.

**7. `kstrl/evolution.py:1487` - the marker row is the right call over a log line or a raise, but it has no read surface.**
Writing it into the data file is well argued: the process that tore the file is the one whose stderr nobody kept, so the log line alone would not survive. And `_repair_entry` correctly omits `run_id` so the row cannot shorten a lookback window. The gap is retrieval. `_read_journal_entries` drops rows without a `run_id`, so the journal's own primary reader never sees it; no `ks` command, doctor check or TUI panel surfaces `journal_repair`. The stated retrieval path is grep, for a string an operator has never encountered. Cost: an unconsumed signal. A row nobody queries records the repair without informing anyone, which is a weaker outcome than the design intends. Adding one line to an existing status or doctor surface would close it; the alternative altitude (route it to `kstrl/inbox.py`, the codebase's actual exception surface) is worth naming but would invert the layering and lands on a file with the same defect, so it is correctly not taken today.

**8. `kstrl/evolution.py:1470-1478` - a depth consequence worth flagging, bordering on correctness.**
`append_entries` was a pure append and is now probe-then-append: a read-modify-write. `evolution.py` takes no lock, while `inbox._append` wraps its append in `control_lock` and `workqueue` has `queue_lock` for the same reason. Two concurrent appenders onto a torn file each observe the tear. Noting as depth (the fix consumes a stronger single-writer assumption than the code it replaced); the correctness reviewer should judge whether that assumption holds.

**9. `kstrl/evolution.py:38, 1443, 1487` - the repair rationale is stated four times.**
The constant comment, the `append_entries` docstring, the `_repair_entry` docstring and the test module docstring each argue why the row has its own `event_type` and why healing forward beats raising. The file's neighbours are equally discursive so the volume is in band, but four copies of one argument drift independently under edit. One authoritative statement with three pointers costs nothing and stays true.

</details>

Two corrections to the reports, since they were written against a moving tree.
The efficiency agent saw `tests/test_tui_embed.py::TestNotifyCapture::test_subprocess_module_is_what_fire_uses` fail; it passes on a clean tree, and its own note says it was reviewing while the tree was mid-edit. The simplification agent's measurement that removing the alias skip reports
`evolution.py:492` was true of the draft it read, where the probe still lived in
`evolution.py`; after the hoist both ways report zero, and the test docstring
now says exactly that rather than repeating the older number.


---

# Review round 1 (findings F1 to F6)

Six findings, none P0 or P1. The reviewer's sandbox blocked every test and mutation run, so all six were static claims. Each was verified by executing.

## F2, the guard passed an ordinary third writer

Round 1's layer 2 read only a positional mode, resolved aliases one hop, and exempted anything anywhere named `append_entries`. Thirteen writer shapes were planted one at a time, each in its own run with `__pycache__` cleared and `PYTHONDONTWRITEBYTECODE=1`.

| planted shape | layer 1 | layer 2 |
|---|---|---|
| 1. `open(config.journal_path, mode="a")` | FAILED | FAILED |
| 2. two-hop alias, `target = journal_path` | FAILED | FAILED |
| 3. `journal_path: Path = config.journal_path` | FAILED | FAILED |
| 4. `open_file = open` then `open_file(...)` | FAILED | FAILED |
| 5a. `os.open` plus `os.write` | FAILED | FAILED |
| 5b. `io.open` | FAILED | FAILED |
| 5c. `builtins.open` | FAILED | FAILED |
| 6. `open(journal_path.resolve(), "a")` | FAILED | FAILED |
| 7. path passed to a helper, opened there | FAILED | passed |
| 8. helper takes the OPEN HANDLE | passed | passed |
| 9. new module, path only ever a parameter | FAILED | passed |
| 10. nested `def append_entries` inside another method | FAILED | FAILED |
| 11. unrelated class with a method named `append_entries` | FAILED | FAILED |

Ten of thirteen fail both layers, two fail layer 1 only, one fails neither.

Layer 2's message is identical in shape across all ten, differing in the offender it names:

```
E   AssertionError: A journal write outside append_entries: it will concatenate onto an
    unterminated tail and eat the entry after it (#312). Route it through
    EvolutionJournal.append_entries. Offenders: ['autonomy.py:811: writes to config.journal_path']
```

The offender string per form: 1 `autonomy.py:811: writes to config.journal_path`, 2 `autonomy.py:813: writes to target`, 3 `autonomy.py:812: writes to journal_path`, 4 `autonomy.py:812: writes to config.journal_path`, 5a `autonomy.py:811: writes to config.journal_path`, 5b and 5c `autonomy.py:812: writes to config.journal_path`, 6 `autonomy.py:812: writes to journal_path.resolve()`, 10 `evolution.py:732: writes to self.config.journal_path`, 11 `autonomy.py:867: writes to config.journal_path`.

Layer 1's message, on form 1:

```
E   AssertionError: The set of places that get hold of a journal path changed. If this is a
    new writer of the evolution journal, route it through EvolutionJournal.append_entries: an
    unguarded append concatenates onto an unterminated tail and eats the entry after it
    (#312). If it is a read, or another file's journal, add it to
    EXPECTED_JOURNAL_PATH_SITES with a reason. Found: {'autonomy.py: config.journal_path': 1,
    'cli.py: journal.config.journal_path': 1, 'decompose.py: journal.config.journal_path': 1,
    'evolution.py: config.journal_path': 5, 'evolution.py: self.config.journal_path': 3,
    'pipeline.py: self.journal_path': 4, 'workqueue.py: self.journal_path': 2}
E   Left contains 1 more item: {'autonomy.py: config.journal_path': 1}
```

**Form 8 is reported, not papered over.** A helper that takes the already-open handle is invisible to both layers: layer 1 sees no `journal_path` attribute, layer 2 sees a write to `handle`, a name it cannot resolve to the journal. Its bound is stated in the guard: `append_entries` is the only place in `kstrl/` that holds a journal handle, so reaching this shape means editing the sanctioned writer, which is the one function a reviewer of a journal change reads. Closing it needs the general alias and type resolution that #324 is about; that issue now also carries a measured live hole in `tests/test_toml_readers.py`, found while checking whether the resolution could simply be shared.

**The guard's own detector is now tested.** Before this round every layer-2 helper could be replaced by a constant with all three guard tests green, because their only assertion was that a list is empty and an empty list is what a switched-off detector returns. `TestTheGuardDetects` adds 16 positive controls on inline snippets. Stub battery after, `__pycache__` cleared, `PYTHONDONTWRITEBYTECODE=1`:

```
stub-is_write_mode-false         11 failed, 8 passed
stub-mentions_journal-false      12 failed, 7 passed
stub-write_target-none           12 failed, 7 passed
stub-journal_aliases-empty        3 failed, 16 passed
stub-open_aliases-bare            9 failed, 10 passed
stub-offenders-empty             12 failed, 7 passed
stub-escapes-empty                1 failed, 18 passed
```

## F1, probe and append were not one transaction

**Decision: state the residual precisely, do not lock.** One `"a+b"` file description now does both the probe and the append, which removes the window in which the path could be replaced or a symlink retargeted between them, and makes a journal this process cannot read raise out of the open rather than be probed as "not torn".

It takes no lock, and that is deliberate. `fcntl.flock` is POSIX-only; this repo already skips its flock tests on Windows and `docs`/CLAUDE.md record it as a known platform gotcha. Adding a second POSIX-only lock to buy a narrower version of a window that a crash has to land inside is not a trade this PR should make on its own. So `append_entries`'s docstring enumerates three residuals by name (a concurrent crash inside the narrowed window, double-recording of one tear by two repairing processes, and interleaving of writes larger than the buffer), and #330 tracks the lock. The docstring does not imply atomicity anywhere.

The repair row and the whole batch now go in one `handle.write`, which narrows residual 3 without closing it: `BufferedWriter.write` flushes and loops above `io.DEFAULT_BUFFER_SIZE`.

## F3, a failed probe silently disabled the repair

The predicate takes an open binary handle rather than a path. A mode-0200 journal cannot be opened `"a+b"` at all, so it raises `PermissionError` out of the open instead of being reported as "not torn" and appended to blind. There is no longer an `except OSError: return False` to be fail-open. `TestAnUnreadableJournal` pins it, skipped when the test runs as root.

## F4, a test that required the defect to stay

`test_an_undecodable_tail_should_cost_one_line_not_the_file` is now `@pytest.mark.xfail(strict=True)` asserting the DESIRED result: a tear inside a multi-byte sequence should cost one line. Today it costs the whole file, because `read_progress_events` wraps the entire read in one `except (OSError, ValueError)`. Strict, so it flips to a failure the moment that is fixed.

## F5, the repair was undiscoverable

`EvolutionJournal.get_repair_count()` reads the marker, `ks evolve --status` prints it when non-zero and stays silent at zero, and `docs/evolution-metrics.md` gained `journal_repair` plus the three other entry types it was missing (`role_usage`, `autonomy_transition`, `spec_issues`) and two corrected writer names. The evolve TUI screen is still silent, which is #333.

## F6, one vacuous assertion

`test_the_repair_row_counts_towards_no_aggregate` compared `torn.get_spec_issue_runs("p")` with `clean.get_spec_issue_runs("p")` when both were empty, which is an assertion that cannot fail. The fixture now contains a real `spec_issues` record and the test asserts `len(clean.get_spec_issue_runs("p")) == 1` before the comparison. Every other clean answer in that test is pinned non-trivially for the same reason (`== 2`, `== 2`, `== 1`).

## Verification

- `uv run pytest tests/ -q`: 4692 passed, 28 skipped, 1 xfailed.
- `uv run mypy kstrl/ --strict`: no issues in 127 source files.
- `uv run ruff check kstrl/ tests/`: all checks passed.
- `uv run pre-commit run` on the staged change: every hook passed, including complexipy, the cyclomatic and file-length ratchets, codespell, vulture, gitleaks and the em-dash check.
- Coverage, fast tier alone: 89.90% against the 79.91 ratchet.

## Round 2 /simplify

Reuse, simplification, and efficiency and altitude. The three findings lists are reproduced verbatim in a PR comment, with a disposition for every finding including the declined ones. They are in a comment rather than here because appending them to this body would take it past GitHub's 65,536 character cap. Round 2's pass is in a second comment, same arrangement.

---

# Review round 2 (findings F7 to F11)

Five findings, all introduced by this PR, all found with execution access that round 1 did not have. Every mutation result below comes from a run with `__pycache__` cleared and `PYTHONDONTWRITEBYTECODE=1`.

## F10, the transaction boundary the F1 decision rests on was untested

This is the same shape as the layer-2 hole caught in round 2: the mechanism was right and nothing held it in place. Two broken versions of `append_entries` passed everything.

`tests/test_journal_write_boundary.py` is new and pins both properties by counting descriptors and writes, through a `CountingHandle` that delegates every call to the handle `open` returned, so the bytes on disk are unchanged. Counting rather than reading the source on purpose: a second open moved into a helper is the same defect, and an AST test would call it clean. A fourth test compares the file written through the instrument with the file written without it, entry for entry and line for line, so a recorder that swallowed a write could not make the other three pass.

Planted mutation 1, the probe and the append on separate handles:

```
E       AssertionError: assert ['a+b', 'a+b'] == ['a+b']
E         Left contains one more item: 'a+b'
FAILED tests/test_journal_write_boundary.py::TestTheTransactionBoundary::test_the_probe_and_the_append_share_one_file_description
FAILED tests/test_journal_write_boundary.py::TestTheTransactionBoundary::test_an_ordinary_append_is_one_open_and_one_write_too
2 failed, 2 passed in 0.08s
```

Planted mutation 2, the newline, the marker and the batch as three writes:

```
E       assert 3 == 1
E        +  where 3 = len([b'\n', b'{"schema_version":2,"timestamp":"2026-09-01T12:00:54Z","event_type":"journal_repair","detail":"the preceding...now."}\n', b'{"timestamp":"2026-08-20T00:00:00Z","project":"beta","event_type":"spec_issues","spec_file":"beta.md"}\n'])
FAILED tests/test_journal_write_boundary.py::TestTheTransactionBoundary::test_a_repair_and_the_entries_it_protects_are_one_write
FAILED tests/test_journal_write_boundary.py::TestTheTransactionBoundary::test_an_ordinary_append_is_one_open_and_one_write_too
2 failed, 2 passed in 0.08s
```

The reviewer's finding is reproduced rather than quoted: in an isolated copy of the tree, each broken version passes 284 tests and 1 xfail across `test_journal_torn_tail`, `test_journal_one_writer`, `test_decompose`, `test_autonomy_ladder` and `test_config_control_plane`. Nothing but the new file notices.

## F9, decision: DETECT the foldable forms, and disclose what remains

Detect. Both shapes are decidable statically, and a guard that can decide something and does not is the hole. `folded_str` folds `ast.Constant`, `+` of foldable pieces, and `JoinedStr` / `FormattedValue`; `dynamic_attribute_read` recognises `getattr(x, <folds to "journal_path">)` and the two subscript spellings of the same read, `x.__dict__[...]` and `vars(x)[...]`; `reaches_journal_dynamically` walks a target's subtree for any of them or for a folded value CONTAINING the filename. Layer 1 now reports a dynamic acquisition as an escape site, layer 2 binds it as an alias and names the write, and one inventory over folded constants replaces the old text search, reproducing its seven modules exactly and additionally seeing the assembled forms.

Measured while writing it, not assumed: CPython folds adjacent string literals into one `Constant` at parse time, so `"evolution" ".jsonl"` needs no code, but an f-string does NOT fold, so `f"evolution{'.jsonl'}"` needs `FormattedValue` handled explicitly. A folder that stopped at `ast.Constant` and `+` would have missed it.

Planted `target = getattr(config, "journal_" + "path")` then `open(target, "a")`:

```
E       AssertionError: The set of places that get hold of a journal path changed. ... Found: {"autonomy.py: getattr(config, 'journal_' + 'path')": 1, 'cli.py: journal.config.journal_path': 1, 'decompose.py: journal.config.journal_path': 1, 'evolution.py: config.journal_path': 5, 'evolution.py: self.config.journal_path': 3, 'pipeline.py: self.journal_path': 4, 'workqueue.py: self.journal_path': 2}
E         Left contains 1 more item:
E         {"autonomy.py: getattr(config, 'journal_' + 'path')": 1}
E       AssertionError: A journal write outside append_entries: it will concatenate onto an unterminated tail and eat the entry after it (#312). Route it through EvolutionJournal.append_entries. Offenders: ['autonomy.py:812: writes to target']
FAILED tests/test_journal_one_writer.py::TestOneWriter::test_no_new_code_gets_hold_of_the_journal_path
FAILED tests/test_journal_one_writer.py::TestOneWriter::test_append_entries_is_the_only_writer_of_the_journal
2 failed, 26 passed in 0.53s
```

Planted `target = Path.cwd() / ".kstrl" / ("evolution" + ".jsonl")` then `open(target, "a")`:

```
E       AssertionError: Somebody spelled or assembled the journal's filename instead of asking EvolutionConfig for it. Sites: {'atomicio.py': 1, 'autonomy.py': 1, 'events.py': 1, 'evolution.py': 1, 'init_cmd.py': 1, 'knowledge.py': 1, 'pipeline.py': 1, 'statedir.py': 1}
E       AssertionError: A journal write outside append_entries: it will concatenate onto an unterminated tail and eat the entry after it (#312). Route it through EvolutionJournal.append_entries. Offenders: ['autonomy.py:812: writes to target']
FAILED tests/test_journal_one_writer.py::TestOneWriter::test_nobody_spells_the_journal_filename_for_themselves
FAILED tests/test_journal_one_writer.py::TestOneWriter::test_append_entries_is_the_only_writer_of_the_journal
2 failed, 26 passed in 0.53s
```

And disclose. What folding cannot decide is named in the guard's docstring and PINNED by `test_a_filename_the_interpreter_has_to_build_is_missed`, which asserts that `root / "".join(("evolution", ".jsonl"))` is NOT reported: `%`-formatting, `str.join`, a name resolved at run time. The disclosure fails if it stops being true. The rule it leaves behind is written down next to it: a shape a reader can decide by looking at it is a shape this guard must decide, and anything else is disclosed. This is the sixth instance of #324's family and the first defeated by constant folding rather than by aliasing, which is recorded there with the measurement.

## F7, the repair was invisible in the state that produces it

`_echo_journal_repairs` now runs before the empty-trends exit. Two tests pin the order: one with an `experiments.tsv` row, one with no `experiments.tsv` at all. Moving the call back below the exit:

```
E       AssertionError: assert '1 interrupted write(s) repaired' in '\n== Experiment Trends ==\nNo experiments recorded yet. Run `ks factory` first.\n'
FAILED tests/test_journal_torn_tail.py::TestTheRepairIsReportable::test_a_repair_is_reported_when_there_are_no_experiments_yet
FAILED tests/test_journal_torn_tail.py::TestTheRepairIsReportable::test_a_recovered_record_is_not_reported_as_lost
2 failed, 27 passed, 1 xfailed in 0.26s
```

This also fired the trap round 2 declined to fix: `tests/test_config_control_plane.py`'s hand-rolled `FakeJournal` had only `get_experiment_trends`, and the moved call reached it. It now subclasses the real journal, which is one line rather than the four the file-length ratchet refused.

## F8, a recovered record was reported as lost

The status line named one outcome where there are two. It now says the line above each marker is either a torn fragment, which is lost, or a whole record that lost only its newline, which is readable again, and tells the operator to read it. `docs/evolution-metrics.md` gained the same distinction as a heading. Restoring the old wording:

```
E       AssertionError: assert 'readable again' in '\n== Experiment Trends ==\nWARN:   journal: 1 interrupted write(s) repaired. A crash left /private/var/folders/... newline; the fragment above each journal_repair row was lost.\nNo experiments recorded yet. Run `ks factory` first.\n'
FAILED tests/test_journal_torn_tail.py::TestTheRepairIsReportable::test_a_recovered_record_is_not_reported_as_lost
1 failed, 28 passed, 1 xfailed in 0.26s
```

The test that catches it uses the case the fix RECOVERS: a tail that lost only its newline, both records readable afterwards.

## F11, decision: DOCUMENT, as residual 4

Not detected, because detecting it means parsing the last LINE on every append rather than the last BYTE, and that fires on any malformed tail rather than on a torn one: a different contract, not a bug fix.

The residual is now stated in full on `append_entries` alongside the other three, and it is narrower than it looks: the newline, the marker and the batch are ONE write, so a crash BETWEEN them is impossible. It needs a partial write, which is residual 3's split of a payload above the buffer. When it happens, nothing is at risk (the fragment is isolated, which was the point) and the fragment line is still on disk; what is missing is the machine-readable row, so `get_repair_count` is a lower bound, which `docs/evolution-metrics.md` now says. `test_a_terminated_but_malformed_tail_is_not_a_tear` pins it, and its docstring says what changes if somebody closes it.

## One correction to an earlier round, found by the /simplify pass

Residual 3 said a batch larger than `io.DEFAULT_BUFFER_SIZE` is split into several raw writes. Measured on this interpreter by counting `write` calls on a `FileIO` under a `BufferedWriter`:

```
      100  raw write calls: 1
     8192  raw write calls: 1
     8193  raw write calls: 1
   500000  raw write calls: 1
  5000000  raw write calls: 1
```

A payload of any size is handed to the raw layer whole. The split is not size-driven, and 8192 was the wrong number in the wrong place: it is where the buffer flushes ITSELF for accumulated small writes. The loop runs only on a SHORT write from the OS, which on a regular file means a signal or ENOSPC. Residual 3 now says that, and residual 4, which had inherited the wrong mechanism and then contradicted itself in its first clause, now says there is no gap between two calls because there is only one call.

Two more of the same kind: `get_repair_count`'s docstring still carried the exact sentence F8 removed, on the method `_echo_journal_repairs` nominates as the argument of record; and layer 2 compared a folded value by equality while the inventory used substring, so `root / (".kstrl/evolution" + ".jsonl")` folded correctly, moved a module count, and was thrown away by the layer whose job is to name the line. Both fixed, both with controls.

## Verification

- `uv run pytest tests/ -q`: 4709 passed, 28 skipped, 1 xfailed.
- `uv run mypy kstrl/ --strict`: no issues in 127 source files.
- `uv run ruff check kstrl/ tests/`: all checks passed.
- `uv run pre-commit run` on the staged change: every hook passed. Three of them had to be answered rather than argued with: `folded_str` scored 23 on the cognitive gate as one recursive function and is now four, `tests/test_journal_torn_tail.py` crossed the 800-line ratchet, which is what split the boundary suite into its own file, and the guard crossed it too once the positive controls had grown, which is what split those into `tests/test_journal_guard_detects.py`.
- Coverage, fast tier alone: 89.90% against the 79.91 ratchet.
