### PR TITLE
fix(decompose): one classifier for the audit buckets, and no blank project name (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ stage, runtime feedback, and an earned-autonomy ladder). See
 
 ### Fixed
 
-- `ks decompose --project-name` and `ks factory --project-name` refuse an
-  empty or whitespace-only name at the command line, exiting 2 and naming
-  the option, instead of running the architect against it. The name is an
+- `ks decompose --project-name`, `ks factory --project-name` and
+  `ks queue add --project-name` refuse an explicit empty or
+  whitespace-only name at the command line, exiting 2 and naming the
+  option, instead of running the architect against it. `queue add`
+  keeps its `""` default, which is how a queued item asks `serve` to
+  name it `queue-<id>`: the refusal is gated on the parameter source,
+  so only a blank the operator typed is refused. The name is an
   identity: it keys the journal audits, the decision register and, under
   `--single-pr`, the branch. Related, and the reason the boundary check
   is worth having: the convergence report's accounting of audits the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ stage, runtime feedback, and an earned-autonomy ladder). See
 
 ### Fixed
 
+- `ks decompose --project-name` and `ks factory --project-name` refuse an
+  empty or whitespace-only name at the command line, exiting 2 and naming
+  the option, instead of running the architect against it. The name is an
+  identity: it keys the journal audits, the decision register and, under
+  `--single-pr`, the branch. Related, and the reason the boundary check
+  is worth having: the convergence report's accounting of audits the
+  trend leaves out is now computed by one classifier per audit, so the
+  three buckets (this project's, another project's, no project recorded)
+  always sum to the audits on disk. At an empty project name the two
+  counts were separate predicates asking the same question, so an audit
+  recording no project was counted both as this project's and as
+  unattributed: five audits on disk reported as eight (#338).
+
 - `kstrl.toml` and the `KSTRL_*` environment are now resolved once, at
   command entry, before a command constructs anything. They used to be
   parsed lazily, by whichever config dataclass first needed its section,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,13 @@ stage, runtime feedback, and an earned-autonomy ladder). See
   option, instead of running the architect against it. `queue add`
   keeps its `""` default, which is how a queued item asks `serve` to
   name it `queue-<id>`: the refusal is gated on the parameter source,
