### PR TITLE
refactor(evolution): the spec-audit reader, its window and its event name live on the journal (#314)

### DIFF
--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -1330,34 +1330,39 @@ def _excluded_history(
     )
 
 
-def _journal_snapshot(
-    journal: EvolutionJournal | None,
-    project_name: str,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], int]:
+@dataclass(frozen=True)
+class AuditSnapshot:
+    """One read of the recorded spec-audit history, in three views.
+
+    A container rather than a tuple because ``audits`` and ``window``
+    are both ``list[dict[str, Any]]``: swapping them typechecks, and
+    they are exactly the pair #280 exists to keep straight - the trend
+    reads the window, the accounting under it reads everything the
+    window left out.
+    """
+
+    #: Every spec audit the journal holds, across every project.
+    audits: list[dict[str, Any]]
+    #: This project's last ``lookback`` audits: what the trend scores.
+    window: list[dict[str, Any]]
+    #: How far back the window reaches, carried so the render can tell
+    #: a windowed-out audit from one the trend could not score.
+    lookback: int
+
+
+def _journal_snapshot(journal: EvolutionJournal | None, project_name: str) -> AuditSnapshot:
     """The recorded audit history behind one convergence report.
 
-    Three things from ONE read: every spec audit the journal holds,
-    this project's window of them, and how far back that window
-    reaches. Together because a journal that is absent has none of the
-    three, which keeps that single fact here instead of three
+    All three views from ONE read, because a journal that is absent has
+    none of the three: that keeps the fact here instead of three
     conditionals at the call site.
 
     Read through ``EvolutionJournal`` rather than through its storage
-    path (#314). The journal's own reader is the only one that would
-    survive the file compacting, rotating or gaining a second segment;
-    a caller holding the path would quietly return less than the
-    journal holds while the trend kept printing, and silent loss of
-    the excluded-history accounting is the defect #280 exists to fix.
-
-    The window comes from ``get_spec_issue_runs`` rather than from a
-    second copy of its rule here, so the trend and the accounting
-    printed under it cannot disagree about which audits belong to this
-    project. Runs are matched by project NAME, not by spec path or
-    content hash: the spec is edited between every round by
-    construction (so a content hash never matches), and the recorded
-    loop in #260 renamed the file mid-loop (so the path does not
-    either). A previous audit of a different file is still reported,
-    with the file names named.
+    path, and windowed by ``get_spec_issue_runs`` rather than by a
+    second copy of its rule here (#314). Why each matters is on those
+    two methods; the short version is that a caller holding the path
+    survives no change of storage, and a second copy of the window rule
+    can drift from the one the accounting uses.
 
     MUST be read BEFORE this run's own audit is appended to the
     journal, or the "previous run" the trend compares against is this
@@ -1369,11 +1374,14 @@ def _journal_snapshot(
     78 MB, against an architect call measured at 119 to 210 seconds.
     """
     if journal is None:
-        return [], [], 0
+        return AuditSnapshot(audits=[], window=[], lookback=0)
     audits = journal.get_spec_audits()
     lookback = journal.config.lookback_runs
