### PR TITLE
refactor(procgroup): one copy of the safe-pgid guard, and a test for verify's (#308)

### DIFF
--- a/kstrl/agents/proc.py
+++ b/kstrl/agents/proc.py
@@ -24,6 +24,8 @@ import weakref
 from collections.abc import Iterator
 from pathlib import Path
 
+from kstrl.procgroup import safe_pgid
+
 # Every adapter yields this line when its subprocess is killed on deadline
 # breach. loop.py matches on the prefix to count timed-out iterations; it is
 # a hint for error reporting, never a control-flow gate (a CustomAgent
@@ -180,23 +182,23 @@ class DeadlineStreamer:
         _ACTIVE.discard(self)
 
     def _signal_group(self, sig: signal.Signals) -> None:
-        pid = self._proc.pid
-        try:
-            # `isinstance(pid, int)` is load-bearing: a mocked Popen's pid
-            # coerces to 1 via MagicMock.__index__, and killpg(1, sig) is
-            # kill(-1, sig) - "signal every process this user can" - which
-            # kills the harness and its whole session. Same reason for the
-            # pgid > 1 and not-our-own-group guards: start_new_session=True
-            # makes the child its own group leader (pgid == child pid), so
-            # any pgid at or below 1, or equal to ours, means something is
-            # wrong and group-kill must not proceed.
-            if hasattr(os, "killpg") and isinstance(pid, int) and pid > 1:
-                pgid = os.getpgid(pid)
-                if pgid > 1 and pgid != os.getpgrp():
-                    os.killpg(pgid, sig)
-                    return
-        except (ProcessLookupError, PermissionError, OSError):
-            pass
+        # Whether a group kill may proceed at all is `procgroup.safe_pgid`'s
+        # question, not this method's: #308 made it the one copy of a rule
+        # that used to be written out here, in `serve` and in `verify`. The
+        # case it exists for is a mocked Popen, whose pid coerces to 1 via
+        # MagicMock.__index__ rather than raising, making killpg(1, sig)
+        # into kill(-1, sig) - every process this user can signal, which
+        # once took down the whole CI runner.
+        pgid = safe_pgid(self._proc)
+        if pgid is not None:
+            try:
+                os.killpg(pgid, sig)
+            except OSError:
+                # ESRCH (the group went between the lookup and the signal)
+                # or EPERM. Fall through to the direct child.
+                pass
+            else:
+                return
         # Group already gone, non-POSIX platform, unsafe pgid, or a mocked
         # proc in tests: fall back to signalling the direct child only.
         try:
@@ -204,7 +206,7 @@ class DeadlineStreamer:
                 self._proc.kill()
             else:
                 self._proc.terminate()
-        except (ProcessLookupError, OSError):
+        except OSError:
             pass
 
     def _write_stdin(self, stdin_text: str | None) -> None:

--- a/kstrl/agents/proc.py
+++ b/kstrl/agents/proc.py
@@ -184,11 +184,8 @@ class DeadlineStreamer:
     def _signal_group(self, sig: signal.Signals) -> None:
         # Whether a group kill may proceed at all is `procgroup.safe_pgid`'s
         # question, not this method's: #308 made it the one copy of a rule
-        # that used to be written out here, in `serve` and in `verify`. The
-        # case it exists for is a mocked Popen, whose pid coerces to 1 via
-        # MagicMock.__index__ rather than raising, making killpg(1, sig)
-        # into kill(-1, sig) - every process this user can signal, which
-        # once took down the whole CI runner.
+        # that used to be written out here, in `serve` and in `verify`. A
+        # None from it is not an error; it degrades to the direct child.
         pgid = safe_pgid(self._proc)
         if pgid is not None:
             try:

--- a/kstrl/procgroup.py
+++ b/kstrl/procgroup.py
@@ -274,9 +274,11 @@ def safe_pgid(process: subprocess.Popen[str]) -> int | None:
     remains the entry point for a bare pgid.
     """
     pid = process.pid
-    # ``killpg`` gates ``getpgid`` as much as itself: both are POSIX-only,
-    # and an absent one raises AttributeError, which no caller catches.
-    if not hasattr(os, "killpg") or not isinstance(pid, int) or pid <= 1:
+    # Each ``hasattr`` sits next to the call it guards: this one over
+    # ``getpgid`` below, and ``_may_signal_group``'s over ``killpg``. Both
+    # are POSIX-only, and an absent one raises AttributeError, which no
+    # caller catches.
+    if not hasattr(os, "getpgid") or not isinstance(pid, int) or pid <= 1:
         return None
     try:
         pgid = os.getpgid(pid)

--- a/kstrl/procgroup.py
+++ b/kstrl/procgroup.py
@@ -232,18 +232,61 @@ def _may_signal_group(pgid: int) -> bool:
     """Whether ``killpg(pgid, ...)`` is safe to issue at all.
 
     ``killpg(1, sig)`` is ``kill(-1, sig)``: every process this user owns.
