### PR TITLE
docs(config): state whose fault a RecursionError is, and pin both directions (#323)

### DIFF
--- a/kstrl/config.py
+++ b/kstrl/config.py
@@ -567,17 +567,17 @@ def load_toml_document(path: Path) -> dict[str, Any]:
     render the message.
 
     Provenance follows (#323): the parse runs 9 to 16 frames deep under
-    ``ks status``, 13 to 52 on the Textual event loop, so a
-    ``RecursionError`` here is the document's. Not by construction:
-    measured, a CALLER at 991 of 1000 frames gets a valid file called
-    unparseable, and IS the runaway. ``raise_if_defect`` has the rest.
+    ``ks status``, 13 on the Textual event loop's own callbacks (one TUI
+    parse inherits its caller's stack), so a ``RecursionError`` here is
+    the document's. Not by construction: measured, a CALLER with 5 or 6
+    of 1000 frames left gets a valid file called unparseable, and IS the
+    runaway. ``raise_if_defect`` has the rest.
 
     ``OSError`` is not in the catch-all's reach at all, which is the
-    stronger form of the guarantee two callers depend on. An earlier
-    draft re-raised it from inside the guard; that clause was correct
-    and unpinnable, because with the I/O already hoisted out there was
-    no way to make a test reach it. A special case no test can enter is
-    a special case that has not been deleted yet.
+    stronger form of the guarantee two callers depend on. Re-raising it
+    from inside the guard was correct and unpinnable: with the I/O
+    hoisted out, no test could reach that clause, and a special case no
+    test can enter is a special case that has not been deleted yet.
 
     The rule, after being wrong three times: a parser's error taxonomy
     belongs to the parser, and a reader naming any class narrower than

--- a/kstrl/config.py
+++ b/kstrl/config.py
@@ -567,9 +567,8 @@ def load_toml_document(path: Path) -> dict[str, Any]:
     render the message.
 
     Provenance follows (#323): the parse runs at stack depth 9 to 16
-    under ``ks status``, so a ``RecursionError`` here is the document's,
-    and every block ``config_preflight`` guards reaches tomllib only
-    through this function, so one above is ours - see ``raise_if_defect``.
+    under ``ks status``, so a ``RecursionError`` here is the document's.
+    One above this call is ours; ``raise_if_defect`` carries that half.
 
     ``OSError`` is not in the catch-all's reach at all, which is the
     stronger form of the guarantee two callers depend on. An earlier

--- a/kstrl/config.py
+++ b/kstrl/config.py
@@ -545,8 +545,10 @@ def load_toml_document(path: Path) -> dict[str, Any]:
       then refuses to build: ``max_iterations = <4301 digits>`` raises
       "Exceeds the limit (4300 digits) for integer string conversion"
       from ``sys.get_int_max_str_digits``. Walked past round 1.
-    - ``RecursionError``, at roughly 496 nested arrays or inline tables,
-      from tomllib's recursive-descent parser. It derives from
+    - ``RecursionError``, from tomllib's recursive-descent parser, at no
+      one depth: at the default limit nested arrays first fail at 497
+      levels from a one-frame caller and 396 under 200 more, inline
+      tables at 331 and 264; the caller's own stack sets it. It derives from
       ``RuntimeError``, NOT ``ValueError``, so it walked past round 2 -
       whose docstring, whose AST guard and whose CLAUDE.md line all
       asserted that ``ValueError`` WAS the whole class. Round 2 stated
@@ -563,6 +565,11 @@ def load_toml_document(path: Path) -> dict[str, Any]:
     covered, since it derives from ``Exception``, with the honest caveat
     that no handler can promise the interpreter has the headroom left to
     render the message.
+
+    Provenance follows (#323): the parse runs at stack depth 9 to 16
+    under ``ks status``, so a ``RecursionError`` here is the document's,
+    and every block ``config_preflight`` guards reaches tomllib only
+    through this function, so one above is ours - see ``raise_if_defect``.
 
     ``OSError`` is not in the catch-all's reach at all, which is the
     stronger form of the guarantee two callers depend on. An earlier

--- a/kstrl/config.py
+++ b/kstrl/config.py
@@ -547,7 +547,7 @@ def load_toml_document(path: Path) -> dict[str, Any]:
       from ``sys.get_int_max_str_digits``. Walked past round 1.
     - ``RecursionError``, from tomllib's recursive-descent parser, at no
       one depth: at the default limit nested arrays first fail at 497
-      levels from a one-frame caller and 396 under 200 more, inline
+      levels from a one-frame caller and 397 under 200 more, inline
       tables at 331 and 264; the caller's own stack sets it. It derives from
       ``RuntimeError``, NOT ``ValueError``, so it walked past round 2 -
       whose docstring, whose AST guard and whose CLAUDE.md line all
@@ -566,9 +566,11 @@ def load_toml_document(path: Path) -> dict[str, Any]:
     that no handler can promise the interpreter has the headroom left to
     render the message.
 
-    Provenance follows (#323): the parse runs at stack depth 9 to 16
-    under ``ks status``, so a ``RecursionError`` here is the document's.
-    One above this call is ours; ``raise_if_defect`` carries that half.
+    Provenance follows (#323): the parse runs 9 to 16 frames deep under
+    ``ks status``, 13 to 52 on the Textual event loop, so a
+    ``RecursionError`` here is the document's. Not by construction:
+    measured, a CALLER at 991 of 1000 frames gets a valid file called
+    unparseable, and IS the runaway. ``raise_if_defect`` has the rest.
 
     ``OSError`` is not in the catch-all's reach at all, which is the
     stronger form of the guarantee two callers depend on. An earlier

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -132,26 +132,34 @@ def raise_if_defect(exc: BaseException) -> None:
 
     ``RecursionError`` is the one that needs an argument rather than a
     rule, and the argument is layering rather than inspection (#323). A
-    kstrl.toml with 600 nested arrays exhausts the stack inside
-    tomllib's recursive descent, and that is the operator's file, not a
-    defect of ours. It never arrives here. Every tomllib parse in
-    ``kstrl/`` ends on a bare ``except Exception``, and
-    ``EXPECTED_TOML_PARSES`` in ``tests/test_toml_readers.py`` is what
-    makes that a closed set rather than a count restated here:
-    ``config.load_toml_document`` re-raises ``ConfigError`` naming the
-    path, and the pyproject.toml and ruff.toml readers in ``verify`` and
-    ``feedforward`` fall back to a default. So a ``RecursionError`` that
+    kstrl.toml with 600 nested arrays exhausts the stack at the default
+    recursion limit inside tomllib's recursive descent, and that is the
+    operator's file, not a defect of ours. It never arrives here. Every
+    tomllib parse in ``kstrl/`` ends on a bare ``except Exception``, and
+    the two-layer census in ``tests/test_toml_readers.py`` is what makes
+    that a closed set rather than a count restated here - layer 1,
+    ``EXPECTED_TOMLLIB_SPELLINGS``, resolves nothing and so cannot miss
+    a reader that spells ``tomllib`` at all. ``load_toml_document``
+    re-raises ``ConfigError`` naming the path, and the pyproject.toml
+    and ruff.toml readers in ``verify`` and ``feedforward`` fall back to
+    a default or to no conventions at all. So a ``RecursionError`` that
     does reach this function is a cycle in kstrl's own code, and the
-    traceback this re-raise keeps is what locates it.
+    traceback this re-raise keeps is what locates it. The closure is
+    over the PARSES, not over the call graph: not every guarded block
+    goes through ``load_toml_document``, and ``init_wizard._detected_text``
+    is the one that does not, reaching
+    ``verify._default_typecheck_command`` on the project's
+    pyproject.toml instead.
 
     Inspecting the exception could not have settled it anyway. Measured
     on 3.12.8 and 3.13.2, both directions give
     ``builtins.RecursionError`` with ``str(exc)`` "maximum recursion
     depth exceeded" and no attribute of its own; only the frames differ,
-    and by the time they could be read the boundary has already
-    answered. ``tests/test_recursion_provenance.py`` pins both
-    directions, at :func:`preflight_config` and at the ``ks status``
-    seam.
+    and by the time they could be read ``load_toml_document`` has
+    already turned the document's into a ``ConfigError``.
+    ``tests/test_recursion_provenance.py`` pins both directions at
+    :func:`preflight_config`, and direction (b) again at
+    :func:`config_problem_lines` and at the ``ks status`` seam.
     """
     if isinstance(exc, RuntimeError) and type(exc).__module__.split(".")[0] != "kstrl":
         raise exc
@@ -554,6 +562,12 @@ def _blamed_toml_value(
     whose value reprs into that message is the one to look at. Reported
     only when exactly one key matches, and phrased as what the file
     says rather than as a diagnosis.
+
+    The ``suppress`` below would swallow a ``RuntimeError`` kstrl did
+    not define, which :func:`raise_if_defect` exists to re-raise. It
+    cannot reach one: this runs only AFTER that function has passed on
+    the exception being reported, and everything ``load_toml_section``
+    raises here has already been converted by ``load_toml_document``.
     """
     hits = []
     for name in sections:

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -134,9 +134,10 @@ def raise_if_defect(exc: BaseException) -> None:
     rule, and the argument is layering rather than inspection (#323). A
     kstrl.toml with 600 nested arrays exhausts the stack inside
     tomllib's recursive descent, and that is the operator's file, not a
-    defect of ours. It never arrives here. There are four tomllib parses
-    in ``kstrl/`` - ``tests/test_toml_readers.py`` pins the census - and
-    every one of them ends on a bare ``except Exception``:
+    defect of ours. It never arrives here. Every tomllib parse in
+    ``kstrl/`` ends on a bare ``except Exception``, and
+    ``EXPECTED_TOML_PARSES`` in ``tests/test_toml_readers.py`` is what
+    makes that a closed set rather than a count restated here:
     ``config.load_toml_document`` re-raises ``ConfigError`` naming the
     path, and the pyproject.toml and ruff.toml readers in ``verify`` and
     ``feedforward`` fall back to a default. So a ``RecursionError`` that

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -564,8 +564,8 @@ def _blamed_toml_value(
     says rather than as a diagnosis.
 
     The ``suppress`` below would swallow a ``RuntimeError`` kstrl did
-    not define, which :func:`raise_if_defect` exists to re-raise. It
-    cannot reach one: this runs only AFTER that function has passed on
+    not define, which :func:`raise_if_defect` exists to re-raise. None
+    has been reproduced: this runs only AFTER that function has passed on
     the exception being reported, and everything ``load_toml_section``
     raises here has already been converted by ``load_toml_document``.
     """

--- a/kstrl/config_preflight.py
+++ b/kstrl/config_preflight.py
@@ -129,6 +129,28 @@ def raise_if_defect(exc: BaseException) -> None:
     ``builtins`` and any dependency's ``RuntimeError`` is not something
     we modelled and so not something we can honestly blame a file for.
     ``tests/test_tui_config_guard.py`` pins both halves.
+
+    ``RecursionError`` is the one that needs an argument rather than a
+    rule, and the argument is layering rather than inspection (#323). A
+    kstrl.toml with 600 nested arrays exhausts the stack inside
+    tomllib's recursive descent, and that is the operator's file, not a
+    defect of ours. It never arrives here. There are four tomllib parses
+    in ``kstrl/`` - ``tests/test_toml_readers.py`` pins the census - and
+    every one of them ends on a bare ``except Exception``:
+    ``config.load_toml_document`` re-raises ``ConfigError`` naming the
+    path, and the pyproject.toml and ruff.toml readers in ``verify`` and
+    ``feedforward`` fall back to a default. So a ``RecursionError`` that
+    does reach this function is a cycle in kstrl's own code, and the
+    traceback this re-raise keeps is what locates it.
+
+    Inspecting the exception could not have settled it anyway. Measured
+    on 3.12.8 and 3.13.2, both directions give
+    ``builtins.RecursionError`` with ``str(exc)`` "maximum recursion
+    depth exceeded" and no attribute of its own; only the frames differ,
+    and by the time they could be read the boundary has already
+    answered. ``tests/test_recursion_provenance.py`` pins both
+    directions, at :func:`preflight_config` and at the ``ks status``
+    seam.
     """
     if isinstance(exc, RuntimeError) and type(exc).__module__.split(".")[0] != "kstrl":
         raise exc

--- a/tests/helpers/bad_toml.py
+++ b/tests/helpers/bad_toml.py
@@ -73,11 +73,15 @@ INT_LIMIT_TOML = b"[run]\nmax_iterations = " + b"9" * _INT_DIGITS + b"\n"
 #: ``ValueError``, and so walked past everything round 2 shipped. That is
 #: #318 round 3.
 #:
-#: Measured by binary search on this machine: 496 standalone, 495 through
-#: the CLI (the seam's own frames cost one level). Scaled off the live
-#: recursion limit rather than fixed at 600, so a run with a raised limit
-#: still nests past it: any depth above the limit exhausts the stack
-#: whatever the limit is, which is also why there is no ``max(600, ...)``
+#: Measured by binary search on this machine at the default limit: the
+#: first depth that raises is 497 from a one-frame caller and 490
+#: through ``ks status``. There is no one threshold. The caller's own
+#: stack sets it, and the CLI parse runs 9 to 16 frames deep, which at
+#: roughly two interpreter frames per array level is the 7 levels the
+#: two numbers differ by. Scaled off the live recursion limit rather
+#: than fixed at 600, so a run with a raised limit still nests past it:
+#: any depth above the limit exhausts the stack whatever the limit is,
+#: which is also why there is no ``max(600, ...)``
 #: floor - it could never bind. Inline tables recurse identically;
 #: arrays are used because they are terser per level. Measured cost of
 #: building it: 0.21 us, 2205 bytes.

--- a/tests/helpers/bad_toml.py
+++ b/tests/helpers/bad_toml.py
@@ -76,9 +76,9 @@ INT_LIMIT_TOML = b"[run]\nmax_iterations = " + b"9" * _INT_DIGITS + b"\n"
 #: Measured by binary search on this machine at the default limit: the
 #: first depth that raises is 497 from a one-frame caller and 490
 #: through ``ks status``. There is no one threshold. The caller's own
-#: stack sets it, and the CLI parse runs 9 to 16 frames deep, which at
-#: roughly two interpreter frames per array level is the 7 levels the
-#: two numbers differ by. Scaled off the live recursion limit rather
+#: stack sets it, and the CLI parse that raises runs 16 frames deep,
+#: which at roughly two interpreter frames per array level is the 7
+#: levels the two numbers differ by. Scaled off the live recursion limit rather
 #: than fixed at 600, so a run with a raised limit still nests past it:
 #: any depth above the limit exhausts the stack whatever the limit is,
 #: which is also why there is no ``max(600, ...)``

--- a/tests/test_recursion_provenance.py
+++ b/tests/test_recursion_provenance.py
@@ -9,36 +9,71 @@ series rather than in competition:
 - ``config.load_toml_document`` catches ``Exception`` around the parse
   and re-raises ``ConfigError`` naming the file, so the document's
   ``RecursionError`` never travels further than that call.
-- Every block whose exception reaches ``config_preflight.raise_if_defect``
-  reaches tomllib only through that function. So a ``RecursionError``
-  that arrives there is kstrl's own by construction, and re-raising it
-  with its traceback intact is right.
+- Every tomllib parse in ``kstrl/`` ends on a bare ``except
+  Exception``, so no document's ``RecursionError`` escapes the parse
+  that raised it: ``load_toml_document`` converts it to
+  ``ConfigError``, and the pyproject.toml and ruff.toml readers in
+  ``verify`` and ``feedforward`` swallow it. Not every guarded block
+  goes through ``load_toml_document`` - ``init_wizard._detected_text``
+  reaches ``verify._default_typecheck_command`` - which is why the
+  closure is over the PARSES and not over the call graph.
 
 These tests pin both directions in-process through
-``preflight_config``, and then direction (b) again at the CLI seam,
-where an operator sees the difference between a reported line and a
-traceback. Direction (a) uses real bytes, and direction (b) a real
-self-calling function rather than a constructed ``RecursionError``,
-because a stub would pass in every broken state.
+``preflight_config``, then direction (b) again at
+:func:`config_problem_lines` and at the CLI seam, where an operator
+sees the difference between a reported line and a traceback. Direction
+(a) uses real bytes, and direction (b) a real self-calling function
+rather than a constructed ``RecursionError``, because a stub would
+pass in every broken state.
 
-What was already pinned, and why it is not enough. Direction (a) lives
-at the loader in ``test_config_toml.py``
+THE RESIDUAL, WHICH IS STATED RATHER THAN TESTED
+------------------------------------------------
+``load_toml_document``'s catch-all converts any ``Exception`` out of
+the parse, so kstrl's OWN runaway that happens to bottom out inside a
+parse is reported to the operator as their broken file. Measured on
+CPython 3.12.8 at the default limit with a valid two-line kstrl.toml:
+a caller holding 991 or 992 of the 1000 frames gets that relabelling,
+and at 993 the ``RecursionError`` is raised before the guard and
+escapes it. A caller that deep is itself the runaway, so the residual
+is one runaway reported as a file rather than as a traceback, in a
+two-frame band. No assertion here pins it: a test would have to key on
+the interpreter's recursion limit and on this one function's frame
+cost, and would move whenever either did.
+
+WHAT IS ALREADY PINNED, AND WHAT IS NEW
+---------------------------------------
+``test_config_guard_survey.py`` is the closest prior art at the shared
+traversal. Its
+``test_the_entry_check_does_not_list_our_own_defect_as_a_config_problem``
+monkeypatches ``EvolutionConfig.load`` to raise ``NotImplementedError``
+- the other ``builtins`` ``RuntimeError`` subclass
+``raise_if_defect``'s docstring names beside ``RecursionError`` - and
+asserts it propagates through BOTH ``collect_config_problems`` and
+:func:`config_problem_lines`.
+Direction (a) lives at the loader in ``test_config_toml.py``
 (``test_a_recursion_error_is_reported_not_raised``), one call below
 :func:`preflight_config`, and at the seam as the ``deep_nest`` row of
 ``TOML_PARSE_FAULTS`` crossed with ``["status"]`` in
 ``test_config_preflight.py`` - which is why the seam test below covers
-only direction (b) rather than restating that cell. Direction (b) lives
-at :func:`load_or_report` in ``test_tui_config_guard.py``
+only direction (b) rather than restating that cell. Direction (b)
+lives at :func:`load_or_report` in ``test_tui_config_guard.py``
 (``test_every_runtimeerror_kstrl_did_not_define_is_re_raised``) and
-raises a CONSTRUCTED ``RecursionError``, so no stack is ever exhausted.
-Neither goes through ``collect_config_problems``, which is the
-traversal all three reporting surfaces share, and neither is a pair:
-the two halves are what make this a provenance claim rather than two
-unrelated handler checks.
+raises a CONSTRUCTED ``RecursionError``, so no stack is ever
+exhausted.
+
+Three things here are not in any of those: a REAL stack exhaustion, so
+the frames are the runaway's and the re-raise has something to keep;
+``warned == []``, which is the only assertion anywhere that the one
+DEGRADING section must not turn a defect of ours into a warning line
+(``test_config_preflight.py:test_a_clean_config_raises_nothing`` makes
+the same assertion about a CLEAN config, which is a different claim);
+and the CLI seam, where the operator gets the traceback rather than a
+reported line.
 """
 
 from __future__ import annotations
 
+import tomllib
 import traceback
 from pathlib import Path
 
@@ -47,16 +82,25 @@ from click.testing import CliRunner
 
 from kstrl.cli import cli
 from kstrl.config import ConfigError
-from kstrl.config_preflight import preflight_config
+from kstrl.config_preflight import config_problem_lines, preflight_config
 from kstrl.evolution import EvolutionConfig
 from tests.helpers.bad_toml import BROAD_FRAGMENT, DEEP_NEST_TOML
 
-VALID_TOML = "[agent]\nname = 'x'\n"
+VALID_TOML = "[agent]\ntype = 'claude-code'\n"
+
+#: Where the standard library's TOML parser lives, resolved rather than
+#: spelled: ``_parser.py`` is CPython-private, so a rename or a split
+#: would make a filename check go quiet instead of red.
+_TOMLLIB_DIR = Path(tomllib.__file__).parent
 
 
 def _runaway(root_dir: Path | None = None) -> None:
     """A loader that recurses forever. kstrl's defect, not the file's."""
     return _runaway(root_dir)
+
+
+def _frame_names(exc: BaseException) -> list[str]:
+    return [f.name for f in traceback.extract_tb(exc.__traceback__)]
 
 
 class TestRecursionErrorProvenance:
@@ -75,25 +119,55 @@ class TestRecursionErrorProvenance:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         (tmp_path / "kstrl.toml").write_text(VALID_TOML, encoding="utf-8")
-        monkeypatch.setattr(EvolutionConfig, "load", staticmethod(_runaway))
+        monkeypatch.setattr(EvolutionConfig, "load", _runaway)
         warned: list[str] = []
         with pytest.raises(RecursionError) as caught:
             preflight_config(tmp_path, warn=warned.append)
         frames = traceback.extract_tb(caught.value.__traceback__)
         assert "_runaway" in [f.name for f in frames]
-        assert "_parser.py" not in [Path(f.filename).name for f in frames]
+        # Re-RAISED by raise_if_defect, not merely never caught by
+        # anything. Narrowing REJECTIONS to (ValueError, TypeError)
+        # makes raise_if_defect unreachable for this exception; the
+        # RecursionError still comes out of preflight_config, so every
+        # other assertion here holds. Measured before this line and the
+        # two like it existed: that mutation left the file 3 of 3 green.
+        assert "raise_if_defect" in [f.name for f in frames]
+        # A DISCLOSURE, not a control. This fixture writes VALID_TOML,
+        # so tomllib is never entered and no production mutation can
+        # turn this line red. It records the direction the frames point
+        # in; the kills are the two assertions above.
+        assert not [f for f in frames if Path(f.filename).is_relative_to(_TOMLLIB_DIR)]
         # [evolution] is the one degrading section. Its degrade path must
         # NOT swallow this: a warning line here would hide the cycle.
         assert warned == []
+
+    def test_the_third_reporting_surface_re_raises_ours_too(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``config_problem_lines`` has a ``raise_if_defect`` of its own.
+
+        It catches SURFACE_REJECTIONS around the traversal and folds an
+        unparseable document back in as one line. That catch sees this
+        ``RecursionError`` a second time, so deleting only ITS
+        ``raise_if_defect`` turns the runaway into a returned string
+        while the test above stays green.
+        """
+        (tmp_path / "kstrl.toml").write_text(VALID_TOML, encoding="utf-8")
+        monkeypatch.setattr(EvolutionConfig, "load", _runaway)
+        with pytest.raises(RecursionError) as caught:
+            config_problem_lines(tmp_path, warn=lambda m: None)
+        assert "config_problem_lines" in _frame_names(caught.value)
+        assert "raise_if_defect" in _frame_names(caught.value)
 
     def test_the_seam_re_raises_ours_instead_of_reporting_a_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.chdir(tmp_path)
         (tmp_path / "kstrl.toml").write_text(VALID_TOML, encoding="utf-8")
-        monkeypatch.setattr(EvolutionConfig, "load", staticmethod(_runaway))
-        result = CliRunner().invoke(cli, ["status"], env={"KSTRL_NO_TUI": "1"})
+        monkeypatch.setattr(EvolutionConfig, "load", _runaway)
+        result = CliRunner().invoke(cli, ["status"])
         assert isinstance(result.exception, RecursionError)
+        assert "raise_if_defect" in _frame_names(result.exception)
         # Not reported as the operator's file, in either register: a
         # kstrl.toml that parses cannot be what an "error:" would name.
         assert "error:" not in result.output

--- a/tests/test_recursion_provenance.py
+++ b/tests/test_recursion_provenance.py
@@ -14,18 +14,21 @@ series rather than in competition:
   that arrives there is kstrl's own by construction, and re-raising it
   with its traceback intact is right.
 
-These tests pin both directions at two levels: in-process through
-``preflight_config``, and at the CLI seam where an operator actually
-sees the difference between a reported line and a traceback. Direction
-(a) uses real bytes, and direction (b) a real self-calling function
-rather than a constructed ``RecursionError``, because a stub would pass
-in every broken state.
+These tests pin both directions in-process through
+``preflight_config``, and then direction (b) again at the CLI seam,
+where an operator sees the difference between a reported line and a
+traceback. Direction (a) uses real bytes, and direction (b) a real
+self-calling function rather than a constructed ``RecursionError``,
+because a stub would pass in every broken state.
 
 What was already pinned, and why it is not enough. Direction (a) lives
 at the loader in ``test_config_toml.py``
 (``test_a_recursion_error_is_reported_not_raised``), one call below
-:func:`preflight_config`. Direction (b) lives at
-:func:`load_or_report` in ``test_tui_config_guard.py``
+:func:`preflight_config`, and at the seam as the ``deep_nest`` row of
+``TOML_PARSE_FAULTS`` crossed with ``["status"]`` in
+``test_config_preflight.py`` - which is why the seam test below covers
+only direction (b) rather than restating that cell. Direction (b) lives
+at :func:`load_or_report` in ``test_tui_config_guard.py``
 (``test_every_runtimeerror_kstrl_did_not_define_is_re_raised``) and
 raises a CONSTRUCTED ``RecursionError``, so no stack is ever exhausted.
 Neither goes through ``collect_config_problems``, which is the
@@ -56,11 +59,6 @@ def _runaway(root_dir: Path | None = None) -> None:
     return _runaway(root_dir)
 
 
-def _tb_names(exc: BaseException) -> tuple[list[str], list[str]]:
-    frames = traceback.extract_tb(exc.__traceback__)
-    return [f.name for f in frames], [Path(f.filename).name for f in frames]
-
-
 class TestRecursionErrorProvenance:
     def test_a_parse_recursion_is_the_files_fault_and_names_the_file(self, tmp_path: Path) -> None:
         toml = tmp_path / "kstrl.toml"
@@ -81,27 +79,22 @@ class TestRecursionErrorProvenance:
         warned: list[str] = []
         with pytest.raises(RecursionError) as caught:
             preflight_config(tmp_path, warn=warned.append)
-        funcs, files = _tb_names(caught.value)
-        assert "_runaway" in funcs
-        assert "_parser.py" not in files
+        frames = traceback.extract_tb(caught.value.__traceback__)
+        assert "_runaway" in [f.name for f in frames]
+        assert "_parser.py" not in [Path(f.filename).name for f in frames]
         # [evolution] is the one degrading section. Its degrade path must
         # NOT swallow this: a warning line here would hide the cycle.
         assert warned == []
 
-    def test_the_seam_reports_the_file_and_re_raises_ours(
+    def test_the_seam_re_raises_ours_instead_of_reporting_a_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.chdir(tmp_path)
-        toml = tmp_path / "kstrl.toml"
-        toml.write_bytes(DEEP_NEST_TOML)
-        result = CliRunner().invoke(cli, ["status"], env={"KSTRL_NO_TUI": "1"})
-        assert not isinstance(result.exception, RecursionError)
-        assert result.exit_code == 1
-        assert "error:" in result.output and BROAD_FRAGMENT in result.output
-
-        toml.write_text(VALID_TOML, encoding="utf-8")
+        (tmp_path / "kstrl.toml").write_text(VALID_TOML, encoding="utf-8")
         monkeypatch.setattr(EvolutionConfig, "load", staticmethod(_runaway))
         result = CliRunner().invoke(cli, ["status"], env={"KSTRL_NO_TUI": "1"})
         assert isinstance(result.exception, RecursionError)
+        # Not reported as the operator's file, in either register: a
+        # kstrl.toml that parses cannot be what an "error:" would name.
         assert "error:" not in result.output
         assert "warning:" not in result.output

--- a/tests/test_recursion_provenance.py
+++ b/tests/test_recursion_provenance.py
@@ -1,0 +1,107 @@
+"""A ``RecursionError``'s provenance is settled by WHERE it is caught.
+
+#323 asked for a predicate that separates "the operator nested a TOML
+array 600 deep" from "kstrl recursed forever", on the grounds that the
+exception object carries nothing that tells them apart. It carries
+nothing, and no predicate is needed, because the two sites are in
+series rather than in competition:
+
+- ``config.load_toml_document`` catches ``Exception`` around the parse
+  and re-raises ``ConfigError`` naming the file, so the document's
+  ``RecursionError`` never travels further than that call.
+- Every block whose exception reaches ``config_preflight.raise_if_defect``
+  reaches tomllib only through that function. So a ``RecursionError``
+  that arrives there is kstrl's own by construction, and re-raising it
+  with its traceback intact is right.
+
+These tests pin both directions at two levels: in-process through
+``preflight_config``, and at the CLI seam where an operator actually
+sees the difference between a reported line and a traceback. Direction
+(a) uses real bytes, and direction (b) a real self-calling function
+rather than a constructed ``RecursionError``, because a stub would pass
+in every broken state.
+
+What was already pinned, and why it is not enough. Direction (a) lives
+at the loader in ``test_config_toml.py``
+(``test_a_recursion_error_is_reported_not_raised``), one call below
+:func:`preflight_config`. Direction (b) lives at
+:func:`load_or_report` in ``test_tui_config_guard.py``
+(``test_every_runtimeerror_kstrl_did_not_define_is_re_raised``) and
+raises a CONSTRUCTED ``RecursionError``, so no stack is ever exhausted.
+Neither goes through ``collect_config_problems``, which is the
+traversal all three reporting surfaces share, and neither is a pair:
+the two halves are what make this a provenance claim rather than two
+unrelated handler checks.
+"""
+
+from __future__ import annotations
+
+import traceback
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from kstrl.cli import cli
+from kstrl.config import ConfigError
+from kstrl.config_preflight import preflight_config
+from kstrl.evolution import EvolutionConfig
+from tests.helpers.bad_toml import BROAD_FRAGMENT, DEEP_NEST_TOML
+
+VALID_TOML = "[agent]\nname = 'x'\n"
+
+
+def _runaway(root_dir: Path | None = None) -> None:
+    """A loader that recurses forever. kstrl's defect, not the file's."""
+    return _runaway(root_dir)
+
+
+def _tb_names(exc: BaseException) -> tuple[list[str], list[str]]:
+    frames = traceback.extract_tb(exc.__traceback__)
+    return [f.name for f in frames], [Path(f.filename).name for f in frames]
+
+
+class TestRecursionErrorProvenance:
+    def test_a_parse_recursion_is_the_files_fault_and_names_the_file(self, tmp_path: Path) -> None:
+        toml = tmp_path / "kstrl.toml"
+        toml.write_bytes(DEEP_NEST_TOML)
+        with pytest.raises(ConfigError) as caught:
+            preflight_config(tmp_path, warn=lambda m: None)
+        assert str(toml) in str(caught.value)
+        assert BROAD_FRAGMENT in str(caught.value)
+        # The cause is kept, so the boundary is visible in the report
+        # rather than inferred from the message alone.
+        assert isinstance(caught.value.__cause__, RecursionError)
+
+    def test_a_kstrl_recursion_is_ours_and_keeps_its_traceback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "kstrl.toml").write_text(VALID_TOML, encoding="utf-8")
+        monkeypatch.setattr(EvolutionConfig, "load", staticmethod(_runaway))
+        warned: list[str] = []
+        with pytest.raises(RecursionError) as caught:
+            preflight_config(tmp_path, warn=warned.append)
+        funcs, files = _tb_names(caught.value)
+        assert "_runaway" in funcs
+        assert "_parser.py" not in files
+        # [evolution] is the one degrading section. Its degrade path must
+        # NOT swallow this: a warning line here would hide the cycle.
+        assert warned == []
+
+    def test_the_seam_reports_the_file_and_re_raises_ours(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        toml = tmp_path / "kstrl.toml"
+        toml.write_bytes(DEEP_NEST_TOML)
+        result = CliRunner().invoke(cli, ["status"], env={"KSTRL_NO_TUI": "1"})
+        assert not isinstance(result.exception, RecursionError)
+        assert result.exit_code == 1
+        assert "error:" in result.output and BROAD_FRAGMENT in result.output
+
+        toml.write_text(VALID_TOML, encoding="utf-8")
+        monkeypatch.setattr(EvolutionConfig, "load", staticmethod(_runaway))
+        result = CliRunner().invoke(cli, ["status"], env={"KSTRL_NO_TUI": "1"})
+        assert isinstance(result.exception, RecursionError)
+        assert "error:" not in result.output
+        assert "warning:" not in result.output

--- a/tests/test_recursion_provenance.py
+++ b/tests/test_recursion_provenance.py
@@ -32,9 +32,9 @@ THE RESIDUAL, WHICH IS STATED RATHER THAN TESTED
 the parse, so kstrl's OWN runaway that happens to bottom out inside a
 parse is reported to the operator as their broken file. Measured on
 CPython 3.12.8 at the default limit with a valid two-line kstrl.toml:
-a caller holding 991 or 992 of the 1000 frames gets that relabelling,
-and at 993 the ``RecursionError`` is raised before the guard and
-escapes it. A caller that deep is itself the runaway, so the residual
+a caller with 5 or 6 of the 1000 frames left gets that relabelling,
+and with 4 or fewer the ``RecursionError`` is raised before the guard
+and escapes it. A caller that deep is itself the runaway, so the residual
 is one runaway reported as a file rather than as a traceback, in a
 two-frame band. No assertion here pins it: a test would have to key on
 the interpreter's recursion limit and on this one function's frame
@@ -133,9 +133,10 @@ class TestRecursionErrorProvenance:
         # two like it existed: that mutation left the file 3 of 3 green.
         assert "raise_if_defect" in [f.name for f in frames]
         # A DISCLOSURE, not a control. This fixture writes VALID_TOML,
-        # so tomllib is never entered and no production mutation can
-        # turn this line red. It records the direction the frames point
-        # in; the kills are the two assertions above.
+        # so the parse returns and leaves no tomllib frame on this
+        # traceback; no production mutation can turn this line red. It
+        # records the direction the frames point in; the kills are the
+        # two assertions above.
         assert not [f for f in frames if Path(f.filename).is_relative_to(_TOMLLIB_DIR)]
         # [evolution] is the one degrading section. Its degrade path must
         # NOT swallow this: a warning line here would hide the cycle.


### PR DESCRIPTION
## Summary

Closes #323

#323 asked for a predicate separating "the operator nested a TOML array 600 deep" from "kstrl recursed forever", on the grounds that the exception object carries nothing that tells them apart. Measured on 3.12.8 and on 3.13.2, the object really does carry nothing: both directions give `builtins.RecursionError`, `str(exc)` "maximum recursion depth exceeded", the same single-string `args`, and no attribute a freshly constructed instance lacks.

A predicate is still not needed, because the two sites are in series rather than in competition. Every tomllib parse in `kstrl/` ends on a bare `except Exception`, so no document's `RecursionError` escapes the parse that raised it: `config.load_toml_document` converts it to a `ConfigError` naming the path, and the pyproject.toml and ruff.toml readers in `verify` and `feedforward` swallow it and fall back to a default or to no conventions at all. The closure is over the PARSES, not over the call graph, and that distinction is load-bearing: `init_wizard._detected_text` is a guarded block that reaches tomllib WITHOUT going through `load_toml_document`, via `resolve_verify_commands` to `verify._default_typecheck_command` on the project's pyproject.toml. The conclusion survives because that parse ends on `except Exception: return DEFAULT_TYPECHECK_COMMAND`, so a `RecursionError` there is swallowed and never reaches `raise_if_defect`. The two-layer census in `tests/test_toml_readers.py` is what keeps the parse set closed; layer 1, `EXPECTED_TOMLLIB_SPELLINGS`, resolves nothing and so cannot miss a reader that spells `tomllib` at all.

**No production behaviour changes.** What changes is that the layering is stated where each half of it lives, with its residual, and pinned by tests.

- `load_toml_document`'s docstring stops naming one depth. Measured at the default limit of 1000 on CPython 3.12.8, with one harness and one caller convention (a chain of exactly N frames above the module frame): nested arrays first raise at 497 levels for N=1, 472 for N=51 and 397 for N=201; inline tables at 331 / 314 / 264, being about three interpreter frames per level against an array's two. The threshold is the caller's remaining stack, not a property of the file, so no constant belongs there.
- The same docstring states the RESIDUAL rather than asserting it away. The catch-all converts any `Exception` out of the parse, so kstrl's own runaway that happens to bottom out inside a parse is reported to the operator as their broken file. Measured with a valid two-line kstrl.toml and a caller recursed to a known depth, stated as headroom because a loop parameter is not a frame count (round 2 found the first version three frames out): with 7 or more of the 1000 frames left the parse succeeds, with 5 or 6 left a valid file is reported unparseable with a `RecursionError` cause, and with 4 or fewer the error is raised before the guard and escapes it. A caller that deep is itself the runaway, so the residual is one runaway reported as a file rather than as a traceback, in a two-frame band. It is stated, not mechanised: a frame-counting predicate needs a threshold nobody has measured, and the measured headroom on the paths that exist is large. The parse runs 9 to 16 frames deep under `ks status`, 14 to 15 under `ks config show`, and 13 on the Textual event loop's own callbacks; one TUI parse runs on its caller's stack and inherits it, 22 from a bare script and 52 under pytest, so the 52 is a property of the test harness, not of the event loop.
- `raise_if_defect`'s docstring says why "ours" holds for `RecursionError`, and why inspecting the exception could not have decided it.
- `tests/test_recursion_provenance.py` pins both directions at `preflight_config`, and direction (b) again at `config_problem_lines` and at the `ks status` seam. Direction (b) uses a real self-calling loader, so a stack is actually exhausted and the frames are the runaway's; direction (a) uses real bytes. Both assert that `raise_if_defect` is in the traceback, so the tests can tell a deliberate re-raise from nothing having caught it at all.
- `tests/helpers/bad_toml.py`'s CLI depth comment is corrected. It said 495 through the CLI and blamed one frame. Binary search through the real CLI (`CliRunner` on `ks status`, first depth whose output carries `UNPARSEABLE_TOML_MESSAGE`): 489 parses, 490 is reported. The gap from 497 is 7 array levels, which at about two interpreter frames per level is the 9-to-16-frame depth of the CLI parse.

Rejected, with the measurement: traceback inspection discriminates cleanly (998 of 1000 traceback frames inside tomllib for a deep file, 0 of 1000 for a runaway) but is unnecessary for anything that reaches `raise_if_defect`; and a scoped `sys.setrecursionlimit` is process-wide, so it can raise a spurious `RecursionError` on another thread while moving the threshold rather than settling provenance.

## What was tested vs assumed (H4)

**Tested.**

- Full suite: 5564 passed / 37 skipped / 38 xfailed on the merge base 568bca4, 5567 / 37 / 38 at the first review head, 5568 / 37 / 38 here. The delta is +4 and it is the four cases in the new file. `mypy kstrl/ --strict` clean over 129 source files, `ruff check kstrl/ tests/` clean, `gen_docs.py --check` clean, `ruff format --check` and `codespell@2.4.3` clean on all four changed files. The full pre-commit hook set ran on both commits of the fix round and every hook passed or skipped for want of matching files.
- `scripts/precommit/file_length_ratchet.py` passes with `kstrl/config.py` at 800 lines against its 800 ceiling. That is zero headroom: the next paragraph in that file is a split, not an edit. It is also what held the provenance paragraph to five lines, which is why the fuller statement of the residual lives in the test file's module docstring.
- Four mutations, each asserting an anchor count of exactly 1 before writing so a silent no-op plant reports COULD-NOT-PLANT rather than passing, each with `__pycache__` purged and `PYTHONDONTWRITEBYTECODE=1`, each bounded at 180s in its own process group with `start_new_session=True` and `os.killpg` on timeout so a hang is reported as a hang. None hung.
  - Narrowing `load_toml_document`'s broad clause to `ValueError`: CAUGHT, 1 of 4 red, with a raw `RecursionError` out of the parser.
  - Deleting `raise_if_defect` from `collect_config_problems`: CAUGHT, 3 of 4 red. Its first anchor reported COULD-NOT-PLANT (the comment block between the `except` and the call), which is recorded as its own outcome and retargeted rather than folded into a pass.
  - Narrowing `REJECTIONS` to `(ValueError, TypeError)`, which makes `raise_if_defect` unreachable: CAUGHT, 3 of 4 red. This was STILL GREEN in this file before this round's fix, measured at the first review head (the repo as a whole catches it in `tests/test_tui_config_guard.py` and `tests/test_serve_cli.py`), and it is the whole reason the `raise_if_defect` frame assertions exist.
  - Deleting `raise_if_defect` from `config_problem_lines` only: CAUGHT, 1 of 4 red. Also STILL GREEN in this file before this round; at repo level `tests/test_config_guard_survey.py` already catches it, so this kill is a duplicate there and new only for a real stack exhaustion. That surface has a `raise_if_defect` of its own which the traversal's call does not stand in for.
- The seam test covers only direction (b), because the direction (a) half restated the `[status-deep_nest]` cell of `TOML_PARSE_FAULTS` crossed with `SEAM_COMMANDS`. Verified rather than assumed: under the `ValueError` mutation, 13 of that matrix's 52 cells go red and `[status-deep_nest]` is one of them, out of 16 failures in the file.
- The in-process direction (b) test asserts `warn` is never called. `[evolution]` is the one degrading section, and a warning line there would hide a cycle rather than surface it. This is the only assertion in the suite about a DEFECT not being degraded into a warning; the `warnings == []` in `test_config_preflight.py` is about a clean config, which is a different claim.
- The Textual event-loop stack depth was listed as assumed in the first round and is now measured: four parses at 13, 13, 13 and 52, mounting the evolve screen under `app.run_test()` with a `tomllib.loads` spy.

**Assumed.**

- The `init_wizard._detected_text` route to `verify._default_typecheck_command` is read from the call chain and from `SURFACE_REJECTIONS`'s own docstring, not re-measured with a spy in this round. Nothing here depends on how many parses that route does, only on the fact that it does not go through `load_toml_document`.
- The 3.13.2 half of the "the object carries nothing" measurement was taken on a second interpreter under `uvx --python 3.13`, not in CI; CI runs 3.12.

After the round-2 text corrections and a merge of origin/main at 9890a33 (PR #347), the full suite on the merged tree is 5592 passed, 37 skipped, 38 xfailed in 323s, bytecode deleted first and `PYTHONDONTWRITEBYTECODE=1`; mypy strict, ruff, gen_docs and the four precommit ratchets are clean, and `kstrl/config.py` is at 800 of 800 lines.

## Measured handoff, not fixed here

`kstrl/feedforward.py:540` and `:586` are both `tomllib.loads(path.read_text(encoding="utf-8"))` INSIDE the `try`, so a read `OSError` is swallowed into the same silent `return` as a parse fault. That is rule (3) of the four states CLAUDE.md records from #318, "ALL the I/O outside the guarded block", and `verify.py:934` and `config.py:635` hoist the read correctly. `tests/test_toml_readers.py`'s failure message states the rule, but `handler_verdict` judges four things - unreadable, too wide, too narrow, out of order - and I/O position is not one of them, so neither offender is visible to it. It does not touch this PR's claim, since an `OSError` is not a `RecursionError`, and it is a different defect class, so per CLAUDE.md's "one defect class, one PR" it belongs here with the numbers attached rather than as a new issue or as scope creep in this branch. Two sites, one guard function to widen.

Seven of the ten `raise_if_defect` call sites are unpinned. Measured by round 2 of review: deleting `raise_if_defect(exc)` from `kstrl/config_report.py:435`, `kstrl/cli.py:3082`, `kstrl/tui/home.py:38`, `kstrl/tui/session.py:208` and `:260`, `kstrl/tui/screens/config.py:248` and `kstrl/tui/screens/init_wizard.py:89` at once leaves the full suite at 5568 passed, 37 skipped, 38 xfailed, byte-identical to the unmutated baseline. The three sites inside `kstrl/config_preflight.py` are the pinned ones. `tests/test_tui_config_walk.py::guarding_handler` clears a `try` whose except clause names `SURFACE_REJECTIONS` without reading the handler body, so `except SURFACE_REJECTIONS: cfg = None` is cleared too. That is a different defect class from #323 (call-site coverage of a re-raise rule, not exception provenance) and is left here as a handoff: the natural home for the census is `tests/test_tui_config_walk.py`, which already walks every TUI config load and has the bindings table to resolve the handler body.

## Checklist

- [x] `uv run pytest tests/` passes
- [x] `uv run mypy kstrl/ --strict` passes
- [x] `uv run ruff check kstrl/ tests/` passes
- [x] `uv run python scripts/gen_docs.py --check` passes (if CLI/config changed)
- [ ] If this maps to a roadmap item, the tracker doc's status is updated in this PR

No roadmap item: #323 came out of the round-3 simplify pass on #319, and no tracker doc names it. No CHANGELOG line either, for the same reason the #318 rounds added none: nothing an operator can observe changed.

## Provenance

- [x] This change was written or substantially assisted by an AI agent
- [ ] It has been reviewed by a human (AI self-review does not count - H1)

AI code review will be run on this PR as an assist at the owner's request; the owner remains the gating reviewer (H1).

## Prompt changes (only if an adversarial prompt body changed)

- [ ] Calibration re-run and the detection delta recorded (H2)
- [ ] `*_PROMPT_VERSION` bumped and the snapshot tuple in
      `tests/test_prompt_versions.py` updated in this diff (H3)

None. No adversarial prompt body changed, so neither box applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtNQsD9BMWmd5razgnKbre

