### PR TITLE
fix(verify): a non-measurement can no longer report a mutation pass (#306, #316)

### DIFF
--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -16,6 +16,14 @@ if TYPE_CHECKING:
     from kstrl.evolution import EvolutionConfig, EvolutionJournal
     from kstrl.interaction import InteractionChannel
 
+    # Annotation only, and the cheapest available: with
+    # `from __future__ import annotations` above, _sense_document's
+    # signature is a string at run time and this block never executes.
+    # Not a deferral - line 104 already imports kstrl.verify at module
+    # scope, so it is on `ks --help`'s import path either way (measured
+    # here at 5.2ms of cli.py's 84.7ms cumulative).
+    from kstrl.verify import VerificationResult
+
 from dataclasses import replace
 
 import click
@@ -3562,7 +3570,55 @@ def status(
         sys.exit(0)
 
 
-SENSE_SCHEMA_VERSION = 1
+#: 2 (#306): a ``not_measured`` array joined the document, and the
+#: meaning of an absent ``mutation_testing`` row changed with it. Under
+#: 1 that absence meant one thing, "turned off in kstrl.toml", because
+#: an enabled mutation check emitted a row even when it had measured
+#: nothing. Under 2 it also covers "asked for, measured nothing", and
+#: ``not_measured`` is what tells the two apart. A v1 reader inferring
+#: "absent means disabled" is wrong about a v2 document, which is why
+#: this is a bump and not a silent addition.
+#:
+#: Scoped to that one check on purpose, because that is all v2
+#: delivers. ``not_measured`` is not yet a complete index of every
+#: check that did not run: ``check_dead_code`` still reports three
+#: non-measurements as passing rows, and ``require_self_critique`` with
+#: no ``progress_file_path`` and no PRD emits neither a row nor a gap.
+#: Both predate this and both are follow-ups on #306; a reader must not
+#: read an empty array as "everything enabled was measured".
+SENSE_SCHEMA_VERSION = 2
+
+
+def _sense_document(path: Path, base: str, result: VerificationResult) -> dict[str, Any]:
+    """The ``ks sense --json`` document, at :data:`SENSE_SCHEMA_VERSION`.
+
+    Its own function because it is a published contract and ``sense``
+    is a 200-line command: a reader checking what v2 promises should not
+    have to find it among the preflight, the base resolution and the
+    terminal rendering.
+    """
+    return {
+        "schema_version": SENSE_SCHEMA_VERSION,
+        "path": str(path),
+        "base_branch": base,
+        "passed": result.passed,
+        "checks": [
+            {
+                "name": check.name,
+                "passed": check.passed,
+                "message": check.message,
+                "details": list(check.details),
+                "duration_seconds": check.duration_seconds,
+                "findings": [f.to_dict() for f in check.findings],
+            }
+            for check in result.checks
+        ],
+        # Beside ``checks``, never inside it: an entry here is a check
+        # that ran no measurement, and putting it in the array a reader
+        # folds with ``all(passed)`` is exactly the defect #306 closed.
+        # Empty for a tree where every enabled check measured something.
+        "not_measured": [gap.to_dict() for gap in result.not_measured],
+    }
 
 
 def _sense_error(message: str, as_json: bool) -> NoReturn:
@@ -3652,9 +3708,12 @@ def sense(
     not a worktree kstrl owns, so it writes nothing to .kstrl/ and never
     edits, stages, commits or leaves bytecode: the dead-code check
     reports what it would remove instead of removing it, and mutation
-    testing is skipped because mutmut works by rewriting source. The
-    exception is the project's OWN configured test / typecheck / lint
-    commands, which are your programs and write their own caches.
+    testing cannot run at all because mutmut works by rewriting source.
+    The exception is the project's OWN configured test / typecheck /
+    lint commands, which are your programs and write their own caches.
+
+    A check that could not run gets NO row: it is reported under
+    not_measured with the reason, never as a passing check (#306).
 
     Most checks read `git diff <base>...HEAD`, so the tree must be a git
     repository with a reachable base unless every diff-based check is
@@ -3746,24 +3805,7 @@ def sense(
     )
 
     if as_json:
-        document: dict[str, Any] = {
-            "schema_version": SENSE_SCHEMA_VERSION,
-            "path": str(path),
-            "base_branch": base,
-            "passed": result.passed,
-            "checks": [
-                {
-                    "name": check.name,
-                    "passed": check.passed,
-                    "message": check.message,
-                    "details": list(check.details),
-                    "duration_seconds": check.duration_seconds,
-                    "findings": [f.to_dict() for f in check.findings],
-                }
-                for check in result.checks
-            ],
-        }
-        click.echo(json.dumps(document, indent=2))
+        click.echo(json.dumps(_sense_document(path, base, result), indent=2))
         sys.exit(0 if result.passed else 1)
 
     force_rich = os.environ.get("GUM_FORCE") == "1"

--- a/kstrl/events.py
+++ b/kstrl/events.py
@@ -196,6 +196,12 @@ class VerificationResultEvent(Event):
     phase: str = ""
     #: True when nothing gated on this verdict.
     advisory: bool = False
+    #: ``"check:reason"`` per check that was asked for and measured
+    #: nothing (#306), e.g. ``"mutation_testing:tool_missing"``.
+    #: Deliberately NOT folded into ``checks``, which names what ran:
+    #: a consumer counting green checks must not count these. Defaults
+    #: empty, so payloads already on disk decode unchanged.
+    not_measured: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -873,6 +879,9 @@ class V1CompatSink:
     GATE verdict as the same row: ``summarize_events`` cannot tell them
     apart, and ``_phase_for_event`` reports the component in phase
     "verify", a phase `ks feature` does not have.
+
+    ``not_measured`` (#306) is dropped here for the same reason, and a
+    v1 reader is not told which enabled check measured nothing.
 
     Nothing is wrong today, because `ks feature` is the only command
     that emits advisory reports and it attaches no ``V1CompatSink``. The

--- a/kstrl/feature_verify.py
+++ b/kstrl/feature_verify.py
@@ -395,6 +395,22 @@ def report_verification(
     # ABSENT from it rather than recorded as passing skips: a machine
     # reader doing ``all(c.passed)`` must never see a check that measured
     # nothing counted as a pass.
+    # ``not_measured`` (#306) rides along for the same reason the two
+    # emitters share an event type at all: a check that was asked for
+    # and measured nothing must look the same in `events.jsonl`
+    # whichever loop ran it.
+    #
+    # UNREACHABLE here today, structurally and not by luck.
+    # ``narrow_to_undiffed`` rewrites the operator's toggles to False
+    # before the checks run, which erases the very bit the sidecar reads
+    # - "was this asked for" - so no gap can be produced on this path
+    # even though ``_announce_verification`` prints the six suppressed
+    # names in prose two lines earlier. Making those six say so in the
+    # field is a change to the suppression layer, not to this emitter,
+    # and it is the same "one owner for every argument that decides
+    # whether a check can honestly run" that #305 tracks. Wired anyway,
+    # because an emitter that drops a field it should carry is how the
+    # two of them come to disagree.
     emit(
         VerificationResultEvent(
             component=component,
@@ -404,6 +420,7 @@ def report_verification(
             duration_seconds=duration,
             phase=phase,
             advisory=True,
+            not_measured=tuple(gap.as_token() for gap in result.not_measured),
         )
     )
     return frozenset(check.name for check in result.checks if not check.passed)

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -2447,6 +2447,22 @@ class ComponentPipeline:
             signatures=failure.signatures,
         )
 
+    def _warn_not_measured(self, comp: Component, verification: VerificationResult) -> None:
+        """Say out loud what Phase 1 was asked to measure and could not.
+
+        #306. Not a gate failure: a gap does not reach
+        ``verification.passed``, and it is deliberately kept out of
+        ``as_context`` too, because no engineer iteration can install a
+        missing binary and a retry would burn ``repair_max_runs``
+        proving it. Not nothing either: before #306 the row said PASS,
+        and omitting the row alone said nothing at all, so a
+        permanently broken mutation gate looked exactly like a working
+        one. This is the third option, and it is the only place the
+        pipeline says it.
+        """
+        for gap in verification.not_measured:
+            self.ui.warn(f"  {comp.id}: {gap.check} not measured ({gap.reason}) - {gap.detail}")
+
     def _phase_verify(
         self,
         comp: Component,
@@ -2580,8 +2596,11 @@ class ComponentPipeline:
                 checks=tuple(c.name for c in verification.checks),
                 failures=tuple(c.message for c in verification.checks if not c.passed),
                 duration_seconds=round(verify_duration, 2),
+                not_measured=tuple(g.as_token() for g in verification.not_measured),
             )
         )
+
+        self._warn_not_measured(comp, verification)
 
         if not verification.passed:
             failing = [c for c in verification.checks if not c.passed]

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -93,6 +93,7 @@ from kstrl.security import SecurityMode, SecurityResult
 from kstrl.verify import (
     SCOPE_UNREADABLE_CHECK,
     CheckResult,
+    MechanicalVerification,
     VerificationResult,
     scope_unreadable_error,
 )
@@ -334,7 +335,20 @@ class PipelineHooks:
     directly.
     """
 
-    run_mechanical_verification: Callable[..., VerificationResult]
+    # Typed by shape, not ``Callable[..., VerificationResult]`` (#316):
+    # Phase 1 is the seam that carries a component's SCOPE, and ``...``
+    # checks nothing about it. See ``verify.MechanicalVerification``.
+    #
+    # The three hooks below were NOT cleared, they were not done. Each
+    # carries the same hazard, measured: `run_review` and
+    # `run_security_review` take adjacent `prd_path` / `worktree_path`
+    # Paths and are called positionally below; `distill_facts` takes
+    # three Paths among ten positional arguments. Transposing any of
+    # those type-checks clean today, exactly as `harness_paths` did.
+    # Tightening them is not one character each - their call sites pass
+    # positionally, so it is a signature plus a call-site change plus a
+    # drift test per hook, in three more modules. Its own issue.
+    run_mechanical_verification: MechanicalVerification
     run_review: Callable[..., ReviewResult]
     run_security_review: Callable[..., SecurityResult]
     distill_facts: Callable[..., tuple[int, str]]

--- a/kstrl/verify.py
+++ b/kstrl/verify.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from kstrl import git, licensing
 
@@ -1794,51 +1794,73 @@ def check_mutation_score(
     base_branch: str,
     threshold: float = 50.0,
     timeout: float = 600.0,
-    read_only: bool = False,
-) -> CheckResult:
+) -> CheckResult | None:
     """Run mutation testing on changed files using mutmut.
 
-    Only mutates Python files changed relative to base_branch.
-    Returns FAIL if mutation score is below threshold.
-    Requires mutmut to be installed (pip install mutmut).
+    Only mutates Python files changed relative to base_branch. Returns
+    FAIL if the mutation score is below threshold, and **None** - no row
+    at all - whenever no score was measured (#306). Four paths reach
+    None: mutmut is not on PATH, the diff changed no non-test Python
+    file, ``mutmut run`` hit ``timeout``, and mutmut generated no
+    mutants. The fifth, read-only, never reaches this function:
+    :func:`_mutation_checks` owns it.
 
-    ``read_only=True`` (``ks sense``, R10.1) skips the check outright:
-    mutmut works by rewriting the source files it mutates, so there is
-    no read-only way to run it. The skip is recorded as a passing check
-    naming the reason rather than dropped, so the measurement says what
-    it did not measure.
+    Each of the four used to return ``passed=True``, so a green
+    ``mutation_testing`` row meant "we did not look" as often as it
+    meant "we looked and it was fine" - and
+    :func:`kstrl.review.build_review_prompt` copied that row into the
+    LLM reviewer's prompt as ``mutation_testing: PASS``.
+
+    None rather than a not-measured STATUS on the row, because
+    ``passed`` is the only field every consumer reads: a third state
+    there still reads as a pass through ``all(c.passed ...)``,
+    ``report_lines``, ``ks sense --json`` and that reviewer prompt, for
+    every reader not yet taught the new field. Absence is also the
+    convention this repo already wrote down - see
+    :func:`kstrl.feature_verify` on its own suppressed checks, "the
+    suppressed checks are ABSENT from it rather than recorded as passing
+    skips: a machine reader doing ``all(c.passed)`` must never see a
+    check that measured nothing counted as a pass" - and what
+    ``mutation_testing = false`` and :func:`narrow_to_undiffed` have
+    always meant here, so no consumer may assume this row exists.
+
+    Nor does None become a FAIL on the two paths where something is
+    genuinely wrong rather than merely absent, missing mutmut and
+    timeout. A failing mechanical check is retry context for the
+    engineer, and installing a binary is not a thing an engineer
+    iteration can do, so a FAIL there spends ``repair_max_runs``
+    iterations on a diff that cannot change the outcome.
+
+    What None costs, stated rather than argued away. An operator who
+    sets ``mutation_testing = true`` with no mutmut on PATH now gets
+    silence where they got a green row; that is a smaller lie, not no
+    lie. And it erases the difference between infra failure (mutmut
+    absent, timed out) and legitimate non-applicability (nothing
+    mutable changed, no mutants generated), which is exactly the
+    distinction L3+ consumes. The placement that keeps both is a SIDECAR
+    on :class:`VerificationResult` - a ``not_measured`` list, or the
+    ``Finding.infrastructure_error`` stream ``check_test_adequacy``
+    already uses and :attr:`CheckResult.findings` already carries -
+    additive, breaking no consumer, and leaving absence-from-``checks``
+    exactly as it is here. Not built here because its consumer is not
+    built either: ``docs/dark-factory-roadmap.md`` puts "mutation infra
+    failure halts for a human rather than skipping
+    (``infrastructure_error`` convention)" in Layer 2 at L3+, and lists
+    that layer under "Not built, and not claimed". Halt is not fail, so
+    the honest state today is silence; what this fixes is silence being
+    spelled ``PASS``.
     """
     import shutil
 
     start = time.monotonic()
 
-    if read_only:
-        return CheckResult(
-            name="mutation_testing",
-            passed=True,
-            message=(
-                "Skipped: mutation testing rewrites the files it mutates and cannot run read-only"
-            ),
-            duration_seconds=time.monotonic() - start,
-        )
-
     if not shutil.which("mutmut"):
-        return CheckResult(
-            name="mutation_testing",
-            passed=True,
-            message="mutmut not installed, skipping",
-            duration_seconds=time.monotonic() - start,
-        )
+        return None
 
     changed = git.get_diff_names(base_branch, cwd)
     py_files = [f for f in changed if f.endswith(".py") and not f.startswith("test")]
     if not py_files:
-        return CheckResult(
-            name="mutation_testing",
-            passed=True,
-            message="No non-test Python files changed",
-            duration_seconds=time.monotonic() - start,
-        )
+        return None
 
     # Run mutmut on changed files only
     paths_arg = " ".join(py_files)
@@ -1849,12 +1871,7 @@ def check_mutation_score(
             timeout=timeout,
         )
     except subprocess.TimeoutExpired:
-        return CheckResult(
-            name="mutation_testing",
-            passed=True,
-            message=f"Mutation testing timed out after {timeout}s, skipping",
-            duration_seconds=time.monotonic() - start,
-        )
+        return None
 
     # Parse mutmut results
     try:
@@ -1887,12 +1904,7 @@ def check_mutation_score(
 
     total = killed + survived
     if total == 0:
-        return CheckResult(
-            name="mutation_testing",
-            passed=True,
-            message="No mutations generated",
-            duration_seconds=time.monotonic() - start,
-        )
+        return None
 
     score = (killed / total) * 100
     details = [
@@ -2170,6 +2182,53 @@ def _scope_checks(
     return []
 
 
+def _mutation_checks(
+    cwd: Path,
+    base_branch: str,
+    config: VerifyConfig,
+    *,
+    read_only: bool,
+) -> list[CheckResult]:
+    """The ``mutation_testing`` row, or no row at all (#306).
+
+    Every reason mutation testing might not produce a score lives here
+    or in :func:`check_mutation_score`, and all of them look the same
+    from outside: nothing is appended. Three are visible from this side
+    - the ``[verify] mutation_testing`` toggle, ``read_only``, and the
+    check's own None - and one place to read them is what stops the
+    caller re-learning any of them.
+
+    ``read_only`` is the one that cannot live inside the check. mutmut
+    works by rewriting the source files it mutates, so ``ks sense`` and
+    :func:`run_undiffed_verification` must not call it at all rather
+    than call it and have it decline: a flag threaded into a check just
+    to be refused is a flag that can return a row, which is how the
+    read-only skip came to report ``passed=True`` in the first place.
+
+    A list for the reason :func:`_scope_checks` returns one. Measured:
+    inlining both conditions at the call site takes
+    :func:`run_mechanical_verification` to cyclomatic 10 against a gate
+    of 10 and cognitive 15 against a gate of 15.
+
+    The other two conditions here - the toggle and ``read_only`` - are
+    decidable before anything runs, which makes this a candidate member
+    of the object #305 tracks (one owner for every argument that decides
+    whether a check can honestly run, alongside
+    :data:`DIFF_DEPENDENT_CHECKS` and :func:`run_undiffed_verification`).
+    The other three cannot join it: mutmut absent, timed out and no
+    mutants are only knowable after the check has run.
+    """
+    if not config.mutation_testing or read_only:
+        return []
+    result = check_mutation_score(
+        cwd,
+        base_branch,
+        config.mutation_threshold,
+        config.mutation_timeout,
+    )
+    return [] if result is None else [result]
+
+
 #: Every check :func:`run_mechanical_verification` appends that answers
 #: its question by reading ``git diff <base>...HEAD``.
 #:
@@ -2312,12 +2371,62 @@ def narrow_to_undiffed(config: VerifyConfig) -> VerifyConfig:
     )
 
 
+class MechanicalVerification(Protocol):
+    """The call shape of :func:`run_mechanical_verification` (#316).
+
+    ``PipelineHooks.run_mechanical_verification`` was typed
+    ``Callable[..., VerificationResult]``, and ``...`` means mypy checks
+    NOTHING about the arguments - which matters because that hook is how
+    the only call site carrying a real component's scope reaches the
+    function. Measured on this branch: with the hook typed ``...``,
+    swapping ``harness_paths=scope.harness_paths`` for
+    ``harness_paths=scope.error`` - a ``str | None`` into a
+    ``list[str] | None`` slot, an authored carve-out replaced by the
+    snapshot's failure to read one - left ``mypy --strict`` reporting
+    SUCCESS. With this Protocol the same swap is
+    ``error: Argument "harness_paths" to "__call__" of
+    "MechanicalVerification" has incompatible type "str | None";
+    expected "list[str] | None"``.
+
+    Making the arguments keyword-only stops a SLOT from being inherited
+    silently; it cannot stop a wrong value being handed to the right
+    name. Only a type can, and only if there is one.
+
+    The defaults below are spelled as real values rather than the
+    conventional ``= ...`` so that ``inspect.Signature`` equality can
+    compare this to the function in one assertion; a Protocol that has
+    drifted is worse than none, because it would type-check calls the
+    function rejects. See
+    ``test_the_protocol_says_exactly_what_the_function_says``.
+    """
+
+    def __call__(
+        self,
+        worktree_path: Path,
+        prd_path: Path | None,
+        base_branch: str,
+        allowed_paths: list[str] | None,
+        config: VerifyConfig,
+        *,
+        allowed_paths_error: str | None = None,
+        harness_paths: list[str] | None = None,
+        pre_run_prd_path: Path | None = None,
+        fixtures_config: FixturesConfig | None = None,
+        policy_config: PolicyConfig | None = None,
+        adequacy_config: AdequacyConfig | None = None,
+        autonomy_level: int = 0,
+        component_id: str | None = None,
+        read_only: bool = False,
+    ) -> VerificationResult: ...
+
+
 def run_mechanical_verification(
     worktree_path: Path,
     prd_path: Path | None,
     base_branch: str,
     allowed_paths: list[str] | None,
     config: VerifyConfig,
+    *,
     allowed_paths_error: str | None = None,
     harness_paths: list[str] | None = None,
     pre_run_prd_path: Path | None = None,
@@ -2329,6 +2438,13 @@ def run_mechanical_verification(
     read_only: bool = False,
 ) -> VerificationResult:
     """Run all mechanical checks. All checks run even if earlier ones fail.
+
+    Everything after ``config`` is keyword-only (#316), so an inserted
+    parameter cannot shift a later argument into a slot that means
+    something else - and three of the arguments here mean opposite
+    things in near-identical types (see :class:`MechanicalVerification`,
+    which covers the half that keyword-only does not). Cost: none. No
+    caller passed any of them positionally.
 
     ``prd_path=None`` (R10.1, ``ks sense``) skips the PRD-dependent
     checks: ``prd_stories``, the approved-fixtures oracle (fixtures are
@@ -2366,11 +2482,17 @@ def run_mechanical_verification(
     ``read_only=True`` (``ks sense``, R10.1) forbids the two checks that
     change the tree they measure: ``dead_code`` drops its ruff auto-fix
     and the ``git add -A`` / ``git commit`` that followed it, and
-    ``mutation_testing`` is skipped because mutmut works by rewriting
-    source. What remains still shells out to the project's OWN
-    configured test / typecheck / lint (and fixture) commands, which
-    are the operator's programs and write their own caches; kstrl
-    suppresses only kstrl's writes.
+    ``mutation_testing`` is not run at all. What remains still shells
+    out to the project's OWN configured test / typecheck / lint (and
+    fixture) commands, which are the operator's programs and write their
+    own caches; kstrl suppresses only kstrl's writes.
+
+    ``mutation_testing`` appends NO ROW rather than a passing one
+    whenever no score was measured, read-only being one of five such
+    reasons (#306). See :func:`_mutation_checks`. A consumer reading
+    ``checks`` must already tolerate the row's absence, because
+    ``[verify] mutation_testing`` defaults to false; what changed is
+    that absence is now the ONLY thing a non-measurement can look like.
     """
     checks: list[CheckResult] = []
 
@@ -2453,16 +2575,14 @@ def run_mechanical_verification(
             )
         )
 
-    if config.mutation_testing:
-        checks.append(
-            check_mutation_score(
-                worktree_path,
-                base_branch,
-                config.mutation_threshold,
-                config.mutation_timeout,
-                read_only=read_only,
-            )
+    checks.extend(
+        _mutation_checks(
+            worktree_path,
+            base_branch,
+            config,
+            read_only=read_only,
         )
+    )
 
     progress_path = self_critique_progress_path(config, worktree_path, prd_path)
     if progress_path is not None:

--- a/kstrl/verify.py
+++ b/kstrl/verify.py
@@ -205,6 +205,79 @@ class CheckResult:
     findings: list[Finding] = field(default_factory=list)
 
 
+#: Why a check that was ASKED FOR produced no measurement. Stable
+#: tokens: they reach `ks sense --json` and `events.jsonl`, so a reader
+#: keys on these and not on the prose beside them.
+#:
+#: A check the operator did not ask for - ``[verify] mutation_testing``
+#: left false - records nothing at all. That is the line the sidecar
+#: draws, and it is what keeps the default quiet: silence is a complete
+#: answer to a question nobody asked, and an incomplete one to a
+#: question they did.
+NOT_MEASURED_READ_ONLY = "read_only"
+NOT_MEASURED_TOOL_MISSING = "tool_missing"
+NOT_MEASURED_NO_TARGET = "no_target"
+NOT_MEASURED_TIMED_OUT = "timed_out"
+NOT_MEASURED_COMMAND_FAILED = "command_failed"
+NOT_MEASURED_NO_MUTANTS = "no_mutants"
+
+
+@dataclass(frozen=True)
+class NotMeasured:
+    """A check that was asked for and produced no measurement (#306).
+
+    The SIDECAR. Deliberately not a :class:`CheckResult`: it never
+    reaches ``checks``, so ``all(c.passed ...)``, ``report_lines``'
+    verdict column, ``ks sense --json``'s ``checks`` array and
+    :func:`kstrl.review.build_review_prompt` cannot read it as a pass -
+    which is the whole of #306. Equally it never reaches
+    :meth:`VerificationResult.as_context`, so it is not retry context:
+    no engineer iteration is spent on a missing binary it cannot
+    install.
+
+    What it buys back is the diagnostic the omission alone destroyed.
+    Absence from ``checks`` is honest but mute, and SEVEN states produce
+    that absence, which an operator who set ``mutation_testing = true``
+    cannot otherwise tell apart from a working gate. Six of them carry
+    one of these records and are separated by ``reason``, one of the
+    ``NOT_MEASURED_*`` constants above. The seventh, the check being
+    turned off, records nothing at all, on purpose: a question nobody
+    asked needs no answer.
+
+    ``detail`` is prose for a human and is never parsed.
+    """
+
+    check: str
+    reason: str
+    detail: str
+
+    def as_line(self) -> str:
+        """The report-table rendering, for :meth:`VerificationResult.report_lines`.
+
+        Not every terminal surface: the factory's Phase 1 warning
+        prefixes the component id and names the reason, because it is
+        one line inside a multi-component run rather than a row under a
+        table that already says which component it is.
+        """
+        return f"  {self.check}  not measured  {self.detail}"
+
+    def as_token(self) -> str:
+        """The ``events.jsonl`` rendering: ``"<check>:<reason>"``.
+
+        Here rather than in the emitters because there are two of them,
+        in :mod:`kstrl.pipeline` and :mod:`kstrl.feature_verify`, and a
+        format spelled twice is one an edit can change in one place
+        only. Same ``<check>:<code>`` shape
+        :func:`kstrl.evolution.split_signature` already reads, so a
+        consumer of that file meets one convention rather than two.
+        """
+        return f"{self.check}:{self.reason}"
+
+    def to_dict(self) -> dict[str, str]:
+        """The ``ks sense --json`` rendering."""
+        return {"check": self.check, "reason": self.reason, "detail": self.detail}
+
+
 def _capped_detail_lines(check: CheckResult, limit: int | None) -> list[str]:
     """``check``'s details, indented, truncated to ``limit`` if given.
 
@@ -224,6 +297,10 @@ class VerificationResult:
 
     passed: bool
     checks: list[CheckResult] = field(default_factory=list)
+    #: Checks that were asked for and measured nothing (#306). The
+    #: sidecar: see :class:`NotMeasured` for why it is beside ``checks``
+    #: rather than in it.
+    not_measured: list[NotMeasured] = field(default_factory=list)
 
     def as_context(self) -> str:
         """Format failures for injection into retry prompt."""
@@ -277,6 +354,12 @@ class VerificationResult:
             if check.passed:
                 continue
             lines.extend(_capped_detail_lines(check, max_detail_lines))
+        # The sidecar, below the table and outside it (#306). Rendered
+        # here rather than by each caller for the reason the table is:
+        # `ks sense` and `ks feature` must not be able to disagree about
+        # whether they mention what was not measured. No verdict column
+        # and no duration - there is no verdict, and nothing was timed.
+        lines.extend(gap.as_line() for gap in self.not_measured)
         return lines
 
 
@@ -1224,6 +1307,22 @@ def _diff_scope_details(
     ]
 
 
+#: The Phase 1 check name for mutation testing, and the ``check`` on
+#: every :class:`NotMeasured` mutation testing produces.
+#:
+#: A constant rather than four literals for a reason that is measured,
+#: not stylistic: ``tests/test_check_name_enrolment.py`` AST-walks
+#: ``kstrl/`` for every name that can reach
+#: ``evolution.category_for_check``, and it resolves literals and
+#: module-level constants - not function-locals. Writing this name once
+#: as ``name = "mutation_testing"`` inside
+#: :func:`check_mutation_score` took it from the 19 names that walk
+#: sees to 18, silently, because the walk fails on an unenrolled name
+#: and cannot fail on one it cannot see. Same rule as the prompt walk
+#: in #299: hoist it to a constant the guard can resolve.
+MUTATION_TESTING_CHECK = "mutation_testing"
+
+
 #: The Phase 1 check name for "no trustworthy scope could be read".
 #:
 #: Deliberately NOT ``scope_source``, which is already taken in the same
@@ -1789,78 +1888,112 @@ def check_test_adequacy(
     )
 
 
+def _count_before(word: str, text: str) -> int:
+    """The integer immediately before the last ``word`` token in ``text``.
+
+    mutmut reports "12 killed" / "3 survived" among prose, and the
+    number is whatever sits in front of the word. Last occurrence wins,
+    because ``mutmut results`` is read after ``mutmut run`` and the
+    later figure is the settled one.
+
+    Extracted from :func:`check_mutation_score` (#306 round 2) because
+    the two copies of this loop, one per word, were most of that
+    function's cyclomatic weight and left no room to tell a FAILED
+    mutmut run apart from an empty one. A missing word yields 0, which
+    is what "no such line" and "the line said zero" both mean here.
+    """
+    count = 0
+    for line in text.splitlines():
+        parts = line.lower().strip().split()
+        for i, part in enumerate(parts):
+            if part == word and i > 0:
+                try:
+                    count = int(parts[i - 1])
+                except ValueError:
+                    pass
+    return count
+
+
 def check_mutation_score(
     cwd: Path,
     base_branch: str,
     threshold: float = 50.0,
     timeout: float = 600.0,
-) -> CheckResult | None:
+) -> CheckResult | NotMeasured:
     """Run mutation testing on changed files using mutmut.
 
-    Only mutates Python files changed relative to base_branch. Returns
-    FAIL if the mutation score is below threshold, and **None** - no row
-    at all - whenever no score was measured (#306). Four paths reach
-    None: mutmut is not on PATH, the diff changed no non-test Python
-    file, ``mutmut run`` hit ``timeout``, and mutmut generated no
-    mutants. The fifth, read-only, never reaches this function:
-    :func:`_mutation_checks` owns it.
+    Only mutates Python files changed relative to base_branch. Returns a
+    :class:`CheckResult` - PASS or FAIL against ``threshold`` - only when
+    a score was actually measured. Every other path returns
+    :class:`NotMeasured`, which is a SIDECAR record and never a row in
+    ``checks`` (#306).
 
-    Each of the four used to return ``passed=True``, so a green
+    Five paths return NotMeasured, and the ``reason`` token separates
+    them because they are not the same event:
+
+    - ``tool_missing``: mutmut is not on PATH. The operator asked for a
+      measurement the machine cannot make.
+    - ``no_target``: the diff changed no non-test Python file. Nothing
+      to mutate; not a fault.
+    - ``timed_out``: ``mutmut run`` exceeded ``timeout``.
+    - ``command_failed``: mutmut ran, exited non-zero and produced no
+      counts. Distinguished from the next by ``returncode`` alone,
+      because a broken mutmut configuration and a clean run with nothing
+      to do produce identical empty output.
+    - ``no_mutants``: mutmut exited zero and generated no mutants.
+
+    The sixth, ``read_only``, never reaches this function:
+    :func:`_mutation_checks` owns it, because mutmut works by rewriting
+    the source files it mutates.
+
+    Every one of those five situations used to return
+    ``CheckResult(passed=True)`` - the last two as a single path, since
+    telling them apart is new here - so a green
     ``mutation_testing`` row meant "we did not look" as often as it
     meant "we looked and it was fine" - and
     :func:`kstrl.review.build_review_prompt` copied that row into the
     LLM reviewer's prompt as ``mutation_testing: PASS``.
 
-    None rather than a not-measured STATUS on the row, because
+    NotMeasured rather than a not-measured STATUS on the row, because
     ``passed`` is the only field every consumer reads: a third state
     there still reads as a pass through ``all(c.passed ...)``,
     ``report_lines``, ``ks sense --json`` and that reviewer prompt, for
-    every reader not yet taught the new field. Absence is also the
-    convention this repo already wrote down - see
+    every reader not yet taught the new field. Absence from ``checks``
+    is also the convention this repo already wrote down - see
     :func:`kstrl.feature_verify` on its own suppressed checks, "the
     suppressed checks are ABSENT from it rather than recorded as passing
     skips: a machine reader doing ``all(c.passed)`` must never see a
-    check that measured nothing counted as a pass" - and what
-    ``mutation_testing = false`` and :func:`narrow_to_undiffed` have
-    always meant here, so no consumer may assume this row exists.
+    check that measured nothing counted as a pass".
 
-    Nor does None become a FAIL on the two paths where something is
-    genuinely wrong rather than merely absent, missing mutmut and
-    timeout. A failing mechanical check is retry context for the
-    engineer, and installing a binary is not a thing an engineer
-    iteration can do, so a FAIL there spends ``repair_max_runs``
-    iterations on a diff that cannot change the outcome.
-
-    What None costs, stated rather than argued away. An operator who
-    sets ``mutation_testing = true`` with no mutmut on PATH now gets
-    silence where they got a green row; that is a smaller lie, not no
-    lie. And it erases the difference between infra failure (mutmut
-    absent, timed out) and legitimate non-applicability (nothing
-    mutable changed, no mutants generated), which is exactly the
-    distinction L3+ consumes. The placement that keeps both is a SIDECAR
-    on :class:`VerificationResult` - a ``not_measured`` list, or the
-    ``Finding.infrastructure_error`` stream ``check_test_adequacy``
-    already uses and :attr:`CheckResult.findings` already carries -
-    additive, breaking no consumer, and leaving absence-from-``checks``
-    exactly as it is here. Not built here because its consumer is not
-    built either: ``docs/dark-factory-roadmap.md`` puts "mutation infra
-    failure halts for a human rather than skipping
-    (``infrastructure_error`` convention)" in Layer 2 at L3+, and lists
-    that layer under "Not built, and not claimed". Halt is not fail, so
-    the honest state today is silence; what this fixes is silence being
-    spelled ``PASS``.
+    And not a FAIL either, on the paths where something is genuinely
+    wrong. A failing mechanical check is retry context for the engineer,
+    and installing a binary is not a thing an engineer iteration can do,
+    so a FAIL there spends ``repair_max_runs`` iterations on a diff that
+    cannot change the outcome. Halting for a human on mutation infra
+    failure is the L3+ behaviour in ``docs/dark-factory-roadmap.md``
+    (Layer 2, "mutation infra failure halts for a human rather than
+    skipping"), halt is not fail, and that layer is unbuilt. The sidecar
+    is the third option: seen by the operator, gating nothing.
     """
     import shutil
 
     start = time.monotonic()
 
     if not shutil.which("mutmut"):
-        return None
+        return NotMeasured(
+            MUTATION_TESTING_CHECK,
+            NOT_MEASURED_TOOL_MISSING,
+            "mutmut is not on PATH, so [verify] mutation_testing measured nothing",
+        )
 
     changed = git.get_diff_names(base_branch, cwd)
     py_files = [f for f in changed if f.endswith(".py") and not f.startswith("test")]
     if not py_files:
-        return None
+        return NotMeasured(
+            MUTATION_TESTING_CHECK,
+            NOT_MEASURED_NO_TARGET,
+            "the diff changed no non-test Python file, so there was nothing to mutate",
+        )
 
     # Run mutmut on changed files only
     paths_arg = " ".join(py_files)
@@ -1871,7 +2004,11 @@ def check_mutation_score(
             timeout=timeout,
         )
     except subprocess.TimeoutExpired:
-        return None
+        return NotMeasured(
+            MUTATION_TESTING_CHECK,
+            NOT_MEASURED_TIMED_OUT,
+            f"mutmut run exceeded [verify] mutation_timeout of {timeout}s",
+        )
 
     # Parse mutmut results
     try:
@@ -1880,31 +2017,13 @@ def check_mutation_score(
     except subprocess.TimeoutExpired:
         output = result.stdout
 
-    # Parse score from mutmut junitxml or text output
-    killed = 0
-    survived = 0
-    for line in (result.stdout + result.stderr + output).splitlines():
-        lower = line.lower().strip()
-        if "killed" in lower:
-            parts = lower.split()
-            for i, p in enumerate(parts):
-                if p == "killed" and i > 0:
-                    try:
-                        killed = int(parts[i - 1])
-                    except ValueError:
-                        pass
-        if "survived" in lower:
-            parts = lower.split()
-            for i, p in enumerate(parts):
-                if p == "survived" and i > 0:
-                    try:
-                        survived = int(parts[i - 1])
-                    except ValueError:
-                        pass
+    text = result.stdout + result.stderr + output
+    killed = _count_before("killed", text)
+    survived = _count_before("survived", text)
 
     total = killed + survived
     if total == 0:
-        return None
+        return _no_counts(result)
 
     score = (killed / total) * 100
     details = [
@@ -1914,7 +2033,7 @@ def check_mutation_score(
 
     if score < threshold:
         return CheckResult(
-            name="mutation_testing",
+            name=MUTATION_TESTING_CHECK,
             passed=False,
             message=f"Mutation score {score:.1f}% below threshold {threshold}%",
             details=details,
@@ -1922,11 +2041,41 @@ def check_mutation_score(
         )
 
     return CheckResult(
-        name="mutation_testing",
+        name=MUTATION_TESTING_CHECK,
         passed=True,
         message=f"Mutation score {score:.1f}% (threshold: {threshold}%)",
         details=details,
         duration_seconds=time.monotonic() - start,
+    )
+
+
+def _no_counts(result: subprocess.CompletedProcess[str]) -> NotMeasured:
+    """Why mutmut produced no killed or survived count.
+
+    Its own function so :func:`check_mutation_score` does not pay a
+    branch for the distinction. Measured: inlining it takes that
+    function from cognitive 9 to 14 against a gate of 15. The distinction is worth having: a
+    broken ``[verify] mutation_command`` and a clean run over code with
+    nothing mutable produce byte-identical empty output, and only
+    ``returncode`` tells them apart. Reporting both as "no mutants" is
+    how a permanently misconfigured mutation gate reads as a quiet,
+    correct no-op.
+    """
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout).strip().splitlines()
+        # Capped for the reason git.py caps its stderr at 500: this
+        # reaches `ks sense --json` and the terminal, and one unbroken
+        # line of tool output has no bound.
+        last = tail[-1][:500] if tail else "no output"
+        return NotMeasured(
+            MUTATION_TESTING_CHECK,
+            NOT_MEASURED_COMMAND_FAILED,
+            f"mutmut run exited {result.returncode} and reported no counts: {last}",
+        )
+    return NotMeasured(
+        MUTATION_TESTING_CHECK,
+        NOT_MEASURED_NO_MUTANTS,
+        "mutmut ran cleanly and generated no mutants, so there is no score",
     )
 
 
@@ -2188,45 +2337,61 @@ def _mutation_checks(
     config: VerifyConfig,
     *,
     read_only: bool,
-) -> list[CheckResult]:
-    """The ``mutation_testing`` row, or no row at all (#306).
+) -> tuple[list[CheckResult], list[NotMeasured]]:
+    """``(rows, gaps)`` for mutation testing: at most one of each (#306).
 
     Every reason mutation testing might not produce a score lives here
-    or in :func:`check_mutation_score`, and all of them look the same
-    from outside: nothing is appended. Three are visible from this side
-    - the ``[verify] mutation_testing`` toggle, ``read_only``, and the
-    check's own None - and one place to read them is what stops the
-    caller re-learning any of them.
+    or in :func:`check_mutation_score`, and all of them keep ``rows``
+    empty. What differs is ``gaps``, and the difference is the point of
+    round 2: a check the operator TURNED OFF records nothing, and a
+    check they turned on that measured nothing records why.
 
-    ``read_only`` is the one that cannot live inside the check. mutmut
-    works by rewriting the source files it mutates, so ``ks sense`` and
-    :func:`run_undiffed_verification` must not call it at all rather
-    than call it and have it decline: a flag threaded into a check just
-    to be refused is a flag that can return a row, which is how the
-    read-only skip came to report ``passed=True`` in the first place.
+    So an absent ``mutation_testing`` row plus an absent gap means
+    disabled, and an absent row plus a gap means asked-for and not
+    delivered. Seven states, one bit and one token to separate them,
+    where before #306 six of the seven produced the same green row.
 
-    A list for the reason :func:`_scope_checks` returns one. Measured:
-    inlining both conditions at the call site takes
+    ``read_only`` is the one reason that cannot live inside the check.
+    mutmut works by rewriting the source files it mutates, so ``ks
+    sense`` and :func:`run_undiffed_verification` must not call it at
+    all rather than call it and have it decline: a flag threaded into a
+    check just to be refused is a flag that can return a row, which is
+    how the read-only skip came to report ``passed=True`` in the first
+    place.
+
+    A pair rather than mutating two lists the caller owns, and a
+    function rather than two branches inline. Measured: inlining the
+    toggle and the read-only test at the call site takes
     :func:`run_mechanical_verification` to cyclomatic 10 against a gate
     of 10 and cognitive 15 against a gate of 15.
 
-    The other two conditions here - the toggle and ``read_only`` - are
-    decidable before anything runs, which makes this a candidate member
-    of the object #305 tracks (one owner for every argument that decides
-    whether a check can honestly run, alongside
-    :data:`DIFF_DEPENDENT_CHECKS` and :func:`run_undiffed_verification`).
-    The other three cannot join it: mutmut absent, timed out and no
-    mutants are only knowable after the check has run.
+    The two conditions decidable before anything runs - the toggle and
+    ``read_only`` - are exactly the subject of #305 (one object owning
+    every argument that decides whether a check can honestly run,
+    alongside :data:`DIFF_DEPENDENT_CHECKS` and
+    :func:`run_undiffed_verification`). The other four cannot join it:
+    mutmut absent, timed out, failed and no mutants are only knowable
+    after the check has run.
     """
-    if not config.mutation_testing or read_only:
-        return []
-    result = check_mutation_score(
+    if not config.mutation_testing:
+        return [], []
+    if read_only:
+        return [], [
+            NotMeasured(
+                MUTATION_TESTING_CHECK,
+                NOT_MEASURED_READ_ONLY,
+                "mutmut rewrites the files it mutates and cannot run read-only",
+            )
+        ]
+    outcome = check_mutation_score(
         cwd,
         base_branch,
         config.mutation_threshold,
         config.mutation_timeout,
     )
-    return [] if result is None else [result]
+    if isinstance(outcome, NotMeasured):
+        return [], [outcome]
+    return [outcome], []
 
 
 #: Every check :func:`run_mechanical_verification` appends that answers
@@ -2244,7 +2409,7 @@ DIFF_DEPENDENT_CHECKS: tuple[str, ...] = (
     "policy_envelope",
     "test_adequacy",
     "dead_code",
-    "mutation_testing",
+    MUTATION_TESTING_CHECK,
 )
 
 
@@ -2488,13 +2653,18 @@ def run_mechanical_verification(
     own caches; kstrl suppresses only kstrl's writes.
 
     ``mutation_testing`` appends NO ROW rather than a passing one
-    whenever no score was measured, read-only being one of five such
+    whenever no score was measured, read-only being one of six such
     reasons (#306). See :func:`_mutation_checks`. A consumer reading
     ``checks`` must already tolerate the row's absence, because
     ``[verify] mutation_testing`` defaults to false; what changed is
     that absence is now the ONLY thing a non-measurement can look like.
+
+    :attr:`VerificationResult.not_measured` is where the reason goes,
+    and it is the half that makes the absence readable rather than
+    merely honest. See :class:`NotMeasured`.
     """
     checks: list[CheckResult] = []
+    not_measured: list[NotMeasured] = []
 
     if prd_path is not None:
         checks.append(check_prd_stories(prd_path, pre_run_prd_path))
@@ -2575,14 +2745,14 @@ def run_mechanical_verification(
             )
         )
 
-    checks.extend(
-        _mutation_checks(
-            worktree_path,
-            base_branch,
-            config,
-            read_only=read_only,
-        )
+    mutation_rows, mutation_gaps = _mutation_checks(
+        worktree_path,
+        base_branch,
+        config,
+        read_only=read_only,
     )
+    checks.extend(mutation_rows)
+    not_measured.extend(mutation_gaps)
 
     progress_path = self_critique_progress_path(config, worktree_path, prd_path)
     if progress_path is not None:
@@ -2607,5 +2777,7 @@ def run_mechanical_verification(
             )
         )
 
+    # ``checks`` only: a check that measured nothing neither passes nor
+    # fails the run (#306).
     passed = all(c.passed for c in checks)
-    return VerificationResult(passed=passed, checks=checks)
+    return VerificationResult(passed=passed, checks=checks, not_measured=not_measured)

--- a/tests/helpers/verify_phase.py
+++ b/tests/helpers/verify_phase.py
@@ -13,11 +13,12 @@ where the repo puts this.
 from __future__ import annotations
 
 import io
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from kstrl.config import KstrlConfig
-from kstrl.events import EventBus, V1CompatSink
+from kstrl.events import CallbackSink, Event, EventBus, V1CompatSink
 from kstrl.factory import (
     AdversarialAgentSelection,
     ComponentResult,
@@ -27,7 +28,7 @@ from kstrl.factory import (
 from kstrl.knowledge import KnowledgeConfig
 from kstrl.manifest import Component, Manifest
 from kstrl.observability import NotifyConfig, NotifyHooks, ProgressLog
-from kstrl.pipeline import ComponentPipeline, FailureAction, PipelineHooks
+from kstrl.pipeline import ComponentPipeline, FailureAction, PipelineHooks, VerifyPhaseResult
 from kstrl.review import ReviewResult
 from kstrl.scope import RunScope
 from kstrl.security import SecurityResult
@@ -83,7 +84,18 @@ def verify_with_cheap_gates(
     )
 
 
-def _pipeline(root: Path, comp: Component, verification: VerificationResult) -> ComponentPipeline:
+def _pipeline(
+    root: Path,
+    comp: Component,
+    verification: VerificationResult,
+    *,
+    ui: PlainUI | None = None,
+) -> ComponentPipeline:
+    """``ui`` is for a caller that needs to READ the narration: the
+    default throws it away. Events are captured the way the rest of the
+    suite does it, with ``pipeline.bus.add_sink`` after construction -
+    ``ComponentPipeline.__init__`` emits nothing, so a sink attached
+    then sees every event a sink passed here would."""
     manifest = Manifest(
         version="1",
         spec_file="spec.md",
@@ -112,7 +124,7 @@ def _pipeline(root: Path, comp: Component, verification: VerificationResult) -> 
             review_mode="skip",
         ),
         base_config=KstrlConfig(),
-        ui=PlainUI(no_color=True, file=io.StringIO()),
+        ui=ui or PlainUI(no_color=True, file=io.StringIO()),
         root_dir=root,
         run_id="run-test",
         bus=EventBus(
@@ -145,17 +157,50 @@ def _pipeline(root: Path, comp: Component, verification: VerificationResult) -> 
 def phase_verify_action(root: Path, failing: list[CheckResult]) -> tuple[FailureAction, str]:
     """``(action, error)`` the REAL ``_phase_verify`` routes to.
 
-    Drives ``ComponentPipeline._phase_verify`` with the verification
-    hook stubbed, rather than re-deriving the condition in the test: a
-    test that reimplements the branch it checks passes when the branch
-    is deleted.
+    Drives ``ComponentPipeline._phase_verify`` rather than re-deriving
+    the condition in the test: a test that reimplements the branch it
+    checks passes when the branch is deleted. Through
+    :func:`phase_verify_surfaces`, so the shape of that call - which
+    ``ComponentResult`` fields Phase 1 needs - is written once in this
+    file and not twice.
+    """
+    surfaces = phase_verify_surfaces(root, VerificationResult(passed=False, checks=failing))
+    assert surfaces.result.failure is not None
+    return surfaces.result.failure.action, surfaces.result.failure.error
+
+
+@dataclass(frozen=True)
+class PhaseVerifySurfaces:
+    """Everything one ``_phase_verify`` call left behind.
+
+    ``phase_verify_action`` answers "what did Phase 1 route to".
+    This answers "what did an operator and an event consumer see",
+    which is the question #306's not-measured sidecar exists for.
+    """
+
+    result: VerifyPhaseResult
+    narration: str
+    events: list[Event]
+
+
+def phase_verify_surfaces(
+    root: Path,
+    verification: VerificationResult,
+) -> PhaseVerifySurfaces:
+    """Drive the REAL ``_phase_verify`` over ``verification``.
+
+    The hook is stubbed to return ``verification`` unchanged, so the
+    aggregation is not re-run here; what is exercised is everything
+    Phase 1 does with the object afterwards.
     """
     comp = component()
-    pipeline = _pipeline(root, comp, VerificationResult(passed=False, checks=failing))
+    narration = io.StringIO()
+    events: list[Event] = []
+    pipeline = _pipeline(root, comp, verification, ui=PlainUI(no_color=True, file=narration))
+    pipeline.bus.add_sink(CallbackSink(events.append))
     result = pipeline._phase_verify(
         comp,
         ComponentResult(comp.id, success=True, iterations=1, duration_seconds=1.0),
         root,
     )
-    assert result.failure is not None
-    return result.failure.action, result.failure.error
+    return PhaseVerifySurfaces(result, narration.getvalue(), events)

--- a/tests/test_check_name_enrolment.py
+++ b/tests/test_check_name_enrolment.py
@@ -244,6 +244,13 @@ class TestEveryCheckNameIsEnrolled:
         assert {"test_suite", "typecheck", "linter"} <= names, "module-constant resolution"
         assert {"diff_scope", "scope_unreadable", "prd_stories"} <= names, "literal names"
         assert {"pr", "engineer", "token_budget"} <= names, "signature prefixes"
+        # #306: this one was not pinned, and so was not protected.
+        # Rewriting `CheckResult(name="mutation_testing", ...)` as
+        # `name=name` off a function-local took the walk from 19 names
+        # to 18 with nothing failing: the walk fails on an unenrolled
+        # name and cannot fail on one it cannot see. Measured on that
+        # branch before the fix.
+        assert "mutation_testing" in names, "check-name constant in the defining module"
 
     def test_no_unenrolled_name_beyond_the_grandfathered_set(self) -> None:
         missing = {

--- a/tests/test_sense_cli.py
+++ b/tests/test_sense_cli.py
@@ -80,9 +80,18 @@ def test_sense_passes_on_clean_tree(tmp_path: Path) -> None:
     result, document = _sense_json(root)
 
     assert result.exit_code == 0, result.output
-    assert document["schema_version"] == 1
+    # 2, not 1 (#306). The literal is pinned deliberately: this document
+    # is a published surface, and the bump is the only thing that tells
+    # a reader an ABSENT check row no longer means "turned off in
+    # kstrl.toml" - it can now also mean "asked for, measured nothing",
+    # which `not_measured` below disambiguates.
+    assert document["schema_version"] == 2
     assert document["path"] == str(root)
     assert document["passed"] is True
+    # Present and empty on a tree where every enabled check measured
+    # something: a reader can always index it, and an empty list is a
+    # positive statement rather than a missing key.
+    assert document["not_measured"] == []
     names = {c["name"] for c in document["checks"]}
     assert _ALWAYS_ON_CHECKS <= names
     for check in document["checks"]:
@@ -194,7 +203,7 @@ def test_sense_exit_2_on_missing_path(tmp_path: Path) -> None:
     assert result.exit_code == 2
     assert result.stderr.startswith("error:")
     document = json.loads(result.stdout)
-    assert document["schema_version"] == 1
+    assert document["schema_version"] == 2
     assert "error" in document
     assert missing in document["error"]
 
@@ -406,3 +415,53 @@ def test_sense_runs_without_git_when_no_check_reads_the_diff(
     assert document["passed"] is True
     names = {c["name"] for c in document["checks"]}
     assert names == {"test_suite", "typecheck", "linter"}
+
+
+def test_sense_reports_mutation_as_not_measured_not_as_a_pass(tmp_path: Path) -> None:
+    """#306 end to end, on a command that can NEVER measure this check.
+
+    `ks sense` is read-only and mutmut works by rewriting the files it
+    mutates, so an operator who turns mutation testing on gets no score
+    here, ever. Before #306 that produced a green ``mutation_testing``
+    row carrying a "skipped" message, which ``all(passed)`` and the LLM
+    reviewer's prompt both read as a pass. Removing the row alone would
+    be honest and mute. Both halves are asserted here: no row, and a
+    reason a human can read.
+    """
+    root = _make_repo(tmp_path)
+    (root / "kstrl.toml").write_text(_kstrl_toml() + "mutation_testing = true\n")
+
+    result, document = _sense_json(root)
+
+    assert result.exit_code == 0, result.output
+    assert [c for c in document["checks"] if c["name"] == "mutation_testing"] == []
+    assert document["not_measured"] == [
+        {
+            "check": "mutation_testing",
+            "reason": "read_only",
+            "detail": "mutmut rewrites the files it mutates and cannot run read-only",
+        }
+    ]
+    # Still a pass: a check that measured nothing neither passes nor
+    # fails, so the sidecar cannot become a gate by the back door.
+    assert document["passed"] is True
+
+
+def test_sense_table_names_what_it_did_not_measure(tmp_path: Path) -> None:
+    """The terminal half of the same fix.
+
+    Most operators read the table, not the JSON. If the gap reached only
+    ``--json`` the sidecar would serve machines and leave the human with
+    the silence that omission alone leaves.
+    """
+    root = _make_repo(tmp_path)
+    (root / "kstrl.toml").write_text(_kstrl_toml() + "mutation_testing = true\n")
+
+    result = _invoke("--root", str(root), "--ui", "plain", "--no-color")
+
+    assert result.exit_code == 0, result.output
+    assert "mutation_testing  not measured" in result.output
+    assert "cannot run read-only" in result.output
+    # The verdict line is unchanged: it counts checks, and a gap is not
+    # a check.
+    assert "sense: PASS" in result.output

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import sys
-from contextlib import ExitStack
+from dataclasses import replace
 from pathlib import Path
+from subprocess import CompletedProcess, TimeoutExpired
 from unittest.mock import patch
 
 import pytest
@@ -13,6 +15,7 @@ import pytest
 from kstrl.fixtures import FixturesConfig
 from kstrl.verify import (
     CheckResult,
+    MechanicalVerification,
     VerificationResult,
     VerifyConfig,
     check_bad_patterns,
@@ -27,6 +30,7 @@ from kstrl.verify import (
     run_mechanical_verification,
 )
 from tests.helpers.tool_output import tool_output
+from tests.helpers.verify_phase import CHEAP_GATES
 
 VITEST_FAILURE_OUTPUT = tool_output("vitest-2.1.9-writers-room.txt")
 
@@ -791,23 +795,72 @@ class TestCheckSelfCritique:
         assert result.passed is True
 
 
+def _mutmut_completed(stdout: str) -> CompletedProcess[str]:
+    """A finished ``mutmut`` invocation with ``stdout`` to parse."""
+    return CompletedProcess(args="mutmut", returncode=0, stdout=stdout, stderr="")
+
+
+#: ``CHEAP_GATES`` plus the opt-in mutation check, so the only row worth
+#: looking at is the one under test. Reused from ``tests.helpers`` rather
+#: than patching ``check_test_suite`` / ``check_typecheck`` /
+#: ``check_linter`` / ``check_diff_scope`` / ``check_bad_patterns`` by
+#: hand, which is a 13-line ``ExitStack`` this file already contained one
+#: copy of.
+MUTATION_GATES = replace(CHEAP_GATES, mutation_testing=True)
+
+
+def _verify_with_stub_mutation(
+    root: Path,
+    measured: CheckResult | None,
+    *,
+    config: VerifyConfig | None = None,
+    **kwargs: bool,
+) -> VerificationResult:
+    """Phase 1 over ``root`` with ``check_mutation_score`` stubbed.
+
+    The whole result, not just the mutation rows: a test that only ever
+    sees the rows cannot tell whether a FAIL still fails the run.
+    """
+    with patch("kstrl.verify.check_mutation_score", return_value=measured):
+        return run_mechanical_verification(
+            root,
+            None,
+            "main",
+            None,
+            config or MUTATION_GATES,
+            **kwargs,
+        )
+
+
+def _mutation_rows(result: VerificationResult) -> list[CheckResult]:
+    return [c for c in result.checks if c.name == "mutation_testing"]
+
+
 class TestCheckMutationScore:
-    def test_skips_when_mutmut_not_installed(self, tmp_path: Path) -> None:
+    """#306: every path that measures no score returns None, not a pass.
+
+    Why None and not a not-measured status is argued once, in
+    ``verify.check_mutation_score``.
+
+    ``is None`` rather than ``not result``: a falsy CheckResult would
+    satisfy the loose form, and the point is that there is no result at
+    all.
+    """
+
+    def test_mutmut_not_installed_measures_nothing(self, tmp_path: Path) -> None:
         with patch("shutil.which", return_value=None):
             result = check_mutation_score(tmp_path, "main")
-        assert result.passed is True
-        assert "not installed" in result.message
+        assert result is None
 
-    def test_skips_when_no_py_files_changed(self, tmp_path: Path) -> None:
+    def test_no_py_files_changed_measures_nothing(self, tmp_path: Path) -> None:
         with (
             patch("shutil.which", return_value="/usr/bin/mutmut"),
             patch("kstrl.verify.git.get_diff_names", return_value=["readme.md"]),
         ):
             result = check_mutation_score(tmp_path, "main")
-        assert result.passed is True
-        assert "No non-test" in result.message
+        assert result is None
 
-    def test_skips_test_files(self, tmp_path: Path) -> None:
+    def test_only_test_files_changed_measures_nothing(self, tmp_path: Path) -> None:
         with (
             patch("shutil.which", return_value="/usr/bin/mutmut"),
             patch(
@@ -816,11 +869,9 @@ class TestCheckMutationScore:
             ),
         ):
             result = check_mutation_score(tmp_path, "main")
-        assert result.passed is True
+        assert result is None
 
-    def test_timeout_passes_gracefully(self, tmp_path: Path) -> None:
-        import subprocess as sp
-
+    def test_timeout_measures_nothing(self, tmp_path: Path) -> None:
         with (
             patch("shutil.which", return_value="/usr/bin/mutmut"),
             patch(
@@ -829,17 +880,197 @@ class TestCheckMutationScore:
             ),
             patch(
                 "kstrl.verify.run_scrubbed",
-                side_effect=sp.TimeoutExpired("mutmut", 600),
+                side_effect=TimeoutExpired("mutmut", 600),
             ),
         ):
             result = check_mutation_score(tmp_path, "main", timeout=600)
+        assert result is None
+
+    def test_no_mutants_generated_measures_nothing(self, tmp_path: Path) -> None:
+        """mutmut ran and produced neither a killed nor a survived count.
+
+        The fifth path, and the same defect as the four the issue named:
+        0/0 is not a score, so it was reported as ``passed=True`` with
+        the message "No mutations generated".
+        """
+        with (
+            patch("shutil.which", return_value="/usr/bin/mutmut"),
+            patch("kstrl.verify.git.get_diff_names", return_value=["src/main.py"]),
+            patch(
+                "kstrl.verify.run_scrubbed",
+                return_value=_mutmut_completed("nothing to report\n"),
+            ),
+        ):
+            result = check_mutation_score(tmp_path, "main")
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "stdout, passed, pct",
+        [("9 killed\n1 survived\n", True, "90.0%"), ("1 killed\n9 survived\n", False, "10.0%")],
+        ids=["above-threshold", "below-threshold"],
+    )
+    def test_a_measured_score_is_the_only_thing_that_gets_a_row(
+        self,
+        tmp_path: Path,
+        stdout: str,
+        passed: bool,
+        pct: str,
+    ) -> None:
+        """The other half of the contract: a real score still reports.
+
+        Without these two the class would be satisfied by a function
+        that returns None unconditionally.
+        """
+        with (
+            patch("shutil.which", return_value="/usr/bin/mutmut"),
+            patch("kstrl.verify.git.get_diff_names", return_value=["src/main.py"]),
+            patch("kstrl.verify.run_scrubbed", return_value=_mutmut_completed(stdout)),
+        ):
+            result = check_mutation_score(tmp_path, "main", threshold=50.0)
+        assert result is not None
+        assert result.name == "mutation_testing"
+        assert result.passed is passed
+        assert pct in result.message
+
+
+class TestMutationRowOnlyExistsWhenMeasured:
+    """#306 at the level every consumer reads: the ``checks`` list."""
+
+    def test_no_measurement_appends_no_row(self, tmp_path: Path) -> None:
+        assert _mutation_rows(_verify_with_stub_mutation(tmp_path, None)) == []
+
+    def test_a_measurement_appends_its_row(self, tmp_path: Path) -> None:
+        """The other half: without this, dropping every row would pass."""
+        measured = CheckResult("mutation_testing", True, "Mutation score 90.0%")
+        result = _verify_with_stub_mutation(tmp_path, measured)
+        assert _mutation_rows(result) == [measured]
         assert result.passed is True
-        assert "timed out" in result.message
+
+    def test_a_failing_measurement_still_fails_the_run(self, tmp_path: Path) -> None:
+        """Omission must not become a way to lose a real FAIL.
+
+        ``result.passed`` is the assertion that earns the name. Without
+        it this is the test above with a boolean flipped, and an
+        aggregation that skipped the mutation row would satisfy both.
+        """
+        measured = CheckResult("mutation_testing", False, "below threshold")
+        result = _verify_with_stub_mutation(tmp_path, measured)
+        assert _mutation_rows(result) == [measured]
+        assert result.passed is False
+
+    def test_toggle_off_appends_no_row(self, tmp_path: Path) -> None:
+        """The pre-existing meaning of an absent row, unchanged: a
+        consumer already could not assume this row exists.
+
+        ``measured`` is a row deliberately, so a toggle read as ``True``
+        would produce one and fail here.
+        """
+        result = _verify_with_stub_mutation(
+            tmp_path,
+            CheckResult("mutation_testing", True),
+            config=CHEAP_GATES,
+        )
+        assert _mutation_rows(result) == []
+
+
+class TestVerificationSignatureIsKeywordOnly:
+    """#316: nothing after ``config`` can be passed positionally.
+
+    Three of the arguments in that block - ``allowed_paths_error``,
+    ``harness_paths`` and, beside them, ``allowed_paths`` - are
+    near-identical types carrying opposite meanings. See
+    ``verify.MechanicalVerification`` for why the type system was not
+    catching a transposition between them.
+
+    Two tests, not three: an "everything after index 4 is keyword-only"
+    assertion is derivable from the exact positional list below, since
+    the function has no ``*args`` or ``**kwargs`` for the two to
+    disagree about.
+    """
+
+    def test_only_the_first_five_parameters_are_positional(self) -> None:
+        params = list(inspect.signature(run_mechanical_verification).parameters.values())
+        positional = [p.name for p in params if p.kind is p.POSITIONAL_OR_KEYWORD]
+        assert positional == [
+            "worktree_path",
+            "prd_path",
+            "base_branch",
+            "allowed_paths",
+            "config",
+        ]
+
+    def test_a_sixth_positional_argument_is_refused(self) -> None:
+        """The rule as behaviour, not only as a signature assertion.
+
+        ``allowed_paths_error`` sat in slot six. ``Signature.bind``
+        rather than a real call: ``pytest.raises`` does not stop the body
+        running, so if the ``*`` this test guards were ever removed, a
+        real call here would shell out to the default test, typecheck and
+        lint commands at 300s timeouts apiece to prove a signature point.
+        ``bind`` raises the same ``TypeError`` without entering the
+        function.
+        """
+        with pytest.raises(TypeError, match="positional argument"):
+            inspect.signature(run_mechanical_verification).bind(
+                Path("."),
+                None,
+                "main",
+                None,
+                VerifyConfig(),
+                "scope unreadable",
+            )
+
+
+def test_the_protocol_says_exactly_what_the_function_says() -> None:
+    """#316: ``MechanicalVerification`` has not drifted from its function.
+
+    One assertion rather than four, because ``Signature.__eq__``
+    compares name, kind, annotation, default VALUE and return
+    annotation in one go - it is strictly stronger than the four
+    field-by-field checks it replaces, which let a Protocol saying
+    ``autonomy_level: int = 1`` through against a function saying 0.
+
+    Most drift is caught before this runs: ``kstrl/factory.py`` binds
+    the real function to the Protocol-typed field, so a Protocol with a
+    wrong annotation, a missing default or a wrong return type is a
+    ``mypy --strict`` error in CI. Measured on this branch, widening
+    ``allowed_paths_error`` in the Protocol produced
+    ``factory.py: error: Argument "run_mechanical_verification" to
+    "PipelineHooks" has incompatible type ... expected
+    "MechanicalVerification"``. What mypy CANNOT see is drift that
+    leaves the function MORE permissive than the Protocol - a parameter
+    the function grows and the Protocol lacks, or a kind that relaxes -
+    because the function still satisfies the Protocol. Those reach the
+    hook's callers as arguments they cannot pass, and this is what
+    catches them.
+
+    ``MechanicalVerification.__call__`` therefore spells its defaults as
+    real values (``= None``, ``= 0``, ``= False``) rather than the
+    conventional ``= ...``. Do not "tidy" that back: ``...`` is a
+    distinct default value, so it makes this comparison fail on every
+    optional parameter and forces the four weaker checks back.
+    """
+    proto = inspect.signature(MechanicalVerification.__call__)
+    params = list(proto.parameters.values())
+    assert params[0].name == "self"
+    without_self = proto.replace(parameters=params[1:])
+    assert without_self == inspect.signature(run_mechanical_verification)
 
 
 class TestCheckDeadCode:
     def test_no_tools_available_skips(self, tmp_path: Path) -> None:
-        """When neither ruff nor vulture are installed, skip gracefully."""
+        """When neither ruff nor vulture are installed, skip gracefully.
+
+        This pins the OLD convention on purpose, and it is the same
+        defect #306 fixed one check over: ``dead_code`` still returns
+        ``passed=True`` having measured nothing, on this path and on its
+        timeout. It is not fixed here because ``dead_code`` fuses two
+        measurements into one row - a ruff auto-fix phase that DID run
+        and a vulture phase that did not - so the honest fix is to split
+        the row, which moves ``DIFF_DEPENDENT_CHECKS``,
+        ``evolution``'s name-to-category table and ``feature_verify``'s
+        name-keyed baselines. Its own issue, not a rider on this one.
+        """
         with patch("shutil.which", return_value=None):
             result = check_dead_code(tmp_path, "main")
         assert result.passed is True
@@ -1175,23 +1406,56 @@ class TestReadOnlyVerification:
         assert any("git commit" in c for c in calls)
         assert "auto-fixed 2" in result.message
 
-    def test_mutation_read_only_skips_without_running_mutmut(
+    @pytest.mark.parametrize(
+        "read_only, expect_row",
+        [(True, False), (False, True)],
+        ids=["read-only", "writable"],
+    )
+    def test_read_only_is_the_only_reason_the_mutation_row_is_missing(
         self,
         tmp_path: Path,
+        read_only: bool,
+        expect_row: bool,
     ) -> None:
-        """mutmut works by rewriting the source it mutates: there is no
-        read-only way to run it, so the check is skipped and says so."""
+        """mutmut rewrites the source it mutates, so read-only cannot run
+        it - and #306: what it leaves behind is NO ROW, not a pass.
+
+        Asserted through ``run_mechanical_verification`` because the row
+        is what every consumer sees, and this is the path the issue was
+        filed from: `ks sense --json` printed ``mutation_testing  True``.
+
+        Both cases, so the flag is provably the only thing that moves:
+        mutmut is on PATH in both, the diff names a non-test Python file
+        in both, and mutmut reports 90% in both. Written first with
+        mutmut ABSENT, and it passed with the read-only gate deleted -
+        the row was missing for the wrong reason. That is the shape of
+        guard this repo keeps shipping, so the writable half is here to
+        make it impossible.
+        """
+        seen: list[str] = []
+
+        def run(cmd: object, **kwargs: object) -> CompletedProcess[str]:
+            seen.append(str(cmd))
+            if "mutmut" in str(cmd):
+                return _mutmut_completed("9 killed\n1 survived\n")
+            return CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
         with (
-            patch("shutil.which", side_effect=self._which),
-            patch("kstrl.verify.run_scrubbed") as mock_run,
+            patch("shutil.which", return_value="/usr/bin/mutmut"),
+            patch("kstrl.verify.run_scrubbed", side_effect=run),
             patch("kstrl.verify.git.get_diff_names", return_value=["src/main.py"]),
         ):
-            result = check_mutation_score(tmp_path, "main", read_only=True)
+            result = run_mechanical_verification(
+                tmp_path,
+                None,
+                "main",
+                None,
+                MUTATION_GATES,
+                read_only=read_only,
+            )
 
-        mock_run.assert_not_called()
-        assert result.passed is True
-        assert "Skipped" in result.message
-        assert "read-only" in result.message
+        assert bool(_mutation_rows(result)) is expect_row
+        assert any("mutmut" in c for c in seen) is expect_row
 
     def test_bad_patterns_writes_no_bytecode_beside_the_source(
         self,
@@ -1217,55 +1481,43 @@ class TestReadOnlyVerification:
         assert list(tmp_path.rglob("*.pyc")) == []
 
     @staticmethod
-    def _forwarded_read_only(
+    def _dead_code_read_only_and_mutation_consulted(
         tmp_path: Path,
         **kwargs: bool,
     ) -> tuple[bool, bool]:
-        """``(dead_code, mutation)`` read_only as actually forwarded."""
-        config = VerifyConfig(dead_code_cleanup=True, mutation_testing=True)
-        with ExitStack() as stack:
-            for name in (
-                "check_test_suite",
-                "check_typecheck",
-                "check_linter",
-                "check_diff_scope",
-                "check_bad_patterns",
-            ):
-                stack.enter_context(
-                    patch(
-                        f"kstrl.verify.{name}",
-                        return_value=CheckResult(name.removeprefix("check_"), True),
-                    )
-                )
-            dc = stack.enter_context(
-                patch(
-                    "kstrl.verify.check_dead_code",
-                    return_value=CheckResult("dead_code", True),
-                )
-            )
-            ms = stack.enter_context(
-                patch(
-                    "kstrl.verify.check_mutation_score",
-                    return_value=CheckResult("mutation_testing", True),
-                )
-            )
-            run_mechanical_verification(
-                tmp_path,
-                None,
-                "main",
-                None,
-                config,
-                **kwargs,
-            )
-            return (
-                bool(dc.call_args.kwargs["read_only"]),
-                bool(ms.call_args.kwargs["read_only"]),
-            )
+        """``(read_only as forwarded to dead_code, mutmut was consulted)``.
+
+        The two halves stopped being symmetric with #306, and that
+        asymmetry is the fix. ``check_dead_code`` still TAKES the flag:
+        read-only runs the same ruff rule set with ``--no-fix`` and
+        reports what the factory would have removed, so there is a
+        narrower thing for it to do. ``check_mutation_score`` no longer
+        takes the flag at all, because there is no narrower thing mutmut
+        can do - so read-only does not call it, and a flag that could
+        only ever return a row is gone.
+        """
+        config = replace(MUTATION_GATES, dead_code_cleanup=True)
+        with (
+            patch(
+                "kstrl.verify.check_dead_code",
+                return_value=CheckResult("dead_code", True),
+            ) as dc,
+            patch(
+                "kstrl.verify.check_mutation_score",
+                return_value=CheckResult("mutation_testing", True),
+            ) as ms,
+        ):
+            run_mechanical_verification(tmp_path, None, "main", None, config, **kwargs)
+        return bool(dc.call_args.kwargs["read_only"]), ms.called
 
     def test_verification_defaults_to_writable(self, tmp_path: Path) -> None:
         """No existing caller passes the flag, so the factory path must
         keep auto-fixing and mutating exactly as it did."""
-        assert self._forwarded_read_only(tmp_path) == (False, False)
+        assert self._dead_code_read_only_and_mutation_consulted(tmp_path) == (False, True)
 
     def test_verification_forwards_read_only(self, tmp_path: Path) -> None:
-        assert self._forwarded_read_only(tmp_path, read_only=True) == (True, True)
+        """dead_code is told; mutation is not called at all."""
+        assert self._dead_code_read_only_and_mutation_consulted(
+            tmp_path,
+            read_only=True,
+        ) == (True, False)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -12,12 +12,22 @@ from unittest.mock import patch
 
 import pytest
 
+from kstrl.events import VerificationResultEvent
 from kstrl.fixtures import FixturesConfig
 from kstrl.verify import (
+    MUTATION_TESTING_CHECK,
+    NOT_MEASURED_COMMAND_FAILED,
+    NOT_MEASURED_NO_MUTANTS,
+    NOT_MEASURED_NO_TARGET,
+    NOT_MEASURED_READ_ONLY,
+    NOT_MEASURED_TIMED_OUT,
+    NOT_MEASURED_TOOL_MISSING,
     CheckResult,
     MechanicalVerification,
+    NotMeasured,
     VerificationResult,
     VerifyConfig,
+    _count_before,
     check_bad_patterns,
     check_dead_code,
     check_diff_scope,
@@ -30,7 +40,7 @@ from kstrl.verify import (
     run_mechanical_verification,
 )
 from tests.helpers.tool_output import tool_output
-from tests.helpers.verify_phase import CHEAP_GATES
+from tests.helpers.verify_phase import CHEAP_GATES, phase_verify_surfaces
 
 VITEST_FAILURE_OUTPUT = tool_output("vitest-2.1.9-writers-room.txt")
 
@@ -811,15 +821,20 @@ MUTATION_GATES = replace(CHEAP_GATES, mutation_testing=True)
 
 def _verify_with_stub_mutation(
     root: Path,
-    measured: CheckResult | None,
+    measured: CheckResult | NotMeasured,
     *,
     config: VerifyConfig | None = None,
     **kwargs: bool,
 ) -> VerificationResult:
     """Phase 1 over ``root`` with ``check_mutation_score`` stubbed.
 
+    ``measured`` is whichever of the two things that function can now
+    return, so a caller has to say which arm it is exercising - a row or
+    a gap - instead of passing None and letting the plumbing decide.
+
     The whole result, not just the mutation rows: a test that only ever
-    sees the rows cannot tell whether a FAIL still fails the run.
+    sees the rows cannot tell whether a FAIL still fails the run, nor
+    whether a gap was recorded beside it.
     """
     with patch("kstrl.verify.check_mutation_score", return_value=measured):
         return run_mechanical_verification(
@@ -836,63 +851,131 @@ def _mutation_rows(result: VerificationResult) -> list[CheckResult]:
     return [c for c in result.checks if c.name == "mutation_testing"]
 
 
+def _gap(detail: str = "mutmut is not on PATH") -> NotMeasured:
+    """The record every not-measured test in this module works from."""
+    return NotMeasured(MUTATION_TESTING_CHECK, NOT_MEASURED_TOOL_MISSING, detail)
+
+
+def _result_with_gap() -> VerificationResult:
+    """A passing result carrying one gap beside one real row.
+
+    The row matters: a result with nothing in ``checks`` cannot show
+    that the gap stayed OUT of them.
+    """
+    return VerificationResult(
+        passed=True,
+        checks=[CheckResult("test_suite", True, "Tests passed")],
+        not_measured=[_gap()],
+    )
+
+
 class TestCheckMutationScore:
-    """#306: every path that measures no score returns None, not a pass.
+    """#306: every path that measures no score returns NotMeasured.
 
-    Why None and not a not-measured status is argued once, in
-    ``verify.check_mutation_score``.
-
-    ``is None`` rather than ``not result``: a falsy CheckResult would
-    satisfy the loose form, and the point is that there is no result at
-    all.
+    Each test names its own ``reason`` token AND asserts that the
+    collaborators downstream of the guard it is named for never ran.
+    Both halves are the round-2 fix, and they exist because round 1
+    asserted only ``result is None``: with that assertion, DELETING the
+    missing-binary guard, the no-Python-file guard or the timeout guard
+    left all three of their own tests passing, because a later exit also
+    returned None. Absence had five causes and the tests could not tell
+    them apart, which is the same defect that made the read-only test
+    wrong. A test that cannot fail for its own named reason is not a
+    test.
     """
 
     def test_mutmut_not_installed_measures_nothing(self, tmp_path: Path) -> None:
-        with patch("shutil.which", return_value=None):
-            result = check_mutation_score(tmp_path, "main")
-        assert result is None
-
-    def test_no_py_files_changed_measures_nothing(self, tmp_path: Path) -> None:
+        """Everything downstream is stubbed to SUCCEED, deliberately: a
+        deleted guard then reaches a 90% pass rather than an exception,
+        so this fails on its own reason and not on a TypeError."""
         with (
-            patch("shutil.which", return_value="/usr/bin/mutmut"),
-            patch("kstrl.verify.git.get_diff_names", return_value=["readme.md"]),
-        ):
-            result = check_mutation_score(tmp_path, "main")
-        assert result is None
-
-    def test_only_test_files_changed_measures_nothing(self, tmp_path: Path) -> None:
-        with (
-            patch("shutil.which", return_value="/usr/bin/mutmut"),
+            patch("shutil.which", return_value=None),
             patch(
                 "kstrl.verify.git.get_diff_names",
-                return_value=["test_main.py", "tests/test_foo.py"],
-            ),
+                return_value=["src/main.py"],
+            ) as diff_names,
+            patch(
+                "kstrl.verify.run_scrubbed",
+                return_value=_mutmut_completed("9 killed\n1 survived\n"),
+            ) as run_scrubbed,
         ):
             result = check_mutation_score(tmp_path, "main")
-        assert result is None
+        assert isinstance(result, NotMeasured)
+        assert result.reason == NOT_MEASURED_TOOL_MISSING
+        # The guard's own observable: nothing downstream of it ran.
+        diff_names.assert_not_called()
+        run_scrubbed.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "changed",
+        [["readme.md"], ["test_main.py", "tests/test_foo.py"]],
+        ids=["no-python", "only-test-python"],
+    )
+    def test_no_mutable_file_changed_measures_nothing(
+        self,
+        tmp_path: Path,
+        changed: list[str],
+    ) -> None:
+        """Both halves of the filter: the ``.py`` clause and the
+        ``startswith("test")`` clause."""
+        with (
+            patch("shutil.which", return_value="/usr/bin/mutmut"),
+            patch("kstrl.verify.git.get_diff_names", return_value=changed),
+            patch(
+                "kstrl.verify.run_scrubbed",
+                return_value=_mutmut_completed("9 killed\n1 survived\n"),
+            ) as run_scrubbed,
+        ):
+            result = check_mutation_score(tmp_path, "main")
+        assert isinstance(result, NotMeasured)
+        assert result.reason == NOT_MEASURED_NO_TARGET
+        # Delete the guard and mutmut is invoked with an EMPTY
+        # --paths-to-mutate and this stub hands back a 90% score, so the
+        # check reports a pass it never measured. That is the shape of
+        # #306 itself.
+        run_scrubbed.assert_not_called()
 
     def test_timeout_measures_nothing(self, tmp_path: Path) -> None:
         with (
             patch("shutil.which", return_value="/usr/bin/mutmut"),
-            patch(
-                "kstrl.verify.git.get_diff_names",
-                return_value=["src/main.py"],
-            ),
+            patch("kstrl.verify.git.get_diff_names", return_value=["src/main.py"]),
             patch(
                 "kstrl.verify.run_scrubbed",
                 side_effect=TimeoutExpired("mutmut", 600),
-            ),
+            ) as run_scrubbed,
         ):
             result = check_mutation_score(tmp_path, "main", timeout=600)
-        assert result is None
+        assert isinstance(result, NotMeasured)
+        assert result.reason == NOT_MEASURED_TIMED_OUT
+        # Exactly the `mutmut run` call and no `mutmut results` after
+        # it: returning on timeout is the point, and falling through
+        # would read counts off a run that never finished.
+        assert run_scrubbed.call_count == 1
+        assert "mutmut run" in str(run_scrubbed.call_args)
+
+    def test_a_failing_mutmut_is_not_an_empty_one(self, tmp_path: Path) -> None:
+        """A broken mutation command and a clean run with nothing to do
+        produce byte-identical empty output; only ``returncode``
+        separates them, and round 1 reported both as the same silence."""
+        broken = CompletedProcess(
+            args="mutmut",
+            returncode=2,
+            stdout="",
+            stderr="error: unrecognised option --paths-to-mutate\n",
+        )
+        with (
+            patch("shutil.which", return_value="/usr/bin/mutmut"),
+            patch("kstrl.verify.git.get_diff_names", return_value=["src/main.py"]),
+            patch("kstrl.verify.run_scrubbed", return_value=broken),
+        ):
+            result = check_mutation_score(tmp_path, "main")
+        assert isinstance(result, NotMeasured)
+        assert result.reason == NOT_MEASURED_COMMAND_FAILED
+        assert "unrecognised option" in result.detail
 
     def test_no_mutants_generated_measures_nothing(self, tmp_path: Path) -> None:
-        """mutmut ran and produced neither a killed nor a survived count.
-
-        The fifth path, and the same defect as the four the issue named:
-        0/0 is not a score, so it was reported as ``passed=True`` with
-        the message "No mutations generated".
-        """
+        """mutmut exited zero and produced neither count. 0/0 is not a
+        score, and round 1 reported it as ``passed=True``."""
         with (
             patch("shutil.which", return_value="/usr/bin/mutmut"),
             patch("kstrl.verify.git.get_diff_names", return_value=["src/main.py"]),
@@ -902,11 +985,29 @@ class TestCheckMutationScore:
             ),
         ):
             result = check_mutation_score(tmp_path, "main")
-        assert result is None
+        assert isinstance(result, NotMeasured)
+        assert result.reason == NOT_MEASURED_NO_MUTANTS
+
+    def test_every_reason_is_a_distinct_token(self) -> None:
+        """Six reasons, six values. A token that duplicated another would
+        make two of them indistinguishable in `ks sense --json` and in
+        `events.jsonl` while every test above still passed."""
+        reasons = [
+            NOT_MEASURED_READ_ONLY,
+            NOT_MEASURED_TOOL_MISSING,
+            NOT_MEASURED_NO_TARGET,
+            NOT_MEASURED_TIMED_OUT,
+            NOT_MEASURED_COMMAND_FAILED,
+            NOT_MEASURED_NO_MUTANTS,
+        ]
+        assert len(set(reasons)) == len(reasons) == 6
 
     @pytest.mark.parametrize(
         "stdout, passed, pct",
-        [("9 killed\n1 survived\n", True, "90.0%"), ("1 killed\n9 survived\n", False, "10.0%")],
+        [
+            ("9 killed\n1 survived\n", True, "90.0%"),
+            ("1 killed\n9 survived\n", False, "10.0%"),
+        ],
         ids=["above-threshold", "below-threshold"],
     )
     def test_a_measured_score_is_the_only_thing_that_gets_a_row(
@@ -919,7 +1020,7 @@ class TestCheckMutationScore:
         """The other half of the contract: a real score still reports.
 
         Without these two the class would be satisfied by a function
-        that returns None unconditionally.
+        that returns NotMeasured unconditionally.
         """
         with (
             patch("shutil.which", return_value="/usr/bin/mutmut"),
@@ -927,23 +1028,76 @@ class TestCheckMutationScore:
             patch("kstrl.verify.run_scrubbed", return_value=_mutmut_completed(stdout)),
         ):
             result = check_mutation_score(tmp_path, "main", threshold=50.0)
-        assert result is not None
+        assert isinstance(result, CheckResult)
         assert result.name == "mutation_testing"
         assert result.passed is passed
         assert pct in result.message
 
 
+class TestCountBefore:
+    """The mutmut counter, extracted in #306 round 2."""
+
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("12 killed", 12),
+            ("Killed: nope", 0),
+            ("", 0),
+            ("killed", 0),
+            ("3 killed\n7 killed\n", 7),
+            ("- 5 KILLED mutants", 5),
+        ],
+        ids=[
+            "plain",
+            "non-numeric",
+            "empty",
+            "no-preceding-token",
+            "last-wins",
+            "case-and-prose",
+        ],
+    )
+    def test_counts(self, text: str, expected: int) -> None:
+        assert _count_before("killed", text) == expected
+
+    def test_a_coloured_line_counts_as_zero(self) -> None:
+        """The limit, named rather than left to look robust.
+
+        Every other tool-output parser in this repo reads text that has
+        been through ``parsers.strip_ansi``; this one reads mutmut's
+        stdout raw, so an ANSI-coloured count is invisible to it. That
+        is pre-existing behaviour carried through the #306 extraction,
+        not something it introduced, and stripping here would be a
+        behaviour change with no measurement behind it. What it must not
+        do is go unrecorded: 0 killed and 0 survived is
+        ``no_mutants``, and this is a way to reach that wrongly.
+        """
+        assert _count_before("killed", "\x1b[32m12\x1b[0m killed") == 0
+
+    def test_words_do_not_bleed(self) -> None:
+        """``survived`` must not be read off a ``killed`` line. Two
+        independent loops made that structurally impossible; one shared
+        helper has to keep it true."""
+        text = "9 killed\n1 survived\n"
+        assert _count_before("killed", text) == 9
+        assert _count_before("survived", text) == 1
+
+
 class TestMutationRowOnlyExistsWhenMeasured:
-    """#306 at the level every consumer reads: the ``checks`` list."""
+    """#306 at the level every consumer reads: ``checks``, and the
+    sidecar beside it."""
 
-    def test_no_measurement_appends_no_row(self, tmp_path: Path) -> None:
-        assert _mutation_rows(_verify_with_stub_mutation(tmp_path, None)) == []
+    def test_no_measurement_appends_no_row_but_records_why(self, tmp_path: Path) -> None:
+        gap = _gap()
+        result = _verify_with_stub_mutation(tmp_path, gap)
+        assert _mutation_rows(result) == []
+        assert result.not_measured == [gap]
 
-    def test_a_measurement_appends_its_row(self, tmp_path: Path) -> None:
+    def test_a_measurement_appends_its_row_and_records_no_gap(self, tmp_path: Path) -> None:
         """The other half: without this, dropping every row would pass."""
         measured = CheckResult("mutation_testing", True, "Mutation score 90.0%")
         result = _verify_with_stub_mutation(tmp_path, measured)
         assert _mutation_rows(result) == [measured]
+        assert result.not_measured == []
         assert result.passed is True
 
     def test_a_failing_measurement_still_fails_the_run(self, tmp_path: Path) -> None:
@@ -958,9 +1112,11 @@ class TestMutationRowOnlyExistsWhenMeasured:
         assert _mutation_rows(result) == [measured]
         assert result.passed is False
 
-    def test_toggle_off_appends_no_row(self, tmp_path: Path) -> None:
-        """The pre-existing meaning of an absent row, unchanged: a
-        consumer already could not assume this row exists.
+    def test_toggle_off_records_nothing_at_all(self, tmp_path: Path) -> None:
+        """The sixth state, and the line the sidecar draws. A check the
+        operator turned OFF gets no row AND no gap: silence is a complete
+        answer to a question nobody asked, and an incomplete one to a
+        question they did.
 
         ``measured`` is a row deliberately, so a toggle read as ``True``
         would produce one and fail here.
@@ -971,6 +1127,116 @@ class TestMutationRowOnlyExistsWhenMeasured:
             config=CHEAP_GATES,
         )
         assert _mutation_rows(result) == []
+        assert result.not_measured == []
+
+
+class TestNotMeasuredIsReportedButNeverGates:
+    """#306 round 2: the sidecar is visible everywhere a human looks and
+    invisible everywhere a machine decides.
+
+    Round 1 omitted the row and stopped there, which was honest and
+    mute: an operator who set ``mutation_testing = true`` with no mutmut
+    installed got a clean report and a gate that silently never fired.
+    """
+
+    def test_a_gap_does_not_fail_the_run(self, tmp_path: Path) -> None:
+        """Through the real aggregation, not the constructor: a check
+        that measured nothing neither passes nor fails."""
+        assert _verify_with_stub_mutation(tmp_path, _gap()).passed is True
+
+    def test_a_gap_is_never_retry_context(self) -> None:
+        """``as_context`` feeds the engineer's next iteration. A missing
+        binary is not something a diff can fix, so it must not appear
+        there and spend ``repair_max_runs`` proving it."""
+        assert _result_with_gap().as_context() == ""
+
+    def test_a_gap_is_never_a_check_row(self) -> None:
+        """The #306 invariant: nothing in the sidecar can be read as a
+        pass by ``all(c.passed ...)``, ``report_lines``' verdict column,
+        the reviewer prompt or ``ks sense --json``'s ``checks`` array,
+        because it is not in ``checks``."""
+        assert [c.name for c in _result_with_gap().checks] == ["test_suite"]
+
+    def test_a_gap_is_rendered_in_the_report(self) -> None:
+        """The half that makes absence readable rather than merely
+        honest."""
+        lines = _result_with_gap().report_lines(durations=False)
+        assert any("mutation_testing  not measured" in line for line in lines)
+        assert any("mutmut is not on PATH" in line for line in lines)
+
+    def test_the_rendered_gap_never_says_pass(self) -> None:
+        """The word matters: `pass` in the verdict column is exactly what
+        #306 removed, so the sidecar line must not reintroduce it."""
+        line = next(
+            line for line in _result_with_gap().report_lines() if "mutation_testing" in line
+        )
+        assert "not measured" in line
+        assert "  pass  " not in line
+
+
+class TestPhase1SaysWhatItDidNotMeasure:
+    """#306 through the REAL Phase 1, not the dataclass.
+
+    ``TestNotMeasuredIsReportedButNeverGates`` above proves the object
+    behaves; this proves the pipeline actually carries it to the two
+    places anyone would look. Both are needed: a sidecar the pipeline
+    drops is the same silence as no sidecar, and it would leave every
+    assertion in that class green.
+    """
+
+    def test_the_operator_is_warned_with_the_reason_and_the_detail(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The warning is the whole point of round 2: before it, an
+        enabled mutation gate that could never run looked identical to
+        one that ran and passed."""
+        surfaces = phase_verify_surfaces(tmp_path, _result_with_gap())
+
+        assert "mutation_testing not measured" in surfaces.narration
+        assert f"({NOT_MEASURED_TOOL_MISSING})" in surfaces.narration
+        assert "mutmut is not on PATH" in surfaces.narration
+
+    def test_the_event_carries_the_gap_beside_the_checks_not_inside_them(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``events.jsonl`` is the integration substrate. A consumer
+        counting ``checks`` must not see a gap there, and a consumer
+        asking "did anything go unmeasured" must have somewhere to
+        look."""
+        surfaces = phase_verify_surfaces(tmp_path, _result_with_gap())
+        emitted = [e for e in surfaces.events if isinstance(e, VerificationResultEvent)]
+
+        assert len(emitted) == 1
+        assert emitted[0].not_measured == ("mutation_testing:tool_missing",)
+        assert emitted[0].checks == ("test_suite",)
+        assert emitted[0].passed is True
+
+    def test_a_run_with_no_gaps_says_nothing(self, tmp_path: Path) -> None:
+        """The quiet default. If this warned on every run the warning
+        would be noise within a day and unread within a week."""
+        clean = VerificationResult(
+            passed=True,
+            checks=[CheckResult("test_suite", True, "Tests passed")],
+        )
+
+        surfaces = phase_verify_surfaces(tmp_path, clean)
+        emitted = [e for e in surfaces.events if isinstance(e, VerificationResultEvent)]
+
+        assert "not measured" not in surfaces.narration
+        assert len(emitted) == 1
+        assert emitted[0].not_measured == ()
+
+    def test_a_gap_does_not_route_phase_1_to_a_failure(self, tmp_path: Path) -> None:
+        """Stated once at the layer that decides. The no-FAIL reasoning
+        is that a missing binary is not something the engineer's next
+        diff can fix, so this must not become a retry or a halt by
+        arriving through the pipeline instead of the aggregation."""
+        surfaces = phase_verify_surfaces(tmp_path, _result_with_gap())
+
+        assert surfaces.result.ran is True
+        assert surfaces.result.failure is None
 
 
 class TestVerificationSignatureIsKeywordOnly:
@@ -1456,6 +1722,12 @@ class TestReadOnlyVerification:
 
         assert bool(_mutation_rows(result)) is expect_row
         assert any("mutmut" in c for c in seen) is expect_row
+        # And the round-2 half: the read-only case is not merely
+        # row-less, it says why. Without this, deleting the gate and
+        # letting some later path swallow the run would still show an
+        # absent row.
+        gaps = [g.reason for g in result.not_measured if g.check == "mutation_testing"]
+        assert gaps == ([] if expect_row else [NOT_MEASURED_READ_ONLY])
 
     def test_bad_patterns_writes_no_bytecode_beside_the_source(
         self,


### PR DESCRIPTION
Closes #306. Closes #316.

Three adjacent lines in `kstrl/verify.py`, so one PR. Both issues carry owner
correction comments; both were re-verified against `origin/main` at `cbdff7c`
before anything moved.

## 1. #306: a green `mutation_testing` row meant "we did not look"

Reproduced on a throwaway repo, `ks sense --json` with `mutation_testing = true`:

```
mutation_testing  True  | Skipped: mutation testing rewrites the files it mutates and cannot run read-only
```

`check_mutation_score` had **five** paths that measured nothing and returned
`CheckResult(passed=True)`, not the four the issue names. The fifth is
`total == 0`, "No mutations generated": mutmut ran and produced neither a killed
nor a survived count, so 0/0 was reported as a pass. Same defect, same function,
same fix, so it is fixed here and called out rather than left.

| path | reaches | before | after |
|---|---|---|---|
| `read_only=True` | `ks sense`, `run_undiffed_verification` | `passed=True` | no row |
| mutmut not installed | `ks factory` | `passed=True` | no row |
| no non-test `.py` in the diff | `ks factory` | `passed=True` | no row |
| `mutmut run` timed out | `ks factory` | `passed=True` | no row |
| no mutants generated | `ks factory` | `passed=True` | no row |

### Where the false pass actually went

Not only the `ks sense` table. `kstrl/review.py:813-816` builds the LLM code
reviewer's `verification_summary` from **every** check, passing ones included.
Run against `origin/main`'s row:

```
verification_summary handed to REVIEWER_PROMPT:
- mutation_testing: PASS - mutmut not installed, skipping

report_lines (ks sense / ks feature table):
  mutation_testing  pass  mutmut not installed, skipping

VerificationResult.passed: True
```

An adversarial role was being told mutation testing passed on a run where mutmut
was not installed.

### Decision: omit the row, not an explicit not-measured status

The issue asks which. **Omit**, for three reasons, in order of weight.

**1. An explicit status on the row cannot deliver the requirement.** The
requirement is that a non-measurement be impossible to read as a pass. `passed`
is the only field every consumer reads: `VerificationResult.passed =
all(c.passed ...)`, `report_lines` prints `pass`, `ks sense --json` emits
`"passed": true`, and the reviewer prompt above prints `PASS`. Adding
`measured: bool` beside `passed` leaves every one of those reading a pass until
it is individually taught the new field, and `SENSE_SCHEMA_VERSION = 1` is a
published surface whose readers this repo cannot enumerate. Widening `passed` to
`bool | None` is worse: `all(c.passed ...)` then goes falsy on a skip and the
gate fails on a check that did not run.

**2. Absence is already this repo's written-down word for "did not run".**
`kstrl/feature_verify.py` says it in prose about its own suppressed checks:
"the suppressed checks are ABSENT from it rather than recorded as passing skips:
a machine reader doing `all(c.passed)` must never see a check that measured
nothing counted as a pass." Beside that, `[verify] mutation_testing` defaults to
`false` and appends no row, and `narrow_to_undiffed` turns four toggles off
because a diff-based check with no diff "would report a pass having measured
nothing, which is worse than not running". So no consumer could already assume
this row exists, omission is not a new contract, and a missing row cannot be
read as a pass by anyone, taught or untaught.

**3. It removes a mechanism rather than adding one.** `check_mutation_score`
loses its `read_only` parameter entirely: a flag whose only job was to return a
row saying it had done nothing is the defect in miniature.

Verified end to end on the same throwaway repo with `mutation_testing = true`:
the `mutation_testing` row is now absent from `ks sense --json` rather than
green.

### What this does not do, stated rather than argued away

**It does not FAIL on a missing mutmut or a timeout**, the two paths where
something is genuinely wrong rather than merely absent. A failing mechanical
check becomes retry context for the engineer, and installing a binary is not a
thing an engineer iteration can do, so a FAIL there spends `repair_max_runs`
iterations on a diff that cannot change the outcome.
`docs/dark-factory-roadmap.md` already places the right behaviour, "mutation
infra failure halts for a human rather than skipping (`infrastructure_error`
convention, halt-over-heroics)", in Layer 2 at L3+, and **halt is not fail**.
That layer is listed there under "Not built, and not claimed".

**So omission costs two things, and both are now written into the docstring
rather than glossed:**

1. An operator who sets `mutation_testing = true` with no mutmut on PATH gets
   silence where they used to get a green row. That is a smaller lie, not no lie.
2. It erases the difference between infra failure (mutmut absent, timed out) and
   legitimate non-applicability (nothing mutable changed, no mutants), which is
   exactly the distinction L3+ consumes.

The placement that keeps both is a **sidecar** on `VerificationResult` (a
`not_measured` list, or the `Finding.infrastructure_error` stream that
`check_test_adequacy` already uses and `CheckResult.findings` already carries):
additive, breaking no consumer, and leaving absence-from-`checks` exactly as it
is here. Not built, because its consumer is not built either. This is a
deliberate deferral to Layer 2, not an oversight.

### Shape of the fix

`check_mutation_score` returns `CheckResult | None`. A new `_mutation_checks`
mirrors the existing `_scope_checks`: it returns a list, owns the
`config.mutation_testing` toggle and the `read_only` rule, and drops a `None`.
The call site is one `extend` with no branch, one fewer decision than the
`if config.mutation_testing` it replaces. Measured: inlining both conditions
instead takes `run_mechanical_verification` to cyclomatic 10 against a gate of 10
and cognitive 15 against a gate of 15, which is why the helper exists.

## 2. #316: keyword-only, and the type that `*,` alone does not buy

Three of the issue's original claims were confirmed stale and are **not** acted
on: the `allowed_paths_error` fail-open is closed, `run_mechanical_verification`
is under both complexity gates (PR #300 did that), and the `ComponentScope`
object refactor is not done, because the ratchets no longer justify it.

**The `*,`.** Everything after `config` is keyword-only. Measured with an AST
walk over every `.py` in the tree: **27 call sites, 23 passing exactly five
positional arguments** (`worktree_path, prd_path, base_branch, allowed_paths,
config`), and **none passing a sixth**. Zero call-site edits, exactly as the
issue's correction says.

**But `*,` alone does not close the defect #316 is about**, and this was measured
rather than argued. With the `*,` applied and
`PipelineHooks.run_mechanical_verification` still typed
`Callable[..., VerificationResult]`, swapping `harness_paths=scope.harness_paths`
for `harness_paths=scope.error` (a `str | None` into a `list[str] | None` slot)
left:

```
Success: no issues found in 127 source files
```

Keyword-only stops a *slot* being inherited silently. It cannot stop a wrong
*value* being handed to the right *name*. Only a type can, and `...` is not one.

So this PR also adds `MechanicalVerification`, a `Protocol` describing the call
shape, and types that one hook field with it. Same planted swap, same command:

```
kstrl/pipeline.py:2501: error: Argument "harness_paths" to "__call__" of "MechanicalVerification" has incompatible type "str | None"; expected "list[str] | None"  [arg-type]
Found 1 error in 1 file (checked 127 source files)
```

**Why widen the PR by that much:** without it, the PR closes #316 without closing
what #316 is actually about. Cost, measured: one Protocol class, one annotation,
one import. Zero call-site changes, zero edits to existing tests, `mypy --strict`
clean, full suite green.

The other three `PipelineHooks` fields are left as `Callable[..., ...]`, and the
comment beside them now says what was **measured** rather than implying they were
cleared: `run_review` and `run_security_review` take adjacent
`prd_path` / `worktree_path` Paths and are called positionally;
`distill_facts` takes three Paths among ten positional arguments. Transposing any
of those type-checks clean today. Tightening them is not one character each,
because their call sites pass positionally, so it is a signature change plus a
call-site change plus a drift test per hook in three more modules. Its own issue.

A drifted Protocol would be worse than none, so
`test_the_protocol_says_exactly_what_the_function_says` compares it to the real
signature with a single `inspect.Signature` equality (name, kind, annotation,
default **value** and return type in one go). `kstrl/factory.py:3138` binds the
real function to the Protocol-typed field, so most drift is already a
`mypy --strict` error in CI; the test covers what mypy cannot see, drift that
leaves the function more permissive than the Protocol.

## Planted mutations

Every guard was checked by planting what it claims to catch and watching it fail.
All runs under `PYTHONDONTWRITEBYTECODE=1` with `__pycache__` cleared before and
after each plant, and the whole set was re-run against the final post-`/simplify`
tree.

**One of them caught a bad test, which is the point of doing it.** The read-only
guard was written with `shutil.which` stubbed so mutmut was *absent*. It
**passed** with the read-only gate deleted, because the row was missing for the
wrong reason. It is now parametrized over the flag with mutmut on PATH and
reporting 90% in both halves, so read-only is provably the only thing that moves.
That is the recurring defect in this batch and it was present in this PR until
the plant found it.

| plant | guard that failed | failure |
|---|---|---|
| remove `*,` | `test_only_the_first_five_parameters_are_positional`, `test_a_sixth_positional_argument_is_refused`, `test_the_protocol_says_exactly_what_the_function_says` | `assert positional == [...]`, `DID NOT RAISE TypeError` |
| drop `or read_only` from `_mutation_checks` | `test_read_only_is_the_only_reason_the_mutation_row_is_missing[read-only]`, `test_verification_forwards_read_only` | `assert True is False`, where True = `[CheckResult(name='mutation_testing', passed=True, message='Mutation score 90.0% (threshold: 50.0%)' ...)]` |
| mutmut-missing returns a passing row | `test_mutmut_not_installed_measures_nothing` | `assert CheckResult(name='mutation_testing', passed=True, message='mutmut not installed, skipping', ...) is None` |
| no-py-files returns a passing row | `test_no_py_files_changed_measures_nothing`, `test_only_test_files_changed_measures_nothing` | `assert CheckResult(name='mutation_testing', passed=True, message='No non-test Python files changed', ...) is None` |
| timeout returns a passing row | `test_timeout_measures_nothing` | `assert CheckResult(name='mutation_testing', passed=True, message='Mutation testing timed out, skipping', ...) is None` |
| no-mutants returns a passing row | `test_no_mutants_generated_measures_nothing` | `assert CheckResult(name='mutation_testing', passed=True, message='No mutations generated', ...) is None` |
| `_mutation_checks` turns a `None` back into a passing row | `test_no_measurement_appends_no_row` | `Left contains one more item: CheckResult(name='mutation_testing', passed=True, message='skipped', ...)` |
| aggregation skips the mutation row | `test_a_failing_measurement_still_fails_the_run` | `assert True is False` on `result.passed` |
| Protocol drops `read_only` | `test_the_protocol_says_exactly_what_the_function_says` | `Signature` inequality naming the missing parameter |
| Protocol says `autonomy_level: int = 1` | `test_the_protocol_says_exactly_what_the_function_says` | `Signature` inequality on the default VALUE |
| Protocol widens `allowed_paths_error` | `mypy --strict` | `pipeline.py:2499: error: Argument "allowed_paths_error" ... incompatible type "str | None"; expected "list[str] | None"` and `factory.py:3138: error: Argument "run_mechanical_verification" to "PipelineHooks" has incompatible type ...` |

Note the last three: the `Signature`-equality test is strictly stronger than the
four field-by-field checks it replaced, which let a Protocol saying
`autonomy_level: int = 1` through against a function saying `0`.

## Tests

New or rewritten, all in `tests/test_verify.py`:

- `TestCheckMutationScore` - `test_mutmut_not_installed_measures_nothing`,
  `test_no_py_files_changed_measures_nothing`,
  `test_only_test_files_changed_measures_nothing`,
  `test_timeout_measures_nothing`, `test_no_mutants_generated_measures_nothing`,
  `test_a_measured_score_is_the_only_thing_that_gets_a_row[above-threshold|below-threshold]`
- `TestMutationRowOnlyExistsWhenMeasured` - `test_no_measurement_appends_no_row`,
  `test_a_measurement_appends_its_row`,
  `test_a_failing_measurement_still_fails_the_run`, `test_toggle_off_appends_no_row`
- `TestReadOnlyVerification` -
  `test_read_only_is_the_only_reason_the_mutation_row_is_missing[read-only|writable]`
  (replaces `test_mutation_read_only_skips_without_running_mutmut`),
  `test_verification_defaults_to_writable`, `test_verification_forwards_read_only`
- `TestVerificationSignatureIsKeywordOnly` -
  `test_only_the_first_five_parameters_are_positional`,
  `test_a_sixth_positional_argument_is_refused`
- `test_the_protocol_says_exactly_what_the_function_says`

## Ratchets, measured before and after

`complexipy` 7.0.1 for cognitive, `ruff` 0.16.4 mccabe for cyclomatic, the pins
the hooks themselves use.

| function | cognitive (gate 15) | cyclomatic (gate 10) |
|---|---|---|
| `run_mechanical_verification` | 12 -> 11 | 9 -> 8 |
| `check_mutation_score` | 41 -> 40 | 17 -> 16 |
| `_mutation_checks` (new) | 3 | 2 |
| `MechanicalVerification.__call__` (new) | 0 | n/a |

`scripts/precommit/cyclomatic_ratchet.py` on the staged index:

```
  IMPROVED   kstrl/verify.py::check_mutation_score  cyclomatic 17 -> 16
  IMPROVED   kstrl/verify.py::run_mechanical_verification  cyclomatic 9 -> 8
```

## Verification

- `uv run pytest tests/` - **4659 passed, 28 skipped, 0 failed**
- fast tier (`-m "not spine"`) 4632 passed; spine tier (`-m spine`) 27 passed
- combined coverage **89.99%** against the 79.91% ratchet in
  `.github/coverage-baseline.txt`
- `uv run mypy kstrl/ --strict` - clean, 127 files
- `uv run ruff check kstrl/ tests/` and `ruff format --check` - clean
- `uv run python scripts/gen_docs.py --check` - README generated sections current
- `pre-commit run --files kstrl/verify.py kstrl/pipeline.py tests/test_verify.py`
  - every hook Passed, including `complexipy`, `cyclomatic complexity does not
  grow`, `forbid em dashes`, `vulture` and gitleaks
- `ks sense --json` on a throwaway repo with `mutation_testing = true` - the row
  is absent, not green

Every command above ran with `PYTHONDONTWRITEBYTECODE=1` and `__pycache__`
cleared first.

Branched from `origin/main` at `cbdff7c` and re-fetched before pushing: `main` had
not moved, and **PR #328 is still open and unmerged**, so there was nothing to
rebase onto and no conflict to resolve. `_signal_process_group`, the function
#328 changes, is untouched by this diff.

## Follow-ups this PR deliberately did not take

1. **`check_dead_code` has the identical defect**, 150 lines away in the same
   file: "Skipped: neither vulture nor custom command available" and "Dead code
   scan timed out after Ns, skipping" both return `passed=True`, and reach the
   reviewer prompt the same way. Not fixed here because `dead_code` fuses two
   measurements into one row (a ruff auto-fix phase that DID run, a vulture phase
   that did not), so the honest fix is splitting the row, which moves
   `DIFF_DEPENDENT_CHECKS`, `evolution`'s name-to-category table and
   `feature_verify`'s name-keyed baselines. `test_no_tools_available_skips` now
   carries a docstring saying it pins the old convention on purpose, so the file
   does not read as holding two intents by accident.
2. **The convention has no mechanism yet.** A guard in the shape of the repo's
   existing AST walks (`test_atomicio.py` on `mkstemp`, `test_process_scoping.py`
   on `pgrep`) would stop the next check growing a passing skip. Declined here:
   with `dead_code`'s four rows still live, such a guard ships with an allowlist
   as long as its enforcement, which is a comment, not a mechanism. It belongs
   with (1).
3. **The other three `PipelineHooks` fields**, as measured above.
4. **`docs/atlas/atlas.json`** records a stale `check_mutation_score` signature.
   It was already stale on `origin/main` (missing `harness_paths` and
   `pre_run_prd_path`), `docs/atlas/README.md` names a generator
   (`scripts/atlas/extract_atlas.py`) that does not exist in this repo, and no CI
   job or hook reads it. Hand-editing a generated file would be an unverifiable
   change, so it is reported rather than touched.

## /simplify findings, round 1, verbatim

Four agents ran against the round-1 staged diff: reuse, simplification,
efficiency, altitude. Their reports, and my disposition of every finding
including the declined ones, are pasted VERBATIM in a PR comment rather than
here: with round 2's findings below they exceed GitHub's 65,536 character cap.
Nothing is trimmed or paraphrased.

---

# Round 2

Review of round 1 raised two P2 must-fix findings and no P0/P1/P3. Both are fixed
on this branch.

## F1: omission removed the operator's only explanation

Round 1 deleted the green row and stopped there. That was right about `checks`
and mute about everything else: `mutation_testing = true` with mutmut absent
produced `passed=True`, no row, and no word on any surface. Seven distinct states
arrived at the same silence, and an external reader could not tell them apart:

| state | what the operator did | round 1 showed | round 2 shows |
|---|---|---|---|
| disabled | left the toggle off | nothing | nothing, deliberately |
| read-only | ran `ks sense` | nothing | `read_only` |
| tool missing | enabled it, no mutmut on PATH | nothing | `tool_missing` |
| no target | changed no non-test Python file | nothing | `no_target` |
| timed out | `mutation_timeout` exceeded | nothing | `timed_out` |
| command failed | broken mutmut invocation, non-zero exit | nothing | `command_failed` |
| no mutants | mutmut ran clean, generated nothing | nothing | `no_mutants` |

Before #306, six of those seven produced the same green row. After round 1 they
produced the same silence. Six of them now say which one they are.

The no-FAIL reasoning from round 1 is unchanged and is not reversed: a missing
binary is not something the engineer's next diff can fix, so a FAIL would spend
`repair_max_runs` proving it. The third option is a non-gating record.

This does reverse one round-1 decision, and it is worth naming which. Round 1's
own /simplify pass raised "Altitude 2, build it: add the `VerificationResult`
sidecar now" and I declined it, on the grounds that its consumer is Layer 2 at
L3+ and a field nothing reads is a silent code path. That was wrong about who the
consumer is. The consumer is the operator reading the report today, not the
unbuilt halt layer. The decline is withdrawn.

### The shape chosen, and where it lives

`NotMeasured` in `kstrl/verify.py`: a frozen dataclass of `check`, `reason`,
`detail`. Deliberately not a `CheckResult`, and it never enters `checks`.

```python
@dataclass(frozen=True)
class NotMeasured:
    check: str
    reason: str
    detail: str
```

`VerificationResult` grew one field beside `checks`:

```python
not_measured: list[NotMeasured] = field(default_factory=list)
```

It owns all three of its renderings, so no consumer spells one itself:
`as_line()` for the report table, `as_token()` for `events.jsonl`
(`"<check>:<reason>"`, the same shape `evolution.split_signature` already reads),
`to_dict()` for `ks sense --json`.

Six reason tokens, one per state that can produce a gap. The seventh state, the
check being turned off, records nothing at all: a question nobody asked needs no
answer, and a warning on every default run is unread within a week.

| token | owner |
|---|---|
| `read_only` | `_mutation_checks` (mutmut rewrites what it mutates) |
| `tool_missing` | `check_mutation_score` |
| `no_target` | `check_mutation_score` |
| `timed_out` | `check_mutation_score` |
| `command_failed` | `_no_counts`, non-zero exit with no counts |
| `no_mutants` | `_no_counts`, zero exit with no counts |

`command_failed` and `no_mutants` are separated because a broken
`mutation_command` and a clean run over nothing mutable produce byte-identical
empty output. Only `returncode` tells them apart, and collapsing them is how a
permanently misconfigured gate reads as a quiet, correct no-op.

### Visible to humans, invisible to machines that decide

| surface | carries the gap | can read it as a pass |
|---|---|---|
| `VerificationResult.checks` | no | n/a |
| `all(c.passed for c in checks)` | no | impossible |
| `VerificationResult.as_context` (retry context) | no | impossible |
| `review.build_review_prompt` | no | impossible |
| `VerificationResult.report_lines` (terminal) | yes, as `not measured` | never says pass |
| `ks sense --json`, `not_measured` array | yes, beside `checks` | separate key |
| `ComponentPipeline._warn_not_measured` | yes, `ui.warn` | not a verdict |
| `VerificationResultEvent.not_measured` | yes, `"check:reason"` | separate field |

`ks sense --json` moves to `SENSE_SCHEMA_VERSION = 2`, because the meaning of an
absent `mutation_testing` row changed: under v1 it meant "turned off", under v2 it
can also mean "asked for, measured nothing", and `not_measured` separates them.
That claim is deliberately scoped to that one check, because that is all v2
delivers. `check_dead_code` still reports three non-measurements as passing rows,
and `require_self_critique` with no `progress_file_path` and no PRD emits neither
a row nor a gap. Both predate this PR, both are named in the constant's own
comment, and both are follow-ups, so no reader takes an empty array for
"everything enabled was measured".

`V1CompatSink` drops `not_measured` on the progress.jsonl path, as it already
drops `phase` and `advisory`. Recorded next to that existing known limitation
rather than left for a reader to find.

On the `ks feature` path the field is unreachable rather than merely empty, and
the comment there now says so structurally: `narrow_to_undiffed` rewrites the
operator's toggles to False before any check runs, which erases the very bit the
sidecar reads. Fixing that is a change to the suppression layer, and it is the
object #305 already tracks.

## F2: three more tests that passed for the wrong reason

The reviewer bypassed the missing-binary, no-Python and timeout guards
independently and all three of their tests still passed, because a later exit
also returned `None`. Reproduced, confirmed, and fixed the way the review asked:
each path now has its own mocks and side effects, asserts its own `reason` token,
and asserts that the collaborators downstream of its guard never ran.

Two of them also carried the weaker defect that deleting the guard raised a
`TypeError` on a bare `MagicMock` rather than reaching a plausible later outcome.
Everything downstream is now stubbed to SUCCEED, so a deleted guard produces a
green 90% score and the test fails on its own assertion rather than on the
interpreter.

## Every guard planted separately

Every run below is under `PYTHONDONTWRITEBYTECODE=1` with every `__pycache__`
under the worktree removed immediately before the run and the source restored
immediately after, and every one was re-run against the final code after the
/simplify fixes landed. Baseline with no plant: `130 passed`.

### 1. `tool_missing`: delete the missing-binary guard

`tests/test_verify.py::TestCheckMutationScore::test_mutmut_not_installed_measures_nothing`

```
>       assert isinstance(result, NotMeasured)
E       AssertionError: assert False
E        +  where False = isinstance(CheckResult(name='mutation_testing', passed=True, message='Mutation score 90.0% (threshold: 50.0%)', details=['Killed:...: 1, Total: 10', 'Score: 90.0% (threshold: 50.0%)'], duration_seconds=2.6999972760677338e-05, parsed=None, findings=[]), NotMeasured)
```

### 2. `no_target`: delete the nothing-to-mutate guard

`tests/test_verify.py::TestCheckMutationScore::test_no_mutable_file_changed_measures_nothing`
(both parametrizations fail)

```
>       assert isinstance(result, NotMeasured)
E       AssertionError: assert False
E        +  where False = isinstance(CheckResult(name='mutation_testing', passed=True, message='Mutation score 90.0% (threshold: 50.0%)', details=['Killed:...d: 1, Total: 10', 'Score: 90.0% (threshold: 50.0%)'], duration_seconds=3.087497316300869e-05, parsed=None, findings=[]), NotMeasured)
```

### 3. `timed_out`: let the timeout fall through to the empty-run path

`tests/test_verify.py::TestCheckMutationScore::test_timeout_measures_nothing`

```
        assert isinstance(result, NotMeasured)
>       assert result.reason == NOT_MEASURED_TIMED_OUT
E       AssertionError: assert 'no_mutants' == 'timed_out'
E
E         - timed_out
E         + no_mutants
```

### 4. `command_failed`: stop distinguishing a non-zero exit

`tests/test_verify.py::TestCheckMutationScore::test_a_failing_mutmut_is_not_an_empty_one`

```
        assert isinstance(result, NotMeasured)
>       assert result.reason == NOT_MEASURED_COMMAND_FAILED
E       AssertionError: assert 'no_mutants' == 'command_failed'
E
E         - command_failed
E         + no_mutants
```

### 5. `no_mutants`: restore the pre-#306 green row for 0/0

`tests/test_verify.py::TestCheckMutationScore::test_no_mutants_generated_measures_nothing`

```
>       assert isinstance(result, NotMeasured)
E       AssertionError: assert False
E        +  where False = isinstance(CheckResult(name='mutation_testing', passed=True, message='No mutants generated', details=[], duration_seconds=2.6708992663770914e-05, parsed=None, findings=[]), NotMeasured)
```

### 6. `read_only`: delete the read-only gate

`tests/test_verify.py::TestReadOnlyVerification::test_read_only_is_the_only_reason_the_mutation_row_is_missing[read-only]`

```
>       assert bool(_mutation_rows(result)) is expect_row
E       AssertionError: assert True is False
E        +  where True = bool([CheckResult(name='mutation_testing', passed=True, message='Mutation score 90.0% (threshold: 50.0%)', details=['Killed... 1, Total: 10', 'Score: 90.0% (threshold: 50.0%)'], duration_seconds=2.4124979972839355e-05, parsed=None, findings=[])])
```

## And every carrier planted separately

A gap the pipeline drops is the same silence as no gap, so each surface that
carries it is planted too.

### 7. Drop the operator warning in Phase 1

`tests/test_verify.py::TestPhase1SaysWhatItDidNotMeasure::test_the_operator_is_warned_with_the_reason_and_the_detail`

```
>       assert "mutation_testing not measured" in surfaces.narration
E       AssertionError: assert 'mutation_testing not measured' in '  Phase 1: mechanical verification for comp-a...\nOK:   Phase 1 passed for comp-a\n'
```

### 8. Drop the gap from the verification event

`tests/test_verify.py::TestPhase1SaysWhatItDidNotMeasure::test_the_event_carries_the_gap_beside_the_checks_not_inside_them`

```
>       assert emitted[0].not_measured == ("mutation_testing:tool_missing",)
E       AssertionError: assert () == ('mutation_te...ool_missing',)
E
E         Right contains one more item: 'mutation_testing:tool_missing'
```

### 9. Drop `not_measured` from the sense JSON document

`tests/test_sense_cli.py::test_sense_reports_mutation_as_not_measured_not_as_a_pass`

```
>       assert document["not_measured"] == [
E       KeyError: 'not_measured'
```

### 10. Stop rendering the gap in `report_lines`

`tests/test_verify.py::TestNotMeasuredIsReportedButNeverGates::test_a_gap_is_rendered_in_the_report`
and `tests/test_sense_cli.py::test_sense_table_names_what_it_did_not_measure`

```
>       assert any("mutation_testing  not measured" in line for line in lines)
E       assert False
```

```
>       assert "mutation_testing  not measured" in result.output
E       AssertionError: assert 'mutation_testing  not measured' in '\n== ks sense ==\n  Path: ...allowed_paths not set)  (0.00s)\n  bad_patterns  pass  Scanned 0 Python files, no issues  (0.01s)\n\nOK: sense: PASS\n'
```

### 11. Name the check through a function-local again

The regression /simplify found in this round's own diff, and the new pin that
catches it. Reintroducing `name = MUTATION_TESTING_CHECK` and passing it to the
two `CheckResult(...)` constructions is exactly what round 2 shipped before the
fix, and it took `tests/test_check_name_enrolment.py` from 19 resolvable check
names to 18 with nothing failing:

`tests/test_check_name_enrolment.py::TestEveryCheckNameIsEnrolled::test_the_walk_sees_the_gates_it_claims_to_guard`

```
>       assert "mutation_testing" in names, "check-name constant in the defining module"
E       AssertionError: check-name constant in the defining module
E       assert 'mutation_testing' in {'aborted', 'bad_patterns', 'dead_code', 'diff', 'diff_scope', 'engineer', ...}
```

## Round-2 complexity, measured

The sidecar took two functions that were ALREADY above complexipy's cognitive
gate of 15 further past it: `cli.py::sense` 25 to 27, and
`pipeline.py::_phase_verify` 20 to 21. The staged hook caught it and failed.
Extracting `_sense_document` and `_warn_not_measured` puts both below where this
branch found them:

```
NEW          kstrl/cli.py::_sense_document                              4  (new)
IMPROVED     kstrl/cli.py::sense                                   25 -> 20  (-5)
NEW          kstrl/pipeline.py::ComponentPipeline::_warn_not_m...       1  (new)
IMPROVED     kstrl/verify.py::check_mutation_score                 40 -> 9  (-31)
REGRESSED    kstrl/verify.py::VerificationResult::report_lines       8 -> 9  (+1)
```

`_phase_verify` no longer appears in the diff at all: it is back at its HEAD
value. `report_lines` at 9 is under the gate. The cyclomatic ratchet
(`does not grow`) passes.

## Round-2 verification

Rebased onto `origin/main` at `1995ec2` before every number below, so PR #328's
`_signal_process_group` refactor is underneath this branch rather than beside it.
This diff does not touch that function (`git diff origin/main...HEAD` mentions it
zero times).

| gate | result |
|---|---|
| `uv run pytest tests/` | 4787 passed, 28 skipped, 6 xfailed |
| `uv run mypy kstrl/ --strict` | Success: no issues found in 127 source files |
| `uv run ruff check kstrl/ tests/` | All checks passed |
| `uv run ruff format --check` | 297 files already formatted |
| `uv run python scripts/gen_docs.py --check` | README generated sections are current |
| fast tier (`-m "not spine"`) | 4760 passed, 28 skipped, 27 deselected |
| spine tier (`-m spine`) | 27 passed |
| combined coverage vs the 79.91 ratchet | 90.11% |
| staged `pre-commit run` | every hook Passed |

## Follow-ups this round names and does not take

1. **`check_dead_code`** still returns `passed=True` on three paths that measured
   nothing, which is the #306 defect verbatim. The honest fix splits the row,
   because `dead_code` fuses a ruff phase that ran with a vulture phase that did
   not, and that moves `DIFF_DEPENDENT_CHECKS`, `evolution`'s name-to-category
   table and `feature_verify`'s name-keyed baselines.
2. **`require_self_critique`** with no `progress_file_path` and no PRD emits
   neither a row nor a gap. One `NotMeasured` with a `not_configured` reason
   closes it, and needs a seventh token.
3. **`narrow_to_undiffed`** forces six toggles off before the checks run, which
   erases the "was this asked for" bit, so `ks feature` can never populate the
   field. Fixing it belongs to the suppression layer and to #305.
4. **Gaps do not reach the PR body or the evolution journal.** `Finding.phase_skipped`
   is the existing channel; routing through it changes behaviour rather than
   structure, so it is not a /simplify change.
5. **`(rows, gaps)`** should become one accumulator partitioned at the return
   before a second check adopts the sidecar.
6. **The reason tokens** should probably be a `StrEnum`, which is the repo's
   convention in 13 modules.

## /simplify, round 2

Ran again over the round-2 diff, four agents. The findings are pasted VERBATIM in
a PR comment rather than here, together with my disposition of every one
including the declined ones: this body already carries the round-1 findings, and
the two rounds together exceed GitHub's 65,536 character cap. Nothing is trimmed
or paraphrased.

The round-2 pass found one regression this round introduced and I had missed: a
check name moved into a function-local, which made `tests/test_check_name_enrolment.py`
blind to `mutation_testing` without failing. That is fixed and pinned, and plant
11 above is its evidence.

---

Not self-reviewed (H1). Do not merge.