-    ``serve._safe_pgid``, ``verify._signal_process_group`` and
-    ``agents.proc`` each carry a copy of this rule (#308); this module
-    needs its own because nothing enforces that its callers came through
-    one of them, and a docstring saying they do is a convention, not a
-    mechanism.
+    ``serve``, ``verify`` and ``agents.proc`` each used to carry a copy of
+    this rule; #308 moved it here and they now reach it through
+    :func:`safe_pgid`. This stays a function of its own because the pgid
+    entry points below take an id from anywhere, so nothing enforces that
+    THEIR callers came through ``safe_pgid``.
 
-    This module only ever sends signal 0, so unlike those three it does
-    NOT exclude the caller's own group: probing it is harmless and is a
-    question the suite legitimately asks. The broadcast pgid is the part
-    that must be refused whatever the signal.
+    The own-group exclusion is deliberately NOT here. The callers inside
+    this module only ever send signal 0, where probing our own group is
+    harmless and is a question the suite legitimately asks;
+    :func:`safe_pgid`, whose callers send real signals, adds that
+    exclusion on top. The broadcast pgid is the part that must be refused
+    whatever the signal.
     """
     return hasattr(os, "killpg") and pgid > 1
+
+
+def safe_pgid(process: subprocess.Popen[str]) -> int | None:
+    """A child's process-group id, or None when group-signalling is unsafe.
+
+    The single copy of the guard ``serve._safe_pgid``,
+    ``verify._signal_process_group`` and ``agents.proc._signal_group``
+    used to write out three times (#308). Driven over one matrix of pid,
+    ``getpgid`` and ``killpg`` outcomes before the move, the three agreed
+    on which pgid was safe for every input; they differed only in the
+    error channel, ``serve`` letting ``getpgid`` raise where the other two
+    swallowed. This takes the swallowing form, so a caller no longer wraps
+    the call in ``except OSError`` to get a None.
+
+    Three things make a pgid unsafe. A pid that is not an ``int``, because
+    a mocked ``Popen``'s pid coerces to 1 through ``MagicMock.__index__``
+    rather than raising - measured on this machine,
+    ``os.getpgid(MagicMock())`` returns 1. A pgid of 1 or below, because
+    ``killpg(1, sig)`` is ``kill(-1, sig)``, every process this user owns,
+    which is how a CI runner was once taken down. And our OWN group,
+    because ``start_new_session=True`` gives the child a group of its own,
+    so seeing ours back means the child never got one and the signal would
+    land on the harness doing the signalling.
+
+    This is the entry point for a ``Popen``. :func:`_may_signal_group`
+    remains the entry point for a bare pgid.
+    """
+    pid = process.pid
+    # ``killpg`` gates ``getpgid`` as much as itself: both are POSIX-only,
+    # and an absent one raises AttributeError, which no caller catches.
+    if not hasattr(os, "killpg") or not isinstance(pid, int) or pid <= 1:
+        return None
+    try:
+        pgid = os.getpgid(pid)
+    except OSError:
+        # ESRCH (already reaped) or EPERM. Either way there is no group id
+        # here that we are entitled to signal.
+        return None
+    if not _may_signal_group(pgid) or pgid == os.getpgrp():
+        return None
+    return pgid
 
 
 def read_group_liveness(pgid: int) -> GroupLiveness:

--- a/kstrl/serve.py
+++ b/kstrl/serve.py
@@ -69,7 +69,7 @@ from pathlib import Path
 from typing import Any, Final, Protocol
 
 from kstrl.agents.base import ARCHITECT_COMPONENT, ARCHITECT_ROLE
-from kstrl.procgroup import read_group_liveness, signal_probe_alive
+from kstrl.procgroup import read_group_liveness, safe_pgid, signal_probe_alive
 from kstrl.runid import run_kind
 from kstrl.statedir import (
     CONTROL_SPEND,
@@ -1421,10 +1421,7 @@ def run_supervised(
 
     # Captured now, while the child is certainly alive: after it is
     # reaped the pgid is unrecoverable (#186 F1).
-    try:
-        pgid: int | None = _safe_pgid(process)
-    except OSError:
-        pgid = None
+    pgid: int | None = safe_pgid(process)
 
     if on_spawn is not None:
         on_spawn(process.pid)
@@ -1524,10 +1521,7 @@ def terminate_process_group(
     detect. Caught by the test that kills only the direct child.
     """
     if pgid is None:
-        try:
-            pgid = _safe_pgid(process)
-        except (ProcessLookupError, OSError):
-            pgid = None
+        pgid = safe_pgid(process)
     if pgid is None:
         # No group to signal and no id to check. Whether the direct child
         # is gone is the most that can honestly be said, and saying so is
@@ -1585,26 +1579,6 @@ def _wait_out_grace(
 def _confirm_group_gone(pgid: int) -> GroupTermination:
     alive, degraded = _group_liveness_for_reap(pgid)
     return GroupTermination(not alive, degraded=degraded)
-
-
-def _safe_pgid(process: subprocess.Popen[str]) -> int | None:
-    """The child's process-group id, or None when it is not safe to signal.
-
-    The guards are load-bearing and are the same ones
-    ``verify._signal_process_group`` documents: a mocked ``Popen``'s pid
-    coerces to 1 via ``MagicMock.__index__``, and ``killpg(1, sig)`` is
-    ``kill(-1, sig)`` - signal every process this user owns. With
-    ``start_new_session=True`` the child leads its own group, so a pgid at
-    or below 1, or equal to ours, means something is wrong and the group
-    kill must not proceed.
-    """
-    pid = process.pid
-    if not isinstance(pid, int) or pid <= 1 or not hasattr(os, "killpg"):
-        return None
-    pgid = os.getpgid(pid)
-    if pgid <= 1 or pgid == os.getpgrp():
-        return None
-    return pgid
 
 
 def _group_liveness_for_reap(pgid: int) -> tuple[bool, str]:

--- a/kstrl/verify.py
+++ b/kstrl/verify.py
@@ -48,6 +48,7 @@ from kstrl.policy import (
     evaluate_policy,
 )
 from kstrl.prd import PRD
+from kstrl.procgroup import safe_pgid
 from kstrl.statedir import STATE_DIR_NAME
 
 # R2.6 env scrub: verification subprocesses execute agent-authored code
@@ -105,27 +106,30 @@ _SCRUB_TERM_GRACE_SECONDS = 5.0
 def _signal_process_group(proc: subprocess.Popen[str], sig: signal.Signals) -> None:
     """Signal the child's whole process group, direct-child fallback.
 
-    The pid/pgid guards are load-bearing: a mocked Popen's pid coerces to
-    1 via ``MagicMock.__index__`` and ``killpg(1, sig)`` is ``kill(-1,
-    sig)`` - signal every process this user owns. ``start_new_session=True``
-    makes the child its own group leader, so a pgid at or below 1 or equal
-    to ours means something is wrong and the group kill must not proceed.
+    The pid/pgid guards that decide whether a group kill may proceed at
+    all live in :func:`kstrl.procgroup.safe_pgid`, which #308 made the one
+    copy of a rule this function used to write out for itself. A None from
+    it - a mocked ``Popen``, a non-POSIX platform, an unsafe pgid, a child
+    already reaped - is not an error here: it degrades to signalling the
+    direct child, which is the whole reason the guard can afford to be
+    strict.
     """
-    pid = proc.pid
-    try:
-        if hasattr(os, "killpg") and isinstance(pid, int) and pid > 1:
-            pgid = os.getpgid(pid)
-            if pgid > 1 and pgid != os.getpgrp():
-                os.killpg(pgid, sig)
-                return
-    except (ProcessLookupError, PermissionError, OSError):
-        pass
+    pgid = safe_pgid(proc)
+    if pgid is not None:
+        try:
+            os.killpg(pgid, sig)
+        except OSError:
+            # ESRCH (the group went between the lookup and the signal) or
+            # EPERM. Fall through and try the direct child instead.
+            pass
+        else:
+            return
     try:
         if sig == signal.SIGKILL:
             proc.kill()
         else:
             proc.terminate()
-    except (ProcessLookupError, OSError):
+    except OSError:
         pass
 
 

--- a/tests/helpers/procs.py
+++ b/tests/helpers/procs.py
@@ -35,7 +35,8 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import NoReturn
+from typing import NoReturn, cast
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -370,3 +371,18 @@ def kill_group(pgid: int) -> None:
         os.killpg(pgid, signal.SIGKILL)
     except (ProcessLookupError, PermissionError, OSError):
         pass
+
+
+def fake_popen(pid: object) -> subprocess.Popen[str]:
+    """A mock ``Popen`` carrying ``pid`` and nothing else.
+
+    The pgid guard's whole subject is a pid that is not a real one, so
+    every suite testing it needs this shape and four of them had built it
+    inline (#308). ``pid`` is deliberately ``object``: the case the guard
+    exists for is a ``MagicMock`` pid, which coerces to 1 through
+    ``MagicMock.__index__`` rather than raising, so a signature that only
+    accepted ``int`` could not express the test that matters.
+    """
+    fake = MagicMock(spec=subprocess.Popen)
+    fake.pid = pid
+    return cast("subprocess.Popen[str]", fake)

--- a/tests/test_hitl_env_scrub.py
+++ b/tests/test_hitl_env_scrub.py
@@ -39,6 +39,7 @@ from kstrl.verify import (
     run_scrubbed,
     scrubbed_subprocess_env,
 )
+from tests.helpers import procs
 
 
 class ScriptedUI(PlainUI):
@@ -379,12 +380,15 @@ class TestTheVerifySignalGuardRoutesThroughProcgroup:
     had two tests for its copy of that rule and agents.proc had three;
     this copy had none, so nothing in the suite would have noticed the
     guard being deleted until `killpg(1, sig)` took the machine down.
-    """
 
-    def _fake_proc(self, pid: object) -> MagicMock:
-        proc = MagicMock(spec=subprocess.Popen)
-        proc.pid = pid
-        return proc
+    What is tested HERE is this call site's own behaviour - the two
+    fallback arms, the signal it carries through, and that it ROUTES
+    through the guard at all. The guard's decision table is
+    `tests/test_safe_pgid.py`'s, and re-pinning it here would reopen one
+    layer up the duplication #308 closed. The two routing cases kept are
+    the two that actually happened: a mocked Popen took down a CI runner,
+    and our own group takes down the run doing the signalling.
+    """
 
     def test_a_real_group_is_signalled_grandchild_and_all(
         self,
@@ -400,40 +404,31 @@ class TestTheVerifySignalGuardRoutesThroughProcgroup:
             cwd=tmp_path,
             start_new_session=True,
         )
+        pgid = os.getpgid(proc.pid)
         try:
-            deadline = time.monotonic() + 10.0
-            while not pid_file.exists() and time.monotonic() < deadline:
-                time.sleep(0.05)
-            grandchild = int(pid_file.read_text().strip())
+            # `procs.read_pid` also waits out the created-but-still-empty
+            # window that `> pidfile` opens, which a bare exists() check
+            # reads as ready and then parses as "".
+            grandchild = procs.read_pid(pid_file, timeout=10.0)
 
             _signal_process_group(proc, signal.SIGKILL)
 
             _assert_process_dies(grandchild)
         finally:
+            # Group-scoped, or a run where the kill under test did NOT
+            # land leaves the grandchild `sleep 300` behind for five
+            # minutes - the orphan class #292 is about, in the test whose
+            # own failure produces it.
+            procs.kill_group(pgid)
             proc.kill()
             proc.wait(timeout=10.0)
-
-    @pytest.mark.parametrize("bad_pid", [None, -1, 0, 1, True])
-    def test_an_unsignallable_pid_falls_back_to_the_direct_child(
-        self,
-        bad_pid: object,
-    ) -> None:
-        killpg_calls: list[tuple[int, int]] = []
-        proc = self._fake_proc(bad_pid)
-
-        with patch.object(os, "killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))):
-            with patch.object(os, "getpgid", lambda pid: 99999):
-                _signal_process_group(proc, signal.SIGTERM)
-
-        assert killpg_calls == [], "kill(-1, sig) must never be issued"
-        proc.terminate.assert_called_once()
 
     def test_a_mocked_popen_falls_back_to_the_direct_child(self) -> None:
         """The exact CI-killer shape. A MagicMock pid coerces to 1 via
         `MagicMock.__index__`, so `getpgid` returns a real 1 rather than
         raising, and `killpg(1, sig)` is `kill(-1, sig)`."""
         killpg_calls: list[tuple[int, int]] = []
-        proc = self._fake_proc(MagicMock())
+        proc = procs.fake_popen(MagicMock())
 
         with patch.object(os, "killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))):
             # A plausible group, so only the isinstance check can reject.
@@ -447,7 +442,7 @@ class TestTheVerifySignalGuardRoutesThroughProcgroup:
         """A pgid equal to ours means `start_new_session` never took, and
         signalling it would kill the verification run doing the signalling."""
         killpg_calls: list[tuple[int, int]] = []
-        proc = self._fake_proc(os.getpid())
+        proc = procs.fake_popen(os.getpid())
 
         with patch.object(os, "killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))):
             _signal_process_group(proc, signal.SIGKILL)
@@ -457,7 +452,7 @@ class TestTheVerifySignalGuardRoutesThroughProcgroup:
 
     def test_sigkill_uses_kill_and_sigterm_uses_terminate(self) -> None:
         """The fallback must carry the SIGNAL through, not just fire."""
-        proc = self._fake_proc(1)
+        proc = procs.fake_popen(1)
 
         _signal_process_group(proc, signal.SIGTERM)
         proc.terminate.assert_called_once()
@@ -481,7 +476,7 @@ class TestTheVerifySignalGuardRoutesThroughProcgroup:
         """`safe_pgid` cleared the group, then the signal itself failed.
         Falling through is the point: the direct child may still be
         reachable, and giving up here would leak it."""
-        proc = self._fake_proc(4242)
+        proc = procs.fake_popen(4242)
 
         def refuse(pgid: int, sig: int) -> None:
             raise exc
@@ -499,7 +494,7 @@ class TestTheVerifySignalGuardRoutesThroughProcgroup:
         group already got it is not harmful, but it is not what the code
         says it does, and a test that cannot tell the arms apart cannot
         catch the `return` being lost."""
-        proc = self._fake_proc(4242)
+        proc = procs.fake_popen(4242)
 
         with patch.object(os, "killpg", lambda pgid, sig: None):
             with patch.object(os, "getpgid", lambda pid: 99999):

--- a/tests/test_hitl_env_scrub.py
+++ b/tests/test_hitl_env_scrub.py
@@ -19,11 +19,12 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import time
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -33,6 +34,7 @@ from kstrl.manifest import Component, ComponentStatus, Manifest
 from kstrl.ui.plain import PlainUI
 from kstrl.verify import (
     VerifyConfig,
+    _signal_process_group,
     check_test_suite,
     run_scrubbed,
     scrubbed_subprocess_env,
@@ -367,3 +369,141 @@ class TestProcessGroupKill:
         assert "timed out" in result.message
         pid = int(pid_file.read_text().strip())
         _assert_process_dies(pid)
+
+
+class TestTheVerifySignalGuardRoutesThroughProcgroup:
+    """#308: `_signal_process_group`'s guard had no test at all.
+
+    The class above proves the group kill WORKS on a real tree. What was
+    never covered is the half that decides whether to attempt it. serve
+    had two tests for its copy of that rule and agents.proc had three;
+    this copy had none, so nothing in the suite would have noticed the
+    guard being deleted until `killpg(1, sig)` took the machine down.
+    """
+
+    def _fake_proc(self, pid: object) -> MagicMock:
+        proc = MagicMock(spec=subprocess.Popen)
+        proc.pid = pid
+        return proc
+
+    def test_a_real_group_is_signalled_grandchild_and_all(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The positive control. Every other test here asserts that
+        killpg did NOT happen, so a guard that refused everything would
+        pass them all while quietly leaking every backgrounded server the
+        group kill exists to collect."""
+        pid_file = tmp_path / "grandchild.pid"
+        proc = subprocess.Popen(
+            ["sh", "-c", f"sleep 300 & echo $! > {pid_file}; wait"],
+            cwd=tmp_path,
+            start_new_session=True,
+        )
+        try:
+            deadline = time.monotonic() + 10.0
+            while not pid_file.exists() and time.monotonic() < deadline:
+                time.sleep(0.05)
+            grandchild = int(pid_file.read_text().strip())
+
+            _signal_process_group(proc, signal.SIGKILL)
+
+            _assert_process_dies(grandchild)
+        finally:
+            proc.kill()
+            proc.wait(timeout=10.0)
+
+    @pytest.mark.parametrize("bad_pid", [None, -1, 0, 1, True])
+    def test_an_unsignallable_pid_falls_back_to_the_direct_child(
+        self,
+        bad_pid: object,
+    ) -> None:
+        killpg_calls: list[tuple[int, int]] = []
+        proc = self._fake_proc(bad_pid)
+
+        with patch.object(os, "killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))):
+            with patch.object(os, "getpgid", lambda pid: 99999):
+                _signal_process_group(proc, signal.SIGTERM)
+
+        assert killpg_calls == [], "kill(-1, sig) must never be issued"
+        proc.terminate.assert_called_once()
+
+    def test_a_mocked_popen_falls_back_to_the_direct_child(self) -> None:
+        """The exact CI-killer shape. A MagicMock pid coerces to 1 via
+        `MagicMock.__index__`, so `getpgid` returns a real 1 rather than
+        raising, and `killpg(1, sig)` is `kill(-1, sig)`."""
+        killpg_calls: list[tuple[int, int]] = []
+        proc = self._fake_proc(MagicMock())
+
+        with patch.object(os, "killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))):
+            # A plausible group, so only the isinstance check can reject.
+            with patch.object(os, "getpgid", lambda pid: 99999):
+                _signal_process_group(proc, signal.SIGTERM)
+
+        assert killpg_calls == []
+        proc.terminate.assert_called_once()
+
+    def test_our_own_group_falls_back_to_the_direct_child(self) -> None:
+        """A pgid equal to ours means `start_new_session` never took, and
+        signalling it would kill the verification run doing the signalling."""
+        killpg_calls: list[tuple[int, int]] = []
+        proc = self._fake_proc(os.getpid())
+
+        with patch.object(os, "killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))):
+            _signal_process_group(proc, signal.SIGKILL)
+
+        assert killpg_calls == []
+        proc.kill.assert_called_once()
+
+    def test_sigkill_uses_kill_and_sigterm_uses_terminate(self) -> None:
+        """The fallback must carry the SIGNAL through, not just fire."""
+        proc = self._fake_proc(1)
+
+        _signal_process_group(proc, signal.SIGTERM)
+        proc.terminate.assert_called_once()
+        proc.kill.assert_not_called()
+
+        _signal_process_group(proc, signal.SIGKILL)
+        proc.kill.assert_called_once()
+        proc.terminate.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ProcessLookupError(3, "no such process"),
+            PermissionError(1, "operation not permitted"),
+        ],
+    )
+    def test_a_refused_group_signal_still_tries_the_direct_child(
+        self,
+        exc: OSError,
+    ) -> None:
+        """`safe_pgid` cleared the group, then the signal itself failed.
+        Falling through is the point: the direct child may still be
+        reachable, and giving up here would leak it."""
+        proc = self._fake_proc(4242)
+
+        def refuse(pgid: int, sig: int) -> None:
+            raise exc
+
+        with patch.object(os, "killpg", refuse):
+            with patch.object(os, "getpgid", lambda pid: 99999):
+                _signal_process_group(proc, signal.SIGTERM)
+
+        proc.terminate.assert_called_once()
+
+    def test_a_group_signal_that_lands_does_not_also_signal_the_child(
+        self,
+    ) -> None:
+        """The `else: return` arm. Signalling the child as well after the
+        group already got it is not harmful, but it is not what the code
+        says it does, and a test that cannot tell the arms apart cannot
+        catch the `return` being lost."""
+        proc = self._fake_proc(4242)
+
+        with patch.object(os, "killpg", lambda pgid, sig: None):
+            with patch.object(os, "getpgid", lambda pid: 99999):
+                _signal_process_group(proc, signal.SIGTERM)
+
+        proc.terminate.assert_not_called()
+        proc.kill.assert_not_called()

--- a/tests/test_procgroup.py
+++ b/tests/test_procgroup.py
@@ -170,10 +170,11 @@ class TestTheGroupIdIsGuardedBeforeAnySignal:
     """#298 round 2: this module signals, so it carries the guard.
 
     `killpg(1, sig)` is `kill(-1, sig)`, every process this user owns.
-    `serve._safe_pgid` has this rule and the module docstring used to
-    appeal to it, which is a convention, not a mechanism: nothing
-    enforces that callers came through it. The triplication across
-    serve / verify / agents.proc is #308; this is procgroup's own half.
+    #308 moved the Popen-level guard here as `safe_pgid` (tested in
+    `tests/test_safe_pgid.py`), so serve, verify and agents.proc now come
+    through this module. `_may_signal_group` stays a function of its own
+    because the pgid entry points take an id from anywhere, and nothing
+    enforces that THEIR callers came through `safe_pgid`.
     """
 
     @pytest.mark.parametrize("pgid", [-1, 0, 1])

--- a/tests/test_procgroup.py
+++ b/tests/test_procgroup.py
@@ -30,7 +30,6 @@ from kstrl.procgroup import (
     GroupLiveness,
     _kernel_says_group_is_empty,
     _Listing,
-    _may_signal_group,
     _read_listing,
     read_group_liveness,
     signal_probe_alive,
@@ -164,45 +163,6 @@ class TestAGoneIsOnlyReportedWhenItIsEvidence:
         and a filtered listing can only ever show FEWER processes."""
         procs.fake_ps(monkeypatch, stdout="50 4242 Ss\n")
         assert read_group_liveness(4242) == GroupLiveness(True)
-
-
-class TestTheGroupIdIsGuardedBeforeAnySignal:
-    """#298 round 2: this module signals, so it carries the guard.
-
-    `killpg(1, sig)` is `kill(-1, sig)`, every process this user owns.
-    #308 moved the Popen-level guard here as `safe_pgid` (tested in
-    `tests/test_safe_pgid.py`), so serve, verify and agents.proc now come
-    through this module. `_may_signal_group` stays a function of its own
-    because the pgid entry points take an id from anywhere, and nothing
-    enforces that THEIR callers came through `safe_pgid`.
-    """
-
-    @pytest.mark.parametrize("pgid", [-1, 0, 1])
-    def test_a_broadcast_pgid_is_never_signalled(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        pgid: int,
-    ) -> None:
-        calls: list[tuple[int, int]] = []
-
-        def recording(target: int, sig: int) -> None:
-            calls.append((target, sig))
-
-        monkeypatch.setattr("kstrl.procgroup.os.killpg", recording)
-        assert _kernel_says_group_is_empty(pgid) is False
-        assert signal_probe_alive(pgid) is True
-        assert calls == [], "kill(-1, sig) must never be issued"
-
-    def test_the_refusals_fail_in_the_conservative_direction(self) -> None:
-        """Not empty, and alive: both keep a caller from calling a run
-        reaped on a question that was never asked."""
-        assert _may_signal_group(1) is False
-        assert _kernel_says_group_is_empty(1) is False
-        assert signal_probe_alive(1) is True
-
-    def test_a_real_group_is_still_signalled(self) -> None:
-        """The positive control, or the guard could be rejecting all."""
-        assert _may_signal_group(os.getpgrp()) is True
 
 
 class TestTheKernelControl:

--- a/tests/test_safe_pgid.py
+++ b/tests/test_safe_pgid.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import ast
 import os
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -70,6 +71,37 @@ class TestTheGroupIdIsGuardedBeforeAnySignal:
     def test_a_real_group_is_still_signalled(self) -> None:
         """The positive control, or the guard could be rejecting all."""
         assert _may_signal_group(os.getpgrp()) is True
+
+    def test_a_platform_with_getpgid_but_no_killpg_cannot_signal(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The `killpg` half of the POSIX gate, on its own.
+
+        Round-1 review found that deleting `hasattr(os, "killpg")` from
+        `_may_signal_group` left all 25 safe-pgid tests green, because
+        the only test that removed a syscall removed BOTH and stopped at
+        the `getpgid` gate in `safe_pgid`. The two gates guard two
+        different calls, so they need separating to be tested: this one
+        leaves `getpgid` in place, so every earlier check passes and the
+        `killpg` gate is the only thing left that can refuse.
+
+        POSIX always has both, so the case cannot arise here naturally.
+        `monkeypatch.delattr` is what makes it exercisable, and it is
+        exact: an absent `killpg` is an AttributeError at the call, which
+        no caller catches, so the wrong answer here is a crash in the
+        timeout path rather than a wrong pgid.
+        """
+        monkeypatch.delattr(os, "killpg")
+
+        assert _may_signal_group(99999) is False
+
+        fake = procs.fake_popen(4242)
+        with patch.object(os, "getpgid", lambda pid: 99999):
+            assert procgroup.safe_pgid(fake) is None, (
+                "a pgid handed back on a platform that cannot signal it is a "
+                "crash in the caller, not a kill"
+            )
 
 
 class TestSafePgidIsTheOneCopyOfThePopenGuard:
@@ -165,31 +197,265 @@ class TestSafePgidIsTheOneCopyOfThePopenGuard:
         assert procgroup.safe_pgid(fake) is None
 
 
+#: The module and callable the net looks for.
+_TARGET_MODULE = "os"
+_TARGET_FUNC = "getpgid"
+
+
+@dataclass(frozen=True)
+class _Scan:
+    """Everything the resolver needs, collected in ONE tree walk.
+
+    The first version of this took four walks per file: imports, class
+    bodies, a fixed-point pass that re-walked on every iteration, and the
+    calls. Measured over the 126 files this net sweeps, that was 942,444
+    node visits against 235,611, and it put the sweep at 0.41s against
+    0.19s for the literal matcher it replaced. Bucketing gets the same
+    answer on all 146 inputs checked, in 0.22s.
+    """
+
+    imports: list[ast.Import]
+    from_imports: list[ast.ImportFrom]
+    #: (targets, value) for every assignment, including class bodies.
+    assigns: list[tuple[list[ast.expr], ast.expr]]
+    #: Names bound in a class body, so reachable as an attribute too.
+    class_bound: set[str]
+    calls: list[ast.Call]
+
+
+def _assign_targets(node: ast.Assign | ast.AnnAssign) -> list[ast.expr]:
+    if isinstance(node, ast.Assign):
+        return list(node.targets)
+    return [node.target]
+
+
+def _class_body_names(node: ast.ClassDef) -> set[str]:
+    """Names a class body binds, so reachable as an attribute of the class."""
+    names: set[str] = set()
+    for stmt in node.body:
+        if isinstance(stmt, ast.Assign | ast.AnnAssign):
+            names.update(t.id for t in _assign_targets(stmt) if isinstance(t, ast.Name))
+    return names
+
+
+def _scan(tree: ast.Module) -> _Scan:
+    scan = _Scan([], [], [], set(), [])
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            scan.imports.append(node)
+        elif isinstance(node, ast.ImportFrom):
+            scan.from_imports.append(node)
+        elif isinstance(node, ast.Assign | ast.AnnAssign):
+            if node.value is not None:
+                scan.assigns.append((_assign_targets(node), node.value))
+        elif isinstance(node, ast.ClassDef):
+            scan.class_bound.update(_class_body_names(node))
+        elif isinstance(node, ast.Call):
+            scan.calls.append(node)
+    return scan
+
+
+def _reaches_target(
+    node: ast.expr,
+    aliases: set[str],
+    direct: set[str],
+    attrs: set[str],
+) -> bool:
+    """Whether this expression evaluates to ``os.getpgid``."""
+    if isinstance(node, ast.Attribute):
+        if (
+            node.attr == _TARGET_FUNC
+            and isinstance(node.value, ast.Name)
+            and node.value.id in aliases
+        ):
+            return True
+        if node.attr in attrs:
+            return True
+    return isinstance(node, ast.Name) and node.id in direct
+
+
+def _module_aliases(scan: _Scan) -> set[str]:
+    """Every name bound to the ``os`` module itself, aliases included."""
+    aliases = {_TARGET_MODULE}
+    for node in scan.imports:
+        for alias in node.names:
+            # `import os.path` binds `os`, which is already in the set.
+            if alias.asname is not None and alias.name == _TARGET_MODULE:
+                aliases.add(alias.asname)
+    return aliases
+
+
+def _imported_callables(scan: _Scan) -> set[str]:
+    """Every name `from os import getpgid` binds to the callable."""
+    direct: set[str] = set()
+    for node in scan.from_imports:
+        if node.module != _TARGET_MODULE or node.level != 0:
+            continue
+        for alias in node.names:
+            if alias.name == _TARGET_FUNC:
+                direct.add(alias.asname or alias.name)
+    return direct
+
+
+def _absorb(
+    targets: list[ast.expr],
+    class_bound: set[str],
+    direct: set[str],
+    attrs: set[str],
+) -> bool:
+    """Bind the targets of one resolving assignment. True if a set grew."""
+    grew = False
+    for target in targets:
+        if isinstance(target, ast.Name):
+            if target.id not in direct:
+                direct.add(target.id)
+                grew = True
+            # A class body's `lookup = os.getpgid` is reachable as
+            # `Cls.lookup` as well, so it belongs in BOTH buckets.
+            if target.id in class_bound and target.id not in attrs:
+                attrs.add(target.id)
+                grew = True
+        elif isinstance(target, ast.Attribute) and target.attr not in attrs:
+            attrs.add(target.attr)
+            grew = True
+    return grew
+
+
+def _bindings(scan: _Scan) -> tuple[set[str], set[str], set[str]]:
+    """(names for the os module, names for the callable, attribute names).
+
+    Resolving IMPORTS AND REBINDS is the whole difference between this
+    net and the one #308 first shipped, which matched the literal shape
+    ``os.getpgid(...)`` and nothing else. Round-1 review defeated that
+    version by planting a complete working fourth guard behind
+    ``import os as operating_system``, and three further spellings went
+    through with it.
+
+    THE TWO NAME BUCKETS ARE NOT ONE. ``direct`` is names that ARE the
+    callable, ``attrs`` is attribute names that resolve to it. Merging
+    them costs precision that ``_MUST_IGNORE`` pins: after
+    ``lookup = os.getpgid`` at module level, an unrelated
+    ``other.lookup(1)`` is not this callable, and one merged set cannot
+    say so.
+    """
+    aliases = _module_aliases(scan)
+    direct = _imported_callables(scan)
+    attrs: set[str] = set()
+
+    # To a fixed point, so `a = os.getpgid; b = a; b(pid)` resolves. No
+    # iteration bound: both sets only grow, over the finite set of names
+    # in one file, so this terminates. An earlier version capped it at 16
+    # and called the cap cycle protection, which was two errors - a cycle
+    # cannot spin a monotonically growing set, and the cap silently
+    # stopped resolving a rebind chain longer than itself.
+    while True:
+        grew = False
+        for targets, value in scan.assigns:
+            if _reaches_target(value, aliases, direct, attrs):
+                grew |= _absorb(targets, scan.class_bound, direct, attrs)
+        if not grew:
+            return aliases, direct, attrs
+
+
+def _getpgid_calls(source: str) -> list[int]:
+    """Line numbers of every call in ``source`` that reaches ``os.getpgid``."""
+    scan = _scan(ast.parse(source))
+    aliases, direct, attrs = _bindings(scan)
+    return sorted(
+        node.lineno for node in scan.calls if _reaches_target(node.func, aliases, direct, attrs)
+    )
+
+
+#: Every spelling the net must flag. `module alias` is the one round-1
+#: review planted a working fourth copy of the guard behind; the three
+#: below it are the rest of what went through with it. The others are
+#: forms the sibling guards in this repo were each separately holed by,
+#: kept as regression cover against a matcher that starts reading
+#: arguments or scope again.
+_MUST_CATCH = {
+    "direct": "import os\npgid = os.getpgid(pid)\n",
+    "keyword argument": "import os\npgid = os.getpgid(pid=pid)\n",
+    "inside a helper": "import os\n\n\ndef helper(pid):\n    return os.getpgid(pid)\n",
+    "nested function": (
+        "import os\n\n\ndef outer():\n    def inner():\n"
+        "        return os.getpgid(1)\n\n    return inner\n"
+    ),
+    "module alias": "import os as operating_system\npgid = operating_system.getpgid(pid)\n",
+    "from import": "from os import getpgid\npgid = getpgid(pid)\n",
+    "from import aliased": "from os import getpgid as gp\npgid = gp(pid)\n",
+    "callable rebind": "import os\nlookup = os.getpgid\npgid = lookup(pid)\n",
+    "rebind of a rebind": "import os\na = os.getpgid\nb = a\npgid = b(pid)\n",
+    "annotated assignment": (
+        "import os\nfrom collections.abc import Callable\n"
+        "lookup: Callable[[int], int] = os.getpgid\npgid = lookup(pid)\n"
+    ),
+    "class attribute": (
+        "import os\n\n\nclass G:\n    lookup = os.getpgid\n\n\npgid = G.lookup(pid)\n"
+    ),
+    "instance attribute": (
+        "import os\n\n\nclass G:\n    lookup = os.getpgid\n\n\npgid = G().lookup(pid)\n"
+    ),
+}
+
+#: Spellings that must NOT be flagged, or the net fails closed so hard
+#: that nobody keeps it. A name is not a binding.
+_MUST_IGNORE = {
+    "unrelated method of the same name": (
+        "class C:\n    def getpgid(self):\n        return 1\n\n\nC().getpgid()\n"
+    ),
+    "unrelated free function of the same name": (
+        "def getpgid(pid):\n    return 1\n\n\ngetpgid(2)\n"
+    ),
+    "the attribute without the call": "import os\nlookup = os.getpgid\n",
+    "a different os call": "import os\npid = os.getpid()\n",
+    # Pins the precision the two name buckets buy: `lookup` is the
+    # callable, `other.lookup` is somebody else's attribute of that name.
+    "the same name as an attribute of something else": (
+        "import os\nlookup = os.getpgid\npgid = other.lookup(1)\n"
+    ),
+}
+
+
 class TestNoCallerCarriesItsOwnCopy:
     """The point of #308: a fourth site would be invisible to the above.
 
-    WHAT THIS NET SEES is an `os.getpgid(...)` call written as an
-    attribute on a name called `os`. That is how all three copies were
-    spelled and how a fourth would most likely be spelled. It does NOT
-    see `from os import getpgid` or a rebound module, which is a known
-    miss rather than a claim: the test below plants that spelling and
-    records that it goes through.
+    WHAT THIS NET SEES is a call that RESOLVES to `os.getpgid` - through
+    module aliases, from-imports, rebinds and class attributes - and not
+    just the literal shape `os.getpgid(...)` that #308 first shipped.
+    Round-1 review defeated that version by planting a complete working
+    guard behind `import os as operating_system`.
+
+    WHAT IT DOES NOT SEE, so the assert message does not overclaim it: a
+    fourth site that gets a pgid from somewhere OTHER than this lookup -
+    a run record, a pidfile, an int off the wire - and signals it. That
+    is the bare-pgid hazard, it is real, and it is #329, not this.
+
+    THIS IS A LOCAL FIX TO A REPO-WIDE DEFECT, and saying so is the
+    point. About eleven AST guards in this tree each re-implement this
+    resolution, and they have been holed one at a time: the timeout audit
+    missed `wait(timeout=None)` and `with Popen(...)`, then still missed
+    `from subprocess import Popen as Spawn` after being repaired once;
+    the toml guard fell to `import tomllib as _tl`; the journal guard to
+    `open(path, mode="a")`; and this one to a module alias. That is five
+    instances of one defect, of which this is the fifth. #324 tracks
+    factoring the resolution onto a shared helper, and two round-2
+    reviewers named `tests/test_toml_readers.py` as the closest existing
+    copy. This class does not solve that, and a reader should not take it
+    as though the problem were local.
+
+    WHAT IT STILL MISSES is recorded by `test_the_remaining_misses`, so
+    the reach is a measured fact rather than a claim.
     """
 
-    def _offenders(self, source: str) -> list[int]:
-        found: list[int] = []
-        for node in ast.walk(ast.parse(source)):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            if (
-                isinstance(func, ast.Attribute)
-                and func.attr == "getpgid"
-                and isinstance(func.value, ast.Name)
-                and func.value.id == "os"
-            ):
-                found.append(node.lineno)
-        return found
+    @pytest.mark.parametrize("spelling", sorted(_MUST_CATCH))
+    def test_every_spelling_of_the_call_is_caught(self, spelling: str) -> None:
+        assert _getpgid_calls(_MUST_CATCH[spelling]) != [], (
+            f"a fourth copy written as {spelling!r} would go through the net"
+        )
+
+    @pytest.mark.parametrize("spelling", sorted(_MUST_IGNORE))
+    def test_a_name_is_not_a_binding(self, spelling: str) -> None:
+        assert _getpgid_calls(_MUST_IGNORE[spelling]) == []
 
     def test_no_module_outside_procgroup_derives_a_pgid(self) -> None:
         owner = REPO_ROOT / "kstrl" / "procgroup.py"
@@ -197,23 +463,39 @@ class TestNoCallerCarriesItsOwnCopy:
         for path in sorted((REPO_ROOT / "kstrl").rglob("*.py")):
             if path == owner:
                 continue
-            for lineno in self._offenders(path.read_text(encoding="utf-8")):
+            for lineno in _getpgid_calls(path.read_text(encoding="utf-8")):
                 offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}")
         assert offenders == [], (
-            "os.getpgid outside procgroup means a fourth copy of the guard; "
-            "call procgroup.safe_pgid instead"
+            "deriving a process-group id outside procgroup is how a fourth "
+            "copy of the safe-pgid guard starts; call procgroup.safe_pgid"
         )
 
-    def test_the_net_still_catches_the_spelling_all_three_copies_used(self) -> None:
-        """The control. Without this the test above passes on an empty
-        walk, a broken parse or a matcher that matches nothing."""
-        assert self._offenders("import os\npgid = os.getpgid(pid)\n") == [2]
-
     def test_the_owner_is_the_only_file_excluded(self) -> None:
+        """The control on the sweep. Without it the test above passes on
+        an empty walk, a broken parse or a matcher that matches nothing."""
         owner = REPO_ROOT / "kstrl" / "procgroup.py"
-        assert self._offenders(owner.read_text(encoding="utf-8")) != []
+        assert _getpgid_calls(owner.read_text(encoding="utf-8")) != []
 
-    def test_a_bare_import_is_a_known_miss(self) -> None:
-        """Written down rather than fixed, so the net's reach is a
-        measured fact and not something a reader has to assume."""
-        assert self._offenders("from os import getpgid\npgid = getpgid(pid)\n") == []
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "known misses, recorded rather than fixed. Marked xfail and "
+            "written the way a PASS should read, so strengthening the "
+            "resolver under #324 reports XPASS instead of breaking a test "
+            "that asserted the hole stays open."
+        ),
+    )
+    @pytest.mark.parametrize(
+        "spelling",
+        [
+            'import os\npgid = getattr(os, "getpgid")(pid)\n',
+            'import importlib\npgid = importlib.import_module("os").getpgid(pid)\n',
+            'import os\nTABLE = {"f": os.getpgid}\npgid = TABLE["f"](pid)\n',
+        ],
+    )
+    def test_the_remaining_misses(self, spelling: str) -> None:
+        """Each needs value tracking through a string or a container,
+        which is where a per-file AST net stops being the right tool.
+        They are also spellings nobody reaches for by accident, unlike
+        the module alias that got through round 1."""
+        assert _getpgid_calls(spelling) != []

--- a/tests/test_safe_pgid.py
+++ b/tests/test_safe_pgid.py
@@ -1,20 +1,16 @@
-"""#308: the safe-pgid guard, tested once in the module that owns it.
+"""#308: the signal guard, tested once in the module that owns it.
 
 `procgroup.safe_pgid` is the one copy of a rule `serve._safe_pgid`,
 `verify._signal_process_group` and `agents.proc._signal_group` each wrote
-out for themselves. Driven over one matrix of pid / `getpgid` / `killpg`
-outcomes BEFORE the move, the three agreed on every safe-or-not decision
-and differed only in whether `getpgid`'s OSError escaped: serve let it
-out and both its call sites mapped it straight back to None, the other
-two swallowed it in place. So this file pins one decision table, not
-three, and each call site keeps its own test that it routes through here
-at all - the half a shared unit test cannot prove.
+out for themselves. Its rationale, and what was measured about the three
+copies before they were merged, is in its own docstring; this file pins
+the decision table rather than restating the argument.
 
-WHY THIS IS NOT IN `tests/test_procgroup.py`, where it otherwise belongs.
-That file was at 798 lines. The `file-length-ratchet` hook fails a file
-that was at or under 800 lines and is now over, so folding these in took
-it to 929 and broke the commit. Merging the two files back together will
-break it again.
+`_may_signal_group` is here too, because `safe_pgid` calls it and tests
+for one rule split across two files drift. It came out of
+`tests/test_procgroup.py`, which is about the `ps` READ: that file was at
+798 lines against a `file-length-ratchet` hook that fails a file crossing
+800, so the two halves needed separating anyway and this is the seam.
 """
 
 from __future__ import annotations
@@ -23,25 +19,66 @@ import ast
 import os
 import subprocess
 from pathlib import Path
-from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from kstrl import procgroup
+from kstrl.procgroup import (
+    _kernel_says_group_is_empty,
+    _may_signal_group,
+    signal_probe_alive,
+)
 from tests.helpers import procs
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-def _popen_with_pid(pid: object) -> subprocess.Popen[str]:
-    fake = MagicMock(spec=subprocess.Popen)
-    fake.pid = pid
-    return cast("subprocess.Popen[str]", fake)
+class TestTheGroupIdIsGuardedBeforeAnySignal:
+    """#298 round 2: this module signals, so it carries the guard.
+
+    `killpg(1, sig)` is `kill(-1, sig)`, every process this user owns.
+    `_may_signal_group` stays a function of its own, rather than folding
+    into `safe_pgid`, because `read_group_liveness` and
+    `signal_probe_alive` take a bare pgid from anywhere and nothing
+    enforces that THEIR callers came through `safe_pgid`.
+    """
+
+    @pytest.mark.parametrize("pgid", [-1, 0, 1])
+    def test_a_broadcast_pgid_is_never_signalled(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        pgid: int,
+    ) -> None:
+        calls: list[tuple[int, int]] = []
+
+        def recording(target: int, sig: int) -> None:
+            calls.append((target, sig))
+
+        monkeypatch.setattr("kstrl.procgroup.os.killpg", recording)
+        assert _kernel_says_group_is_empty(pgid) is False
+        assert signal_probe_alive(pgid) is True
+        assert calls == [], "kill(-1, sig) must never be issued"
+
+    def test_the_refusals_fail_in_the_conservative_direction(self) -> None:
+        """Not empty, and alive: both keep a caller from calling a run
+        reaped on a question that was never asked."""
+        assert _may_signal_group(1) is False
+        assert _kernel_says_group_is_empty(1) is False
+        assert signal_probe_alive(1) is True
+
+    def test_a_real_group_is_still_signalled(self) -> None:
+        """The positive control, or the guard could be rejecting all."""
+        assert _may_signal_group(os.getpgrp()) is True
 
 
 class TestSafePgidIsTheOneCopyOfThePopenGuard:
-    """Every branch of the decision, negative cases and the control."""
+    """Every branch of the decision, the negatives and the control.
+
+    This is the table. Each of the three call sites keeps its own test
+    that it ROUTES through here, which is the half a shared unit test
+    cannot prove, and does not re-pin the table on top of it.
+    """
 
     def test_a_real_child_still_gets_its_group(self) -> None:
         """The positive control. Every other test here asserts a None, so
@@ -71,7 +108,7 @@ class TestSafePgidIsTheOneCopyOfThePopenGuard:
         out of `getpgid`: it coerces to 1 through `MagicMock.__index__`
         (measured on this machine, `os.getpgid(MagicMock())` returns 1),
         and `killpg(1, sig)` is `kill(-1, sig)`."""
-        fake = _popen_with_pid(MagicMock())
+        fake = procs.fake_popen(MagicMock())
         # A plausible group, so the pgid checks cannot be what rejects it
         # and only the isinstance check can.
         with patch.object(os, "getpgid", lambda pid: 99999):
@@ -81,20 +118,20 @@ class TestSafePgidIsTheOneCopyOfThePopenGuard:
     def test_a_pid_that_cannot_own_a_group_is_refused(self, bad_pid: object) -> None:
         """`True` is in here on purpose: `isinstance(True, int)` is True,
         so `pid <= 1` is the only thing that rejects it."""
-        fake = _popen_with_pid(bad_pid)
+        fake = procs.fake_popen(bad_pid)
         with patch.object(os, "getpgid", lambda pid: 99999):
             assert procgroup.safe_pgid(fake) is None
 
     @pytest.mark.parametrize("broadcast", [-1, 0, 1])
     def test_a_broadcast_pgid_is_refused(self, broadcast: int) -> None:
-        fake = _popen_with_pid(4242)
+        fake = procs.fake_popen(4242)
         with patch.object(os, "getpgid", lambda pid: broadcast):
             assert procgroup.safe_pgid(fake) is None
 
     def test_our_own_group_is_refused(self) -> None:
         """Signalling our own group kills the process doing the
         signalling. Seeing ours back means `start_new_session` never took."""
-        fake = _popen_with_pid(os.getpid())
+        fake = procs.fake_popen(os.getpid())
         assert procgroup.safe_pgid(fake) is None
 
     @pytest.mark.parametrize(
@@ -106,11 +143,9 @@ class TestSafePgidIsTheOneCopyOfThePopenGuard:
         ],
     )
     def test_a_failed_lookup_is_a_none_and_not_a_raise(self, exc: OSError) -> None:
-        """The one place the three copies differed. serve let `getpgid`
-        raise and both its call sites mapped it straight back to None, so
-        swallowing here is the same decision with less ceremony - and the
-        two callers that always swallowed keep the behaviour they had."""
-        fake = _popen_with_pid(4242)
+        """The one place the three copies differed, so the one that had to
+        be decided rather than moved."""
+        fake = procs.fake_popen(4242)
 
         def raiser(pid: int) -> int:
             raise exc
@@ -118,16 +153,15 @@ class TestSafePgidIsTheOneCopyOfThePopenGuard:
         with patch.object(os, "getpgid", raiser):
             assert procgroup.safe_pgid(fake) is None
 
-    def test_a_platform_without_killpg_is_refused(
+    def test_a_platform_without_the_syscalls_is_refused(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """POSIX gating. `getpgid` is absent on the same platforms as
-        `killpg`, and an absent one raises AttributeError, which no caller
-        catches - so the hasattr has to come BEFORE the lookup, not after."""
+        """POSIX gating. An absent `getpgid` raises AttributeError, which
+        no caller catches, so its hasattr has to come BEFORE the lookup."""
         monkeypatch.delattr(os, "killpg")
         monkeypatch.delattr(os, "getpgid")
-        fake = _popen_with_pid(4242)
+        fake = procs.fake_popen(4242)
         assert procgroup.safe_pgid(fake) is None
 
 
@@ -138,8 +172,8 @@ class TestNoCallerCarriesItsOwnCopy:
     attribute on a name called `os`. That is how all three copies were
     spelled and how a fourth would most likely be spelled. It does NOT
     see `from os import getpgid` or a rebound module, which is a known
-    miss rather than a claim - the test below plants both spellings and
-    records which one is caught.
+    miss rather than a claim: the test below plants that spelling and
+    records that it goes through.
     """
 
     def _offenders(self, source: str) -> list[int]:

--- a/tests/test_safe_pgid.py
+++ b/tests/test_safe_pgid.py
@@ -206,12 +206,9 @@ _TARGET_FUNC = "getpgid"
 class _Scan:
     """Everything the resolver needs, collected in ONE tree walk.
 
-    The first version of this took four walks per file: imports, class
-    bodies, a fixed-point pass that re-walked on every iteration, and the
-    calls. Measured over the 126 files this net sweeps, that was 942,444
-    node visits against 235,611, and it put the sweep at 0.41s against
-    0.19s for the literal matcher it replaced. Bucketing gets the same
-    answer on all 146 inputs checked, in 0.22s.
+    One walk rather than the four the first version took: 235,611 node
+    visits over the 126 files swept, against 942,444, and 0.22s against
+    0.41s. Same answer on all 146 inputs checked.
     """
 
     imports: list[ast.Import]
@@ -307,51 +304,74 @@ def _absorb(
     grew = False
     for target in targets:
         if isinstance(target, ast.Name):
-            if target.id not in direct:
-                direct.add(target.id)
-                grew = True
+            grew |= target.id not in direct
+            direct.add(target.id)
             # A class body's `lookup = os.getpgid` is reachable as
             # `Cls.lookup` as well, so it belongs in BOTH buckets.
-            if target.id in class_bound and target.id not in attrs:
+            if target.id in class_bound:
+                grew |= target.id not in attrs
                 attrs.add(target.id)
-                grew = True
-        elif isinstance(target, ast.Attribute) and target.attr not in attrs:
+        elif isinstance(target, ast.Attribute):
+            grew |= target.attr not in attrs
             attrs.add(target.attr)
-            grew = True
+    return grew
+
+
+def _absorb_module(targets: list[ast.expr], aliases: set[str]) -> bool:
+    """Bind the targets of an assignment whose value IS the os module.
+
+    Round-2 review defeated the first version of this resolver with
+    ``_o = os``: it resolved a rebound CALLABLE and not a rebound MODULE,
+    while three docstrings said it did both. Two characters, and a
+    complete working fourth guard went through again.
+
+    Only plain ``ast.Name`` targets. ``G.mod = os`` then
+    ``G.mod.getpgid(pid)`` needs an attribute-to-module map that nothing
+    else here would use; it is a recorded miss instead.
+    """
+    grew = False
+    for target in targets:
+        if isinstance(target, ast.Name):
+            grew |= target.id not in aliases
+            aliases.add(target.id)
     return grew
 
 
 def _bindings(scan: _Scan) -> tuple[set[str], set[str], set[str]]:
     """(names for the os module, names for the callable, attribute names).
 
-    Resolving IMPORTS AND REBINDS is the whole difference between this
-    net and the one #308 first shipped, which matched the literal shape
-    ``os.getpgid(...)`` and nothing else. Round-1 review defeated that
-    version by planting a complete working fourth guard behind
-    ``import os as operating_system``, and three further spellings went
-    through with it.
-
     THE TWO NAME BUCKETS ARE NOT ONE. ``direct`` is names that ARE the
-    callable, ``attrs`` is attribute names that resolve to it. Merging
-    them costs precision that ``_MUST_IGNORE`` pins: after
-    ``lookup = os.getpgid`` at module level, an unrelated
-    ``other.lookup(1)`` is not this callable, and one merged set cannot
-    say so.
+    callable, ``attrs`` is attribute names that resolve to it, and
+    ``_MUST_IGNORE`` pins the difference: one merged set cannot tell
+    ``other.lookup(1)`` from the callable after ``lookup = os.getpgid``.
+
+    WHERE ``attrs`` OVER-MATCHES, measured rather than assumed. It holds
+    bare attribute NAMES with no owner and no scope, so a file that binds
+    ``self.lookup = os.getpgid`` anywhere also flags an unrelated
+    ``something_else.lookup(1)``, and one unrelated class attribute named
+    ``lookup`` promotes a module-level rebind of the same name. Owner
+    tracking is the fix and it belongs in #324's shared resolver, not in
+    a twelfth private copy. The direction is the tolerable one: this net
+    fails loudly and a false positive costs a reader one look, where a
+    false negative is a fourth copy of the guard shipping unnoticed.
     """
     aliases = _module_aliases(scan)
     direct = _imported_callables(scan)
     attrs: set[str] = set()
 
-    # To a fixed point, so `a = os.getpgid; b = a; b(pid)` resolves. No
-    # iteration bound: both sets only grow, over the finite set of names
-    # in one file, so this terminates. An earlier version capped it at 16
-    # and called the cap cycle protection, which was two errors - a cycle
-    # cannot spin a monotonically growing set, and the cap silently
+    # To a fixed point, so `a = os.getpgid; b = a; b(pid)` resolves
+    # whatever order `ast.walk` happens to hand the assignments over in.
+    # No iteration bound: the sets only grow, over the finite set of
+    # names in one file, so this terminates. An earlier version capped it
+    # at 16 and called the cap cycle protection, which was two errors - a
+    # cycle cannot spin a monotonically growing set, and the cap silently
     # stopped resolving a rebind chain longer than itself.
     while True:
         grew = False
         for targets, value in scan.assigns:
-            if _reaches_target(value, aliases, direct, attrs):
+            if isinstance(value, ast.Name) and value.id in aliases:
+                grew |= _absorb_module(targets, aliases)
+            elif _reaches_target(value, aliases, direct, attrs):
                 grew |= _absorb(targets, scan.class_bound, direct, attrs)
         if not grew:
             return aliases, direct, attrs
@@ -366,12 +386,23 @@ def _getpgid_calls(source: str) -> list[int]:
     )
 
 
-#: Every spelling the net must flag. `module alias` is the one round-1
-#: review planted a working fourth copy of the guard behind; the three
-#: below it are the rest of what went through with it. The others are
-#: forms the sibling guards in this repo were each separately holed by,
-#: kept as regression cover against a matcher that starts reading
-#: arguments or scope again.
+#: Every spelling the net must flag.
+#:
+#: Four of these are spellings that a review round planted a COMPLETE,
+#: working fourth copy of the guard behind and watched go through:
+#: `module alias`, `from import`, `callable rebind` and `class attribute`
+#: in round 1, and `module rebind` in round 2. The rest are forms the
+#: sibling guards in this repo were each separately holed by, kept as
+#: regression cover against a matcher that starts reading arguments or
+#: scope again. Order here carries no meaning: `parametrize` sorts.
+#:
+#: Two rows exist to pin resolver machinery that nothing else reaches,
+#: which is why they read as contrived. `global installed later` is the
+#: only input where the fixed point changes the answer (every one of the
+#: 127 real files converges in a single pass), and `attribute assigned
+#: on self` is the only input that reaches `_absorb`'s attribute-target
+#: branch. Both were watched failing against a mutant that removes what
+#: they pin.
 _MUST_CATCH = {
     "direct": "import os\npgid = os.getpgid(pid)\n",
     "keyword argument": "import os\npgid = os.getpgid(pid=pid)\n",
@@ -381,6 +412,8 @@ _MUST_CATCH = {
         "        return os.getpgid(1)\n\n    return inner\n"
     ),
     "module alias": "import os as operating_system\npgid = operating_system.getpgid(pid)\n",
+    "module rebind": "import os\nx = os\npgid = x.getpgid(pid)\n",
+    "module rebind chain": "import os\na = os\nb = a\npgid = b.getpgid(pid)\n",
     "from import": "from os import getpgid\npgid = getpgid(pid)\n",
     "from import aliased": "from os import getpgid as gp\npgid = gp(pid)\n",
     "callable rebind": "import os\nlookup = os.getpgid\npgid = lookup(pid)\n",
@@ -394,6 +427,21 @@ _MUST_CATCH = {
     ),
     "instance attribute": (
         "import os\n\n\nclass G:\n    lookup = os.getpgid\n\n\npgid = G().lookup(pid)\n"
+    ),
+    # A module that installs its hook from one function and uses it from
+    # another defined above it. `ast.walk` hands the inner assignment over
+    # before the outer one, so a single resolution pass never sees it.
+    "global installed later": (
+        "import os\n\n_resolve = None\n\n\ndef derive(pid):\n"
+        "    hop = _resolve\n    return hop(pid)\n\n\ndef install():\n"
+        "    global _resolve\n\n    _resolve = os.getpgid\n"
+    ),
+    # An `ast.Attribute` on the LEFT of the assignment, which no other row
+    # here produces.
+    "attribute assigned on self": (
+        "import os\n\n\nclass Holder:\n    def __init__(self) -> None:\n"
+        "        self.lookup = os.getpgid\n\n"
+        "    def derive(self, pid):\n        return self.lookup(pid)\n"
     ),
 }
 
@@ -410,6 +458,9 @@ _MUST_IGNORE = {
     "a different os call": "import os\npid = os.getpid()\n",
     # Pins the precision the two name buckets buy: `lookup` is the
     # callable, `other.lookup` is somebody else's attribute of that name.
+    # This holds only while no attribute of that name is bound anywhere in
+    # the same file; `attrs` carries no owner. `_bindings` says where that
+    # over-matches and why the fix is #324's, not a twelfth private copy's.
     "the same name as an attribute of something else": (
         "import os\nlookup = os.getpgid\npgid = other.lookup(1)\n"
     ),
@@ -420,10 +471,11 @@ class TestNoCallerCarriesItsOwnCopy:
     """The point of #308: a fourth site would be invisible to the above.
 
     WHAT THIS NET SEES is a call that RESOLVES to `os.getpgid` - through
-    module aliases, from-imports, rebinds and class attributes - and not
-    just the literal shape `os.getpgid(...)` that #308 first shipped.
-    Round-1 review defeated that version by planting a complete working
-    guard behind `import os as operating_system`.
+    module aliases, module rebinds, from-imports, callable rebinds and
+    class attributes - and not just the literal shape `os.getpgid(...)`
+    that #308 first shipped. Two review rounds each defeated the version
+    before it by planting a complete working guard: round 1 behind
+    `import os as operating_system`, round 2 behind `_o = os`.
 
     WHAT IT DOES NOT SEE, so the assert message does not overclaim it: a
     fourth site that gets a pgid from somewhere OTHER than this lookup -
@@ -436,15 +488,22 @@ class TestNoCallerCarriesItsOwnCopy:
     missed `wait(timeout=None)` and `with Popen(...)`, then still missed
     `from subprocess import Popen as Spawn` after being repaired once;
     the toml guard fell to `import tomllib as _tl`; the journal guard to
-    `open(path, mode="a")`; and this one to a module alias. That is five
-    instances of one defect, of which this is the fifth. #324 tracks
-    factoring the resolution onto a shared helper, and two round-2
-    reviewers named `tests/test_toml_readers.py` as the closest existing
-    copy. This class does not solve that, and a reader should not take it
-    as though the problem were local.
+    `open(path, mode="a")`; and this one to a module alias, then to a
+    module rebind after being repaired once. #324 tracks factoring the
+    resolution onto a shared helper. Two of the existing copies already
+    hold pieces of it: `tests/test_toml_readers.py` resolves module
+    rebinds through a fixed point, which THIS net had to be taught twice,
+    and `tests/test_tui_config_walk.py` exposes a target-agnostic
+    `collect_bindings` that resolves 7 of the 14 rows below with no
+    changes. Neither was reused here (see the PR body for the measured
+    reasons), and that is itself the shape of the problem: the fix
+    already existed in the tree and the guard was holed anyway. This
+    class does not solve #324, and a reader should not take it as though
+    the problem were local.
 
-    WHAT IT STILL MISSES is recorded by `test_the_remaining_misses`, so
-    the reach is a measured fact rather than a claim.
+    WHAT IT STILL MISSES is recorded by `test_the_remaining_misses`,
+    which is a strict xfail, so a recorded miss cannot quietly stop being
+    one.
     """
 
     @pytest.mark.parametrize("spelling", sorted(_MUST_CATCH))
@@ -477,12 +536,13 @@ class TestNoCallerCarriesItsOwnCopy:
         assert _getpgid_calls(owner.read_text(encoding="utf-8")) != []
 
     @pytest.mark.xfail(
-        strict=False,
+        strict=True,
+        raises=AssertionError,
         reason=(
-            "known misses, recorded rather than fixed. Marked xfail and "
-            "written the way a PASS should read, so strengthening the "
-            "resolver under #324 reports XPASS instead of breaking a test "
-            "that asserted the hole stays open."
+            "known misses, recorded rather than fixed. Written the way a "
+            "PASS should read, so strengthening the resolver under #324 "
+            "fails this test and forces the row into `_MUST_CATCH` rather "
+            "than leaving a stale note behind."
         ),
     )
     @pytest.mark.parametrize(
@@ -491,11 +551,20 @@ class TestNoCallerCarriesItsOwnCopy:
             'import os\npgid = getattr(os, "getpgid")(pid)\n',
             'import importlib\npgid = importlib.import_module("os").getpgid(pid)\n',
             'import os\nTABLE = {"f": os.getpgid}\npgid = TABLE["f"](pid)\n',
+            "import os\n\n\nclass G:\n    mod = os\n\n\npgid = G.mod.getpgid(pid)\n",
+            "import os\n\nhop, other = _resolve, None\n_resolve = os.getpgid\npgid = hop(1)\n",
         ],
     )
     def test_the_remaining_misses(self, spelling: str) -> None:
-        """Each needs value tracking through a string or a container,
-        which is where a per-file AST net stops being the right tool.
-        They are also spellings nobody reaches for by accident, unlike
-        the module alias that got through round 1."""
+        """Each needs something this resolver does not do: value tracking
+        through a string or a container, an attribute-to-module map, or
+        destructuring a tuple assignment. That is where a per-file AST net
+        stops being the right tool.
+
+        `strict=True` and `raises=AssertionError` together are what make
+        this a ratchet rather than a note. Round-2 review measured the
+        first version: with `strict=False` and no `raises`, XFAIL, XPASS
+        and a resolver that raises on entry were all green, so the record
+        could go stale in silence. Now closing a hole fails here, and
+        gutting the resolver fails here."""
         assert _getpgid_calls(spelling) != []

--- a/tests/test_safe_pgid.py
+++ b/tests/test_safe_pgid.py
@@ -1,0 +1,185 @@
+"""#308: the safe-pgid guard, tested once in the module that owns it.
+
+`procgroup.safe_pgid` is the one copy of a rule `serve._safe_pgid`,
+`verify._signal_process_group` and `agents.proc._signal_group` each wrote
+out for themselves. Driven over one matrix of pid / `getpgid` / `killpg`
+outcomes BEFORE the move, the three agreed on every safe-or-not decision
+and differed only in whether `getpgid`'s OSError escaped: serve let it
+out and both its call sites mapped it straight back to None, the other
+two swallowed it in place. So this file pins one decision table, not
+three, and each call site keeps its own test that it routes through here
+at all - the half a shared unit test cannot prove.
+
+WHY THIS IS NOT IN `tests/test_procgroup.py`, where it otherwise belongs.
+That file was at 798 lines. The `file-length-ratchet` hook fails a file
+that was at or under 800 lines and is now over, so folding these in took
+it to 929 and broke the commit. Merging the two files back together will
+break it again.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+from pathlib import Path
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kstrl import procgroup
+from tests.helpers import procs
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _popen_with_pid(pid: object) -> subprocess.Popen[str]:
+    fake = MagicMock(spec=subprocess.Popen)
+    fake.pid = pid
+    return cast("subprocess.Popen[str]", fake)
+
+
+class TestSafePgidIsTheOneCopyOfThePopenGuard:
+    """Every branch of the decision, negative cases and the control."""
+
+    def test_a_real_child_still_gets_its_group(self) -> None:
+        """The positive control. Every other test here asserts a None, so
+        a guard that rejected everything would pass all of them while
+        silently turning every group kill in the factory into a
+        direct-child kill that leaks the grandchildren it exists to
+        collect."""
+        child = subprocess.Popen(
+            ["sleep", "30"],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Read before the assertions, so a failure cannot leave the
+        # cleanup asking `getpgid` about a pid that has since gone.
+        pgid = os.getpgid(child.pid)
+        try:
+            assert pgid != os.getpgrp(), "start_new_session must give it its own"
+            assert procgroup.safe_pgid(child) == pgid
+        finally:
+            procs.kill_group(pgid)
+            child.kill()
+            child.wait(timeout=10.0)
+
+    def test_a_mocked_popen_is_refused(self) -> None:
+        """The CI-killer shape. A MagicMock pid does NOT raise TypeError
+        out of `getpgid`: it coerces to 1 through `MagicMock.__index__`
+        (measured on this machine, `os.getpgid(MagicMock())` returns 1),
+        and `killpg(1, sig)` is `kill(-1, sig)`."""
+        fake = _popen_with_pid(MagicMock())
+        # A plausible group, so the pgid checks cannot be what rejects it
+        # and only the isinstance check can.
+        with patch.object(os, "getpgid", lambda pid: 99999):
+            assert procgroup.safe_pgid(fake) is None
+
+    @pytest.mark.parametrize("bad_pid", [None, -1, 0, 1, True, "1234"])
+    def test_a_pid_that_cannot_own_a_group_is_refused(self, bad_pid: object) -> None:
+        """`True` is in here on purpose: `isinstance(True, int)` is True,
+        so `pid <= 1` is the only thing that rejects it."""
+        fake = _popen_with_pid(bad_pid)
+        with patch.object(os, "getpgid", lambda pid: 99999):
+            assert procgroup.safe_pgid(fake) is None
+
+    @pytest.mark.parametrize("broadcast", [-1, 0, 1])
+    def test_a_broadcast_pgid_is_refused(self, broadcast: int) -> None:
+        fake = _popen_with_pid(4242)
+        with patch.object(os, "getpgid", lambda pid: broadcast):
+            assert procgroup.safe_pgid(fake) is None
+
+    def test_our_own_group_is_refused(self) -> None:
+        """Signalling our own group kills the process doing the
+        signalling. Seeing ours back means `start_new_session` never took."""
+        fake = _popen_with_pid(os.getpid())
+        assert procgroup.safe_pgid(fake) is None
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ProcessLookupError(3, "no such process"),
+            PermissionError(1, "operation not permitted"),
+            OSError(5, "input/output error"),
+        ],
+    )
+    def test_a_failed_lookup_is_a_none_and_not_a_raise(self, exc: OSError) -> None:
+        """The one place the three copies differed. serve let `getpgid`
+        raise and both its call sites mapped it straight back to None, so
+        swallowing here is the same decision with less ceremony - and the
+        two callers that always swallowed keep the behaviour they had."""
+        fake = _popen_with_pid(4242)
+
+        def raiser(pid: int) -> int:
+            raise exc
+
+        with patch.object(os, "getpgid", raiser):
+            assert procgroup.safe_pgid(fake) is None
+
+    def test_a_platform_without_killpg_is_refused(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """POSIX gating. `getpgid` is absent on the same platforms as
+        `killpg`, and an absent one raises AttributeError, which no caller
+        catches - so the hasattr has to come BEFORE the lookup, not after."""
+        monkeypatch.delattr(os, "killpg")
+        monkeypatch.delattr(os, "getpgid")
+        fake = _popen_with_pid(4242)
+        assert procgroup.safe_pgid(fake) is None
+
+
+class TestNoCallerCarriesItsOwnCopy:
+    """The point of #308: a fourth site would be invisible to the above.
+
+    WHAT THIS NET SEES is an `os.getpgid(...)` call written as an
+    attribute on a name called `os`. That is how all three copies were
+    spelled and how a fourth would most likely be spelled. It does NOT
+    see `from os import getpgid` or a rebound module, which is a known
+    miss rather than a claim - the test below plants both spellings and
+    records which one is caught.
+    """
+
+    def _offenders(self, source: str) -> list[int]:
+        found: list[int] = []
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "getpgid"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "os"
+            ):
+                found.append(node.lineno)
+        return found
+
+    def test_no_module_outside_procgroup_derives_a_pgid(self) -> None:
+        owner = REPO_ROOT / "kstrl" / "procgroup.py"
+        offenders: list[str] = []
+        for path in sorted((REPO_ROOT / "kstrl").rglob("*.py")):
+            if path == owner:
+                continue
+            for lineno in self._offenders(path.read_text(encoding="utf-8")):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}")
+        assert offenders == [], (
+            "os.getpgid outside procgroup means a fourth copy of the guard; "
+            "call procgroup.safe_pgid instead"
+        )
+
+    def test_the_net_still_catches_the_spelling_all_three_copies_used(self) -> None:
+        """The control. Without this the test above passes on an empty
+        walk, a broken parse or a matcher that matches nothing."""
+        assert self._offenders("import os\npgid = os.getpgid(pid)\n") == [2]
+
+    def test_the_owner_is_the_only_file_excluded(self) -> None:
+        owner = REPO_ROOT / "kstrl" / "procgroup.py"
+        assert self._offenders(owner.read_text(encoding="utf-8")) != []
+
+    def test_a_bare_import_is_a_known_miss(self) -> None:
+        """Written down rather than fixed, so the net's reach is a
+        measured fact and not something a reader has to assume."""
+        assert self._offenders("from os import getpgid\npgid = getpgid(pid)\n") == []

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -29,6 +29,7 @@ from kstrl.agents.base import ARCHITECT_COMPONENT, ARCHITECT_ROLE
 from kstrl.findings import Finding
 from kstrl.inbox import Inbox, InboxConfig, ItemKind
 from kstrl.manifest import Component, ComponentStatus, Manifest
+from kstrl.procgroup import safe_pgid
 from kstrl.reducer import ComponentState, RunState
 from kstrl.serve import (
     BACKOFF_CAP_SECONDS,
@@ -1780,8 +1781,6 @@ class TestProcessGroupSupervision:
         so this was never silent overall - but this test did not pin
         what its name says.
         """
-        from kstrl.procgroup import safe_pgid
-
         fake = MagicMock()
         with (
             patch("kstrl.serve.safe_pgid", wraps=safe_pgid) as guard,

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -67,7 +67,6 @@ from kstrl.serve import (
     serve_lock,
     terminate_process_group,
 )
-from kstrl.serve import _safe_pgid as _safe_pgid_of
 
 #: Captured at import, BEFORE the autouse _no_spend fixture patches
 #: kstrl.serve.read_run_spend. A test that imports the name in its body
@@ -1766,35 +1765,35 @@ class TestProcessGroupSupervision:
     def test_a_mocked_popen_never_signals_a_broad_group(self) -> None:
         """killpg(1, sig) is kill(-1, sig): every process this user owns.
 
-        A mocked Popen's pid coerces to 1 via MagicMock.__index__, so the
-        pgid guard is what stops a test from signalling the whole session.
-        ``verify._signal_process_group`` documents the same rule; this
-        pins it for the serve runner too.
+        The guard itself moved to `procgroup.safe_pgid` in #308 and is
+        unit-tested there. What stays here is the half that move cannot
+        prove: that THIS caller still routes through it, so a mocked Popen
+        reaching `terminate_process_group` signals nothing at all.
         """
         from unittest.mock import MagicMock
 
-        from kstrl.serve import _safe_pgid
-
         fake = MagicMock()
-        # Force getpgid to return a plausible group so the pgid<=1 guard
-        # cannot be what rejects it; only the isinstance check can.
-        with patch("kstrl.serve.os.getpgid", return_value=99999):
-            assert _safe_pgid(fake) is None
-
         with patch("kstrl.serve.os.killpg") as killpg:
+            # A plausible group, so the pgid guard cannot be what rejects
+            # it and only the isinstance check can.
             with patch("kstrl.serve.os.getpgid", return_value=99999):
                 fake.poll.return_value = 0
                 assert terminate_process_group(fake).reaped is True
             assert killpg.call_count == 0, "must never signal a bogus group"
 
     def test_our_own_process_group_is_never_signalled(self) -> None:
+        """Same routing question for `terminate_process_group`'s lazy
+        lookup: a pid whose group is ours must come back as None, so the
+        function takes its no-pgid branch and signals nothing."""
         import subprocess as sp
 
         fake = MagicMock(spec=sp.Popen)
         fake.pid = os.getpid()
         fake.poll.return_value = None
-        # getpgid(our pid) == our group, which the guard must reject.
-        assert _safe_pgid_of(fake) is None
+        with patch("kstrl.serve.os.killpg") as killpg:
+            outcome = terminate_process_group(fake)
+            assert "no process-group id was available" in outcome.degraded
+            assert killpg.call_count == 0
 
     def test_the_supervised_timeout_reaps_descendants(
         self,
@@ -2253,7 +2252,12 @@ class TestARefusedSignalIsNotAnUnknown:
         """The other end of the same contract: `degraded` is empty only
         when the group was measured, and this path inspects no group."""
         fake = MagicMock(spec=subprocess.Popen)
-        fake.pid = os.getpid()  # our own group, which _safe_pgid refuses
+        # Our own group, which `procgroup.safe_pgid` refuses. Nothing here
+        # patches `killpg`, so this test is also the loudest proof the
+        # guard is live: with the own-group check removed it issues a real
+        # `killpg(<our pgid>, SIGTERM)` and kills the test runner (#308,
+        # measured - the run died on signal 15 during this test).
+        fake.pid = os.getpid()
         fake.poll.return_value = None
         result = terminate_process_group(fake)
         assert result.reaped is False

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1769,16 +1769,30 @@ class TestProcessGroupSupervision:
         unit-tested there. What stays here is the half that move cannot
         prove: that THIS caller still routes through it, so a mocked Popen
         reaching `terminate_process_group` signals nothing at all.
+
+        THE SPY IS LOAD-BEARING, not decoration. Round-1 review deleted
+        the `safe_pgid(process)` call from `terminate_process_group` and
+        this test stayed green: with no lookup, `pgid` is None, the
+        function takes its no-pgid branch, and "nothing was signalled" is
+        true for the wrong reason. Asserting the guard was ASKED is the
+        only thing here that tells the two apart. Complete removal of
+        signalling is still caught next door by the real-tree tests,
+        so this was never silent overall - but this test did not pin
+        what its name says.
         """
-        from unittest.mock import MagicMock
+        from kstrl.procgroup import safe_pgid
 
         fake = MagicMock()
-        with patch("kstrl.serve.os.killpg") as killpg:
+        with (
+            patch("kstrl.serve.safe_pgid", wraps=safe_pgid) as guard,
+            patch("kstrl.serve.os.killpg") as killpg,
+        ):
             # A plausible group, so the pgid guard cannot be what rejects
             # it and only the isinstance check can.
             with patch("kstrl.serve.os.getpgid", return_value=99999):
                 fake.poll.return_value = 0
                 assert terminate_process_group(fake).reaped is True
+            guard.assert_called_once_with(fake)
             assert killpg.call_count == 0, "must never signal a bogus group"
 
     # The own-group half of this routing question is

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1781,19 +1781,11 @@ class TestProcessGroupSupervision:
                 assert terminate_process_group(fake).reaped is True
             assert killpg.call_count == 0, "must never signal a bogus group"
 
-    def test_our_own_process_group_is_never_signalled(self) -> None:
-        """Same routing question for `terminate_process_group`'s lazy
-        lookup: a pid whose group is ours must come back as None, so the
-        function takes its no-pgid branch and signals nothing."""
-        import subprocess as sp
-
-        fake = MagicMock(spec=sp.Popen)
-        fake.pid = os.getpid()
-        fake.poll.return_value = None
-        with patch("kstrl.serve.os.killpg") as killpg:
-            outcome = terminate_process_group(fake)
-            assert "no process-group id was available" in outcome.degraded
-            assert killpg.call_count == 0
+    # The own-group half of this routing question is
+    # `TestARefusedSignalIsNotAnUnknown::test_a_missing_pgid_is_reported_as_unmeasured`,
+    # which builds the identical fake and asserts the identical outcome
+    # WITHOUT patching `killpg`. That makes it the stronger of the two, so
+    # #308 deleted the copy that used to live here rather than keep both.
 
     def test_the_supervised_timeout_reaps_descendants(
         self,


### PR DESCRIPTION
Closes #308.

Tidying, not a bug fix, exactly as the issue's own correction comment says. The
three-way diff below agrees with it: the copies had not drifted on any decision
any of them makes, so there is no bug narrative here and none has been
manufactured.

## 1. The three-way diff, measured before anything moved

The three copies were driven over one matrix of pid / `getpgid` / `killpg`
outcomes using the real production functions, not by reading them. `serve`
returns a pgid and the other two call `killpg`, so the comparable observable is
"which pgid, if any, was returned or reached `killpg`", plus whether the
direct-child fallback (`fb`) fired.

```
case                         | serve            | verify           | fb   | agents.proc      | fb
-------------------------------------------------------------------------------------------------
magicmock pid (coerces to 1) | pgid None        | pgid None        | term | pgid None        | term
pid None                     | pgid None        | pgid None        | term | pgid None        | term
pid 0                        | pgid None        | pgid None        | term | pgid None        | term
pid 1                        | pgid None        | pgid None        | term | pgid None        | term
pid -1                       | pgid None        | pgid None        | term | pgid None        | term
pid 2, pgid 99999            | pgid 99999       | pgid 99999       | -    | pgid 99999       | -
pid 2, pgid 1 (broadcast)    | pgid None        | pgid None        | term | pgid None        | term
pid 2, pgid 0                | pgid None        | pgid None        | term | pgid None        | term
pid 2, pgid -1               | pgid None        | pgid None        | term | pgid None        | term
pid 2, pgid == ours          | pgid None        | pgid None        | term | pgid None        | term
pid 2, getpgid ESRCH         | RAISED ProcessLookupError | pgid None | term | pgid None | term  <== serve/verify DIVERGE
pid 2, getpgid EPERM         | RAISED PermissionError    | pgid None | term | pgid None | term  <== serve/verify DIVERGE
pid 2, getpgid OSError       | RAISED OSError   | pgid None        | term | pgid None        | term  <== serve/verify DIVERGE
pid True (bool is an int)    | pgid None        | pgid None        | term | pgid None        | term
pid 2, killpg EPERM          | pgid 99999       | pgid 99999       | term | pgid 99999       | term

divergences: 3
```

Two findings, and one correction to the correction.

**A. `verify._signal_process_group` and `agents.proc._signal_group` were
behaviourally identical, whole function.** Zero divergences across all 15
inputs, including the fallback arm. The correction comment says "only the pgid
calculation is shared, not the whole function". That is true of the *three*-way
comparison, because `serve.terminate_process_group` genuinely has a different
shape (no direct-child fallback; it splits ESRCH from EPERM into a
`GroupTermination`). It understates the *two*-way one: for that pair the
fallback, the exception set and the SIGKILL/SIGTERM split were the same code
with different comments around it.

**B. `serve._safe_pgid` differed from both in the error CHANNEL only.** It let
`os.getpgid`'s `OSError` propagate where the other two swallowed it. The
safe-or-not DECISION was identical on every input, and the difference had no
consequence at either call site: `serve.py:1424` caught `OSError` and
`terminate_process_group` caught `(ProcessLookupError, OSError)`, which is the
same set written twice since both are `OSError` subclasses. Both mapped it
straight back to `None`.

So there was no semantic drift to report. The unified function takes the
swallowing form, which is the one decision this change had to make rather than
move, and it deletes both of serve's now-dead `try/except` wrappers. Re-running
the identical matrix afterwards gives **divergences: 0**, every cell unchanged
except the three `RAISED` ones becoming `pgid None`.

## 2. What changed

- **`kstrl/procgroup.py`** gains `safe_pgid(process) -> int | None`, delegating
  the broadcast rule to the existing `_may_signal_group` and adding the
  own-group exclusion on top. `_may_signal_group` stays a function of its own
  because `read_group_liveness` and `signal_probe_alive` take a bare pgid from
  anywhere; its docstring no longer claims the three copies are an unfixable
  convention.
- **`kstrl/serve.py`** loses `_safe_pgid` and both `try/except` wrappers.
- **`kstrl/verify.py`** and **`kstrl/agents/proc.py`** call `safe_pgid` and keep
  their own `killpg` in a `try`, so a refused signal still degrades to the
  direct child. Their `except (ProcessLookupError, PermissionError, OSError)`
  tuples collapse to `except OSError`: both are `OSError` subclasses, so this is
  the identical set, and a comment names ESRCH and EPERM so the documentation
  the tuple was carrying is not lost.
- **Tests.** Only `verify._signal_process_group` lacked coverage for its guard.
  `tests/test_hitl_env_scrub.py` gains a class for it. The decision table is
  pinned once in a new `tests/test_safe_pgid.py`, which also holds
  `_may_signal_group`'s tests (one rule, one file) and an AST net against a
  fourth copy. It is a separate file from `tests/test_procgroup.py` because that
  file was at 798 lines against a `file-length-ratchet` hook that fails a file
  crossing 800; the split is drawn at the seam between the `ps` READ and the
  SIGNAL guard, and leaves `test_procgroup.py` at 759 rather than 799.

## 3. Every guard was watched failing on the mutation it claims to catch

Eleven mutations, planted one at a time. Every run cleared `__pycache__` and ran
under `PYTHONDONTWRITEBYTECODE=1`, because CPython invalidates a `.pyc` on
mtime-seconds plus size and two same-size edits inside one second reuse the
stale one. The pytest child ran with `start_new_session=True`, which turned out
to matter. The sweep was re-run in full against the post-`/simplify` tree, since
both the gate and the tests moved; the numbers below are that second sweep.

| | mutation | caught by |
|---|---|---|
| MP1 | delete the pid guard | 10 tests across all four sites |
| MP2 | `pid <= 1` becomes `pid < 1` | `test_a_pid_that_cannot_own_a_group_is_refused[1]`, `[True]` |
| MP3 | drop the broadcast check | `test_a_broadcast_pgid_is_refused[-1,0,1]` |
| MP4 | drop the own-group check | the runner dying on signal 15 |
| MP5 | let `getpgid`'s OSError escape | `test_a_failed_lookup_is_a_none_and_not_a_raise[exc0,1,2]` + 2 real-tree tests |
| MP6 | check hasattr AFTER the lookup | `test_a_platform_without_the_syscalls_is_refused` |
| MP7 | reject every pgid | 5 tests, all of them positive controls |
| MV1 | lose the `else: return` | `test_a_group_signal_that_lands_does_not_also_signal_the_child` |
| MV2 | swap kill and terminate | `test_sigkill_uses_kill_and_sigterm_uses_terminate` + 4 |
| MV3 | a refused signal gives up | `test_a_refused_group_signal_still_tries_the_direct_child[exc0,1]` |
| MV4 | verify re-derives the pgid | `test_no_module_outside_procgroup_derives_a_pgid` + 4 |

`problems: 0`, no survivors.

### Exact failure text

MP4, dropping the own-group check, on the three call sites:

```
____ TestSafePgidIsTheOneCopyOfThePopenGuard.test_our_own_group_is_refused _____
        fake = _popen_with_pid(os.getpid())
>       assert procgroup.safe_pgid(fake) is None
E       AssertionError: assert 74018 is None
E        +  where 74018 = <function safe_pgid at 0x10766fec0>(<MagicMock spec='Popen' id='4420982624'>)

_ TestTheVerifySignalGuardRoutesThroughProcgroup.test_our_own_group_falls_back_to_the_direct_child _
>       assert killpg_calls == []
E       assert [(74018, <Sig....SIGKILL: 9>)] == []
E         Left contains one more item: (74018, <Signals.SIGKILL: 9>)

__ TestProcessGroupSupervision.test_our_own_process_group_is_never_signalled ___
>           assert "no process-group id was available" in outcome.degraded
E           AssertionError: assert 'no process-group id was available' in ''
E            +  where '' = GroupTermination(reaped=False, degraded='', occupied='').degraded
```

MV4, verify bypassing the guard:

```
_ TestTheVerifySignalGuardRoutesThroughProcgroup.test_a_mocked_popen_falls_back_to_the_direct_child _
    assert killpg_calls == []
E   assert [(99999, <Sig...SIGTERM: 15>)] == []
E     Left contains one more item: (99999, <Signals.SIGTERM: 15>)
```

MP1, deleting the pid guard, at the verify site:

```
_ TestTheVerifySignalGuardRoutesThroughProcgroup.test_an_unsignallable_pid_falls_back_to_the_direct_child[None] _
    assert killpg_calls == [], "kill(-1, sig) must never be issued"
E   AssertionError: kill(-1, sig) must never be issued
E   assert [(99999, <Sig...SIGTERM: 15>)] == []
```

MP7, the guard that refuses everything, against the positive control:

```
_ TestSafePgidIsTheOneCopyOfThePopenGuard.test_a_real_child_still_gets_its_group _
    assert procgroup.safe_pgid(child) == pgid
E   AssertionError: assert None == 77872
E    +  where None = <function safe_pgid at 0x108126480>(<Popen: returncode: None args: ['sleep', '30']>)
```

### Two results worth recording

**The pid check and the pgid check are each other's safety net.** Deleting the
pid guard alone leaves `test_mock_pid_falls_back_to_terminate` green, because
that test does not patch `getpgid`, so the mock's pid coerces to 1,
`os.getpgid(1)` returns 1 (measured on this machine), and the broadcast check
rejects it instead. That overlap is also what made planting MP1 safe to run at
all.

**Removing the own-group check does not fail a test, it kills the runner.** The
full sweep died on signal 15 during
`tests/test_serve.py::TestARefusedSignalIsNotAnUnknown::test_a_missing_pgid_is_reported_as_unmeasured`,
a pre-existing test that sets `fake.pid = os.getpid()` and deliberately does
**not** patch `killpg`, so without the guard it issues a real
`killpg(<our pgid>, SIGTERM)`. `start_new_session=True` on the pytest child is
what kept that inside the run. That test now says so in a comment, and it is why
the duplicate own-group test this PR briefly added to `test_serve.py` was
deleted again rather than kept: the older one is the stronger of the two.

## 4. `/simplify` findings, verbatim

Four independent reviewers. Every finding is reproduced below in full, applied
or declined.

### Reuse

> **1. `kstrl/verify.py:106` and `kstrl/agents/proc.py:184` - the two signal-group functions are now byte-identical, and the diff edits both by hand**
>
> `verify._signal_process_group` and `DeadlineStreamer._signal_group` are the same 14-line body modulo `proc` vs `self._proc`: `safe_pgid` -> `try: os.killpg` -> `except OSError: pass` -> `else: return` -> `if sig == SIGKILL: kill() else terminate()` -> `except OSError: pass`. #308 extracted the guard but left the wrapper duplicated. The cost is demonstrated inside this very diff: both copies were narrowed from `except (ProcessLookupError, OSError)` to `except OSError`, and both grew the identical `else: return` arm, in two separate hunks. `kstrl/procgroup.py` has no such function (surface is `_may_signal_group`, `safe_pgid`, `read_group_liveness`, `signal_probe_alive`, `_kernel_says_group_is_empty`); the extraction should have gone one level further: `procgroup.signal_group_or_child(process, sig)` called from both. Two copies of the SIGKILL/terminate mapping and of the error family to keep in step, plus the two duplicated test classes in finding 2.
>
> **2. `tests/test_hitl_env_scrub.py:374` - the new test class duplicates `TestSignalGroupSafety` at `tests/test_timeout_enforcement.py:378` test-for-test**
>
> Same fake-proc builder, same `[None, -1, 0, 1]` parametrize (new one adds `True`), same "MagicMock pid coerces to 1" case, same own-group case, same `killpg_calls == []` + `terminate.assert_called_once()` assertions. Because the two production bodies are identical (finding 1), the two classes exercise the same code twice. And `safe_pgid`'s full decision table is now pinned a third time in `tests/test_safe_pgid.py`. The routing claim the new class exists to make ("this call site still goes through the guard") needs one test, not the re-parametrised matrix. Cost: one decision table maintained in three files, so a change to the guard means three test edits.
>
> **3. `tests/test_hitl_env_scrub.py:404` - hand-rolled pidfile wait loop instead of `tests.helpers.procs.read_pid`**
>
> ```python
> deadline = time.monotonic() + 10.0
> while not pid_file.exists() and time.monotonic() < deadline:
>     time.sleep(0.05)
> grandchild = int(pid_file.read_text().strip())
> ```
> `procs.read_pid(pid_file, timeout=10.0)` is exactly this, and additionally waits out the exists-but-still-empty window (`> pid_file` creates the file on the redirect and fills it a moment later) that this loop does not. `tests/test_timeout_enforcement.py:50` already imports it for the same `sleep 300 & echo $! > pidfile; wait` fixture. `tests/test_hitl_env_scrub.py` does not import `tests.helpers.procs` at all. Cost: a second, weaker copy of a read the helper module was created to own. Related: that shell string is now written three times in this one file (`:354`, `:366`, `:399`).
>
> **4. `tests/test_safe_pgid.py:52` - hand-rolled "spawn a session leader, take its pgid, tear it down"**
>
> The `subprocess.Popen(["sleep","30"], start_new_session=True, stdout=DEVNULL, stderr=DEVNULL)` + `os.getpgid` + `finally: kill_group / kill / wait` block already exists as the body of `tests/helpers/procs.py:319 dead_group()` (that spawn plus the kill), and is copied at `tests/test_serve.py:2220` and `tests/test_process_scoping.py:247`. `dead_group`'s own docstring argues the case: "Lives here rather than being copied into each suite because a copied fixture is one that stops matching the helper it feeds." The missing helper is a `live_group()` contextmanager next to `dead_group` yielding `(Popen, pgid)` with the cleanup; this makes the fourth copy.
>
> **5. `tests/test_safe_pgid.py:134` - the AST net re-rolls scaffolding that `tests/test_procgroup.py` already carries for the same owner file**
>
> `tests/test_procgroup.py:673-757` has `_callee_name`, `_call_arguments`, `_scannable_sources()` (over `_SCANNED_ROOTS = ("kstrl","tests")`), and the exact "skip `_PS_OWNER = "kstrl/procgroup.py"`, collect `f"{rel}:{lineno}"`, assert `offenders == []`, plus an owner-still-matches control" loop. The new `_offenders` + rglob loop + `test_the_owner_is_the_only_file_excluded` re-implements every piece for `os.getpgid`, over the same owner module, with narrower reach (kstrl only, not tests).
>
> Direct answer to the question you asked: **there is no shared AST-walk helper in `tests/`; every net rolls its own.** `tests/test_atomicio.py:377` (`_called_names`), `tests/test_process_scoping.py:83-115` (`_is_subprocess_call`/`_command_literals`/`_scannable_sources`), `tests/test_toml_readers.py:140+`, `tests/test_timeout_enforcement.py:1118-1335` (`_wait_calls`/`_subprocess_aliases`/`_spawn_sites`) and `tests/test_procgroup.py:673-714` each carry their own callee matcher and source sweep. So this is the sixth roll, and the nearest one lives in the file that owns the same module. Minimum reuse: import `_callee_name`/`_scannable_sources` from `test_procgroup`, or hoist them to a `tests/helpers/` module now that there are six callers. Also `REPO_ROOT` at `tests/test_safe_pgid.py:34` is the fifth copy of `Path(__file__).resolve().parent.parent` (`tests/conftest.py:31`, `test_safemode.py:23`, `test_procgroup.py:40`, `test_progress_scope.py:1181`).
>
> **6. `tests/test_safe_pgid.py:37` and `tests/test_hitl_env_scrub.py:384` - the same fake-Popen builder added twice in one diff**
>
> `_popen_with_pid` and `_fake_proc` are both `MagicMock(spec=subprocess.Popen)` + `.pid = pid`. `tests/test_serve.py:1790` and `:2254` build it inline as well. One helper in `tests/helpers/procs.py` covers all four; the `cast` in the new one is the only difference.
>
> Non-finding I checked and am not reporting: `safe_pgid` tests `hasattr(os, "killpg")` and then calls `_may_signal_group`, which tests it again. That is a deliberate gate before `getpgid` (documented in the comment), not a duplicated rule.

### Simplification

> **1. `kstrl/verify.py:106-133` and `kstrl/agents/proc.py:184-209` are now byte-identical logic under two names**
>
> The diff converged them: same `safe_pgid` call, same `try/except OSError: pass / else: return`, same `SIGKILL -> kill() else terminate()` fallback, same `except OSError: pass`. The only difference is `proc` vs `self._proc`, and both are `subprocess.Popen[str]` (proc.py builds its with `text=True` at line 94). Before the diff they differed in comment text; now nothing distinguishes them.
>
> The "different Popen holders" objection does not hold: `_signal_group` reads nothing off `self` but `self._proc`. Simpler form: `procgroup.signal_group_or_child(proc: subprocess.Popen[str], sig: signal.Signals) -> None` next to `safe_pgid` (procgroup needs one new `import signal`); `verify._signal_process_group` disappears entirely and `_signal_group` becomes a one-line delegator, or the two `self._signal_group(...)` calls in `kill()` (proc.py:152, 156) call it directly.
>
> Cost as it stands: ~16 lines of body plus two separately-worded explanations of the same fallback, in a change whose stated purpose is removing a rule written three times. #308 unified the guard and left the caller shape duplicated twice.
>
> **2. `kstrl/procgroup.py:279` and `:287` - the `hasattr(os, "killpg")` check runs twice, and the second can never fire**
>
> Line 279 gates on `killpg`; line 287 calls `_may_signal_group(pgid)`, which is `hasattr(os, "killpg") and pgid > 1`. Reaching 287 already proves the hasattr. The comment at 277-278 exists only to explain why a `killpg` check is standing in for the `getpgid` call it actually protects.
>
> Simpler form that keeps every semantic and drops the redundancy: gate line 279 on `hasattr(os, "getpgid")` (the call it guards), leave the `killpg` gate to `_may_signal_group` (the call *it* guards). Each hasattr then sits next to its own call, the 277-278 comment becomes unnecessary, and `test_a_platform_without_killpg_is_refused` (tests/test_safe_pgid.py, deletes both attrs) still passes unchanged.
>
> Cost: a reader has to derive that one of two identical predicates is dead on this path, and a two-line comment is spent papering over the mismatch.
>
> **3. `kstrl/agents/proc.py:185-191` - the comment restates `safe_pgid`'s docstring**
>
> "a mocked Popen, whose pid coerces to 1 via MagicMock.__index__ rather than raising, making killpg(1, sig) into kill(-1, sig)... once took down the whole CI runner" is paragraph 2 of `procgroup.safe_pgid`'s docstring (procgroup.py:266-273), written again in a function that no longer implements that rule. `verify.py:109-115` does this correctly: it names `safe_pgid` as the owner and explains only what the None means *here*.
>
> Simpler form: keep the first sentence (routing), drop the rationale, matching verify. Cost: two copies of one rationale to keep in step, which is the exact failure mode #308 was opened to remove.
>
> **4. `tests/test_hitl_env_scrub.py:417-456` - `safe_pgid`'s decision table is re-pinned at the call site**
>
> `test_an_unsignallable_pid_falls_back_to_the_direct_child` (the `[None, -1, 0, 1, True]` parametrize), `test_a_mocked_popen_falls_back_to_the_direct_child` and `test_our_own_group_falls_back_to_the_direct_child` are the same three cases as `tests/test_safe_pgid.py::test_a_pid_that_cannot_own_a_group_is_refused` / `test_a_mocked_popen_is_refused` / `test_our_own_group_is_refused`, re-asserted through verify. `test_sigkill_uses_kill_and_sigterm_uses_terminate` (line 458) also re-covers the `pid=1 -> terminate` case the parametrize already covers.
>
> The file's own rationale is that each call site should prove it *routes through* the guard. One negative case proves routing; three do not prove more. The genuinely site-specific tests here are the real-tree control (389), the `except` arm (477) and the `else: return` arm (495), and those should stay.
>
> Simpler form: keep one negative routing case (the own-group one, since it needs no patching) and drop the other two plus the redundant SIGTERM half of 458. Cost: ~30 lines, and a decision table now pinned in two files, so widening it later fails in both.
>
> **5. `tests/test_serve.py:1784-1796` - the rewritten `test_our_own_process_group_is_never_signalled` duplicates `test_a_missing_pgid_is_reported_as_unmeasured` at 2251-2264**
>
> Same construction (`MagicMock(spec=Popen)`, `pid = os.getpid()`, `poll -> None`), same call, same two assertions (`degraded` contains "no process-group id", nothing signalled). The older one's comment explicitly argues that *not* patching `killpg` is the point ("the loudest proof the guard is live"); the new one patches it. So the file now holds two tests of one input taking opposite positions on how to test it.
>
> Simpler form: delete the new one, or fold its extra intent into the existing test. Also in the same block:
> - 1779: `patch("kstrl.serve.os.getpgid", ...)` names a module that no longer performs the lookup (it works only because it mutates the shared `os` module). `patch.object(os, "getpgid", ...)` says what is actually happening.
> - 1773 `from unittest.mock import MagicMock` and 1788 `import subprocess as sp` are function-local imports of names already imported at module level (lines 24 and 18). The diff edited both blocks and removed the neighbouring local `from kstrl.serve import _safe_pgid` but left these.
>
> Cost: two tests that must be edited together, plus a patch target that misdirects the reader about which module calls `getpgid`.
>
> **6. `kstrl/procgroup.py:262-268`, `tests/test_safe_pgid.py:3-10`, `tests/test_safe_pgid.py:64-69` - the "three copies agreed, differed only in the error channel" paragraph is written three times**
>
> Verbatim in substance in all three places (`serve` let `getpgid` raise, its call sites mapped it back to None, the other two swallowed). Simpler form: keep it in the `safe_pgid` docstring, which is where a reader of the code will land, and let the two test docstrings point at it. The same is true of `_may_signal_group`'s "nothing enforces that THEIR callers came through `safe_pgid`" sentence (procgroup.py:238-240), copied into `tests/test_procgroup.py:173-176`.
>
> Cost: one design rationale in three places; the next change to it will update some and not others.
>
> Nothing found that qualifies as dead code left in `kstrl/serve.py` after `_safe_pgid` was deleted - `os`, `subprocess` and `signal_probe_alive` all still have live uses, and ruff is clean.

### Efficiency

> **1. `tests/test_safe_pgid.py:160` (`test_no_module_outside_procgroup_derives_a_pgid`) - adds a 14th independent full read+parse of `kstrl/`.**
> Measured: `kstrl/` is 127 `.py` files / 2.55 MB / 236,452 AST nodes. One read + `ast.parse` + `ast.walk` pass costs **167-173 ms** (min of 5). The test's own pytest duration is **0.17 s**, matching. That parse is not new work in kind: `tests/test_procgroup.py::TestOnlyOneModuleShellsOutToPs::test_no_second_ps_call_exists` (**0.51 s**) already reads and parses exactly the same 127 files in the same session, and 12 other test modules run their own whole-tree walks (`test_atomicio`, `test_process_scoping`, `test_prompt_enrollment_walk`, `test_tui_config_walk`, `test_state_dir_scope`, `test_check_name_enrolment`, `test_config_preflight`, ...). Running those 12 files together: **14.47 s for 410 tests**, dominated by the walks. Only the `getpgid` matcher in `_offenders` is new; the read and parse are duplicated. A session-scoped fixture handing out `{path: parsed AST}` would drop the marginal cost of this net (and each future one) from ~170 ms to the walk alone. Marginal cost this diff adds: **+0.17 s** to the suite. The pattern is pre-existing, so this is the diff extending it, not introducing it.
>
> **2. `tests/test_hitl_env_scrub.py:413` - the `finally` reaps only the direct child, so a failing run orphans `sleep 300` for five minutes.**
> `proc.kill(); proc.wait()` kills the `sh`; the backgrounded `sleep 300` survives if the group kill under test did not land, which is precisely the case the test exists to catch. `tests/test_safe_pgid.py:52` in this same diff does the cheaper thing (`procs.kill_group(pgid)` before `child.kill()`). Low severity: the pre-existing `TestProcessGroupKill` tests in this file use the same `sleep 300` with no group cleanup at all, so the new test is no worse than its neighbours, and it at least reaps the direct child.
>
> ## Checked and clear (numbers, so you know it was measured, not assumed)
>
> **Import cost of `from kstrl.procgroup import safe_pgid` in `kstrl/agents/proc.py:27` - no measurable startup cost.**
> `procgroup` imports only `os`, `subprocess`, `contextlib`, `dataclasses`, all already in `sys.modules` on the CLI path before `verify` is reached, so it pulls in **zero new modules**. Its own load costs **1.20 ms cold** (mean of 10, no `.pyc`) and **0.65 ms warm** (mean of 10, `.pyc` present), once per process. A/B of `import kstrl.cli` against a worktree at `HEAD~1` (n=25, repeated twice, cold): before median 218.0 / 219.2 ms, after median 219.2 / 219.9 ms; before mean 220.2 / 219.7 ms, after mean 219.8 / 218.5 ms. The sign of the delta flips between repeats, so it is inside run-to-run noise on a 219 ms startup. Worth recording: `kstrl.procgroup` was **not** on the CLI import path before this change (317 modules loaded) and is now (318) - but it arrives via `verify.py:51`, which the CLI imports, not via `agents/proc.py`. `procgroup` has no module-level work beyond constants and two frozen dataclasses.
>
> **Per-call overhead of `safe_pgid` versus the three originals - +24.6 ns, negligible.**
> `timeit`, n=200,000, against a real `sleep 5` child: `safe_pgid` **306.4 ns/call** vs a hand-inlined copy of the old `serve._safe_pgid` **281.9 ns/call**. `kstrl/procgroup.py:279` and `:248` do evaluate `hasattr(os, "killpg")` twice per call (once in `safe_pgid`, again inside `_may_signal_group`) - the `hasattr` measures **22.3 ns** and the extra nested call **38.4 ns**. For scale, the `os.getpgid` syscall that immediately follows is **125.4 ns**, and the function runs a handful of times per process (once per supervised spawn, once per timeout kill). Not worth collapsing.
>
> **`test_a_real_child_still_gets_its_group` (`sleep 30`) - keep it as is.** Whole-test duration **0.02 s**, call phase under 5 ms. A real fork/exec is not costing anything here, and the codebase's preference for real-process controls is satisfied for free.
>
> **`test_a_real_group_is_signalled_grandchild_and_all` polling - bounded and cheap.** 10 s deadline, 0.05 s interval, one `stat` + one `read_text` per poll; measured whole-test duration **0.17 s**, so it exits after ~2-3 polls in practice. (Side note outside my angle: `tests/helpers/procs.read_pid` already implements this loop and also tolerates the created-but-empty-file window.)
>
> **No new retention.** The diff adds no closures, no captured environments, and nothing that feeds `procgroup._ABANDONED`; `safe_pgid` holds no reference past its return.

### Altitude

> **1. `kstrl/verify.py:106` and `kstrl/agents/proc.py:184` - the un-extracted remainder is not "only the calculation", it is the whole function, character for character.**
>
> I normalised both bodies and diffed them: after `safe_pgid` lands, the 14 lines following it are byte-identical modulo `proc` vs `self._proc`. Not similar - identical. The issue's own correction ("only the pgid calculation is shared, not the whole function") is true of the *three*-way comparison, because `serve.terminate_process_group` genuinely has a different shape: no direct-child fallback, and it splits ESRCH from EPERM into a `GroupTermination` rather than swallowing. It understates the *two*-way one.
>
> Both sides, since you asked for them:
>
> - *Stop here.* `procgroup` today is a measurement module. Every public function answers a question (`read_group_liveness`, `signal_probe_alive`, `safe_pgid`); the only signal it sends is signal 0. Moving `signal_group_or_child` in widens the charter from "answer questions about groups" to "kill things", and the 176-line module docstring is built entirely around the discipline of answering. The task said not to manufacture scope, and the issue set the scope.
> - *Go further.* The remaining 14 lines encode a policy, not plumbing: a group signal that raises degrades to the direct child, and `SIGKILL -> kill()` else `terminate()`. That is exactly as easy to get wrong as the pgid rule, and it was exactly as untested at `verify` before this change (zero tests) as the pgid rule was. The repo's standing argument - "if there is no mechanism, there is no plan" - applies unchanged: nothing stops a third caller writing the fallback with `except (ProcessLookupError, OSError)` and no `else: return`, which is the shape both sites had two commits ago.
>
> **Recommendation:** file the follow-up, do not widen this PR. Two reasons it is a follow-up and not a gap here: the issue scoped it, and the move needs a decision about `procgroup`'s charter that this diff should not be making silently. But record in the follow-up that the code is already identical text, so it is a move, not a design. Concrete cost of leaving it: two copies of a 14-line policy, each with its own hand-written comment block explaining the same `except OSError` fall-through, and two independent test suites pinning it (7 new tests in `test_hitl_env_scrub.py`, 3 existing in `test_timeout_enforcement.py`).
>
> **2. `kstrl/procgroup.py:231` - the visibility is inverted relative to the argument the docstring makes.**
>
> `_may_signal_group(pgid)` is private; `safe_pgid(process)` is public. Its docstring argues, correctly, that it must exist separately because "nothing enforces that THEIR callers came through `safe_pgid`". But `serve.terminate_process_group` takes `pgid: int | None = None` as a public parameter and issues `os.killpg(pgid, sig)` at `kstrl/serve.py:1544` on a pgid it did not compute. That is the one bare-pgid signaller in the tree outside `procgroup`, it is guarded by provenance alone, and the leading underscore is what stops it using the mechanism. The module's own thesis is that provenance-by-convention is not a mechanism, so the layering enforces the thing the docstring says is not good enough. Cost: `terminate_process_group(proc, pgid=1)` is a broadcast that no mechanism refuses, and the only fix available to a `serve` maintainer is to re-derive the rule - the fourth copy #308 exists to prevent. Making `_may_signal_group` public and calling it at `serve.py:1544` is a one-line change.
>
> **3. `tests/test_safe_pgid.py:1` - "the ratchet made me" is a symptom, and the split was drawn around the new code rather than on a seam that exists.**
>
> The file's docstring is honest about the reason, which is worth something. But the diff leaves `tests/test_procgroup.py` at 799 lines against an 800 ceiling that fails on at-or-under -> over: one line of headroom, and the next two-line edit trips it. The change documents the trap instead of relieving it.
>
> There is a real seam in `test_procgroup.py` and the split did not use it. `TestTheGroupIdIsGuardedBeforeAnySignal` (169), `TestTheKernelControl` (208) and `TestTheSignalProbeIsKeptAsTheDegradedReading` (531) are the signalling half, ~258 lines; everything else is the `ps` read. Lifting those three into the new file leaves the `ps` file at ~540 with room to grow and puts `safe_pgid`'s tests next to `_may_signal_group`'s - which matters, because `safe_pgid` *calls* `_may_signal_group` and their tests are now in different files. It would also co-locate the two AST ownership nets (`TestOnlyOneModuleShellsOutToPs` at 717, `TestNoCallerCarriesItsOwnCopy` in the new file), which currently enforce the same "procgroup owns this syscall" rule from two files, leaving a third net with no obvious home. Cost as it stands: one guard's tests in two files, one module's nets in two files, and a 799-line file still one edit from the hook.
>
> **4. `tests/test_hitl_env_scrub.py:417,431,446` - the new caller suite re-derives the decision table the unification just made single-copy.**
>
> `test_an_unsignallable_pid_falls_back_to_the_direct_child` (parametrized over `[None, -1, 0, 1, True]`), `test_a_mocked_popen_falls_back_to_the_direct_child` and `test_our_own_group_falls_back_to_the_direct_child` are the same inputs and the same decisions as `test_safe_pgid.py`'s `test_a_pid_that_cannot_own_a_group_is_refused`, `test_a_mocked_popen_is_refused` and `test_our_own_group_is_refused`. Routing is proved by one negative case; these are three. The same diff shows the correct pattern one file over: `tests/test_serve.py` was *trimmed* from asserting `_safe_pgid(fake) is None` down to asserting only that `terminate_process_group` signals nothing. `verify` went the other way. The class is named `...RoutesThroughProcgroup`, and four of its seven tests do route-test; three test the table. Cost: the decision table now has two copies to keep in step, which is the duplication #308 closed, reopened one layer up in the tests.
>
> ## Considered and not reported
>
> `safe_pgid` swallowing `getpgid`'s `OSError` is at the right level. Both `serve` call sites mapped the exception straight back to `None`, so pushing the swallow inward deleted two `try/except` blocks and changed no behaviour; `test_a_failed_lookup_is_a_none_and_not_a_raise` pins it. The one wrinkle - `None` now means both "unsafe to signal" and "lookup failed", in a module whose `GroupLiveness` exists precisely because collapsing "cannot measure" into a boolean was #298 - does not cost anything, because no caller acts differently on the two and `serve`'s `degraded` string ("no process-group id was available") is true of both.

### Disposition

**Applied** (second commit):

- Simplification 2. `safe_pgid` now gates on `hasattr(os, "getpgid")`, the call
  it actually protects, and leaves `killpg` to `_may_signal_group`. The
  papering-over comment is gone. Its test deletes both attributes, so it still
  passes and the mutation that moves the check after the lookup is still caught.
- Simplification 5. The duplicate `test_our_own_process_group_is_never_signalled`
  is deleted; a comment records that the survivor is stronger because it does
  not patch `killpg`, which the mutation sweep then demonstrated by killing the
  runner. The `patch("kstrl.serve.os.getpgid")` and local-import sub-points went
  with the deleted test.
- Simplification 3. `agents/proc`'s comment trimmed to the routing claim.
- Simplification 4 and 6, Reuse 2, Altitude 4. The verify class keeps its four
  site-specific tests plus two routing cases and no longer re-pins the decision
  table. Two rather than the recommended one, because the two kept are the two
  incidents that actually happened: a mocked Popen took down a CI runner, and
  the own-group case kills the run doing the signalling. Duplicated rationale
  paragraphs in the test docstrings now point at `safe_pgid`'s.
- Reuse 3 and Efficiency 2. `procs.read_pid` replaces the weaker pidfile poll,
  and the cleanup is `procs.kill_group(pgid)` before the direct child, so a
  failing run no longer orphans `sleep 300` for five minutes.
- Reuse 6. `procs.fake_popen(pid)` in `tests/helpers/procs.py`, used by both new
  suites.
- Altitude 3, in a targeted form. `_may_signal_group`'s tests moved next to
  `safe_pgid`'s, since `safe_pgid` calls it and one rule split across two files
  drifts. `tests/test_procgroup.py` is now 759 lines rather than 799, so the
  ratchet pressure is relieved and not merely documented. The other two classes
  the reviewer named stayed put: `TestTheKernelControl` and
  `TestTheSignalProbeIsKeptAsTheDegradedReading` are about the `ps`-versus-probe
  reading, which is that file's subject.

**Declined:**

- Reuse 1 / Simplification 1 / Altitude 1, folding the whole
  signal-group-else-child wrapper into `procgroup`. Three reviewers raised it
  and all three are right that the two bodies are identical text. Declined here
  on the altitude reviewer's own recommendation: the issue scoped this change to
  the pgid calculation, and moving the wrapper widens `procgroup` from a module
  that answers questions to one that sends real signals. That is a charter
  decision, and a PR whose job was to move a rule should not make it silently.
  **Recommended follow-up**, and worth recording in it that the code is already
  identical text, so it is a move rather than a design.
- Altitude 2, guarding `serve.terminate_process_group`'s caller-supplied `pgid`
  through a public `may_signal_group`. This is the most valuable thing the
  review found and it is a genuine hole: that parameter is the one bare-pgid
  signalling path outside `procgroup` and nothing but provenance protects it.
  Declined because it is a behaviour change, not a cleanup: it needs a decision
  about what `terminate_process_group` should RETURN when handed an unsafe pgid,
  and `/simplify` is explicitly quality-only. **Recommended follow-up, and the
  one I would file first.**
- Reuse 4, a `live_group()` contextmanager. Correct in principle and
  `dead_group`'s docstring argues for it, but with the cleanup fix applied this
  diff has one caller; making it a helper means also converting
  `test_serve.py:2220` and `test_process_scoping.py:247`, which are outside this
  change.
- Reuse 5, hoisting the AST-walk scaffolding. The reviewer confirmed there is no
  shared helper and that six suites each roll their own. Consolidating six files'
  worth of nets is its own change; the new one is 20 lines and carries a control
  test and a written-down known miss, which is more than most of the other five
  have.
- Efficiency 1, a session-scoped parsed-AST fixture. The +0.17 s is real and the
  reviewer is right that it is the fourteenth full parse, but the fix is a
  repo-wide fixture serving 13 pre-existing callers, not something this diff
  should introduce alone.

## Verification

- `uv run pytest tests/` : **4674 passed, 28 skipped**
- `uv run mypy kstrl/ --strict` : **no issues in 127 source files**
- `uv run ruff check kstrl/ tests/` : **all checks passed**
- `uv run pre-commit run` (staged) : **all hooks pass**, including
  `file-length-ratchet`, `cyclomatic-ratchet`, `vulture`, `no-mocks-in-production`
  and `no-em-dash`
- Mutation sweep against the shipped tree: **11 planted, 11 caught, 0 survivors**

---

# Round 2

Review round 1 verified the behaviour work independently: a 15-case old-vs-new
matrix with zero disagreements, and the signal-15 finding reproduced at return
code -15. It returned one P2 and two test gaps. All three are addressed below.

## 0. Framing correction: this guard is defence in depth, not a live bug

Round-1 review pointed out that the PR reads as though it patches something
currently broken. It does not, and the body should say so.

I verified this rather than taking it on trust. `kstrl/` holds four
`subprocess.Popen` constructions. The three whose children can reach
`safe_pgid` all pass `start_new_session=True`:

| constructor | flag | reaches the guard at |
|---|---|---|
| `kstrl/serve.py:1408` | `start_new_session=True` on line 1417 | `serve.py:1424`, `serve.py:1524` |
| `kstrl/verify.py:156` | `start_new_session=True` on line 164 | `verify.py:117`, through the `_signal_process_group` calls on lines 169 and 177 |
| `kstrl/agents/proc.py:94` | `start_new_session=True` on line 102 | `agents/proc.py:189` |

The fourth is `procgroup._read_ps` at `kstrl/procgroup.py:334`. It omits
`start_new_session` deliberately, documented in its own docstring, so the `ps`
child stays in the caller's group. Its process never reaches `safe_pgid`;
`_kill_or_abandon` signals that child directly.

So on today's code no `safe_pgid` path can return pgid 0 or the caller's own
group. **The pgid-0 and own-group refusals are defence in depth against a
future constructor that drops the flag, not a fix for a live defect.**

The one present-tense behaviour change in this PR is still the one section 1
measured: `verify._signal_process_group` did not have the pid guard or the
own-group check, and now does. That is the divergence, and it is why this PR
is a behaviour change at all rather than pure tidying.

## 1. F1: the fourth-copy net missed four spellings (fixed, then fixed again)

Round-1 review planted a complete, working fourth copy of the guard behind
`import os as operating_system` and the shipped net let it through. The net
matched the literal shape `os.getpgid(...)` and nothing else.

The net now resolves bindings before it matches: module aliases, module
rebinds, from-imports, and assignment chains to a fixed point.

**The round-2 `/simplify` pass then defeated the round-2 net the same way.**
It planted a fourth guard behind `_o = os` and watched it go through: the
resolver handled a rebound CALLABLE and not a rebound MODULE, while three
docstrings said it did both. Two characters. That fix is `a1d4155`, the
planted form is the fifth in the table below, and it is the sharpest evidence
in this PR for the #324 argument below: a guard repaired once was holed
again on the next rung, by the next reviewer, inside one PR.

### The exact failure text, one form at a time

Each form is a complete working fourth guard written into
`kstrl/fourth_copy_probe.py` and run against the net alone. Every run cleared
`__pycache__` first and set `PYTHONDONTWRITEBYTECODE=1`.

The failure body is identical for all five apart from the offending line
number, so it is shown in full once and by its differing lines after that.

**Form 1, module alias.** The one that beat the shipped net.

```python
import os as operating_system
...
    pgid = operating_system.getpgid(pid)
```

```
_ TestNoCallerCarriesItsOwnCopy.test_no_module_outside_procgroup_derives_a_pgid _

self = <tests.test_safe_pgid.TestNoCallerCarriesItsOwnCopy object at 0x10b4cc530>

    def test_no_module_outside_procgroup_derives_a_pgid(self) -> None:
        owner = REPO_ROOT / "kstrl" / "procgroup.py"
        offenders: list[str] = []
        for path in sorted((REPO_ROOT / "kstrl").rglob("*.py")):
            if path == owner:
                continue
            for lineno in _getpgid_calls(path.read_text(encoding="utf-8")):
                offenders.append(f"{path.relative_to(REPO_ROOT)}:{lineno}")
>       assert offenders == [], (
            "deriving a process-group id outside procgroup is how a fourth "
            "copy of the safe-pgid guard starts; call procgroup.safe_pgid"
        )
E       AssertionError: deriving a process-group id outside procgroup is how a fourth copy of the safe-pgid guard starts; call procgroup.safe_pgid
E       assert ['kstrl/fourt..._probe.py:13'] == []
E         
E         Left contains one more item: 'kstrl/fourth_copy_probe.py:13'
E         Use -v to get more diff

tests/test_safe_pgid.py:468: AssertionError
=========================== short test summary info ============================
FAILED tests/test_safe_pgid.py::TestNoCallerCarriesItsOwnCopy::test_no_module_outside_procgroup_derives_a_pgid
1 failed in 0.26s
```

**Form 2, `from os import getpgid`.**

```python
from os import getpgid, getpgrp
...
    pgid = getpgid(pid)
```

```
E       AssertionError: deriving a process-group id outside procgroup is how a fourth copy of the safe-pgid guard starts; call procgroup.safe_pgid
E       assert ['kstrl/fourt..._probe.py:13'] == []
E         
E         Left contains one more item: 'kstrl/fourth_copy_probe.py:13'
E         Use -v to get more diff
```

**Form 3, callable rebind.**

```python
_lookup = os.getpgid
...
    pgid = _lookup(pid)
```

```
E       AssertionError: deriving a process-group id outside procgroup is how a fourth copy of the safe-pgid guard starts; call procgroup.safe_pgid
E       assert ['kstrl/fourt..._probe.py:15'] == []
E         
E         Left contains one more item: 'kstrl/fourth_copy_probe.py:15'
E         Use -v to get more diff
```

**Form 4, rebound class attribute.**

```python
class GroupLookup:
    resolve = os.getpgid
...
    pgid = GroupLookup.resolve(pid)
```

```
E       AssertionError: deriving a process-group id outside procgroup is how a fourth copy of the safe-pgid guard starts; call procgroup.safe_pgid
E       assert ['kstrl/fourt..._probe.py:17'] == []
E         
E         Left contains one more item: 'kstrl/fourth_copy_probe.py:17'
E         Use -v to get more diff
```

**Form 5, module rebind.** The one that beat the round-2 net, found by this
PR's own `/simplify` pass rather than by the coordinator.

```python
_o = os
...
    pgid = _o.getpgid(pid)
```

```
E       AssertionError: deriving a process-group id outside procgroup is how a fourth copy of the safe-pgid guard starts; call procgroup.safe_pgid
E       assert ['kstrl/fourt..._probe.py:15'] == []
E
E         Left contains one more item: 'kstrl/fourth_copy_probe.py:15'
E         Use -v to get more diff
```

Harness verdict: `forms that still go through: 0`.

### The resolver's own parts are each pinned

A resolver whose parts are not individually pinned can lose one silently,
which is how the shipped net came to match a single literal shape. Five
mutations, one per feature, cache cleared and `PYTHONDONTWRITEBYTECODE=1`:

| mutation | verdict | what failed |
|---|---|---|
| MR1 drop module-alias resolution | CAUGHT | `test_every_spelling_of_the_call_is_caught[module alias]` |
| MR2 drop from-import resolution | CAUGHT | `[from import]`, `[from import aliased]` |
| MR3 drop the rebind fixed point | CAUGHT | `[annotated assignment]`, `[callable rebind]`, `[class attribute]`, `[instance attribute]`, `[rebind of a rebind]` |
| MR4 merge the two name buckets | CAUGHT | `test_a_name_is_not_a_binding[the same name as an attribute of something else]` |
| MR5 stop collecting class-body bindings | CAUGHT | `[class attribute]`, `[instance attribute]` |

`survivors: 0`. MR4 is the one worth naming: it proves the split between
"names that ARE the callable" and "attribute names that resolve to it" is load
bearing. Merge them and a module-level `lookup = os.getpgid` turns an
unrelated `other.lookup(1)` into a false positive.

### What the net still does not catch

Stated rather than hidden, and recorded in `test_the_remaining_misses`:

- `getattr(os, "getpgid")(pid)`
- `importlib.import_module("os").getpgid(pid)`
- a dispatch table: `TABLE = {"f": os.getpgid}` then `TABLE["f"](pid)`
- a module held as a class attribute: `class G: mod = os` then `G.mod.getpgid(pid)`
- a tuple assignment: `hop, other = _resolve, None`

Each needs something this resolver does not do: value tracking through a
string or a container, an attribute-to-module map, or destructuring.

**A correction to what this section said in its first draft.** It claimed the
marker was a ratchet that "fails loudly if one ever starts passing". It was
not. Round-2 `/simplify` measured that `strict=False` with no `raises=` made
XFAIL, XPASS **and a resolver that raised on entry** all green, so the record
could go stale in silence. It is now `strict=True, raises=AssertionError`,
and mutations MR9 and MR10 below show it failing in both directions.

### This is the fifth local fix of one defect, and #324 is the reason to say so

I am not writing this resolution up as a local win. **#324** tracks that this
repo has roughly eleven AST-walking test guards, each re-implementing walk,
parse, find calls, resolve which module a name refers to. Each has been holed
independently: #319 round 2 by `import tomllib as _tl`, #321 round 1 by
`wait(timeout=None)` and `with Popen(...)`, #321 round 2 by
`_P = subprocess.Popen` and `getattr(subprocess, "Popen")`.

**PR #328 is now the next data point on that list, not a counterexample to
it.** The guard this PR shipped in round 1 was defeated by the same alias hole,
by the same kind of probe, one review round later. Fixing it here fixes one
guard. The other ten are untouched and still individually holed.

Per the coordinator's instruction this PR does not attempt the global fix.
What it does do is leave the resolution in a shape a later hoist can lift
mechanically: the module and callable are named once at the top as
`_TARGET_MODULE` and `_TARGET_FUNC`, and every resolution function takes the
name sets as arguments rather than closing over them.

## 2. Gap 1: the `killpg` availability check (test added)

Round-1 review removed the availability check from `_may_signal_group` and all
25 safe-pgid tests stayed green. The check was unpinned.

**Decision: add a test, not an argument for why it cannot be exercised.** It
can be exercised on POSIX, with `monkeypatch.delattr`.

The review note asked me to confirm which attribute the code now gates on,
since my own round-1 `/simplify` pass moved the `safe_pgid` guard from
`hasattr(os, "killpg")` to `hasattr(os, "getpgid")`. Both checks exist and they
gate different calls: `safe_pgid` checks `getpgid` because that is the call it
is about to make, and `_may_signal_group` checks `killpg` because that is the
call its callers are about to make. The new test deletes `killpg` **only**,
leaving `getpgid` present, which is exactly what isolates the second gate from
the first.

`tests/test_safe_pgid.py::TestTheGroupIdIsGuardedBeforeAnySignal::test_a_platform_with_getpgid_but_no_killpg_cannot_signal`

Mutation `GAP1`: `return hasattr(os, "killpg") and pgid > 1` becomes
`return pgid > 1`. Cache cleared, `PYTHONDONTWRITEBYTECODE=1`:

```
E   assert True is False
E    +  where True = _may_signal_group(99999)
FAILED tests/test_safe_pgid.py::TestTheGroupIdIsGuardedBeforeAnySignal::test_a_platform_with_getpgid_but_no_killpg_cannot_signal
```

## 3. Gap 2: the serve mock test (test reshaped)

Round-1 review deleted the `safe_pgid(process)` call from
`terminate_process_group` and the serve mock test stayed green. The test was
named for routing and pinned something weaker.

**Decision: reshape the test to spy on the real function rather than argue.**
It now patches `kstrl.serve.safe_pgid` with `wraps=safe_pgid`, so the real
guard still runs and the call is recorded:

```python
from kstrl.procgroup import safe_pgid

with (
    patch("kstrl.serve.safe_pgid", wraps=safe_pgid) as guard,
    patch("kstrl.serve.os.killpg") as killpg,
):
    ...
    guard.assert_called_once_with(fake)
    assert killpg.call_count == 0, "must never signal a bogus group"
```

Mutation `GAP2`: delete `pgid = safe_pgid(process)`. Cache cleared,
`PYTHONDONTWRITEBYTECODE=1`:

```
E   assert False is True
E    +  where False = GroupTermination(reaped=False, degraded='no process-group id was available, so only the direct child was inspected and any descendant it left is unaccounted for', occupied='').reaped
E   AssertionError: Expected 'safe_pgid' to be called once. Called 0 times.
FAILED tests/test_serve.py::TestProcessGroupSupervision::test_terminate_process_group_reaps_the_tree
FAILED tests/test_serve.py::TestProcessGroupSupervision::test_a_mocked_popen_never_signals_a_broad_group
```

Two tests now fail, not one. The real-process test catches the loss as a
behaviour regression and the mock test catches it as a routing regression.

## 4. Out of scope by agreement: #329

Round-1 review agreed with the judgement that declined the bare-pgid path in
`serve.terminate_process_group(process, pgid=...)`, which signals a
caller-supplied pgid with no guard at all. It is filed as **#329** and is not
widened into this PR: fixing it is a behaviour change on a public signature,
not the cleanup #308 asked for.

## 5. Round-2 verification

Re-run after every round-2 change, all with `__pycache__` cleared and
`PYTHONDONTWRITEBYTECODE=1`:

| check | result |
|---|---|
| four previously-missed guard forms | `forms that still go through: 0` |
| MR1 to MR5 resolver mutations | `survivors: 0` |
| GAP1 and GAP2 | `survivors: 0` |
| round-1 eleven-mutation production sweep (MP1 to MP7, MV1 to MV4) | `problems: 0` |
| `uv run mypy kstrl/ --strict` | `Success: no issues found in 127 source files` |
| `uv run ruff check kstrl tests` | `All checks passed!` |
| `uv run pytest tests/ -q` | `4690 passed, 28 skipped, 3 xfailed in 283.56s` |
| `uv run pre-commit run` (staged) | every hook passes |

These are the numbers as of commit `457c8af`. The round-2 `/simplify` pass then
changed the code again (`a1d4155`); its own verification table, in the findings
comment on this PR, is the current one.

Two pre-commit hooks pushed back on the first round-2 draft and both were fixed
rather than silenced. `cyclomatic-ratchet` reported
`tests/test_safe_pgid.py::_bindings cyclomatic 17 (limit 10)`, and complexipy
reported `_scan` at cognitive 23 against its limit of 15. The resolver was split
into `_module_aliases`, `_imported_callables`, `_absorb` and `_class_body_names`
rather than taking the `# noqa: C901` escape hatch. All five resolver mutations
and all four planted forms were then re-run against the split version and still
fail exactly as recorded above.


## Round-2 `/simplify` findings

The four round-2 `/simplify` agent reports are reproduced VERBATIM in a PR comment rather than here: inlining them would put this body past GitHub's 65,536 character cap. Nothing is trimmed or paraphrased; the comment holds every finding including the declined ones with their reasons.