-    window = journal.get_spec_issue_runs(project_name, lookback, audits=audits)
-    return audits, window, lookback
+    return AuditSnapshot(
+        audits=audits,
+        window=journal.get_spec_issue_runs(project_name, lookback, audits=audits),
+        lookback=lookback,
+    )
 
 
 def _surface_convergence(
@@ -1981,15 +1989,15 @@ def _decompose_spec_impl(
     # ONE read feeds both the trend and the accounting under it, so the
     # two are computed over the same snapshot and cannot disagree
     # because the file changed between two reads.
-    audits, history, lookback = _journal_snapshot(journal, project_name)
+    snapshot = _journal_snapshot(journal, project_name)
     # #280: the trend is keyed on the project name, so a rename starts a
     # fresh one and the runs before it drop out of view. Keying
     # differently would be worse (the spec is edited every round, so a
     # content hash never matches, and #260's own loop renamed the file
     # too), so what is fixed is the silence rather than the key.
     _surface_convergence(
-        _build_convergence(spec_issues, spec_path.name, history),
-        _excluded_history(audits, project_name, spec_path.name, lookback),
+        _build_convergence(spec_issues, spec_path.name, snapshot.window),
+        _excluded_history(snapshot.audits, project_name, spec_path.name, snapshot.lookback),
         project_name,
         ui,
     )

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -1339,6 +1339,24 @@ class AuditSnapshot:
     they are exactly the pair #280 exists to keep straight - the trend
     reads the window, the accounting under it reads everything the
     window left out.
+
+    ``frozen=True`` for the rebinding guarantee, not to make this a
+    value that can key a dict. Because ``eq`` is on too, the decorator
+    would otherwise generate a ``__hash__`` that hashes the two lists
+    and raises ``TypeError: unhashable type: 'list'`` from inside a
+    method nobody wrote, so the class advertises a capability it does
+    not have. Tuples would not fix it: the elements are ``dict``, and
+    hashing a tuple hashes its elements, measured. ``__hash__ = None``
+    is the honest answer: set in the body, it is an explicit hash the
+    decorator leaves alone. It says unhashable, names THIS class when
+    somebody tries, and leaves ``==`` and the frozen fields untouched.
+
+    Not generalised, deliberately. Measured: nine other frozen
+    dataclasses in ``kstrl/`` declare a top-level ``list``/``dict``/``set``
+    field and still advertise a hash that raises. They are left alone
+    here because this PR introduced ``AuditSnapshot`` and that is the one
+    it owns; a sweep of the other nine wants its own change with a guard
+    behind it, rather than nine edits nothing keeps true.
     """
 
     #: Every spec audit the journal holds, across every project.
@@ -1348,6 +1366,8 @@ class AuditSnapshot:
     #: How far back the window reaches, carried so the render can tell
     #: a windowed-out audit from one the trend could not score.
     lookback: int
+
+    __hash__ = None  # type: ignore[assignment]
 
 
 def _journal_snapshot(journal: EvolutionJournal | None, project_name: str) -> AuditSnapshot:

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -37,6 +37,12 @@ from kstrl.events import (
     RunStarted,
     SpecIssueRecorded,
 )
+from kstrl.evolution import (
+    SPEC_ISSUES_EVENT,
+    EvolutionConfig,
+    EvolutionJournal,
+    entry_str,
+)
 from kstrl.guards import ScopeHazard, scope_entry_hazard
 from kstrl.linear import (
     LinearClient,
@@ -50,7 +56,6 @@ from kstrl.manifest import (
     Manifest,
 )
 from kstrl.names import validate_branch_name, validate_component_id
-from kstrl.observability import read_progress_events
 from kstrl.prd import PRD
 
 logger = logging.getLogger(__name__)
@@ -62,7 +67,6 @@ SPEC_ISSUE_APPLIES_COMPONENT = "component"
 SPEC_ISSUE_APPLIES_SPEC = "spec"
 
 if TYPE_CHECKING:
-    from kstrl.evolution import EvolutionJournal
     from kstrl.ui.base import UI
 
 
@@ -796,20 +800,6 @@ def _surface_spec_issues(issues: list[SpecIssue], ui: UI) -> None:
 # next to manifest.json so one directory holds the decompose outputs.
 SPEC_ISSUES_REL_PATH = Path("scripts") / "kstrl" / "spec-issues.json"
 
-# The journal's discriminator for one recorded spec audit. Named because
-# this module both writes it and reads it back, and the two must agree.
-#
-# It is NOT the only copy: ``EvolutionJournal.get_spec_issue_runs``
-# hardcodes the same literal, and that file is under concurrent edit on
-# another branch, so it is not converted here. The constant belongs on
-# the storage layer rather than on this writer; filed as #314. What
-# keeps the two from drifting meanwhile is a mechanism rather than this
-# comment - ``test_the_journal_reader_agrees_with_the_event_name_written``
-# writes an entry through this module and reads it back through the
-# journal, so changing this name alone fails that test and fourteen
-# others.
-SPEC_ISSUES_EVENT = "spec_issues"
-
 
 def _issue_dict(issue: SpecIssue) -> dict[str, str]:
     """One issue as the five JSON keys every artifact writes it under."""
@@ -1010,8 +1000,6 @@ def _spec_audit_journal(root_dir: Path, ui: UI) -> EvolutionJournal | None:
     Which exceptions that covers is ``load_or_none``'s to know, not
     this call site's.
     """
-    from kstrl.evolution import EvolutionConfig, EvolutionJournal
-
     config = EvolutionConfig.load_or_none(root_dir, warn=ui.warn)
     if config is None or not config.enabled:
         return None
@@ -1032,7 +1020,7 @@ def _record_spec_issues_event(
     but the failure is surfaced as a warning rather than swallowed:
     the journal is an audit trail, so a silent skip would defeat it.
     No ``run_id`` field: decompose runs before a factory run id exists,
-    which is why ``EvolutionJournal.get_spec_issue_runs`` reads these
+    which is why ``EvolutionJournal.get_spec_audits`` reads these
     entries rather than the run-windowed reader.
     """
     if journal is None:
@@ -1124,9 +1112,9 @@ def _stored_issues(entry: dict[str, Any]) -> list[SpecIssue] | None:
         return None
     stored = [
         SpecIssue(
-            severity=_entry_str(i, "severity"),
-            kind=_entry_str(i, "kind"),
-            summary=_entry_str(i, "summary"),
+            severity=entry_str(i, "severity"),
+            kind=entry_str(i, "kind"),
+            summary=entry_str(i, "summary"),
         )
         for i in raw
         if isinstance(i, dict)
@@ -1151,7 +1139,7 @@ def _build_convergence(
     for entry in history:
         stored = _stored_issues(entry)
         if stored is not None:
-            audits.append((_entry_str(entry, "spec_file"), stored))
+            audits.append((entry_str(entry, "spec_file"), stored))
             trend.append(sum(1 for i in stored if i.severity == "blocker"))
     if not audits:
         return None
@@ -1166,36 +1154,6 @@ def _build_convergence(
         previous_spec_file=previous_spec_file,
         repeated=sum(1 for i in previous_issues if _issue_identity(i) in current_ids),
         blocker_trend=(*trend, current_counts["blocker"]),
-    )
-
-
-def _spec_convergence(
-    issues: list[SpecIssue],
-    entries: list[dict[str, Any]],
-    project_name: str,
-    spec_file: str,
-    lookback: int,
-) -> SpecConvergence | None:
-    """Compare this run against this project's recorded audit history.
-
-    Runs are matched by project name, not by spec path or content
-    hash: the spec is edited between every round by construction (so a
-    content hash never matches), and the recorded loop in #260 renamed
-    the file mid-loop (so the path does not either). A previous audit
-    of a different file is still reported, with the file names named.
-
-    ``lookback`` is how far back the trend reaches: the journal's own
-    knob rather than a number invented here, read as "the last N spec
-    audits" - decompose writes one audit per run, with or without a
-    factory run behind it.
-
-    MUST be called on entries read BEFORE this run's own is appended to
-    the journal, or the "previous run" it compares against is this one.
-    """
-    return _build_convergence(
-        issues,
-        spec_file,
-        _windowed_audits(_spec_audits(entries), project_name, lookback),
     )
 
 
@@ -1293,48 +1251,39 @@ class ExcludedHistory:
         return max(0, self.own_recorded - counted - self.unreadable(counted))
 
 
-def _entry_str(entry: dict[str, Any], key: str) -> str:
-    """A string field of a journal entry, or "" for anything else.
-
-    NOT ``str(entry.get(key, ""))``: that renders a JSON ``null`` as
-    the literal ``"None"``, which round 1 of review reproduced as a
-    phantom project named 'None' passing the emptiness guard below and
-    a spec file printed as ``None``. A null field is an absent field.
-    """
-    value = entry.get(key)
-    return value if isinstance(value, str) else ""
-
-
 def _excluded_projects(
-    entries: list[dict[str, Any]],
+    audits: list[dict[str, Any]],
     project_name: str,
     spec_file: str,
 ) -> tuple[ExcludedProject, ...]:
-    """Spec audits in ``entries`` recorded under some other project.
+    """Recorded spec audits under some project OTHER than this one.
+
+    Takes audits, not raw journal entries: which rows are spec audits
+    is ``EvolutionJournal.get_spec_audits``'s to decide (#314), and a
+    second copy of that rule here is how the accounting and the trend
+    could come to disagree about the same journal.
 
     Ordered so the display cap drops only the weakest evidence: a
     project that audited the file this run audited sorts first, then
     the rest by how much history they hold. The cap itself never drops
     a spec-file match; see ``_excluded_line``.
 
-    Entries with no project name are skipped rather than grouped under
+    Audits with no project name are skipped rather than grouped under
     "": an unnamed project is not somewhere the operator can go and
     look, so pointing at it is not evidence.
     """
     by_project: dict[str, list[str]] = {}
     last_seen: dict[str, str] = {}
-    for entry in entries:
-        if entry.get("event_type") != SPEC_ISSUES_EVENT:
-            continue
-        project = _entry_str(entry, "project")
+    for entry in audits:
+        project = entry_str(entry, "project")
         if not project or project == project_name:
             continue
-        by_project.setdefault(project, []).append(_entry_str(entry, "spec_file"))
+        by_project.setdefault(project, []).append(entry_str(entry, "spec_file"))
         # Only a timestamp that exists replaces one that exists. Round 2
         # of review: assigning unconditionally let one trailing entry
         # with no timestamp erase a good date every earlier entry for
         # that project carried, losing evidence to a single bad row.
-        if timestamp := _entry_str(entry, "timestamp"):
+        if timestamp := entry_str(entry, "timestamp"):
             last_seen[project] = timestamp
     excluded = [
         ExcludedProject(
@@ -1349,34 +1298,8 @@ def _excluded_projects(
     return tuple(sorted(excluded, key=lambda e: (not e.read_this_spec, -e.audits, e.project)))
 
 
-def _spec_audits(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Just the recorded spec audits, in file order."""
-    return [e for e in entries if e.get("event_type") == SPEC_ISSUES_EVENT]
-
-
-def _windowed_audits(
-    audits: list[dict[str, Any]],
-    project_name: str,
-    last_n: int,
-) -> list[dict[str, Any]]:
-    """The trend's history: the last ``last_n`` audits of one project.
-
-    The same rule as ``EvolutionJournal.get_spec_issue_runs``, applied
-    to entries already in memory so one read serves both the trend and
-    the accounting below it. Round 2 of review: the call site has both
-    results in scope, so the second parse of the same file bought
-    nothing. ``test_the_windowing_rule_matches_the_journals_own``
-    pins this against the journal's copy, because a duplicated rule
-    that drifts would make the trend and the accounting disagree.
-    Folding both into the journal is filed as #314, and doing so leaves
-    ``get_spec_issue_runs`` with no production caller today.
-    """
-    mine = [e for e in audits if _entry_str(e, "project") == project_name]
-    return mine[-last_n:] if last_n > 0 else []
-
-
 def _excluded_history(
-    entries: list[dict[str, Any]],
+    audits: list[dict[str, Any]],
     project_name: str,
     spec_file: str,
     lookback: int,
@@ -1386,10 +1309,12 @@ def _excluded_history(
     Empty for a first audit in a fresh repo, so the lines it feeds
     never fire on the common case.
 
-    Takes ``entries`` rather than reading, so the caller reads once and
-    the trend and the accounting are computed over the same snapshot.
-    That also removes any chance of the two disagreeing because the
-    file changed between two reads.
+    Takes the audits rather than reading them, so the caller reads once
+    and the trend and the accounting are computed over the same
+    snapshot. That also removes any chance of the two disagreeing
+    because the file changed between two reads. Selecting the audits
+    out of the journal's entries is the journal's own job (#314), not a
+    rule restated here.
 
     Deliberately NOT windowed by ``lookback_runs``; ``lookback`` is
     carried only so the render can tell a windowed-out audit from one
@@ -1397,40 +1322,46 @@ def _excluded_history(
     excludes that was itself windowed would omit history silently,
     which is the bug this exists to fix.
     """
-    audits = _spec_audits(entries)
     return ExcludedHistory(
-        own_recorded=sum(1 for e in audits if _entry_str(e, "project") == project_name),
+        own_recorded=sum(1 for e in audits if entry_str(e, "project") == project_name),
         projects=_excluded_projects(audits, project_name, spec_file),
-        unattributed=sum(1 for e in audits if not _entry_str(e, "project")),
+        unattributed=sum(1 for e in audits if not entry_str(e, "project")),
         lookback=lookback,
     )
 
 
-def _journal_snapshot(journal: EvolutionJournal | None) -> tuple[list[dict[str, Any]], int]:
-    """Every entry in the journal, and how far back the trend may reach.
+def _journal_snapshot(
+    journal: EvolutionJournal | None,
+    project_name: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], int]:
+    """The recorded audit history behind one convergence report.
 
-    Both together because both callers need both, and because a
-    journal that is absent has no entries AND no window: returning
-    the pair keeps that single fact in one place instead of a
-    conditional at the call site.
+    Three things from ONE read: every spec audit the journal holds,
+    this project's window of them, and how far back that window
+    reaches. Together because a journal that is absent has none of the
+    three, which keeps that single fact here instead of three
+    conditionals at the call site.
 
-    Read through ``read_progress_events`` rather than through
-    ``EvolutionJournal``, because no public reader on it returns the
-    whole entry set: ``get_spec_issue_runs`` filters to one project
-    inside the reader by design.
+    Read through ``EvolutionJournal`` rather than through its storage
+    path (#314). The journal's own reader is the only one that would
+    survive the file compacting, rotating or gaining a second segment;
+    a caller holding the path would quietly return less than the
+    journal holds while the trend kept printing, and silent loss of
+    the excluded-history accounting is the defect #280 exists to fix.
 
-    That is a layering compromise and not a free one. It reaches past
-    ``EvolutionJournal`` to that journal's own storage path, so a
-    journal that ever compacts, rotates or gains a second segment would
-    leave this reading less than the journal holds while the journal's
-    own reader kept working. Silent loss of the accounting is precisely
-    what #280 exists to fix, so the risk is pinned rather than trusted:
-    ``test_the_windowing_rule_matches_the_journals_own`` fails if the
-    two readers ever see different entries. A reader on
-    ``EvolutionJournal`` is the right home and would delete this
-    function; it is not added here because that file is under
-    concurrent edit on another branch. Filed as #314 rather than
-    raced.
+    The window comes from ``get_spec_issue_runs`` rather than from a
+    second copy of its rule here, so the trend and the accounting
+    printed under it cannot disagree about which audits belong to this
+    project. Runs are matched by project NAME, not by spec path or
+    content hash: the spec is edited between every round by
+    construction (so a content hash never matches), and the recorded
+    loop in #260 renamed the file mid-loop (so the path does not
+    either). A previous audit of a different file is still reported,
+    with the file names named.
+
+    MUST be read BEFORE this run's own audit is appended to the
+    journal, or the "previous run" the trend compares against is this
+    one.
 
     One read per decompose, and the whole file: measured at 6.9 KB per
     factory run in this repo, so 1 MB is about 150 runs and 10 MB about
@@ -1438,8 +1369,11 @@ def _journal_snapshot(journal: EvolutionJournal | None) -> tuple[list[dict[str, 
     78 MB, against an architect call measured at 119 to 210 seconds.
     """
     if journal is None:
-        return [], 0
-    return read_progress_events(journal.config.journal_path), journal.config.lookback_runs
+        return [], [], 0
+    audits = journal.get_spec_audits()
+    lookback = journal.config.lookback_runs
+    window = journal.get_spec_issue_runs(project_name, lookback, audits=audits)
+    return audits, window, lookback
 
 
 def _surface_convergence(
@@ -2047,15 +1981,15 @@ def _decompose_spec_impl(
     # ONE read feeds both the trend and the accounting under it, so the
     # two are computed over the same snapshot and cannot disagree
     # because the file changed between two reads.
-    entries, lookback = _journal_snapshot(journal)
+    audits, history, lookback = _journal_snapshot(journal, project_name)
     # #280: the trend is keyed on the project name, so a rename starts a
     # fresh one and the runs before it drop out of view. Keying
     # differently would be worse (the spec is edited every round, so a
     # content hash never matches, and #260's own loop renamed the file
     # too), so what is fixed is the silence rather than the key.
     _surface_convergence(
-        _spec_convergence(spec_issues, entries, project_name, spec_path.name, lookback),
-        _excluded_history(entries, project_name, spec_path.name, lookback),
+        _build_convergence(spec_issues, spec_path.name, history),
+        _excluded_history(audits, project_name, spec_path.name, lookback),
         project_name,
         ui,
     )

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -44,6 +44,15 @@ JOURNAL_SCHEMA_VERSION = 2
 # grepped: it is the only durable trace that a crash tore the file.
 JOURNAL_REPAIR_EVENT = "journal_repair"
 
+# #260: the event_type of one recorded spec audit. ``decompose`` writes
+# these rows and :meth:`EvolutionJournal.get_spec_audits` selects on
+# them, so the name belongs on the layer that defines the journal's
+# schema rather than on the writer (#314). It lived in ``decompose``
+# until then, with this module holding a second copy as a literal, and
+# the cost of that placement is the reason it moved: a reader added
+# HERE reaches for the nearest spelling, which was the literal.
+SPEC_ISSUES_EVENT = "spec_issues"
+
 
 # The header row record_run writes to experiments.tsv, at module scope so
 # that a test can assert against the columns the writer actually emits
@@ -480,6 +489,29 @@ def signatures_from_findings(phase: str, findings: Iterable[Finding]) -> list[st
 
 def _timestamp_now() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def entry_str(entry: dict[str, Any], key: str) -> str:
+    """One string field of a JSON-decoded journal record, "" when absent.
+
+    A null or non-string field is an ABSENT field, not a value to be
+    stringified. ``str(None)`` renders the literal "None", which #280
+    round 1 reproduced as a phantom project named 'None' in the
+    convergence report and a spec file printed as ``None``. Nothing is
+    assumed about a record beyond it being a JSON object, so a journal
+    written by an older version, or edited by hand, still reads.
+
+    Lives here rather than in ``decompose`` (#314) because the window
+    in :meth:`EvolutionJournal.get_spec_issue_runs` matches a project
+    by this rule and the report's accounting matches by the same one.
+    Two copies of it would let the trend and the accounting disagree
+    about which audits belong to the project being reported on.
+
+    Applies to a record's nested objects too, which is what the stored
+    issue list is: same JSON, same rule.
+    """
+    value = entry.get(key)
+    return value if isinstance(value, str) else ""
 
 
 def _journal_line(entry: dict[str, Any]) -> str:
@@ -1436,31 +1468,71 @@ class EvolutionJournal:
         )
 
     # ------------------------------------------------------------------
-    # get_spec_issue_runs
+    # get_spec_audits / get_spec_issue_runs
     # ------------------------------------------------------------------
 
-    def get_spec_issue_runs(self, project: str, last_n: int = 10) -> list[dict[str, Any]]:
-        """The last N recorded spec audits for ``project``, oldest first (#260).
+    def get_spec_audits(self) -> list[dict[str, Any]]:
+        """Every recorded spec audit in the journal, oldest first (#314).
+
+        The whole set, across every project, because the caller that
+        accounts for the history a windowed trend leaves out needs
+        exactly what the window drops: filtering by project here would
+        hide the thing it is asking for.
+
+        This is the read surface a caller uses INSTEAD of opening
+        ``config.journal_path`` for itself. The difference is not
+        cosmetic: if the journal ever compacts, rotates or gains a
+        second segment, this method is what changes, while a caller
+        holding the path would quietly return less than the journal
+        holds - and silent loss of the excluded-history accounting is
+        the defect #280 exists to fix.
 
         Deliberately NOT routed through :meth:`_read_journal_entries`:
         that reader keeps only entries whose ``run_id`` is among the
-        last N distinct run ids, and a ``spec_issues`` entry carries no
-        ``run_id`` at all (decompose runs before a factory run id
-        exists), so every one of them is dropped there. Reading the raw
-        entries is what makes the architect's own history readable.
+        last N distinct run ids, and a spec audit carries no ``run_id``
+        at all (decompose runs before a factory run id exists), so
+        every one of them is dropped there. Reading the raw entries is
+        what makes the architect's own history readable.
+        """
+        return [e for e in self._read_all_entries() if e.get("event_type") == SPEC_ISSUES_EVENT]
+
+    def get_spec_issue_runs(
+        self,
+        project: str,
+        last_n: int = 10,
+        audits: list[dict[str, Any]] | None = None,
+    ) -> list[dict[str, Any]]:
+        """The last N recorded spec audits for ``project``, oldest first (#260).
+
+        The one place the window rule lives (#314). ``decompose`` had a
+        second copy of it, and two copies of one rule can drift: if
+        they had, the convergence trend and the accounting printed
+        under it would have disagreed about the same journal.
 
         ``last_n`` counts spec audits, not factory runs - a spec audit
         happens once per decompose, whether or not a factory run
         follows. Windowed here rather than by the caller, matching
         :meth:`get_experiment_trends`.
 
+        ``audits`` lets a caller that has already called
+        :meth:`get_spec_audits` window that snapshot instead of reading
+        the file a second time, so the window and any accounting over
+        the same entries cannot disagree because the file moved between
+        two reads. The event-type filter is applied either way, so
+        passing raw entries answers the same as passing audits.
+
         Nothing is assumed about an entry beyond it being a JSON
-        object, so journals written by older versions read cleanly.
+        object, so journals written by older versions read cleanly. A
+        project is matched by :func:`entry_str`, so a null or
+        non-string ``project`` field is an unattributed audit rather
+        than a project named "None".
         """
+        source = self.get_spec_audits() if audits is None else audits
         runs = [
             entry
-            for entry in self._read_all_entries()
-            if entry.get("event_type") == "spec_issues" and entry.get("project") == project
+            for entry in source
+            if entry.get("event_type") == SPEC_ISSUES_EVENT
+            and entry_str(entry, "project") == project
         ]
         return runs[-last_n:] if last_n > 0 else []
 
@@ -1606,8 +1678,8 @@ class EvolutionJournal:
         """Read JSONL journal and return entries from the last N distinct runs.
 
         Entries without a ``run_id`` are dropped, because the window is
-        defined in terms of runs. ``spec_issues`` entries are exactly
-        that case; :meth:`get_spec_issue_runs` reads those instead.
+        defined in terms of runs. Spec audits are exactly that case;
+        :meth:`get_spec_audits` reads those instead.
         """
         entries = self._read_all_entries()
         if not entries:

--- a/tests/helpers/journal.py
+++ b/tests/helpers/journal.py
@@ -26,7 +26,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from kstrl.evolution import JOURNAL_REPAIR_EVENT, EvolutionConfig, EvolutionJournal
+from kstrl.evolution import (
+    JOURNAL_REPAIR_EVENT,
+    SPEC_ISSUES_EVENT,
+    EvolutionConfig,
+    EvolutionJournal,
+)
 from kstrl.observability import read_progress_events
 
 #: A partial JSONL line: valid JSON up to the point the process died,
@@ -70,12 +75,20 @@ def terminate(path: Path) -> None:
     path.write_bytes(path.read_bytes() + b"\n")
 
 
-def audit(project: str) -> dict[str, Any]:
+def audit(project: Any, spec_file: str | None = None) -> dict[str, Any]:
+    """One recorded spec audit.
+
+    ``project`` is typed ``Any`` because a hand-edited or foreign
+    journal can carry a null or a number there, and the readers promise
+    to tolerate it; ``spec_file`` defaults to one named after the
+    project and is passed explicitly when a test needs the rows told
+    apart.
+    """
     return {
         "timestamp": "2026-08-20T00:00:00Z",
         "project": project,
-        "event_type": "spec_issues",
-        "spec_file": f"{project}.md",
+        "event_type": SPEC_ISSUES_EVENT,
+        "spec_file": f"{project}.md" if spec_file is None else spec_file,
     }
 
 
@@ -101,7 +114,7 @@ def audits_in(path: Path) -> list[str]:
     return [
         str(entry.get("project"))
         for entry in read_progress_events(path)
-        if entry.get("event_type") == "spec_issues"
+        if entry.get("event_type") == SPEC_ISSUES_EVENT
     ]
 
 

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -1681,6 +1681,24 @@ class TestOneJournalRead:
     def test_no_journal_reads_nothing_and_windows_nothing(self) -> None:
         assert _journal_snapshot(None, "mine") == AuditSnapshot(audits=[], window=[], lookback=0)
 
+    def test_the_snapshot_says_unhashable_instead_of_pretending(self) -> None:
+        """A frozen dataclass with ``eq`` on gets a generated
+        ``__hash__``, and this one holds two lists, so the generated one
+        raised ``unhashable type: 'list'`` from a method nobody wrote.
+        Nothing hashes a snapshot; making it hashable is not available
+        either, since tuple fields would still hold ``dict`` elements.
+        So it says so, and names itself when somebody tries.
+
+        Both halves asserted: the message alone would pass on a class
+        that had simply kept the broken generated hash.
+        """
+        snapshot = AuditSnapshot(audits=[{"project": "mine"}], window=[], lookback=3)
+
+        assert AuditSnapshot.__hash__ is None
+        with pytest.raises(TypeError, match="unhashable type: 'AuditSnapshot'"):
+            hash(snapshot)
+        assert snapshot == AuditSnapshot(audits=[{"project": "mine"}], window=[], lookback=3)
+
 
 class TestExcludedAccountingLine:
     """#280 round 1, finding 2: the same-project half of the accounting."""

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -6,10 +6,12 @@ import io
 import json
 from collections.abc import Iterator, Sequence
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from kstrl.decompose import (
+    AuditSnapshot,
     ExcludedHistory,
     SpecBlockerError,
     SpecConvergence,
@@ -30,7 +32,7 @@ from kstrl.decompose import (
 from kstrl.evolution import SPEC_ISSUES_EVENT, EvolutionConfig, EvolutionJournal
 from kstrl.prd import PRD
 from kstrl.ui.plain import PlainUI
-from tests.helpers.journal import tear
+from tests.helpers.journal import audit, journal_at, tear
 
 
 class MockDecomposeAgent:
@@ -1204,7 +1206,7 @@ class TestExcludedHistory:
         spec_file: str = "mine.md",
         lookback: int = 10,
     ) -> ExcludedHistory:
-        audits = _journal_snapshot(journal, project)[0]
+        audits = _journal_snapshot(journal, project).audits
         return _excluded_history(audits, project, spec_file, lookback)
 
     def _lines(
@@ -1257,7 +1259,8 @@ class TestExcludedHistory:
             ]
         )
 
-        excluded = _excluded_projects(_journal_snapshot(journal, "mine")[0], "mine", "mine.md")
+        audits = _journal_snapshot(journal, "mine").audits
+        excluded = _excluded_projects(audits, "mine", "mine.md")
 
         assert [(e.project, e.audits) for e in excluded] == [("other", 1)]
 
@@ -1576,7 +1579,7 @@ class TestUnattributedAudits:
         journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
         journal.append_entries(entries)
 
-        audits = _journal_snapshot(journal, "mine")[0]
+        audits = _journal_snapshot(journal, "mine").audits
         history = _excluded_history(audits, "mine", "mine.md", 10)
 
         assert len(audits) == 4
@@ -1587,18 +1590,17 @@ class TestOneJournalRead:
     """#280 round 2, findings 6 and 7, and #314: one read, taken through
     ``EvolutionJournal`` rather than past it."""
 
-    def _journal(self, tmp_path: Path, entries: list[dict[str, object]]) -> EvolutionJournal:
-        journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
+    def _journal(
+        self,
+        tmp_path: Path,
+        entries: list[dict[str, Any]],
+        lookback_runs: int | None = None,
+    ) -> EvolutionJournal:
+        journal = journal_at(tmp_path)
+        if lookback_runs is not None:
+            journal.config.lookback_runs = lookback_runs
         journal.append_entries(entries)
         return journal
-
-    def _audit(self, project: str, spec_file: str) -> dict[str, object]:
-        return {
-            "event_type": SPEC_ISSUES_EVENT,
-            "project": project,
-            "spec_file": spec_file,
-            "timestamp": "2026-08-20T00:00:00Z",
-        }
 
     def test_the_journal_is_parsed_once_per_report(
         self,
@@ -1637,25 +1639,22 @@ class TestOneJournalRead:
     ) -> None:
         """#314 item 1. ``_journal_snapshot`` used to open
         ``journal.config.journal_path`` itself, which works only while
-        the file is the whole story: if the journal ever compacts,
-        rotates or gains a second segment, the caller holding the path
-        keeps printing a trend while the accounting under it goes
-        quiet, and silent loss of that accounting is the defect #280
-        exists to fix.
+        the file is the whole story; ``get_spec_audits`` says what that
+        costs when it stops being.
 
         Proved by giving the journal a reader that answers something
         the file does not contain. A snapshot that reaches for the path
         cannot see it, so this fails on the shortcut rather than on the
         hypothetical second segment nobody has written yet.
         """
-        journal = self._journal(tmp_path, [self._audit("mine", "on-disk.md")])
-        elsewhere = [self._audit("mine", "b.md"), self._audit("other", "c.md")]
+        journal = self._journal(tmp_path, [audit("mine", "on-disk.md")])
+        elsewhere = [audit("mine", "b.md"), audit("other", "c.md")]
         monkeypatch.setattr(EvolutionJournal, "get_spec_audits", lambda self: elsewhere)
 
-        audits, window, _ = _journal_snapshot(journal, "mine")
+        snapshot = _journal_snapshot(journal, "mine")
 
-        assert [a["spec_file"] for a in audits] == ["b.md", "c.md"]
-        assert [w["spec_file"] for w in window] == ["b.md"]
+        assert [a["spec_file"] for a in snapshot.audits] == ["b.md", "c.md"]
+        assert [w["spec_file"] for w in snapshot.window] == ["b.md"]
 
     def test_the_window_is_the_journals_own_over_the_journals_own_lookback(
         self,
@@ -1668,19 +1667,19 @@ class TestOneJournalRead:
         the snapshot has to reach it with the journal's own
         ``lookback_runs`` rather than a number of its own.
         """
-        entries: list[dict[str, object]] = [
-            self._audit("mine" if n % 2 else "other", f"spec-{n}.md") for n in range(9)
-        ]
-        journal = self._journal(tmp_path, entries)
+        entries = [audit("mine" if n % 2 else "other", f"spec-{n}.md") for n in range(9)]
 
         for lookback in (1, 3, 10):
-            journal.config.lookback_runs = lookback
-            assert _journal_snapshot(journal, "mine")[1] == journal.get_spec_issue_runs(
+            # A journal of its own per lookback: one file appended to
+            # three times would compare a growing history against
+            # itself and pass whatever the window did.
+            journal = self._journal(tmp_path / f"lookback-{lookback}", entries, lookback)
+            assert _journal_snapshot(journal, "mine").window == journal.get_spec_issue_runs(
                 "mine", last_n=lookback
             )
 
     def test_no_journal_reads_nothing_and_windows_nothing(self) -> None:
-        assert _journal_snapshot(None, "mine") == ([], [], 0)
+        assert _journal_snapshot(None, "mine") == AuditSnapshot(audits=[], window=[], lookback=0)
 
 
 class TestExcludedAccountingLine:

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -752,6 +752,12 @@ MINOR_ISSUE: dict[str, object] = {
 }
 
 
+def _blockers(count: int) -> list[dict[str, object]]:
+    """``count`` blockers the de-duplicator keeps apart, so an audit's
+    recorded blocker count is the number asked for."""
+    return [{**BLOCKER_ISSUE, "summary": f"blocker {n}"} for n in range(count)]
+
+
 def _run_decompose(
     tmp_path: Path,
     output: str,
@@ -2069,6 +2075,26 @@ class TestSpecConvergenceThroughDecompose:
             "1, 1, 1 (blockers, oldest run first; 1 older audit(s) outside the "
             "lookback window)" in output
         )
+
+    def test_the_window_keeps_the_newest_audits(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Direction, not just size. Every other window test in this
+        file records audits that raise the same count, so ``[:last_n]``
+        and ``[-last_n:]`` produce identical output and the whole suite
+        stays green with the trend reading the OLDEST audits: measured,
+        with the rule inverted, before this test existed. The counts
+        differ per run here, so the trend line says which end was kept.
+        """
+        monkeypatch.setenv("KSTRL_EVOLUTION_LOOKBACK_RUNS", "2")
+        for count in (1, 2, 3):
+            self._run(tmp_path, _blockers(count))
+        output = self._run(tmp_path, _blockers(4))
+
+        assert "2, 3, 4 (blockers, oldest run first" in output
+        assert "1, 2, 4" not in output
 
     def test_no_report_when_the_journal_is_off(
         self,

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import pytest
 
 from kstrl.decompose import (
-    SPEC_ISSUES_EVENT,
     ExcludedHistory,
     SpecBlockerError,
     SpecConvergence,
@@ -24,13 +23,11 @@ from kstrl.decompose import (
     _issue_dicts,
     _journal_snapshot,
     _parse_spec_issues,
-    _spec_audits,
     _stored_issues,
     _validate_decompose_output,
-    _windowed_audits,
     decompose_spec,
 )
-from kstrl.evolution import EvolutionConfig, EvolutionJournal
+from kstrl.evolution import SPEC_ISSUES_EVENT, EvolutionConfig, EvolutionJournal
 from kstrl.prd import PRD
 from kstrl.ui.plain import PlainUI
 from tests.helpers.journal import tear
@@ -1201,7 +1198,8 @@ class TestExcludedHistory:
         spec_file: str = "mine.md",
         lookback: int = 10,
     ) -> ExcludedHistory:
-        return _excluded_history(_journal_snapshot(journal)[0], project, spec_file, lookback)
+        audits = _journal_snapshot(journal, project)[0]
+        return _excluded_history(audits, project, spec_file, lookback)
 
     def _lines(
         self,
@@ -1236,15 +1234,24 @@ class TestExcludedHistory:
         assert excluded[0].read_this_spec is False
         assert excluded[0].last_recorded == "2026-08-20T00:00:00Z"
 
-    def test_only_spec_audits_count(self) -> None:
+    def test_only_spec_audits_count(self, tmp_path: Path) -> None:
         """The journal carries component results and experiments too.
-        Counting those would inflate the number the operator reads."""
-        entries = [
-            self._entry("other", event_type="component_result"),
-            self._entry("other", event_type=SPEC_ISSUES_EVENT),
-        ]
+        Counting those would inflate the number the operator reads.
 
-        excluded = _excluded_projects(entries, "mine", "mine.md")
+        Through the snapshot rather than by handing this function a
+        component_result directly: since #314 the selection is
+        ``EvolutionJournal.get_spec_audits``'s, so the end-to-end path
+        is where the claim is still true.
+        """
+        journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
+        journal.append_entries(
+            [
+                self._entry("other", event_type="component_result"),
+                self._entry("other", event_type=SPEC_ISSUES_EVENT),
+            ]
+        )
+
+        excluded = _excluded_projects(_journal_snapshot(journal, "mine")[0], "mine", "mine.md")
 
         assert [(e.project, e.audits) for e in excluded] == [("other", 1)]
 
@@ -1548,9 +1555,11 @@ class TestUnattributedAudits:
         assert history.other_audits == 1
         assert history.unattributed == 2
 
-    def test_every_spec_audit_lands_in_exactly_one_bucket(self) -> None:
+    def test_every_spec_audit_lands_in_exactly_one_bucket(self, tmp_path: Path) -> None:
         """The property the accounting docstring claims, checked rather
-        than asserted in prose."""
+        than asserted in prose. Read back through the journal, so the
+        component_result is dropped by the reader that owns that rule
+        (#314) and the buckets still sum to the audits on disk."""
         entries: list[dict[str, object]] = [
             {"event_type": SPEC_ISSUES_EVENT, "project": "mine"},
             {"event_type": SPEC_ISSUES_EVENT, "project": "mine"},
@@ -1558,21 +1567,32 @@ class TestUnattributedAudits:
             {"event_type": SPEC_ISSUES_EVENT, "project": None},
             {"event_type": "component_result", "project": "mine"},
         ]
+        journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
+        journal.append_entries(entries)
 
-        history = _excluded_history(entries, "mine", "mine.md", 10)
-        audits = sum(1 for e in entries if e.get("event_type") == SPEC_ISSUES_EVENT)
+        audits = _journal_snapshot(journal, "mine")[0]
+        history = _excluded_history(audits, "mine", "mine.md", 10)
 
-        assert history.own_recorded + history.other_audits + history.unattributed == audits
+        assert len(audits) == 4
+        assert history.own_recorded + history.other_audits + history.unattributed == len(audits)
 
 
 class TestOneJournalRead:
-    """#280 round 2, findings 6 and 7: one read, and a pin on the
-    layering shortcut that read takes."""
+    """#280 round 2, findings 6 and 7, and #314: one read, taken through
+    ``EvolutionJournal`` rather than past it."""
 
     def _journal(self, tmp_path: Path, entries: list[dict[str, object]]) -> EvolutionJournal:
         journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
         journal.append_entries(entries)
         return journal
+
+    def _audit(self, project: str, spec_file: str) -> dict[str, object]:
+        return {
+            "event_type": SPEC_ISSUES_EVENT,
+            "project": project,
+            "spec_file": spec_file,
+            "timestamp": "2026-08-20T00:00:00Z",
+        }
 
     def test_the_journal_is_parsed_once_per_report(
         self,
@@ -1581,17 +1601,21 @@ class TestOneJournalRead:
     ) -> None:
         """The trend and the accounting used to read the same file
         twice. The call site has both in scope, so one read feeds both
-        and they cannot disagree because the file moved between them."""
-        import kstrl.decompose
+        and they cannot disagree because the file moved between them.
 
-        reads: list[Path] = []
-        real = kstrl.decompose.read_progress_events
+        Counted at ``_read_all_entries``, the journal's single read
+        point, so dropping the ``audits=`` argument that lets the
+        window reuse the snapshot fails here rather than costing a
+        silent second parse.
+        """
+        reads: list[int] = []
+        real = EvolutionJournal._read_all_entries
 
-        def counting(path: Path) -> list[dict[str, object]]:
-            reads.append(path)
-            return real(path)
+        def counting(self: EvolutionJournal) -> list[dict[str, object]]:
+            reads.append(1)
+            return real(self)
 
-        monkeypatch.setattr(kstrl.decompose, "read_progress_events", counting)
+        monkeypatch.setattr(EvolutionJournal, "_read_all_entries", counting)
         _run_decompose(
             tmp_path,
             _single_component_output([_story()], spec_issues=[BLOCKER_ISSUE]),
@@ -1600,33 +1624,57 @@ class TestOneJournalRead:
 
         assert len(reads) == 1
 
-    def test_the_windowing_rule_matches_the_journals_own(self, tmp_path: Path) -> None:
-        """``_journal_snapshot`` reaches past ``EvolutionJournal`` to its
-        storage path and ``_windowed_audits`` restates the window rule
-        that ``get_spec_issue_runs`` owns. Both are deferrals to
-        #314, and a deferral needs a mechanism: if the journal ever
-        compacts, rotates or gains a second segment, or if the window
-        rule changes, the two stop agreeing and this fails. Silent loss
-        of the accounting is the defect #280 exists to fix.
+    def test_the_report_reads_through_the_journal_not_its_storage_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """#314 item 1. ``_journal_snapshot`` used to open
+        ``journal.config.journal_path`` itself, which works only while
+        the file is the whole story: if the journal ever compacts,
+        rotates or gains a second segment, the caller holding the path
+        keeps printing a trend while the accounting under it goes
+        quiet, and silent loss of that accounting is the defect #280
+        exists to fix.
+
+        Proved by giving the journal a reader that answers something
+        the file does not contain. A snapshot that reaches for the path
+        cannot see it, so this fails on the shortcut rather than on the
+        hypothetical second segment nobody has written yet.
+        """
+        journal = self._journal(tmp_path, [self._audit("mine", "on-disk.md")])
+        elsewhere = [self._audit("mine", "b.md"), self._audit("other", "c.md")]
+        monkeypatch.setattr(EvolutionJournal, "get_spec_audits", lambda self: elsewhere)
+
+        audits, window, _ = _journal_snapshot(journal, "mine")
+
+        assert [a["spec_file"] for a in audits] == ["b.md", "c.md"]
+        assert [w["spec_file"] for w in window] == ["b.md"]
+
+    def test_the_window_is_the_journals_own_over_the_journals_own_lookback(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """#314 item 2. ``_windowed_audits`` was a second copy of the
+        rule ``get_spec_issue_runs`` owns, and two copies of one rule
+        can drift; if they had, the trend and the accounting would have
+        disagreed about the same journal. There is one copy now, and
+        the snapshot has to reach it with the journal's own
+        ``lookback_runs`` rather than a number of its own.
         """
         entries: list[dict[str, object]] = [
-            {
-                "event_type": SPEC_ISSUES_EVENT,
-                "project": "mine" if n % 2 else "other",
-                "spec_file": "spec.md",
-                "timestamp": f"2026-08-{n + 1:02d}T00:00:00Z",
-            }
-            for n in range(9)
+            self._audit("mine" if n % 2 else "other", f"spec-{n}.md") for n in range(9)
         ]
         journal = self._journal(tmp_path, entries)
 
-        for last_n in (0, 1, 3, 10):
-            assert _windowed_audits(
-                _spec_audits(_journal_snapshot(journal)[0]), "mine", last_n
-            ) == journal.get_spec_issue_runs("mine", last_n=last_n)
+        for lookback in (1, 3, 10):
+            journal.config.lookback_runs = lookback
+            assert _journal_snapshot(journal, "mine")[1] == journal.get_spec_issue_runs(
+                "mine", last_n=lookback
+            )
 
     def test_no_journal_reads_nothing_and_windows_nothing(self) -> None:
-        assert _journal_snapshot(None) == ([], 0)
+        assert _journal_snapshot(None, "mine") == ([], [], 0)
 
 
 class TestExcludedAccountingLine:
@@ -1982,13 +2030,17 @@ class TestSpecConvergenceThroughDecompose:
         self,
         tmp_path: Path,
     ) -> None:
-        """Round 1 of review, finding 5. ``SPEC_ISSUES_EVENT`` names the
-        discriminator this module writes and reads, but
-        ``EvolutionJournal.get_spec_issue_runs`` hardcodes the same
-        literal independently and that file is under concurrent edit on
-        another branch. This is the mechanism that makes the two
-        diverging impossible to ship quietly: change the constant alone
-        and the trend the journal reader feeds goes empty here.
+        """Round 1 of review, finding 5, and #314 item 3. There is one
+        ``SPEC_ISSUES_EVENT`` now, on ``evolution`` where the journal's
+        schema is defined, and the writer imports it; the second copy
+        this module used to hold, and the third the journal held as a
+        literal, are gone.
+
+        The end-to-end round trip is still worth its own test, because
+        one constant makes the two spellings agree by construction but
+        says nothing about the row actually reaching the reader: change
+        the constant and this passes, break the write path and it
+        fails.
         """
         self._run(tmp_path, [BLOCKER_ISSUE], project_name="writers-room")
         runs = EvolutionJournal(EvolutionConfig.load(tmp_path)).get_spec_issue_runs("writers-room")

--- a/tests/test_event_name_shapes.py
+++ b/tests/test_event_name_shapes.py
@@ -1,0 +1,376 @@
+"""Positive controls for the event-name guard: source it MUST flag.
+
+The guard lives in ``tests/test_event_names_have_one_home.py``. Its
+layer-2 assertion is that a dict is empty, and an empty dict is also what
+a switched-off matcher returns, so without this file every shape below
+could be dropped from the matcher and that file would stay green.
+Measured before this existed: each of the twenty matcher functions
+stubbed to a constant in turn, and all twenty are noticed here.
+
+Round 1 of review on #336 is what this file is made of. The matcher then
+looked at ``ast.Dict`` and at ``ast.Compare`` and at nothing else, and
+six ordinary shapes went past it with the whole fast tier green: a
+``dict()`` call, an item assignment after the dict was built,
+``setdefault``, ``update(**kwargs)``, ``match``/``case``, and a walrus.
+Two of them were planted as real methods on ``EvolutionJournal`` and
+produced ruff clean, mypy --strict clean, and 4776 passed. Every miss was
+in the SKIP direction: a shape the matcher could not resolve, so it did
+not look and reported clean. That is the defect class #324 exists to
+record, and this repo has now logged eight instances of it.
+
+Separate from the guard for the reason ``test_journal_guard_detects.py``
+gives about its own sibling: that file walks the package and pins what is
+there, this one feeds the matcher snippets and pins what it says.
+
+Every shape here was MEASURED against the matcher, before and after,
+under the ``__pycache__`` discipline: CPython invalidates cached bytecode
+on ``(mtime_seconds, size)``, so two same-size edits inside one second
+reuse stale bytecode and hand back a false pass.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from kstrl.evolution import SPEC_ISSUES_EVENT
+from tests.test_event_names_have_one_home import (
+    event_name_spellings,
+    literal_event_names,
+)
+
+
+def hits(source: str, event_name: str = SPEC_ISSUES_EVENT) -> list[str]:
+    """What the matcher says about one snippet."""
+    return literal_event_names(ast.parse(source), event_name)
+
+
+WRITE = "line 2: writes 'spec_issues' as the event_type"
+READ = "line 2: compares event_type against 'spec_issues'"
+
+
+class TestEveryWritingShape:
+    """A row is written. Every way of attaching the name to the column.
+
+    ``ast.Dict`` was the only one of these the first matcher knew.
+    """
+
+    def test_a_dict_literal(self) -> None:
+        assert hits('\nrow = {"event_type": "spec_issues", "project": p}\n') == [WRITE]
+
+    def test_a_dict_call_with_keywords(self) -> None:
+        """Shape B. ``C408`` would lint this, and this repo does not
+        select ``C4``, so it is clean to ruff as well as to the matcher."""
+        assert hits('\nrow = dict(event_type="spec_issues", project=p)\n') == [WRITE]
+
+    def test_an_item_assignment_after_construction(self) -> None:
+        """Shape C: the dict literal is innocent, the next line is not."""
+        assert hits('\nrow["event_type"] = "spec_issues"\n') == [WRITE]
+
+    def test_setdefault(self) -> None:
+        """Shape D."""
+        assert hits('\nrow.setdefault("event_type", "spec_issues")\n') == [WRITE]
+
+    def test_update_with_keywords(self) -> None:
+        """Shape F."""
+        assert hits('\nrow.update(event_type="spec_issues")\n') == [WRITE]
+
+    def test_an_attribute_assignment(self) -> None:
+        assert hits('\nself.event_type = "spec_issues"\n') == [WRITE]
+
+    def test_dict_unpacking_beside_the_literal_pair(self) -> None:
+        """The ``**`` entry is a ``None`` key, and the pair beside it is
+        still a pair. Asserted rather than assumed."""
+        assert hits('\nrow = {**base, "event_type": "spec_issues"}\n') == [WRITE]
+
+    def test_a_dict_comprehension(self) -> None:
+        assert hits('\nrow = {"event_type": "spec_issues" for _k in keys}\n') == [WRITE]
+
+    def test_a_bare_pair_a_dict_can_be_built_from(self) -> None:
+        """``dict([("event_type", <name>)])`` and every other shape made
+        of the same two-element pair."""
+        assert hits('\nrow = dict([("event_type", "spec_issues")])\n') == [WRITE]
+
+    def test_a_constructor_keyword(self) -> None:
+        """A ``TypedDict``, a dataclass or a model: the keyword is what
+        is matched, not the callable, so all of them count."""
+        assert hits('\nrow = JournalRow(event_type="spec_issues")\n') == [WRITE]
+
+    def test_a_partial_binding_the_keyword(self) -> None:
+        assert hits('\nwrite = functools.partial(sink, event_type="spec_issues")\n') == [WRITE]
+
+    def test_the_get_default_spells_the_name(self) -> None:
+        """The fallback is the same bare literal deciding the same thing.
+
+        Four rows in ``evolution.py`` classify a pre-column entry this
+        way with ``component_result``, and every one of them was
+        invisible to the first matcher.
+        """
+        assert hits('\nkind = entry.get("event_type", "spec_issues")\n') == [WRITE]
+
+    def test_the_pop_default_spells_the_name(self) -> None:
+        assert hits('\nkind = row.pop("event_type", "spec_issues")\n') == [WRITE]
+
+    def test_a_bare_pair_in_a_list_counts_too(self) -> None:
+        """``dict([["event_type", <name>]])``. One word in the matcher,
+        and without this control that word can be deleted green."""
+        assert hits('\nrow = dict([["event_type", "spec_issues"]])\n') == [WRITE]
+
+    def test_a_second_constant_is_layer_ones_job_not_this_one(self) -> None:
+        """The column discipline, asserted from the side that costs.
+
+        ``_SPEC = "spec_issues"`` binds the name to a plain local, which
+        never reaches the ``event_type`` column, so layer 2 says nothing.
+        An earlier version of the matcher DID flag it, and that version
+        also failed ``SPEC_ISSUES_KEY = "spec_issues"`` for the
+        architect's JSON vocabulary and would fail ``events.py`` lines
+        343 and 646 the moment the enrolment follow-up reaches
+        ``contract_result``. Layer 1 counts this spelling instead, where
+        a new row with a reason is the normal outcome.
+        """
+        assert hits('\n_SPEC = "spec_issues"\n') == []
+        assert hits('\nSPEC_ISSUES_EVENT = "spec_issues"\n') == []
+
+
+class TestEveryReadingShape:
+    """A row is selected. Every way of comparing the column to the name.
+
+    ``ast.Compare`` with a direct ``.get`` or subscript operand was the
+    only one of these the first matcher knew.
+    """
+
+    def test_a_plain_comparison(self) -> None:
+        assert hits('\nflag = entry.get("event_type") == "spec_issues"\n') == [READ]
+
+    def test_the_reversed_and_membership_spellings(self) -> None:
+        assert hits('\nflag = "spec_issues" == entry["event_type"]\n') == [READ]
+        assert hits('\nflag = entry.get("event_type") in ("spec_issues", "other")\n') == [
+            "line 2: compares event_type against ('spec_issues', 'other')"
+        ]
+
+    def test_an_assembled_spelling_is_not_a_way_past_it(self) -> None:
+        """``folded_str`` is why: a text search and a bare
+        ``ast.Constant`` check both miss these."""
+        assert hits('\nflag = entry.get("event_type") == "spec" + "_issues"\n') == [
+            "line 2: compares event_type against 'spec' + '_issues'"
+        ]
+        assert hits('\nflag = entry.get("event_type") == f"spec_issues"\n') == [
+            "line 2: compares event_type against f'spec_issues'"
+        ]
+
+    def test_a_match_statement(self) -> None:
+        """Shape G. ``ast.Match`` holds no comparison operator at all."""
+        source = '\nmatch entry.get("event_type"):\n    case "spec_issues":\n        pass\n'
+        assert hits(source) == ["line 3: compares event_type against 'spec_issues'"]
+
+    def test_an_or_pattern_in_a_case(self) -> None:
+        source = (
+            '\nmatch entry.get("event_type"):\n    case "role_usage" | "spec_issues":\n'
+            "        pass\n"
+        )
+        assert hits(source) == ["line 3: compares event_type against 'spec_issues'"]
+
+    def test_a_mapping_pattern(self) -> None:
+        """``case {"event_type": <name>}`` names the column itself, so it
+        needs no subject read to be decidable."""
+        source = '\nmatch entry:\n    case {"event_type": "spec_issues"}:\n        pass\n'
+        assert hits(source) == ["line 3: compares event_type against 'spec_issues'"]
+
+    def test_a_walrus_into_a_compare(self) -> None:
+        """Shape J. Caught by the deep operand walk, not by the alias
+        table, which is why the next test exists."""
+        source = '\nif (found := entry.get("event_type")) == "spec_issues":\n    pass\n'
+        assert hits(source) == [READ]
+
+    def test_a_walrus_bound_on_an_earlier_line(self) -> None:
+        """The only customer of ``_bound_names``'s ``ast.NamedExpr``
+        branch. Measured: delete that branch and every other test in this
+        file still passes, so without this one the branch is an eleven
+        line wrapper no test can tell apart from ``assignment_parts``."""
+        source = (
+            '\nif (found := entry.get("event_type")):\n    pass\nflag = found == "spec_issues"\n'
+        )
+        assert hits(source) == ["line 4: compares event_type against 'spec_issues'"]
+
+    def test_an_alias_bound_on_an_earlier_line(self) -> None:
+        """The plainest reader there is, and neither half of it is an
+        operand that reads the column."""
+        source = '\nfound = entry.get("event_type")\nflag = found == "spec_issues"\n'
+        assert hits(source) == ["line 3: compares event_type against 'spec_issues'"]
+
+    def test_an_annotated_alias(self) -> None:
+        source = '\nfound: str | None = entry.get("event_type")\nflag = found == "spec_issues"\n'
+        assert hits(source) == ["line 3: compares event_type against 'spec_issues'"]
+
+    def test_an_alias_chain_of_any_length(self) -> None:
+        """Iterated to a fixed point, so a second hop is not a way past."""
+        source = '\nfound = entry.get("event_type")\nagain = found\nflag = again == "spec_issues"\n'
+        assert hits(source) == ["line 4: compares event_type against 'spec_issues'"]
+
+    def test_an_itemgetter_acquisition(self) -> None:
+        """``operator.itemgetter("event_type")`` is a read the same way
+        ``.get`` is, and the name it binds carries that."""
+        source = '\nread = operator.itemgetter("event_type")\nflag = read(entry) == "spec_issues"\n'
+        assert hits(source) == ["line 3: compares event_type against 'spec_issues'"]
+
+    def test_a_method_on_the_read_with_no_comparison_at_all(self) -> None:
+        source = '\nflag = str(entry.get("event_type", "")).startswith("spec_issues")\n'
+        assert hits(source) == [READ]
+
+    def test_an_if_elif_chain(self) -> None:
+        source = (
+            '\nif entry.get("event_type") == "role_usage":\n    pass\n'
+            'elif entry.get("event_type") == "spec_issues":\n    pass\n'
+        )
+        assert hits(source) == ["line 4: compares event_type against 'spec_issues'"]
+
+    def test_the_second_enrolled_name_is_detected_too(self) -> None:
+        """The walk is driven by ``ENROLLED_EVENT_CONSTANTS`` rather than
+        by one hardcoded name, so enrolling the next constant costs one
+        line instead of a copy of this file."""
+        source = '\nflag = entry.get("event_type") == "journal_repair"\n'
+        assert hits(source, "journal_repair") == [
+            "line 2: compares event_type against 'journal_repair'"
+        ]
+
+
+class TestTheOtherVocabularyIsLeftAlone:
+    """The false-positive side. Without these, "flag everything" passes.
+
+    ``spec_issues`` is the architect's own JSON key as well as a journal
+    event name. Flagging that vocabulary would make this guard something
+    to be silenced rather than obeyed, so the line is drawn at the
+    COLUMN: a spelling that never reaches ``event_type`` is somebody
+    else's word.
+    """
+
+    def test_the_architect_json_key_is_not_a_journal_row(self) -> None:
+        """``spec_issues`` is also the key the architect returns its
+        findings under, and ``DECOMPOSE_PROMPT`` spells it in prose."""
+        assert hits('\nissues = data.get("spec_issues") or []\n') == []
+        assert hits('\nPROMPT = "return a spec_issues array"\n') == []
+        assert hits('\npayload = {"spec_issues": [], "components": []}\n') == []
+
+    def test_prose_is_not_a_spelling(self) -> None:
+        assert hits('\ndef f():\n    """A spec_issues row is what decompose writes."""\n') == []
+
+    def test_another_column_compared_against_the_name(self) -> None:
+        assert hits('\nflag = entry.get("kind") == "spec_issues"\n') == []
+
+    def test_an_unrelated_row_and_an_unrelated_comparison(self) -> None:
+        source = (
+            '\nrow = {"project": "spec_issues_demo", "event_type": "role_usage"}\n'
+            'flag = row["project"] == "other"\n'
+        )
+        assert hits(source) == []
+
+
+class TestLayerOneCatchesWhatLayerTwoCannot:
+    """The shapes the matcher does not enumerate, counted by the net.
+
+    Without this class the two-layer claim is prose. Each case asserts
+    BOTH halves: layer 2 says nothing, and layer 1 counts the spelling.
+    Asserting only the second would pass on a matcher that had never been
+    narrowed; asserting only the first would pass on a net that had been
+    switched off.
+
+    Every one of these was planted into ``kstrl/evolution.py`` on its own
+    and measured: layer 2 green, layer 1 red.
+    """
+
+    def spellings(self, tmp_path: Path, source: str) -> int:
+        path = tmp_path / "other.py"
+        path.write_text(source, encoding="utf-8")
+        return event_name_spellings(path)
+
+    def check(self, tmp_path: Path, source: str, expected: int = 1) -> None:
+        assert hits(source) == [], "layer 2 was expected to be silent here"
+        assert self.spellings(tmp_path, source) == expected
+
+    def test_a_dispatch_table_keyed_by_the_name(self, tmp_path: Path) -> None:
+        """Decidable, and deliberately not decided by layer 2.
+
+        ``{"spec_issues": handler}`` is indistinguishable from the
+        architect's own JSON vocabulary, whose natural shape is a dict
+        keyed by exactly that word, and from the TUI's artifact label.
+        Layer 2 flagging it would put the matcher in the way of code that
+        has nothing to do with the journal, and a guard in the way gets
+        silenced. Layer 1 counts it, where a row with a reason is the
+        normal outcome.
+        """
+        self.check(tmp_path, '\ntable = {"spec_issues": handle}\nf = table[e["event_type"]]\n')
+
+    def test_a_read_behind_a_function_boundary(self, tmp_path: Path) -> None:
+        """Aliases are resolved through bindings, not through calls.
+
+        ``pick(entry) == "spec_issues"`` where ``pick`` reads the column
+        in another function needs a call graph, which is the resolution
+        #324 records eleven guards getting wrong independently. Not
+        attempted in layer 2 on purpose, and it does not have to be.
+        """
+        source = (
+            '\ndef pick(entry):\n    return entry.get("event_type")\n\n\n'
+            'flag = pick(entry) == "spec_issues"\n'
+        )
+        self.check(tmp_path, source)
+
+    def test_a_parameter_default_naming_the_column(self, tmp_path: Path) -> None:
+        self.check(tmp_path, '\ndef emit(event_type="spec_issues"):\n    pass\n')
+
+    def test_setattr_of_the_column(self, tmp_path: Path) -> None:
+        self.check(tmp_path, '\nsetattr(row, "event_type", "spec_issues")\n')
+
+    def test_a_tuple_unpacked_assignment(self, tmp_path: Path) -> None:
+        self.check(tmp_path, '\nSPEC, OTHER = "spec_issues", "role_usage"\n')
+
+    def test_the_name_arriving_through_a_loop_variable(self, tmp_path: Path) -> None:
+        source = '\nfor name in ["spec_issues"]:\n    rows.append({"event_type": name})\n'
+        self.check(tmp_path, source)
+
+    def test_a_function_returning_the_bare_name(self, tmp_path: Path) -> None:
+        self.check(tmp_path, '\ndef kind():\n    return "spec_issues"\n')
+
+    def test_a_second_constant_and_the_compare_that_follows_it(self, tmp_path: Path) -> None:
+        """Both spellings counted: the declaration and nothing else,
+        because the comparison operand is a bare ``ast.Name`` that
+        folding cannot decide. That is precisely why catching the
+        declaration is what keeps the undecidable half small."""
+        source = '\n_SPEC = "spec_issues"\nflag = e.get("event_type") == _SPEC\n'
+        self.check(tmp_path, source)
+
+    def test_the_net_is_not_simply_counting_everything(self, tmp_path: Path) -> None:
+        """The false-positive side of layer 1. Without this, a net that
+        returned the node count would pass every test above."""
+        assert self.spellings(tmp_path, '\nrow = {"event_type": "role_usage"}\n') == 0
+        assert self.spellings(tmp_path, '\nlabel = "spec_issues_demo"\n') == 0
+        assert self.spellings(tmp_path, '\ndef f():\n    """A spec_issues row."""\n') == 0
+
+
+class TestTheDisclosedMisses:
+    """What NEITHER layer sees, asserted so it stays true.
+
+    One thing, after #336. A disclosure nothing tests is a sentence that
+    ages; this is where somebody widening ``folded_str`` finds out the
+    docstrings have to change.
+    """
+
+    def test_a_name_the_interpreter_has_to_build_is_missed(self, tmp_path: Path) -> None:
+        """``str.format``, ``"".join``, ``%``-formatting and a run-time
+        lookup all answer ``None`` to constant folding, so neither the
+        matcher nor the net can see the name.
+
+        The bound on it: a WRITER of such a row still has to reach the
+        ``event_type`` column, and a reader still has to obtain a value
+        to compare, so this hides an individual site rather than the
+        practice. It is the residual ``folded_str`` already discloses
+        next door, reached from here.
+        """
+        for source in (
+            '\nflag = e.get("event_type") == "{}_issues".format("spec")\n',
+            '\nflag = e.get("event_type") == names["spec"]\n',
+            '\nflag = e.get("event_type") == "".join(("spec", "_issues"))\n',
+        ):
+            assert hits(source) == [], source
+            path = tmp_path / "other.py"
+            path.write_text(source, encoding="utf-8")
+            assert event_name_spellings(path) == 0, source

--- a/tests/test_event_names_have_one_home.py
+++ b/tests/test_event_names_have_one_home.py
@@ -1,0 +1,572 @@
+"""An enrolled journal event name is spelled once, in ``kstrl/evolution.py``.
+
+``spec_issues`` used to be spelled twice: a constant in ``decompose``,
+which writes the row, and a literal in ``evolution``, which selects on
+it. The cost of that placement was not that the two disagreed - a
+round-trip test made that loud - but that a reader added in
+``evolution`` reaches for the nearest spelling, and the nearest spelling
+was the literal.
+
+Split out of ``tests/test_evolution.py`` on #336, and the seam is the one
+``tests/test_journal_one_writer.py`` already documents about its own
+split: that file is about what the journal DOES, measured against real
+rows in a real file, and this one is a static guard over the whole
+package with no journal in it at all. Different subject, different
+failure message, different reason to fail. The 800-line ratchet could not
+prompt the split, because it reports rather than fails once a file is
+already over, and ``test_evolution.py`` was at 1407 lines.
+
+TWO LAYERS, because one of them is a net and the other is a message.
+
+LAYER 1, :func:`event_name_spellings`, counts every expression in
+``kstrl/`` whose folded value IS an enrolled event name, per module. It
+is the net: a row cannot be written or selected by a name the module
+never spells, so a second spelling in any shape has to appear here
+first, whatever it does with the string afterwards. It resolves nothing
+and enumerates no node types, which is the point. #324 records that this
+repo has about eleven AST guards each re-implementing that resolution and
+each holed independently, and layer 2 below was the twelfth: round 1 of
+review on #336 measured six ordinary shapes walking straight past it.
+
+LAYER 2, :func:`literal_event_names`, enumerates shapes and names the
+offending line and its direction. It is not redundant. Layer 1 can only
+say "this module's spelling count moved", which is the wrong message when
+the answer is "you wrote a journal row with a bare literal, import the
+constant". Layer 1 in turn catches what layer 2 cannot, and after #336
+that is a longer list than layer 2's residual disclosure: a dispatch
+table keyed by the name, a read behind a function boundary, a parameter
+default, ``setattr``, a tuple-unpacked assignment, a function returning
+the bare name. All measured.
+
+What NEITHER layer sees is one thing, and it is disclosed on
+``folded_str`` next door and pinned in
+``tests/test_event_name_shapes.py``: a name the interpreter has to build.
+``"{}_issues".format("spec")``, ``"".join(...)``, ``%``-formatting, a
+run-time lookup. Constant folding answers ``None`` for all of them.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterable
+from pathlib import Path
+
+from kstrl.evolution import JOURNAL_REPAIR_EVENT, SPEC_ISSUES_EVENT
+from tests.test_journal_one_writer import (
+    assignment_parts,
+    folded_str,
+    label,
+    package_sources,
+    parsed,
+)
+
+#: The journal event names that have been hoisted to a constant, and so
+#: must never be spelled as a literal in ``kstrl/`` again. Five more are
+#: still bare literals (``component_result`` nine times in
+#: ``evolution.py`` alone, which is exactly what layer 2 counts there,
+#: plus ``role_usage``, ``contract_result``, ``autonomy_transition`` and
+#: ``findings_superseded``); converting them is a follow-up, and
+#: enrolling each one here is what makes that follow-up enforceable
+#: rather than merely intended.
+ENROLLED_EVENT_CONSTANTS = {
+    "SPEC_ISSUES_EVENT": SPEC_ISSUES_EVENT,
+    "JOURNAL_REPAIR_EVENT": JOURNAL_REPAIR_EVENT,
+}
+
+#: The journal column every row is written under and selected on. A bare
+#: literal of the COLUMN is not the defect; a bare literal of the event
+#: NAME attached to it is.
+EVENT_TYPE_KEY = "event_type"
+
+
+# --- layer 1: the net -----------------------------------------------------
+
+
+def event_name_spellings(source_file: Path) -> int:
+    """How many expressions in one module fold to an enrolled event name.
+
+    EQUALITY of the folded value, not substring, which is the opposite
+    of the choice ``folded_filename_sites`` makes next door and for the
+    opposite reason. That guard looks for a filename, and prose
+    mentioning ``evolution.jsonl`` folds to a whole docstring that
+    CONTAINS it. This one looks for a whole event name, and
+    ``DECOMPOSE_PROMPT`` spells ``spec_issues`` several times in a
+    prompt body that folds to thousands of characters. Substring would
+    put every one of those in the inventory and make the guard something
+    to be silenced; equality picks out the six places that actually hold
+    the bare string.
+
+    Counted per module so an unrelated edit does not fail it.
+    """
+    names = set(ENROLLED_EVENT_CONSTANTS.values())
+    return sum(1 for node in ast.walk(parsed(source_file)) if folded_str(node) in names)
+
+
+#: Every place in ``kstrl/`` that spells an enrolled event name outright,
+#: with how many times each module does it.
+#:
+#: Adding a row is not forbidden, it is the point: the diff that adds one
+#: is where somebody says why new code spells the name for itself instead
+#: of importing the constant. Three modules today, and only ONE of the
+#: six occurrences is the journal's own vocabulary. The other five are
+#: two other vocabularies that happen to share the word, which is why
+#: layer 2 draws its line at the ``event_type`` column rather than at the
+#: string, and why this layer is a pinned COUNT rather than an assertion
+#: that the count is zero.
+EXPECTED_EVENT_NAME_SPELLINGS: dict[str, int] = {
+    # The architect's own JSON key, twice (validation and _parse_spec_issues),
+    # plus the TUI artifact label emitted with ArtifactWritten.
+    "decompose.py": 3,
+    # The two declarations. This is the one home.
+    "evolution.py": 2,
+    # The TUI reading that artifact label back.
+    "tui/screens/decompose.py": 1,
+}
+
+
+# --- layer 2: the message -------------------------------------------------
+
+
+def literal_event_names(
+    tree: ast.Module,
+    event_name: str,
+    aliases: frozenset[str] | None = None,
+) -> list[str]:
+    """Every place this module names ``event_name`` as a bare literal.
+
+    Two directions, because a journal row is WRITTEN in one and SELECTED
+    in the other, and a bare spelling in either is the defect. The shapes
+    each direction covers are listed on :func:`_literal_event_writes`,
+    :func:`_call_event_hits` and :func:`_literal_event_reads`, and every
+    one of them has a positive control in
+    ``tests/test_event_name_shapes.py``, because a matcher that quietly
+    stops matching returns the same empty list as a clean tree.
+
+    Round 1 of review on #336 is why that list is long, and why layer 1
+    exists at all. This function looked at ``ast.Dict`` and at
+    ``ast.Compare`` and at nothing else, and six ordinary shapes walked
+    past it, all six measured rather than argued: ``dict(event_type=...)``,
+    an item assignment after the dict was built, ``setdefault``,
+    ``update(**kwargs)``, ``match``/``case`` and a walrus. Two were
+    planted as real methods on ``EvolutionJournal`` and the whole fast
+    tier stayed green. Every miss was in the skip direction, which is the
+    defect class #324 exists to record. Enumerating node types does not
+    converge by inspection, so coverage is layer 1's job now and this
+    layer's job is to say which line and which direction.
+
+    Deliberately NOT "the string appears in this file". ``spec_issues``
+    is also the architect's own JSON key and the TUI's artifact label, so
+    ``DECOMPOSE_PROMPT`` spells it in prose and ``_parse_spec_issues``
+    reads ``data.get("spec_issues")`` off the agent's output. Those are
+    other vocabularies that happen to share a word, and flagging them
+    would make this layer something to be silenced rather than obeyed.
+    ``TestTheOtherVocabularyIsLeftAlone`` feeds the matcher both kinds,
+    so neither half is taken on trust. The line is the ``event_type``
+    column: a spelling that never reaches it is somebody else's word, and
+    layer 1 is what still counts those.
+
+    ``aliases`` is a loop invariant the caller may hoist. It depends on
+    the tree alone, so recomputing it per event name is pure waste:
+    measured at 254 calls over 127 modules for two names, of which 127
+    were duplicates, and the guard test goes 0.61 s to 0.46 s with this
+    and the node walk hoisted. It is O(names x modules) on a computation
+    that does not depend on names, and this file commits to five more
+    names.
+    """
+    resolved = event_type_aliases(tree) if aliases is None else aliases
+    return [hit for node in ast.walk(tree) for hit in _hits_at(node, event_name, resolved)]
+
+
+def _hits_at(node: ast.AST, event_name: str, aliases: frozenset[str]) -> list[str]:
+    """One node, handed to whichever half of the guard owns its shape."""
+    if isinstance(node, ast.Compare):
+        return _literal_event_reads(node, event_name, aliases)
+    if isinstance(node, ast.Match):
+        return _match_event_reads(node, event_name, aliases)
+    if isinstance(node, ast.MatchMapping):
+        return _mapping_pattern_reads(node, event_name)
+    if isinstance(node, ast.Call):
+        return _call_event_hits(node, event_name, aliases)
+    return _literal_event_writes(node, event_name)
+
+
+# --- the writing half -----------------------------------------------------
+
+
+def _literal_event_writes(node: ast.AST, event_name: str) -> list[str]:
+    """Every shape that BINDS the event-type column to a bare name.
+
+    ``{"event_type": <name>}``, the same pair inside a dict
+    comprehension, a bare two-element pair (which is what
+    ``dict([("event_type", <name>)])`` is made of), and an assignment
+    whose TARGET is the column.
+
+    ``{**base, "event_type": <name>}`` needs nothing extra: the explicit
+    pair is still a pair, and the ``**`` entry is the ``None`` key this
+    skips. Measured, not assumed.
+    """
+    if isinstance(node, ast.Dict):
+        return _pair_hits(zip(node.keys, node.values, strict=True), event_name)
+    if isinstance(node, ast.DictComp):
+        return _pair_hits([(node.key, node.value)], event_name)
+    if isinstance(node, ast.Tuple | ast.List) and len(node.elts) == 2:
+        return _pair_hits([(node.elts[0], node.elts[1])], event_name)
+    if isinstance(node, ast.Assign | ast.AnnAssign):
+        return _assignment_hits(node, event_name)
+    return []
+
+
+def _pair_hits(
+    pairs: Iterable[tuple[ast.expr | None, ast.expr]],
+    event_name: str,
+) -> list[str]:
+    """``<the column>: <the name>`` pairs, whatever holds them.
+
+    Only the KEY is optional, and only because ``ast.Dict`` spells
+    ``{**base}`` as a ``None`` key. A value slot is never ``None``:
+    measured over 1626 dict literals in ``kstrl/`` and ``tests/``, zero.
+    """
+    return [
+        _write_hit(value)
+        for key, value in pairs
+        if key is not None and folded_str(key) == EVENT_TYPE_KEY and folded_str(value) == event_name
+    ]
+
+
+def _assignment_hits(node: ast.Assign | ast.AnnAssign, event_name: str) -> list[str]:
+    """``row["event_type"] = <name>`` and ``self.event_type = <name>``.
+
+    The column discipline, kept. An earlier version of this rule flagged
+    ANY assignment whose value folded to an enrolled name, so that a
+    second constant declaring the string was caught. That reached one
+    shape and broke the line every other rule here holds: it would fail
+    on ``SPEC_ISSUES_KEY = "spec_issues"``, which is the obvious next
+    cleanup of the architect's own JSON vocabulary in ``decompose.py``,
+    with a message telling the author to import the JOURNAL's constant.
+    It would also fail on ``kstrl/events.py`` lines 343 and 646, which
+    are the event STREAM's discriminator, the moment the enrolment
+    follow-up this file commits to reaches ``contract_result`` and
+    ``autonomy_transition``. A guard that fails the follow-up it exists
+    to enable is a guard that gets silenced.
+
+    A second constant is still caught, by layer 1, where "here is the row
+    and here is the reason" is the normal outcome rather than a failure
+    to argue with. That is what having a net underneath buys.
+    """
+    targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+    if node.value is None or folded_str(node.value) != event_name:
+        return []
+    return [_write_hit(node.value) for target in targets if _names_the_column(target)]
+
+
+def _names_the_column(target: ast.expr) -> bool:
+    """``x["event_type"]`` or ``x.event_type`` as an assignment target."""
+    if isinstance(target, ast.Subscript):
+        return folded_str(target.slice) == EVENT_TYPE_KEY
+    return isinstance(target, ast.Attribute) and target.attr == EVENT_TYPE_KEY
+
+
+def _call_event_hits(node: ast.Call, event_name: str, aliases: frozenset[str]) -> list[str]:
+    """The three ways a CALL names the event with no dict literal in sight."""
+    return (
+        _keyword_hits(node, event_name)
+        + _keyed_argument_hits(node, event_name)
+        + _method_on_a_read_hits(node, event_name, aliases)
+    )
+
+
+def _keyword_hits(node: ast.Call, event_name: str) -> list[str]:
+    """``event_type=<name>`` on any call.
+
+    Any call rather than ``dict`` alone: the same keyword builds a
+    ``TypedDict``, a dataclass or model, a ``functools.partial`` and an
+    ``update(**kwargs)``, and singling out ``dict`` by name would leave
+    every one of those free. Ruff is no help either. This repo selects
+    ``E``, ``F``, ``I``, ``UP`` and ``B``, so ``C408`` is not on and
+    ``dict(event_type=...)`` lints clean. ``F401`` catches the shape in
+    ``decompose.py`` only by accident, because line 1031 is that module's
+    sole USE of the imported constant, so replacing it leaves the import
+    unused. Inside ``evolution.py``, where the constant is declared,
+    there is no import to go unused and nothing fires at all.
+    """
+    return [
+        _write_hit(keyword.value)
+        for keyword in node.keywords
+        if keyword.arg == EVENT_TYPE_KEY and folded_str(keyword.value) == event_name
+    ]
+
+
+def _keyed_argument_hits(node: ast.Call, event_name: str) -> list[str]:
+    """``<method>("event_type", <name>)``: the value, or the default.
+
+    ``setdefault`` writes the name. ``get`` and ``pop`` spell it as the
+    fallback, which is the same bare literal deciding the same thing:
+    ``entry.get("event_type", "component_result")`` is how four rows in
+    ``evolution.py`` classify an entry that predates the column. Matched
+    on the shape rather than on a list of method names, so a wrapper of
+    any of them counts too.
+
+    Folded EQUALITY on each remaining argument, not a deep walk, for the
+    same reason ``_assignment_hits`` keeps its column: an argument that
+    merely CONTAINS the name somewhere is a different claim.
+    """
+    if not _keys_on_the_column(node):
+        return []
+    return [_write_hit(arg) for arg in node.args[1:] if folded_str(arg) == event_name]
+
+
+def _keys_on_the_column(node: ast.AST) -> bool:
+    """``<anything>.<method>("event_type", ...)``.
+
+    Shared by both halves, because one call shape does both jobs:
+    ``get``, ``pop`` and ``setdefault`` name the column as their first
+    argument and are reads, and the same three spell the event name as
+    their second and are writes. ``operator.itemgetter("event_type")``
+    is the read half with no second argument at all.
+    """
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and bool(node.args)
+        and folded_str(node.args[0]) == EVENT_TYPE_KEY
+    )
+
+
+def _method_on_a_read_hits(
+    node: ast.Call,
+    event_name: str,
+    aliases: frozenset[str],
+) -> list[str]:
+    """``<a read>.startswith(<name>)``: a selection with no ``==`` in it.
+
+    A deep walk on the argument here, unlike ``_keyed_argument_hits``,
+    because the receiver has already established that this expression is
+    about the column, so ``in ("spec_issues", "other")``-style nesting on
+    the argument is the same claim rather than a wider one.
+    """
+    if not isinstance(node.func, ast.Attribute):
+        return []
+    if not _reads_event_type(node.func.value, aliases):
+        return []
+    return [_read_hit(arg) for arg in node.args if _names_the_event(arg, event_name)]
+
+
+# --- the reading half -----------------------------------------------------
+
+
+def _literal_event_reads(
+    node: ast.Compare,
+    event_name: str,
+    aliases: frozenset[str],
+) -> list[str]:
+    """``entry.get("event_type") == <literal>`` and its ``!=`` and ``in``
+    spellings, in either operand order."""
+    operands = [node.left, *node.comparators]
+    if not any(_reads_event_type(operand, aliases) for operand in operands):
+        return []
+    return [
+        _read_hit(operand)
+        for operand in operands
+        if not _reads_event_type(operand, aliases) and _names_the_event(operand, event_name)
+    ]
+
+
+def _match_event_reads(node: ast.Match, event_name: str, aliases: frozenset[str]) -> list[str]:
+    """``match entry.get("event_type"): case <name>:``, or-patterns and all.
+
+    ``ast.Match`` holds no comparison operator at all, so a guard that
+    walks ``ast.Compare`` cannot see a dispatch written this way even
+    though it is the shape somebody adding a reader of several event
+    types reaches for first.
+    """
+    if not _reads_event_type(node.subject, aliases):
+        return []
+    return [
+        _read_hit(value)
+        for case in node.cases
+        for value in _pattern_literals(case.pattern)
+        if folded_str(value) == event_name
+    ]
+
+
+def _mapping_pattern_reads(node: ast.MatchMapping, event_name: str) -> list[str]:
+    """``case {"event_type": <name>}``: the column and the value, in the
+    pattern itself.
+
+    Needs no subject read, because the pattern names the column.
+    """
+    return [
+        _read_hit(value)
+        for key, pattern in zip(node.keys, node.patterns, strict=True)
+        if folded_str(key) == EVENT_TYPE_KEY
+        for value in _pattern_literals(pattern)
+        if folded_str(value) == event_name
+    ]
+
+
+def _pattern_literals(pattern: ast.pattern) -> list[ast.expr]:
+    """The literals a case pattern matches against, at any depth."""
+    return [node.value for node in ast.walk(pattern) if isinstance(node, ast.MatchValue)]
+
+
+def _reads_event_type(node: ast.expr, aliases: frozenset[str]) -> bool:
+    """Does this expression read the event-type column, at any depth?
+
+    Walks rather than testing the top node alone, so ``str(e["event_type"])``,
+    the walrus ``(found := e.get("event_type"))`` and a local the module
+    bound to a read all count.
+    """
+    return any(_is_event_type_read(child, aliases) for child in ast.walk(node))
+
+
+def _is_event_type_read(node: ast.AST, aliases: frozenset[str]) -> bool:
+    """One node: ``x["event_type"]``, any method call whose first argument
+    is the column (``get``, ``pop``, ``setdefault``,
+    ``operator.itemgetter``), or a name bound to one of those."""
+    if isinstance(node, ast.Subscript):
+        return folded_str(node.slice) == EVENT_TYPE_KEY
+    if isinstance(node, ast.Name):
+        return node.id in aliases
+    return _keys_on_the_column(node)
+
+
+def _names_the_event(operand: ast.expr, event_name: str) -> bool:
+    """Does this operand spell the event name, at any depth?
+
+    Walks children so ``in ("spec_issues", "component_result")`` is seen,
+    and folds each one so an assembled spelling is not a way past.
+    """
+    return any(folded_str(child) == event_name for child in ast.walk(operand))
+
+
+# --- names that stand in for a read ---------------------------------------
+
+
+def event_type_aliases(tree: ast.Module) -> frozenset[str]:
+    """Local names bound to a read of the column, to a fixed point.
+
+    ``found = entry.get("event_type")`` on one line and ``found ==
+    "spec_issues"`` on the next is the plainest reader there is, and
+    neither half is an ``ast.Compare`` operand that reads the column. So
+    is the walrus bound on one line and compared on a later one.
+    Iterated to a fixed point the way ``journal_aliases`` does next door,
+    so a chain of any length closes.
+
+    Message quality rather than coverage, now that layer 1 exists: every
+    shape this reaches spells the name outright, so the net counts it
+    either way. What this buys is "line 42 compares event_type against
+    'spec_issues'" instead of "decompose.py's spelling count moved".
+
+    Collected per MODULE rather than per scope, which is the trade-off
+    that function makes too: a name bound to a read anywhere means "the
+    event type" everywhere in the file. That over-reports rather than
+    under-reports, and over-reporting is the direction a guard is allowed
+    to be wrong in. Measured: 1 of 127 modules in ``kstrl/`` binds any
+    alias at all.
+    """
+    nodes = list(ast.walk(tree))
+    names: frozenset[str] = frozenset()
+    while True:
+        found = _alias_sweep(nodes, names)
+        if found <= names:
+            return names
+        names |= found
+
+
+def _alias_sweep(nodes: list[ast.AST], names: frozenset[str]) -> frozenset[str]:
+    """The names ONE pass binds to a read, given what is known so far."""
+    found: set[str] = set()
+    for node in nodes:
+        targets, value = _bound_names(node)
+        if value is not None and _reads_event_type(value, names):
+            found.update(targets)
+    return frozenset(found)
+
+
+def _bound_names(node: ast.AST) -> tuple[list[str], ast.expr | None]:
+    """The plain names one binding binds, and what it binds them to.
+
+    ``assignment_parts`` next door already answers this for ``Assign``
+    and ``AnnAssign``. The walrus is added here rather than there because
+    it is both a binding and an operand, and the one-writer guard has no
+    use for it. Pinned by
+    ``test_a_walrus_bound_on_an_earlier_line``, because the walrus INSIDE
+    a compare is caught by ``_reads_event_type``'s deep walk and so does
+    not reach this branch at all.
+    """
+    if isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
+        return [node.target.id], node.value
+    return assignment_parts(node)
+
+
+# --- how a hit reads ------------------------------------------------------
+
+
+def _write_hit(value: ast.expr) -> str:
+    return f"line {value.lineno}: writes {ast.unparse(value)} as the event_type"
+
+
+def _read_hit(operand: ast.expr) -> str:
+    return f"line {operand.lineno}: compares event_type against {ast.unparse(operand)}"
+
+
+class TestJournalEventNamesHaveOneHome:
+    """#314 item 3, and #336 round 1 for the shape of the mechanism.
+
+    Two assertions, one per layer. Both are pinned inventories rather
+    than "this list is empty" alone, because an empty list is also what a
+    switched-off detector returns. The shape controls in
+    ``tests/test_event_name_shapes.py`` are what make layer 2's assertion
+    mean something: measured, every one of the twenty matcher functions
+    can be stubbed to a constant, and each stub is noticed there.
+    """
+
+    def test_nobody_spells_an_enrolled_event_name_for_themselves(self) -> None:
+        """Layer 1, the net: pin every spelling of the name itself.
+
+        A row cannot be written or selected by a name the module never
+        spells, so NEW code that spells one has to change this dict,
+        whatever shape it uses. That is why this layer resolves nothing
+        and enumerates no node types: an exact count of folded values has
+        no shape list to be incomplete.
+
+        Measured, on the shapes layer 2 discloses that it misses: a
+        dispatch table keyed by the name, a read behind a function
+        boundary, a parameter default, ``setattr``, a tuple-unpacked
+        assignment and a function returning the bare name are all caught
+        HERE. What survives both layers is one thing, disclosed on
+        ``folded_str`` and pinned in ``test_event_name_shapes.py``: a
+        name the interpreter has to build.
+        """
+        built: dict[str, int] = {}
+        for source_file in package_sources():
+            hits = event_name_spellings(source_file)
+            if hits:
+                built[label(source_file)] = hits
+
+        assert built == EXPECTED_EVENT_NAME_SPELLINGS, (
+            "The set of places that spell an enrolled journal event name changed. If "
+            "this is a journal row being written or selected, import the constant "
+            "evolution.py declares for it. If it is the architect's JSON key or the "
+            "TUI's artifact label, which share the word, add the row with a reason. "
+            f"Found: {built}"
+        )
+
+    def test_no_module_names_an_enrolled_event_as_a_literal(self) -> None:
+        """Layer 2, the message: name the offending line and its direction."""
+        found: dict[str, list[str]] = {}
+        for source_file in package_sources():
+            tree = parsed(source_file)
+            aliases = event_type_aliases(tree)
+            hits = [
+                f"{constant}: {hit}"
+                for constant, event_name in sorted(ENROLLED_EVENT_CONSTANTS.items())
+                for hit in literal_event_names(tree, event_name, aliases)
+            ]
+            if hits:
+                found[label(source_file)] = hits
+
+        assert found == {}, (
+            "A journal row is written or selected by a bare literal instead of the "
+            f"constant evolution.py declares for it. Import the constant. Sites: {found}"
+        )

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 
 from kstrl.evolution import (
+    JOURNAL_REPAIR_EVENT,
     JOURNAL_SCHEMA_VERSION,
     SPEC_ISSUES_EVENT,
     EvolutionConfig,
@@ -22,6 +23,13 @@ from kstrl.evolution import (
 )
 from kstrl.factory import FactoryResult
 from kstrl.manifest import Component, ComponentStatus, Manifest
+from tests.helpers.journal import audit, journal_at
+from tests.test_journal_one_writer import (
+    folded_str,
+    label,
+    package_sources,
+    parsed,
+)
 
 
 def _make_manifest(
@@ -1120,12 +1128,9 @@ class TestSpecAudits:
     and the one window rule built on it."""
 
     def _journal(self, tmp_path: Path, entries: list[dict[str, Any]]) -> EvolutionJournal:
-        journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
+        journal = journal_at(tmp_path)
         journal.append_entries(entries)
         return journal
-
-    def _audit(self, project: Any, spec_file: str = "spec.md") -> dict[str, Any]:
-        return {"event_type": SPEC_ISSUES_EVENT, "project": project, "spec_file": spec_file}
 
     def test_every_project_is_returned_unwindowed(self, tmp_path: Path) -> None:
         """The accounting under the trend counts the history the trend
@@ -1134,7 +1139,7 @@ class TestSpecAudits:
         """
         journal = self._journal(
             tmp_path,
-            [self._audit("mine"), self._audit("other"), self._audit(None)],
+            [audit("mine"), audit("other"), audit(None)],
         )
 
         assert [e.get("project") for e in journal.get_spec_audits()] == ["mine", "other", None]
@@ -1145,7 +1150,7 @@ class TestSpecAudits:
             tmp_path,
             [
                 {"run_id": "r1", "event_type": "component_result", "component": "a"},
-                self._audit("mine"),
+                audit("mine"),
             ],
         )
 
@@ -1159,8 +1164,8 @@ class TestSpecAudits:
         """``audits=`` is what lets ONE read feed both the trend and the
         accounting computed over the same entries, so the two cannot
         disagree because the file moved between two reads."""
-        journal = self._journal(tmp_path, [self._audit("mine", "on-disk.md")])
-        elsewhere = [self._audit("mine", "b.md"), self._audit("other", "c.md")]
+        journal = self._journal(tmp_path, [audit("mine", "on-disk.md")])
+        elsewhere = [audit("mine", "b.md"), audit("other", "c.md")]
 
         def refuse(self: EvolutionJournal) -> list[dict[str, Any]]:
             raise AssertionError("read the file despite being handed a snapshot")
@@ -1178,7 +1183,7 @@ class TestSpecAudits:
         project."""
         entries: list[dict[str, Any]] = [
             {"event_type": "component_result", "project": "mine", "spec_file": "wrong.md"},
-            self._audit("mine", "right.md"),
+            audit("mine", "right.md"),
         ]
         journal = self._journal(tmp_path, entries)
 
@@ -1193,7 +1198,7 @@ class TestSpecAudits:
         the slice left the ENTIRE suite green, because every other
         window test records audits that raise the same counts.
         """
-        journal = self._journal(tmp_path, [self._audit("mine", f"spec-{n}.md") for n in range(5)])
+        journal = self._journal(tmp_path, [audit("mine", f"spec-{n}.md") for n in range(5)])
 
         assert [r["spec_file"] for r in journal.get_spec_issue_runs("mine", last_n=2)] == [
             "spec-3.md",
@@ -1203,7 +1208,7 @@ class TestSpecAudits:
     def test_a_non_positive_window_reads_nothing(self, tmp_path: Path) -> None:
         """``lookback_runs = 0`` means the trend reads nothing, and the
         report says so out loud rather than claiming no audit exists."""
-        journal = self._journal(tmp_path, [self._audit("mine")])
+        journal = self._journal(tmp_path, [audit("mine")])
 
         assert journal.get_spec_issue_runs("mine", last_n=0) == []
         assert journal.get_spec_issue_runs("mine", last_n=-1) == []
@@ -1219,7 +1224,7 @@ class TestSpecAudits:
         """
         journal = self._journal(
             tmp_path,
-            [self._audit(None, "null.md"), self._audit(7, "int.md"), self._audit("", "empty.md")],
+            [audit(None, "null.md"), audit(7, "int.md"), audit("", "empty.md")],
         )
 
         assert [r["spec_file"] for r in journal.get_spec_issue_runs("")] == [
@@ -1230,56 +1235,67 @@ class TestSpecAudits:
 
 
 # ---------------------------------------------------------------------------
-# SPEC_ISSUES_EVENT has one home (#314 item 3)
+# Journal event names have one home (#314 item 3)
 # ---------------------------------------------------------------------------
 
-#: The package under test, located the way every other AST-walking test
-#: in this suite locates it (test_journal_one_writer, test_atomicio).
-KSTRL_PACKAGE = Path(__file__).resolve().parent.parent / "kstrl"
+#: The journal event names that have been hoisted to a constant, and so
+#: must never be spelled as a literal in ``kstrl/`` again. Five more are
+#: still bare literals (``component_result`` nine times in this module
+#: alone, plus ``role_usage``, ``contract_result``,
+#: ``autonomy_transition`` and ``findings_superseded``); converting them
+#: is a follow-up, and enrolling each one here is what makes that
+#: follow-up enforceable rather than merely intended.
+ENROLLED_EVENT_CONSTANTS = {
+    "SPEC_ISSUES_EVENT": SPEC_ISSUES_EVENT,
+    "JOURNAL_REPAIR_EVENT": JOURNAL_REPAIR_EVENT,
+}
 
 
-def spec_issues_literals(source: str) -> list[str]:
-    """Every place this source names the spec-audit event as a literal.
+def literal_event_names(tree: ast.Module, event_name: str) -> list[str]:
+    """Every place this module names ``event_name`` as a bare literal.
 
-    Two shapes, because the row is written in one and selected in the
-    other:
+    Two shapes, because a journal row is written in one and selected in
+    the other:
 
-    - a dict entry ``{"event_type": "spec_issues"}``, which is a writer;
+    - a dict entry ``{"event_type": <literal>}``, which is a writer;
     - a comparison of an ``event_type`` lookup against the literal,
       which is a reader.
 
     Deliberately NOT "the string appears in this file". ``spec_issues``
-    is also the architect's own JSON key, so ``DECOMPOSE_PROMPT``
-    spells it several times in prose and ``_parse_spec_issues`` reads
+    is also the architect's own JSON key, so ``DECOMPOSE_PROMPT`` spells
+    it several times in prose and ``_parse_spec_issues`` reads
     ``data.get("spec_issues")`` off the agent's output. Those are a
-    different vocabulary that happens to share a word, and flagging
-    them would make this guard something to be silenced rather than
-    obeyed. ``TestSpecIssuesEventHasOneHome`` feeds the detector both
-    kinds so neither half is taken on trust.
+    different vocabulary that happens to share a word, and flagging them
+    would make this guard something to be silenced rather than obeyed.
+    ``TestJournalEventNamesHaveOneHome`` feeds the detector both kinds,
+    so neither half is taken on trust.
+
+    Literals are decided by ``test_journal_one_writer.folded_str``
+    rather than by a bare ``ast.Constant`` check, so ``"spec" +
+    "_issues"`` and the f-string spelling are seen as well. What folding
+    cannot decide is disclosed on that function and holds here
+    unchanged.
     """
     found: list[str] = []
-    for node in ast.walk(ast.parse(source)):
+    for node in ast.walk(tree):
         if isinstance(node, ast.Dict):
-            found.extend(_literal_event_writes(node))
+            found.extend(_literal_event_writes(node, event_name))
         if isinstance(node, ast.Compare):
-            found.extend(_literal_event_reads(node))
+            found.extend(_literal_event_reads(node, event_name))
     return found
 
 
-def _literal_event_writes(node: ast.Dict) -> list[str]:
-    """``{"event_type": "spec_issues"}`` entries of one dict literal."""
+def _literal_event_writes(node: ast.Dict, event_name: str) -> list[str]:
+    """``{"event_type": <literal>}`` entries of one dict literal."""
     return [
         f"line {value.lineno}: writes {ast.unparse(value)} as the event_type"
         for key, value in zip(node.keys, node.values, strict=True)
-        if isinstance(key, ast.Constant)
-        and key.value == "event_type"
-        and isinstance(value, ast.Constant)
-        and value.value == SPEC_ISSUES_EVENT
+        if key is not None and folded_str(key) == "event_type" and folded_str(value) == event_name
     ]
 
 
-def _literal_event_reads(node: ast.Compare) -> list[str]:
-    """``entry.get("event_type") == "spec_issues"`` and its ``!=``/``in``
+def _literal_event_reads(node: ast.Compare, event_name: str) -> list[str]:
+    """``entry.get("event_type") == <literal>`` and its ``!=`` and ``in``
     spellings, in either operand order."""
     operands = [node.left, *node.comparators]
     if not any(_reads_event_type(operand) for operand in operands):
@@ -1287,87 +1303,105 @@ def _literal_event_reads(node: ast.Compare) -> list[str]:
     return [
         f"line {node.lineno}: compares event_type against {ast.unparse(operand)}"
         for operand in operands
-        if SPEC_ISSUES_EVENT in _constant_strings(operand)
+        if not _reads_event_type(operand) and _names_the_event(operand, event_name)
     ]
 
 
 def _reads_event_type(node: ast.expr) -> bool:
     """``x.get("event_type", ...)`` or ``x["event_type"]``."""
     if isinstance(node, ast.Subscript):
-        return isinstance(node.slice, ast.Constant) and node.slice.value == "event_type"
+        return folded_str(node.slice) == "event_type"
     return (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
         and node.func.attr == "get"
         and bool(node.args)
-        and isinstance(node.args[0], ast.Constant)
-        and node.args[0].value == "event_type"
+        and folded_str(node.args[0]) == "event_type"
     )
 
 
-def _constant_strings(node: ast.expr) -> set[str]:
-    """The string constants this operand contains, tuple/list included,
-    so ``in ("spec_issues", "component_result")`` is seen."""
-    return {
-        child.value
-        for child in ast.walk(node)
-        if isinstance(child, ast.Constant) and isinstance(child.value, str)
-    }
+def _names_the_event(operand: ast.expr, event_name: str) -> bool:
+    """Does this operand spell the event name, at any depth?
+
+    Walks children so ``in ("spec_issues", "component_result")`` is
+    seen, and folds each one so an assembled spelling is not a way past.
+    """
+    return any(folded_str(child) == event_name for child in ast.walk(operand))
 
 
-class TestSpecIssuesEventHasOneHome:
-    """#314 item 3: the journal's discriminator is named once, here.
+class TestJournalEventNamesHaveOneHome:
+    """#314 item 3: an enrolled journal event name is spelled once, in
+    ``kstrl/evolution.py``, and imported everywhere else.
 
-    It used to be spelled twice - a constant in ``decompose``, which
-    writes the row, and a literal in this module, which selects on it.
-    The cost of that placement was not that the two disagreed (a
-    round-trip test made that loud) but that a reader added HERE
-    reaches for the nearest spelling, and the nearest spelling was the
-    literal.
+    ``spec_issues`` used to be spelled twice: a constant in
+    ``decompose``, which writes the row, and a literal in this module,
+    which selects on it. The cost of that placement was not that the two
+    disagreed - a round-trip test made that loud - but that a reader
+    added HERE reaches for the nearest spelling, and the nearest
+    spelling was the literal.
     """
 
-    def test_no_module_names_the_event_as_a_literal(self) -> None:
+    def _hits(self, source: str, event_name: str = SPEC_ISSUES_EVENT) -> list[str]:
+        return literal_event_names(ast.parse(source), event_name)
+
+    def test_no_module_names_an_enrolled_event_as_a_literal(self) -> None:
         found: dict[str, list[str]] = {}
-        for source_file in sorted(KSTRL_PACKAGE.rglob("*.py")):
-            hits = spec_issues_literals(source_file.read_text(encoding="utf-8"))
+        for source_file in package_sources():
+            hits = [
+                f"{constant}: {hit}"
+                for constant, event_name in sorted(ENROLLED_EVENT_CONSTANTS.items())
+                for hit in literal_event_names(parsed(source_file), event_name)
+            ]
             if hits:
-                found[source_file.name] = hits
+                found[label(source_file)] = hits
 
         assert found == {}, (
-            "A spec-audit row is written or selected by a bare literal instead of "
-            f"evolution.SPEC_ISSUES_EVENT. Import the constant. Sites: {found}"
+            "A journal row is written or selected by a bare literal instead of the "
+            f"constant evolution.py declares for it. Import the constant. Sites: {found}"
         )
 
     def test_the_detector_sees_a_literal_writer(self) -> None:
         """A guard whose only assertion is that a list is empty cannot
         notice its own detector being switched off."""
-        hits = spec_issues_literals('entry = {"event_type": "spec_issues", "project": p}')
+        hits = self._hits('entry = {"event_type": "spec_issues", "project": p}')
 
         assert hits == ["line 1: writes 'spec_issues' as the event_type"]
 
     def test_the_detector_sees_a_literal_reader(self) -> None:
-        hits = spec_issues_literals(
-            'rows = [e for e in xs if e.get("event_type") == "spec_issues"]'
-        )
+        hits = self._hits('rows = [e for e in xs if e.get("event_type") == "spec_issues"]')
 
         assert hits == ["line 1: compares event_type against 'spec_issues'"]
 
     def test_the_detector_sees_the_reversed_and_membership_spellings(self) -> None:
         """Neither operand order nor ``in`` is a way past it."""
-        reversed_hits = spec_issues_literals('flag = "spec_issues" == e["event_type"]')
-        membership = spec_issues_literals(
-            'flag = e.get("event_type") in ("spec_issues", "component_result")'
-        )
+        reversed_hits = self._hits('flag = "spec_issues" == e["event_type"]')
+        membership = self._hits('flag = e.get("event_type") in ("spec_issues", "other")')
 
         assert reversed_hits == ["line 1: compares event_type against 'spec_issues'"]
-        assert membership == [
-            "line 1: compares event_type against ('spec_issues', 'component_result')"
-        ]
+        assert membership == ["line 1: compares event_type against ('spec_issues', 'other')"]
+
+    def test_an_assembled_spelling_is_not_a_way_past_it(self) -> None:
+        """``folded_str`` is why: a text search and a bare
+        ``ast.Constant`` check both miss these, and #327 round 2 is the
+        record of somebody reaching for exactly this shape."""
+        concatenated = self._hits('flag = e.get("event_type") == "spec" + "_issues"')
+        formatted = self._hits('flag = e.get("event_type") == f"spec_issues"')
+
+        assert concatenated == ["line 1: compares event_type against 'spec' + '_issues'"]
+        assert formatted == ["line 1: compares event_type against f'spec_issues'"]
+
+    def test_the_second_enrolled_name_is_detected_too(self) -> None:
+        """The walk is driven by ``ENROLLED_EVENT_CONSTANTS`` rather than
+        by one hardcoded name, so enrolling the next constant costs one
+        line instead of a copy of this file."""
+        hits = self._hits('flag = e.get("event_type") == "journal_repair"', JOURNAL_REPAIR_EVENT)
+
+        assert hits == ["line 1: compares event_type against 'journal_repair'"]
 
     def test_the_architects_own_json_key_is_not_flagged(self) -> None:
         """``spec_issues`` is also the key the architect returns its
         findings under, and DECOMPOSE_PROMPT spells it in prose. A guard
         that fired on those would be silenced rather than obeyed."""
-        assert spec_issues_literals('issues = data.get("spec_issues") or []') == []
-        assert spec_issues_literals('PROMPT = "return a spec_issues array"') == []
-        assert spec_issues_literals('payload = {"spec_issues": [], "components": []}') == []
+        assert self._hits('issues = data.get("spec_issues") or []') == []
+        assert self._hits('PROMPT = "return a spec_issues array"') == []
+        assert self._hits('payload = {"spec_issues": [], "components": []}') == []

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import ast
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from kstrl.evolution import (
     JOURNAL_SCHEMA_VERSION,
+    SPEC_ISSUES_EVENT,
     EvolutionConfig,
     EvolutionJournal,
     FailurePattern,
@@ -1110,3 +1113,239 @@ class TestSpecIssueRuns:
 
         entries = journal._read_journal_entries()
         assert [e["component"] for e in entries] == ["a"]
+
+
+class TestSpecAudits:
+    """#314: the unwindowed reader the excluded-history accounting needs,
+    and the one window rule built on it."""
+
+    def _journal(self, tmp_path: Path, entries: list[dict[str, Any]]) -> EvolutionJournal:
+        journal = EvolutionJournal(EvolutionConfig.load(tmp_path))
+        journal.append_entries(entries)
+        return journal
+
+    def _audit(self, project: Any, spec_file: str = "spec.md") -> dict[str, Any]:
+        return {"event_type": SPEC_ISSUES_EVENT, "project": project, "spec_file": spec_file}
+
+    def test_every_project_is_returned_unwindowed(self, tmp_path: Path) -> None:
+        """The accounting under the trend counts the history the trend
+        LEAVES OUT, so a reader that filtered by project or applied the
+        window would hide exactly what the caller is asking for (#280).
+        """
+        journal = self._journal(
+            tmp_path,
+            [self._audit("mine"), self._audit("other"), self._audit(None)],
+        )
+
+        assert [e.get("project") for e in journal.get_spec_audits()] == ["mine", "other", None]
+
+    def test_other_event_types_are_excluded(self, tmp_path: Path) -> None:
+        """The journal carries component results and repair rows too."""
+        journal = self._journal(
+            tmp_path,
+            [
+                {"run_id": "r1", "event_type": "component_result", "component": "a"},
+                self._audit("mine"),
+            ],
+        )
+
+        assert [e["event_type"] for e in journal.get_spec_audits()] == [SPEC_ISSUES_EVENT]
+
+    def test_a_supplied_snapshot_is_windowed_without_a_second_read(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``audits=`` is what lets ONE read feed both the trend and the
+        accounting computed over the same entries, so the two cannot
+        disagree because the file moved between two reads."""
+        journal = self._journal(tmp_path, [self._audit("mine", "on-disk.md")])
+        elsewhere = [self._audit("mine", "b.md"), self._audit("other", "c.md")]
+
+        def refuse(self: EvolutionJournal) -> list[dict[str, Any]]:
+            raise AssertionError("read the file despite being handed a snapshot")
+
+        monkeypatch.setattr(EvolutionJournal, "get_spec_audits", refuse)
+
+        runs = journal.get_spec_issue_runs("mine", audits=elsewhere)
+
+        assert [r["spec_file"] for r in runs] == ["b.md"]
+
+    def test_a_supplied_snapshot_answers_the_same_as_raw_entries(self, tmp_path: Path) -> None:
+        """The event-type filter is applied either way, so a caller that
+        hands over unfiltered entries gets the reader's own answer
+        rather than a component_result that happens to name a
+        project."""
+        entries: list[dict[str, Any]] = [
+            {"event_type": "component_result", "project": "mine", "spec_file": "wrong.md"},
+            self._audit("mine", "right.md"),
+        ]
+        journal = self._journal(tmp_path, entries)
+
+        assert journal.get_spec_issue_runs("mine", audits=entries) == journal.get_spec_issue_runs(
+            "mine"
+        )
+
+    def test_an_unattributed_audit_belongs_to_no_project(self, tmp_path: Path) -> None:
+        """#314: the window matches a project through ``entry_str``, the
+        rule the report's accounting already used, so a null or
+        non-string ``project`` is an unattributed audit and not a
+        project whose name happens to be empty. Before the fold the
+        method compared the raw field, and the two answered differently
+        for a query on "": the report's rule counted these, the
+        journal's did not.
+        """
+        journal = self._journal(
+            tmp_path,
+            [self._audit(None, "null.md"), self._audit(7, "int.md"), self._audit("", "empty.md")],
+        )
+
+        assert [r["spec_file"] for r in journal.get_spec_issue_runs("")] == [
+            "null.md",
+            "int.md",
+            "empty.md",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# SPEC_ISSUES_EVENT has one home (#314 item 3)
+# ---------------------------------------------------------------------------
+
+#: The package under test, located the way every other AST-walking test
+#: in this suite locates it (test_journal_one_writer, test_atomicio).
+KSTRL_PACKAGE = Path(__file__).resolve().parent.parent / "kstrl"
+
+
+def spec_issues_literals(source: str) -> list[str]:
+    """Every place this source names the spec-audit event as a literal.
+
+    Two shapes, because the row is written in one and selected in the
+    other:
+
+    - a dict entry ``{"event_type": "spec_issues"}``, which is a writer;
+    - a comparison of an ``event_type`` lookup against the literal,
+      which is a reader.
+
+    Deliberately NOT "the string appears in this file". ``spec_issues``
+    is also the architect's own JSON key, so ``DECOMPOSE_PROMPT``
+    spells it several times in prose and ``_parse_spec_issues`` reads
+    ``data.get("spec_issues")`` off the agent's output. Those are a
+    different vocabulary that happens to share a word, and flagging
+    them would make this guard something to be silenced rather than
+    obeyed. ``TestSpecIssuesEventHasOneHome`` feeds the detector both
+    kinds so neither half is taken on trust.
+    """
+    found: list[str] = []
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Dict):
+            found.extend(_literal_event_writes(node))
+        if isinstance(node, ast.Compare):
+            found.extend(_literal_event_reads(node))
+    return found
+
+
+def _literal_event_writes(node: ast.Dict) -> list[str]:
+    """``{"event_type": "spec_issues"}`` entries of one dict literal."""
+    return [
+        f"line {value.lineno}: writes {ast.unparse(value)} as the event_type"
+        for key, value in zip(node.keys, node.values, strict=True)
+        if isinstance(key, ast.Constant)
+        and key.value == "event_type"
+        and isinstance(value, ast.Constant)
+        and value.value == SPEC_ISSUES_EVENT
+    ]
+
+
+def _literal_event_reads(node: ast.Compare) -> list[str]:
+    """``entry.get("event_type") == "spec_issues"`` and its ``!=``/``in``
+    spellings, in either operand order."""
+    operands = [node.left, *node.comparators]
+    if not any(_reads_event_type(operand) for operand in operands):
+        return []
+    return [
+        f"line {node.lineno}: compares event_type against {ast.unparse(operand)}"
+        for operand in operands
+        if SPEC_ISSUES_EVENT in _constant_strings(operand)
+    ]
+
+
+def _reads_event_type(node: ast.expr) -> bool:
+    """``x.get("event_type", ...)`` or ``x["event_type"]``."""
+    if isinstance(node, ast.Subscript):
+        return isinstance(node.slice, ast.Constant) and node.slice.value == "event_type"
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and bool(node.args)
+        and isinstance(node.args[0], ast.Constant)
+        and node.args[0].value == "event_type"
+    )
+
+
+def _constant_strings(node: ast.expr) -> set[str]:
+    """The string constants this operand contains, tuple/list included,
+    so ``in ("spec_issues", "component_result")`` is seen."""
+    return {
+        child.value
+        for child in ast.walk(node)
+        if isinstance(child, ast.Constant) and isinstance(child.value, str)
+    }
+
+
+class TestSpecIssuesEventHasOneHome:
+    """#314 item 3: the journal's discriminator is named once, here.
+
+    It used to be spelled twice - a constant in ``decompose``, which
+    writes the row, and a literal in this module, which selects on it.
+    The cost of that placement was not that the two disagreed (a
+    round-trip test made that loud) but that a reader added HERE
+    reaches for the nearest spelling, and the nearest spelling was the
+    literal.
+    """
+
+    def test_no_module_names_the_event_as_a_literal(self) -> None:
+        found: dict[str, list[str]] = {}
+        for source_file in sorted(KSTRL_PACKAGE.rglob("*.py")):
+            hits = spec_issues_literals(source_file.read_text(encoding="utf-8"))
+            if hits:
+                found[source_file.name] = hits
+
+        assert found == {}, (
+            "A spec-audit row is written or selected by a bare literal instead of "
+            f"evolution.SPEC_ISSUES_EVENT. Import the constant. Sites: {found}"
+        )
+
+    def test_the_detector_sees_a_literal_writer(self) -> None:
+        """A guard whose only assertion is that a list is empty cannot
+        notice its own detector being switched off."""
+        hits = spec_issues_literals('entry = {"event_type": "spec_issues", "project": p}')
+
+        assert hits == ["line 1: writes 'spec_issues' as the event_type"]
+
+    def test_the_detector_sees_a_literal_reader(self) -> None:
+        hits = spec_issues_literals(
+            'rows = [e for e in xs if e.get("event_type") == "spec_issues"]'
+        )
+
+        assert hits == ["line 1: compares event_type against 'spec_issues'"]
+
+    def test_the_detector_sees_the_reversed_and_membership_spellings(self) -> None:
+        """Neither operand order nor ``in`` is a way past it."""
+        reversed_hits = spec_issues_literals('flag = "spec_issues" == e["event_type"]')
+        membership = spec_issues_literals(
+            'flag = e.get("event_type") in ("spec_issues", "component_result")'
+        )
+
+        assert reversed_hits == ["line 1: compares event_type against 'spec_issues'"]
+        assert membership == [
+            "line 1: compares event_type against ('spec_issues', 'component_result')"
+        ]
+
+    def test_the_architects_own_json_key_is_not_flagged(self) -> None:
+        """``spec_issues`` is also the key the architect returns its
+        findings under, and DECOMPOSE_PROMPT spells it in prose. A guard
+        that fired on those would be silenced rather than obeyed."""
+        assert spec_issues_literals('issues = data.get("spec_issues") or []') == []
+        assert spec_issues_literals('PROMPT = "return a spec_issues array"') == []
+        assert spec_issues_literals('payload = {"spec_issues": [], "components": []}') == []

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -1186,6 +1186,28 @@ class TestSpecAudits:
             "mine"
         )
 
+    def test_the_window_keeps_the_newest_audits_not_the_oldest(self, tmp_path: Path) -> None:
+        """``[-last_n:]``, and the sign is the whole point: "the last N
+        recorded audits" read backwards is a trend the operator has
+        already acted on. Measured before this test existed: inverting
+        the slice left the ENTIRE suite green, because every other
+        window test records audits that raise the same counts.
+        """
+        journal = self._journal(tmp_path, [self._audit("mine", f"spec-{n}.md") for n in range(5)])
+
+        assert [r["spec_file"] for r in journal.get_spec_issue_runs("mine", last_n=2)] == [
+            "spec-3.md",
+            "spec-4.md",
+        ]
+
+    def test_a_non_positive_window_reads_nothing(self, tmp_path: Path) -> None:
+        """``lookback_runs = 0`` means the trend reads nothing, and the
+        report says so out loud rather than claiming no audit exists."""
+        journal = self._journal(tmp_path, [self._audit("mine")])
+
+        assert journal.get_spec_issue_runs("mine", last_n=0) == []
+        assert journal.get_spec_issue_runs("mine", last_n=-1) == []
+
     def test_an_unattributed_audit_belongs_to_no_project(self, tmp_path: Path) -> None:
         """#314: the window matches a project through ``entry_str``, the
         rule the report's accounting already used, so a null or

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ast
 import json
 from pathlib import Path
 from typing import Any
@@ -10,7 +9,6 @@ from typing import Any
 import pytest
 
 from kstrl.evolution import (
-    JOURNAL_REPAIR_EVENT,
     JOURNAL_SCHEMA_VERSION,
     SPEC_ISSUES_EVENT,
     EvolutionConfig,
@@ -24,12 +22,6 @@ from kstrl.evolution import (
 from kstrl.factory import FactoryResult
 from kstrl.manifest import Component, ComponentStatus, Manifest
 from tests.helpers.journal import audit, journal_at
-from tests.test_journal_one_writer import (
-    folded_str,
-    label,
-    package_sources,
-    parsed,
-)
 
 
 def _make_manifest(
@@ -1232,176 +1224,3 @@ class TestSpecAudits:
             "int.md",
             "empty.md",
         ]
-
-
-# ---------------------------------------------------------------------------
-# Journal event names have one home (#314 item 3)
-# ---------------------------------------------------------------------------
-
-#: The journal event names that have been hoisted to a constant, and so
-#: must never be spelled as a literal in ``kstrl/`` again. Five more are
-#: still bare literals (``component_result`` nine times in this module
-#: alone, plus ``role_usage``, ``contract_result``,
-#: ``autonomy_transition`` and ``findings_superseded``); converting them
-#: is a follow-up, and enrolling each one here is what makes that
-#: follow-up enforceable rather than merely intended.
-ENROLLED_EVENT_CONSTANTS = {
-    "SPEC_ISSUES_EVENT": SPEC_ISSUES_EVENT,
-    "JOURNAL_REPAIR_EVENT": JOURNAL_REPAIR_EVENT,
-}
-
-
-def literal_event_names(tree: ast.Module, event_name: str) -> list[str]:
-    """Every place this module names ``event_name`` as a bare literal.
-
-    Two shapes, because a journal row is written in one and selected in
-    the other:
-
-    - a dict entry ``{"event_type": <literal>}``, which is a writer;
-    - a comparison of an ``event_type`` lookup against the literal,
-      which is a reader.
-
-    Deliberately NOT "the string appears in this file". ``spec_issues``
-    is also the architect's own JSON key, so ``DECOMPOSE_PROMPT`` spells
-    it several times in prose and ``_parse_spec_issues`` reads
-    ``data.get("spec_issues")`` off the agent's output. Those are a
-    different vocabulary that happens to share a word, and flagging them
-    would make this guard something to be silenced rather than obeyed.
-    ``TestJournalEventNamesHaveOneHome`` feeds the detector both kinds,
-    so neither half is taken on trust.
-
-    Literals are decided by ``test_journal_one_writer.folded_str``
-    rather than by a bare ``ast.Constant`` check, so ``"spec" +
-    "_issues"`` and the f-string spelling are seen as well. What folding
-    cannot decide is disclosed on that function and holds here
-    unchanged.
-    """
-    found: list[str] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Dict):
-            found.extend(_literal_event_writes(node, event_name))
-        if isinstance(node, ast.Compare):
-            found.extend(_literal_event_reads(node, event_name))
-    return found
-
-
-def _literal_event_writes(node: ast.Dict, event_name: str) -> list[str]:
-    """``{"event_type": <literal>}`` entries of one dict literal."""
-    return [
-        f"line {value.lineno}: writes {ast.unparse(value)} as the event_type"
-        for key, value in zip(node.keys, node.values, strict=True)
-        if key is not None and folded_str(key) == "event_type" and folded_str(value) == event_name
-    ]
-
-
-def _literal_event_reads(node: ast.Compare, event_name: str) -> list[str]:
-    """``entry.get("event_type") == <literal>`` and its ``!=`` and ``in``
-    spellings, in either operand order."""
-    operands = [node.left, *node.comparators]
-    if not any(_reads_event_type(operand) for operand in operands):
-        return []
-    return [
-        f"line {node.lineno}: compares event_type against {ast.unparse(operand)}"
-        for operand in operands
-        if not _reads_event_type(operand) and _names_the_event(operand, event_name)
-    ]
-
-
-def _reads_event_type(node: ast.expr) -> bool:
-    """``x.get("event_type", ...)`` or ``x["event_type"]``."""
-    if isinstance(node, ast.Subscript):
-        return folded_str(node.slice) == "event_type"
-    return (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "get"
-        and bool(node.args)
-        and folded_str(node.args[0]) == "event_type"
-    )
-
-
-def _names_the_event(operand: ast.expr, event_name: str) -> bool:
-    """Does this operand spell the event name, at any depth?
-
-    Walks children so ``in ("spec_issues", "component_result")`` is
-    seen, and folds each one so an assembled spelling is not a way past.
-    """
-    return any(folded_str(child) == event_name for child in ast.walk(operand))
-
-
-class TestJournalEventNamesHaveOneHome:
-    """#314 item 3: an enrolled journal event name is spelled once, in
-    ``kstrl/evolution.py``, and imported everywhere else.
-
-    ``spec_issues`` used to be spelled twice: a constant in
-    ``decompose``, which writes the row, and a literal in this module,
-    which selects on it. The cost of that placement was not that the two
-    disagreed - a round-trip test made that loud - but that a reader
-    added HERE reaches for the nearest spelling, and the nearest
-    spelling was the literal.
-    """
-
-    def _hits(self, source: str, event_name: str = SPEC_ISSUES_EVENT) -> list[str]:
-        return literal_event_names(ast.parse(source), event_name)
-
-    def test_no_module_names_an_enrolled_event_as_a_literal(self) -> None:
-        found: dict[str, list[str]] = {}
-        for source_file in package_sources():
-            hits = [
-                f"{constant}: {hit}"
-                for constant, event_name in sorted(ENROLLED_EVENT_CONSTANTS.items())
-                for hit in literal_event_names(parsed(source_file), event_name)
-            ]
-            if hits:
-                found[label(source_file)] = hits
-
-        assert found == {}, (
-            "A journal row is written or selected by a bare literal instead of the "
-            f"constant evolution.py declares for it. Import the constant. Sites: {found}"
-        )
-
-    def test_the_detector_sees_a_literal_writer(self) -> None:
-        """A guard whose only assertion is that a list is empty cannot
-        notice its own detector being switched off."""
-        hits = self._hits('entry = {"event_type": "spec_issues", "project": p}')
-
-        assert hits == ["line 1: writes 'spec_issues' as the event_type"]
-
-    def test_the_detector_sees_a_literal_reader(self) -> None:
-        hits = self._hits('rows = [e for e in xs if e.get("event_type") == "spec_issues"]')
-
-        assert hits == ["line 1: compares event_type against 'spec_issues'"]
-
-    def test_the_detector_sees_the_reversed_and_membership_spellings(self) -> None:
-        """Neither operand order nor ``in`` is a way past it."""
-        reversed_hits = self._hits('flag = "spec_issues" == e["event_type"]')
-        membership = self._hits('flag = e.get("event_type") in ("spec_issues", "other")')
-
-        assert reversed_hits == ["line 1: compares event_type against 'spec_issues'"]
-        assert membership == ["line 1: compares event_type against ('spec_issues', 'other')"]
-
-    def test_an_assembled_spelling_is_not_a_way_past_it(self) -> None:
-        """``folded_str`` is why: a text search and a bare
-        ``ast.Constant`` check both miss these, and #327 round 2 is the
-        record of somebody reaching for exactly this shape."""
-        concatenated = self._hits('flag = e.get("event_type") == "spec" + "_issues"')
-        formatted = self._hits('flag = e.get("event_type") == f"spec_issues"')
-
-        assert concatenated == ["line 1: compares event_type against 'spec' + '_issues'"]
-        assert formatted == ["line 1: compares event_type against f'spec_issues'"]
-
-    def test_the_second_enrolled_name_is_detected_too(self) -> None:
-        """The walk is driven by ``ENROLLED_EVENT_CONSTANTS`` rather than
-        by one hardcoded name, so enrolling the next constant costs one
-        line instead of a copy of this file."""
-        hits = self._hits('flag = e.get("event_type") == "journal_repair"', JOURNAL_REPAIR_EVENT)
-
-        assert hits == ["line 1: compares event_type against 'journal_repair'"]
-
-    def test_the_architects_own_json_key_is_not_flagged(self) -> None:
-        """``spec_issues`` is also the key the architect returns its
-        findings under, and DECOMPOSE_PROMPT spells it in prose. A guard
-        that fired on those would be silenced rather than obeyed."""
-        assert self._hits('issues = data.get("spec_issues") or []') == []
-        assert self._hits('PROMPT = "return a spec_issues array"') == []
-        assert self._hits('payload = {"spec_issues": [], "components": []}') == []

--- a/tests/test_journal_one_writer.py
+++ b/tests/test_journal_one_writer.py
@@ -442,9 +442,14 @@ def folded_filename_sites(source_file: Path) -> int:
 #: progress log and the queue journal). They are pinned anyway, because
 #: separating them from the evolution journal by name alone is a guess
 #: and #324 is the record of what guessing costs.
+#: ``decompose.py`` had a row here until #314. It read the path to get
+#: the spec-audit history that ``EvolutionJournal`` had no public reader
+#: for; it now asks ``get_spec_audits`` instead, so the row is gone and
+#: putting it back fails this test - which is the point, because a read
+#: that holds the path is one compaction away from silently returning
+#: less than the journal holds (#280).
 EXPECTED_JOURNAL_PATH_SITES: dict[str, int] = {
     "cli.py: journal.config.journal_path": 1,
-    "decompose.py: journal.config.journal_path": 1,
     "evolution.py: config.journal_path": 5,
     "evolution.py: self.config.journal_path": 3,
     "pipeline.py: self.journal_path": 4,

--- a/tests/test_journal_one_writer.py
+++ b/tests/test_journal_one_writer.py
@@ -442,12 +442,9 @@ def folded_filename_sites(source_file: Path) -> int:
 #: progress log and the queue journal). They are pinned anyway, because
 #: separating them from the evolution journal by name alone is a guess
 #: and #324 is the record of what guessing costs.
-#: ``decompose.py`` had a row here until #314. It read the path to get
-#: the spec-audit history that ``EvolutionJournal`` had no public reader
-#: for; it now asks ``get_spec_audits`` instead, so the row is gone and
-#: putting it back fails this test - which is the point, because a read
-#: that holds the path is one compaction away from silently returning
-#: less than the journal holds (#280).
+#: ``decompose.py`` had a row here until #314; it asks
+#: ``EvolutionJournal.get_spec_audits`` now, and that method's docstring
+#: is where the reason lives.
 EXPECTED_JOURNAL_PATH_SITES: dict[str, int] = {
     "cli.py: journal.config.journal_path": 1,
     "evolution.py: config.journal_path": 5,


### PR DESCRIPTION
Closes #314 (do not merge yet; not merging or closing from here).

`decompose` reached past `EvolutionJournal` into its storage path, held a second copy of the window rule the journal owns, and the event-name constant lived on the writer while the storage layer kept its own literal. All three were deferred by #311 rather than raced against a file under concurrent edit. `evolution.py` has since settled (#327, #334), so they are folded here.

## The two claims verified before building

**`get_spec_issue_runs` had no production caller.** By AST walk over `kstrl/`, not by grep: zero `ast.Name`, `ast.Attribute` or `ast.ImportFrom` references. Only docstrings named it. It was a public method kept alive by its own tests.

**No import cycle.** `kstrl.evolution` does not reach `kstrl.decompose` through any module-level import, transitively, with `TYPE_CHECKING` blocks excluded. So `decompose` can import it at module scope, which is what lets `SPEC_ISSUES_EVENT` and `entry_str` be imported rather than duplicated.

The measured cost of that eager import, since it is the one thing this change makes slower. `import kstrl.cli`, interleaved subprocess pairs against `main`:

| condition | main | this branch | delta |
|---|---|---|---|
| `PYTHONDONTWRITEBYTECODE=1`, caches cleared, n=30 | 202.6 ms | 206.9 ms | +4.3 ms (+2.1%) |
| `__pycache__` warm, n=25 | 81.3 ms | 82.1 ms | +0.8 ms (+1.0%) |

The warm row is production: an actual `ks` invocation pays +0.8 ms. `sys.modules` gains exactly three entries (`kstrl.evolution`, `csv`, `_csv`); `kstrl.evolution`'s own imports are `kstrl.observability` and `kstrl.verify`, both of which `cli.py` already loads, so there is no transitive fan-out.

## The caller trace

Direct readers of the spec-audit journal before this change:

| Site | What it did |
|---|---|
| `decompose._journal_snapshot` | `read_progress_events(journal.config.journal_path)` - the production reach-past |
| `decompose._windowed_audits` | a second copy of `get_spec_issue_runs`'s rule |
| `decompose._spec_audits` | a second copy of "which rows are spec audits" |
| `decompose._excluded_projects` | a third copy of the same filter |
| `decompose.SPEC_ISSUES_EVENT` | the constant, on the writer |
| `evolution.get_spec_issue_runs` | the same name again, as a bare literal |
| `tests/helpers/journal.py` (x2) | the same literal in shared test infrastructure |

`kstrl/cli.py:3503` and `kstrl/reducer.py:647` also call `read_progress_events`, but on the progress log, which is a different file. `kstrl/cli.py:689` interpolates `journal.config.journal_path` into an operator message and does not read it. Neither is in scope.

## What moved

- **`EvolutionJournal.get_spec_audits`** is the new unwindowed reader: every recorded spec audit, across every project. Unfiltered by project on purpose - the accounting that reports what the trend leaves out needs exactly what the window drops.
- **`get_spec_issue_runs` is the one place the window rule lives, and has a production caller again.** Its `audits=` parameter lets the single read feed both the trend and the accounting, which is what #280 round 2's one-read pin asked for.
- **`SPEC_ISSUES_EVENT` and `entry_str` move to `kstrl/evolution.py`**, the layer that defines the journal's schema. `decompose` imports both.
- **Deleted:** `_windowed_audits`, `_spec_audits`, `_spec_convergence`, `_entry_str`. `_excluded_history` and `_excluded_projects` take audits and no longer restate which rows are audits.
- `_journal_snapshot` returns a frozen `AuditSnapshot(audits, window, lookback)`.

## Behaviour difference found, reported rather than absorbed

`get_spec_issue_runs` matched a project with `entry.get("project") == project`. The report's rule, in `_windowed_audits` and `_excluded_history`, used `_entry_str`, which reads a null or non-string field as absent.

The two answer differently for exactly one query: `project == ""` against an audit whose `project` field is absent or not a string. The raw comparison excludes it; the `entry_str` rule counts it as belonging to the project named `""`. Reachable: `ks decompose --project-name ""` satisfies click's `required=True`.

**The production rule is the one kept**, so nothing recorded changes. `get_spec_issue_runs` had no production caller, so nothing observed its old rule. `TestSpecAudits::test_an_unattributed_audit_belongs_to_no_project` pins the kept rule and fails on a revert to the raw comparison.

## A pre-existing hole the mutation pass found

With `get_spec_issue_runs` reading `runs[:last_n]` instead of `runs[-last_n:]`, **the entire fast tier stayed green** - 4771 passed. Every window test in the suite recorded audits raising the same blocker count, so the oldest N and the newest N rendered identically. The trend could have shipped reading a history the operator had already acted on.

The hole predates this issue (`_windowed_audits` had the same slice and the same absence of a test), but the fold makes one rule serve both consumers, so it is closed here: two tests, one per layer, both failing on the inverted slice.

## Planted mutations, with the exact failure text

Every run with `PYTHONDONTWRITEBYTECODE=1` and `__pycache__` cleared first. Each mutation is planted, the guards run, the file is restored by rewriting its original text (never by `git checkout`).

**1. `_journal_snapshot` reads the storage path again** - 5 failures, including:

```
FAILED tests/test_journal_one_writer.py::TestOneWriter::test_no_new_code_gets_hold_of_the_journal_path
E   AssertionError: The set of places that get hold of a journal path changed. If this is
    a new writer of the evolution journal, route it through EvolutionJournal.append_entries:
    an unguarded append concatenates onto an unterminated tail and eats the entry after it
    (#312). If it is a read, or another file's journal, add it to EXPECTED_JOURNAL_PATH_SITES
    with a reason. Found: {'cli.py: journal.config.journal_path': 1, 'decompose.py:
    journal.config.journal_path': 1, ...}
E   Left contains 1 more item:
E   {'decompose.py: journal.config.journal_path': 1}

FAILED tests/test_decompose.py::TestOneJournalRead::test_the_report_reads_through_the_journal_not_its_storage_path
E   AssertionError: assert ['on-disk.md'] == ['b.md', 'c.md']
```

**2. the window drops `audits=` and re-reads** - 1 failure:

```
FAILED tests/test_decompose.py::TestOneJournalRead::test_the_journal_is_parsed_once_per_report
E   assert 2 == 1
E    +  where 2 = len([1, 1])
```

**3. the window keeps the oldest N** - 2 failures:

```
FAILED tests/test_evolution.py::TestSpecAudits::test_the_window_keeps_the_newest_audits_not_the_oldest
E   AssertionError: assert ['spec-0.md', 'spec-1.md'] == ['spec-3.md', 'spec-4.md']

FAILED tests/test_decompose.py::TestSpecConvergenceThroughDecompose::test_the_window_keeps_the_newest_audits
E   AssertionError: assert '2, 3, 4 (blockers, oldest run first' in '...'
```

**4. a reader spells the event as a literal** - 1 failure:

```
FAILED tests/test_evolution.py::TestJournalEventNamesHaveOneHome::test_no_module_names_an_enrolled_event_as_a_literal
E   AssertionError: A journal row is written or selected by a bare literal instead of the constant evolution.py declares for it. Import the constant. Sites: {'evolution.py': ["SPEC_ISSUES_EVENT: line 1497: compares event_type against 'spec_issues'"]}
```

**5. the writer spells the event as a literal** - same test:

```
E   Sites: {'decompose.py': ["SPEC_ISSUES_EVENT: line 1031: writes 'spec_issues' as the event_type"]}
```

**6. the detector's reader half is switched off** (`if False and isinstance(node, ast.Compare)`) - 4 failures, so the positive controls notice their own detector going quiet rather than going blind:

```
FAILED ...::test_the_detector_sees_a_literal_reader
E   assert [] == ["line 1: compares event_type against 'spec_issues'"]
FAILED ...::test_the_detector_sees_the_reversed_and_membership_spellings
FAILED ...::test_an_assembled_spelling_is_not_a_way_past_it
FAILED ...::test_the_second_enrolled_name_is_detected_too
```

**7. the project match reverts to the raw comparison** - 1 failure:

```
FAILED tests/test_evolution.py::TestSpecAudits::test_an_unattributed_audit_belongs_to_no_project
E   AssertionError: assert ['empty.md'] == ['null.md', 'int.md', 'empty.md']
```

**8. `journal_repair` spelled as a literal** (the SECOND enrolled name, to prove the generalisation is live over the package and not only over snippets) - 1 failure:

```
E   Sites: {'evolution.py': ["JOURNAL_REPAIR_EVENT: line 1467: compares event_type against 'journal_repair'"]}
```

### The AST walk was checked for blindness, not just for green

#327's layer-1 net loses its `decompose.py` row here. Removing a row from a guard is exactly the change that could turn a red guard into a blind one, so the walker's output was inspected rather than inferred: **5 rows, 15 occurrences** after (6 rows, 16 before), matching `EXPECTED_JOURNAL_PATH_SITES` exactly. It still sees `cli.py`, `evolution.py` (both spellings), `pipeline.py` and `workqueue.py`.

## Tests

Added:

- `TestSpecAudits` (7): unwindowed across all projects; other event types excluded; `audits=` windows without a second read; a supplied snapshot answers the same as raw entries; the window keeps the newest; a non-positive window reads nothing; an unattributed audit belongs to no project.
- `TestJournalEventNamesHaveOneHome` (7): the package walk, plus positive controls for the writer shape, the reader shape, the reversed and `in` spellings, the concatenated and f-string spellings, the second enrolled name, and a negative control for the architect's own `spec_issues` JSON key.
- `TestOneJournalRead` (4, rewritten): parsed once per report, counted at `_read_all_entries`; the report reads through the journal, proved by a reader answering something the file does not contain; the window is the journal's own over the journal's own lookback; no journal reads nothing.
- `TestSpecConvergenceThroughDecompose::test_the_window_keeps_the_newest_audits`.

Retired: `test_the_windowing_rule_matches_the_journals_own`, whose subject (the deferral) no longer exists. `test_only_spec_audits_count` and `test_every_spec_audit_lands_in_exactly_one_bucket` now go through the journal, because the selection rule moved there.

## CI

- fast tier: `4776 passed, 28 skipped, 6 xfailed` in 270 s
- spine tier: `27 passed` in 19 s
- `ruff check kstrl/ tests/`: clean. `ruff format --check`: 297 files already formatted.
- `mypy kstrl/ --strict`: no issues in 127 source files
- coverage: 90.09% total, against the 79.91% ratchet in `.github/coverage-baseline.txt`
- full pre-commit (including complexipy, vulture, codespell, GitGuardian, the cyclomatic and file-length ratchets, no-em-dash): passed on every commit

## `/simplify` findings, verbatim

Four angles ran over the branch diff. Applied and declined are both below, in full.

<details>
<summary><b>Reuse</b> (7 findings)</summary>

**1. `kstrl/evolution.py:494` - `entry_str` is a third module-level copy of "string field or default"**
`kstrl/workqueue.py:269 _as_str(data, key, default="")` has a byte-identical body (`value = data.get(...); return value if isinstance(value, str) else default`) and 21 call sites. `kstrl/events.py:727` is the same rule inside `_coerce`, and `events.py:738-739`, `serve.py:2672`, `tui/screens/launch.py:102`, `tui/screens/init_wizard.py:228-231` inline it again. The new one is the only *public* one, so it is the natural single home, but nothing was folded into it. Cost: the "a null field is an absent field" reasoning in the new docstring now exists in prose in one place and as unexplained code in six others; a future fix (bools, whitespace, `None` vs `""` distinction) lands in one copy. Concrete move: put one helper in `kstrl/observability.py` (already the owner of `read_progress_events`, already imported by `evolution.py`, and imports neither `workqueue` nor `evolution`, so no cycle) and have `workqueue._as_str` delegate.

**2. `tests/test_evolution.py:1238, 1331` - `KSTRL_PACKAGE` + `sorted(rglob("*.py"))` re-implements `package_sources()`**
`tests/test_journal_one_writer.py:45 package_sources()` is exactly this, and cross-file import of that module's guard helpers is already established (`tests/test_journal_guard_detects.py:28-35` imports `KSTRL_PACKAGE`, `label`, `journal_path_escapes`). The new guard also parses the whole package for itself rather than using `test_journal_one_writer.py:57 parsed()`, the shared text-keyed tree cache that exists precisely because three walkers were each parsing the package. Measured here, not quoted: 127 modules, **113 ms for one full parse pass**. Cost: one more uncached pass per session, and the walker inventory drifts (a new `kstrl/` subpackage or an exclusion added to `package_sources()` never reaches this guard). Reuse needs a small signature change - `spec_issues_literals` takes `source: str` so its snippet tests work, so pass it a tree (`parsed(path)`) and keep an `ast.parse` only in the snippet tests.

**3. `tests/test_evolution.py:1334` - keys the failure dict on `source_file.name` instead of `label()`**
`tests/test_journal_one_writer.py:28 label()` exists specifically because ten basenames occur twice in `kstrl/`, and its own docstring names `decompose.py` as one of them (`kstrl/decompose.py` and `kstrl/tui/screens/decompose.py`) - the exact file this change is about. `tests/test_journal_guard_detects.py:214-215` already pins that behaviour. Cost: when this guard fires on the TUI copy it prints `decompose.py`, and the reader opens the wrong file. Free fix: import `label`.

**4. `tests/test_evolution.py:1308 _constant_strings` - a weaker re-implementation of `folded_str`**
`tests/test_journal_one_writer.py:116 folded_str` / `147 folded_concat` / `173 folded_parts` already answer "the string this expression is KNOWN to evaluate to", with positive controls in `test_journal_guard_detects.py`. That file's own rule is stated explicitly: "a shape a reader can decide by looking at it is a shape this guard must decide". `_constant_strings` matches raw `ast.Constant` only, so `e.get("event_type") == "spec" + "_issues"` and the f-string spelling walk past the new guard while the sibling guard decides both. Cost: two divergent notions of "is this literal that string" in one test suite, and the newer one is the one guarding the constant this PR just created. Reuse: apply `folded_str` per operand, keeping the tuple/list walk for the `in (...)` case.

**5. `tests/test_evolution.py:1122-1131` and `tests/test_decompose.py:1595` - a fourth and fifth copy of the audit-record builder**
`tests/helpers/journal.py:73 audit(project)` and `:96 journal_at(tmp_path)` exist for exactly this, and `test_journal_write_boundary.py` / `test_journal_torn_tail.py` already import them; `tests/test_decompose.py:33` already imports from that module. Within `test_decompose.py` the new `TestOneJournalRead._audit` (1595) is field-for-field identical to `TestExcludedHistory._entry` (1186) - same four keys, same `"2026-08-20T00:00:00Z"` default - and duplicates the module-level `_journal_with` (792) as `TestOneJournalRead._journal` (1590). In `test_evolution.py`, `TestSpecAudits._journal` (1122) is the third `_journal` in that file (672, 1037) and `_audit` (1127) overlaps `TestSpecIssueRuns._spec_entry` (1040) directly above it. Cost: the shape of a recorded spec audit is now spelled in five places; a schema field added to the row has to be found in all of them, and the helper module's docstring already flags that some of its builders have one caller - this diff had two chances to raise that count and took neither.

**6. `tests/helpers/journal.py:77` and `:104` - the bare `"spec_issues"` literal the new constant was created to remove**
The diff's own claim is that "there is one `SPEC_ISSUES_EVENT` now", and `TestSpecIssuesEventHasOneHome` enforces it - but only over `kstrl/`, so these two survive. The helper already imports `JOURNAL_REPAIR_EVENT` from `kstrl.evolution`, so importing `SPEC_ISSUES_EVENT` costs nothing. `audits_in()` (`:101-105`) additionally re-implements the filter that is now `EvolutionJournal.get_spec_audits()`. Cost: the guard's stated failure mode ("a reader added here reaches for the nearest spelling") is left standing in the file test authors read first.

**7. `kstrl/evolution.py:1497` (in `get_spec_audits`) - same one-liner as `get_repair_count` at 1467**
Both are `[e for e in self._read_all_entries() if e.get("event_type") == <CONST>]`. Low cost today (two sites), but it is the third such filter in the class counting the inline ones at 938/960/1331/1385, and a private `_entries_of_type(event_type)` would give the new `audits=`-style snapshot reuse one place to live.

## Not findings

`_blockers` (`tests/test_decompose.py:755`) has no existing equivalent - the inline `{**BLOCKER_ISSUE, ...}` at 1780 is a differently-shaped one-off. The `KSTRL_PACKAGE` constant duplication in isolation is a repo-wide convention (`test_atomicio.py:48`, `test_toml_readers.py:111`), so finding 2 is about `package_sources`/`parsed`, not the constant. No existing generic "constant, not literal" AST guard exists anywhere in `tests/`, so the guard's concept is genuinely new; only its plumbing is duplicated.

</details>

<details>
<summary><b>Simplification</b> (10 findings)</summary>

**1. `kstrl/evolution.py:1499-1537` - the `audits=` parameter's default path is production-dead, and it forces a redundant filter plus an extra contract to defend.**
`_journal_snapshot` is the only production caller of `get_spec_issue_runs`, and it *always* passes `audits=`. So `source = self.get_spec_audits() if audits is None else audits` exists for tests only, and on the live path the event-type filter runs twice over the same rows (once in `get_spec_audits`, again in the comprehension). The parameter also invents a public promise ("passing raw entries answers the same as passing audits") that nothing needs, and that promise is what pays for the 6-line docstring paragraph and `test_a_supplied_snapshot_answers_the_same_as_raw_entries` (test_evolution.py:1175-1187).

Simpler form that keeps both constraints (journal owns read + window, one parse per report):

```python
def window_spec_audits(audits: list[dict[str, Any]], project: str, last_n: int) -> list[dict[str, Any]]:
    mine = [e for e in audits if entry_str(e, "project") == project]
    return mine[-last_n:] if last_n > 0 else []
```

module-level in `evolution.py` beside `entry_str`; `get_spec_issue_runs(project, last_n=10)` becomes `return window_spec_audits(self.get_spec_audits(), project, last_n)` and `_journal_snapshot` calls `window_spec_audits(audits, project_name, lookback)`. Cost removed: one optional param, one redundant `event_type` comparison per row, ~6 docstring lines, one test.

**2. `kstrl/decompose.py:1350-1360, 1367-1369` - `_journal_snapshot`'s docstring now restates two comments sitting on its own call site.**
The paragraph "Runs are matched by project NAME, not by spec path or content hash..." duplicates the comment at `decompose.py:1985-1989` ("the trend is keyed on the project name... the spec is edited every round, so a content hash never matches, and #260's own loop renamed the file too"), and "MUST be read BEFORE this run's own audit is appended" duplicates `decompose.py:1977-1979`. Both paragraphs came from the deleted `_spec_convergence`, which was a *different* function; folding them into `_journal_snapshot` put them one line from their own restatement. Delete both from the docstring (the call-site comments are the ones a reader hits first), or delete the comments. ~12 lines.

**3. `kstrl/decompose.py:1347`, `kstrl/evolution.py:1484`, `tests/test_decompose.py:1640`, `tests/test_journal_one_writer.py:449` - the "if the journal ever compacts, rotates or gains a second segment" argument is spelled four times.**
Three of the four are added or rewritten by this diff. It belongs once, on `get_spec_audits` (evolution.py:1484), which is the thing that would change. The other three can cite it in a clause ("see `get_spec_audits`"). Same pattern for "one read so the two cannot disagree because the file moved between two reads": five copies now (decompose.py:1315, 1339, 1982; evolution.py:1519; test_evolution.py:1159), two of them new.

**4. `kstrl/decompose.py:1127` - `_build_convergence` should take the deleted wrapper's name.**
`_spec_convergence` existed only to window-then-build; with it gone, `_build_convergence` is the only convergence function and the `_build_` prefix distinguishes it from nothing. Rename to `_spec_convergence` (the name is free, and it matches the `SpecConvergence` it returns). 11 call sites, all in tests plus one in `_decompose_spec_impl`.

**5. `tests/test_evolution.py:1122-1128` and `tests/test_decompose.py:1590-1601` - two new private `_journal` / `_audit` helpers that already exist in `tests/helpers/journal.py`.**
`journal_at(tmp_path)` and `audit(project)` are there, and `test_decompose.py` already imports `tear` from that module. The new `TestSpecAudits._journal` is byte-identical to `TestOneJournalRead._journal`; the two `_audit` bodies differ only by a timestamp field. `test_evolution.py:1037` has a *third* `_journal` in the class immediately above. Simpler: add `spec_file: str | None = None` to `helpers.journal.audit` and import `audit, journal_at` in both files. ~20 lines of test scaffolding removed, and the three journal builders stop drifting.

**6. `tests/test_evolution.py:1308-1316` - `_constant_strings` is one call site and collapses into its caller.**
Five module-level AST helpers is one more than the walk needs. Inline it as the `any(...)` it feeds:

```python
if any(isinstance(c, ast.Constant) and c.value == SPEC_ISSUES_EVENT for c in ast.walk(operand))
```

That also drops the `isinstance(child.value, str)` guard, which exists only to satisfy the `set[str]` return type. The other four (`spec_issues_literals`, `_literal_event_writes`, `_literal_event_reads`, `_reads_event_type`) each carry distinct logic and should stay.

**7. `kstrl/decompose.py:1333-1377` - the 3-tuple wants to be a frozen dataclass.**
Four call sites now index it positionally (`_journal_snapshot(journal, project)[0]` at test_decompose.py:1207, 1260, 1579; `[1]` at 1678), so which of two same-typed `list[dict[str, Any]]` you get is decided by a bare integer. `@dataclass(frozen=True) class AuditSnapshot: audits, window, lookback` matches the project's own convention ("`@dataclass` for data containers, `frozen=True` when immutable") and makes `snapshot.window` read at the call site. Low-cost, and the production unpack at decompose.py:1984 is unaffected.

**8. `kstrl/decompose.py:1984` - the local `history` names the window, four lines above `_excluded_history` names something else.**
`audits, history, lookback = _journal_snapshot(...)`, then `_excluded_history(audits, ...)`. The docstring one function up calls the same value "the window". Rename the local to `window`.

**9. `tests/test_decompose.py:2079-2097` duplicates `tests/test_evolution.py:1189-1203`.**
Both pin the slice direction, and both docstrings make the same "measured with the rule inverted, the suite stayed green" claim. Since #314 the direction can only be wrong in one place (`get_spec_issue_runs`), and the unit test covers it in three lines; the decompose-level copy pays four full `_run` decompose invocations plus the `_blockers` helper for the same rule. It does add one thing the unit test does not: that the render prints the window in order. If that is the point, say so and keep it; otherwise the unit test is sufficient.

**10. `tests/test_decompose.py:1677` - `journal.config.lookback_runs = lookback` mutates the config in a loop.**
Works because `EvolutionConfig` is not frozen, but it means each iteration inherits the previous one's state on a shared object. `self._journal(tmp_path, entries)` is already a per-iteration builder; passing the lookback through it (or constructing `EvolutionConfig(journal_path=..., lookback_runs=lookback)`) is the same length and does not reach into another object's field.

## Not flagged

- `SPEC_ISSUES_EVENT` moving to `evolution.py` and the top-level `EvolutionConfig`/`EvolutionJournal` import replacing the function-local one are both net simplifications. No cycle (`evolution.py` does not import `decompose`), and `ruff check kstrl tests` is clean.
- The AST guard's scan root is `kstrl/` only, so three literal `"spec_issues"` spellings survive in tests (`tests/helpers/journal.py:80` and `:107`, `tests/test_evolution.py:1044`). Widening the walk is more work, not less; but `helpers/journal.py` already imports from `kstrl.evolution`, so those two could use the constant for free.
- Docstring length on `get_spec_audits` and `_excluded_history` is in keeping with the file. Only the four- and five-way repeats in finding 3 are genuine bloat.

</details>

<details>
<summary><b>Efficiency</b> (no findings)</summary>

## EFFICIENCY review: no findings worth acting on

I measured all four items you named. Every one lands below the noise floor of the thing it sits inside. Details and numbers below.

### 1. Module-level `from kstrl.evolution import (...)` - `kstrl/decompose.py:40-45`

**Not worth flagging.** Your measurement reproduces, and the production number is smaller than the one you took.

Method: `git archive main kstrl` and `git archive HEAD kstrl` into two isolated trees, timed `import kstrl.cli` in interleaved subprocesses (main, head, main, head, ...) to cancel machine drift, 30 pairs.

| condition | main | HEAD | delta |
|---|---|---|---|
| `PYTHONDONTWRITEBYTECODE=1`, caches cleared (n=30) | 202.6 ms median | 206.9 ms | **+4.3 ms (+2.1%)** |
| `__pycache__` warm (n=25) | 81.3 ms median | 82.1 ms | **+0.8 ms (+1.0%)** |

The warm row is the one that matters: the real checkout has `kstrl/__pycache__` populated, so an actual `ks` invocation pays +0.8 ms, not +4.3 ms. `PYTHONDONTWRITEBYTECODE=1` measures the compile, which production does once and then never again.

What is actually pulled in, by `sys.modules` diff: exactly three entries - `kstrl.evolution`, `csv`, `_csv`. Nothing else. Split by cold-import timing after `kstrl.cli` is already loaded: `csv` 0.22 ms, the `evolution` module body 3.58 ms. `kstrl.evolution`'s only imports are `kstrl.observability` and `kstrl.verify`, both of which `cli.py` already imports at module level, so there is no transitive fan-out. Its module-level statements are a logger, four constants, five `re.compile` calls and two dicts - no I/O, no env reads.

### 2. The re-applied event-type filter - `kstrl/evolution.py:1530-1537`

**Not worth flagging, and the diff is net negative on work anyway.**

Built a synthetic journal at your stated 6.9 KB per factory run, one spec audit per run:

| journal | `get_spec_audits()` (read + parse) | window as shipped | window without the redundant filter | redundant filter costs |
|---|---|---|---|---|
| 1011 KB, 2650 entries, 150 audits | 2934 us | 7.8 us | 5.8 us | **2.0 us (0.07%)** |
| 10108 KB, 26353 entries, 1500 audits | 34279 us | 86.5 us | 72.0 us | **14.5 us (0.04%)** |

Two microseconds behind a three-millisecond read. The filter is load-bearing for the documented contract (`audits=` accepts raw entries and still answers correctly, pinned by `test_a_supplied_snapshot_answers_the_same_as_raw_entries`), so removing it would trade a correctness guarantee for 0.07%.

Worth recording the other direction: **the diff removes more work than it adds.** `main`'s `decompose.py` called `_spec_audits(entries)` twice over the *whole* entry list - once at line 1198 (`_spec_convergence`) and once at line 1400 (`_excluded_history`). HEAD filters once inside `get_spec_audits` and shares the result. One full-entries pass at 2650 entries measures 30.8 us, so the net is about **-29 us per report**.

### 3. `_read_all_entries` - one read per report, confirmed

`_read_all_entries` has three call sites in `evolution.py` (`get_spec_audits`, the repair-row count, `_read_journal_entries`); only `get_spec_audits` is on this path, `_journal_snapshot` calls it once, and the window reuses that list via `audits=`. `tests/test_decompose.py::TestOneJournalRead::test_the_journal_is_parsed_once_per_report` counts calls at `_read_all_entries` itself and asserts `== 1`; the class passes (4 tests, 0.13 s). No caching layer exists or is needed.

### 4. `TestSpecIssuesEventHasOneHome` - `tests/test_evolution.py:1119` - **does not need the `parsed()` cache**

Measured: **0.21 s** for the class alone, **0.27 s** inside a full `test_evolution.py` run (of 0.45 s total). Breakdown over 127 modules / 65,797 lines / 237,085 nodes:

```
read only            1.7 ms
parse only         186.1 ms
walk pre-parsed     60.8 ms
guard as written   187.3 ms
```

The guard makes **exactly one** parse pass and **one** `ast.walk`, with both the `ast.Dict` and `ast.Compare` checks inside the same walk. `test_journal_one_writer`'s `_PARSED` cache exists because *three* walkers in that one file each parsed the package for themselves (0.20 s of its 0.71 s). A cache in front of a single-pass walker saves nothing - it is a dict lookup added to a path with no second lookup. The nested `_constant_strings` walk is gated behind `_reads_event_type`, so it only fires on comparisons that already mention `event_type`.

Scale: full suite is 294.33 s (4801 passed). This test is 0.09% of it, and it joins 13 other test files in `tests/` that already each make their own full-package `rglob("*.py")` pass. Sharing a parse across those files would save roughly 190 ms per file per suite run, but that is a cross-file coupling argument about an existing convention, not something this diff introduced.

### Also checked, nothing found

- No long-lived closures over an enclosing scope in production code. The two new closures (`counting`, `refuse`) are `monkeypatch.setattr` targets in tests and are reverted per-test.
- `entry_str` is imported by name into `decompose`, so the cross-module move costs no attribute lookup at call time.
- `_excluded_history` walks its `audits` list three times (two `sum()` genexps plus `_excluded_projects`) - about 4 passes over 150 items, single-digit microseconds, and identical in shape to `main`. The diff did not introduce it.

### One note on the target

`kstrl/decompose.py` has uncommitted working-tree changes from a sibling agent (`_journal_snapshot`'s 3-tuple has become a frozen `AuditSnapshot` dataclass). That is an altitude/clarity change; it does not alter any measurement above - same single read, same `audits=` reuse.

</details>

<details>
<summary><b>Altitude</b> (8 findings)</summary>

**1. `kstrl/evolution.py:46-52` - the constant landed in the right module; the same module's worst duplication of the same pattern is untouched, and the new guard cannot see it.**

The rationale written into the new constant is "a reader added HERE reaches for the nearest spelling, which was the literal." That argument is 9x truer for `component_result`, which is spelled as a bare literal nine times across five lines in this same file: `730` (write), `938`, `960`, `1331`, `1385` (each `entry.get("event_type", "component_result") == "component_result"`). The `.get` default there also encodes a schema rule ("a row with no `event_type` is a component result") in a string literal repeated four times.

Verdict on the brief's question: fixing one event type is the **right scope for issue 314** (which names one), and the other four are not the same defect - `role_usage` (evolution.py:613), `contract_result` (factory.py:3834), `autonomy_transition` (autonomy.py:787) and `findings_superseded` (pipeline.py:1256) are each written once with no production reader spelling the name back, so they never had the two-modules-two-spellings cost item 3 fixed. `component_result` is different: it is nine spellings in the module this PR is editing.

Cost: the PR establishes "journal event names are constants at the top of evolution.py" and leaves the file's own dominant counter-example in place, so the convention reads as an exception rather than a rule.
**Follow-up** for the `component_result` conversion (it touches five aggregates and their tests). But see 2 - the guard should be generalised in this PR so the follow-up is enforceable.

**2. `tests/test_evolution.py:1241-1345` - a 105-line AST detector hardcoded to one event name. Generalise it here; it is nearly free and green today.**

`spec_issues_literals`, `_literal_event_writes`, `_literal_event_reads` all close over `SPEC_ISSUES_EVENT` directly. The next event constant needs a copy of all of it, and the realistic outcome of "copy 105 lines" is "no guard."

The generalisation is one parameter: `spec_issues_literals(source, event_name)` driven from a set of enrolled constants. It passes today for `{SPEC_ISSUES_EVENT, JOURNAL_REPAIR_EVENT}` - I checked, `journal_repair` has zero literal spellings in `kstrl/` (only its definition at evolution.py:45 and the constant use at 1467). Enrolling the remaining four then becomes a one-line diff per event as each gets a constant, which is what makes finding 1's follow-up a real commitment rather than an intention.

One implementation note if you do it: for `entry.get("event_type", "component_result") == "component_result"`, `_constant_strings` walks into the getter call and will find the name in the `.get` default too, so the reported message names the whole call. Still a true positive, just an odd string; skip `ast.Call` defaults or accept the wording.
**Fix in this PR** (parameterise + enroll the two that pass). Conversions in the follow-up.

**3. `kstrl/evolution.py:1499-1541` - the `audits=` parameter is a special case layered onto the shared reader, exactly the shape this angle is looking for.**

`get_spec_issue_runs` now has two contracts: read the file, or window a list the caller already has. The optional-source branch forces a defensive re-application of the event-type filter (line 1533), and that in turn needed its own test to state the equivalence (`test_a_supplied_snapshot_answers_the_same_as_raw_entries`). The parameter is also misnamed relative to what it accepts - that test proves it takes raw entries, not audits.

The underlying mechanism generalises cleanly instead: a module-level pure function

```python
def spec_audit_window(audits: list[dict[str, Any]], project: str, last_n: int) -> list[dict[str, Any]]
```

called by `get_spec_issue_runs` (over `self.get_spec_audits()`) and by `decompose._journal_snapshot` (over the snapshot it already holds). One copy of the window rule - which is what #314 item 2 asked for - with no optional-source branch, no re-filter, and the equivalence test disappears because there is no second path to be equivalent to.

Cost of leaving it: a public method with a performance escape hatch that changes its data source, plus a test whose only job is to say the escape hatch behaves.
**Fix in this PR.**

**4. `kstrl/evolution.py:494-514` - `entry_str` is in the right module for the shared *rule* and the wrong module for the *function*.**

Nine of its ten call sites are in `decompose.py`; the single evolution-side use is the project match at line 1535. The docstring opens by defining it over "a JSON-decoded journal record" and then has to append a paragraph excusing the nested-issue case, which is the docstring paying for the placement.

Two separable things are fused here. The shared rule is "how a project is matched on an audit row" - that genuinely belongs on evolution, as `audit_project(entry) -> str`, and stating it that way removes the need for `decompose` to import a string accessor at all for that purpose. The generic accessor is a JSON util with no journal content; `kstrl/events.py` already has the identical idiom inlined four times (738, 739, 752, 767), which is where the real duplication is.

**Follow-up** for the shared util. The `audit_project` framing is small enough for this PR if you want the docstring exception gone.

**5. `kstrl/evolution.py:1499` - `get_spec_issue_runs` is named for its history; `get_spec_audits` is named for its layer.**

The sibling settles the vocabulary: the row is a spec audit. `get_spec_issue_runs` then spends two sentences of its own docstring correcting its name - "The last N recorded spec audits for `project`" and "`last_n` counts spec audits, not factory runs". A name that needs its docstring to disown it is the tell.

There is exactly one production caller (`decompose._journal_snapshot`) plus tests, so the rename is cheap now and gets more expensive with every future caller. `get_recent_spec_audits(project, last_n)` matches the sibling; or, under finding 3, the method collapses into `spec_audit_window` and the name question goes away.
**Fix in this PR.**

**6. `kstrl/decompose.py:1330, 1372-1376` - a bare 3-tuple whose first two elements are the same type.**

`_journal_snapshot` returns `tuple[list[dict[str, Any]], list[dict[str, Any]], int]`, unpacked positionally at the call site and indexed as `[0]` / `[1]` in four tests. Swapping the first two typechecks, and the trend/accounting split is exactly the pair #280 exists to keep straight. The project convention (CLAUDE.md: `@dataclass`, `frozen=True` when immutable) points at a three-field frozen container; it also gives the "all three or none" fact a name instead of a docstring paragraph.
**Fix in this PR** (small).

**7. `kstrl/evolution.py:1474` - the depth the issue was pointing at: the journal now owns *which rows are audits*, but not *what a row contains*.**

`get_spec_audits` returns `list[dict[str, Any]]`, and `decompose` still reads `"project"`, `"spec_file"`, `"timestamp"` and the nested `"severity"`/`"kind"`/`"summary"` by literal key across `_excluded_projects`, `_excluded_history`, `_stored_issues` and `_build_convergence`. That is the reason `entry_str` had to be exported to a second module at all (finding 4), and the reason the window rule needed a snapshot-passing escape hatch (finding 3).

A frozen `SpecAudit` returned by `get_spec_audits` would put the row's field names in the module that defines the schema, delete `entry_str` from `decompose` entirely, and make findings 4 and 5 moot. Today a journal schema change turns those fields into `""` silently in the convergence report.
**Follow-up** - it touches every test that builds raw audit dicts, and racing evolution.py again is what #314 exists to avoid. Worth filing with the reasoning above, because it is the fix the three smaller ones are approximating.

**8. `tests/test_journal_one_writer.py:445-451` - the inventory is the right mechanism. No positive rule is available. Minor nit on the tombstone.**

Dropping the `decompose.py` row is correct, and an inventory-of-expected-sites is the right shape here, not a bandaid: a positive rule "nothing outside evolution.py holds the journal path" cannot be written, because `cli.py:689` legitimately interpolates `journal.config.journal_path` into an operator message, and the `pipeline.py`/`workqueue.py` rows are a different file that the file's own docstring says cannot be told apart without the type resolution #324 is about. The inventory's stated design ("adding a row is not forbidden, it is the point") is the honest version of that.

Nit: the six-line tombstone comment describes an invariant the inventory does not enforce - holding the path is still allowed, as the `cli.py` row proves; what it enforces is that changing the set requires editing the dict and explaining why. And tombstones for removed rows accumulate. One line pointing at `get_spec_audits`, with the rationale living in that method's docstring (where it already is, verbatim), would carry the same information.
**Optional, this PR.**

</details>

### What was applied

| Finding | Action |
|---|---|
| Reuse 2, 3, 4 / Simplification 6 / Altitude 2 | Applied. The guard reuses `package_sources`, `parsed`, `label` and `folded_str` from `test_journal_one_writer`, is driven by an `ENROLLED_EVENT_CONSTANTS` table, and gained a positive control for the concatenated and f-string spellings plus one for the second enrolled name. `_constant_strings` is gone. |
| Reuse 5, 6 / Simplification 5 | Applied. `helpers.journal.audit` grows a `spec_file` argument and uses `SPEC_ISSUES_EVENT`; `audits_in` uses the constant. The new tests use `audit` and `journal_at`. |
| Simplification 7 / Altitude 6 | Applied. Frozen `AuditSnapshot`. |
| Simplification 8 | Applied, as `snapshot.window` at the call site. |
| Simplification 10 | Applied. A journal per lookback, and its own comment on why: appending to one file three times would compare a growing history against itself. |
| Simplification 2, 3 / Altitude 8 | Applied. The repeated arguments live on `get_spec_audits`; the docstring, the test and the tombstone cite it. |

### What was declined, and why

| Finding | Reason |
|---|---|
| **Simplification 1 / Altitude 3** - replace `audits=` with a module-level `window_spec_audits` | This is the one finding I am overruling on purpose. Both agents are right that the parameter is a second contract. But the shape they propose puts `get_spec_issue_runs` back to having **no production caller**, which is precisely the state issue #314 calls out ("a public method kept alive by its own tests, which is worse than either owning the rule or deleting it"). The issue's own second option is "make it the one place the window lives, called with pre-read entries", and `audits=` is literally that. The measured cost of the redundant filter is 2.0 us behind a 2934 us read (0.07%), and the filter is what makes the parameter safe against raw entries. |
| **Altitude 5** - rename `get_spec_issue_runs` | Declined for this PR. The issue and the decision to route it back both name this method; renaming it in the same commit that changes its signature makes the audit trail across #260, #280 and #314 harder to follow for a reader who has only the names. Worth a follow-up once it has settled. |
| **Simplification 4** - rename `_build_convergence` to `_spec_convergence` | Declined. Reusing a just-deleted function's name for a function with a different signature makes `git log -L` across #260 and #280 read as if one function changed shape. The clarity gain is small; the churn is 11 call sites. |
| **Reuse 1 / Altitude 4** - fold `entry_str` with `workqueue._as_str`, or split it into `audit_project` | Declined for this PR. The fold is a real duplication and belongs in `observability.py`, but it touches `workqueue.py`, `events.py`, `serve.py` and two TUI screens, well outside this seam. The `audit_project` split is worse than what shipped: `decompose` still needs the generic accessor for `spec_file`, `timestamp` and the issue fields, so it would get a private `_entry_str` back and the rule would live in two homes again. Follow-up. |
| **Altitude 1** - convert `component_result` and the other four event names | Declined for this PR, out of #314's scope. Enrolling `JOURNAL_REPAIR_EVENT` in the guard (finding 2, applied) is what makes the follow-up enforceable rather than intended: each conversion is now one line in `ENROLLED_EVENT_CONSTANTS`. |
| **Altitude 7** - a frozen `SpecAudit` row type | Declined for this PR. It touches every test that builds a raw audit dict, and racing `evolution.py` again is what #314 exists to avoid. This is the fix the smaller ones approximate, and it is worth filing. |
| **Reuse 7** - a private `_entries_of_type` on `EvolutionJournal` | Declined. Two sites, and the second is `get_repair_count`, which #327 landed this morning; the churn on another PR's fresh code costs more review than the duplication costs. |
| **Simplification 9** - drop the decompose-level direction test | Declined. It is not a duplicate: the unit test pins what the rule does, the end-to-end test pins that `decompose` **routes through** that rule and renders the window in order. Mutation 3 fails both, which is the point - if only the unit test existed, a decompose that quietly rewindowed for itself would still pass. |

## Known limits of the guards, stated rather than implied

- The inventory in `test_journal_one_writer.py` is what stops `decompose` reaching for the path again. It does not stop a NEW second copy of the window rule inside `_journal_snapshot` that happens to agree with the journal's; `test_the_window_is_the_journals_own_over_the_journals_own_lookback` is an agreement test and can only fail on a rule that differs. Code review is the mechanism for that one.
- The event-name walk covers `kstrl/` only. `tests/` is not walked; the two literals that were there are converted, but a new one in a test would not fail.
- Folding decides `"spec" + "_issues"` and the plain f-string. It does not decide `"".join(...)`, `%`-formatting, or a name resolved at run time, exactly as `folded_str` discloses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHYpsJ8ecHLh5HdrswJtJK