-  so only a blank the operator typed is refused. The name is an
-  identity: it keys the journal audits, the decision register and, under
-  `--single-pr`, the branch. Related, and the reason the boundary check
+  so only a blank the operator typed is refused. A queue item already
+  on disk with a whitespace-only name, added before this change, is
+  poisoned on its next attempt instead of run: the child `ks factory`
+  refuses the name and `serve` files the refusal as needing a human.
+  The name is an identity: it keys the journal audits, the decision
+  register and, under `--single-pr`, the branch. Related, and the reason
+  the boundary check
   is worth having: the convergence report's accounting of audits the
   trend leaves out is now computed by one classifier per audit, so the
   three buckets (this project's, another project's, no project recorded)

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -186,13 +186,22 @@ def _reject_blank_project_name(
     substituting "x" would write a manifest, a branch and a journal
     audit under something else.
 
-    Not on ``ks queue add``: its ``--project-name`` defaults to "" as
-    the sentinel ``serve`` derives ``queue-<id>`` from, and Click runs
-    a callback over an option's own default. A queued item with a
-    whitespace name still reaches this check, because ``serve`` spawns
-    a child ``ks factory --project-name``, which refuses it with exit 2.
+    On all three ``--project-name`` options, ``ks queue add``
+    included, whose "" default is the sentinel ``serve`` derives
+    ``queue-<id>`` from. Click runs a callback over an option's own
+    default, so the refusal is gated on the parameter SOURCE rather
+    than left off the option: a "" the operator never typed is
+    returned untouched, an explicit "" or "   " is refused. A source
+    this cannot resolve is refused too, because a check that cannot
+    prove the value came from the default must flag, not clear.
+
+    ``tests/test_project_name_boundary.py`` walks the Click tree and
+    fails if a fourth ``project_name`` parameter appears without this
+    callback, so the boundary is closed by census rather than by a
+    list of the options someone remembered.
     """
-    if value is not None and not value.strip():
+    source = ctx.get_parameter_source(param.name) if param.name else None
+    if value is not None and not value.strip() and source is not ParameterSource.DEFAULT:
         raise click.BadParameter("must not be empty or whitespace-only", ctx=ctx, param=param)
     return value
 
@@ -4810,7 +4819,12 @@ def _resolve_queue_item(queue: Any, item_id: str, ui_impl: UI) -> Any:
 @click.argument("spec", type=click.Path(exists=True, path_type=Path))
 @click.option("--priority", type=int, default=0, help="Higher runs first")
 @click.option("--title", default="", help="Human label (default: spec filename)")
-@click.option("--project-name", default="", help="Factory project name")
+@click.option(
+    "--project-name",
+    default="",
+    callback=_reject_blank_project_name,
+    help="Factory project name",
+)
 @click.option(
     "--auto-merge/--stop-at-pr",
     "auto_merge",

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -196,9 +196,10 @@ def _reject_blank_project_name(
     prove the value came from the default must flag, not clear.
 
     ``tests/test_project_name_boundary.py`` walks the Click tree and
-    fails if a fourth ``project_name`` parameter appears without this
-    callback, so the boundary is closed by census rather than by a
-    list of the options someone remembered.
+    fails if a fourth ``--project-name`` option, or a fourth parameter
+    bound to ``project_name``, appears without this callback, so the
+    boundary is closed by census rather than by a list of the options
+    someone remembered.
     """
     source = ctx.get_parameter_source(param.name) if param.name else None
     if value is not None and not value.strip() and source is not ParameterSource.DEFAULT:
@@ -4823,7 +4824,7 @@ def _resolve_queue_item(queue: Any, item_id: str, ui_impl: UI) -> Any:
     "--project-name",
     default="",
     callback=_reject_blank_project_name,
-    help="Factory project name",
+    help="Factory project name (omit it and serve derives queue-<id>)",
 )
 @click.option(
     "--auto-merge/--stop-at-pr",

--- a/kstrl/cli.py
+++ b/kstrl/cli.py
@@ -165,6 +165,38 @@ def _use_cli_value(ctx: click.Context, name: str) -> bool:
     return ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE
 
 
+def _reject_blank_project_name(
+    ctx: click.Context,
+    param: click.Parameter,
+    value: str | None,
+) -> str | None:
+    """Refuse an empty or whitespace-only project name at the boundary (#338).
+
+    The project name is an identity: it keys the journal audits, the
+    decision register and, under ``--single-pr``, the branch. "" was
+    accepted by Click and is the one value at which the convergence
+    accounting counted an audit with no project as BOTH this project's
+    and unattributed, reporting five audits as eight. Refusing it here
+    means no downstream reader has to carry a special case for it, and
+    the refusal lands before the architect is invoked, measured at 119
+    to 210 seconds against a frontier model on a real spec.
+
+    Rejects or returns the value VERBATIM; it never strips. " x " is a
+    strange name but it is the name the operator typed, and quietly
+    substituting "x" would write a manifest, a branch and a journal
+    audit under something else.
+
+    Not on ``ks queue add``: its ``--project-name`` defaults to "" as
+    the sentinel ``serve`` derives ``queue-<id>`` from, and Click runs
+    a callback over an option's own default. A queued item with a
+    whitespace name still reaches this check, because ``serve`` spawns
+    a child ``ks factory --project-name``, which refuses it with exit 2.
+    """
+    if value is not None and not value.strip():
+        raise click.BadParameter("must not be empty or whitespace-only", ctx=ctx, param=param)
+    return value
+
+
 # Accepted spellings for the agent type across the config surface.
 # kstrl.toml documents "claude" | "codex" | "custom"; the --agent-type
 # flags and KSTRL_AGENT_TYPE historically use "claude-code" | "codex" |
@@ -2006,6 +2038,7 @@ def feature(
 @click.option(
     "--project-name",
     required=True,
+    callback=_reject_blank_project_name,
     help="Name for this factory project",
 )
 @click.option(
@@ -2216,6 +2249,7 @@ def decompose(
 )
 @click.option(
     "--project-name",
+    callback=_reject_blank_project_name,
     help="Name for this factory project (required with --spec)",
 )
 @click.option(

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -1588,7 +1588,7 @@ class ExcludedHistory:
       wording claimed the whole journal.
     - ``projects`` covers every audit under some other project name.
     - ``unattributed`` covers audits whose ``project`` field is absent,
-      null or not a string, FOR A NON-EMPTY project name; at "" those
+      null, empty or not a string, FOR A NON-EMPTY project name; at "" those
       audits are this project's own, which is what :func:`_audit_bucket`
       decides. Round 2 of review found these counted by neither of the
       other two: three audits on disk reported as one.
@@ -1644,7 +1644,7 @@ def _audit_bucket(
     it cost. ``own_recorded`` was ``entry_str(e, "project") ==
     project_name`` and ``unattributed`` was ``not entry_str(e,
     "project")``. Those are two spellings of the same question at
-    ``project_name == ""``, so an audit with an absent, null or
+    ``project_name == ""``, so an audit with an absent, null, empty or
     non-string project satisfied both and was counted twice: five
     audits on disk, eight bucket placements. One call per audit places
     it once, so the three counts sum to the audits by construction

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -11,7 +11,7 @@ from collections import Counter
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from kstrl.agents.base import (
     ARCHITECT_COMPONENT,
@@ -1575,8 +1575,11 @@ class ExcludedHistory:
     Three buckets, because there are three ways for the report to see
     less than the journal holds, and #280 is that any of them going
     unsaid is the failure the report cannot afford. Each round of
-    review found another one being missed, so they are enumerated here
-    and every ``spec_issues`` entry falls into exactly one:
+    review found another one being missed, so they are enumerated here.
+    Every ``spec_issues`` entry falls into exactly one, and
+    :func:`_audit_bucket` is the only place that decides which: #338 is
+    what happened when two of the three were computed by separate
+    predicates that agreed at every project name except "".
 
     - ``own_recorded`` counts THIS project's audits on disk. The trend
       may count fewer, because ``lookback_runs`` windows it and because
@@ -1629,6 +1632,42 @@ class ExcludedHistory:
         return max(0, self.own_recorded - counted - self.unreadable(counted))
 
 
+def _audit_bucket(
+    entry: dict[str, Any],
+    project_name: str,
+) -> Literal["own", "other", "unattributed"]:
+    """Which of ``ExcludedHistory``'s three buckets one spec audit is in.
+
+    The ONLY place the rule lives, because #338 is what two copies of
+    it cost. ``own_recorded`` was ``entry_str(e, "project") ==
+    project_name`` and ``unattributed`` was ``not entry_str(e,
+    "project")``. Those are two spellings of the same question at
+    ``project_name == ""``, so an audit with an absent, null or
+    non-string project satisfied both and was counted twice: five
+    audits on disk, eight bucket placements. One call per audit places
+    it once, so the three counts sum to the audits by construction
+    rather than by the two predicates happening to disagree.
+
+    The ORDER is the decision, and it is own before unattributed.
+    :meth:`EvolutionJournal.get_spec_issue_runs` windows the trend by
+    the identical ``entry_str(entry, "project") == project`` expression,
+    so at "" the trend counts those audits. Calling them unattributed
+    here would make ``own_recorded`` 0 for a trend showing 3, and would
+    make the rendered note claiming neither the trend nor the
+    cross-project line counts them false about audits the trend just
+    counted. Agreeing with the window keeps one answer for one journal.
+
+    For every non-empty ``project_name`` the order is unobservable:
+    ``project == project_name`` and ``not project`` cannot both hold.
+    """
+    project = entry_str(entry, "project")
+    if project == project_name:
+        return "own"
+    if not project:
+        return "unattributed"
+    return "other"
+
+
 def _excluded_projects(
     audits: list[dict[str, Any]],
     project_name: str,
@@ -1654,7 +1693,7 @@ def _excluded_projects(
     last_seen: dict[str, str] = {}
     for entry in audits:
         project = entry_str(entry, "project")
-        if not project or project == project_name:
+        if _audit_bucket(entry, project_name) != "other":
             continue
         by_project.setdefault(project, []).append(entry_str(entry, "spec_file"))
         # Only a timestamp that exists replaces one that exists. Round 2
@@ -1700,10 +1739,11 @@ def _excluded_history(
     excludes that was itself windowed would omit history silently,
     which is the bug this exists to fix.
     """
+    buckets = Counter(_audit_bucket(e, project_name) for e in audits)
     return ExcludedHistory(
-        own_recorded=sum(1 for e in audits if entry_str(e, "project") == project_name),
+        own_recorded=buckets["own"],
         projects=_excluded_projects(audits, project_name, spec_file),
-        unattributed=sum(1 for e in audits if not entry_str(e, "project")),
+        unattributed=buckets["unattributed"],
         lookback=lookback,
     )
 

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -1692,9 +1692,9 @@ def _excluded_projects(
     by_project: dict[str, list[str]] = {}
     last_seen: dict[str, str] = {}
     for entry in audits:
-        project = entry_str(entry, "project")
         if _audit_bucket(entry, project_name) != "other":
             continue
+        project = entry_str(entry, "project")
         by_project.setdefault(project, []).append(entry_str(entry, "spec_file"))
         # Only a timestamp that exists replaces one that exists. Round 2
         # of review: assigning unconditionally let one trailing entry

--- a/kstrl/decompose.py
+++ b/kstrl/decompose.py
@@ -1588,8 +1588,10 @@ class ExcludedHistory:
       wording claimed the whole journal.
     - ``projects`` covers every audit under some other project name.
     - ``unattributed`` covers audits whose ``project`` field is absent,
-      null or not a string. Round 2 of review found these counted by
-      neither of the other two: three audits on disk reported as one.
+      null or not a string, FOR A NON-EMPTY project name; at "" those
+      audits are this project's own, which is what :func:`_audit_bucket`
+      decides. Round 2 of review found these counted by neither of the
+      other two: three audits on disk reported as one.
 
     ``lookback`` is carried so the render can separate the two reasons
     the trend counts fewer than ``own_recorded``. An audit outside the

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -575,6 +575,46 @@ class TestResolveBaseBranch:
         assert resolve_base_branch(absent, root) == "master"
 
 
+def _halting_decompose(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Record what the CLI resolved, then halt before anything is spent.
+
+    Module-level rather than a staticmethod because two classes assert
+    about the arguments the CLI hands `decompose_spec`: #259 about the
+    base branch it resolved, #338 about the project name it let
+    through. A second copy would let them disagree about what "reached
+    decompose" means.
+    """
+    import kstrl.cli as cli_mod
+    from kstrl.decisions import SpecDecision
+    from kstrl.decompose import SpecBlockerError
+
+    seen: dict[str, object] = {}
+
+    def fake_decompose(**kwargs: object) -> None:
+        seen.update(kwargs)
+        # Halt before anything is provisioned; the assertion is on
+        # what the CLI resolved, not on what decompose does with it.
+        raise SpecBlockerError(
+            [
+                SpecDecision(
+                    issue="halt-question",
+                    question="halt",
+                    disposition="escalated",
+                    resolution="the owner must say",
+                )
+            ]
+        )
+
+    monkeypatch.setattr(cli_mod, "decompose_spec", fake_decompose)
+    return seen
+
+
+def _spec_at(root: Path) -> Path:
+    spec = root / "spec.md"
+    spec.write_text("# Spec\n")
+    return spec
+
+
 class TestBaseBranchFlagDefaults:
     """#259: --base-branch defaults to detection, not the literal `main`.
 
@@ -582,45 +622,13 @@ class TestBaseBranchFlagDefaults:
     literal default without even the detection call.
     """
 
-    @staticmethod
-    def _capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
-        import kstrl.cli as cli_mod
-        from kstrl.decisions import SpecDecision
-        from kstrl.decompose import SpecBlockerError
-
-        seen: dict[str, object] = {}
-
-        def fake_decompose(**kwargs: object) -> None:
-            seen.update(kwargs)
-            # Halt before anything is provisioned; the assertion is on
-            # what the CLI resolved, not on what decompose does with it.
-            raise SpecBlockerError(
-                [
-                    SpecDecision(
-                        issue="halt-question",
-                        question="halt",
-                        disposition="escalated",
-                        resolution="the owner must say",
-                    )
-                ]
-            )
-
-        monkeypatch.setattr(cli_mod, "decompose_spec", fake_decompose)
-        return seen
-
-    @staticmethod
-    def _spec(root: Path) -> Path:
-        spec = root / "spec.md"
-        spec.write_text("# Spec\n")
-        return spec
-
     def _invoke(self, command: str, root: Path, *extra: str) -> Result:
         return CliRunner().invoke(
             cli,
             [
                 command,
                 "--spec",
-                str(self._spec(root)),
+                str(_spec_at(root)),
                 "--project-name",
                 "test",
                 "--root",
@@ -637,7 +645,7 @@ class TestBaseBranchFlagDefaults:
     def test_decompose_detects_when_flag_is_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        seen = self._capture(monkeypatch)
+        seen = _halting_decompose(monkeypatch)
         root = _repo_on(tmp_path, "master")
         assert self._invoke("decompose", root).exit_code == 2
         assert seen["base_branch"] == "master"
@@ -645,7 +653,7 @@ class TestBaseBranchFlagDefaults:
     def test_factory_detects_when_flag_is_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        seen = self._capture(monkeypatch)
+        seen = _halting_decompose(monkeypatch)
         root = _repo_on(tmp_path, "master")
         assert self._invoke("factory", root).exit_code == 2
         assert seen["base_branch"] == "master"
@@ -653,7 +661,77 @@ class TestBaseBranchFlagDefaults:
     def test_explicit_flag_still_wins(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        seen = self._capture(monkeypatch)
+        seen = _halting_decompose(monkeypatch)
         root = _repo_on(tmp_path, "master")
         assert self._invoke("factory", root, "--base-branch", "trunk").exit_code == 2
         assert seen["base_branch"] == "trunk"
+
+
+class TestBlankProjectName:
+    """#338: an empty or whitespace-only --project-name is refused.
+
+    `""` was accepted by both commands that call `decompose_spec`, and
+    it is the one name at which the convergence accounting counted an
+    audit with no project twice. The name is refused at the boundary
+    now, before the architect runs: measured at 119 to 210 seconds
+    against a frontier model, so the cost of finding out later is real.
+
+    `factory` had a body check that rejected `""` and passed `"   "`.
+    """
+
+    def _invoke(
+        self,
+        command: str,
+        root: Path,
+        project_name: str,
+    ) -> Result:
+        return CliRunner().invoke(
+            cli,
+            [
+                command,
+                "--spec",
+                str(_spec_at(root)),
+                "--project-name",
+                project_name,
+                "--root",
+                str(root),
+                "--agent-cmd",
+                "true",
+                "--ui",
+                "plain",
+                "--no-color",
+            ],
+        )
+
+    @pytest.mark.parametrize("command", ["decompose", "factory"])
+    @pytest.mark.parametrize("project_name", ["", "   ", "\t"])
+    def test_a_blank_name_exits_two_and_names_the_option(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        command: str,
+        project_name: str,
+    ) -> None:
+        seen = _halting_decompose(monkeypatch)
+        root = _repo_on(tmp_path, "master")
+
+        result = self._invoke(command, root, project_name)
+
+        assert result.exit_code == 2
+        assert "--project-name" in result.output
+        # The halting stub records every call, so an empty dict is the
+        # proof nothing was spent rather than the proof it halted.
+        assert seen == {}
+
+    def test_a_name_with_surrounding_space_reaches_decompose_verbatim(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No silent substitution: the callback rejects or returns the
+        value unchanged. Stripping " x " to "x" would write a manifest,
+        a branch and a journal audit under a name the operator never
+        typed."""
+        seen = _halting_decompose(monkeypatch)
+        root = _repo_on(tmp_path, "master")
+
+        assert self._invoke("decompose", root, " x ").exit_code == 2
+        assert seen["project_name"] == " x "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -707,6 +707,11 @@ class TestBlankProjectName:
         result = _invoke_spec_command(command, root, project_name=project_name)
 
         assert result.exit_code == 2
+        # The halting stub ALSO exits 2, so the exit code alone does not
+        # discriminate: on the base commit it passed while the other
+        # lines failed. Naming the halt banner is what makes it a check
+        # on the callback rather than on the halt path.
+        assert "Architect escalated" not in result.output
         assert "--project-name" in result.output
         # The halting stub records every call, so an empty dict is the
         # proof nothing was spent rather than the proof it halted.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -615,6 +615,39 @@ def _spec_at(root: Path) -> Path:
     return spec
 
 
+def _invoke_spec_command(
+    command: str,
+    root: Path,
+    *extra: str,
+    project_name: str = "test",
+) -> Result:
+    """Drive `decompose` or `factory` down the --spec path.
+
+    One copy of the argv for the same reason `_halting_decompose` is
+    one copy: two classes assert about what the CLI hands
+    `decompose_spec`, and a second flag list would let them drift about
+    what invoking the command means.
+    """
+    return CliRunner().invoke(
+        cli,
+        [
+            command,
+            "--spec",
+            str(_spec_at(root)),
+            "--project-name",
+            project_name,
+            "--root",
+            str(root),
+            "--agent-cmd",
+            "true",
+            "--ui",
+            "plain",
+            "--no-color",
+            *extra,
+        ],
+    )
+
+
 class TestBaseBranchFlagDefaults:
     """#259: --base-branch defaults to detection, not the literal `main`.
 
@@ -622,32 +655,12 @@ class TestBaseBranchFlagDefaults:
     literal default without even the detection call.
     """
 
-    def _invoke(self, command: str, root: Path, *extra: str) -> Result:
-        return CliRunner().invoke(
-            cli,
-            [
-                command,
-                "--spec",
-                str(_spec_at(root)),
-                "--project-name",
-                "test",
-                "--root",
-                str(root),
-                "--agent-cmd",
-                "true",
-                "--ui",
-                "plain",
-                "--no-color",
-                *extra,
-            ],
-        )
-
     def test_decompose_detects_when_flag_is_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         seen = _halting_decompose(monkeypatch)
         root = _repo_on(tmp_path, "master")
-        assert self._invoke("decompose", root).exit_code == 2
+        assert _invoke_spec_command("decompose", root).exit_code == 2
         assert seen["base_branch"] == "master"
 
     def test_factory_detects_when_flag_is_absent(
@@ -655,7 +668,7 @@ class TestBaseBranchFlagDefaults:
     ) -> None:
         seen = _halting_decompose(monkeypatch)
         root = _repo_on(tmp_path, "master")
-        assert self._invoke("factory", root).exit_code == 2
+        assert _invoke_spec_command("factory", root).exit_code == 2
         assert seen["base_branch"] == "master"
 
     def test_explicit_flag_still_wins(
@@ -663,7 +676,7 @@ class TestBaseBranchFlagDefaults:
     ) -> None:
         seen = _halting_decompose(monkeypatch)
         root = _repo_on(tmp_path, "master")
-        assert self._invoke("factory", root, "--base-branch", "trunk").exit_code == 2
+        assert _invoke_spec_command("factory", root, "--base-branch", "trunk").exit_code == 2
         assert seen["base_branch"] == "trunk"
 
 
@@ -679,30 +692,6 @@ class TestBlankProjectName:
     `factory` had a body check that rejected `""` and passed `"   "`.
     """
 
-    def _invoke(
-        self,
-        command: str,
-        root: Path,
-        project_name: str,
-    ) -> Result:
-        return CliRunner().invoke(
-            cli,
-            [
-                command,
-                "--spec",
-                str(_spec_at(root)),
-                "--project-name",
-                project_name,
-                "--root",
-                str(root),
-                "--agent-cmd",
-                "true",
-                "--ui",
-                "plain",
-                "--no-color",
-            ],
-        )
-
     @pytest.mark.parametrize("command", ["decompose", "factory"])
     @pytest.mark.parametrize("project_name", ["", "   ", "\t"])
     def test_a_blank_name_exits_two_and_names_the_option(
@@ -715,7 +704,7 @@ class TestBlankProjectName:
         seen = _halting_decompose(monkeypatch)
         root = _repo_on(tmp_path, "master")
 
-        result = self._invoke(command, root, project_name)
+        result = _invoke_spec_command(command, root, project_name=project_name)
 
         assert result.exit_code == 2
         assert "--project-name" in result.output
@@ -733,5 +722,5 @@ class TestBlankProjectName:
         seen = _halting_decompose(monkeypatch)
         root = _repo_on(tmp_path, "master")
 
-        assert self._invoke("decompose", root, " x ").exit_code == 2
+        assert _invoke_spec_command("decompose", root, project_name=" x ").exit_code == 2
         assert seen["project_name"] == " x "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -717,6 +717,21 @@ class TestBlankProjectName:
         # proof nothing was spent rather than the proof it halted.
         assert seen == {}
 
+    def test_a_blank_name_beside_a_manifest_is_refused_too(self, tmp_path: Path) -> None:
+        """`factory --manifest` never reads the name, and used to accept
+        `""` beside it. The callback fires at parse time regardless of
+        which path the body would take, so the refusal is the same."""
+        manifest = tmp_path / "m.json"
+        manifest.write_text("{}\n", encoding="utf-8")
+
+        result = CliRunner().invoke(
+            cli,
+            ["factory", "--manifest", str(manifest), "--project-name", "", "--no-color"],
+        )
+
+        assert result.exit_code == 2
+        assert "--project-name" in result.output
+
     def test_a_name_with_surrounding_space_reaches_decompose_verbatim(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -2219,6 +2219,49 @@ class TestUnattributedAudits:
         assert len(audits) == 4
         assert history.own_recorded + history.other_audits + history.unattributed == len(audits)
 
+    @pytest.mark.parametrize("name", ["", "mine", "nobody", " mine ", "   "])
+    def test_the_partition_holds_for_every_project_name(self, tmp_path: Path, name: str) -> None:
+        """#338: the test above pins the property at one project name,
+        and the two counts were computed by two predicates that agree
+        everywhere except at "". There ``x == project_name`` and
+        ``not x`` are the same question, so an audit with an absent,
+        null or non-string project was counted as this project's AND as
+        unattributed: seven audits, eleven placements.
+
+        The second assertion is the one that fixes WHICH bucket takes
+        it. ``EvolutionJournal.get_spec_issue_runs`` matches a project
+        by the same ``entry_str`` expression, so at "" the trend counts
+        those audits; ``own_recorded`` has to count them too, or the
+        accounting printed under the trend contradicts it and the note
+        saying neither counts them is false.
+        """
+        entries: list[dict[str, Any]] = [
+            audit("mine"),
+            audit("mine", "b.md"),
+            audit("other"),
+            audit(None, "null.md"),
+            audit(7, "int.md"),
+            audit("", "empty.md"),
+            # The helper always writes the key; an absent one is the
+            # shape a journal from an older version carries.
+            {
+                "timestamp": "2026-08-20T00:00:00Z",
+                "event_type": SPEC_ISSUES_EVENT,
+                "spec_file": "absent.md",
+            },
+        ]
+        journal = journal_at(tmp_path)
+        journal.append_entries(entries)
+
+        audits = _journal_snapshot(journal, name).audits
+        history = _excluded_history(audits, name, "mine.md", 10)
+
+        assert len(audits) == len(entries)
+        assert history.own_recorded + history.other_audits + history.unattributed == len(audits)
+        assert history.own_recorded == len(
+            journal.get_spec_issue_runs(name, len(audits), audits=audits)
+        )
+
 
 class TestOneJournalRead:
     """#280 round 2, findings 6 and 7, and #314: one read, taken through

--- a/tests/test_project_name_boundary.py
+++ b/tests/test_project_name_boundary.py
@@ -15,13 +15,18 @@ all three: the untyped default is left alone, an explicit blank is
 refused.
 
 The census here is the guard for instance N+1. It walks the Click tree
-and counts every parameter named `project_name` that it OBTAINS, so a
-fourth option appears as an unexplained delta rather than as a site
-outside a list someone maintained by hand. It CLEARS each site, so it
-clears only on `callback is _reject_blank_project_name`, an object
-identity it can prove; and it pins both the count and the command
-paths, so a walk that has gone blind fails red instead of agreeing
-with an empty result.
+and counts every parameter it OBTAINS that spells the `--project-name`
+flag or binds the `project_name` destination, so a fourth option
+appears as an unexplained delta rather than as a site outside a list
+someone maintained by hand. Keyed on the flag as well as the
+destination because round 2 of review planted
+`@click.option("--project-name", "project")`, an idiom `cli.py` uses
+eight times, and a census keyed on the destination alone cleared it.
+It CLEARS each site, so it clears only on
+`callback is _reject_blank_project_name`, an object identity it can
+prove; and it pins both the count and the command paths, so a walk
+that has gone blind fails red instead of agreeing with an empty
+result.
 """
 
 from __future__ import annotations
@@ -31,6 +36,7 @@ from pathlib import Path
 
 import click
 import pytest
+from click.core import ParameterSource
 from click.testing import CliRunner, Result
 
 from kstrl.cli import _reject_blank_project_name, cli
@@ -76,11 +82,23 @@ def _every_parameter(
             yield from _every_parameter(sub, here)
 
 
-def _project_name_sites() -> dict[str, click.Parameter]:
+def _takes_a_project_name(param: click.Parameter) -> bool:
+    """The flag an operator types, or the destination the body reads.
+
+    Either alone is a list of the options that happen to use one
+    spelling: `"--project-name"` with a renamed destination is what
+    round 2 planted, and `project_name` bound from some other flag is
+    the reverse. Widening the key can only add sites, and the count is
+    a set equality, so over-matching fails red rather than clearing.
+    """
+    return param.name == "project_name" or "--project-name" in param.opts
+
+
+def _project_name_sites(root: click.Command = cli) -> dict[str, click.Parameter]:
     sites: dict[str, click.Parameter] = {}
-    for where, param in _every_parameter(cli):
-        if param.name == "project_name":
-            assert where not in sites, f"two project_name parameters on {where}"
+    for where, param in _every_parameter(root):
+        if _takes_a_project_name(param):
+            assert where not in sites, f"two project-name parameters on {where}"
             sites[where] = param
     return sites
 
@@ -90,12 +108,92 @@ class TestProjectNameCensus:
         assert set(_project_name_sites()) == EXPECTED_PROJECT_NAME_SITES
 
     def test_every_one_of_them_carries_the_rejecting_callback(self) -> None:
+        sites = _project_name_sites()
+        # Stand-alone: an empty walk must not clear this layer either.
+        assert sites
         uncovered = {
             where
-            for where, param in _project_name_sites().items()
+            for where, param in sites.items()
             if param.callback is not _reject_blank_project_name
         }
         assert uncovered == set()
+
+    def test_the_census_sees_the_flag_under_a_renamed_destination(self) -> None:
+        """Round 2 of review planted this shape and the census cleared it.
+
+        `cli.py` binds `"--all"` to `show_all` and `"--state"` to
+        `states`; a `--project-name` written the same way has
+        `param.name == "project"` and was invisible to a census keyed
+        on the destination. Planted on a throwaway group rather than
+        on `cli`, so the pinned census above is unaffected.
+        """
+
+        @click.group()
+        def root() -> None:
+            pass
+
+        @root.command()
+        @click.option("--project-name", "project")
+        def renamed(project: str | None) -> None:
+            pass
+
+        @root.command()
+        @click.option("--project-name")
+        def default_destination(project_name: str | None) -> None:
+            pass
+
+        @root.command()
+        @click.option("--name", "project_name")
+        def other_flag(project_name: str | None) -> None:
+            pass
+
+        @root.command()
+        @click.option("--project")
+        def unrelated(project: str | None) -> None:
+            pass
+
+        sites = _project_name_sites(root)
+        assert set(sites) == {
+            "root renamed",
+            "root default-destination",
+            "root other-flag",
+        }
+        assert all(param.callback is None for param in sites.values())
+
+
+class TestTheCallbackFailsClosed:
+    """The two branches no CLI path reaches today, pinned directly.
+
+    No option here declares `envvar=` or `prompt=` and Click never
+    hands a declared option a `None` name, so neither branch changes
+    what an operator sees. They are pinned because `_use_cli_value`
+    sits eight lines above and clears on `ParameterSource.COMMANDLINE`;
+    harmonising the two would widen this callback's clearing set from
+    one source to four.
+    """
+
+    def test_a_blank_from_the_environment_is_refused(self) -> None:
+        param = click.Option(["--project-name"])
+        ctx = click.Context(click.Command("probe", params=[param]))
+        ctx.set_parameter_source("project_name", ParameterSource.ENVIRONMENT)
+
+        with pytest.raises(click.BadParameter):
+            _reject_blank_project_name(ctx, param, "   ")
+
+    def test_a_blank_the_default_supplied_is_returned(self) -> None:
+        param = click.Option(["--project-name"], default="")
+        ctx = click.Context(click.Command("probe", params=[param]))
+        ctx.set_parameter_source("project_name", ParameterSource.DEFAULT)
+
+        assert _reject_blank_project_name(ctx, param, "") == ""
+
+    def test_an_unresolvable_parameter_name_is_refused(self) -> None:
+        param = click.Option(["--project-name"])
+        ctx = click.Context(click.Command("probe", params=[param]))
+        param.name = None
+
+        with pytest.raises(click.BadParameter):
+            _reject_blank_project_name(ctx, param, "")
 
 
 def _spec_at(root: Path) -> Path:

--- a/tests/test_project_name_boundary.py
+++ b/tests/test_project_name_boundary.py
@@ -1,0 +1,148 @@
+"""#338: every `--project-name` in the CLI tree refuses a blank name.
+
+The defect class is "a blank project name accepted at a CLI boundary".
+The project name is an identity: it keys the journal audits, the
+decision register and, under `--single-pr`, the branch, and "" is the
+one value at which the convergence accounting counted an audit with no
+project as BOTH this project's and unattributed.
+
+Round 1 of review found the class half-fixed. `ks decompose` and
+`ks factory` had the callback; `ks queue add` did not, because Click
+runs a callback over an option's own default and that option's default
+is the "" sentinel `serve._derive_project_name` turns into
+`queue-<id>`. Gating the refusal on `ctx.get_parameter_source` serves
+all three: the untyped default is left alone, an explicit blank is
+refused.
+
+The census here is the guard for instance N+1. It walks the Click tree
+and counts every parameter named `project_name` that it OBTAINS, so a
+fourth option appears as an unexplained delta rather than as a site
+outside a list someone maintained by hand. It CLEARS each site, so it
+clears only on `callback is _reject_blank_project_name`, an object
+identity it can prove; and it pins both the count and the command
+paths, so a walk that has gone blind fails red instead of agreeing
+with an empty result.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner, Result
+
+from kstrl.cli import _reject_blank_project_name, cli
+from kstrl.workqueue import Queue, QueueConfig
+
+#: Every command path in the Click tree that takes a project name.
+#: Pinned rather than counted alone so a walk that stops recursing
+#: fails on the missing path instead of on a number nobody reads.
+#: `cli queue add` is nested one group deep, which is what makes its
+#: presence proof that the walk descends.
+EXPECTED_PROJECT_NAME_SITES = {
+    "cli decompose",
+    "cli factory",
+    "cli queue add",
+}
+
+
+def _every_parameter(
+    command: click.Command,
+    path: tuple[str, ...] = (),
+) -> Iterator[tuple[str, click.Parameter]]:
+    """Yield (command path, parameter) for the whole tree under `command`.
+
+    Enumerates what it obtains - a command, then its `params`, then its
+    subcommands - and never decides that some parameter shape is
+    uninteresting, so the only way for a site to escape is for the
+    command itself to be unreachable from `cli`.
+
+    `list_commands`/`get_command` rather than the `commands` dict:
+    those are the methods a lazily loaded group would override, and a
+    group that lists a name it cannot resolve raises here rather than
+    being skipped.
+    """
+    here = (*path, command.name or "<anonymous>")
+    where = " ".join(here)
+    for param in command.params:
+        yield where, param
+    if isinstance(command, click.Group):
+        ctx = click.Context(command)
+        for name in command.list_commands(ctx):
+            sub = command.get_command(ctx, name)
+            assert sub is not None, f"{where} lists {name!r} but cannot resolve it"
+            yield from _every_parameter(sub, here)
+
+
+def _project_name_sites() -> dict[str, click.Parameter]:
+    sites: dict[str, click.Parameter] = {}
+    for where, param in _every_parameter(cli):
+        if param.name == "project_name":
+            assert where not in sites, f"two project_name parameters on {where}"
+            sites[where] = param
+    return sites
+
+
+class TestProjectNameCensus:
+    def test_the_tree_has_exactly_the_three_known_project_name_options(self) -> None:
+        assert set(_project_name_sites()) == EXPECTED_PROJECT_NAME_SITES
+
+    def test_every_one_of_them_carries_the_rejecting_callback(self) -> None:
+        uncovered = {
+            where
+            for where, param in _project_name_sites().items()
+            if param.callback is not _reject_blank_project_name
+        }
+        assert uncovered == set()
+
+
+def _spec_at(root: Path) -> Path:
+    spec = root / "feature.md"
+    spec.write_text("# Feature\n\nDo the thing.\n", encoding="utf-8")
+    return spec
+
+
+def _queue_add(root: Path, *extra: str) -> Result:
+    return CliRunner().invoke(
+        cli,
+        ["queue", "add", str(_spec_at(root)), *extra, "--root", str(root), "--no-color"],
+    )
+
+
+class TestQueueAddBlankProjectName:
+    """The third boundary: what `serve` later spawns a child factory with."""
+
+    @pytest.mark.parametrize("project_name", ["", "   ", "\t"])
+    def test_an_explicit_blank_name_exits_two_and_queues_nothing(
+        self, tmp_path: Path, project_name: str
+    ) -> None:
+        result = _queue_add(tmp_path, "--project-name", project_name)
+
+        assert result.exit_code == 2
+        assert "--project-name" in result.output
+        # Refused at parse time, so the item never reached the queue and
+        # `serve` never spawns a child factory that has to refuse it.
+        assert Queue(tmp_path, QueueConfig()).items() == []
+
+    def test_the_absent_flag_still_stores_the_empty_sentinel(self, tmp_path: Path) -> None:
+        """The "" default is load-bearing and the source gate protects it.
+
+        `serve` reads `item.project_name or _derive_project_name(item)`,
+        so "" is how an item says "name me `queue-<id>`". Click runs the
+        callback over that default, which is why the refusal keys on the
+        parameter source instead of on the value alone.
+        """
+        result = _queue_add(tmp_path)
+
+        assert result.exit_code == 0
+        items = Queue(tmp_path, QueueConfig()).items()
+        assert len(items) == 1
+        assert items[0].project_name == ""
+
+    def test_a_name_with_surrounding_space_is_stored_verbatim(self, tmp_path: Path) -> None:
+        result = _queue_add(tmp_path, "--project-name", " x ")
+
+        assert result.exit_code == 0
+        assert Queue(tmp_path, QueueConfig()).items()[0].project_name == " x "


### PR DESCRIPTION
## Summary

`ExcludedHistory` documents a partition: every recorded spec audit lands in exactly one of this project's, another project's, or no project recorded, so the three buckets sum to the audits on disk. The first and third counts were separate predicates over the same list, `entry_str(e, "project") == project_name` and `not entry_str(e, "project")`. Those ask the same question when `project_name` is `""`, so an audit whose project field is absent, null or not a string satisfied both and was counted twice. Measured on one fixture: five audits on disk, eight bucket placements.

`_audit_bucket` in `kstrl/decompose.py` is now the only place the rule lives, and one call per audit places it once, so the sum is an identity rather than two predicates happening to agree. The order is own before unattributed, which keeps `own_recorded` equal to what `EvolutionJournal.get_spec_issue_runs` counts at `""`: that method windows by the identical expression, so calling those audits unattributed here would report 0 under a trend showing 3, and would make the rendered note saying neither counts them false about audits the trend just counted. For every non-empty name the order is unobservable.

`--project-name` is also refused at the boundary. It is an identity: it keys the journal audits, the decision register and, under `--single-pr`, the branch. Click accepted `""` on `ks decompose`, and `ks factory`'s body check rejected `""` while passing `"   "`. `_reject_blank_project_name` is a Click callback on all three `--project-name` options in the CLI tree, exiting 2 and naming the option before the architect runs, which is measured at 119 to 210 seconds against a frontier model. It never strips: `" x "` passes through verbatim, because substituting `"x"` would write a manifest, a branch and a journal audit under a name the operator never typed.

The third option, `ks queue add --project-name`, is the round-1 review finding. Its `""` default is the sentinel `serve._derive_project_name` turns into `queue-<id>`, and Click runs a callback over an option's own default, so the refusal is gated on `ctx.get_parameter_source(param.name) is not ParameterSource.DEFAULT`. A `""` the operator never typed is returned untouched; an explicit `""` or `"   "` is refused. `decompose` and `factory` have no default, so an absent optional still arrives as `None` and is skipped by the first clause. A source the callback cannot resolve is refused, because a check that cannot prove the value came from the default must flag rather than clear.

`tests/test_project_name_boundary.py` is the guard for instance N+1, closed by construction rather than by a list of enrolled options: it walks the Click tree, counts every parameter it obtains that spells the `--project-name` flag or binds the `project_name` destination, and pins both the count at three and the three command paths, so a fourth option is an unexplained census delta and a walk that has gone blind fails on a missing path instead of agreeing with an empty result. Round 2 of review planted `@click.option("--project-name", "project")`, an idiom `cli.py` already uses eight times, and the census keyed on the destination alone cleared it; the key now takes either spelling, a test plants that shape on a throwaway group, and the layer that clears asserts the walk saw something before it clears.

Closes #338

## Behaviour changes

- `ks decompose --project-name ""` used to produce a manifest with `projectName: ""`, a register keyed `""` and a journal audit with `"project": ""`. It now exits 2 before the architect runs.
- `ks factory --spec ... --project-name "   "` used to be accepted. It now exits 2, and the message for `""` changes from `--project-name is required with --spec` to Click's.
- `ks factory --manifest m.json --project-name ""` used to be accepted with the name ignored, because the manifest carries its own. It now exits 2. Raised by review as an undisclosed change; the manifest branch never reads `project_name`, so nothing downstream changes.
- `ks queue add --project-name ""` and `--project-name "   "` now exit 2. `ks queue add` with the flag absent is unchanged: the item still stores `""` and `serve` still derives `queue-<id>` from it. The option's help text now says so.
- A queue item already on disk with a whitespace-only `project_name`, added before this change, used to run. It is now poisoned on its next attempt: `serve` passes the stored name to the child `ks factory`, the callback exits 2, and `classify_run` records that as `UNCLASSIFIABLE` with `may_retry=False`, so the item gets `needs_human` and an inbox item on attempt 1. There is no queue migration. Deriving `queue-<id>` from a name the operator typed was considered and rejected as the silent substitution the callback itself refuses; if the owner wants this closed in code, the consistent version is for `serve` to refuse the item with a reason that names the cause.

## What was tested vs assumed (H4)

Tested, by running it:

- Full suite, bytecode deleted first and `PYTHONDONTWRITEBYTECODE=1`: **5583 passed, 37 skipped, 38 xfailed** in 285s. Branch baseline before any of this was 5564 passed, 37 skipped, 38 xfailed; 19 new cases.
- `uv run mypy kstrl/ --strict` clean, `uv run ruff check kstrl/ tests/` clean, `uv run python scripts/gen_docs.py --check` clean. `file_length_ratchet.py` and `cyclomatic_ratchet.py` exit 0, and the full `pre-commit` hook set ran on each commit.
- The three static guards that AST-walk `decompose.py` and `cli.py`, run before and after the round-2 changes: `tests/test_journal_one_writer.py`, `tests/test_event_names_have_one_home.py`, `tests/test_config_preflight.py`, 117 passed and 1 xfailed both times. `origin/main` has not moved from 568bca4, which is the merge base, so there is nothing to merge.
- Red first: the new parametrized `test_the_partition_holds_for_every_project_name` reports eleven placements for seven audits at `""` on the previous production code, and passes at the other four names. Five of the six `TestBlankProjectName` cases are red on the base commit; the sixth, `""` on `factory`, was already refused by that command's own body check, so it was green before and after. It is `"   "` and `"\t"` that command let through.
- Mutations, each planted alone with `__pycache__` deleted first, every one confirmed to apply before the run. All caught, none hung, none failed to plant. M1, restoring the two separate sums: **caught**, at `""` only, 11 placements against 7 audits. M2, swapping the two branches of `_audit_bucket`: **caught**, on the window-agreement assertion, which is the one that fixes which bucket takes the audit rather than only that the sum is right. M3, dropping each `decompose` and `factory` callback: **caught**. M6, removing the parameter-source gate: **caught**, the `queue add` default path goes red. M7, removing the `queue add` callback: **caught**, by the callback census and the three explicit-blank cases. M8, stopping the Click-tree walk from recursing into groups: **caught**, by the path census. M9, adding a fourth unguarded `project_name` option to `ks queue ls`: **caught**, by both census layers.
- The serve-side consequence of a whitespace name, measured by the round-1 reviewer against the real `classify_run` rather than reasoned from the spawn site: a child `ks factory` exiting 2 with Click's message is `UNCLASSIFIABLE` with `may_retry=False`, so the item is poisoned on attempt 1 with `needs_human` and an inbox item. Loud, but the refusal landed in the daemon rather than at the command that took the input, and the cause was only in `evidence["output_tail"]`. That path is now unreachable from `ks queue add` for items queued after this lands, which refuses the name at parse time and queues nothing; an item queued before it still takes that path, as the behaviour change above says.
- Round-2 mutations, same discipline: reverting the census key to the destination name alone: **caught**, by the planted renamed-destination test. Widening the callback to clear on every source but `COMMANDLINE`: **caught**, by the environment-source test and the unresolvable-name test. Flipping the unresolvable-name fallback to `DEFAULT`: **caught**, by the unresolvable-name test. Full suite after the round-2 changes: **5588 passed, 37 skipped, 38 xfailed** in 339s, bytecode deleted first and PYTHONDONTWRITEBYTECODE=1; the first run of this suite was killed part way by another lane and re-run from scratch.

Assumed, not measured: nothing outstanding. The one assumption in the round-1 body, the serve-side behaviour above, has been measured.

## Checklist

- [x] `uv run pytest tests/` passes
- [x] `uv run mypy kstrl/ --strict` passes
- [x] `uv run ruff check kstrl/ tests/` passes
- [x] `uv run python scripts/gen_docs.py --check` passes (if CLI/config changed)
- [ ] If this maps to a roadmap item, the tracker doc's status is updated in this PR

## Provenance

- [x] This change was written or substantially assisted by an AI agent
- [ ] It has been reviewed by a human (AI self-review does not count - H1)

AI code review will be run on this PR as an assist at the owner's request; the owner remains the gating reviewer (H1).

## Prompt changes (only if an adversarial prompt body changed)

None. No `*_PROMPT` constant and no text reaching an LLM role's prompt is touched, so H2 and H3 do not apply.

- [ ] Calibration re-run and the detection delta recorded (H2)
- [ ] `*_PROMPT_VERSION` bumped and the snapshot tuple in
      `tests/test_prompt_versions.py` updated in this diff (H3)

## Quality pass

A four-angle cleanup review over the diff applied two changes, neither of which moves behaviour: `_excluded_projects` now binds `project` below the classifier guard instead of above it, so the value is not recomputed for skipped entries; and the two `_invoke` methods in `tests/test_cli.py`, the same eleven-flag argv with the project name varying, collapse to one module-level `_invoke_spec_command`, taking the file from 737 to 726 lines. One finding was skipped: `entry_str(entry, "project") == project_name` still appears in `kstrl/evolution.py::get_spec_issue_runs` as well as in `_audit_bucket`, and a shared predicate would make the agreement hold by construction. That is a change to a shared journal API outside this diff, and the agreement is currently pinned by an assertion in the new test, so it is left as a named follow-up rather than folded in here.

`_audit_bucket` is called twice per audit, once by `_excluded_projects` and once by `_excluded_history`. Raised in review and left: the list is a journal's spec audits, tens of entries, and `_excluded_projects` has eleven direct test callers whose signature is not worth changing for an unmeasurable cost.

## Handoffs from review, not fixed here

- A branch-unsafe name still pays for the architect: `--single-pr --project-name "my project"` runs the architect for 119 to 210 seconds and then `validate_branch_name` exits 1. Pre-existing, recorded in this lane's plan, and a different class (expensive-failure ordering); hoisting the check touches `decompose_spec` and the TUI launch path.
- The TUI strips the project name (`tui/screens/launch.py` reads `.value.strip()`) while the CLI keeps `" x "` verbatim, so one identity has two answers at two entrances. Pre-existing and not an instance of this class, since the TUI already refuses blanks. Settling it means deciding whether verbatim or stripped is the one answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtNQsD9BMWmd5razgnKbre

