### PR TITLE
fix(evolution): give the unenrolled gates a category, and an infrastructure one for the four with no home (#315)

### DIFF
--- a/kstrl/autonomy_replay.py
+++ b/kstrl/autonomy_replay.py
@@ -43,23 +43,13 @@ from kstrl.verify import SCOPE_UNREADABLE_CHECK
 
 DEFAULT_EXPERIMENTS_PATH = Path(".kstrl/experiments.tsv")
 
-#: `common_failure` prefixes that mark an infrastructure casualty rather
-#: than a judgement. Kept as a prefix tuple so a new plumbing failure
-#: family is one entry, not a new code path.
+#: The prefixes this module adds to the ones the journal's own
+#: taxonomy supplies. It asks a WIDER question than that taxonomy does:
+#: the journal asks which part of the factory produced a failure, this
+#: asks whether the run yielded a verdict about the factory's JUDGEMENT
+#: at all, and a failure can be a gate's honest verdict and still answer
+#: that with no.
 #:
-#: #315: the first four come from `evolution.INFRASTRUCTURE_CHECKS`
-#: rather than being retyped here. The two consumers disagreed about
-#: `pr:merge-conflict` - plumbing to this module, an engineer-loop
-#: failure to the journal - and a taxonomy that answers a question twice
-#: will eventually answer it two ways. Deriving means enrolling a check
-#: as infrastructure in `_CATEGORY_BY_CHECK` reaches both in one edit,
-#: and the enrolment guard forces every emitted name through that table.
-#:
-#: _REPLAY_ONLY_PREFIXES is the deliberate remainder: this module asks a
-#: WIDER question than the journal's category does. The journal asks
-#: which part of the factory produced a failure; this asks whether the
-#: run yielded a verdict about the factory's JUDGEMENT at all, and a
-#: failure can be a gate's honest verdict and still answer that with no.
 #: `scope_unreadable:` (#294) is the harness failing to establish its own
 #: input: the component's scope could not be read from the pre-run tree,
 #: so nothing was ever measured about the change. The same reasoning that
@@ -90,6 +80,24 @@ _REPLAY_ONLY_PREFIXES: tuple[str, ...] = (
     "timeout:",
 )
 
+#: `common_failure` prefixes that mark an infrastructure casualty rather
+#: than a judgement. Kept as a prefix tuple so a new plumbing failure
+#: family is one entry, not a new code path.
+#:
+#: #315: every check the journal files as `infrastructure` is in here by
+#: construction, rather than being retyped. The two consumers disagreed
+#: about `pr:merge-conflict` - plumbing to this module, an engineer-loop
+#: failure to the journal - and a taxonomy that answers a question twice
+#: will eventually answer it two ways. Deriving means enrolling a check
+#: as infrastructure in `_CATEGORY_BY_CHECK` reaches both in one edit,
+#: and the enrolment guard forces every emitted name through that table.
+#: `_REPLAY_ONLY_PREFIXES` above is the deliberate remainder. The sorted
+#: tuple interleaves the two halves, so read the two sources, not the
+#: order.
+#:
+#: `tests/test_check_name_enrolment.py` pins the contents through
+#: `RunRecord.infra_aborted` rather than against this tuple, so a
+#: property that stopped consulting it would be caught.
 INFRA_FAILURE_PREFIXES: tuple[str, ...] = tuple(
     sorted({f"{check}:" for check in INFRASTRUCTURE_CHECKS} | set(_REPLAY_ONLY_PREFIXES))
 )

--- a/kstrl/autonomy_replay.py
+++ b/kstrl/autonomy_replay.py
@@ -38,15 +38,28 @@ from kstrl.autonomy import (
     AutonomyState,
     DemotionTrigger,
 )
+from kstrl.evolution import INFRASTRUCTURE_CHECKS
 from kstrl.verify import SCOPE_UNREADABLE_CHECK
 
 DEFAULT_EXPERIMENTS_PATH = Path(".kstrl/experiments.tsv")
 
 #: `common_failure` prefixes that mark an infrastructure casualty rather
-#: than a judgement. Derived from the recorded failure taxonomy: `pr:` is
-#: push/create/merge plumbing. Kept as a prefix tuple so a new plumbing
-#: failure family is one entry, not a new code path.
+#: than a judgement. Kept as a prefix tuple so a new plumbing failure
+#: family is one entry, not a new code path.
 #:
+#: #315: the first four come from `evolution.INFRASTRUCTURE_CHECKS`
+#: rather than being retyped here. The two consumers disagreed about
+#: `pr:merge-conflict` - plumbing to this module, an engineer-loop
+#: failure to the journal - and a taxonomy that answers a question twice
+#: will eventually answer it two ways. Deriving means enrolling a check
+#: as infrastructure in `_CATEGORY_BY_CHECK` reaches both in one edit,
+#: and the enrolment guard forces every emitted name through that table.
+#:
+#: _REPLAY_ONLY_PREFIXES is the deliberate remainder: this module asks a
+#: WIDER question than the journal's category does. The journal asks
+#: which part of the factory produced a failure; this asks whether the
+#: run yielded a verdict about the factory's JUDGEMENT at all, and a
+#: failure can be a gate's honest verdict and still answer that with no.
 #: `scope_unreadable:` (#294) is the harness failing to establish its own
 #: input: the component's scope could not be read from the pre-run tree,
 #: so nothing was ever measured about the change. The same reasoning that
@@ -56,13 +69,29 @@ DEFAULT_EXPERIMENTS_PATH = Path(".kstrl/experiments.tsv")
 #: evidence about the factory's judgement. #294 makes that more likely
 #: rather than less, because refusing the component before its engineer
 #: runs makes this the modal signature of the run instead of one of
-#: three retries.
-INFRA_FAILURE_PREFIXES: tuple[str, ...] = (
-    "pr:",
+#: three retries. The journal keeps it under `verification` all the same:
+#: it IS a Phase 1 gate result, and #294 gave it its own gate, its own
+#: table row and its own proposal arm on that basis. That divergence is
+#: the point of splitting this constant in two, and
+#: `tests/test_check_name_enrolment.py` pins both halves of it.
+#:
+#: `git:`, `infra:` and `timeout:` name families no version of kstrl has
+#: ever emitted: measured with `git log -S`, all three strings entered
+#: the tree in 606cbb1, the commit that created this tuple, and no call
+#: site produces them. Kept because an experiments.tsv row outlives the
+#: code that wrote it and the cost of a prefix that matches nothing is
+#: zero. They are NOT enrolled in `_CATEGORY_BY_CHECK`: that table
+#: describes names kstrl emits, and the enrolment guard would make any
+#: real `git:` gate enrol itself on the day it lands.
+_REPLAY_ONLY_PREFIXES: tuple[str, ...] = (
+    f"{SCOPE_UNREADABLE_CHECK}:",
     "git:",
     "infra:",
     "timeout:",
-    f"{SCOPE_UNREADABLE_CHECK}:",
+)
+
+INFRA_FAILURE_PREFIXES: tuple[str, ...] = tuple(
+    sorted({f"{check}:" for check in INFRASTRUCTURE_CHECKS} | set(_REPLAY_ONLY_PREFIXES))
 )
 
 

--- a/kstrl/autonomy_replay.py
+++ b/kstrl/autonomy_replay.py
@@ -50,6 +50,13 @@ DEFAULT_EXPERIMENTS_PATH = Path(".kstrl/experiments.tsv")
 #: at all, and a failure can be a gate's honest verdict and still answer
 #: that with no.
 #:
+#: ONE OF THE FOUR IS LIVE. `scope_unreadable:` is emitted by kstrl and
+#: is the reason this constant exists; `git:`, `infra:` and `timeout:`
+#: match nothing this code can produce, and the paragraph below says how
+#: that was measured. Stated here as well as there because a reader who
+#: takes the list at face value inherits the wrong prior about how much
+#: of the ladder's evidence these four remove.
+#:
 #: `scope_unreadable:` (#294) is the harness failing to establish its own
 #: input: the component's scope could not be read from the pre-run tree,
 #: so nothing was ever measured about the change. The same reasoning that
@@ -63,14 +70,28 @@ DEFAULT_EXPERIMENTS_PATH = Path(".kstrl/experiments.tsv")
 #: it IS a Phase 1 gate result, and #294 gave it its own gate, its own
 #: table row and its own proposal arm on that basis. That divergence is
 #: the point of splitting this constant in two, and
-#: `tests/test_check_name_enrolment.py` pins both halves of it.
+#: `tests/test_infrastructure_category_consumers.py` pins both halves of
+#: it, through the property rather than against this tuple.
 #:
 #: `git:`, `infra:` and `timeout:` name families no version of kstrl has
 #: ever emitted: measured with `git log -S`, all three strings entered
 #: the tree in 606cbb1, the commit that created this tuple, and no call
-#: site produces them. Kept because an experiments.tsv row outlives the
-#: code that wrote it and the cost of a prefix that matches nothing is
-#: zero. They are NOT enrolled in `_CATEGORY_BY_CHECK`: that table
+#: site produces them. #339 re-measured it four ways and got the same
+#: answer: none of the three appears in `kstrl/` as a signature prefix,
+#: none is in `_CATEGORY_BY_CHECK`, none is in `_classify_check`'s range,
+#: and none is producible by any of the four check-name producers
+#: `tests/test_check_name_enrolment.py` enumerates.
+#:
+#: Kept, and #339 review is why that needs saying carefully: an earlier
+#: draft of this comment defended them as protecting historical rows,
+#: which cannot be true alongside the sentence above it. If no version
+#: ever emitted the strings then no experiments.tsv row contains them,
+#: and deleting them would change nothing that exists. They stay because
+#: a prefix that matches nothing costs nothing to carry and because
+#: removing them is a decision about what this constant is FOR - whether
+#: it guards against families kstrl has never written - which is worth
+#: making on its own rather than as a tidy-up inside a categorisation
+#: fix. They are NOT enrolled in `_CATEGORY_BY_CHECK`: that table
 #: describes names kstrl emits, and the enrolment guard would make any
 #: real `git:` gate enrol itself on the day it lands.
 _REPLAY_ONLY_PREFIXES: tuple[str, ...] = (
@@ -95,8 +116,8 @@ _REPLAY_ONLY_PREFIXES: tuple[str, ...] = (
 #: tuple interleaves the two halves, so read the two sources, not the
 #: order.
 #:
-#: `tests/test_check_name_enrolment.py` pins the contents through
-#: `RunRecord.infra_aborted` rather than against this tuple, so a
+#: `tests/test_infrastructure_category_consumers.py` pins the contents
+#: through `RunRecord.infra_aborted` rather than against this tuple, so a
 #: property that stopped consulting it would be caught.
 INFRA_FAILURE_PREFIXES: tuple[str, ...] = tuple(
     sorted({f"{check}:" for check in INFRASTRUCTURE_CHECKS} | set(_REPLAY_ONLY_PREFIXES))
@@ -181,7 +202,22 @@ class ReplayReport:
     decisive_runs: int
     infra_aborted_runs: int
     projects: list[str]
+    #: Merges in DECISIVE runs only, which is the population the ladder
+    #: promotes on. #339: this used to sum every row, so a run Ctrl-C'd
+    #: after merging 24 components printed "Components merged: 24" two
+    #: lines under "infra-aborted: 1 (excluded)" while contributing
+    #: nothing to a promotion. Two populations, one label.
     components_merged: int
+    #: The merges the line above deliberately leaves out, so the total is
+    #: still recoverable and the exclusion is visible rather than a
+    #: number that quietly got smaller. Rendered only when non-zero,
+    #: unlike the infra-aborted count above it, because a report with
+    #: nothing excluded has nothing to disclose.
+    #:
+    #: No default: a hand-built report would otherwise claim silently
+    #: that nothing was excluded, which is the exact under-report this
+    #: field exists to stop.
+    merged_in_excluded_runs: int
     would_promote: list[str] = field(default_factory=list)
     would_demote: list[str] = field(default_factory=list)
     final_level: int = int(AutonomyLevel.L1_SUPERVISED)
@@ -200,7 +236,12 @@ class ReplayReport:
             f"Runs recorded:        {self.total_runs}",
             f"  decisive:           {self.decisive_runs}",
             f"  infra-aborted:      {self.infra_aborted_runs} (excluded)",
-            f"Components merged:    {self.components_merged}",
+            f"Components merged:    {self.components_merged} (in decisive runs)",
+            *(
+                [f"  in excluded runs:   {self.merged_in_excluded_runs} (not counted)"]
+                if self.merged_in_excluded_runs
+                else []
+            ),
             f"Projects:             {', '.join(self.projects) or '(none)'}",
             "",
             "Thresholds replayed (ALL UNMEASURED PLACEHOLDERS):",
@@ -254,7 +295,8 @@ def replay(runs: list[RunRecord]) -> ReplayReport:
         decisive_runs=sum(1 for r in runs if r.decisive),
         infra_aborted_runs=sum(1 for r in runs if r.infra_aborted),
         projects=sorted({r.project for r in runs if r.project}),
-        components_merged=sum(r.completed for r in runs),
+        components_merged=sum(r.completed for r in runs if r.decisive),
+        merged_in_excluded_runs=sum(r.completed for r in runs if not r.decisive),
     )
     for run in runs:
         if not run.decisive:

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -234,9 +234,7 @@ class FailurePattern:
     # "scope_creep" for a review concern) - the part after the colon in
     # the full "<check>:<code>" signature
     error_signature: str
-    # One of CATEGORIES, decided by category_for_check when the pattern
-    # is built and never written to the journal, so correcting the table
-    # also corrects what is reported about runs already recorded.
+    # A _CATEGORY_BY_CHECK value; see category_for_check.
     category: str
 
 
@@ -367,23 +365,29 @@ def _classify_check(error: str) -> str:
 # difference is the number.
 _DIGIT_RUN_RE = re.compile(r"\d+")
 
-#: The categories a FailurePattern can carry. ``"infrastructure"``
-#: (#315) is for a failure that is neither a gate's verdict on the
-#: change nor the engineer's loop: the run was shut down, hit the token
-#: ceiling, could not merge, could not fetch its own diff. Before it
-#: existed those fell through to ``"iteration"`` and ``ks evolve``
-#: reported them as engineer-loop problems, which is advice aimed at an
-#: agent that could not have prevented any of them.
-#:
-#: Not ``Finding.category``'s ``"infrastructure_error"``
-#: (:mod:`kstrl.findings`), which marks one ROLE RUN that failed to
-#: execute inside an otherwise healthy component. Different taxonomy,
-#: different consumer, deliberately different spelling so a grep for
-#: either does not silently return the other.
-CATEGORIES: frozenset[str] = frozenset(
-    {"verification", "review", "security", "contract", "infrastructure", "iteration"}
-)
-
+# The categories are verification, review, security, contract,
+# iteration and, since #315, infrastructure. That last one is for a
+# failure that is neither a gate's verdict on the change nor the
+# engineer's loop: the run was shut down, hit the token ceiling, could
+# not merge, could not fetch its own diff, could not provision a
+# worktree. Before it existed those fell through to "iteration", so the
+# journal filed them as engineer-loop problems and the evolve screen's
+# category column said so: a verdict about an agent that could not have
+# prevented any of them.
+#
+# NOT Finding.category's "infrastructure_error" (kstrl/findings.py),
+# which marks one ROLE RUN that failed to execute inside an otherwise
+# healthy component. Different taxonomy, different consumer,
+# deliberately different spelling so a grep for either does not silently
+# return the other. They also disagree, on purpose and measurably:
+# factory's live autonomy accounting asks the FINDING question
+# (`_infra_casualty`) while the replay asks the SIGNATURE question, and
+# `pr:merge-conflict` attaches no infrastructure finding. Reconciling
+# those two is not this table's job.
+#
+# tests/test_check_name_enrolment.py pins the whole table row by row, so
+# a new row, a dropped row or a typo in a category is a red test with
+# the diff as its audit trail.
 _CATEGORY_BY_CHECK = {
     "linter": "verification",
     "typecheck": "verification",
@@ -404,17 +408,30 @@ _CATEGORY_BY_CHECK = {
     "fixtures": "verification",
     "policy_envelope": "verification",
     "test_adequacy": "verification",
+    # #315 round 2: a failure recorded with no signatures= is filed
+    # under its PHASE (pipeline._record_failure_signatures), so these
+    # two are check names as much as any gate is. "verify" is the phase
+    # spelling of the mechanical gates above; "provisioning" is a
+    # worktree that would not build, which no agent can write code
+    # against.
+    "verify": "verification",
+    "provisioning": "infrastructure",
     # #315: recorded outside a CheckResult, by pipeline.fail(signatures=
     # ["<prefix>:<code>"]). None of these is a verdict on the change.
     "aborted": "infrastructure",
     "token_budget": "infrastructure",
     "pr": "infrastructure",
     "diff": "infrastructure",
-    # #315: the fallback already answers "iteration" for this one. The
-    # row is here so the table states every name kstrl emits rather than
-    # most of them, and so that a reader cannot tell an unenrolled name
-    # from a deliberate one by its absence.
+    # #315: the fallback already answers "iteration" for these two. The
+    # rows are here so the table states every name kstrl emits rather
+    # than most of them, and so that a reader cannot tell an unenrolled
+    # name from a deliberate one by its absence. "unknown" is what
+    # _classify_check returns when it cannot recognise a legacy error
+    # string: not the engineer's fault so much as nobody's, and inventing
+    # a category for "we could not tell" would be a worse answer than
+    # the one this table has always given.
     "engineer": "iteration",
+    "unknown": "iteration",
     "review": "review",
     "security": "security",
     "contract": "contract",
@@ -484,8 +501,11 @@ def category_for_check(check_name: str) -> str:
     uncategorised.
 
     The answer is computed here, at read time, and never stored in the
-    journal, so a correction to the table also corrects what
-    ``ks evolve`` reports about runs that already happened.
+    journal - measured: a ``record_run`` entry has no ``category`` key
+    and experiments.tsv records the signature only. So a correction to
+    the table also corrects what is reported about runs that already
+    happened. The one surface that displays it is the evolve screen's
+    patterns table; the ``ks evolve`` CLI prints the check name.
     """
     return _CATEGORY_BY_CHECK.get(check_name, "iteration")
 

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -379,11 +379,26 @@ _DIGIT_RUN_RE = re.compile(r"\d+")
 # which marks one ROLE RUN that failed to execute inside an otherwise
 # healthy component. Different taxonomy, different consumer,
 # deliberately different spelling so a grep for either does not silently
-# return the other. They also disagree, on purpose and measurably:
-# factory's live autonomy accounting asks the FINDING question
-# (`_infra_casualty`) while the replay asks the SIGNATURE question, and
-# `pr:merge-conflict` attaches no infrastructure finding. Reconciling
-# those two is not this table's job.
+# return the other.
+#
+# They also disagree, on purpose and measurably. factory's live autonomy
+# accounting asks the FINDING question (`_infra_casualty`) while the
+# replay asks the SIGNATURE question, and #339 review counted the
+# divergence rather than leaving it at the one example this comment used
+# to give. Six signatures, in both directions:
+#
+#   - the whole `pr:` family, `provisioning:` and `aborted:shutdown` are
+#     infrastructure to the replay and attach no finding at all, so the
+#     live side calls them judgement;
+#   - `review:infrastructure` and `security:infrastructure` are the
+#     reverse: a finding is attached, but `review`/`security` are not
+#     infrastructure prefixes, so the replay counts them as evidence;
+#   - `scope_unreadable:` depends on which producer fired - the Phase 1
+#     gate attaches a finding, the pre-launch refusal in factory does
+#     not.
+#
+# Reconciling those is not this table's job (#332 holds factory.py), but
+# an undercount was, because it read as a single known exception.
 #
 # tests/test_check_name_enrolment.py pins the whole table row by row, so
 # a new row, a dropped row or a typo in a category is a red test with
@@ -494,11 +509,31 @@ def category_for_check(check_name: str) -> str:
     four of them into the ``"infrastructure"`` category that had to be
     invented to hold them, and nothing is grandfathered any more.
 
-    ``tests/test_check_name_enrolment.py`` is the mechanism: it
-    AST-walks ``kstrl/`` for every constructed check name and every
-    ``signatures=["<prefix>:<code>"]`` literal, and fails on one this
-    table does not carry. A new gate cannot reach the journal
-    uncategorised.
+    ``tests/test_check_name_enrolment.py`` is the mechanism, and #339
+    review corrected what it establishes. It AST-walks ``kstrl/`` for
+    the four places a component's failure signatures are written - a
+    ``CheckResult`` name, a ``signatures=`` argument, the ``phase=`` of
+    a failure recorded with neither, and a direct
+    ``component_failure_signatures[...] = [...]`` assignment - and fails
+    on a name this table does not carry. What it does NOT establish is
+    that no gate can reach the journal uncategorised, which is what this
+    docstring claimed while the fourth producer was invisible to it and
+    eight of nine shape mutations survived.
+
+    What it establishes now, in three files and stated as three separate
+    claims because they hold three separate things:
+
+    - a producer site the walk RECOGNISES and cannot read is enumerated
+      in its ``BLIND_SITES`` ledger rather than dropped, which is what
+      the old walk did;
+    - ``tests/test_signature_spellings.py`` pins every signature-shaped
+      string in the package whatever container it sits in, so a producer
+      in a shape nobody has thought of still has to appear somewhere;
+    - ``tests/test_check_name_shapes.py`` pins what the walk SAYS about
+      each shape, including the shapes it says nothing about, because a
+      shape the walk does not recognise leaves no trace in either of the
+      two above. That is a limit, not a proof, and it is the limit
+      ``pipeline._fail_pr_flow`` lived in until #339 review.
 
     The answer is computed here, at read time, and never stored in the
     journal - measured: a ``record_run`` entry has no ``category`` key

--- a/kstrl/evolution.py
+++ b/kstrl/evolution.py
@@ -234,7 +234,10 @@ class FailurePattern:
     # "scope_creep" for a review concern) - the part after the colon in
     # the full "<check>:<code>" signature
     error_signature: str
-    category: str  # "verification", "review", "security", "contract", "iteration"
+    # One of CATEGORIES, decided by category_for_check when the pattern
+    # is built and never written to the journal, so correcting the table
+    # also corrects what is reported about runs already recorded.
+    category: str
 
 
 @dataclass
@@ -303,8 +306,8 @@ def _normalize_error(error: str) -> str:
     return slug[:80] if slug else "unknown"
 
 
-def _classify_check(error: str) -> tuple[str, str]:
-    """Return (check_name, category) inferred from the error text.
+def _classify_check(error: str) -> str:
+    """Return the check name inferred from the error text.
 
     The legacy fallback, used wherever a component has no in-memory
     ``failure_signatures`` entry - which is EVERY ``ks evolve`` or
@@ -320,25 +323,32 @@ def _classify_check(error: str) -> tuple[str, str]:
     state no agent can influence, which is the thing the arm exists to
     prevent. Matched FIRST because the text also contains words the
     later rules claim.
+
+    #315: this returned ``(check_name, category)`` until every caller
+    was measured to discard the category, making it a SECOND place a
+    category was decided that no consumer could reach. A dead answer
+    that can silently disagree with the live one is how the live one
+    later gets "fixed" in the wrong file, so the category is gone from
+    here and ``category_for_check`` is the only decision.
     """
     lower = error.lower()
 
     if SCOPE_UNREADABLE_ERROR_PREFIX.lower() in lower:
-        return SCOPE_UNREADABLE_CHECK, "verification"
+        return SCOPE_UNREADABLE_CHECK
     if any(kw in lower for kw in ("ruff", "flake8", "pylint", "lint")):
-        return "linter", "verification"
+        return "linter"
     if any(kw in lower for kw in ("mypy", "pyright", "typecheck", "type error")):
-        return "typecheck", "verification"
+        return "typecheck"
     if any(kw in lower for kw in ("pytest", "test", "assert", "unittest")):
-        return "test_suite", "verification"
+        return "test_suite"
     if any(kw in lower for kw in ("review", "finding", "reviewer")):
-        return "review", "review"
+        return "review"
     if any(kw in lower for kw in ("contract", "integration")):
-        return "contract", "contract"
+        return "contract"
     if any(kw in lower for kw in ("mechanical verification failed",)):
-        return "verification", "verification"
+        return "verification"
 
-    return "unknown", "iteration"
+    return "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -357,6 +367,23 @@ def _classify_check(error: str) -> tuple[str, str]:
 # difference is the number.
 _DIGIT_RUN_RE = re.compile(r"\d+")
 
+#: The categories a FailurePattern can carry. ``"infrastructure"``
+#: (#315) is for a failure that is neither a gate's verdict on the
+#: change nor the engineer's loop: the run was shut down, hit the token
+#: ceiling, could not merge, could not fetch its own diff. Before it
+#: existed those fell through to ``"iteration"`` and ``ks evolve``
+#: reported them as engineer-loop problems, which is advice aimed at an
+#: agent that could not have prevented any of them.
+#:
+#: Not ``Finding.category``'s ``"infrastructure_error"``
+#: (:mod:`kstrl.findings`), which marks one ROLE RUN that failed to
+#: execute inside an otherwise healthy component. Different taxonomy,
+#: different consumer, deliberately different spelling so a grep for
+#: either does not silently return the other.
+CATEGORIES: frozenset[str] = frozenset(
+    {"verification", "review", "security", "contract", "infrastructure", "iteration"}
+)
+
 _CATEGORY_BY_CHECK = {
     "linter": "verification",
     "typecheck": "verification",
@@ -371,10 +398,36 @@ _CATEGORY_BY_CHECK = {
     "mutation_testing": "verification",
     "prd_stories": "verification",
     "verification": "verification",
+    # #315: mechanical gates that the table did not carry, so every
+    # approved-fixtures failure, policy-envelope breach and
+    # test-adequacy block was filed under the engineer loop.
+    "fixtures": "verification",
+    "policy_envelope": "verification",
+    "test_adequacy": "verification",
+    # #315: recorded outside a CheckResult, by pipeline.fail(signatures=
+    # ["<prefix>:<code>"]). None of these is a verdict on the change.
+    "aborted": "infrastructure",
+    "token_budget": "infrastructure",
+    "pr": "infrastructure",
+    "diff": "infrastructure",
+    # #315: the fallback already answers "iteration" for this one. The
+    # row is here so the table states every name kstrl emits rather than
+    # most of them, and so that a reader cannot tell an unenrolled name
+    # from a deliberate one by its absence.
+    "engineer": "iteration",
     "review": "review",
     "security": "security",
     "contract": "contract",
 }
+
+#: Checks whose failures are infrastructure, derived from the table so
+#: there is ONE answer rather than two lists to keep in step:
+#: :data:`kstrl.autonomy_replay.INFRA_FAILURE_PREFIXES` builds its
+#: prefixes from this, so enrolling a check as infrastructure reaches
+#: both consumers in one edit (#315).
+INFRASTRUCTURE_CHECKS: frozenset[str] = frozenset(
+    name for name, category in _CATEGORY_BY_CHECK.items() if category == "infrastructure"
+)
 
 # Cap on distinct per-check signatures so one catastrophic run (e.g. 40
 # distinct ruff rules) cannot flood the journal entry.
@@ -416,21 +469,23 @@ def split_signature(signature: str) -> tuple[str, str]:
 def category_for_check(check_name: str) -> str:
     """Map a check/gate name to a FailurePattern category.
 
-    An unlisted name falls through to "iteration", which files a Phase 1
-    gate under the engineer loop. Enrolling a new check in
-    ``_CATEGORY_BY_CHECK`` is a convention with no mechanism, and
-    measured on this tree the convention does not hold: AST-walking
-    ``kstrl/`` for ``CheckResult`` names finds ``fixtures``,
-    ``policy_envelope`` and ``test_adequacy`` absent from the table, so
-    three verification gates are already miscategorised here (#315).
-    That predates #294 and correcting it changes recorded
-    categorisation, so it is not that change's to make.
+    An unlisted name falls through to "iteration", which files a gate
+    under the engineer loop. Enrolling a new check in
+    ``_CATEGORY_BY_CHECK`` was a convention with no mechanism, and
+    measured during #294 the convention did not hold for eight of the
+    nineteen names ``kstrl/`` emits. All eight are enrolled as of #315,
+    four of them into the ``"infrastructure"`` category that had to be
+    invented to hold them, and nothing is grandfathered any more.
 
     ``tests/test_check_name_enrolment.py`` is the mechanism: it
-    AST-walks ``kstrl/`` for every constructed check name and fails on
-    one this table does not carry, with those three grandfathered by
-    name so the gate could land without the behaviour change. A new
-    check cannot join them quietly.
+    AST-walks ``kstrl/`` for every constructed check name and every
+    ``signatures=["<prefix>:<code>"]`` literal, and fails on one this
+    table does not carry. A new gate cannot reach the journal
+    uncategorised.
+
+    The answer is computed here, at read time, and never stored in the
+    journal, so a correction to the table also corrects what
+    ``ks evolve`` reports about runs that already happened.
     """
     return _CATEGORY_BY_CHECK.get(check_name, "iteration")
 
@@ -676,7 +731,7 @@ class EvolutionJournal:
                 comp_signatures = list(failure_signatures.get(comp.id) or [])
                 if not comp_signatures:
                     # Legacy fallback: classify the flattened string.
-                    legacy_check, _ = _classify_check(comp.error)
+                    legacy_check = _classify_check(comp.error)
                     legacy_sig = _normalize_error(comp.error)
                     if legacy_sig:
                         comp_signatures = [f"{legacy_check}:{legacy_sig}"]
@@ -759,12 +814,7 @@ class EvolutionJournal:
                 continue
             sigs = list(failure_signatures.get(comp.id) or [])
             if not sigs:
-                sigs = [
-                    signature_for_error(
-                        _classify_check(comp.error)[0],
-                        comp.error,
-                    )
-                ]
+                sigs = [signature_for_error(_classify_check(comp.error), comp.error)]
             for sig in sigs:
                 failure_sigs[sig] = failure_sigs.get(sig, 0) + 1
         common_failure = max(failure_sigs, key=failure_sigs.get, default="") if failure_sigs else ""  # type: ignore[arg-type]
@@ -847,7 +897,7 @@ class EvolutionJournal:
                 continue
             sigs = list(signatures_by_component.get(comp.id) or [])
             if not sigs:
-                legacy_check, _ = _classify_check(comp.error)
+                legacy_check = _classify_check(comp.error)
                 legacy_sig = _normalize_error(comp.error)
                 if not legacy_sig:
                     continue

--- a/kstrl/pipeline.py
+++ b/kstrl/pipeline.py
@@ -1797,7 +1797,20 @@ class ComponentPipeline:
         comp.completed_at = _iso_now()
         comp.failed_phase = "pr"
         comp.failed_check = "pr_flow"
-        self._record_failure_signatures(comp, "pr", comp.error, None)
+        # Spelled out with keywords, and read that way. #339: this
+        # is the third caller of the funnel and the only one that is
+        # not `fail` / `retry_or_fail`, so no `signatures=` is ever
+        # handed to it and the phase becomes the check name. It was
+        # invisible to every layer of
+        # `tests/test_check_name_enrolment.py`: not a fail call, no
+        # keyword, no colon in "pr" for the spellings net to see.
+        # Mutating "pr" to "bogus_flow" left 4737 tests green.
+        self._record_failure_signatures(
+            comp,
+            phase="pr",
+            error=comp.error,
+            signatures=None,
+        )
         self._end_attempt(comp)
         skipped = self.manifest.cascade_skip(comp.id)
         self.factory_result.failed.append(comp.id)
@@ -2294,6 +2307,39 @@ class ComponentPipeline:
                         "Rejected at HITL checkpoint",
                         phase="pr",
                         check="hitl_reject",
+                        # THE RULE FOR ALL THREE CHECKPOINT BRANCHES,
+                        # stated here and pointed at from the other two.
+                        # Without an explicit `signatures=` the PHASE
+                        # becomes the check name, and `pr` is the row
+                        # that holds push, create and merge plumbing -
+                        # infrastructure since #315, which throws the
+                        # whole run out of the autonomy ladder's
+                        # evidence. So: a branch that carries a VERDICT
+                        # about the change must name it, and a branch
+                        # that carries no verdict must not. A person
+                        # looking at the change and refusing it is the
+                        # most decisive verdict about the factory's
+                        # judgement there is; it reached the journal as
+                        # `pr:rejected-at-hitl-checkpoint`.
+                        #
+                        # The phase stays "pr" because that is the
+                        # vocabulary these branches have always used and
+                        # `failed_phase` is written to the manifest.
+                        # Note it is not where this happens:
+                        # `_phase_started(comp, "pr")` fires below all
+                        # three branches, so by the module's own
+                        # accounting the checkpoint precedes the phase
+                        # it is filed under. Renaming it is a separate
+                        # decision, and #339 review declined to make it
+                        # here because the three branches need three
+                        # different categories, so no one phase name can
+                        # serve them. The mechanism that would remove
+                        # the literals entirely is keying the fallback
+                        # on `check` rather than `phase` - the branches
+                        # already carry hitl_reject / merge_gate /
+                        # hitl_retry - and that is blocked on
+                        # factory.py.
+                        signatures=["review:hitl-rejected"],
                     ),
                     verify=verify,
                     diff=diff,
@@ -2317,6 +2363,11 @@ class ComponentPipeline:
                         "approve with `ks inbox retry <id>`",
                         phase="pr",
                         check="merge_gate",
+                        # #339: deliberately NO signatures=. Nobody
+                        # answered the gate, so there is no verdict to
+                        # record and the `pr` fallback is correct: the
+                        # ladder treats the run as an outage, which is
+                        # what it was. See the rule at hitl_reject above.
                     ),
                     verify=verify,
                     diff=diff,
@@ -2340,6 +2391,11 @@ class ComponentPipeline:
                         ctx.to_json(),
                         phase="pr",
                         check="hitl_retry",
+                        # #339: a human asking for changes is a verdict
+                        # ON the change, so it names one. Same rule as
+                        # hitl_reject above, and it had the same defect
+                        # until this round.
+                        signatures=["review:hitl-changes-requested"],
                     ),
                     verify=verify,
                     diff=diff,

--- a/tests/helpers/astfold.py
+++ b/tests/helpers/astfold.py
@@ -1,0 +1,392 @@
+"""Fold a ``kstrl/`` expression to the string it is KNOWN to evaluate to.
+
+Shared by the two guards over the journal's failure signatures -
+``tests/test_check_name_enrolment.py``, which resolves the four
+producers and asserts the category table carries what they emit, and
+``tests/test_signature_spellings.py``, which enumerates no node types
+and pins every signature-shaped string in the package. They ask
+different questions of the same folding, and #339 review is the reason
+there is only one copy of it.
+
+Not ``tests.test_journal_one_writer.folded_str``, which answers a
+narrower question with the same word. That one is strict: any
+undecidable piece makes the whole answer ``None``, and a bare ``Name``
+is always undecidable, because it is looking for a filename and a
+partial filename is not one. A check name is a PREFIX, so a partial
+answer is often a complete one - ``f"contract:tier_{n}"`` names its
+check as plainly as a literal does - and package-level constants have to
+resolve, because ``verify`` builds its gate names out of
+``gateparse.GATE_TEST``. Hence :data:`HOLE` and :class:`Folded`.
+
+That is a difference in the ANSWER, not in the rules, and #339 review
+measured how small it is: over the 22,738 ``kstrl/`` expressions
+containing no ``ast.Name``, ``folded_str`` and a strict reading of
+``fold`` (``None`` whenever the result carries a :data:`HOLE`) agree on
+every one, and over all 119,605 expressions the only 471 disagreements
+are the deliberate name-resolution branch. So the strict answer is a
+two-line wrapper over this one and the two SHOULD converge. They are not
+merged here because ``test_journal_one_writer.py`` guards #312 and
+changing what it folds is that guard's own measurement to make, not a
+side effect of a categorisation fix. Read this paragraph as a pointer to
+that work, not as a reason the copies must stay.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+KSTRL_DIR = Path(__file__).resolve().parent.parent.parent / "kstrl"
+
+#: Stands in for a piece of a string the walk cannot decide.
+#:
+#: TWO NULs, not one. #339 review measured the obvious choice wrong:
+#: ``kstrl/`` holds three literals containing a single ``\x00``
+#: (``git.py``, ``pipeline.py``, ``workqueue.py``), so a one-NUL marker
+#: is a claim about the package that the package already contradicts.
+#: A doubled NUL appears in no literal there today, and
+#: ``tests/test_signature_spellings.py`` asserts that rather than
+#: leaving it as a claim - which is the whole standard this file exists
+#: to meet.
+HOLE = "\x00\x00"
+
+
+@dataclass(frozen=True)
+class Folded:
+    """A string expression's value, with a marker for each unknown piece.
+
+    ``text`` is what the interpreter would produce with every
+    undecidable piece replaced by :data:`HOLE`. ``first_hole`` is the
+    expression that produced the leftmost of those, and it is what makes
+    an unknown piece answerable rather than merely flagged: the one
+    consumer that rescues a hole needs the NODE, not the fact that there
+    was one.
+
+    Only the first, measured: 4,496 folds carry a hole, 5,485 holes in
+    all, and no reader can reach any hole but the leftmost, because a
+    check name is what precedes the first colon.
+    """
+
+    text: str
+    first_hole: ast.expr | None
+
+
+def _is_str_constant(node: ast.expr | None) -> bool:
+    return isinstance(node, ast.Constant) and isinstance(node.value, str)
+
+
+def _string_bindings(node: ast.stmt) -> dict[str, str]:
+    """``{name: value}`` for one statement, empty unless it binds a str.
+
+    Handles the annotated form as well as the plain one: ``gateparse``
+    declares ``GATE_TOOLS`` and friends with annotations, so an
+    ``ast.Assign``-only reader would silently drop a check name and
+    leave this whole module passing vacuously.
+    """
+    if isinstance(node, ast.AnnAssign):
+        if isinstance(node.target, ast.Name) and _is_str_constant(node.value):
+            return {node.target.id: node.value.value}  # type: ignore[union-attr]
+        return {}
+    if not isinstance(node, ast.Assign) or not _is_str_constant(node.value):
+        return {}
+    return {t.id: node.value.value for t in node.targets if isinstance(t, ast.Name)}  # type: ignore[attr-defined]
+
+
+def called_name(func: ast.expr) -> str:
+    """The bare callable name, through an attribute access.
+
+    ``verify.CheckResult(...)`` and ``CheckResult(...)`` are the same
+    construction to this walk. No call site uses the qualified form
+    today, which is exactly why an ``ast.Name``-only reader would not
+    fail when one is added.
+    """
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+@lru_cache(maxsize=1)
+def parsed_modules() -> tuple[tuple[str, ast.Module], ...]:
+    """Every ``kstrl/`` module, parsed once for the whole session.
+
+    Measured before caching: the census re-parsed all 124 files on each
+    of its five calls and parsed the package a second time inside the
+    constant collector, costing 1.52 s, about 70 percent of the
+    scope-related test files' total runtime.
+    """
+    return tuple(
+        (str(path.relative_to(KSTRL_DIR.parent)), ast.parse(path.read_text(encoding="utf-8")))
+        for path in sorted(KSTRL_DIR.rglob("*.py"))
+    )
+
+
+def _positional_parameters(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """A function's positional parameters, receiver excluded.
+
+    Excluded so the answer indexes a call's ``args`` directly: the
+    receiver of ``self.fail(...)`` is in ``node.func``, not in
+    ``node.args``.
+    """
+    names = [a.arg for a in (*node.args.posonlyargs, *node.args.args)]
+    return names[1:] if names[:1] in (["self"], ["cls"]) else names
+
+
+def _annotated_fields(node: ast.ClassDef) -> list[str]:
+    """A dataclass's fields, in the order its constructor takes them."""
+    return [
+        stmt.target.id
+        for stmt in node.body
+        if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+    ]
+
+
+@lru_cache(maxsize=1)
+def _positional_parameters_by_name() -> dict[str, list[list[str]]]:
+    """Every definition in ``kstrl/``, as ``name -> parameter lists``.
+
+    ONE pass, indexed, rather than a walk per question. #339 review
+    measured the per-key version at 6 cache misses in a four-file run,
+    each re-walking all 127 modules to find one ``def``: 241 ms on a
+    quiet machine and 581 ms under load, of which 124 ms landed inside
+    ``_census`` alone. This pass costs 58 ms once for all 1,775 names
+    and is flat in the number of questions asked.
+
+    A LIST of parameter lists per name, not one: two definitions can
+    share a name, and which of them a call site meant is exactly what
+    :func:`parameter_index` refuses to guess.
+    """
+    found: dict[str, list[list[str]]] = {}
+    for _rel, tree in parsed_modules():
+        for node in ast.walk(tree):
+            name = getattr(node, "name", None)
+            if not isinstance(name, str):
+                continue
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                found.setdefault(name, []).append(_positional_parameters(node))
+            elif isinstance(node, ast.ClassDef):
+                found.setdefault(name, []).append(_annotated_fields(node))
+    return found
+
+
+def parameter_index(name: str, parameter: str) -> int | None:
+    """Where ``parameter`` sits positionally in ``name``'s definition.
+
+    Read off the ``def`` (or the dataclass body), never written down.
+    #339 review measured the hand-written version: four integers next to
+    a walk that parses the very tree that states them, and six of eight
+    off-by-one mutations to them left the guards green. An index is a
+    FACT about the definition, so deriving it deletes both the integers
+    and the argument for what they should be.
+
+    ``None`` when no ``kstrl/`` definition of that name has the
+    parameter, or when two definitions disagree about where it sits. The
+    first is what keeps ``feature_cmd``'s one-argument local ``fail``
+    out of the census by construction rather than by a special case; the
+    second is the safe end of an ambiguity, because a guard that guessed
+    between two positions would read the wrong argument and report a
+    confident wrong name.
+    """
+    positions = {
+        names.index(parameter)
+        for names in _positional_parameters_by_name().get(name, ())
+        if parameter in names
+    }
+    return positions.pop() if len(positions) == 1 else None
+
+
+@lru_cache(maxsize=1)
+def module_level_strings() -> dict[str, dict[str, str]]:
+    """Module-level ``NAME = "literal"`` bindings, keyed by module."""
+    return {
+        rel: {k: v for node in tree.body for k, v in _string_bindings(node).items()}
+        for rel, tree in parsed_modules()
+    }
+
+
+def unambiguous_pool(per_module: dict[str, dict[str, str]]) -> dict[str, str]:
+    """Constants that mean ONE thing across the whole package.
+
+    A check name is usually defined in one module and used in another:
+    ``verify`` builds its gates from ``gateparse.GATE_TEST``. So the
+    walk cannot resolve names against the using module alone. Pooling
+    every module's constants into one flat dict is the obvious fix and
+    is wrong in a way nothing would report: two modules binding the same
+    name to different values would resolve to whichever file sorts last,
+    silently attributing one module's check name to another's.
+
+    So a name is poolable only when every definition of it agrees. A
+    genuinely ambiguous name resolves to nothing and, if it is a check
+    name, surfaces as a blind site rather than as the wrong answer.
+    There are no collisions today; this is here so the walk has a reason
+    to be correct rather than a coincidence.
+    """
+    values: dict[str, set[str]] = {}
+    for constants in per_module.values():
+        for name, value in constants.items():
+            values.setdefault(name, set()).add(value)
+    return {name: next(iter(v)) for name, v in values.items() if len(v) == 1}
+
+
+@lru_cache(maxsize=1)
+def pool() -> dict[str, str]:
+    return unambiguous_pool(module_level_strings())
+
+
+def _fold_part(node: ast.expr, own: dict[str, str]) -> Folded:
+    """A piece of a larger string: never ``None``, a hole at worst."""
+    folded = fold(node, own)
+    return folded if folded is not None else Folded(HOLE, node)
+
+
+def _fold_join(nodes: list[ast.expr], own: dict[str, str]) -> Folded:
+    parts = [_fold_part(n, own) for n in nodes]
+    return Folded(
+        "".join(p.text for p in parts),
+        next((p.first_hole for p in parts if p.first_hole is not None), None),
+    )
+
+
+def _fold_name(node: ast.Name, own: dict[str, str]) -> Folded | None:
+    """A module-level string constant, defining module first."""
+    value = own.get(node.id) or pool().get(node.id)
+    return Folded(value, None) if value is not None else None
+
+
+def _fold_placeholder(node: ast.FormattedValue, own: dict[str, str]) -> Folded:
+    """``!r`` and a format spec both change the result, so only the plain
+    placeholder folds; the rest is a hole, not a guess."""
+    if node.conversion == -1 and node.format_spec is None:
+        return _fold_part(node.value, own)
+    return Folded(HOLE, node)
+
+
+def _fold_concat(node: ast.BinOp, own: dict[str, str]) -> Folded | None:
+    """``"check" + ":code"``, and nothing else that uses an operator.
+
+    At least one side has to be evidently a string, or ``a + b`` on two
+    unknowns would fold to two holes and read as a string expression.
+
+    Measured: 125 ``BinOp``/``Add`` nodes in ``kstrl/`` fold, and none of
+    them is a signature today, so this branch is here for the shape
+    rather than for a site. ``tests/test_signature_spellings.py`` has a
+    fixture for it, because a branch nothing exercises is a branch
+    nobody knows is broken - and a concatenation is exactly what
+    somebody writes to get past a string search (#327 F9).
+    """
+    if not isinstance(node.op, ast.Add):
+        return None
+    if fold(node.left, own) is None and fold(node.right, own) is None:
+        return None
+    return _fold_join([node.left, node.right], own)
+
+
+def fold(node: ast.AST, own: dict[str, str]) -> Folded | None:
+    """What this expression is known to evaluate to, or ``None``.
+
+    ``None`` means "not evidently a string expression at all", which is
+    a different answer from "a string with an unknown piece" - the
+    latter is a :data:`HOLE`. Only the shapes that can be decided
+    without an interpreter are handled; a call, a subscript, a
+    ``%``-format or a ``.join`` is ``None`` here and the caller records
+    a blind site rather than pretending.
+
+    Split across five functions for the same reason
+    ``test_journal_one_writer.folded_str`` is split across four: the
+    recursion costs 18 on the cognitive gate in one, and that hook fails
+    rather than advises.
+    """
+    if isinstance(node, ast.Constant):
+        return Folded(node.value, None) if isinstance(node.value, str) else None
+    if isinstance(node, ast.Name):
+        return _fold_name(node, own)
+    if isinstance(node, ast.JoinedStr):
+        return _fold_join(node.values, own)
+    if isinstance(node, ast.FormattedValue):
+        return _fold_placeholder(node, own)
+    if isinstance(node, ast.BinOp):
+        return _fold_concat(node, own)
+    return None
+
+
+#: What a journal signature looks like. The head is a check name, so it
+#: is a lower-case identifier; the code is a ``signature_slug`` (lower
+#: alphanumerics and hyphens), a linter rule, or a ``Finding.category``,
+#: and it may carry further colons - ``pr:coverage-unverified:no-diffstat``
+#: is real. Whitespace and path separators are what this excludes, which
+#: is what keeps ordinary prose, URLs and traceback lines out. A
+#: :data:`HOLE` is allowed in the CODE and never in the head.
+_SIGNATURE_SHAPE = re.compile(r"[a-z][a-z0-9_]*:[A-Za-z0-9_.:\x00-]+")
+
+
+def folded_nodes(tree: ast.AST, own: dict[str, str]) -> Iterator[Folded]:
+    """Every subexpression of ``tree`` that folds to a string.
+
+    One walk for both guards. #339 review found them shipping a copy
+    each - the net in ``tests/test_signature_spellings.py`` and
+    ``_names_in`` in ``tests/test_check_name_enrolment.py`` - which is
+    the exact "two copies that can be widened apart" hazard this module
+    was created to remove, reintroduced inside the same change. The
+    enrolment guard's extra step, rescuing an unresolved head from the
+    call sites, layers on top of the yielded value rather than needing a
+    walk of its own.
+    """
+    for node in ast.walk(tree):
+        folded = fold(node, own)
+        if folded is not None:
+            yield folded
+
+
+def signature_head(folded: Folded) -> str | None:
+    """The check name of a folded signature, or ``None``.
+
+    ``split_signature`` takes everything before the FIRST colon, so the
+    code being unknown costs nothing: ``f"contract:tier_{n}"`` names its
+    check as plainly as a literal does, and the walk this replaces
+    folded it to nothing because one piece was unknown.
+    """
+    if not _SIGNATURE_SHAPE.fullmatch(folded.text):
+        return None
+    head = folded.text.partition(":")[0]
+    return None if HOLE in head else head
+
+
+@dataclass(frozen=True)
+class Scope:
+    """One node's enclosing function, and the dotted path naming it."""
+
+    qualname: str
+    function: ast.FunctionDef | ast.AsyncFunctionDef | None
+
+
+def scoped_nodes(tree: ast.Module) -> Iterator[tuple[ast.AST, Scope]]:
+    """Every node of one module, paired with the function enclosing it.
+
+    A generator rather than the ``{id(node): Scope}`` map this started
+    as. #339 review measured that map at 159,548 entries across the
+    package to answer 71 questions, and it cost more than the memory: it
+    needed a paragraph arguing that no node is collected underneath it
+    so no id is reused, and a ``.get(..., <module scope>)`` fallback at
+    every call site that could not fire. Yielding the pair deletes the
+    dict, the id keying, the argument and the fallbacks.
+    """
+
+    def descend(
+        node: ast.AST, path: tuple[str, ...], scope: Scope
+    ) -> Iterator[tuple[ast.AST, Scope]]:
+        for child in ast.iter_child_nodes(node):
+            yield child, scope
+            if isinstance(child, ast.ClassDef):
+                yield from descend(child, path + (child.name,), scope)
+            elif isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                inner = Scope(".".join(path + (child.name,)), child)
+                yield from descend(child, path + (child.name,), inner)
+            else:
+                yield from descend(child, path, scope)
+
+    yield from descend(tree, (), Scope("<module>", None))

--- a/tests/helpers/astfold.py
+++ b/tests/helpers/astfold.py
@@ -82,10 +82,18 @@ def _is_str_constant(node: ast.expr | None) -> bool:
 def _string_bindings(node: ast.stmt) -> dict[str, str]:
     """``{name: value}`` for one statement, empty unless it binds a str.
 
-    Handles the annotated form as well as the plain one: ``gateparse``
-    declares ``GATE_TOOLS`` and friends with annotations, so an
-    ``ast.Assign``-only reader would silently drop a check name and
-    leave this whole module passing vacuously.
+    Handles the annotated form as well as the plain one. #339 review
+    measured what that is worth today and the honest answer is nothing:
+    ``kstrl/`` has three module-level annotated string constants
+    (``agents/base.ARCHITECT_ROLE``, ``names.ROLE_KEY_PREFIX``,
+    ``serve.SPAWNED_RUN_KIND``) and none is a check name, so deleting
+    the branch leaves the census identical. An earlier version of this
+    docstring claimed ``gateparse`` needed it; ``gateparse`` declares
+    ``GATE_TEST`` and friends with a plain ``ast.Assign``. The branch
+    stays because ``ast.Assign``-only readers are a logged defect class
+    in this repo (``assignment_parts`` in
+    ``tests/test_journal_one_writer.py`` carries the same note for the
+    same reason), but it is future-proofing, not a live requirement.
     """
     if isinstance(node, ast.AnnAssign):
         if isinstance(node.target, ast.Name) and _is_str_constant(node.value):
@@ -353,7 +361,7 @@ def signature_head(folded: Folded) -> str | None:
     if not _SIGNATURE_SHAPE.fullmatch(folded.text):
         return None
     head = folded.text.partition(":")[0]
-    return None if HOLE in head else head
+    return head
 
 
 @dataclass(frozen=True)

--- a/tests/helpers/replay.py
+++ b/tests/helpers/replay.py
@@ -1,0 +1,61 @@
+"""One builder for the ``RunRecord``s the ladder tests replay.
+
+``tests/helpers/journal.py`` already states the rule this exists to
+follow: the record builders live here when more than one file needs the
+same records. #339 review measured five hand-rolled builders across two
+files, one of them byte-for-byte identical to another, so a tenth field
+on ``RunRecord`` would have been a five-place edit.
+
+Kwargs-override rather than one function per shape, because the shapes
+differ in one or two fields and naming each combination is how five
+builders happened in the first place. The defaults describe a run that
+merged one component and failed nothing.
+"""
+
+from __future__ import annotations
+
+from kstrl.autonomy_replay import RunRecord
+
+
+def run_record(**overrides: object) -> RunRecord:
+    """A ``RunRecord`` with the given fields, defaults for the rest."""
+    fields: dict[str, object] = {
+        "run_id": "r1",
+        "timestamp": "2026-07-20T00:00:00Z",
+        "project": "demo",
+        "components_total": 1,
+        "completed": 1,
+        "failed": 0,
+        "skipped": 0,
+        "retry_rate": 0.0,
+        "common_failure": "",
+    }
+    fields.update(overrides)
+    return RunRecord(**fields)  # type: ignore[arg-type]
+
+
+def clean_run(index: int) -> RunRecord:
+    """One run that merged a component and failed nothing.
+
+    Distinct timestamps because a replay reports the run a promotion
+    would have fired on, and a report that names the same instant twelve
+    times is unreadable.
+    """
+    return run_record(
+        run_id=f"r{index}",
+        timestamp=f"2026-07-{(index % 28) + 1:02d}T00:00:00Z",
+        project="p",
+    )
+
+
+def failing_run(signature: str) -> RunRecord:
+    """One run that merged nothing and failed on ``signature``."""
+    return run_record(
+        run_id="bad",
+        timestamp="2026-07-28T00:00:00Z",
+        project="p",
+        completed=0,
+        failed=1,
+        retry_rate=1.0,
+        common_failure=signature,
+    )

--- a/tests/test_autonomy_ladder.py
+++ b/tests/test_autonomy_ladder.py
@@ -28,8 +28,9 @@ from kstrl.autonomy import (
     flag_bundle_for,
     manual_override_notes,
 )
-from kstrl.autonomy_replay import RunRecord, load_runs, replay, replay_file
+from kstrl.autonomy_replay import load_runs, replay, replay_file
 from tests.helpers.component_prd import write_component_prd
+from tests.helpers.replay import clean_run, failing_run, run_record
 
 
 def _eligible_state(level: AutonomyLevel = AutonomyLevel.L1_SUPERVISED) -> AutonomyState:
@@ -357,20 +358,10 @@ class TestConfig:
 # --------------------------------------------------------------------------
 # Threshold replay
 # --------------------------------------------------------------------------
-def _run(**kwargs: object) -> RunRecord:
-    base = dict(
-        run_id="r1",
-        timestamp="2026-07-20T00:00:00Z",
-        project="demo",
-        components_total=1,
-        completed=1,
-        failed=0,
-        skipped=0,
-        retry_rate=0.0,
-        common_failure="",
-    )
-    base.update(kwargs)
-    return RunRecord(**base)  # type: ignore[arg-type]
+#: #339: the defaults moved to ``tests/helpers/replay.py`` when a second
+#: file needed the same records and hand-rolled them, one of them
+#: byte-for-byte identical to ``_clean`` below.
+_run = run_record
 
 
 class TestReplay:
@@ -948,19 +939,7 @@ class TestPromotionAuthority:
 class TestReplayAdvancesLevels:
     """The replay must traverse levels, not re-report the same eligibility."""
 
-    @staticmethod
-    def _clean(index: int) -> RunRecord:
-        return RunRecord(
-            run_id=f"r{index}",
-            timestamp=f"2026-07-{(index % 28) + 1:02d}T00:00:00Z",
-            project="p",
-            components_total=1,
-            completed=1,
-            failed=0,
-            skipped=0,
-            retry_rate=0.0,
-            common_failure="",
-        )
+    _clean = staticmethod(clean_run)
 
     def test_level_advances_past_l1(self) -> None:
         report = replay([self._clean(i) for i in range(12)])
@@ -978,19 +957,7 @@ class TestReplayAdvancesLevels:
 
     def test_demotes_after_reaching_a_higher_level(self) -> None:
         runs = [self._clean(i) for i in range(60)]
-        runs.append(
-            RunRecord(
-                run_id="bad",
-                timestamp="2026-07-28T00:00:00Z",
-                project="p",
-                components_total=1,
-                completed=0,
-                failed=1,
-                skipped=0,
-                retry_rate=1.0,
-                common_failure="review:prd_criterion",
-            )
-        )
+        runs.append(failing_run("review:prd_criterion"))
         report = replay(runs)
         assert report.would_demote
         assert report.final_level == int(AutonomyLevel.L3_ENVELOPED_AUTO)

--- a/tests/test_check_name_enrolment.py
+++ b/tests/test_check_name_enrolment.py
@@ -13,69 +13,108 @@ This is the mechanism, in the shape the repo already uses three times
 that can reach ``category_for_check`` and fail on one the table does not
 carry.
 
-Three things the walk learned the hard way, each after a version of it
-claimed to be complete:
+FOUR PRODUCERS, each found after a version of this file claimed to have
+them all. A component's failure signatures are whatever ends up in
+``pipeline.component_failure_signatures``, and that mapping is written
+from four places:
 
-- It resolves module-level string constants, not just literals, across
-  module boundaries but only where a name means one thing package-wide.
-  The
-  first version matched literals only and its anti-vacuity test caught
-  that it saw NONE of ``test_suite``, ``typecheck`` or ``linter``: those
-  name themselves through ``gateparse.GATE_TEST`` and reach
-  ``CheckResult`` via ``verify._failed_gate_result``. A guard that
-  misses the three most important gates is worse than no guard, because
-  it reads as covered. Annotated constants (``NAME: str = "..."``) count
-  too, because ``gateparse`` already uses that form.
-- It reads ``signatures=["<prefix>:<code>"]`` literals as well as check
-  names. Those prefixes go through the same ``split_signature`` ->
-  ``category_for_check`` path, and five of them were unenrolled while
-  the first version of this module claimed "no NEW check can join it
-  quietly". That claim was false for every failure recorded outside a
-  ``CheckResult``.
-- It resolves the ``phase=`` of a failure recorded with NEITHER of the
-  above (:func:`_phase_fallback_name`), which is how
-  ``provisioning:worktree-setup-failed`` sat unenrolled through two
-  rounds of this module claiming to have found every producer.
+- a ``CheckResult`` name, which ``evolution.signatures_from_verification``
+  turns into ``"<name>:<code>"``.
+- a ``signatures=["<check>:<code>"]`` argument, handed straight to
+  ``PhaseFailure`` and never through a ``CheckResult``.
+- the ``phase`` of a failure recorded with NEITHER of those, because
+  ``pipeline._record_failure_signatures`` falls back to
+  ``signature_for_error(phase or "unknown", error)``. Censused at that
+  funnel AND at the two entry points that call it, ``fail`` and
+  ``retry_or_fail``, because the phase is a literal at their call sites
+  and a parameter inside them. #339 review is why the funnel is in that
+  list: keying on the two entry points alone missed ``_fail_pr_flow``,
+  which calls the funnel directly, and mutating its ``"pr"`` to
+  ``"bogus_flow"`` left 4737 tests green.
+- a direct ``component_failure_signatures[comp] = [...]`` assignment,
+  which bypasses ``_record_failure_signatures`` altogether. Four sites,
+  in ``factory`` and ``pipeline``, invisible to every earlier version of
+  this walk because none of them is a call.
+
+THE RESOLUTION IS SEPARATE FROM THE DETECTION, which is the correction
+#339 review made to this file. Detecting a producer site and reading the
+name out of it are two jobs, and folding them into one meant a site
+whose name would not resolve was DROPPED - silently, in the skip
+direction #324 is about. Now a site that resolves feeds the census and a
+site that does not feeds :data:`BLIND_SITES`, which is pinned. Measured
+on the branch that added this: eight of nine shape mutations survived
+the old walk, including ``phase="review"`` at the coverage-refusal call
+site, which two reviewers found independently.
+
+TWO LAYERS, borrowed from #336 (which landed on main as
+``tests/test_event_names_have_one_home.py``, after this branch was cut),
+where widening a matcher was measured to be necessary but not
+sufficient: seven ordinary shapes walked past the widened version. The
+numbering is #336's, so a reader following the citation finds the same
+two things under the same two labels.
+
+- LAYER 1 is ``tests/test_signature_spellings.py``: a net that
+  enumerates no node types at all and pins every expression in
+  ``kstrl/`` whose folded value has the shape of a journal signature,
+  by module. It cannot say what a new spelling MEANS, so it is a pinned
+  inventory rather than an assertion, and it is what catches a producer
+  in a container nothing here has thought of.
+- LAYER 2 is this file: the four producers above, named, resolved, and
+  asserted against the table. It gives the right message ("add a row to
+  ``_CATEGORY_BY_CHECK``") and it names the offending site.
+
+A THIRD file holds this one from the other side.
+``tests/test_signature_spellings.py`` pins what is IN the package;
+``tests/test_check_name_shapes.py`` feeds the two matchers below a
+snippet per shape and pins what they SAY, including the shapes they say
+nothing about. #339 review is why it exists: :data:`BLIND_SITES`
+inventories this walk's own resolution failures, which is a strictly
+smaller set than the producer shapes that exist, so a shape the matchers
+do not enumerate is not a blind site - it is silence. That is exactly
+how ``_fail_pr_flow`` survived.
+
+Both layers fold expressions with ``tests/helpers/astfold.py``, which is
+where the string-folding lives so there is one copy of it rather than
+two that can be widened apart.
 
 What the walk CANNOT see, stated rather than left as a silent gap:
-``evolution.signatures_from_findings`` composes ``"<phase>:<category>"``
-from a runtime ``phase`` argument, so the ``security`` and ``contract``
-prefixes appear in no literal anywhere in ``kstrl/``, and neither do
-``verification`` and ``unknown``, which only ever come back out of
-``evolution._classify_check``. They are enrolled today, and
-:data:`ENROLLED_BUT_INVISIBLE` plus
+``evolution._classify_check`` RETURNS ``verification`` and ``unknown``
+for a legacy flattened error string, so no call site anywhere carries
+them. They are enrolled today, and :data:`ENROLLED_BUT_INVISIBLE` plus
 :meth:`TestEveryCheckNameIsEnrolled.test_the_walk_covers_every_enrolled_name_but_these`
 say so by measurement rather than by claim.
 
-That second test is the one aimed at this repo's dominant defect (#324):
-a guard that goes BLIND rather than red. Every miss logged there is in
-the skip direction - a refactor moves a name out of the shape the
-matcher recognises, the matcher sees fewer sites and reports clean. This
-file has already been bitten once, by #306. So the walk is now pinned
-from both ends: an emitted name the table does not carry fails, AND an
-enrolled name the walk stops seeing fails.
-
-#315 emptied the grandfathered set this module shipped with. All eight
-names it carried are enrolled, four of them into the ``infrastructure``
-category invented to hold them, and the two the widened walk then
-surfaced are enrolled too. The guard has no exceptions left, which is a
-claim it made once before while a whole producer was invisible to it, so
-read it as "no exception this walk can see" and keep asking what it
-cannot.
+That test is the one aimed at this repo's dominant defect (#324): a
+guard that goes BLIND rather than red. Every miss logged there is in the
+skip direction - a refactor moves a name out of the shape the matcher
+recognises, the matcher sees fewer sites and reports clean. This file
+has already been bitten once, by #306, and once more by #339. So the
+walk is pinned from three ends: an emitted name the table does not carry
+fails, an enrolled name the walk stops seeing fails, and a producer site
+whose name the walk cannot read is enumerated rather than dropped.
 """
 
 from __future__ import annotations
 
 import ast
-from functools import lru_cache
-from pathlib import Path
+from collections.abc import Iterator
+from functools import cache, lru_cache
 
-import pytest
-
-from kstrl.autonomy_replay import INFRA_FAILURE_PREFIXES, RunRecord
-from kstrl.evolution import _CATEGORY_BY_CHECK, INFRASTRUCTURE_CHECKS
-
-KSTRL_DIR = Path(__file__).resolve().parent.parent / "kstrl"
+from kstrl.evolution import _CATEGORY_BY_CHECK
+from tests.helpers.astfold import (
+    HOLE,
+    Folded,
+    Scope,
+    called_name,
+    fold,
+    folded_nodes,
+    module_level_strings,
+    parameter_index,
+    parsed_modules,
+    scoped_nodes,
+    signature_head,
+    unambiguous_pool,
+)
 
 #: Calls whose first argument (or ``name=``) is a check name.
 #: ``CheckResult`` is the type itself; ``_failed_gate_result`` is the
@@ -83,21 +122,63 @@ KSTRL_DIR = Path(__file__).resolve().parent.parent / "kstrl"
 #: through.
 CHECK_NAME_CALLS = frozenset({"CheckResult", "_failed_gate_result"})
 
-#: Calls that record a component failure. When one carries no
-#: ``signatures=``, its ``phase=`` becomes the check name. See
-#: :func:`_phase_fallback_name`.
-PHASE_FALLBACK_CALLS = frozenset({"fail", "retry_or_fail"})
+#: Calls that put a ``phase`` on the path to the fallback, and where each
+#: one's ``phase`` sits among its positional arguments (the receiver not
+#: counted). When no truthy ``signatures`` travels with it, that phase
+#: becomes the check name.
+#:
+#: ``_record_failure_signatures`` is the FUNNEL - ``fail`` and
+#: ``retry_or_fail`` both call it, and it is where the fallback actually
+#: lives - so it is keyed here alongside the two public entry points, in
+#: the shape ``tests/test_journal_one_writer.py`` uses when it keys on
+#: ``append_entries`` being the only writer. #339 review is why: keying
+#: on the two entry points alone missed ``_fail_pr_flow``, a third caller
+#: of the funnel that reaches it directly, and mutating its phase to
+#: ``"bogus_flow"`` left 4737 tests green. The two entry points stay
+#: because they are where the phase is a LITERAL and can be read; the
+#: funnel's own two internal callers pass a parameter through and land in
+#: :data:`BLIND_SITES`, which is the point of having that ledger.
+#:
+#: ``PhaseFailure`` is not a call that records anything - it is the typed
+#: carrier ``_route_failure`` unpacks into ``fail`` / ``retry_or_fail`` -
+#: but its ``phase`` reaches the fallback by exactly the same route, and
+#: ``_route_failure`` hands on ``failure.phase``, which the walk cannot
+#: read. Keyed here so the ten construction sites are censused where the
+#: phase is a literal. Measured: it changes neither the names nor the
+#: blind sites today, because every phase it spells is one another site
+#: already gives. ``tests/test_check_name_shapes.py`` is what holds it,
+#: and an eleventh site with a new phase is what it is for.
+#:
+#: A NAME set, not a name-to-index table. The previous version of this
+#: wrote the positional index of each ``phase`` by hand, and #339 review
+#: measured what that bought: six of eight off-by-one mutations to those
+#: four integers left every guard green, because all but one call site
+#: passes ``phase`` by keyword. The index is a fact about the
+#: definition, so :func:`astfold.parameter_index` reads it off the
+#: ``def``, and it also keeps ``feature_cmd``'s one-argument local
+#: ``fail`` out of the census BY CONSTRUCTION - that definition has no
+#: ``phase`` parameter - rather than by the special case the integers
+#: needed a paragraph to defend.
+PHASE_FALLBACK_CALLS = frozenset(
+    {
+        "_record_failure_signatures",
+        "fail",
+        "retry_or_fail",
+        "PhaseFailure",
+    }
+)
+
+#: The container the fourth producer writes into directly.
+#: ``pipeline.component_failure_signatures`` and the local
+#: ``component_failure_signatures`` ``factory`` hands it are the same
+#: mapping under two spellings, so the suffix is what is matched.
+SIGNATURE_CONTAINER_SUFFIX = "failure_signatures"
+
 
 #: Enrolled names the walk provably cannot see, with the reason each is
 #: invisible. Anything else in the table must be reachable by the walk,
 #: or the walk has gone blind and says nothing (#324).
 ENROLLED_BUT_INVISIBLE = {
-    # signatures_from_findings composes "<phase>:<category>" from a
-    # runtime argument. "review" is NOT here: pipeline also emits
-    # "review:divergence" and friends as literals, so the walk does see
-    # that one, and claiming otherwise would excuse a real blind spot.
-    "security": "composed from a runtime phase argument",
-    "contract": "composed from a runtime phase argument",
     # _classify_check RETURNS these for a legacy flattened error string.
     # They are never arguments, so no call site carries them.
     "verification": "returned by _classify_check, never passed to a call",
@@ -147,186 +228,396 @@ EXPECTED_CATEGORIES = {
     "contract": "contract",
 }
 
+#: Producer sites the walk DETECTS but whose check name it cannot read,
+#: as ``(module, enclosing qualname, expression, why)``. Pinned by
+#: ``TestTheBlindSitesAreEnumerated.test_the_ledger_is_exactly_these_sites``,
+#: so a new one is a red test and a resolved one is a red test too.
+#:
+#: The standard is ``tests/test_journal_one_writer.py``: "The test below
+#: asserts that miss, so this disclosure fails if it stops being true."
+#: A disclosure with no test behind it is how #339 review found this
+#: file claiming "a new gate cannot reach the journal uncategorised"
+#: while a whole producer was invisible to it.
+#:
+#: WHAT THIS LEDGER DOES NOT CLOSE, said plainly because the resemblance
+#: to its precedent is misleading. ``EXPECTED_JOURNAL_PATH_SITES`` in
+#: ``tests/test_journal_one_writer.py`` inventories every place the
+#: resource is OBTAINED, so a new way of obtaining it lands in the list
+#: whatever it looks like: closed by construction. This inventories the
+#: places the walk GAVE UP, which is a different quantity. It is closed
+#: only over the producer shapes ``_name_sites`` and ``_signature_sites``
+#: already enumerate. A producer written in a shape neither of them
+#: matches is not resolved AND not recorded here: it is silence, and the
+#: ledger staying the same length is not evidence of anything.
+#:
+#: That is not hypothetical - it is how ``pipeline._fail_pr_flow``
+#: survived two review rounds. #324 is the tracking item that closes the
+#: class properly, by giving every guard in this repo one shared AST
+#: walker instead of a hand-rolled matcher each; this file is the tenth
+#: instance of that defect and should be retired onto it rather than
+#: widened again.
+#:
+#: ``tests/test_signature_chokepoint.py`` is the one pin in this story
+#: that DOES have the precedent's guarantee, and it is the answer to the
+#: paragraph above until #324 lands: a check name cannot reach
+#: ``category_for_check`` without touching a ``*failure_signatures``
+#: name, and it pins all five such sites. Measured: a new writer
+#: reaching the mapping through a local alias, with a signature the fold
+#: cannot read, is invisible to the census, to this ledger, to
+#: ``tests/test_check_name_shapes.py`` and to the spellings net, and
+#: fails that pin alone.
+#:
+#: No line numbers: they rot on every edit above them and would make
+#: this list a thing to be regenerated rather than read. The expression
+#: text is what pins the site, so changing what a blind site computes is
+#: a red test.
+#: Every row today is a PASS-THROUGH or a RUNTIME COMPOSER, which is
+#: the shape of an acceptable blind site: the string is decided
+#: somewhere the walk does read, and the row says where. A site whose
+#: name is decided HERE and cannot be read is not acceptable, and there
+#: are none left - the last one was ``_coverage_failure``, resolved by
+#: :func:`_from_the_callers`.
+BLIND_SITES: tuple[tuple[str, str, str, str], ...] = (
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline._phase_verify",
+        "signatures_from_verification(verification.checks)",
+        "composed at run time from the CheckResult names the gates built; "
+        "those names are censused at their CheckResult call sites",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline._record_failure_signatures",
+        "list(signatures)",
+        "pass-through: re-emits what fail/retry_or_fail was handed, censused at those call sites",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline._record_failure_signatures",
+        "signature_for_error(phase or 'unknown', error)",
+        "the phase= fallback itself; the phase is censused at the "
+        "fail/retry_or_fail call sites and 'unknown' is enrolled outright",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline._review_failure",
+        "signatures_from_findings('review', review_result.as_findings())",
+        "composed at run time as '<phase>:<Finding.category>'; the phase is "
+        "the literal in this call and the category comes from findings.py",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline._route_failure",
+        "failure.signatures",
+        "pass-through: a PhaseFailure built at one of the sites above. "
+        "This row appears TWICE on purpose - _route_failure has two "
+        "branches spelling it, the comparison is a sorted list rather "
+        "than a set, and collapsing them would hide one of the two",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline._route_failure",
+        "failure.signatures",
+        "pass-through, the second of the two branches named above",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline._route_failure",
+        "failure.phase",
+        "pass-through: the phase of a PhaseFailure built elsewhere in this "
+        "module. PhaseFailure is a PHASE_FALLBACK_CALL in its own right, so "
+        "each of those phases is censused where it is written",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline._route_failure",
+        "failure.phase",
+        "pass-through, the second of the same two branches",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline._security_failure",
+        "signatures_from_findings('security', sec_result.as_findings())",
+        "composed at run time, as _review_failure above",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline.fail",
+        "phase",
+        "pass-through of its own parameter into _record_failure_signatures; "
+        "censused at the fail() call sites, which is why fail is itself a "
+        "PHASE_FALLBACK_CALL",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline.retry_or_fail",
+        "phase",
+        "pass-through of its own parameter into _record_failure_signatures; "
+        "censused at the retry_or_fail() call sites",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline.retry_or_fail",
+        "phase",
+        "the second of two, and a different call: the retries-exhausted route "
+        "hands the same parameter on to fail(), censused at the same sites",
+    ),
+    (
+        "kstrl/pipeline.py",
+        "ComponentPipeline.retry_or_fail",
+        "signatures",
+        "pass-through of its own parameter, censused at its call sites",
+    ),
+    (
+        "kstrl/verify.py",
+        "_failed_gate_result",
+        "name",
+        "pass-through of its own parameter; _failed_gate_result is itself a "
+        "CHECK_NAME_CALL, so every caller is censused",
+    ),
+)
 
-def _string_bindings(node: ast.stmt) -> dict[str, str]:
-    """``{name: value}`` for one statement, empty unless it binds a str.
 
-    Handles the annotated form as well as the plain one: ``gateparse``
-    declares ``GATE_TOOLS`` and friends with annotations, so an
-    ``ast.Assign``-only reader would silently drop a check name and
-    leave this whole module passing vacuously.
+# --- where a name is written, and what it is called there -----------------
+
+
+def _keyword_arguments(func_name: str, keyword: str) -> Iterator[tuple[str, ast.expr]]:
+    """``(module, expression)`` for every ``keyword=`` at a call to ``func_name``."""
+    for rel, tree in parsed_modules():
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or called_name(node.func) != func_name:
+                continue
+            yield from ((rel, kw.value) for kw in node.keywords if kw.arg == keyword)
+
+
+@cache
+def _keyword_values(func_name: str, keyword: str) -> frozenset[str] | None:
+    """Every string passed as ``keyword`` at a call to ``func_name``.
+
+    ``None`` when any call site passes something this walk cannot
+    decide, so a partial answer is never mistaken for a complete one.
+    That distinction is the whole point: a check name read off SOME of
+    its callers is a guess.
+
+    Asked one key at a time rather than indexed. #339 review measured
+    the index at 1,742 ``(callable, keyword)`` entries and 60 ms to
+    answer the one question the census asks of it, and the sticky-None
+    merge it needed is an early return here.
+
+    That holds while the census asks ONE question, which is what it does
+    today: one cache miss a run, 60 ms either way. Re-measured on #339,
+    the per-key walk is linear in keys (62 / 100 / 144 / 209 ms for one
+    to four) where the index is flat, so the crossover is at two. A
+    second key is the moment to index, not a later one.
+
+    Keyed on the BARE callable name, so two same-named functions merge.
+    That over-matches rather than under-matches, and the direction is
+    the point: an extra name surfaces as unenrolled, which is a red test
+    a human resolves, where a missed name is the silence #324 is about.
     """
-    if isinstance(node, ast.AnnAssign):
-        if isinstance(node.target, ast.Name) and _is_str_constant(node.value):
-            return {node.target.id: node.value.value}  # type: ignore[union-attr]
-        return {}
-    if not isinstance(node, ast.Assign) or not _is_str_constant(node.value):
-        return {}
-    return {t.id: node.value.value for t in node.targets if isinstance(t, ast.Name)}  # type: ignore[attr-defined]
+    found: set[str] = set()
+    for rel, value in _keyword_arguments(func_name, keyword):
+        folded = fold(value, module_level_strings()[rel])
+        if folded is None or HOLE in folded.text:
+            return None
+        found.add(folded.text)
+    return frozenset(found)
 
 
-def _is_str_constant(node: ast.expr | None) -> bool:
-    return isinstance(node, ast.Constant) and isinstance(node.value, str)
+def _parameter_names(func: ast.FunctionDef | ast.AsyncFunctionDef) -> frozenset[str]:
+    args = func.args
+    return frozenset(a.arg for a in (*args.posonlyargs, *args.args, *args.kwonlyargs))
 
 
-def _called_name(func: ast.expr) -> str:
-    """The bare callable name, through an attribute access.
+def _from_the_callers(folded: Folded, scope: Scope) -> frozenset[str]:
+    """Check names read off the call sites, when the name is a parameter.
 
-    ``verify.CheckResult(...)`` and ``CheckResult(...)`` are the same
-    construction to this walk. No call site uses the qualified form
-    today, which is exactly why an ``ast.Name``-only reader would not
-    fail when one is added.
+    ``pipeline._coverage_failure`` builds
+    ``f"{phase}:coverage-unverified:{reason}"`` from its own ``phase``
+    argument, so the check name is nowhere in that function. Both #339
+    reviewers mutated a caller's ``phase="review"`` to a bogus string
+    and measured the suite still green. One interprocedural step fixes
+    that and nothing less does: the name is decided by the callers.
+
+    Deliberately narrow. It fires only when the head of the signature is
+    exactly the parameter and the callers all pass it by keyword, which
+    is what makes the answer complete rather than a sample. Anything
+    else stays a blind site, so the rescue can move a row OUT of
+    :data:`BLIND_SITES` and can never make the walk quieter.
+
+    It also assumes the callers CALL BY BARE NAME, because that is what
+    ``called_name`` resolves. Route the same function through a dispatch
+    table or a ``functools.partial`` and this returns nothing and the row
+    goes back to :data:`BLIND_SITES`, which is the safe end of that
+    failure but is a limit rather than a property (#339 review, A6).
     """
-    if isinstance(func, ast.Name):
-        return func.id
-    if isinstance(func, ast.Attribute):
-        return func.attr
-    return ""
+    head = folded.first_hole
+    if scope.function is None or not isinstance(head, ast.Name):
+        return frozenset()
+    if not folded.text.startswith(HOLE + ":"):
+        return frozenset()
+    if head.id not in _parameter_names(scope.function):
+        return frozenset()
+    return _keyword_values(scope.function.name, head.id) or frozenset()
 
 
-def _name_argument(node: ast.AST) -> ast.expr | None:
-    """The expression giving the check name, for a call that has one."""
-    if not isinstance(node, ast.Call) or _called_name(node.func) not in CHECK_NAME_CALLS:
-        return None
-    for kw in node.keywords:
-        if kw.arg == "name":
-            return kw.value
-    return node.args[0] if node.args else None
+# --- the four producers ---------------------------------------------------
 
 
-def _signature_prefixes(node: ast.AST) -> list[str]:
-    """Check prefixes of any ``signatures=["check:code"]`` literal.
+def _writes_signatures(target: ast.expr) -> bool:
+    """A subscript assignment into a ``*failure_signatures`` mapping.
 
-    These never pass through a ``CheckResult``: ``pipeline`` hands them
-    straight to ``PhaseFailure``. They reach ``category_for_check`` via
-    ``split_signature`` all the same.
+    The fourth producer, and the only one that is not a call: ``factory``
+    and ``pipeline`` set four components' signatures directly, bypassing
+    ``_record_failure_signatures``. A census keyed on ``signatures=``
+    could not see them at all.
     """
-    if not isinstance(node, ast.Call):
-        return []
-    found: list[str] = []
-    for kw in node.keywords:
-        if kw.arg != "signatures" or not isinstance(kw.value, ast.List):
-            continue
-        for element in kw.value.elts:
-            if _is_str_constant(element) and ":" in element.value:  # type: ignore[attr-defined]
-                found.append(element.value.split(":", 1)[0])  # type: ignore[attr-defined]
-    return found
+    if not isinstance(target, ast.Subscript):
+        return False
+    container = target.value
+    name = getattr(container, "attr", None) or getattr(container, "id", "")
+    return isinstance(name, str) and name.endswith(SIGNATURE_CONTAINER_SUFFIX)
 
 
-def _phase_fallback_name(node: ast.AST) -> ast.expr | None:
-    """The ``phase=`` of a failure recorded with no ``signatures=``.
+def _listed(value: ast.expr) -> list[ast.expr]:
+    """The elements of a signature list, or the list expression itself."""
+    return list(value.elts) if isinstance(value, ast.List) else [value]
 
-    The THIRD producer, found by the #315 review after two rounds of
-    this file claiming to have them all. ``pipeline._record_failure_
-    signatures`` falls back to ``signature_for_error(phase or "unknown",
-    error)`` whenever a ``fail`` / ``retry_or_fail`` call omits
-    ``signatures=``, so the PHASE becomes the check name and reaches
-    ``category_for_check`` like any other. Measured before the walk saw
-    it: ``provisioning:worktree-setup-failed`` - a worktree that would
-    not provision, the purest infrastructure failure in the system - was
-    filed under the engineer loop, next to a docstring in this file
-    claiming the guard admitted no exceptions.
 
-    A ``phase=`` keyword is REQUIRED for a match, not just the callable
-    name: ``feature_cmd`` has a local helper also called ``fail``, and
-    matching on the name alone credited six of its call sites with the
-    check name "unknown". Requiring the keyword excludes them by shape
-    rather than by an exclusion list that would rot. The direction of
-    the remaining error matters: an unrelated future ``fail(phase=...)``
-    is over-matched and surfaces as an unenrolled name, which is a red
-    test a human resolves, not a silent skip.
+def _signatures_taken(node: ast.expr | None) -> bool | None:
+    """Will the recorder take these ``signatures`` over the phase?
+
+    Three answers, and the two producers read opposite ends of it.
+    ``_record_failure_signatures`` branches on a plain ``if signatures:``,
+    so ``True`` means the phase cannot become a check name and ``False``
+    means no signature can come out of this expression. ``None`` is a
+    run-time value, where EITHER branch can fire and so neither producer
+    may skip.
+
+    ``node is None`` is the argument being absent, which is the same
+    thing to the recorder as an empty one.
+
+    Two-valued before #339 review, as ``"signatures" in keywords``, and
+    both mistakes it made were in the silencing direction: a literal
+    ``None`` at ``_fail_pr_flow`` counted as signatures and hid the
+    phase, and ``signatures=failure.signatures`` at ``_route_failure``
+    did the same with a value the walk cannot decide at all.
     """
-    if not isinstance(node, ast.Call) or _called_name(node.func) not in PHASE_FALLBACK_CALLS:
-        return None
-    keywords = {kw.arg: kw.value for kw in node.keywords}
-    if "signatures" in keywords:
-        return None
-    return keywords.get("phase")
-
-
-@lru_cache(maxsize=1)
-def _parsed_modules() -> tuple[tuple[str, ast.Module], ...]:
-    """Every ``kstrl/`` module, parsed once for the whole session.
-
-    Measured before caching: ``_check_names`` re-parsed all 124 files on
-    each of its five calls and parsed the package a second time inside
-    the constant collector, costing 1.52 s, about 70 percent of the
-    scope-related test files' total runtime.
-    """
-    return tuple(
-        (str(path.relative_to(KSTRL_DIR.parent)), ast.parse(path.read_text(encoding="utf-8")))
-        for path in sorted(KSTRL_DIR.rglob("*.py"))
-    )
-
-
-@lru_cache(maxsize=1)
-def _module_level_strings() -> dict[str, dict[str, str]]:
-    """Module-level ``NAME = "literal"`` bindings, keyed by module."""
-    return {
-        rel: {k: v for node in tree.body for k, v in _string_bindings(node).items()}
-        for rel, tree in _parsed_modules()
-    }
-
-
-def unambiguous_pool(per_module: dict[str, dict[str, str]]) -> dict[str, str]:
-    """Constants that mean ONE thing across the whole package.
-
-    A check name is usually defined in one module and used in another:
-    ``verify`` builds its gates from ``gateparse.GATE_TEST``. So the
-    walk cannot resolve names against the using module alone. Pooling
-    every module's constants into one flat dict is the obvious fix and
-    is wrong in a way nothing would report: two modules binding the same
-    name to different values would resolve to whichever file sorts last,
-    silently attributing one module's check name to another's.
-
-    So a name is poolable only when every definition of it agrees. A
-    genuinely ambiguous name resolves to nothing and, if it is a check
-    name, surfaces as unenrolled rather than as the wrong answer. There
-    are no collisions today; this is here so the walk has a reason to be
-    correct rather than a coincidence.
-    """
-    values: dict[str, set[str]] = {}
-    for constants in per_module.values():
-        for name, value in constants.items():
-            values.setdefault(name, set()).add(value)
-    return {name: next(iter(v)) for name, v in values.items() if len(v) == 1}
-
-
-def _resolve(
-    value: ast.expr | None,
-    own: dict[str, str],
-    pool: dict[str, str],
-) -> str | None:
-    """A string from a literal or a module-level constant reference.
-
-    The defining module wins over the pool, so a module that shadows an
-    imported name is read as itself.
-    """
-    if _is_str_constant(value):
-        return value.value  # type: ignore[union-attr,return-value]
-    if isinstance(value, ast.Name):
-        return own.get(value.id) or pool.get(value.id)
+    if node is None:
+        return False
+    if isinstance(node, ast.List | ast.Tuple | ast.Set):
+        return bool(node.elts)
+    if isinstance(node, ast.Constant):
+        return bool(node.value)
     return None
 
 
+def _phase_argument(node: ast.Call, keywords: dict[str | None, ast.expr]) -> ast.expr | None:
+    """The ``phase`` handed to a failure recorder, keyword or positional."""
+    name = called_name(node.func)
+    if name not in PHASE_FALLBACK_CALLS:
+        return None
+    if "phase" in keywords:
+        return keywords["phase"]
+    index = parameter_index(name, "phase")
+    if index is None:
+        return None
+    return node.args[index] if len(node.args) > index else None
+
+
+def _name_sites(node: ast.AST) -> list[ast.expr]:
+    """Expressions that give a check name OUTRIGHT, with no code after it."""
+    if not isinstance(node, ast.Call):
+        return []
+    keywords: dict[str | None, ast.expr] = {kw.arg: kw.value for kw in node.keywords}
+    if called_name(node.func) in CHECK_NAME_CALLS:
+        named = keywords.get("name") or (node.args[0] if node.args else None)
+        return [named] if named is not None else []
+    if _signatures_taken(keywords.get("signatures")) is True:
+        return []
+    phase = _phase_argument(node, keywords)
+    return [phase] if phase is not None else []
+
+
+def _signature_sites(node: ast.AST) -> list[ast.expr]:
+    """Expressions that give a whole ``"<check>:<code>"`` signature."""
+    if isinstance(node, ast.Assign):
+        if any(_writes_signatures(t) for t in node.targets):
+            return _listed(node.value)
+        return []
+    if isinstance(node, ast.Call):
+        signatures = {kw.arg: kw.value for kw in node.keywords}.get("signatures")
+        # A provably empty `signatures=` is not a signature the walk
+        # failed to read, it is the absence of one, and a BLIND_SITES row
+        # for `signatures=None` is a row no reader can act on.
+        if signatures is not None and _signatures_taken(signatures) is not False:
+            return _listed(signatures)
+    return []
+
+
+def _name_at(expr: ast.expr, own: dict[str, str]) -> frozenset[str]:
+    """The check name a bare-name expression is known to give."""
+    folded = fold(expr, own)
+    if folded is None or HOLE in folded.text:
+        return frozenset()
+    return frozenset({folded.text})
+
+
+def _names_in(expr: ast.expr, own: dict[str, str], scope: Scope) -> frozenset[str]:
+    """Every check name a signature expression is known to give.
+
+    The whole SUBTREE, so a conditional, an f-string and a list all
+    answer without this knowing what any of them is.
+    """
+    found: set[str] = set()
+    for folded in folded_nodes(expr, own):
+        head = signature_head(folded)
+        if head is not None:
+            found.add(head)
+        else:
+            found |= _from_the_callers(folded, scope)
+    return frozenset(found)
+
+
+def _producer_sites(
+    tree: ast.Module, own: dict[str, str]
+) -> Iterator[tuple[Scope, ast.expr, frozenset[str]]]:
+    """Every producer expression in one module, with the names it gives.
+
+    An empty name set is the whole point of yielding the expression
+    alongside it: that is a site the walk DETECTED and could not read,
+    and the census records it rather than dropping it.
+    """
+    for node, scope in scoped_nodes(tree):
+        for expr in _name_sites(node):
+            yield scope, expr, _name_at(expr, own)
+        for expr in _signature_sites(node):
+            yield scope, expr, _names_in(expr, own, scope)
+
+
 @lru_cache(maxsize=1)
-def _check_names() -> dict[str, str]:
-    """Every name ``kstrl/`` can send to ``category_for_check``."""
-    per_module = _module_level_strings()
-    pool = unambiguous_pool(per_module)
+def _census() -> tuple[dict[str, str], tuple[tuple[str, str, str], ...]]:
+    """The names ``kstrl/`` emits, and the sites whose name would not read."""
     found: dict[str, str] = {}
-    for rel, tree in _parsed_modules():
-        own = per_module[rel]
-        for node in ast.walk(tree):
-            names = [
-                _resolve(_name_argument(node), own, pool),
-                _resolve(_phase_fallback_name(node), own, pool),
-                *_signature_prefixes(node),
-            ]
+    blind: list[tuple[str, str, str]] = []
+    for rel, tree in parsed_modules():
+        own = module_level_strings()[rel]
+        for scope, expr, names in _producer_sites(tree, own):
             for name in names:
-                if name:
-                    found.setdefault(name, rel)
-    return found
+                found.setdefault(name, rel)
+            if not names:
+                blind.append((rel, scope.qualname, ast.unparse(expr)))
+    return found, tuple(sorted(blind))
+
+
+def check_names() -> dict[str, str]:
+    """Every name ``kstrl/`` can send to ``category_for_check``."""
+    return _census()[0]
+
+
+def blind_sites() -> tuple[tuple[str, str, str], ...]:
+    """Every producer site whose check name the walk cannot read."""
+    return _census()[1]
 
 
 class TestEveryCheckNameIsEnrolled:
@@ -334,7 +625,7 @@ class TestEveryCheckNameIsEnrolled:
         """A walk that matches nothing passes vacuously forever. Each
         group below is one resolution path, and each was broken at some
         point in this file's short history."""
-        names = set(_check_names())
+        names = set(check_names())
         assert {"test_suite", "typecheck", "linter"} <= names, "module-constant resolution"
         assert {"diff_scope", "scope_unreadable", "prd_stories"} <= names, "literal names"
         assert {"pr", "engineer", "token_budget"} <= names, "signature prefixes"
@@ -343,6 +634,13 @@ class TestEveryCheckNameIsEnrolled:
         # producer. `provisioning` is the one that proves it resolves
         # across modules: the call is in factory.py, not pipeline.py.
         assert {"provisioning", "verify"} <= names, "phase= fallback names"
+        # #339 review: the fourth producer, four direct assignments into
+        # component_failure_signatures that are not calls at all.
+        assert "contract" in names, "component_failure_signatures[...] = [...]"
+        # #339 review: the check name is the enclosing function's own
+        # argument, so it is decided by the callers and by nothing in
+        # the function that writes it.
+        assert "security" in names, "a check name resolved from the call sites"
         # #306: this one was not pinned, and so was not protected.
         # Rewriting `CheckResult(name="mutation_testing", ...)` as
         # `name=name` off a function-local took the walk from 19 names
@@ -356,7 +654,7 @@ class TestEveryCheckNameIsEnrolled:
         left: a name kstrl emits and the table does not carry is a
         failure filed under whichever category the fallback picks."""
         missing = {
-            name: where for name, where in _check_names().items() if name not in _CATEGORY_BY_CHECK
+            name: where for name, where in check_names().items() if name not in _CATEGORY_BY_CHECK
         }
         assert not missing, (
             f"names emitted by kstrl/ but absent from "
@@ -370,9 +668,9 @@ class TestEveryCheckNameIsEnrolled:
         was in the skip direction: the matcher stopped resolving a name,
         saw fewer sites and reported clean. Pinning the enrolled names it
         cannot see turns the next such refactor from a silent narrowing
-        into a red test, for the whole table rather than the four names
-        the anti-vacuity test happens to list."""
-        invisible = set(_CATEGORY_BY_CHECK) - set(_check_names())
+        into a red test, for the whole table rather than the names the
+        anti-vacuity test happens to list."""
+        invisible = set(_CATEGORY_BY_CHECK) - set(check_names())
         assert invisible == set(ENROLLED_BUT_INVISIBLE), (
             f"the walk sees a different set of enrolled names than "
             f"expected. Newly invisible: {sorted(invisible - set(ENROLLED_BUT_INVISIBLE))} "
@@ -384,18 +682,14 @@ class TestEveryCheckNameIsEnrolled:
 
     def test_the_runtime_composed_phases_are_enrolled(self) -> None:
         """``signatures_from_findings`` builds these from a runtime
-        argument, so for two of the three no literal exists for the walk
-        to find. Kept after #315 added a whole-table pin that also
+        argument. Kept after #315 added a whole-table pin that also
         catches a dropped row: this one names the REASON these three
         cannot be dropped, and a pin is satisfied by editing the
-        expectation. ``review`` is asserted with them because it is
-        composed the same way, even though the walk does happen to see a
-        literal for it in ``pipeline``."""
+        expectation."""
         for phase in ("review", "security", "contract"):
             assert phase in _CATEGORY_BY_CHECK, (
                 f"{phase!r} is composed into failure signatures by "
-                f"evolution.signatures_from_findings and must stay enrolled; "
-                f"the AST walk cannot see it."
+                f"evolution.signatures_from_findings and must stay enrolled."
             )
 
     def test_the_table_still_says_what_it_is_pinned_to_say(self) -> None:
@@ -415,89 +709,49 @@ class TestEveryCheckNameIsEnrolled:
         assert "SHARED" not in unambiguous_pool(conflicting)
 
 
-def _run_dominated_by(signature: str) -> RunRecord:
-    """A recorded run whose modal failure was ``signature``.
+class TestTheBlindSitesAreEnumerated:
+    """#339 review: the guard's docstring said "a new gate cannot reach
+    the journal uncategorised" and that was false. The walk resolved
+    three ``signatures=`` sites out of six, could not see the fourth
+    producer at all, and DROPPED every site it could not read instead of
+    reporting it.
 
-    Asserting through ``RunRecord`` rather than against
-    ``INFRA_FAILURE_PREFIXES`` on purpose: ``infra_aborted`` is what
-    decides a run's fate, and a test that reads the constant directly
-    would stay green if the property stopped consulting it.
+    Dropping is the failure mode #324 is about, so the ledger below is
+    the correction: detection is separate from resolution, and a site
+    whose name will not resolve is enumerated rather than forgotten.
     """
-    return RunRecord(
-        run_id="r1",
-        timestamp="2026-01-01T00:00:00Z",
-        project="p",
-        components_total=1,
-        completed=0,
-        failed=1,
-        skipped=0,
-        retry_rate=0.0,
-        common_failure=signature,
-    )
 
-
-class TestTheTwoInfrastructureConsumersAgree:
-    """#315: the journal and the autonomy replay both decide what counts
-    as infrastructure, and before this they disagreed about
-    ``pr:merge-conflict`` - plumbing to the replay, an engineer-loop
-    failure to the journal. The replay now derives its prefixes from the
-    journal's table, so the shared part cannot drift. What is left is one
-    deliberate difference, pinned here so that changing either side
-    without the other is a red test rather than a quiet divergence.
-
-    Every assertion goes through ``RunRecord.infra_aborted``, the
-    property that actually decides whether a run counts as evidence
-    about the factory's judgement. An earlier version of this class
-    asserted ``startswith(INFRA_FAILURE_PREFIXES)`` instead, which
-    cannot fail while the tuple is built from ``INFRASTRUCTURE_CHECKS``:
-    it restated the constructor rather than testing anything."""
-
-    @pytest.mark.parametrize("check", sorted(INFRASTRUCTURE_CHECKS))
-    def test_an_infrastructure_check_costs_the_run_its_verdict(self, check: str) -> None:
-        assert _run_dominated_by(f"{check}:any-code").infra_aborted, (
-            f"{check!r} is 'infrastructure' in the journal but a decisive "
-            f"judgement failure to autonomy_replay."
+    def test_the_ledger_is_exactly_these_sites(self) -> None:
+        """Both directions. A new blind site fails because the walk
+        found a producer it cannot read; a resolved one fails because
+        the ledger is now claiming a limit that no longer exists, which
+        is the disclosure-without-a-test this file was pulled up for."""
+        measured = sorted(blind_sites())
+        pinned = sorted((rel, qual, expr) for rel, qual, expr, _ in BLIND_SITES)
+        assert measured == pinned, (
+            f"the set of producer sites whose check name the walk cannot "
+            f"read has moved. Newly blind: {sorted(set(measured) - set(pinned))} "
+            f"(read the name if you can, and add a BLIND_SITES row with a "
+            f"reason if you cannot). No longer blind: "
+            f"{sorted(set(pinned) - set(measured))} (delete its row)."
         )
-        assert not _run_dominated_by(f"{check}:any-code").decisive
 
-    def test_the_replay_treats_exactly_these_signatures_as_plumbing(self) -> None:
-        """The contents, not the derivation. The four rows beyond the
-        journal's own are the replay asking a WIDER question: not 'which
-        part of the factory failed' but 'did this run yield a verdict
-        about the factory's judgement at all', which a gate's honest
-        verdict can answer with no. Spelled out here so that adding a
-        fifth is a visible edit in two files."""
-        assert set(INFRA_FAILURE_PREFIXES) == {
-            "aborted:",
-            "diff:",
-            "pr:",
-            "provisioning:",
-            "token_budget:",
-            # Replay-only; see autonomy_replay._REPLAY_ONLY_PREFIXES.
-            "scope_unreadable:",
-            "git:",
-            "infra:",
-            "timeout:",
-        }
+    def test_every_blind_site_says_why(self) -> None:
+        """A ledger row with no reason is a silencer. The reason is what
+        a future reader needs to decide whether the limit is still
+        acceptable."""
+        for rel, qual, expr, why in BLIND_SITES:
+            assert why.strip(), f"{rel} {qual} {expr} has no stated reason"
 
-    def test_the_scope_refusal_is_the_deliberate_divergence(self) -> None:
-        """``scope_unreadable`` is a Phase 1 gate result, so the journal
-        files it under verification (#294 gave it its own gate, table row
-        and proposal arm on that basis). It is still an infrastructure
-        casualty for the replay: nothing was measured about the change,
-        so the run says nothing about judgement. Both halves asserted,
-        because the divergence is only defensible while it is on
-        purpose."""
-        assert _CATEGORY_BY_CHECK["scope_unreadable"] == "verification"
-        assert "scope_unreadable" not in INFRASTRUCTURE_CHECKS
-        assert _run_dominated_by("scope_unreadable:no-trustworthy-scope").infra_aborted
-
-    def test_a_judgement_failure_still_counts_as_evidence(self) -> None:
-        """The other direction, or the class above would pass with every
-        run called plumbing. ``diff:`` must not swallow ``diff_scope:``
-        either: a scope violation is a verdict on the change, and the
-        colon is the only thing separating the two names."""
-        assert not _run_dominated_by("diff_scope:files-outside-allowed-scope").infra_aborted
-        assert _run_dominated_by("diff_scope:files-outside-allowed-scope").decisive
-        assert not _run_dominated_by("review:scope_creep").infra_aborted
-        assert not _run_dominated_by("test_suite:assertion-error").infra_aborted
+    def test_a_producer_the_walk_cannot_read_is_not_dropped(self) -> None:
+        """The property, on a fixture, rather than on the tree. This is
+        what the old walk got wrong: it resolved what it could and said
+        nothing about the rest, so a producer moving out of reach looked
+        exactly like a producer that had gone away."""
+        tree = ast.parse('component_failure_signatures[c] = [f"{whatever}:code"]\n')
+        sites = [
+            (expr, scope) for node, scope in scoped_nodes(tree) for expr in _signature_sites(node)
+        ]
+        assert len(sites) == 1, "the assignment producer was not detected"
+        expr, scope = sites[0]
+        assert _names_in(expr, {}, scope) == frozenset(), "it must not resolve"

--- a/tests/test_check_name_enrolment.py
+++ b/tests/test_check_name_enrolment.py
@@ -550,6 +550,11 @@ def _signature_sites(node: ast.AST) -> list[ast.expr]:
         # A provably empty `signatures=` is not a signature the walk
         # failed to read, it is the absence of one, and a BLIND_SITES row
         # for `signatures=None` is a row no reader can act on.
+        #
+        # The first clause is a TYPE narrowing, not a condition:
+        # `_signatures_taken(None)` already answers False by its own
+        # contract, so the second clause covers the absent case. It is
+        # here because `_listed` takes `ast.expr`, not `ast.expr | None`.
         if signatures is not None and _signatures_taken(signatures) is not False:
             return _listed(signatures)
     return []
@@ -637,10 +642,16 @@ class TestEveryCheckNameIsEnrolled:
         # #339 review: the fourth producer, four direct assignments into
         # component_failure_signatures that are not calls at all.
         assert "contract" in names, "component_failure_signatures[...] = [...]"
-        # #339 review: the check name is the enclosing function's own
-        # argument, so it is decided by the callers and by nothing in
-        # the function that writes it.
-        assert "security" in names, "a check name resolved from the call sites"
+        # #339 review round 2 measured this line inert as first written
+        # ("security" in names): `security` is spelled at another site,
+        # so deleting the whole interprocedural rescue left it green.
+        # The property that actually moves is the rescue taking a row
+        # OUT of the ledger, so that is what is asserted.
+        assert (
+            "kstrl/pipeline.py",
+            "ComponentPipeline._coverage_failure",
+            "f'{phase}:coverage-unverified:{reason}'",
+        ) not in blind_sites(), "a check name resolved from the call sites"
         # #306: this one was not pinned, and so was not protected.
         # Rewriting `CheckResult(name="mutation_testing", ...)` as
         # `name=name` off a function-local took the walk from 19 names
@@ -736,22 +747,16 @@ class TestTheBlindSitesAreEnumerated:
             f"{sorted(set(pinned) - set(measured))} (delete its row)."
         )
 
+    # The property this class asserts on a FIXTURE - a detected producer
+    # whose name will not resolve must be reported rather than dropped -
+    # is pinned next door, by
+    # tests/test_check_name_shapes.py::test_a_pass_through_is_detected_and_unread.
+    # It was spelled twice on #339, in twelve lines here and three
+    # there, on the same fixture string; the shorter one asserts more.
+
     def test_every_blind_site_says_why(self) -> None:
         """A ledger row with no reason is a silencer. The reason is what
         a future reader needs to decide whether the limit is still
         acceptable."""
         for rel, qual, expr, why in BLIND_SITES:
             assert why.strip(), f"{rel} {qual} {expr} has no stated reason"
-
-    def test_a_producer_the_walk_cannot_read_is_not_dropped(self) -> None:
-        """The property, on a fixture, rather than on the tree. This is
-        what the old walk got wrong: it resolved what it could and said
-        nothing about the rest, so a producer moving out of reach looked
-        exactly like a producer that had gone away."""
-        tree = ast.parse('component_failure_signatures[c] = [f"{whatever}:code"]\n')
-        sites = [
-            (expr, scope) for node, scope in scoped_nodes(tree) for expr in _signature_sites(node)
-        ]
-        assert len(sites) == 1, "the assignment producer was not detected"
-        expr, scope = sites[0]
-        assert _names_in(expr, {}, scope) == frozenset(), "it must not resolve"

--- a/tests/test_check_name_enrolment.py
+++ b/tests/test_check_name_enrolment.py
@@ -34,21 +34,26 @@ Two things the walk learned the hard way, both from its own tests:
 
 What the walk CANNOT see, stated rather than left as a silent gap:
 ``evolution.signatures_from_findings`` composes ``"<phase>:<category>"``
-from a runtime ``phase`` argument, so the ``review``, ``security`` and
-``contract`` prefixes appear in no literal anywhere in ``kstrl/``. They
-are enrolled today, and
-:meth:`TestEveryCheckNameIsEnrolled.test_the_runtime_composed_phases_are_enrolled`
-asserts it directly, because the walk will not notice if that stops
-being true.
+from a runtime ``phase`` argument, so the ``security`` and ``contract``
+prefixes appear in no literal anywhere in ``kstrl/``, and neither does
+``verification``, which only ever comes back out of
+``evolution._classify_check``. They are enrolled today, and
+:data:`ENROLLED_BUT_INVISIBLE` plus
+:meth:`TestEveryCheckNameIsEnrolled.test_the_walk_covers_every_enrolled_name_but_these`
+say so by measurement rather than by claim.
 
-Names already unenrolled when this walk was written are listed in
-:data:`UNENROLLED_AT_INTRODUCTION` rather than fixed here, and tracked
-in #315. Correcting them changes what ``ks evolve`` reports for journal
-history already written, which is a behaviour change with nothing to do
-with #294 and wants its own justification. Grandfathering by name is
-what makes the gate landable today: the debt is enumerated, and nothing
-new can join it without a visible edit. The set is guarded in both
-directions, so it cannot rot into a lie.
+That second test is the one aimed at this repo's dominant defect (#324):
+a guard that goes BLIND rather than red. Every miss logged there is in
+the skip direction - a refactor moves a name out of the shape the
+matcher recognises, the matcher sees fewer sites and reports clean. This
+file has already been bitten once, by #306. So the walk is now pinned
+from both ends: an emitted name the table does not carry fails, AND an
+enrolled name the walk stops seeing fails.
+
+#315 emptied the grandfathered set this module shipped with. All eight
+names it carried are enrolled, four of them into the ``infrastructure``
+category invented to hold them, so the guard now admits no exceptions at
+all.
 """
 
 from __future__ import annotations
@@ -59,7 +64,13 @@ from pathlib import Path
 
 import pytest
 
-from kstrl.evolution import _CATEGORY_BY_CHECK
+from kstrl.autonomy_replay import _REPLAY_ONLY_PREFIXES, INFRA_FAILURE_PREFIXES
+from kstrl.evolution import (
+    _CATEGORY_BY_CHECK,
+    CATEGORIES,
+    INFRASTRUCTURE_CHECKS,
+    category_for_check,
+)
 
 KSTRL_DIR = Path(__file__).resolve().parent.parent / "kstrl"
 
@@ -69,24 +80,34 @@ KSTRL_DIR = Path(__file__).resolve().parent.parent / "kstrl"
 #: through.
 CHECK_NAME_CALLS = frozenset({"CheckResult", "_failed_gate_result"})
 
-#: Names that ``kstrl/`` emits and ``_CATEGORY_BY_CHECK`` did not carry
-#: on the day this walk was added, so ``category_for_check`` files them
-#: under ``"iteration"``. The first three are Phase 1 gates; the rest are
-#: signature prefixes for failures recorded outside a ``CheckResult``.
-#: Tracked in #315. Do not add to this set to make a new name pass;
-#: enrol the name instead.
-UNENROLLED_AT_INTRODUCTION = frozenset(
-    {
-        "fixtures",
-        "policy_envelope",
-        "test_adequacy",
-        "aborted",
-        "token_budget",
-        "pr",
-        "engineer",
-        "diff",
-    }
-)
+#: Enrolled names the walk provably cannot see, with the reason each is
+#: invisible. Anything else in the table must be reachable by the walk,
+#: or the walk has gone blind and says nothing (#324).
+ENROLLED_BUT_INVISIBLE = {
+    # signatures_from_findings composes "<phase>:<category>" from a
+    # runtime argument. "review" is NOT here: pipeline also emits
+    # "review:divergence" and friends as literals, so the walk does see
+    # that one, and claiming otherwise would excuse a real blind spot.
+    "security": "composed from a runtime phase argument",
+    "contract": "composed from a runtime phase argument",
+    # _classify_check RETURNS this one for a legacy flattened error
+    # string. It is never an argument, so no call site carries it.
+    "verification": "returned by _classify_check, never passed to a call",
+}
+
+#: What #315 decided, pinned name by name. The table is data, so a
+#: careless edit to it is a one-character behaviour change to ``ks
+#: evolve``; this is the test that has to be edited alongside it.
+CATEGORY_DECIDED_IN_315 = {
+    "fixtures": "verification",
+    "policy_envelope": "verification",
+    "test_adequacy": "verification",
+    "aborted": "infrastructure",
+    "token_budget": "infrastructure",
+    "pr": "infrastructure",
+    "diff": "infrastructure",
+    "engineer": "iteration",
+}
 
 
 def _string_bindings(node: ast.stmt) -> dict[str, str]:
@@ -252,11 +273,12 @@ class TestEveryCheckNameIsEnrolled:
         # branch before the fix.
         assert "mutation_testing" in names, "check-name constant in the defining module"
 
-    def test_no_unenrolled_name_beyond_the_grandfathered_set(self) -> None:
+    def test_every_emitted_name_is_enrolled(self) -> None:
+        """#315 emptied the grandfathered set, so this has no exceptions
+        left: a name kstrl emits and the table does not carry is a
+        failure filed under whichever category the fallback picks."""
         missing = {
-            name: where
-            for name, where in _check_names().items()
-            if name not in _CATEGORY_BY_CHECK and name not in UNENROLLED_AT_INTRODUCTION
+            name: where for name, where in _check_names().items() if name not in _CATEGORY_BY_CHECK
         }
         assert not missing, (
             f"names emitted by kstrl/ but absent from "
@@ -265,17 +287,60 @@ class TestEveryCheckNameIsEnrolled:
             f"the engineer loop. Add a row to that table."
         )
 
+    def test_the_walk_covers_every_enrolled_name_but_these(self) -> None:
+        """The blind-guard test (#324). Every miss logged in that issue
+        was in the skip direction: the matcher stopped resolving a name,
+        saw fewer sites and reported clean. Pinning the enrolled names it
+        cannot see turns the next such refactor from a silent narrowing
+        into a red test, for the whole table rather than the four names
+        the anti-vacuity test happens to list."""
+        invisible = set(_CATEGORY_BY_CHECK) - set(_check_names())
+        assert invisible == set(ENROLLED_BUT_INVISIBLE), (
+            f"the walk sees a different set of enrolled names than "
+            f"expected. Newly invisible: {sorted(invisible - set(ENROLLED_BUT_INVISIBLE))} "
+            f"(a refactor probably moved a name out of the shape the walk "
+            f"matches - fix the walk, do not add the name here). Newly "
+            f"visible: {sorted(set(ENROLLED_BUT_INVISIBLE) - invisible)} "
+            f"(delete its row from ENROLLED_BUT_INVISIBLE)."
+        )
+
     def test_the_runtime_composed_phases_are_enrolled(self) -> None:
         """``signatures_from_findings`` builds these from a runtime
         argument, so no literal exists for the walk to find. Asserted by
         hand because the walk provably cannot cover them: removing
-        ``security`` from the table does not fail any other test here."""
+        ``security`` from the table does not fail any other test here.
+        ``review`` is asserted with them because it is composed the same
+        way, even though a literal for it does exist elsewhere."""
         for phase in ("review", "security", "contract"):
             assert phase in _CATEGORY_BY_CHECK, (
                 f"{phase!r} is composed into failure signatures by "
                 f"evolution.signatures_from_findings and must stay enrolled; "
                 f"the AST walk cannot see it."
             )
+
+    def test_every_row_carries_a_category_that_exists(self) -> None:
+        """A typo in a category value invents a category. Nothing else
+        would notice: ``category_for_check`` returns whatever the table
+        says, and the one consumer that displays it prints any string."""
+        unknown = {
+            name: category
+            for name, category in _CATEGORY_BY_CHECK.items()
+            if category not in CATEGORIES
+        }
+        assert not unknown, (
+            f"rows in _CATEGORY_BY_CHECK naming a category that is not in "
+            f"evolution.CATEGORIES: {unknown}."
+        )
+
+    @pytest.mark.parametrize(("name", "category"), sorted(CATEGORY_DECIDED_IN_315.items()))
+    def test_the_names_315_enrolled_keep_the_category_it_gave_them(
+        self, name: str, category: str
+    ) -> None:
+        """Each of these was filed under ``iteration`` by the fallback,
+        so ``ks evolve`` called a merge conflict or a policy-envelope
+        breach an engineer-loop problem."""
+        assert name in _check_names(), f"{name!r} is no longer emitted by kstrl/"
+        assert category_for_check(name) == category
 
     def test_a_colliding_constant_resolves_to_nothing(self) -> None:
         """The wrong answer is worse than no answer: a name two modules
@@ -285,14 +350,48 @@ class TestEveryCheckNameIsEnrolled:
         conflicting = {"a.py": {"SHARED": "x"}, "b.py": {"SHARED": "z"}}
         assert "SHARED" not in unambiguous_pool(conflicting)
 
-    @pytest.mark.parametrize("name", sorted(UNENROLLED_AT_INTRODUCTION))
-    def test_the_grandfathered_set_still_describes_real_debt(self, name: str) -> None:
-        """Two ways the list could lie: a name no longer emitted, and a
-        name since enrolled. Both make it stale."""
-        assert name in _check_names(), (
-            f"{name!r} is no longer emitted by kstrl/; remove it from UNENROLLED_AT_INTRODUCTION."
-        )
-        assert name not in _CATEGORY_BY_CHECK, (
-            f"{name!r} is now enrolled in _CATEGORY_BY_CHECK; remove it from "
-            f"UNENROLLED_AT_INTRODUCTION."
-        )
+
+class TestTheTwoInfrastructureConsumersAgree:
+    """#315: the journal and the autonomy replay both decide what counts
+    as infrastructure, and before this they disagreed about
+    ``pr:merge-conflict`` - plumbing to the replay, an engineer-loop
+    failure to the journal. The replay now derives its prefixes from the
+    journal's table, so the shared part cannot drift. What is left is one
+    deliberate difference, pinned here so that changing either side
+    without the other is a red test rather than a quiet divergence."""
+
+    def test_every_infrastructure_check_is_an_infra_abort_for_the_replay(self) -> None:
+        for check in INFRASTRUCTURE_CHECKS:
+            assert f"{check}:any-code".startswith(INFRA_FAILURE_PREFIXES), (
+                f"{check!r} is 'infrastructure' in the journal but a decisive "
+                f"judgement failure to autonomy_replay."
+            )
+
+    def test_the_replays_extra_prefixes_are_exactly_the_documented_ones(self) -> None:
+        """The replay asks a wider question than the journal's category:
+        not 'which part of the factory failed' but 'did this run yield a
+        verdict about the factory's judgement at all'. A gate's honest
+        verdict can still answer no. Anything beyond this list is an
+        undocumented divergence."""
+        derived = {f"{check}:" for check in INFRASTRUCTURE_CHECKS}
+        assert set(INFRA_FAILURE_PREFIXES) - derived == set(_REPLAY_ONLY_PREFIXES)
+
+    def test_the_scope_refusal_is_the_deliberate_divergence(self) -> None:
+        """``scope_unreadable`` is a Phase 1 gate result, so the journal
+        files it under verification (#294 gave it its own gate, table row
+        and proposal arm on that basis). It is still an infrastructure
+        casualty for the replay: nothing was measured about the change,
+        so the run says nothing about judgement. Both halves asserted,
+        because the divergence is only defensible while it is on
+        purpose."""
+        assert category_for_check("scope_unreadable") == "verification"
+        assert "scope_unreadable" not in INFRASTRUCTURE_CHECKS
+        assert "scope_unreadable:no-trustworthy-scope".startswith(INFRA_FAILURE_PREFIXES)
+
+    def test_the_prefixes_cannot_swallow_a_neighbouring_check(self) -> None:
+        """``diff:`` must not match ``diff_scope:``: a scope violation is
+        the reviewer's verdict on the change and decisive evidence about
+        it. The colon is what separates them, so it is load-bearing and
+        tested rather than assumed."""
+        assert not "diff_scope:files-outside-allowed-scope".startswith(INFRA_FAILURE_PREFIXES)
+        assert not "review:scope_creep".startswith(INFRA_FAILURE_PREFIXES)

--- a/tests/test_check_name_enrolment.py
+++ b/tests/test_check_name_enrolment.py
@@ -64,13 +64,8 @@ from pathlib import Path
 
 import pytest
 
-from kstrl.autonomy_replay import _REPLAY_ONLY_PREFIXES, INFRA_FAILURE_PREFIXES
-from kstrl.evolution import (
-    _CATEGORY_BY_CHECK,
-    CATEGORIES,
-    INFRASTRUCTURE_CHECKS,
-    category_for_check,
-)
+from kstrl.autonomy_replay import INFRA_FAILURE_PREFIXES, RunRecord
+from kstrl.evolution import _CATEGORY_BY_CHECK, INFRASTRUCTURE_CHECKS
 
 KSTRL_DIR = Path(__file__).resolve().parent.parent / "kstrl"
 
@@ -79,6 +74,11 @@ KSTRL_DIR = Path(__file__).resolve().parent.parent / "kstrl"
 #: shared builder the three subprocess gates package their failures
 #: through.
 CHECK_NAME_CALLS = frozenset({"CheckResult", "_failed_gate_result"})
+
+#: Calls that record a component failure. When one carries no
+#: ``signatures=``, its ``phase=`` becomes the check name. See
+#: :func:`_phase_fallback_name`.
+PHASE_FALLBACK_CALLS = frozenset({"fail", "retry_or_fail"})
 
 #: Enrolled names the walk provably cannot see, with the reason each is
 #: invisible. Anything else in the table must be reachable by the walk,
@@ -90,23 +90,53 @@ ENROLLED_BUT_INVISIBLE = {
     # that one, and claiming otherwise would excuse a real blind spot.
     "security": "composed from a runtime phase argument",
     "contract": "composed from a runtime phase argument",
-    # _classify_check RETURNS this one for a legacy flattened error
-    # string. It is never an argument, so no call site carries it.
+    # _classify_check RETURNS these for a legacy flattened error string.
+    # They are never arguments, so no call site carries them.
     "verification": "returned by _classify_check, never passed to a call",
+    "unknown": "returned by _classify_check, never passed to a call",
 }
 
-#: What #315 decided, pinned name by name. The table is data, so a
-#: careless edit to it is a one-character behaviour change to ``ks
-#: evolve``; this is the test that has to be edited alongside it.
-CATEGORY_DECIDED_IN_315 = {
+#: The whole of ``_CATEGORY_BY_CHECK``, pinned row by row rather than in
+#: part. The table is data, so an edit to it is a behaviour change with
+#: no code diff to review: it decides what the journal calls a failure
+#: and, through ``INFRASTRUCTURE_CHECKS``, which runs the autonomy replay
+#: counts as evidence about the factory's judgement. Pinning all of it
+#: is the same audit-trail shape ``tests/test_prompt_versions.py`` uses:
+#: the table and its expectation move together in one diff, or CI is red.
+#: A partial mirror was tried first and gave a future author no rule for
+#: whether a new row belonged in it.
+EXPECTED_CATEGORIES = {
+    "linter": "verification",
+    "typecheck": "verification",
+    "test_suite": "verification",
+    "diff_scope": "verification",
+    "scope_unreadable": "verification",
+    "bad_patterns": "verification",
+    "self_critique": "verification",
+    "dead_code": "verification",
+    "mutation_testing": "verification",
+    "prd_stories": "verification",
+    "verification": "verification",
+    # #315: the three Phase 1 gates the table did not carry.
     "fixtures": "verification",
     "policy_envelope": "verification",
     "test_adequacy": "verification",
+    # #315 round 2: the phase names a failure recorded without
+    # signatures= is filed under.
+    "verify": "verification",
+    "provisioning": "infrastructure",
+    # #315: the category invented for the four failures that are neither
+    # a gate's verdict nor the engineer's loop.
     "aborted": "infrastructure",
     "token_budget": "infrastructure",
     "pr": "infrastructure",
     "diff": "infrastructure",
+    # #315: the fallback's answer, stated rather than inherited.
     "engineer": "iteration",
+    "unknown": "iteration",
+    "review": "review",
+    "security": "security",
+    "contract": "contract",
 }
 
 
@@ -173,6 +203,37 @@ def _signature_prefixes(node: ast.AST) -> list[str]:
             if _is_str_constant(element) and ":" in element.value:  # type: ignore[attr-defined]
                 found.append(element.value.split(":", 1)[0])  # type: ignore[attr-defined]
     return found
+
+
+def _phase_fallback_name(node: ast.AST) -> ast.expr | None:
+    """The ``phase=`` of a failure recorded with no ``signatures=``.
+
+    The THIRD producer, found by the #315 review after two rounds of
+    this file claiming to have them all. ``pipeline._record_failure_
+    signatures`` falls back to ``signature_for_error(phase or "unknown",
+    error)`` whenever a ``fail`` / ``retry_or_fail`` call omits
+    ``signatures=``, so the PHASE becomes the check name and reaches
+    ``category_for_check`` like any other. Measured before the walk saw
+    it: ``provisioning:worktree-setup-failed`` - a worktree that would
+    not provision, the purest infrastructure failure in the system - was
+    filed under the engineer loop, next to a docstring in this file
+    claiming the guard admitted no exceptions.
+
+    A ``phase=`` keyword is REQUIRED for a match, not just the callable
+    name: ``feature_cmd`` has a local helper also called ``fail``, and
+    matching on the name alone credited six of its call sites with the
+    check name "unknown". Requiring the keyword excludes them by shape
+    rather than by an exclusion list that would rot. The direction of
+    the remaining error matters: an unrelated future ``fail(phase=...)``
+    is over-matched and surfaces as an unenrolled name, which is a red
+    test a human resolves, not a silent skip.
+    """
+    if not isinstance(node, ast.Call) or _called_name(node.func) not in PHASE_FALLBACK_CALLS:
+        return None
+    keywords = {kw.arg: kw.value for kw in node.keywords}
+    if "signatures" in keywords:
+        return None
+    return keywords.get("phase")
 
 
 @lru_cache(maxsize=1)
@@ -249,7 +310,11 @@ def _check_names() -> dict[str, str]:
     for rel, tree in _parsed_modules():
         own = per_module[rel]
         for node in ast.walk(tree):
-            names = [_resolve(_name_argument(node), own, pool), *_signature_prefixes(node)]
+            names = [
+                _resolve(_name_argument(node), own, pool),
+                _resolve(_phase_fallback_name(node), own, pool),
+                *_signature_prefixes(node),
+            ]
             for name in names:
                 if name:
                     found.setdefault(name, rel)
@@ -265,6 +330,11 @@ class TestEveryCheckNameIsEnrolled:
         assert {"test_suite", "typecheck", "linter"} <= names, "module-constant resolution"
         assert {"diff_scope", "scope_unreadable", "prd_stories"} <= names, "literal names"
         assert {"pr", "engineer", "token_budget"} <= names, "signature prefixes"
+        # #315 round 2: failures recorded with no signatures= are filed
+        # under their phase, and the walk was blind to that whole
+        # producer. `provisioning` is the one that proves it resolves
+        # across modules: the call is in factory.py, not pipeline.py.
+        assert {"provisioning", "verify"} <= names, "phase= fallback names"
         # #306: this one was not pinned, and so was not protected.
         # Rewriting `CheckResult(name="mutation_testing", ...)` as
         # `name=name` off a function-local took the walk from 19 names
@@ -306,11 +376,13 @@ class TestEveryCheckNameIsEnrolled:
 
     def test_the_runtime_composed_phases_are_enrolled(self) -> None:
         """``signatures_from_findings`` builds these from a runtime
-        argument, so no literal exists for the walk to find. Asserted by
-        hand because the walk provably cannot cover them: removing
-        ``security`` from the table does not fail any other test here.
-        ``review`` is asserted with them because it is composed the same
-        way, even though a literal for it does exist elsewhere."""
+        argument, so for two of the three no literal exists for the walk
+        to find. Kept after #315 added a whole-table pin that also
+        catches a dropped row: this one names the REASON these three
+        cannot be dropped, and a pin is satisfied by editing the
+        expectation. ``review`` is asserted with them because it is
+        composed the same way, even though the walk does happen to see a
+        literal for it in ``pipeline``."""
         for phase in ("review", "security", "contract"):
             assert phase in _CATEGORY_BY_CHECK, (
                 f"{phase!r} is composed into failure signatures by "
@@ -318,29 +390,13 @@ class TestEveryCheckNameIsEnrolled:
                 f"the AST walk cannot see it."
             )
 
-    def test_every_row_carries_a_category_that_exists(self) -> None:
-        """A typo in a category value invents a category. Nothing else
-        would notice: ``category_for_check`` returns whatever the table
-        says, and the one consumer that displays it prints any string."""
-        unknown = {
-            name: category
-            for name, category in _CATEGORY_BY_CHECK.items()
-            if category not in CATEGORIES
-        }
-        assert not unknown, (
-            f"rows in _CATEGORY_BY_CHECK naming a category that is not in "
-            f"evolution.CATEGORIES: {unknown}."
-        )
-
-    @pytest.mark.parametrize(("name", "category"), sorted(CATEGORY_DECIDED_IN_315.items()))
-    def test_the_names_315_enrolled_keep_the_category_it_gave_them(
-        self, name: str, category: str
-    ) -> None:
-        """Each of these was filed under ``iteration`` by the fallback,
-        so ``ks evolve`` called a merge conflict or a policy-envelope
-        breach an engineer-loop problem."""
-        assert name in _check_names(), f"{name!r} is no longer emitted by kstrl/"
-        assert category_for_check(name) == category
+    def test_the_table_still_says_what_it_is_pinned_to_say(self) -> None:
+        """Every row, not a sample. A typo in a category value invents a
+        category nothing would reject; a dropped row silently re-files a
+        gate under the engineer loop; an added row can move a run out of
+        the autonomy replay's evidence. All three are one diff away and
+        none of them changes a line of code."""
+        assert _CATEGORY_BY_CHECK == EXPECTED_CATEGORIES
 
     def test_a_colliding_constant_resolves_to_nothing(self) -> None:
         """The wrong answer is worse than no answer: a name two modules
@@ -351,6 +407,27 @@ class TestEveryCheckNameIsEnrolled:
         assert "SHARED" not in unambiguous_pool(conflicting)
 
 
+def _run_dominated_by(signature: str) -> RunRecord:
+    """A recorded run whose modal failure was ``signature``.
+
+    Asserting through ``RunRecord`` rather than against
+    ``INFRA_FAILURE_PREFIXES`` on purpose: ``infra_aborted`` is what
+    decides a run's fate, and a test that reads the constant directly
+    would stay green if the property stopped consulting it.
+    """
+    return RunRecord(
+        run_id="r1",
+        timestamp="2026-01-01T00:00:00Z",
+        project="p",
+        components_total=1,
+        completed=0,
+        failed=1,
+        skipped=0,
+        retry_rate=0.0,
+        common_failure=signature,
+    )
+
+
 class TestTheTwoInfrastructureConsumersAgree:
     """#315: the journal and the autonomy replay both decide what counts
     as infrastructure, and before this they disagreed about
@@ -358,23 +435,42 @@ class TestTheTwoInfrastructureConsumersAgree:
     failure to the journal. The replay now derives its prefixes from the
     journal's table, so the shared part cannot drift. What is left is one
     deliberate difference, pinned here so that changing either side
-    without the other is a red test rather than a quiet divergence."""
+    without the other is a red test rather than a quiet divergence.
 
-    def test_every_infrastructure_check_is_an_infra_abort_for_the_replay(self) -> None:
-        for check in INFRASTRUCTURE_CHECKS:
-            assert f"{check}:any-code".startswith(INFRA_FAILURE_PREFIXES), (
-                f"{check!r} is 'infrastructure' in the journal but a decisive "
-                f"judgement failure to autonomy_replay."
-            )
+    Every assertion goes through ``RunRecord.infra_aborted``, the
+    property that actually decides whether a run counts as evidence
+    about the factory's judgement. An earlier version of this class
+    asserted ``startswith(INFRA_FAILURE_PREFIXES)`` instead, which
+    cannot fail while the tuple is built from ``INFRASTRUCTURE_CHECKS``:
+    it restated the constructor rather than testing anything."""
 
-    def test_the_replays_extra_prefixes_are_exactly_the_documented_ones(self) -> None:
-        """The replay asks a wider question than the journal's category:
-        not 'which part of the factory failed' but 'did this run yield a
-        verdict about the factory's judgement at all'. A gate's honest
-        verdict can still answer no. Anything beyond this list is an
-        undocumented divergence."""
-        derived = {f"{check}:" for check in INFRASTRUCTURE_CHECKS}
-        assert set(INFRA_FAILURE_PREFIXES) - derived == set(_REPLAY_ONLY_PREFIXES)
+    @pytest.mark.parametrize("check", sorted(INFRASTRUCTURE_CHECKS))
+    def test_an_infrastructure_check_costs_the_run_its_verdict(self, check: str) -> None:
+        assert _run_dominated_by(f"{check}:any-code").infra_aborted, (
+            f"{check!r} is 'infrastructure' in the journal but a decisive "
+            f"judgement failure to autonomy_replay."
+        )
+        assert not _run_dominated_by(f"{check}:any-code").decisive
+
+    def test_the_replay_treats_exactly_these_signatures_as_plumbing(self) -> None:
+        """The contents, not the derivation. The four rows beyond the
+        journal's own are the replay asking a WIDER question: not 'which
+        part of the factory failed' but 'did this run yield a verdict
+        about the factory's judgement at all', which a gate's honest
+        verdict can answer with no. Spelled out here so that adding a
+        fifth is a visible edit in two files."""
+        assert set(INFRA_FAILURE_PREFIXES) == {
+            "aborted:",
+            "diff:",
+            "pr:",
+            "provisioning:",
+            "token_budget:",
+            # Replay-only; see autonomy_replay._REPLAY_ONLY_PREFIXES.
+            "scope_unreadable:",
+            "git:",
+            "infra:",
+            "timeout:",
+        }
 
     def test_the_scope_refusal_is_the_deliberate_divergence(self) -> None:
         """``scope_unreadable`` is a Phase 1 gate result, so the journal
@@ -384,14 +480,16 @@ class TestTheTwoInfrastructureConsumersAgree:
         so the run says nothing about judgement. Both halves asserted,
         because the divergence is only defensible while it is on
         purpose."""
-        assert category_for_check("scope_unreadable") == "verification"
+        assert _CATEGORY_BY_CHECK["scope_unreadable"] == "verification"
         assert "scope_unreadable" not in INFRASTRUCTURE_CHECKS
-        assert "scope_unreadable:no-trustworthy-scope".startswith(INFRA_FAILURE_PREFIXES)
+        assert _run_dominated_by("scope_unreadable:no-trustworthy-scope").infra_aborted
 
-    def test_the_prefixes_cannot_swallow_a_neighbouring_check(self) -> None:
-        """``diff:`` must not match ``diff_scope:``: a scope violation is
-        the reviewer's verdict on the change and decisive evidence about
-        it. The colon is what separates them, so it is load-bearing and
-        tested rather than assumed."""
-        assert not "diff_scope:files-outside-allowed-scope".startswith(INFRA_FAILURE_PREFIXES)
-        assert not "review:scope_creep".startswith(INFRA_FAILURE_PREFIXES)
+    def test_a_judgement_failure_still_counts_as_evidence(self) -> None:
+        """The other direction, or the class above would pass with every
+        run called plumbing. ``diff:`` must not swallow ``diff_scope:``
+        either: a scope violation is a verdict on the change, and the
+        colon is the only thing separating the two names."""
+        assert not _run_dominated_by("diff_scope:files-outside-allowed-scope").infra_aborted
+        assert _run_dominated_by("diff_scope:files-outside-allowed-scope").decisive
+        assert not _run_dominated_by("review:scope_creep").infra_aborted
+        assert not _run_dominated_by("test_suite:assertion-error").infra_aborted

--- a/tests/test_check_name_enrolment.py
+++ b/tests/test_check_name_enrolment.py
@@ -13,7 +13,8 @@ This is the mechanism, in the shape the repo already uses three times
 that can reach ``category_for_check`` and fail on one the table does not
 carry.
 
-Two things the walk learned the hard way, both from its own tests:
+Three things the walk learned the hard way, each after a version of it
+claimed to be complete:
 
 - It resolves module-level string constants, not just literals, across
   module boundaries but only where a name means one thing package-wide.
@@ -31,12 +32,16 @@ Two things the walk learned the hard way, both from its own tests:
   the first version of this module claimed "no NEW check can join it
   quietly". That claim was false for every failure recorded outside a
   ``CheckResult``.
+- It resolves the ``phase=`` of a failure recorded with NEITHER of the
+  above (:func:`_phase_fallback_name`), which is how
+  ``provisioning:worktree-setup-failed`` sat unenrolled through two
+  rounds of this module claiming to have found every producer.
 
 What the walk CANNOT see, stated rather than left as a silent gap:
 ``evolution.signatures_from_findings`` composes ``"<phase>:<category>"``
 from a runtime ``phase`` argument, so the ``security`` and ``contract``
-prefixes appear in no literal anywhere in ``kstrl/``, and neither does
-``verification``, which only ever comes back out of
+prefixes appear in no literal anywhere in ``kstrl/``, and neither do
+``verification`` and ``unknown``, which only ever come back out of
 ``evolution._classify_check``. They are enrolled today, and
 :data:`ENROLLED_BUT_INVISIBLE` plus
 :meth:`TestEveryCheckNameIsEnrolled.test_the_walk_covers_every_enrolled_name_but_these`
@@ -52,8 +57,11 @@ enrolled name the walk stops seeing fails.
 
 #315 emptied the grandfathered set this module shipped with. All eight
 names it carried are enrolled, four of them into the ``infrastructure``
-category invented to hold them, so the guard now admits no exceptions at
-all.
+category invented to hold them, and the two the widened walk then
+surfaced are enrolled too. The guard has no exceptions left, which is a
+claim it made once before while a whole producer was invisible to it, so
+read it as "no exception this walk can see" and keep asking what it
+cannot.
 """
 
 from __future__ import annotations

--- a/tests/test_check_name_shapes.py
+++ b/tests/test_check_name_shapes.py
@@ -1,0 +1,330 @@
+"""Positive controls for the check-name guard: source it MUST read.
+
+The guard lives in ``tests/test_check_name_enrolment.py``. Its census
+answers with a set of names and a ledger of the sites it could not read,
+and BOTH of those are also what a switched-off matcher produces: a
+producer shape nobody enumerated yields no name and no ledger row, so it
+is silence rather than a red test.
+
+That is not hypothetical. ``BLIND_SITES`` inventories the walk's own
+resolution FAILURES, which is a strictly smaller set than the producer
+shapes that exist, and its precedent ``EXPECTED_JOURNAL_PATH_SITES`` is
+closed by construction where this is not: that one enumerates every place
+a resource is obtained, so a new way of obtaining it lands in the list,
+while a new way of writing a check name lands nowhere. #339 review found
+``pipeline._fail_pr_flow`` sitting in exactly that gap - a positional
+call to the recording funnel, no ``signatures=``, and no colon in
+``"pr"`` for the other layer's net to catch either. Mutating it to
+``"bogus_flow"`` left 4737 tests green, and neither the census nor the
+ledger moved.
+
+So this file feeds the two matchers a snippet per shape and pins what
+they SAY, including the shapes they say nothing about. A matcher branch
+deleted here is a red test rather than a quieter walk.
+
+Separate from the guard for the reason ``tests/test_event_name_shapes.py``
+gives about its own sibling on main: that file walks the package and pins
+what is there, this one feeds the matchers snippets and pins what they
+answer.
+
+Every shape here was measured against the matchers under the
+``__pycache__`` discipline: CPython invalidates cached bytecode on
+``(mtime_seconds, size)``, so two same-size edits inside one second reuse
+stale bytecode and hand back a false pass.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from tests.helpers.astfold import parameter_index
+from tests.test_check_name_enrolment import _producer_sites
+from tests.test_signature_spellings import signature_heads
+
+
+def read(source: str, own: dict[str, str] | None = None) -> list[tuple[str, list[str]]]:
+    """``(expression, names)`` for every producer site in one snippet.
+
+    A list rather than a set: a site the matchers DETECT and cannot read
+    answers with an empty name list, and that is a different fact from
+    no site at all. Collapsing the two is the exact mistake this file
+    exists to make visible.
+    """
+    return [
+        (ast.unparse(expr), sorted(names))
+        for _scope, expr, names in _producer_sites(ast.parse(source), own or {})
+    ]
+
+
+def names(source: str, own: dict[str, str] | None = None) -> list[str]:
+    """Every check name the matchers read out of one snippet."""
+    return sorted({name for _expr, found in read(source, own) for name in found})
+
+
+def net(source: str, own: dict[str, str] | None = None) -> set[str]:
+    """What layer 1 counts in the same snippet."""
+    return signature_heads(ast.parse(source), own or {})
+
+
+class TestEveryShapeThatGivesACheckName:
+    """One per producer, and one per spelling within a producer.
+
+    Deleting any branch of ``_name_sites`` or ``_signature_sites`` turns
+    one of these red. Before this file, the same deletions turned nothing
+    red as long as some OTHER site in the package still spelled the same
+    name, which every one of them did.
+    """
+
+    def test_a_check_result_names_its_gate_positionally(self) -> None:
+        assert names('CheckResult("linter", passed=False)\n') == ["linter"]
+
+    def test_a_check_result_names_its_gate_by_keyword(self) -> None:
+        assert names('CheckResult(name="typecheck", passed=False)\n') == ["typecheck"]
+
+    def test_the_shared_gate_builder_counts_too(self) -> None:
+        """``verify._failed_gate_result`` is the second CHECK_NAME_CALL:
+        the three subprocess gates package their failures through it and
+        never construct a ``CheckResult`` themselves."""
+        assert names('_failed_gate_result("fixtures", "boom")\n') == ["fixtures"]
+
+    def test_a_signatures_argument(self) -> None:
+        assert names('self.fail(comp, err, signatures=["token_budget:exceeded"])\n') == [
+            "token_budget"
+        ]
+
+    def test_a_direct_assignment_into_the_container(self) -> None:
+        """The producer that is not a call at all. Both spellings of the
+        mapping, because ``factory`` passes its own local in and
+        ``SIGNATURE_CONTAINER_SUFFIX`` is what joins them."""
+        assert names('component_failure_signatures[c] = ["contract:tier-failed"]\n') == ["contract"]
+        assert names('self.component_failure_signatures[c] = ["engineer:stall"]\n') == ["engineer"]
+
+    def test_a_dynamic_tail_still_gives_the_head(self) -> None:
+        """``f"contract:tier_{n}"`` is the real shape of that producer."""
+        assert names('component_failure_signatures[c] = [f"contract:tier_{n}"]\n') == ["contract"]
+
+    def test_a_conditional_gives_both_arms(self) -> None:
+        """``_setpoint_failure`` picks its signature with an ``IfExp``.
+        Both arms are read, because the walk descends the SUBTREE rather
+        than enumerating expression types."""
+        source = 'self.fail(c, e, signatures=["review:a" if x else "security:b"])\n'
+        assert names(source) == ["review", "security"]
+
+    def test_a_module_constant_resolves(self) -> None:
+        """#306's shape: the name is a constant in the defining module,
+        not a literal at the call site."""
+        source = "CheckResult(name=MUTATION, passed=False)\n"
+        assert names(source, {"MUTATION": "mutation_testing"}) == ["mutation_testing"]
+
+
+class TestTheEntryPointsAndTheFunnel:
+    """The phase fallback, which is where #339 review found the hole.
+
+    ``pipeline._record_failure_signatures`` files a failure under its
+    PHASE whenever no truthy ``signatures`` reaches it, and it has three
+    callers: ``fail``, ``retry_or_fail`` and ``_fail_pr_flow``. Keying
+    the matcher on the first two named the phase at their call sites and
+    said nothing at all about the third.
+    """
+
+    def test_the_two_entry_points_by_keyword(self) -> None:
+        assert names('self.fail(comp, err, phase="provisioning")\n') == ["provisioning"]
+        assert names('self.retry_or_fail(comp, err, ctx, phase="verify")\n') == ["verify"]
+
+    def test_the_funnel_called_directly_and_positionally(self) -> None:
+        """THE REGRESSION. This is ``_fail_pr_flow`` as it was written:
+        no ``phase=`` keyword, no ``signatures=``, and a phase with no
+        colon in it. Every layer was silent, and mutating the string left
+        the whole suite green."""
+        assert names('self._record_failure_signatures(comp, "pr", err, None)\n') == ["pr"]
+        assert net('self._record_failure_signatures(comp, "pr", err, None)\n') == set()
+
+    def test_the_funnel_called_by_keyword(self) -> None:
+        """How ``_fail_pr_flow`` is written now. Both spellings are read,
+        so the fix is not load-bearing on the call staying keyword."""
+        source = 'self._record_failure_signatures(comp, phase="pr", error=e, signatures=None)\n'
+        assert names(source) == ["pr"]
+
+    def test_every_keyed_name_is_read_positionally_too(self) -> None:
+        """THE INDEX, pinned by behaviour rather than by an integer.
+
+        ``_phase_argument`` falls back to the position of ``phase`` in
+        the callable's own definition, and #339 review measured why that
+        has to be tested here: when the four indices were written by
+        hand, six of eight off-by-one mutations to them left every guard
+        green, because 25 of the 27 call sites in ``kstrl/`` pass
+        ``phase`` by keyword and the two that do not resolve to nothing.
+        One positional snippet per keyed name is what makes a wrong
+        index a red test."""
+        assert names('self.fail(comp, err, "provisioning")\n') == ["provisioning"]
+        assert names('self.retry_or_fail(comp, err, ctx, "verify")\n') == ["verify"]
+        assert names('self._record_failure_signatures(comp, "pr", err, None)\n') == ["pr"]
+        assert names('PhaseFailure(action, err, "deploy")\n') == ["deploy"]
+
+    def test_a_definition_without_a_phase_contributes_no_index(self) -> None:
+        """The other end of the derivation, and the special case it
+        replaced. ``feature_cmd`` has a one-argument local ``fail``;
+        ``pipeline.fail`` is what puts ``phase`` at index 2. Reading the
+        index off the DEFINITION means a name with no such parameter
+        anywhere answers ``None`` and is skipped, instead of needing a
+        rule that says so."""
+        assert parameter_index("fail", "phase") == 2
+        assert parameter_index("fail", "not_a_parameter") is None
+        assert parameter_index("no_such_callable_anywhere", "phase") is None
+
+    def test_a_typed_carrier_names_its_phase(self) -> None:
+        """``PhaseFailure`` records nothing itself; ``_route_failure``
+        unpacks it into ``fail`` / ``retry_or_fail`` and hands on
+        ``failure.phase``, which the walk cannot read. Reading the phase
+        where it is WRITTEN is what closes that."""
+        assert names('PhaseFailure(action=a, error=e, phase="deploy")\n') == ["deploy"]
+
+    def test_a_truthy_signatures_argument_retires_the_phase(self) -> None:
+        """The recorder branches on ``if signatures:``, so a phase that
+        cannot be reached is not a check name. ``factory`` depends on
+        this: its scope refusal passes ``phase="scope"`` with a real
+        signature, and reading that phase would put an unenrollable
+        name in the census."""
+        source = 'self.fail(c, e, phase="scope", signatures=["scope_unreadable:no-scope"])\n'
+        assert names(source) == ["scope_unreadable"]
+
+    def test_an_empty_signatures_argument_does_not(self) -> None:
+        """The other end of the same predicate, and the wrinkle that made
+        the first fix wrong: the previous test was ``"signatures" in
+        keywords``, so a literal ``None`` counted as signatures and hid
+        the phase."""
+        for empty in ("None", "[]", '""'):
+            source = f'self.fail(c, e, phase="pr", signatures={empty})\n'
+            assert names(source) == ["pr"], source
+
+    def test_an_undecidable_signatures_argument_does_not_either(self) -> None:
+        """``_route_failure`` hands on ``failure.signatures``, which is
+        ``None`` at run time for any ``PhaseFailure`` built without one.
+        Unknown is not evidence that the phase is unreachable, so both
+        expressions are reported: the phase, and the signatures."""
+        source = "self.fail(c, e, phase=failure.phase, signatures=failure.signatures)\n"
+        assert read(source) == [("failure.phase", []), ("failure.signatures", [])]
+
+
+class TestTheShapesThatSayNothing:
+    """Pinned because silence is what this guard fails INTO.
+
+    Each of these is either a site the matchers detect and cannot read -
+    which must appear as an empty-name row, and therefore in
+    ``BLIND_SITES`` - or a shape that is deliberately not a producer.
+    Without this class, both look identical from outside.
+    """
+
+    def test_a_pass_through_is_detected_and_unread(self) -> None:
+        """The property, stated on a fixture. A producer that moves out
+        of reach must not look like a producer that went away."""
+        assert read('component_failure_signatures[c] = [f"{whatever}:code"]\n') == [
+            ("f'{whatever}:code'", [])
+        ]
+
+    def test_the_funnels_own_callers_pass_a_parameter(self) -> None:
+        """``fail`` and ``retry_or_fail`` hand their own ``phase``
+        parameter to the funnel. Detected, unreadable here, and read at
+        THEIR call sites instead, which is why all three names are keyed
+        rather than only the funnel."""
+        assert read("self._record_failure_signatures(comp, phase, error, signatures)\n") == [
+            ("phase", [])
+        ]
+
+    def test_a_same_named_local_helper_is_not_a_recorder(self) -> None:
+        """``feature_cmd`` has a one-argument helper also called
+        ``fail``. Matching on the bare callable name once credited six of
+        its call sites with the check name ``"unknown"``; the positional
+        index is what keeps that from happening, and it is asserted here
+        because no other test can tell the two apart."""
+        assert read("fail(detail)\n") == []
+        assert read('fail("understand phase exited 2")\n') == []
+
+    def test_a_carrier_with_a_real_signature_is_not_read_twice(self) -> None:
+        """``PhaseFailure`` with signatures gives the signature and not
+        the phase, so enrolment is never asked about a phase the
+        recorder will not use."""
+        source = (
+            'PhaseFailure(action=a, error=e, phase="review", signatures=["review:divergence"])\n'
+        )
+        assert names(source) == ["review"]
+
+    def test_an_absent_signatures_argument_is_not_a_blind_site(self) -> None:
+        """``signatures=None`` is the ABSENCE of a signature, not one the
+        walk failed to read. Enumerating it would put a row in
+        ``BLIND_SITES`` that no reader can act on."""
+        detected = [expr for expr, _found in read('self.fail(c, e, phase="pr", signatures=None)\n')]
+        assert detected == ["'pr'"]
+
+    def test_prose_and_an_unrelated_call_are_not_producers(self) -> None:
+        """The false-positive side. Without it, "detect everything"
+        passes every test above."""
+        assert read('self.ui.warn("Review: the gate failed")\n') == []
+        assert read('log = {"check": "linter"}\n') == []
+        assert read("CheckResult()\n") == []
+
+
+class TestLayerOneCatchesWhatLayerTwoCannot:
+    """The two-layer claim, asserted rather than described.
+
+    Each case pins BOTH halves: the matchers say nothing, and the net in
+    ``tests/test_signature_spellings.py`` counts the spelling. Asserting
+    only the first would pass on a matcher nobody had ever narrowed;
+    asserting only the second would pass on a net that had been switched
+    off.
+    """
+
+    def check(self, source: str, expected: set[str]) -> None:
+        assert names(source) == [], "the matchers were expected to be silent here"
+        assert net(source) == expected
+
+    def test_a_signature_returned_straight_out_of_a_function(self) -> None:
+        """The #299 shape, in this vocabulary: a body never bound to
+        anything the matcher keys on."""
+        self.check('def sig():\n    return "engineer:no-progress-stall"\n', {"engineer"})
+
+    def test_a_signature_in_a_dispatch_table(self) -> None:
+        self.check('TABLE = {"stall": "engineer:no-progress-stall"}\n', {"engineer"})
+
+    def test_a_signature_appended_rather_than_assigned(self) -> None:
+        self.check('sigs.append("token_budget:exceeded")\n', {"token_budget"})
+
+    def test_a_signature_in_a_default_argument(self) -> None:
+        self.check('def record(sig="diff:fetch-failed"):\n    pass\n', {"diff"})
+
+    def test_a_signature_built_by_a_comprehension(self) -> None:
+        self.check('sigs = [f"contract:{c}" for c in cs]\n', {"contract"})
+
+    def test_the_net_is_not_simply_counting_every_colon(self) -> None:
+        """The false-positive side of layer 1, or a net that returned
+        every string would pass all five above."""
+        assert net('msg = "Note: the gate failed"\n') == set()
+        assert net('url = "https://example.test/x"\n') == set()
+
+
+class TestWhatNEITHERLAYERSEES:
+    """The residual, asserted so the disclosure stays true.
+
+    A string the interpreter has to BUILD answers nothing to folding, so
+    the net cannot count it and the matchers cannot read it. The bound on
+    it: such a site still has to reach ``component_failure_signatures``
+    through one of the four producers, so it appears in ``BLIND_SITES``
+    as an unread row rather than vanishing - which is the difference
+    between a disclosed limit and the silence ``_fail_pr_flow`` sat in.
+    """
+
+    def test_a_runtime_built_signature_is_seen_but_not_read(self) -> None:
+        for built in (
+            '"%s:code" % phase',
+            '":".join((phase, "code"))',
+            '"{}:code".format(phase)',
+        ):
+            source = f"self.fail(c, e, signatures=[{built}])\n"
+            assert names(source) == [], built
+            assert net(source) == set(), built
+            # Through ``ast.unparse`` on both sides: the ledger stores
+            # unparsed text, which normalises quoting, and pinning the
+            # source spelling instead would fail on a re-quote rather
+            # than on a change of behaviour.
+            unparsed = ast.unparse(ast.parse(built, mode="eval").body)
+            assert read(source) == [(unparsed, [])], built

--- a/tests/test_infrastructure_category_consumers.py
+++ b/tests/test_infrastructure_category_consumers.py
@@ -1,0 +1,282 @@
+"""The journal's ``infrastructure`` category, and what it costs the ladder.
+
+``evolution._CATEGORY_BY_CHECK`` decides what the journal calls a
+failure. ``autonomy_replay.INFRA_FAILURE_PREFIXES`` decides which runs
+count as evidence about the factory's judgement. Since #315 the second
+is DERIVED from the first, so the table is no longer only a label on a
+report: enrolling a check as ``infrastructure`` removes every run that
+failure dominates from the autonomy ladder's evidence.
+
+Split out of ``tests/test_check_name_enrolment.py`` on #339, and the
+seam is the one ``tests/test_journal_one_writer.py`` documents about its
+own split: that file is a static AST guard over ``kstrl/`` with no
+journal and no ladder in it, and this one runs the two consumers on real
+records and asserts what they do. Different subject, different failure
+message, different reason to fail. The 800-line ratchet is what forced
+the timing, but the seam was already there.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kstrl import autonomy_replay
+from kstrl.autonomy import AutonomyLevel
+from kstrl.autonomy_replay import INFRA_FAILURE_PREFIXES, RunRecord, replay
+from kstrl.evolution import _CATEGORY_BY_CHECK, INFRASTRUCTURE_CHECKS, signature_for_error
+from tests.helpers.replay import clean_run, failing_run, run_record
+
+#: A recorded run whose modal failure was the given signature.
+#:
+#: Asserting through ``RunRecord`` rather than against
+#: ``INFRA_FAILURE_PREFIXES`` on purpose: ``infra_aborted`` is what
+#: decides a run's fate, and a test that reads the constant directly
+#: would stay green if the property stopped consulting it.
+#:
+#: An alias rather than a second builder. #339 review found this file
+#: and ``tests/helpers/replay.py`` shipping two names for the same
+#: record in one change, which is how the five hand-rolled builders that
+#: helper replaced got started.
+_run_dominated_by = failing_run
+
+
+def _prefixes_without(prefix: str) -> tuple[str, ...]:
+    return tuple(sorted(set(INFRA_FAILURE_PREFIXES) - {prefix}))
+
+
+def _prefixes_with(prefix: str) -> tuple[str, ...]:
+    return tuple(sorted(set(INFRA_FAILURE_PREFIXES) | {prefix}))
+
+
+class TestTheTwoInfrastructureConsumersAgree:
+    """#315: the journal and the autonomy replay both decide what counts
+    as infrastructure, and before this they disagreed about
+    ``pr:merge-conflict`` - plumbing to the replay, an engineer-loop
+    failure to the journal. The replay now derives its prefixes from the
+    journal's table, so the shared part cannot drift. What is left is one
+    deliberate difference, pinned here so that changing either side
+    without the other is a red test rather than a quiet divergence.
+
+    Every assertion goes through ``RunRecord.infra_aborted``, the
+    property that actually decides whether a run counts as evidence
+    about the factory's judgement. An earlier version of this class
+    asserted ``startswith(INFRA_FAILURE_PREFIXES)`` instead, which
+    cannot fail while the tuple is built from ``INFRASTRUCTURE_CHECKS``:
+    it restated the constructor rather than testing anything."""
+
+    @pytest.mark.parametrize("check", sorted(INFRASTRUCTURE_CHECKS))
+    def test_an_infrastructure_check_costs_the_run_its_verdict(self, check: str) -> None:
+        assert _run_dominated_by(f"{check}:any-code").infra_aborted, (
+            f"{check!r} is 'infrastructure' in the journal but a decisive "
+            f"judgement failure to autonomy_replay."
+        )
+        assert not _run_dominated_by(f"{check}:any-code").decisive
+
+    def test_the_replay_treats_exactly_these_signatures_as_plumbing(self) -> None:
+        """The contents, not the derivation. The four rows beyond the
+        journal's own are the replay asking a WIDER question: not 'which
+        part of the factory failed' but 'did this run yield a verdict
+        about the factory's judgement at all', which a gate's honest
+        verdict can answer with no. Spelled out here so that adding a
+        fifth is a visible edit in two files."""
+        assert set(INFRA_FAILURE_PREFIXES) == {
+            "aborted:",
+            "diff:",
+            "pr:",
+            "provisioning:",
+            "token_budget:",
+            # Replay-only; see autonomy_replay._REPLAY_ONLY_PREFIXES.
+            "scope_unreadable:",
+            "git:",
+            "infra:",
+            "timeout:",
+        }
+
+    def test_the_scope_refusal_is_the_deliberate_divergence(self) -> None:
+        """``scope_unreadable`` is a Phase 1 gate result, so the journal
+        files it under verification (#294 gave it its own gate, table row
+        and proposal arm on that basis). It is still an infrastructure
+        casualty for the replay: nothing was measured about the change,
+        so the run says nothing about judgement. Both halves asserted,
+        because the divergence is only defensible while it is on
+        purpose."""
+        assert _CATEGORY_BY_CHECK["scope_unreadable"] == "verification"
+        assert "scope_unreadable" not in INFRASTRUCTURE_CHECKS
+        assert _run_dominated_by("scope_unreadable:no-trustworthy-scope").infra_aborted
+
+    def test_a_judgement_failure_still_counts_as_evidence(self) -> None:
+        """The other direction, or the class above would pass with every
+        run called plumbing. ``diff:`` must not swallow ``diff_scope:``
+        either: a scope violation is a verdict on the change, and the
+        colon is the only thing separating the two names."""
+        assert not _run_dominated_by("diff_scope:files-outside-allowed-scope").infra_aborted
+        assert _run_dominated_by("diff_scope:files-outside-allowed-scope").decisive
+        assert not _run_dominated_by("review:scope_creep").infra_aborted
+        assert not _run_dominated_by("test_suite:assertion-error").infra_aborted
+
+    def test_a_human_rejection_is_a_verdict_not_an_outage(self) -> None:
+        """#339 review, P2-1. A person looking at the change and saying
+        no is the most decisive evidence about the factory's judgement
+        there is. It reached the journal as
+        ``pr:rejected-at-hitl-checkpoint`` because the HITL checkpoint
+        fails at ``phase="pr"`` and the phase becomes the check name, so
+        the ``pr`` row - real push, create and merge plumbing - swallowed
+        it and the replay threw the whole run away."""
+        assert _run_dominated_by("review:hitl-rejected").decisive
+        assert not _run_dominated_by("review:hitl-rejected").infra_aborted
+
+    def test_asking_for_changes_is_a_verdict_too(self) -> None:
+        """#339 A4, the sibling branch 46 lines below the one P2-1
+        fixed. ``CheckpointDecision.RETRY`` is a human reading the change
+        and asking for different work, which is a judgement about the
+        change by the same argument that makes a rejection one."""
+        assert _run_dominated_by("review:hitl-changes-requested").decisive
+        assert not _run_dominated_by("review:hitl-changes-requested").infra_aborted
+
+    def test_the_unanswered_gate_stays_an_outage(self) -> None:
+        """The third HITL-adjacent branch, and the one that is NOT a
+        verdict: ``PARKED`` means the merge gate could not be put to
+        anybody, so nothing was decided about the change and the run says
+        nothing about the factory's judgement. It keeps the ``pr:``
+        fallback deliberately, which is why the branch above it carries a
+        ``signatures=`` and this one carries a comment saying it must
+        not.
+
+        Derived through ``signature_for_error`` rather than pasted,
+        because the slug is truncated at 63 characters and a pasted copy
+        would pin the truncation rather than the check name."""
+        parked = signature_for_error("pr", "Parked awaiting merge approval (no interactive UI)")
+        assert parked.startswith("pr:")
+        assert _CATEGORY_BY_CHECK["pr"] == "infrastructure"
+        assert _run_dominated_by(parked).infra_aborted
+        assert not _run_dominated_by(parked).decisive
+
+
+class TestTheTableMovesTheLadder:
+    """#339 review, P2-3. The derivation is a real coupling and it had no
+    test: every assertion above stops at ``infra_aborted``, one run at a
+    time, and none of them showed the thing that actually changes when
+    the journal's table is edited, which is where the autonomy ladder
+    ends up.
+
+    Both directions are here because the coupling is NOT monotone, and
+    that is the part a reader gets wrong. Enrolling a check as
+    infrastructure removes runs from the evidence, and a removed run can
+    be a run that would have DEMOTED, so more infrastructure can leave
+    the ladder HIGHER. The PR that introduced this measured exactly that
+    on one unchanged ``experiments.tsv``, in both directions on different
+    data.
+
+    ``monkeypatch.setattr`` on the module global is the technique, and it
+    works because ``RunRecord.infra_aborted`` looks the tuple up at call
+    time rather than closing over it. Measured before relying on it.
+    """
+
+    def test_enrolling_a_check_leaves_the_ladder_higher(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The non-monotone direction. Twelve clean runs promote L1 to
+        L2, then one run dies on the token ceiling. Counted as a verdict
+        that run is a failure and demotes; counted as plumbing it is
+        skipped and the promotion stands."""
+        runs = [clean_run(i) for i in range(12)] + [failing_run("token_budget:exhausted")]
+
+        monkeypatch.setattr(
+            autonomy_replay, "INFRA_FAILURE_PREFIXES", _prefixes_without("token_budget:")
+        )
+        before = replay(runs)
+        assert before.final_level == int(AutonomyLevel.L1_SUPERVISED)
+        assert before.decisive_runs == 13
+        assert before.would_demote
+
+        monkeypatch.undo()
+        after = replay(runs)
+        assert after.final_level == int(AutonomyLevel.L2_GATED_MERGE)
+        assert after.decisive_runs == 12
+        assert after.infra_aborted_runs == 1
+        assert not after.would_demote
+
+    def test_enrolling_a_check_leaves_the_ladder_lower(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The direction a reader expects, on data where the excluded
+        runs were the evidence FOR a promotion rather than against one.
+        ``sufficient_data`` flips with it, which is what changes
+        ``ks autonomy replay``'s exit status from 0 to 2."""
+        runs = [
+            run_record(
+                run_id=f"r{i}",
+                timestamp=f"2026-07-{(i % 28) + 1:02d}T00:00:00Z",
+                project="p",
+                common_failure="diff:could-not-fetch-diff",
+            )
+            for i in range(12)
+        ]
+
+        monkeypatch.setattr(autonomy_replay, "INFRA_FAILURE_PREFIXES", _prefixes_without("diff:"))
+        before = replay(runs)
+        assert before.final_level == int(AutonomyLevel.L2_GATED_MERGE)
+        assert before.sufficient_data
+
+        monkeypatch.undo()
+        after = replay(runs)
+        assert after.final_level == int(AutonomyLevel.L1_SUPERVISED)
+        assert after.decisive_runs == 0
+        assert not after.sufficient_data
+
+    def test_one_new_row_in_the_journal_table_is_enough(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The warning, as a mechanism. ``test_suite`` is a real gate and
+        a real verdict; filing it as infrastructure would be a one-line
+        edit to ``_CATEGORY_BY_CHECK`` with no code diff, and it would
+        promote the factory a rung on data where the tests were failing.
+        That is the direction this coupling is dangerous in, so it is
+        asserted rather than described."""
+        runs = [clean_run(i) for i in range(12)] + [failing_run("test_suite:assertion-error")]
+
+        assert replay(runs).final_level == int(AutonomyLevel.L1_SUPERVISED)
+
+        monkeypatch.setattr(
+            autonomy_replay, "INFRA_FAILURE_PREFIXES", _prefixes_with("test_suite:")
+        )
+        assert replay(runs).final_level == int(AutonomyLevel.L2_GATED_MERGE)
+
+
+class TestTheReportCountsOnePopulation:
+    """#339 review, P2-2. A Ctrl-C during a run that had already merged
+    24 components files `aborted:shutdown`, which #315 made
+    infrastructure, so the replay skips the run entirely - and the
+    report still printed "Components merged: 24" two lines under
+    "infra-aborted: 1 (excluded)". Two populations under one label, and
+    the bigger one was the one that counted for nothing."""
+
+    def _ctrl_c_run(self) -> RunRecord:
+        return run_record(
+            run_id="interrupted",
+            timestamp="2026-07-29T00:00:00Z",
+            project="p",
+            components_total=25,
+            completed=24,
+            failed=1,
+            common_failure="aborted:shutdown",
+        )
+
+    def test_the_headline_counts_the_runs_the_ladder_counts(self) -> None:
+        report = replay([clean_run(0), self._ctrl_c_run()])
+        assert report.infra_aborted_runs == 1
+        assert report.components_merged == 1
+        assert report.merged_in_excluded_runs == 24
+
+    def test_the_excluded_merges_are_shown_rather_than_dropped(self) -> None:
+        """Not counted is not the same as not reported: the total has to
+        stay recoverable, or the fix trades one wrong number for a
+        missing one."""
+        text = replay([clean_run(0), self._ctrl_c_run()]).render()
+        assert "Components merged:    1 (in decisive runs)" in text
+        assert "in excluded runs:   24 (not counted)" in text
+
+    def test_a_clean_sample_says_nothing_about_exclusions(self) -> None:
+        """The line only appears when there is something to disclose."""
+        text = replay([clean_run(i) for i in range(3)]).render()
+        assert "in excluded runs" not in text

--- a/tests/test_infrastructure_category_consumers.py
+++ b/tests/test_infrastructure_category_consumers.py
@@ -18,6 +18,8 @@ the timing, but the seam was already there.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from kstrl import autonomy_replay
@@ -62,15 +64,27 @@ class TestTheTwoInfrastructureConsumersAgree:
     about the factory's judgement. An earlier version of this class
     asserted ``startswith(INFRA_FAILURE_PREFIXES)`` instead, which
     cannot fail while the tuple is built from ``INFRASTRUCTURE_CHECKS``:
-    it restated the constructor rather than testing anything."""
+    it restated the constructor rather than testing anything.
+
+    ``decisive`` is asserted ONCE, in the test below, and not beside
+    every ``infra_aborted``. #339 review measured why: these records all
+    have ``completed + failed > 0``, so ``decisive`` reduces to ``not
+    infra_aborted`` and a second assertion beside the first is its own
+    negation restated. One case establishes that ``decisive`` consults
+    the property; the rest would only repeat the signature literal, and
+    a typo in the repeat would silently change what it tests."""
 
     @pytest.mark.parametrize("check", sorted(INFRASTRUCTURE_CHECKS))
     def test_an_infrastructure_check_costs_the_run_its_verdict(self, check: str) -> None:
-        assert _run_dominated_by(f"{check}:any-code").infra_aborted, (
+        run = _run_dominated_by(f"{check}:any-code")
+        assert run.infra_aborted, (
             f"{check!r} is 'infrastructure' in the journal but a decisive "
             f"judgement failure to autonomy_replay."
         )
-        assert not _run_dominated_by(f"{check}:any-code").decisive
+        # The one place `decisive` is asserted next to `infra_aborted`:
+        # it is what couples the property to the ladder's evidence, and
+        # asserting it again elsewhere would restate this negation.
+        assert not run.decisive
 
     def test_the_replay_treats_exactly_these_signatures_as_plumbing(self) -> None:
         """The contents, not the derivation. The four rows beyond the
@@ -100,8 +114,10 @@ class TestTheTwoInfrastructureConsumersAgree:
         so the run says nothing about judgement. Both halves asserted,
         because the divergence is only defensible while it is on
         purpose."""
+        # Not also `"scope_unreadable" not in INFRASTRUCTURE_CHECKS`:
+        # that set is comprehended from this table on the category, so
+        # the line above already entails it.
         assert _CATEGORY_BY_CHECK["scope_unreadable"] == "verification"
-        assert "scope_unreadable" not in INFRASTRUCTURE_CHECKS
         assert _run_dominated_by("scope_unreadable:no-trustworthy-scope").infra_aborted
 
     def test_a_judgement_failure_still_counts_as_evidence(self) -> None:
@@ -110,7 +126,6 @@ class TestTheTwoInfrastructureConsumersAgree:
         either: a scope violation is a verdict on the change, and the
         colon is the only thing separating the two names."""
         assert not _run_dominated_by("diff_scope:files-outside-allowed-scope").infra_aborted
-        assert _run_dominated_by("diff_scope:files-outside-allowed-scope").decisive
         assert not _run_dominated_by("review:scope_creep").infra_aborted
         assert not _run_dominated_by("test_suite:assertion-error").infra_aborted
 
@@ -122,7 +137,6 @@ class TestTheTwoInfrastructureConsumersAgree:
         fails at ``phase="pr"`` and the phase becomes the check name, so
         the ``pr`` row - real push, create and merge plumbing - swallowed
         it and the replay threw the whole run away."""
-        assert _run_dominated_by("review:hitl-rejected").decisive
         assert not _run_dominated_by("review:hitl-rejected").infra_aborted
 
     def test_asking_for_changes_is_a_verdict_too(self) -> None:
@@ -130,7 +144,6 @@ class TestTheTwoInfrastructureConsumersAgree:
         fixed. ``CheckpointDecision.RETRY`` is a human reading the change
         and asking for different work, which is a judgement about the
         change by the same argument that makes a rejection one."""
-        assert _run_dominated_by("review:hitl-changes-requested").decisive
         assert not _run_dominated_by("review:hitl-changes-requested").infra_aborted
 
     def test_the_unanswered_gate_stays_an_outage(self) -> None:
@@ -149,7 +162,6 @@ class TestTheTwoInfrastructureConsumersAgree:
         assert parked.startswith("pr:")
         assert _CATEGORY_BY_CHECK["pr"] == "infrastructure"
         assert _run_dominated_by(parked).infra_aborted
-        assert not _run_dominated_by(parked).decisive
 
 
 class TestTheTableMovesTheLadder:
@@ -204,13 +216,7 @@ class TestTheTableMovesTheLadder:
         ``sufficient_data`` flips with it, which is what changes
         ``ks autonomy replay``'s exit status from 0 to 2."""
         runs = [
-            run_record(
-                run_id=f"r{i}",
-                timestamp=f"2026-07-{(i % 28) + 1:02d}T00:00:00Z",
-                project="p",
-                common_failure="diff:could-not-fetch-diff",
-            )
-            for i in range(12)
+            replace(clean_run(i), common_failure="diff:could-not-fetch-diff") for i in range(12)
         ]
 
         monkeypatch.setattr(autonomy_replay, "INFRA_FAILURE_PREFIXES", _prefixes_without("diff:"))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -23,6 +23,7 @@ from kstrl import git
 from kstrl.agents.base import UsageRecord, UsageTotals
 from kstrl.config import KstrlConfig
 from kstrl.events import CallbackSink, Event, EventBus, PhaseCompleted, V1CompatSink
+from kstrl.evolution import category_for_check
 from kstrl.factory import (
     AdversarialAgentSelection,
     ComponentResult,
@@ -1036,6 +1037,16 @@ class TestCheckpointAndPrTransitions:
         assert comp.retries == 0
         assert comp.status == ComponentStatus.FAILED.value
         assert comp.failed_check == "hitl_reject"
+        # #339 P2-1: the journal signature, not the phase. Without an
+        # explicit `signatures=` the phase becomes the check name and a
+        # human refusing the change is recorded as
+        # `pr:rejected-at-hitl-checkpoint`, which _CATEGORY_BY_CHECK
+        # files as infrastructure and the autonomy replay then discards
+        # as an outage. Asserted on the recorded signature rather than
+        # on the argument, because the argument is not what the journal
+        # reads.
+        assert pipeline.component_failure_signatures["comp-a"] == ["review:hitl-rejected"]
+        assert category_for_check("review") == "review"
         assert dep.status == ComponentStatus.SKIPPED.value
         assert result.failed == ["comp-a"]
 
@@ -1055,6 +1066,14 @@ class TestCheckpointAndPrTransitions:
         assert comp.retries == 1
         assert comp.status == ComponentStatus.PENDING.value
         assert comp.failed_check == "hitl_retry"
+        # #339 A4: the sibling of the rejection branch, and it had the
+        # same defect 46 lines below the fix. A human asking for changes
+        # is a verdict on the change, so the signature says `review:`
+        # rather than letting the phase file it under `pr`, which
+        # _CATEGORY_BY_CHECK carries as infrastructure.
+        recorded = pipeline.component_failure_signatures["comp-a"]
+        assert recorded == ["review:hitl-changes-requested"]
+        assert category_for_check("review") == "review"
         assert "Human reviewer requested changes" in (pipeline.component_contexts["comp-a"])
 
     def test_merge_pending_parks_component(

--- a/tests/test_signature_chokepoint.py
+++ b/tests/test_signature_chokepoint.py
@@ -1,0 +1,145 @@
+"""The chokepoint every check name has to pass through, inventoried.
+
+Split out of ``tests/test_check_name_enrolment.py`` on #339 review,
+and the seam is a difference in GUARANTEE rather than in subject.
+
+That file walks ``kstrl/`` for four producer SHAPES, resolves the check
+names out of them and asserts the category table carries what it finds.
+Everything it knows is bounded by a shape somebody enumerated, so a
+producer written in an unimagined shape is silence: not resolved, and
+not recorded in its ``BLIND_SITES`` ledger either. That ledger lists the
+places the walk gave up, which is a strictly smaller set than the places
+a check name can be written, and #339 review found ``_fail_pr_flow``
+living in the gap between the two for two review rounds.
+
+This file has the other guarantee, the one
+``tests/test_journal_one_writer.py`` gets from
+``EXPECTED_JOURNAL_PATH_SITES``: "code cannot write to a file whose path
+it never obtained." The same sentence holds here. A check name cannot
+reach ``evolution.category_for_check`` without passing through
+``pipeline.component_failure_signatures``, so every producer must touch
+one of the five names below, whatever shape it is written in. No matcher
+to widen, no shape to recognise, nothing to go blind.
+
+Measured both ways on #339. The day ``_fail_pr_flow`` was written,
+``self._record_failure_signatures`` went from two occurrences to three
+and this pin would have gone red. And a new writer reaching the mapping
+through a local alias with a runtime-built signature - the shape nothing
+else here can see - fails this pin and no other.
+
+Until #324 gives every guard in this repo one shared AST walker, this is
+the part of the check-name enrolment story that is closed by
+construction.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from tests.helpers.astfold import parsed_modules
+from tests.test_check_name_enrolment import SIGNATURE_CONTAINER_SUFFIX
+
+#: EVERY mention of a ``*failure_signatures`` name in ``kstrl/``, as
+#: ``(module, spelling) -> occurrences``. The chokepoint inventory, and
+#: the only thing in this file that is closed BY CONSTRUCTION.
+#:
+#: The distinction #339 review drew, and it is the one that matters here.
+#: :data:`BLIND_SITES` lists the walk's own resolution FAILURES, and
+#: ``tests/test_check_name_shapes.py`` lists the shapes its author
+#: thought of. Both are bounded by what somebody already knew. This is
+#: not: a check name cannot reach ``category_for_check`` without passing
+#: through ``pipeline.component_failure_signatures``, which is the same
+#: sentence ``tests/test_journal_one_writer.py`` makes its
+#: ``EXPECTED_JOURNAL_PATH_SITES`` out of ("code cannot write to a file
+#: whose path it never obtained"), so every producer must touch one of
+#: these names whatever shape it is written in.
+#:
+#: Measured against the defect this PR is downstream of: the day
+#: ``_fail_pr_flow`` was written, ``self._record_failure_signatures``
+#: went from 2 occurrences to 3 and this pin would have gone red, with
+#: no matcher to widen and no shape to recognise. It was instead
+#: invisible for as long as it took two review rounds to find it.
+#:
+#: Counts rather than a set, because a THIRD caller of the recorder is
+#: the event worth catching and the module already had two. The counts
+#: are expected to move: the diff that moves one is where somebody says
+#: whether the new site's check name is censused.
+EXPECTED_SIGNATURE_CONTAINER_SITES: dict[tuple[str, str], int] = {
+    # The recorder itself, and its three callers: fail, retry_or_fail
+    # and _fail_pr_flow.
+    ("kstrl/pipeline.py", "self._record_failure_signatures"): 3,
+    # The mapping, under all three spellings it is reached by.
+    ("kstrl/pipeline.py", "self.component_failure_signatures"): 9,
+    ("kstrl/pipeline.py", "component_failure_signatures"): 1,
+    ("kstrl/factory.py", "component_failure_signatures"): 5,
+    # The reader: record_run takes the mapping as an argument and writes
+    # each component's list into the journal entry.
+    ("kstrl/evolution.py", "failure_signatures"): 4,
+}
+
+
+def signature_container_sites() -> dict[tuple[str, str], int]:
+    """``(module, spelling) -> occurrences`` for the chokepoint names.
+
+    Names and attributes only. A string literal ``"failure_signatures"``
+    is the journal's COLUMN rather than the mapping, and counting it
+    would make this inventory move on an unrelated edit to a dict key.
+    """
+    found: dict[tuple[str, str], int] = {}
+    for rel, tree in parsed_modules():
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and node.id.endswith(SIGNATURE_CONTAINER_SUFFIX):
+                spelling = node.id
+            elif isinstance(node, ast.Attribute) and node.attr.endswith(SIGNATURE_CONTAINER_SUFFIX):
+                spelling = ast.unparse(node)
+            else:
+                continue
+            found[(rel, spelling)] = found.get((rel, spelling), 0) + 1
+    return found
+
+
+class TestTheChokepointIsInventoried:
+    """The closed-by-construction half, in the shape of
+    ``tests/test_journal_one_writer.py``'s ``EXPECTED_JOURNAL_PATH_SITES``.
+
+    Every other guard in this file and its two siblings is bounded by a
+    shape somebody enumerated, so a producer written in an unimagined
+    shape is silence rather than a red test. This one is not: a check
+    name reaches the journal through
+    ``pipeline.component_failure_signatures`` or it does not reach it at
+    all, so the census of that name's mentions moves whenever a producer
+    is added, whatever the producer looks like.
+    """
+
+    def test_the_chokepoint_is_touched_in_exactly_these_places(self) -> None:
+        """The message names the action, because this pin fires on
+        ordinary refactors too and a pin whose message is 'update the
+        number' teaches nothing."""
+        measured = signature_container_sites()
+        pinned = EXPECTED_SIGNATURE_CONTAINER_SITES
+        grown = sorted(key for key, n in measured.items() if pinned.get(key) != n)
+        shrunk = sorted(key for key, n in pinned.items() if measured.get(key) != n)
+        assert measured == pinned, (
+            f"the places kstrl/ touches a *{SIGNATURE_CONTAINER_SUFFIX} name "
+            f"have moved. Added or grown: {grown}. Gone or shrunk: {shrunk}. "
+            f"If a new site WRITES a component's signatures, make sure the "
+            f"check name it writes is censused: check_names() must contain "
+            f"it, or BLIND_SITES must say why it cannot be read. Then "
+            f"update the count here."
+        )
+
+    def test_the_recorder_has_the_callers_the_walk_assumes(self) -> None:
+        """Named separately from the count above because it is the
+        specific claim ``PHASE_FALLBACK_CALLS`` rests on: keying the
+        producer on ``fail`` and ``retry_or_fail`` was correct only
+        while those were the recorder's ONLY callers, and it stopped
+        being correct without anything going red. Three now: the two
+        entry points and ``_fail_pr_flow``."""
+        callers = EXPECTED_SIGNATURE_CONTAINER_SITES[
+            ("kstrl/pipeline.py", "self._record_failure_signatures")
+        ]
+        assert callers == 3, (
+            "the failure-signature recorder has a different number of "
+            "call sites. A new one files its failure under its PHASE "
+            "unless it passes signatures=, so census that phase."
+        )

--- a/tests/test_signature_spellings.py
+++ b/tests/test_signature_spellings.py
@@ -1,0 +1,230 @@
+"""Every signature-shaped string in ``kstrl/``, counted by no shape at all.
+
+``tests/test_check_name_enrolment.py`` names four producers, resolves
+them and asserts the table carries what they emit. That is the layer
+with the right message, and it is also the layer that keeps being holed:
+each of the four was found only after a version of it claimed to have
+them all, and #339 review measured eight of nine ordinary shape
+mutations surviving it.
+
+This is the other layer, borrowed whole from #336 (which landed on main
+as ``tests/test_event_names_have_one_home.py``, after this branch was
+cut), where widening a matcher was measured to be necessary but not
+sufficient: seven more ordinary shapes walked past the widened version,
+and the answer was a guard that enumerates no node types.
+
+THE NET: every expression in the package whose folded value has the
+shape of a journal signature, ``"<check>:<code>"``, wherever it sits. A
+component's failure signature cannot be written by a string the package
+never spells, so a fifth producer - in a container, a dispatch table, a
+return value, a comprehension, a default argument, whatever nobody has
+thought of - has to appear here first, whatever it does with the string
+afterwards.
+
+WHY THIS IS AN INVENTORY AND NOT AN ASSERTION. The net cannot tell a
+journal signature from any other colon-joined pair, and the package has
+several of those: ``findings`` spells ``"cwe:..."`` and ``"owasp:..."``,
+``linear`` spells issue keys, ``pipeline`` spells inbox dedupe keys like
+``"halted:..."``. Requiring every head to be enrolled would put those in
+``_CATEGORY_BY_CHECK``, which is worse than the hole - a table that
+carries names the journal never files stops being readable as the list
+of names it does. So the net pins WHERE the package spells such strings,
+and the diff that adds a row is where somebody says which kind it is.
+
+WHAT THE NET CANNOT SEE is one thing and it is the same thing the #336
+guard discloses: a string the interpreter has to build. ``":".join(...)``,
+``%``-formatting, ``"".format(...)``, a run-time lookup. Folding answers
+nothing for those. It DOES see an f-string whose tail is dynamic, since
+the check name is everything before the first colon.
+"""
+
+from __future__ import annotations
+
+import ast
+from functools import lru_cache
+
+from tests.helpers.astfold import (
+    HOLE,
+    fold,
+    folded_nodes,
+    module_level_strings,
+    parsed_modules,
+    signature_head,
+)
+
+#: ``(module, check part)`` for every signature-shaped string in the
+#: package. A SET rather than the per-module counts #336 pins, because
+#: the question here is which NAMES a module can write, not how many
+#: times it writes them: a second ``"pr:..."`` in ``pipeline`` changes
+#: nothing about enrolment, and failing on it would make this a thing to
+#: be regenerated rather than read.
+#:
+#: THE RULE FOR A NEW ROW, since eight of these heads are also pinned in
+#: ``EXPECTED_CATEGORIES`` and #339 review asked what decides that.
+#: Every signature-shaped string goes here, enrolled or not. The
+#: enrolled eight are NOT derived from ``_CATEGORY_BY_CHECK``, on
+#: purpose: derivation would answer "which module spells this" with
+#: "whichever one does", and this list is what turns a ``pr:`` literal
+#: MOVING to another module, or being deleted, into a red test. The
+#: three-place edit for a genuinely new check name is the same audit
+#: trail ``tests/test_prompt_versions.py`` asks for, not an oversight.
+EXPECTED_SPELLINGS: frozenset[tuple[str, str]] = frozenset(
+    {
+        # --- journal signatures: these eight ARE check names, and every
+        # one is enrolled in evolution._CATEGORY_BY_CHECK.
+        ("kstrl/factory.py", "contract"),
+        ("kstrl/factory.py", "scope_unreadable"),
+        ("kstrl/pipeline.py", "aborted"),
+        ("kstrl/pipeline.py", "diff"),
+        ("kstrl/pipeline.py", "engineer"),
+        ("kstrl/pipeline.py", "pr"),
+        ("kstrl/pipeline.py", "review"),
+        ("kstrl/pipeline.py", "token_budget"),
+        # --- other vocabularies that share the shape. None of these
+        # reaches component_failure_signatures, and enrolling any of
+        # them would make the category table unreadable as the list of
+        # names the journal files.
+        # Divergence's own reasons for a trip.
+        ("kstrl/divergence.py", "concern"),
+        ("kstrl/divergence.py", "criterion"),
+        # An autonomy demotion record, not a component failure.
+        ("kstrl/factory.py", "demotion"),
+        # Finding metadata: CWE and OWASP ids, and the keys a finding
+        # serialises its own fields under.
+        ("kstrl/findings.py", "adequacy"),
+        ("kstrl/findings.py", "attempt"),
+        ("kstrl/findings.py", "category"),
+        ("kstrl/findings.py", "cwe"),
+        ("kstrl/findings.py", "model"),
+        ("kstrl/findings.py", "owasp"),
+        ("kstrl/findings.py", "phase"),
+        ("kstrl/findings.py", "policy"),
+        # A GitHub label namespace.
+        ("kstrl/intake_github.py", "kstrl"),
+        # Inbox dedupe keys and the budget label, all keyed the same way
+        # and none of them a failure signature.
+        ("kstrl/pipeline.py", "adequacy"),
+        ("kstrl/pipeline.py", "budget"),
+        ("kstrl/pipeline.py", "halted"),
+        ("kstrl/pipeline.py", "merge"),
+        ("kstrl/pipeline.py", "policy"),
+    }
+)
+
+
+def signature_heads(tree: ast.AST, own: dict[str, str]) -> set[str]:
+    """The check part of every folded signature in one tree.
+
+    THE NET ITSELF, one tree at a time, so
+    ``tests/test_check_name_shapes.py`` can hold it to the shapes the
+    other layer misses rather than re-implementing six lines that could
+    then be widened apart from these.
+    """
+    return {
+        head for folded in folded_nodes(tree, own) if (head := signature_head(folded)) is not None
+    }
+
+
+@lru_cache(maxsize=1)
+def signature_spellings() -> frozenset[tuple[str, str]]:
+    """``(module, check part)`` for every folded signature in ``kstrl/``.
+
+    Cached for the session, as ``parsed_modules`` and ``_census`` are.
+    Measured on #339 review: 93 ms a pass and two tests call it, so the
+    second pass was pure duplicate.
+    """
+    return frozenset(
+        (rel, head)
+        for rel, tree in parsed_modules()
+        for head in signature_heads(tree, module_level_strings()[rel])
+    )
+
+
+class TestTheSignatureSpellingsAreInventoried:
+    def test_the_package_spells_exactly_these(self) -> None:
+        """A new row is not forbidden, it is the point: the diff that
+        adds one is where somebody says whether a new signature-shaped
+        string reaches the journal. If it does, enrol its check part in
+        ``evolution._CATEGORY_BY_CHECK`` as well."""
+        measured = signature_spellings()
+        assert measured == EXPECTED_SPELLINGS, (
+            f"new spellings: {sorted(measured - EXPECTED_SPELLINGS)} (if any "
+            f"of these reaches component_failure_signatures, enrol its check "
+            f"part in evolution._CATEGORY_BY_CHECK too). Gone: "
+            f"{sorted(EXPECTED_SPELLINGS - measured)}."
+        )
+
+    def test_the_net_sees_the_producers_the_other_layer_names(self) -> None:
+        """Anti-vacuity, and the specific claim this layer makes: it
+        finds the fourth producer without knowing that an assignment is
+        a producer, and the conditional in ``_setpoint_failure`` without
+        knowing what an ``IfExp`` is.
+
+        This guards the EXPECTATION, not the net: the equality above
+        already implies every membership below, so nothing here can fail
+        while that passes. What it stops is a future author deleting
+        these four from the pin to make a red test go away, which is the
+        one edit that would silently un-cover all four producers."""
+        measured = signature_spellings()
+        assert ("kstrl/factory.py", "contract") in measured, "a direct assignment"
+        assert ("kstrl/pipeline.py", "engineer") in measured, "a direct assignment"
+        assert ("kstrl/pipeline.py", "review") in measured, "a conditional expression"
+        assert ("kstrl/factory.py", "scope_unreadable") in measured, "an f-string constant"
+
+    def test_a_dynamic_tail_does_not_hide_the_check_name(self) -> None:
+        """``f"contract:tier_{n}"`` is the fourth producer's actual
+        shape, and the version of the walk this replaces folded it to
+        nothing because one piece was unknown."""
+        node = ast.parse('f"contract:tier_{n}"', mode="eval").body
+        folded = fold(node, {})
+        assert folded is not None
+        assert signature_head(folded) == "contract"
+
+    def test_a_dynamic_check_name_is_not_guessed(self) -> None:
+        """The other half. An unknown HEAD must fold to nothing here, or
+        the net would invent a check name; the enrolment layer resolves
+        that case from the call sites instead."""
+        node = ast.parse('f"{phase}:coverage-unverified"', mode="eval").body
+        folded = fold(node, {})
+        assert folded is not None
+        assert signature_head(folded) is None
+
+    def test_a_concatenation_folds_like_a_literal(self) -> None:
+        """The ``+`` branch of the fold has no site in ``kstrl/`` today -
+        125 concatenations, none of them a signature - so it is measured
+        here or it is not measured at all. A concatenation is exactly
+        what somebody writes to get past a string search (#327 F9)."""
+        node = ast.parse('"review" + ":setpoint_disagreement"', mode="eval").body
+        folded = fold(node, {})
+        assert folded is not None
+        assert signature_head(folded) == "review"
+
+    def test_prose_is_not_a_signature(self) -> None:
+        """A guard that fires on every colon in the package is a guard
+        that gets silenced. Three real shapes from this tree."""
+        for text in ("Note: the thing failed", "https://example.test/x", "Error:"):
+            node = ast.parse(repr(text), mode="eval").body
+            folded = fold(node, {})
+            assert folded is not None
+            assert signature_head(folded) is None, text
+
+
+def test_no_literal_in_the_package_contains_the_hole_marker() -> None:
+    """The marker's whole job is to be distinguishable from text, and
+    #339 review measured the first attempt at it wrong: a single NUL
+    already appears in three ``kstrl/`` literals, so the docstring
+    claiming otherwise was a claim the package contradicted. Lives here
+    rather than next to the constant because it needs the package walk,
+    and it is asserted rather than believed because that is the standard
+    this pair of guards exists to hold."""
+    colliding = [
+        (rel, node.lineno)
+        for rel, tree in parsed_modules()
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str) and HOLE in node.value
+    ]
+    assert not colliding, (
+        f"a literal in kstrl/ now contains the hole marker, so a folded "
+        f"string cannot be told from one with an undecidable piece: "
+        f"{colliding}. Lengthen astfold.HOLE."
+    )


### PR DESCRIPTION
Closes #315.

## What was wrong

`evolution.category_for_check` maps a check name onto a `FailurePattern.category` and falls through to `"iteration"` for anything `_CATEGORY_BY_CHECK` does not carry. Eight of the nineteen names the enrolment walk could see were unenrolled, so the journal filed them under the engineer loop: three Phase 1 gates (`fixtures`, `policy_envelope`, `test_adequacy`), four failures recorded outside a `CheckResult` (`aborted`, `token_budget`, `pr`, `diff`), and `engineer`, which the fallback got right by accident.

The four in the middle had no correct home. The table offered `verification`, `review`, `security` and `contract`, and the fallback was the engineer's loop. A shutdown, a blown token ceiling, a merge conflict and a diff that would not fetch are none of those.

While reviewing the fix, a third producer of check names turned up that the guard could not see at all. See "What the review found" below.

## What changed

1. `fixtures`, `policy_envelope`, `test_adequacy` are enrolled as `verification`.
2. A new `infrastructure` category holds `aborted`, `token_budget`, `pr`, `diff` and (round 2) `provisioning`.
3. `engineer` is enrolled as `iteration` explicitly, along with `unknown`. Neither changes an answer; both stop the table being readable as "most of the names".
4. `autonomy_replay.INFRA_FAILURE_PREFIXES` derives from `evolution.INFRASTRUCTURE_CHECKS` instead of retyping the same judgement. The two consumers disagreed about `pr:merge-conflict`: plumbing to the replay, an engineer-loop failure to the journal. Enrolling a check as infrastructure now reaches both in one edit.
5. `verify` and `provisioning` are enrolled, from the third producer the review found.
6. `_classify_check` no longer returns a category. All three callers discarded it, so it was a second, unreachable answer that could silently disagree with the live one.
7. `tests/test_check_name_enrolment.py` loses its grandfathered set entirely, gains the third producer, gains a blind-guard test, and gains a whole-table pin.

`UNENROLLED_AT_INTRODUCTION` is empty and deleted. The guard now admits no exceptions.

### The deliberate divergence, and why it is not "one answer serves both"

`scope_unreadable` stays `verification` in the journal and remains an infrastructure abort for the replay. The two consumers ask different questions. The journal asks which part of the factory produced a failure, and a scope refusal is a Phase 1 gate result: #294 gave it its own gate, its own table row and its own proposal arm on exactly that basis. The replay asks whether the run yielded a verdict about the factory's JUDGEMENT, and a gate's honest verdict can still answer no, because nothing was ever measured about the change.

So the relation is: infrastructure implies non-decisive, plus a documented remainder. The remainder is `autonomy_replay._REPLAY_ONLY_PREFIXES`, and `TestTheTwoInfrastructureConsumersAgree` pins both halves, through `RunRecord.infra_aborted` rather than against the constant.

`git:`, `infra:` and `timeout:` stay in that remainder. Measured with `git log -S`: all three strings entered the tree in 606cbb1, the commit that created the tuple, and no call site has ever produced them. They are kept because an experiments.tsv row outlives the code that wrote it and a prefix that matches nothing costs nothing. They are deliberately NOT enrolled in `_CATEGORY_BY_CHECK`, which describes names kstrl emits.

## Exactly what a user sees differently

Measured, not reasoned: the same seeded journal (two runs, signatures `pr:merge-conflict` and `fixtures:missing-approved-file`) read on `origin/main` and on this branch.

**`ks evolve` stdout: identical.** Byte for byte. The CLI prints `[check_name] description (seen in N components)` and never prints a category. `kstrl/cli.py` contains the string "category" zero times. The generated proposal files are also byte-identical (`diff -r` over the two `.kstrl/proposals` directories reports no difference), because `propose_improvements` branches on `pattern.check_name`, never on `pattern.category`.

**The evolve screen's patterns table changes.** That table (`ks tui`, evolve, patterns tab) has a `category` column, and it is the only surface in the product that displays this value.

Before:

```
  pr           merge-conflict                  2    1  iteration
  fixtures     missing-approved-file           2    1  iteration
```

After:

```
  pr           merge-conflict                  2    1  infrastructure
  fixtures     missing-approved-file           2    1  verification
```

This applies to runs that already happened. The category is computed at read time and never stored: measured by writing a real journal through `record_run` and listing the keys of the resulting entry, which are `schema_version, timestamp, run_id, project, component_id, event_type, status, retries, error, check_name, error_signature, failure_signatures, failed_phase, failed_check, duration_seconds, iteration_count, findings, findings_summary, usage, knowledge_utilization`. No `category` key, and no value equal to any category name. experiments.tsv stores the signature (`pr:merge-conflict`), not a category. Nothing on disk carries a stale category, so no migration exists to write.

**`ks autonomy replay` changes.** This is the behaviour change with teeth. `INFRA_FAILURE_PREFIXES` goes from 5 entries to 9:

```
before: pr:  git:  infra:  timeout:  scope_unreadable:
after:  aborted:  diff:  git:  infra:  pr:  provisioning:
        scope_unreadable:  timeout:  token_budget:
```

A run whose modal failure signature is `aborted:shutdown`, `token_budget:exceeded`, `diff:fetch-failed` or `provisioning:worktree-setup-failed` is now reported as infra-aborted and excluded from `decisive_runs`, instead of counting as evidence about the factory's judgement. It shows up in the report's `infra-aborted: N (excluded)` line rather than the `decisive: N` line, and it no longer feeds a simulated promotion or demotion. That is the module's own definition applied consistently: a run that died on a shutdown or a worktree it could not build says nothing about whether the factory's reviews are trustworthy.

Nothing else in the product reads `FailurePattern.category`. The full enumeration of consumers: `kstrl/tui/screens/evolve.py:205` (renders it), and nothing else. `kstrl/reducer.py`, `kstrl/pipeline.py`, `kstrl/pr.py` and `kstrl/findings.py` all use `Finding.category`, a different taxonomy with different values.

## Corrections to the issue text

Six claims checked, four confirmed, three corrected.

**Confirmed.**

- The walk really did see 19 names, and they are exactly the 19 the issue lists. Printed.
- All eight grandfathered names really did return `iteration` through `category_for_check`. Printed.
- The category really is read-time and nothing on disk carries it. Measured, above.
- `propose_improvements` really does branch on the check's name, not its category (`evolution.py:986` onward), so the triage note is right and proposals are unchanged by this fix.

**Corrected.**

1. **`ks evolve` was never the surface.** The issue says a recurring fixtures failure "is therefore reported by `ks evolve` as an engineer-loop problem". The `ks evolve` CLI never prints the category. The miscategorisation is real, but the surface is the evolve screen's patterns table, plus the autonomy replay through `INFRASTRUCTURE_CHECKS`.

2. **`_CATEGORY_BY_CHECK` was not the only place a category was decided.** `_classify_check` returned `(check_name, category)` and every one of its three call sites discarded the second element. Nothing got it right by accident because nothing read it, but a dead answer that can silently disagree with the live one is how the live one later gets fixed in the wrong file. It now returns the check name only.

3. **The walk had a third producer, not two.** Both #310 and the issue describe two producers (`CheckResult` names and `signatures=` literals). There is a third: `pipeline._record_failure_signatures` falls back to `signature_for_error(phase or "unknown", error)` when a `fail` / `retry_or_fail` call carries no `signatures=`, so the `phase=` argument becomes the check name. Two live sites, both unenrolled: `provisioning` (`factory.py:3414`) and `verify` (`pipeline.py:2146`).

Two smaller notes, neither a correction to the issue:

- The test module's own docstring claimed `review`, `security` and `contract` "appear in no literal anywhere in `kstrl/`". False for `review`: `pipeline` emits `review:divergence`, `review:setpoint-budget-exhausted` and `review:infrastructure` as literals, so the walk does see it. Fixed. The genuinely invisible enrolled names are `security`, `contract`, `verification` and `unknown`, and they are now enumerated with a reason each in `ENROLLED_BUT_INVISIBLE` and pinned.
- Two `signatures=` sites remain that the walk cannot read: `pipeline.py:2849` builds `f"{phase}:coverage-unverified:{reason}"` and `pipeline.py:3340` uses a conditional expression. Both resolve to prefixes that are already enrolled (`review`, `security`), so neither hides an unenrolled name today.

## What the review found

`/simplify` ran four agents against the first commit. Two findings were serious enough to change the shape of the fix, and both are the repo's own dominant defect class.

**A guard that was blind, not red.** The walk covered two of the three producers. Measured on the first commit: `provisioning:worktree-setup-failed`, a worktree that would not build, was filed under the engineer loop AND counted as decisive evidence for autonomy promotion, while `test_every_emitted_name_is_enrolled` was green next to a docstring saying the guard admitted no exceptions. The walk now resolves `phase=` on `fail` / `retry_or_fail` calls that carry no `signatures=`, and sees 21 names. It requires the `phase=` keyword rather than matching the callable name alone: `feature_cmd` has a local helper also called `fail`, and matching on the name credited six of its call sites with the name "unknown".

**Two guards that could not fail.** `INFRA_FAILURE_PREFIXES` is built as `derived | replay_only`, so `test_every_infrastructure_check_is_an_infra_abort_for_the_replay` restated the constructor, and `set(INFRA_FAILURE_PREFIXES) - derived == set(_REPLAY_ONLY_PREFIXES)` reduces to `replay_only - derived == replay_only`, which holds for any contents of `replay_only`. Both are gone. The class now pins the tuple's contents and runs every assertion through `RunRecord.infra_aborted`, the property that actually decides a run's fate.

## Mutations planted, and what happened

Every run under the `__pycache__` discipline: `find . -name __pycache__ -type d -exec rm -rf {} +` then `PYTHONDONTWRITEBYTECODE=1 uv run pytest ... -p no:cacheprovider`.

| Mutation | Expected | Result |
|---|---|---|
| M1: add `signatures=["planted_gate:unenrolled"]` to a pipeline failure | red | RED, `test_every_emitted_name_is_enrolled` |
| M2: rename a `CheckResult(name="fixtures")` to `"planted_check"` | red | RED, same test |
| M3: typo a category value (`"verifcation"`) | red | RED, whole-table pin |
| M4: delete the `"pr": "infrastructure"` row | red | RED, 3 enrolment tests plus 2 pre-existing `test_autonomy_ladder` tests, which is the derivation proving it is live |
| M5: move `policy_envelope` into a function-local so the walk cannot resolve it | red | RED, blind-guard test |
| M6: same for `dead_code`, an enrolled name no hand-written assertion lists | red here, green on main | RED on this branch, **GREEN on `origin/main`** |
| M7: change a `retry_or_fail(phase="verify")` to `phase="deployment"` | red | RED, 3 tests, including the anti-vacuity one |
| M8: add a bogus `engineer:` to `_REPLAY_ONLY_PREFIXES` | red | RED, prefix-contents test. Under the assertion it replaced, provably green |

M6 is the one worth reading. `dead_code` is enrolled, was never grandfathered, and is not one of the names the anti-vacuity test lists by hand. On `origin/main`, hiding it from the walk leaves all 12 tests passing: the guard could not fail on a name it could not see. On this branch it fails with "Newly invisible: ['dead_code']". That is the #324 defect class, closed for the whole table rather than for four hand-picked names.

## Verification

- `uv run pytest tests/ -v`: 4789 passed, 28 skipped, 6 xfailed.
- `uv run mypy kstrl/ --strict`: no issues in 127 source files.
- `uv run ruff check kstrl/ tests/` and `ruff format --check`: clean.
- Pre-commit hooks on both commits: all passed (complexipy, cyclomatic ratchet, codespell, vulture, gitleaks, shellcheck, file-length ratchet, em-dash, mock, agent-docs).
- `gitleaks dir . --redact` (the manual tree-scan hook) reports 1 finding, `aws-access-token` at `tests/test_policy_envelope.py:222`. It reports the same 1 finding on `origin/main`. Pre-existing test fixture, untouched here.
- Coverage: 90.11% against the 79.91% ratchet.

## Known divergence not closed here, and not created here

`factory._infra_casualty` (`factory.py:2701`) decides infrastructure-ness for the LIVE autonomy ladder from `Finding.is_infrastructure_error`, a different signal from the signature taxonomy this PR unifies. `token_budget` and `diff` failures attach an infrastructure finding; `pr:merge-conflict` and `aborted:shutdown` do not. So the live ladder can call a run judged while the replay calls it plumbing. That disagreement already existed for `pr:` before this PR, and this PR adds `aborted:` to it. Closing it means editing `kstrl/factory.py`, which has an open PR against it (#332), so it is left alone and stated. It deserves its own issue.

`docs/atlas/atlas.json` carries a stale `INFRA_FAILURE_PREFIXES` value: it still reads `('pr:', 'git:', 'infra:', 'timeout:')`, which has been wrong since #294 added `scope_unreadable:`. No generator for it exists in this repo and no CI job checks it, so it is left alone rather than hand-edited into a different kind of wrong.

## /simplify findings, verbatim

Four agents, one angle each, run against the first commit (94c5f6d). Reproduced in full, including the ones declined.

### Reuse

> **1. `kstrl/autonomy_replay.py:93-94` (and the predicate at `:115`) - the colon-suffixed prefix tuple re-implements `evolution.split_signature`.**
> `evolution.py:462` already owns the `"<check>:<code>"` format (`split_signature` returns `(check, code)`), and the enrolment walk's own docstring says signature literals "reach `category_for_check` via `split_signature`". The new code instead re-derives the format by appending `":"` to every check name and prefix-matching. The module now imports from `evolution` anyway, so `split_signature(self.common_failure)[0] in _INFRA_CHECKS` is available and gives the identical answer on every input (a signature with no colon fails both ways; `diff_scope:` fails both ways). Cost: the colon is hand-written in four places (`autonomy_replay.py:87`, `:94`; `tests/test_check_name_enrolment.py:365`, `:376`), and `test_the_prefixes_cannot_swallow_a_neighbouring_check` (`tests/test_check_name_enrolment.py:392-397`) exists only to guard a hazard the existing helper does not have. Two parsers of one string format, one of them untested against the format's owner.
>
> **2. `tests/test_check_name_enrolment.py:365, 389, 396-397` - the new tests re-implement `RunRecord.infra_aborted` instead of calling it.**
> `kstrl/autonomy_replay.py:113-115` is the consumer; `tests/test_autonomy_ladder.py:437` already exercises it as `runs[0].infra_aborted is True`. The class is named `TestTheTwoInfrastructureConsumersAgree` but asserts `"x:code".startswith(INFRA_FAILURE_PREFIXES)` inline, never touching the consumer. Cost: if `infra_aborted` stops reading `INFRA_FAILURE_PREFIXES` (which is what fix 1 would do), all four tests stay green while asserting nothing about the thing they are named after - the same blind-guard failure mode the file's own docstring cites as this repo's dominant defect.
>
> **3. `kstrl/evolution.py:410-413` - the four `"infrastructure"` rows are a third encoding of a fact the emitting call sites already carry twice.**
> At each of the four sites `pipeline` already passes `phase="aborted"/"token_budget"/"pr"/"diff"` next to the signature literal, and `kstrl/findings.py:82-87` (`Finding.is_infrastructure_error`) is the existing shared predicate for infrastructure-ness - `factory.py:2701` and `serve.py:902` both consume it, and `serve.py`'s docstring says explicitly that a second copy of the rule is how the taxonomies drift. The new table is a fourth list nobody derives from those. Measured cost, not hypothetical: `pipeline.py:1583` (token_budget) and `:2671` (diff) do build `Finding.infrastructure_error`, but `pipeline.py:1788` (`pr:merge-conflict`) and `:1378` (`aborted:shutdown`) build none. So after this change `evolution` calls those two runs infrastructure while `factory._infra_casualty` calls the same component a judged failure, and both feed a `decisive` definition (`factory.py:2707`, `autonomy_replay.py:124`). The change removes one two-way disagreement about `pr:merge-conflict` and opens another.
>
> **4. `kstrl/evolution.py:384-386` and `:388-422` - the key set now duplicates `context.PHASE_RANK` in full.**
> All seven `PHASE_RANK` keys (`kstrl/context.py:36-44`: engineer, verification, diff, review, security, contract, pr) are now keys of `_CATEGORY_BY_CHECK`, and four of the six `CATEGORIES` values are also `PHASE_RANK` keys. `context.py:229-230` already validates a phase against that dict and raises on an unknown one. Cost: a new phase needs a `PHASE_RANK` entry, a `_CATEGORY_BY_CHECK` row and possibly a `CATEGORIES` member, with no link between them - and the enrolment walk provably cannot see a runtime-composed phase (`ENROLLED_BUT_INVISIBLE`, `tests/test_check_name_enrolment.py:86-99`), so a new phase is precisely the case the new guard misses. Deriving the phase-named rows from `PHASE_RANK` would make that case red instead of invisible.
>
> **5. `tests/test_check_name_enrolment.py:86-99` vs `:307-319` - two hand-maintained lists of runtime-composed phases in one file, already disagreeing.**
> `ENROLLED_BUT_INVISIBLE` lists `security` and `contract` as "composed from a runtime phase argument"; `test_the_runtime_composed_phases_are_enrolled` iterates `("review", "security", "contract")` for the same reason, and the new docstring has to explain why `review` is in one and not the other. Cost: a new composed phase needs both edits, the divergence is carried as prose rather than as a derivation, and the second list is a literal tuple that nothing checks against the first.
>
> **6. `tests/test_check_name_enrolment.py:101-111` - `CATEGORY_DECIDED_IN_315` restates 8 of the 22 table rows.**
> Low value, and pinning data tables is a defensible pattern; flagging the shape only. Cost: a partial mirror of `_CATEGORY_BY_CHECK` keyed to an issue number rather than to a property, so 14 rows are unpinned and a future author has no rule telling them whether a new row belongs in it. `test_every_row_carries_a_category_that_exists` (`:321`) is the property-shaped guard and covers the whole table.
>
> Nothing in the diff duplicates `review.VALID_CONCERN_CATEGORIES` or `security.VALID_CATEGORIES`; `CATEGORIES` follows that existing convention rather than colliding with it, and `INFRASTRUCTURE_CHECKS` being derived from the table (rather than typed out) is the right call - findings 1 and 3 are about which taxonomy it derives from, not about the derivation itself.

Disposition: **2 applied** (every assertion in that class now goes through `RunRecord.infra_aborted`, and the helper says why). **6 applied**, harder than proposed: the partial mirror is now a whole-table pin, which subsumed the property-shaped guard, so that test is gone too. **1 declined**: `split_signature` and prefix matching are the same answer on every input the module can see, so this is a style preference, and the prefix tuple is a documented public constant with an existing rationale ("a new plumbing family is one entry, not a new code path"). Rewriting it widens the diff into behaviour-neutral churn in a module #315 only needed to reconcile. The colon test survives as `test_a_judgement_failure_still_counts_as_evidence`, which now earns its place as the other direction of the class. **3 declined as out of scope, and stated in the PR instead**: the `factory._infra_casualty` divergence is real and pre-existing for `pr:`, this PR adds `aborted:` to it, and closing it means editing `kstrl/factory.py`, which has an open PR (#332). It deserves its own issue. **4 declined**: deriving category rows from `context.PHASE_RANK` couples two taxonomies that agree by coincidence, not by construction (`PHASE_RANK` orders retry context; `_CATEGORY_BY_CHECK` classifies failures), and the round-2 fix addresses the underlying complaint directly by making the walk SEE phase-derived names. **5 applied**: the two lists no longer disagree, and the docstring says why the second still exists (a pin is satisfied by editing the expectation; the named test says why the row cannot go).

### Simplification

> **1. `tests/test_check_name_enrolment.py:307` - `test_the_runtime_composed_phases_are_enrolled` is now dead weight, and its docstring is now false.**
> The docstring still says "removing `security` from the table does not fail any other test here", and the diff appends a sentence about `review` instead of deleting that claim. Measured by popping each row from `_CATEGORY_BY_CHECK` and running the siblings: `security` and `contract` now redden `test_the_walk_covers_every_enrolled_name_but_these` (they are in `ENROLLED_BUT_INVISIBLE`), and `review` reddens `test_every_emitted_name_is_enrolled`. All three are held twice. Cost: a stale justification a future reader will trust, plus a third guard nobody can retire without re-deriving what I just derived. Simpler form: delete the test; `ENROLLED_BUT_INVISIBLE` already carries the same two names with the same reason string.
>
> **2. `tests/test_check_name_enrolment.py:364` and `:371` - the two `TestTheTwoInfrastructureConsumersAgree` agreement tests restate the constructor they are testing.**
> `INFRA_FAILURE_PREFIXES` is built as `{f"{c}:" for c in INFRASTRUCTURE_CHECKS} | set(_REPLAY_ONLY_PREFIXES)`, so `test_every_infrastructure_check_is_an_infra_abort_for_the_replay` cannot fail: `"X:any-code".startswith("X:")` is true for every derived member by construction. And the second test's LHS reduces to `set(_REPLAY_ONLY_PREFIXES) - derived`, so it can only fail on an overlap between the two halves. It cannot see a bogus prefix added to `_REPLAY_ONLY_PREFIXES`, which is precisely what its docstring promises to catch ("Anything beyond this list is an undocumented divergence"). Cost: two tests and a class docstring that read as policy coverage while pinning nothing, so the real content of the tuple is unpinned. Simpler and strictly stronger, one test replacing both: `assert set(INFRA_FAILURE_PREFIXES) == {f"{c}:" for c in INFRASTRUCTURE_CHECKS} | {"scope_unreadable:", "git:", "infra:", "timeout:"}` with those four spelled out in the test file.
>
> **3. `kstrl/autonomy_replay.py:50` - "the first four come from `evolution.INFRASTRUCTURE_CHECKS`" is false of the constant it annotates.**
> The tuple is `sorted(...)`, so it is `('aborted:', 'diff:', 'git:', 'infra:', 'pr:', 'scope_unreadable:', 'timeout:', 'token_budget:')` and the first four include two replay-only prefixes (`git:`, `infra:`) while excluding two derived ones (`pr:`, `token_budget:`). Cost: a reader who indexes the tuple to find the derived half gets the wrong half; the comment describes the pre-sort mental model. Fix: "four of them", or name them.
>
> **4. `tests/test_check_name_enrolment.py:343` - `assert name in _check_names()` duplicates the blind-guard test, eight times over.**
> Measured by hiding `pr` from the walk: `test_the_walk_covers_every_enrolled_name_but_these` already goes red, with the better diagnostic ("Newly invisible: ..., a refactor probably moved a name out of the shape the walk matches"). Cost: one cause reddens nine tests instead of one, and the parametrized message ("`pr` is no longer emitted by kstrl/") is the misleading one, since the usual reason is a walk that went blind, not a deleted call site. Simpler: keep only the `category_for_check(name) == category` line, which is the one thing the test's name promises.
>
> **5. `kstrl/evolution.py:384` - `CATEGORIES` is a new public constant that no code in `kstrl/` reads.**
> Sole consumer is `test_every_row_carries_a_category_that_exists`. Nothing validates `FailurePattern.category` against it at construction, so the new field comment "One of CATEGORIES" is a claim only a test upholds. It is also exactly `set(_CATEGORY_BY_CHECK.values())` today, so it earns its keep only as a hand-written list the guard compares against - and that list belongs beside the guard. Simpler: move the frozenset into the test file next to the assertion (identical guard strength), leaving `evolution.py` fourteen lines and one public name lighter. Keep the "not `Finding.category`'s `infrastructure_error`" paragraph, but attach it to `_CATEGORY_BY_CHECK`, where the spelling decision actually lives.
>
> **6. `kstrl/evolution.py:237` and `:487` - the same non-obvious fact is now written twice in near-identical words.**
> "decided by `category_for_check` ... never written to the journal, so correcting the table also corrects what is reported about runs already recorded" (field comment) and "The answer is computed here, at read time, and never stored in the journal, so a correction to the table also corrects what `ks evolve` reports about runs that already happened" (function docstring). Cost: two copies to keep in step, and the field comment is the copy nobody editing the function will see. Simpler: keep it on `category_for_check`, where the behaviour is, and reduce the field comment to "One of `CATEGORIES`; see `category_for_check`".
>
> Nothing here is a correctness bug: the 18 tests in the file pass, and `INFRA_FAILURE_PREFIXES` derives correctly.

Disposition: **2, 3, 4, 5 and 6 applied**, 4 by deleting the parametrized test altogether once the whole-table pin subsumed it, and 5 by deleting `CATEGORIES` and moving its prose onto the table. **1 declined in part**: the stale sentence is gone, but the test stays. A whole-table pin is satisfied by editing the expectation, so the named test is what tells the author WHY `security` and `contract` cannot go, and its cost is one assertion loop. The rewritten docstring says exactly that.

### Efficiency

> **No efficiency defects worth fixing.** Both of the specific concerns you flagged were measured and came back clean. Numbers below so the conclusion is auditable.
>
> **1. `kstrl/autonomy_replay.py:41` - the new `from kstrl.evolution import INFRASTRUCTURE_CHECKS` does not meaningfully cost anything.** Not a finding.
>
> - Raw A/B, 5 runs each, warm: `import kstrl.autonomy, kstrl.verify` (origin/main's exact dep set for this module) = **26.7-27.5 ms**; `import kstrl.autonomy_replay` at HEAD = **29.9-30.8 ms**. Delta approximately **3.1 ms**, split by `-X importtime` into `kstrl.observability` 759 us + `kstrl.evolution` own body 875 us (the 42.3 ms cumulative you see under `kstrl.evolution` is almost entirely `kstrl.verify`, which `autonomy_replay` already imported before this change).
> - **No CLI path imports `autonomy_replay` eagerly.** The only import site in `kstrl/` is `kstrl/cli.py:4464`, inside the `autonomy_replay_cmd` body. Repo-wide, the only other importers are two test files.
> - On that one real path the marginal cost is smaller still, because `kstrl.cli` already loads `observability` and `verify` (verified: after `import kstrl.cli`, `'kstrl.observability' in sys.modules` is `True`, `'kstrl.evolution'` is `False`). Measured `import kstrl.evolution` after `import kstrl.cli`: **1.02, 1.03, 1.04, 1.07 ms** (first run 4.38 ms, cold-cache outlier). Against `ks autonomy replay --help` wall time of **0.10-0.11 s**, that is approximately 1% of the single command that reaches it and 0% of every other command.
>
> **2. `tests/test_check_name_enrolment.py:290` - `test_the_walk_covers_every_enrolled_name_but_these` reuses the cached walk. No second parse.** Not a finding.
>
> - `uv run pytest tests/test_check_name_enrolment.py --durations=5`: **18 passed in 0.57s** (0.32 s on a warm re-run), with `test_the_walk_sees_the_gates_it_claims_to_guard` holding **0.24-0.33 s** of it and everything else under the 5 ms floor. At `--durations=0 -vv`, the new test and all five other new items report **0.00s**.
> - Direct proof: `ast.parse` monkeypatched around `pytest.main` counts **187** calls for the whole file against **127** `.py` files in `kstrl/`; `_parsed_modules` is `@lru_cache(maxsize=1)` and is the file's only `ast.parse` site (line 188). The package is parsed exactly once. Item count went 12 to 18; the 6 new items cost nothing measurable.
>
> Sub-noise observations, listed only for completeness
>
> 3. `kstrl/autonomy_replay.py:115` - the derived prefix tuple grew from 5 entries to 8, so `common_failure.startswith(INFRA_FAILURE_PREFIXES)` does more work. Measured worst case (no match, every prefix tried), 2M iterations: **39.6 ns to 44.6 ns, +5.0 ns per call**. `infra_aborted` is a non-cached property read approximately 4x per row in `replay`; a 1000-row `experiments.tsv` pays approximately 20 us total.
>
> 4. `kstrl/evolution.py:384` - `CATEGORIES` has no production consumer: `grep` finds it referenced only by a docstring comment and by `tests/test_check_name_enrolment.py:328`. It is a 6-element frozenset built at every `import kstrl.evolution`. Construction of both new module-level constants together measures **0.76 us per import**. Correct placement (module level, not per call); flagging only that it is a test-only export living in a production module.
>
> 5. `kstrl/evolution.py:309` - the `_classify_check` narrowing is a small net **win**, not a cost: dropping the discarded tuple element saves **2.4 ns per call** (37.8 to 35.4 ns, 2M iterations) on the legacy-fallback path.
>
> Nothing here is worth changing. The derived-constant work is all at module scope where it belongs, the AST walk is properly cached, and the one import the diff adds lands behind an already-lazy CLI import.

Disposition: nothing to apply. Observation 4 was independently raised by two other agents and is applied there (`CATEGORIES` is gone). Observation 3 is 5 ns and the tuple is now 9 entries rather than 8, which is 1 ns more of nothing.

### Altitude

> The change is mostly at the right depth: replacing a convention with a table plus a walk is the correct level, and killing `_classify_check`'s dead second return value is a genuine depth fix (one decision, one place). Five things sit at the wrong altitude.
>
> **1. The guard is written at the call-site-shape level, not at the choke point, and it already misses a third producer.**
> `tests/test_check_name_enrolment.py:81,159,244` / `kstrl/evolution.py:456`
>
> Three things in `kstrl/` produce a check prefix that reaches `category_for_check`. The walk covers two (`CheckResult`/`_failed_gate_result` name args, `signatures=[...]` literals). The third is `pipeline._record_failure_signatures` (`kstrl/pipeline.py:1291`), which falls back to `signature_for_error(phase or "unknown", error)` whenever `signatures=` is absent, so the `phase=` argument becomes the check name. Measured on this tree:
>
> ```
> provisioning   sig=provisioning:worktree-setup-failed   category=iteration  infra_abort=False
> verify         sig=verify:mechanical-verification-...   category=iteration  infra_abort=False
> ```
>
> Two live call sites hit it: `kstrl/factory.py:3413` (`pipeline.fail(..., phase="provisioning", check="worktree_setup")`, no `signatures=`) and `kstrl/pipeline.py:2150` (`retry_or_fail(..., phase="verify", check="diff_scope")`, no `signatures=`). Cost: a worktree-provisioning failure - the purest infrastructure failure in the system - is still filed under the engineer loop by `ks evolve` and still counts as a **decisive** run for autonomy promotion. That is exactly the defect #315 claims to close, and `test_every_emitted_name_is_enrolled` is green (18 passed) while it happens, next to a docstring saying "the guard now admits no exceptions at all". The altitude fix is to guard where the prefix is produced (`signature_for_error` / `_record_failure_signatures`) rather than enumerating call shapes, or at minimum to resolve `phase=` in `_check_names`.
>
> **2. Deriving the replay's predicate from the journal's category turns a taxonomy edit into an autonomy-policy edit - and it already fired, unannounced.**
> `kstrl/autonomy_replay.py:93`
>
> `INFRA_FAILURE_PREFIXES` went from 5 prefixes to 8: `aborted:`, `diff:` and `token_budget:` are new. That feeds `RunRecord.infra_aborted` to `decisive` to `decisive_runs` to `MIN_DECISIVE_RUNS`, i.e. the promotion gate. The docstrings argue only about `pr:merge-conflict`; nothing states that the replay's decisive-run definition just widened, and no test in `tests/test_autonomy_ladder.py` covers the three new prefixes. The pin that would catch a future recategorisation, `CATEGORY_DECIDED_IN_315` (`tests/test_check_name_enrolment.py:101,336`), is a bare `assert category_for_check(name) == category` whose docstring mentions only `ks evolve`; someone fixing a journal categorisation will satisfy it by editing the expectation and never learn they moved an autonomy threshold.
>
> **3. The taxonomy is in the journal module, and a peer consumer now imports it - the repo's own habit is a third, small module.**
> `kstrl/autonomy_replay.py:41`, `kstrl/evolution.py:429`
>
> `kstrl/` is full of tiny shared-vocabulary modules that exist precisely so two consumers do not import each other: `delimiters.py` (38 lines), `runid.py` (43), `gateparse.py` (119), `procgroup.py`, `atomicio.py`, `statedir.py`. Here a 300-line replay module takes a module-level dependency on a 1678-line journal/proposals module to get one frozenset; `kstrl/autonomy.py:781` keeps its own `from kstrl.evolution import ...` inside a function body. Concrete cost: `_CATEGORY_BY_CHECK` stays private while `INFRASTRUCTURE_CHECKS` is a public projection shaped for exactly one consumer, so the next consumer that needs "which checks are verification" gets a second bespoke export plus a second bespoke test class. `checks_in_category(category)`, or a `kstrl/failure_taxonomy.py` that both import, costs the same to write today.
>
> **4. `CATEGORIES` as a bare `frozenset[str]` is against the house pattern, and it exists only to feed a test.**
> `kstrl/evolution.py:384`
>
> Measured: 14 `StrEnum` classes in `kstrl/`. The two closest analogues both use *StrEnum as the authority plus a frozenset derived from it* - `kstrl/divergence.py:155` (`_VALID_MODES = frozenset(m.value for m in DivergenceMode)`) and `kstrl/review.py:65` (`VALID_CRITERION_VERDICTS = frozenset({ReviewVerdict.PASS.value, ...})`). Bare `frozenset[str]` is reserved for vocabularies kstrl *validates but does not author*: LLM output (`review.VALID_CONCERN_CATEGORIES`, `security.VALID_CATEGORIES`, `knowledge.VALID_SCOPES`) and config strings (`linear._VALID_AUTH_MODES`). These six categories are authored in-house, as literals, in the same file. Cost: `CATEGORIES` has exactly one consumer, the new `test_every_row_carries_a_category_that_exists` (`tests/test_check_name_enrolment.py:321`), which exists only because the table's values are unchecked `str`. Typing the table `dict[str, Category]` makes a typo a `mypy --strict` error at the edit site and deletes both the constant and the test.
>
> **5. The `scope_unreadable` divergence is the model missing an attribute, not a special case worth three docstrings.**
> `kstrl/autonomy_replay.py:86`, `tests/test_check_name_enrolment.py:364,371`
>
> A check has two independent properties: which part of the factory produced the failure (category), and whether the run said anything about the factory's judgement (decisive). Expressing the second as "category == infrastructure, plus a hand-kept remainder tuple" is precisely why `scope_unreadable` needs an essay to defend. One table with two columns per check states it once and deletes `_REPLAY_ONLY_PREFIXES`, the derivation, and the divergence tests. Supporting evidence that the current shape proves little: `test_every_infrastructure_check_is_an_infra_abort_for_the_replay` (line 364) cannot fail while `INFRA_FAILURE_PREFIXES` is built from `INFRASTRUCTURE_CHECKS` on line 93, and `test_the_replays_extra_prefixes_are_exactly_the_documented_ones` (line 371) is `(A | B) - A == B`. Both pin the derivation, not the taxonomy. `test_the_prefixes_cannot_swallow_a_neighbouring_check` is the one in that class that earns its place.

Disposition: **1 applied**, and it is the most valuable finding of the four reviews. Verified independently before acting: the phase fallback is real, the two sites are real, and both names were unenrolled. The walk now resolves `phase=`, and `provisioning` and `verify` are enrolled. I took the narrower of the two suggested fixes (resolve `phase=` in the walk, not a guard inside `signature_for_error`) because the walk is where the other two producers are already covered and a runtime guard cannot fail at review time. **2 applied**: the widening is now stated in the PR body in the "what a user sees differently" section with the before and after tuple, and the pin's own comment says an added row can move a run out of the replay's evidence. **5 applied in part** (the two tautologies are gone) and **declined in part**: a second column per check is a redesign of a taxonomy this issue was asked to correct, not replace, and it would move `scope_unreadable` again, which #294 settled deliberately. The divergence is stated once, in the constant that holds it, and tested through the consumer. **3 declined**: a new module for one frozenset adds a mechanism to remove an import, and the import is measured at 1 ms behind an already-lazy CLI import. If a second consumer appears, that is the moment the module earns its keep. **4 declined**: the whole-table pin makes the runtime check unnecessary rather than making it stronger, so the frozenset and its test are deleted rather than replaced by an enum. A `Category` StrEnum would type-ripple into `FailurePattern.category`, which is written to no schema and read by exactly one Rich `Text()` call. The house-pattern argument is fair and this is a judgement call.



---

## Round 3: the altitude pass, and where this stops

Six findings from an altitude review, all measured. Four were do-now. The round was then scoped down by the owner mid-flight, for a process reason worth recording: every PR in this batch hand-rolls its own AST matcher and hand-rolls the same hole. Instance 8 was #336, instance 9 was round 1 here, instance 10 is the producer below. That is not converging, so **#324 (one shared `tests/helpers/astwalk.py`) is being pulled forward to close the class in one place** and this PR stops widening its own matcher.

### A1. A third caller of the funnel, and a live check name nothing guarded

`pipeline._record_failure_signatures` files a failure under its PHASE whenever no truthy `signatures` reaches it. Round 2 keyed the guard on `fail` and `retry_or_fail`, which are two of that funnel's THREE callers. The third is `_fail_pr_flow`:

```python
self._record_failure_signatures(comp, "pr", comp.error, None)
```

Positional, so no `phase=` keyword. Not a `fail`/`retry_or_fail` call. Not an assignment into a `*failure_signatures` mapping. And `"pr"` has no colon, so the spellings net could not see it either. `_producer_sites` returned nothing for that node: neither resolved, nor recorded as a blind site. Mutating `"pr"` to `"bogus_flow"` left the suite green.

The producer is now keyed on the funnel itself, the way `test_journal_one_writer.py` keys on `append_entries` being the only writer, and on `PhaseFailure`, whose `phase` reaches the same fallback through `_route_failure`.

Two things had to move with it.

**The signatures test ignored the value.** `"signatures" in keywords` was true for a literal `None`, which silenced the phase, and true for `signatures=failure.signatures` at `_route_failure`, where the value is decided at run time and the fallback really can fire. It is now `_signatures_taken`, three-valued: `True` means the recorder provably takes them and the phase is unreachable, `False` means provably nothing is there, `None` means neither producer may skip.

**The positional index is derived, not written down.** The first version of this fix hardcoded four integers. The altitude pass measured what they bought: six of eight off-by-one mutations to them left every guard green, because 25 of the 27 call sites in `kstrl/` pass `phase` by keyword and the two that do not resolve to nothing. An index is a fact about the definition, so `astfold.parameter_index` reads it off the `def` (or the dataclass body). It also keeps `feature_cmd`'s one-argument local `fail` out of the census **by construction**, deleting the special case the integers needed a paragraph to defend.

Census 21 to 23 names. `BLIND_SITES` gains five pass-through rows, each with a stated reason.

### The distinction this round is actually about

`BLIND_SITES` looked like `EXPECTED_JOURNAL_PATH_SITES` and does not behave like it, and that resemblance is what let `_fail_pr_flow` survive two review rounds.

- `EXPECTED_JOURNAL_PATH_SITES` inventories **every place the resource is obtained**. A new way of obtaining it lands in the list whatever it looks like. Closed by construction.
- `BLIND_SITES` inventories **the places the walk gave up**. It is closed only over the producer shapes the walk already enumerates. A producer written in a shape neither matcher matches is not resolved AND not recorded: it is silence, and the ledger staying the same length is not evidence of anything.

That is now written in the `BLIND_SITES` docstring itself, naming #324 as the tracking item, so the next reader hits it where they would otherwise inherit the wrong prior.

It is also pinned rather than merely disclosed. `tests/test_signature_chokepoint.py` is the one guard here with the precedent's guarantee: a check name cannot reach `category_for_check` without touching a `*failure_signatures` name, and there are five such sites in `kstrl/`. Measured both ways:

- The day `_fail_pr_flow` was written, `self._record_failure_signatures` went from 2 occurrences to 3 and this pin would have gone red, with no matcher to widen and no shape to recognise.
- A new writer reaching the mapping through a **local alias** with a **runtime-built** signature is invisible to the census, to `BLIND_SITES`, to the shapes file and to the spellings net. It fails this pin and nothing else. Measured by planting it.

### A4. The two sibling branches that still had P2-1's bug

All four `phase="pr"` HITL-adjacent outcomes, measured before this round:

| outcome | `infra_aborted` | `decisive` | verdict |
|---|---|---|---|
| `pr:rejected-at-hitl-checkpoint` | True | False | fixed by P2-1 |
| `pr:retry-requested-at-hitl-checkpoint` | True | False | NOT fixed |
| `pr:parked-awaiting-merge-approval-...` | True | False | NOT fixed |
| `pr:pr-merge-failed-conflict-with-base` | True | False | genuinely plumbing |

A human asking for changes is a verdict on the change by this PR's own argument, and it was being discarded 46 lines below the fix. It now carries `signatures=["review:hitl-changes-requested"]`. PARKED deliberately keeps the `pr:` fallback with a comment saying why: nobody answered the gate, so there is no verdict to record.

The rule is stated **once**, at the first of the three branches, and the other two point at it. Three copies of one rule in prose is the signature of a missing mechanism, and the mechanism is keying the fallback on `check` rather than `phase` (the branches already carry `hitl_reject` / `merge_gate` / `hitl_retry`, which is exactly the vocabulary that distinguishes them, while all three carry `phase="pr"`). That is blocked on `factory.py`.

One claim was also corrected rather than defended: "the phase stays `pr` because that is where it happened" is not true by the module's own accounting. `_phase_started(comp, "pr")` fires below all three checkpoint branches.

### A5. Three of the four replay-only prefixes can never match

Only `scope_unreadable:` is live. `git:`, `infra:` and `timeout:` were re-measured four ways: none appears in `kstrl/` as a signature prefix, none is in `_CATEGORY_BY_CHECK`, none is in `_classify_check`'s range, and none is producible by any enumerated producer. The comment now says which one is live at the **top** of the block.

They are not deleted. The earlier draft defended keeping them by saying deletion would change how historical rows are read, and that cannot be true alongside the measurement above it: if no version ever emitted the strings, no `experiments.tsv` row contains them. The false sentence is gone. They stay because a prefix that matches nothing costs nothing, and because removing them is a decision about what the constant is for, worth making on its own rather than inside a categorisation fix.

### A3 and A6: settled, with the reasons recorded

**A3** (a named ledger type for `component_failure_signatures`) is blocked on `factory.py`, which #332 holds. The pipeline-only half would leave two writers outside the ledger, strictly worse than the current suffix match. Worth recording: what holds that producer is the invisibility pin, not the suffix matcher, verified by mutating the container name to an alias and watching two tests go red.

**A6** (`_from_the_callers`) stays. It is a general rule that fails safe into `BLIND_SITES` and was measured red. Its docstring now says it assumes callers call by BARE NAME, so routing through a dispatch table or a `functools.partial` would quietly return the row to `BLIND_SITES`.

## The producer table, with the mutation that proves each row

Every mutation ran after `find . -name __pycache__ -type d -exec rm -rf {} +` with `PYTHONDONTWRITEBYTECODE=1`, because CPython invalidates bytecode on `(mtime_seconds, size)` and two same-size edits inside one second reuse stale bytecode. Every file was restored to its pre-mutation SHA-256, checked.

| what was mutated | result |
|---|---|
| `_fail_pr_flow`'s `phase="pr"` to `"bogus_flow"` | RED: `test_every_emitted_name_is_enrolled` |
| `hitl_retry`'s `signatures=` deleted | RED: `test_checkpoint_retry_consumes_a_retry` |
| `hitl_reject`'s `signatures=` deleted | RED: `test_checkpoint_reject_fails_component` |
| `_record_failure_signatures` dropped from `PHASE_FALLBACK_CALLS` | RED, 5 failed |
| `PhaseFailure` dropped from `PHASE_FALLBACK_CALLS` | RED, 2 failed |
| the positional fallback dropped (`index = None`) | RED, 4 failed |
| `_signatures_taken` always True | RED, 8 failed |
| `_failed_gate_result` dropped from `CHECK_NAME_CALLS` | RED, 1 failed |
| the `ast.Assign` producer branch deleted | RED, 7 failed |
| `_from_the_callers` returns nothing | RED, 1 failed |
| `parameter_index` off by one | RED, 5 failed |
| the receiver no longer excluded from the index | RED, 5 failed |
| dataclass fields ignored by the index | RED, 1 failed |
| a fourth caller of the funnel planted, literal phase | RED, 2 failed |
| a new caller planted whose phase is computed | RED, 2 failed (chokepoint + ledger) |
| a new writer planted via a local alias, runtime-built signature | RED, 1 failed: **the chokepoint pin alone** |

## P2-5: `ks autonomy replay` can change its exit status on unchanged data

Disclosure, not a code change. `kstrl/cli.py` ends that command with `sys.exit(0 if report.sufficient_data else 2)`, and this PR moves runs out of `decisive_runs`, which is what `sufficient_data` counts. A scripted caller treating non-zero as failure can start failing on an `experiments.tsv` that has not changed.

Measured, the same file replayed on `origin/main` and on this branch:

```
10 rows, all dominated by provisioning:worktree-setup-failed
  origin/main  decisive=10  infra_aborted=0   Final L2  sufficient_data=True   exit=0
  this branch  decisive=0   infra_aborted=10  Final L1  sufficient_data=False  exit=2
```

Being precise about what that file is: it is constructed, not a captured run. On the only two real `experiments.tsv` files available, this branch changes **nothing**. The live 5-row file reports `decisive=2 infra_aborted=3 exit=2` on both sides; the 856-row archive reports `decisive=800 infra_aborted=0 merged=737 L2 exit=0` on both sides, with **zero rows** moving verdict. Those rows predate the four newly-derived prefixes: their `common_failure` values are legacy slugs with no colon (`test-failure`, `mechanical-verification-failed`, `did-not-complete`), so no prefix matches on either side. The exit-status change is real, but it needs a row dominated by `aborted:`, `diff:`, `provisioning:` or `token_budget:` to fire.

## P2-2 and P2-4, both landed

**P2-2**: a Ctrl-C that discarded a run which had merged 24 components still printed "Components merged: 24" two lines under "infra-aborted: 1 (excluded)". Two populations under one label, and the bigger one counted for nothing. The report now says `Components merged: N (in decisive runs)` and adds `in excluded runs: N (not counted)` when there is something to disclose, so the total stays recoverable.

**P2-4**: the comment at `evolution.py` claimed one live/replay disagreement. There are six, in both directions, and they are now counted rather than exemplified.

## Deliberately left for #324

Named so nobody re-finds them and thinks they are new:

1. **`BLIND_SITES` is not closed over unenumerated producer shapes.** Disclosed in its docstring, backed by the chokepoint pin, not otherwise fixed here.
2. **`tests/test_check_name_shapes.py` is a fifth bespoke positive-control file.** It was already written when the scope call came, so it stays and was not extended. It pins matcher branches usefully, but it enumerates shapes its author already thought of, so it cannot close the unknown-unknown gap it was written for. #324 replaces the need for it.
3. **Two AST string folders in `tests/`.** `astfold.fold` subsumes `test_journal_one_writer.folded_str`: measured, they agree on all 22,738 name-free expressions in `kstrl/`, and all 471 disagreements across 119,605 expressions are the deliberate name-resolution branch. The strict answer is a two-line wrapper over the new one. Not merged here because that file guards #312 and changing what it folds is that guard's own measurement to make. The `astfold` docstring now says so rather than implying the copies must stay.
4. **`called_name` is the fifth copy of a three-line helper** (`test_procgroup.py`, `test_atomicio.py`, `test_process_scoping.py`, `test_timeout_enforcement.py` have the other four). Exporting one and deleting four touches files a parallel subprocess sweep holds.
5. **Two independent parse caches over the same 124 files**, one in `astfold`, one in `test_journal_one_writer`, each with its own measurement paragraph. Roughly 162 ms of avoidable work per session by the existing helper's own number, plus two vocabularies for the same file (`kstrl/pipeline.py` vs `pipeline.py`) across guards that cite each other.
6. **A third qualified-scope walk.** `astfold.scoped_nodes` is the better implementation (measured: it covers 18,066 nodes `test_tui_config_walk.own_nodes` never yields), but retiring the two older copies onto it changes what those guards report and needs their own measurement.

## Known coverage gap, pre-existing and unchanged (P3-3)

Five of the eight `return` statements in `evolution._classify_check` are never executed by the suite: rewriting all five to `return "linter"` left it green. Identical on `origin/main`, 38 missed statements on both sides, so this PR neither creates nor widens it. Recorded here rather than filed, per the move to class sweeps.
