### PR TITLE
test(events): the event-name guard walks tests/ too, and the test-side copy of the spec-audit reader goes (#337)

### DIFF
--- a/tests/helpers/astwalk/corpus.py
+++ b/tests/helpers/astwalk/corpus.py
@@ -82,16 +82,27 @@ def test_sources(exclude: Path | None = None) -> list[Path]:
     otherwise scan itself. Never empty, for the reason above: excluding
     the caller cannot empty a directory that holds the caller.
 
-    Reach this through the module, ``astwalk.test_sources()``, and never
-    by a from-import: pytest collects any module-level name matching
-    ``test*``, so the import binds a third "test" in the calling module
-    and pytest runs the helper as one. Measured in
-    ``test_event_names_have_one_home.py``: 2 collected becomes 3.
+    The hazard this name carries is a MODULE PYTEST COLLECTS, not a
+    from-import: pytest collects any module-level name matching
+    ``test*``, so a from-import binds an extra "test" there and pytest
+    runs the helper as one. ``__test__ = False`` below is what makes
+    that safe rather than a rule every caller has to remember, which
+    is why the rule is stated as the hazard and not as the import
+    style. ``astwalk/__init__.py`` from-imports this name and must;
+    pytest does not collect ``tests/helpers/``. Measured in
+    ``test_event_names_have_one_home.py``: with a from-import and no
+    ``__test__``, 2 collected became 3 and the third PASSED, emitting
+    only a ``PytestReturnNotNoneWarning`` into a suite that already
+    emits eight. With ``__test__ = False`` the same from-import
+    collects 2.
     """
     skip = exclude.resolve() if exclude is not None else None
     found = [path for path in sorted(TESTS_DIR.rglob("*.py")) if path.resolve() != skip]
     assert found, _EMPTY.format(what="tests/", root=TESTS_DIR)
     return found
+
+
+test_sources.__test__ = False  # type: ignore[attr-defined]
 
 
 #: What an empty corpus means, said once. It is never a real answer: both

--- a/tests/helpers/astwalk/corpus.py
+++ b/tests/helpers/astwalk/corpus.py
@@ -81,6 +81,12 @@ def test_sources(exclude: Path | None = None) -> list[Path]:
     A guard naming the shapes it forbids in its own fixtures would
     otherwise scan itself. Never empty, for the reason above: excluding
     the caller cannot empty a directory that holds the caller.
+
+    Reach this through the module, ``astwalk.test_sources()``, and never
+    by a from-import: pytest collects any module-level name matching
+    ``test*``, so the import binds a third "test" in the calling module
+    and pytest runs the helper as one. Measured in
+    ``test_event_names_have_one_home.py``: 2 collected becomes 3.
     """
     skip = exclude.resolve() if exclude is not None else None
     found = [path for path in sorted(TESTS_DIR.rglob("*.py")) if path.resolve() != skip]

--- a/tests/helpers/journal.py
+++ b/tests/helpers/journal.py
@@ -23,9 +23,15 @@ weakest case for this module and worth revisiting if it stays that way.
 ``audits_in`` takes the journal rather than its path and reads through
 ``EvolutionJournal.get_spec_audits``, so a test asserting on what the
 journal reads back is not asserting on a second copy of that reader's
-selection rule (#337). ``repair_rows_in`` still takes a path, because
-no production reader returns repair rows to route it through:
-``get_repair_count`` returns an int.
+selection rule (#337). ``repair_rows_in`` takes the journal too, for a
+separate reason that round 1 of review on #337 separated out: there is
+no production reader to route it THROUGH, because ``get_repair_count``
+returns an int, but the PARAMETER is a different question. Handing it a
+path made six call sites in ``test_journal_torn_tail.py`` write
+``repair_rows_in(journal.config.journal_path)`` next to
+``audits_in(journal)``, and reaching through ``config.journal_path`` at
+a call site is what ``EvolutionJournal.get_spec_audits``' own docstring
+calls the defect.
 """
 
 from __future__ import annotations
@@ -122,5 +128,15 @@ def audits_in(journal: EvolutionJournal) -> list[str]:
     return [str(entry.get("project")) for entry in journal.get_spec_audits()]
 
 
-def repair_rows_in(path: Path) -> list[dict[str, Any]]:
-    return [e for e in read_progress_events(path) if e.get("event_type") == JOURNAL_REPAIR_EVENT]
+def repair_rows_in(journal: EvolutionJournal) -> list[dict[str, Any]]:
+    """Every repair row this journal's file holds, in order.
+
+    Reads the file rather than a production reader: no reader returns
+    repair rows. The selection rule is this helper's own and is the one
+    copy of it in the suite.
+    """
+    return [
+        entry
+        for entry in read_progress_events(journal.config.journal_path)
+        if entry.get("event_type") == JOURNAL_REPAIR_EVENT
+    ]

--- a/tests/helpers/journal.py
+++ b/tests/helpers/journal.py
@@ -19,6 +19,13 @@ ones with a single caller today. The RECORD BUILDERS and READERS
 entries as the cost file; ``component_result``, ``audits_in`` and
 ``repair_rows_in`` have one caller each at the moment, which is the
 weakest case for this module and worth revisiting if it stays that way.
+
+``audits_in`` takes the journal rather than its path and reads through
+``EvolutionJournal.get_spec_audits``, so a test asserting on what the
+journal reads back is not asserting on a second copy of that reader's
+selection rule (#337). ``repair_rows_in`` still takes a path, because
+no production reader returns repair rows to route it through:
+``get_repair_count`` returns an int.
 """
 
 from __future__ import annotations
@@ -110,12 +117,13 @@ def journal_at(tmp_path: Path) -> EvolutionJournal:
     return EvolutionJournal(EvolutionConfig.load(tmp_path))
 
 
-def audits_in(path: Path) -> list[str]:
-    return [
-        str(entry.get("project"))
-        for entry in read_progress_events(path)
-        if entry.get("event_type") == SPEC_ISSUES_EVENT
-    ]
+def audits_in(journal: EvolutionJournal) -> list[str]:
+    """The projects of every spec audit the journal reads back, in order.
+
+    Through ``EvolutionJournal.get_spec_audits``, not a private copy of
+    its selection rule (#337).
+    """
+    return [str(entry.get("project")) for entry in journal.get_spec_audits()]
 
 
 def repair_rows_in(path: Path) -> list[dict[str, Any]]:

--- a/tests/helpers/journal.py
+++ b/tests/helpers/journal.py
@@ -118,11 +118,7 @@ def journal_at(tmp_path: Path) -> EvolutionJournal:
 
 
 def audits_in(journal: EvolutionJournal) -> list[str]:
-    """The projects of every spec audit the journal reads back, in order.
-
-    Through ``EvolutionJournal.get_spec_audits``, not a private copy of
-    its selection rule (#337).
-    """
+    """The projects of every spec audit the journal reads back, in order."""
     return [str(entry.get("project")) for entry in journal.get_spec_audits()]
 
 

--- a/tests/test_astwalk_nets.py
+++ b/tests/test_astwalk_nets.py
@@ -654,6 +654,13 @@ class TestTheCorpusIsTheOneEveryGuardMeant:
         own = Path(__file__)
         assert own.resolve() not in [p.resolve() for p in astwalk.test_sources(exclude=own)]
 
+    def test_the_corpus_helper_is_not_collected_as_a_test(self) -> None:
+        """A from-import of ``test_sources`` into a guard module makes pytest
+        collect the helper as a test that passes. ``__test__ = False`` is
+        the mechanism; this is its control, since deleting the line fails
+        nothing else (#337 round 2)."""
+        assert astwalk.test_sources.__test__ is False  # type: ignore[attr-defined]
+
     def test_a_label_distinguishes_two_files_of_the_same_basename(self) -> None:
         """Ten basenames occur twice in ``kstrl/``, and a message naming a
         file the reader cannot find is worse than no message."""

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -1432,11 +1432,17 @@ def _journal_rows(tmp_path: Path) -> list[dict[str, Any]]:
     and drops the copy.
     """
     journal = tmp_path / ".kstrl" / "evolution.jsonl"
-    return [
-        json.loads(line)
-        for line in journal.read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
+    rows: list[dict[str, Any]] = []
+    for line in journal.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        # Strict in both dimensions: a line that parses but is not an
+        # object would satisfy `"run_id" not in row` and pass silently.
+        if not isinstance(row, dict):
+            raise AssertionError(f"journal line is not an object: {line!r}")
+        rows.append(row)
+    return rows
 
 
 class TestSpecIssuesPersistence:

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -1419,6 +1419,26 @@ def _journal_with(tmp_path: Path, entries: list[dict[str, object]]) -> Evolution
     return journal
 
 
+def _journal_rows(tmp_path: Path) -> list[dict[str, Any]]:
+    """Every line of the journal file, parsed STRICTLY, in file order.
+
+    Not a second copy of any selection rule - it selects nothing. It is
+    here because ``get_spec_audits`` reads through
+    ``read_progress_events``, which is deliberately tolerant and SKIPS a
+    line it cannot parse. A test whose subject is what the WRITER put on
+    disk cannot ask that reader: a malformed row would be skipped and
+    the count would still come out right. The helper #337 deleted parsed
+    strictly as a side effect of being a copy; this keeps the strictness
+    and drops the copy.
+    """
+    journal = tmp_path / ".kstrl" / "evolution.jsonl"
+    return [
+        json.loads(line)
+        for line in journal.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
 class TestSpecIssuesPersistence:
     """R1.7: red-team output becomes a durable artifact + journal event."""
 
@@ -1516,6 +1536,7 @@ class TestSpecIssuesPersistence:
                 root_dir=tmp_path,
             )
 
+        assert len(_journal_rows(tmp_path)) == 1, "the writer put more than the audit on disk"
         events = journal_at(tmp_path).get_spec_audits()
         assert len(events) == 1
         assert events[0]["halted"] is True
@@ -1527,10 +1548,42 @@ class TestSpecIssuesPersistence:
             tmp_path,
             _single_component_output([_story()], spec_issues=[MINOR_ISSUE]),
         )
+        assert len(_journal_rows(tmp_path)) == 1, "the writer put more than the audit on disk"
         events = journal_at(tmp_path).get_spec_audits()
         assert len(events) == 1
         assert events[0]["halted"] is False
         assert events[0]["counts"] == {"blocker": 0, "major": 0, "minor": 1}
+
+    def test_the_event_type_on_disk_is_the_wire_value(self, tmp_path: Path) -> None:
+        """The one deliberate literal in the test tree, and why it is one.
+
+        Every other site writes the row and reads it back through
+        SPEC_ISSUES_EVENT, so renaming the constant renames both sides
+        and nothing goes red. Measured in round 1 of review on #337:
+        with SPEC_ISSUES_EVENT set to "spec_audit_row" and the two
+        guard-side literals updated the way somebody doing the rename
+        would update them, 437 passed and 1 xfailed while the journal
+        wrote an event_type no journal already on disk carries. Rows
+        already written are what makes the wire value not the constant's
+        to change, so it is pinned here, once, against the bytes.
+
+        Asserted as a substring of the file rather than as
+        ``row["event_type"] == ...`` because that second shape is
+        exactly what layer 2 of the event-name guard forbids, and one
+        deliberate site is not worth an allowlist in a layer that has
+        none.
+        """
+        self._run(
+            tmp_path,
+            _single_component_output([_story()], spec_issues=[MINOR_ISSUE]),
+        )
+
+        raw = (tmp_path / ".kstrl" / "evolution.jsonl").read_text(encoding="utf-8")
+
+        assert '"event_type":"spec_issues"' in raw, (
+            "the spec audit on disk no longer carries the wire value spec_issues. "
+            f"Renaming SPEC_ISSUES_EVENT does not rename rows already written: {raw}"
+        )
 
 
 class TestPrdValidationInsideRetryLoop:
@@ -2444,11 +2497,22 @@ class TestSpecConvergenceThroughDecompose:
     def test_journal_entries_still_carry_no_run_id(self, tmp_path: Path) -> None:
         """The report reads entries the run-windowed reader drops; if a
         run_id ever appears here, that reader would start windowing
-        spec audits by factory run and this feature would go quiet."""
-        self._run(tmp_path, [BLOCKER_ISSUE])
-        events = journal_at(tmp_path).get_spec_audits()
+        spec audits by factory run and this feature would go quiet.
 
-        assert events and all("run_id" not in e for e in events)
+        Read off the bytes rather than through ``get_spec_audits``: the
+        subject is what decompose PUT on disk, so a reader that dropped
+        or renamed an unknown key could answer this question "no run_id"
+        about rows that carry one, which is the failure the paragraph
+        above names. Every row this run writes is a spec audit
+        (``_record_spec_issues_event`` is decompose's only journal
+        write), so nothing is selected here and no selection rule is
+        copied.
+        """
+        self._run(tmp_path, [BLOCKER_ISSUE])
+        rows = _journal_rows(tmp_path)
+
+        assert rows, "the run wrote no journal rows, so this assertion pins nothing"
+        assert all("run_id" not in row for row in rows), rows
 
     def test_a_legacy_entry_without_run_id_does_not_break_the_read(
         self,

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -1419,13 +1419,6 @@ def _journal_with(tmp_path: Path, entries: list[dict[str, object]]) -> Evolution
     return journal
 
 
-def _read_spec_issue_events(tmp_path: Path) -> list[dict[str, object]]:
-    journal = tmp_path / ".kstrl" / "evolution.jsonl"
-    assert journal.exists(), "journal event was not written"
-    entries = [json.loads(line) for line in journal.read_text().splitlines() if line.strip()]
-    return [e for e in entries if e.get("event_type") == SPEC_ISSUES_EVENT]
-
-
 class TestSpecIssuesPersistence:
     """R1.7: red-team output becomes a durable artifact + journal event."""
 
@@ -1460,7 +1453,7 @@ class TestSpecIssuesPersistence:
         assert artifact.exists()
         assert exc_info.value.artifact_path == artifact
 
-        content = json.loads(artifact.read_text())
+        content = json.loads(artifact.read_text(encoding="utf-8"))
         assert content["project"] == "test"
         assert content["specFile"] == "spec.md"
         assert content["halted"] is True
@@ -1482,7 +1475,7 @@ class TestSpecIssuesPersistence:
             _single_component_output([_story()], spec_issues=[MINOR_ISSUE]),
         )
         assert artifact.exists()
-        content = json.loads(artifact.read_text())
+        content = json.loads(artifact.read_text(encoding="utf-8"))
         assert content["halted"] is False
         assert content["counts"] == {"blocker": 0, "major": 0, "minor": 1}
         assert content["issues"][0]["summary"] == "Edge case unspecified"
@@ -1496,7 +1489,7 @@ class TestSpecIssuesPersistence:
             _single_component_output([_story()], spec_issues=[]),
         )
         assert artifact.exists()
-        content = json.loads(artifact.read_text())
+        content = json.loads(artifact.read_text(encoding="utf-8"))
         assert content["halted"] is False
         assert content["issues"] == []
 
@@ -1523,7 +1516,7 @@ class TestSpecIssuesPersistence:
                 root_dir=tmp_path,
             )
 
-        events = _read_spec_issue_events(tmp_path)
+        events = journal_at(tmp_path).get_spec_audits()
         assert len(events) == 1
         assert events[0]["halted"] is True
         assert events[0]["counts"] == {"blocker": 1, "major": 0, "minor": 0}
@@ -1534,7 +1527,7 @@ class TestSpecIssuesPersistence:
             tmp_path,
             _single_component_output([_story()], spec_issues=[MINOR_ISSUE]),
         )
-        events = _read_spec_issue_events(tmp_path)
+        events = journal_at(tmp_path).get_spec_audits()
         assert len(events) == 1
         assert events[0]["halted"] is False
         assert events[0]["counts"] == {"blocker": 0, "major": 0, "minor": 1}
@@ -2453,7 +2446,7 @@ class TestSpecConvergenceThroughDecompose:
         run_id ever appears here, that reader would start windowing
         spec audits by factory run and this feature would go quiet."""
         self._run(tmp_path, [BLOCKER_ISSUE])
-        events = _read_spec_issue_events(tmp_path)
+        events = journal_at(tmp_path).get_spec_audits()
 
         assert events and all("run_id" not in e for e in events)
 

--- a/tests/test_decompose.py
+++ b/tests/test_decompose.py
@@ -1423,7 +1423,7 @@ def _read_spec_issue_events(tmp_path: Path) -> list[dict[str, object]]:
     journal = tmp_path / ".kstrl" / "evolution.jsonl"
     assert journal.exists(), "journal event was not written"
     entries = [json.loads(line) for line in journal.read_text().splitlines() if line.strip()]
-    return [e for e in entries if e.get("event_type") == "spec_issues"]
+    return [e for e in entries if e.get("event_type") == SPEC_ISSUES_EVENT]
 
 
 class TestSpecIssuesPersistence:
@@ -1668,7 +1668,7 @@ class TestSpecConvergenceReport:
         spec_file: str = "spec.md",
     ) -> dict[str, object]:
         """One prior journal entry, in the shape decompose writes."""
-        entry: dict[str, object] = {"event_type": "spec_issues", "spec_file": spec_file}
+        entry: dict[str, object] = {"event_type": SPEC_ISSUES_EVENT, "spec_file": spec_file}
         if issues is not None:
             entry["issues"] = _issue_dicts(issues)
         return entry
@@ -1763,7 +1763,7 @@ class TestSpecConvergenceReport:
         operator hand-edited, must read rather than raise."""
         history: list[dict[str, object]] = [
             {
-                "event_type": "spec_issues",
+                "event_type": SPEC_ISSUES_EVENT,
                 "issues": [
                     "not a dict",
                     {"severity": "blocker"},

--- a/tests/test_event_names_have_one_home.py
+++ b/tests/test_event_names_have_one_home.py
@@ -236,10 +236,10 @@ def literal_event_names(
     through ``all_nodes``, which memoises it, so the second name reuses
     the first name's walk instead of repeating it.
 
-    Measured as process CPU time over the 332-module corpus this layer
+    Measured as process CPU time over the 334-module corpus this layer
     walks, three sweeps each, parse cache warmed first so the number is
-    about the walk: 1.26-1.27 s a sweep with a raw ``ast.walk``,
-    0.75-0.76 s with the memo warm. The earlier wall-clock version of
+    about the walk: 1.36-1.37 s a sweep with a raw ``ast.walk``,
+    0.80-0.81 s with the memo warm. The earlier wall-clock version of
     this number could not be reproduced without knowing what else the
     machine was running, which is why it is stated as CPU here.
     """
@@ -537,7 +537,7 @@ def event_type_aliases(tree: ast.Module) -> frozenset[str]:
     (#337 round 1: the earlier sentence gave the ``kstrl/`` number only,
     which was two thirds short of the walk). ``kstrl/``: 1 of 129
     modules binds any alias, 6 names, all in ``evolution.py``.
-    ``tests/``: 4 of 204 modules, 10 names, in ``test_factory.py``,
+    ``tests/``: 4 of 206 modules, 10 names, in ``test_factory.py``,
     ``test_journal_torn_tail.py``, ``test_resume_ergonomics.py`` and
     ``test_usage_meter.py``. Three of those names are generic
     (``entry``, ``rows``, ``results``), so an unrelated ``entry ==

--- a/tests/test_event_names_have_one_home.py
+++ b/tests/test_event_names_have_one_home.py
@@ -17,6 +17,9 @@ prompt the split, because it reports rather than fails once a file is
 already over, and ``test_evolution.py`` was at 1407 lines.
 
 TWO LAYERS, because one of them is a net and the other is a message.
+They walk different corpora, and the claim each makes is the corpus it
+walks: layer 2 covers ``kstrl/`` and ``tests/``, layer 1 covers
+``kstrl/``.
 
 LAYER 1, :func:`event_name_spellings`, counts every expression in
 ``kstrl/`` whose folded value IS an enrolled event name, per module. It
@@ -27,9 +30,19 @@ and enumerates no node types, which is the point. #324 records that this
 repo has about eleven AST guards each re-implementing that resolution and
 each holed independently, and layer 2 below was the twelfth: round 1 of
 review on #336 measured six ordinary shapes walking straight past it.
+It stops at ``kstrl/`` deliberately (#337). Measured over ``tests/`` it
+counts 46 spellings in 13 modules, 24 of them in ``test_decompose.py``
+alone, where they are the architect's own JSON key inside a fixture
+payload. A pinned dict over that would move on every fixture that adds
+an architect payload, which is the guard that gets silenced
+``_assignment_hits`` warns about.
 
 LAYER 2, :func:`literal_event_names`, enumerates shapes and names the
-offending line and its direction. It is not redundant. Layer 1 can only
+offending line and its direction. It walks ``kstrl/`` AND ``tests/``
+(#337): a test that spells the name for itself while asserting on
+production behaviour is asserting partly on its own copy of it, and the
+six sites the widened corpus found were all of that kind. It is not
+redundant. Layer 1 can only
 say "this module's spelling count moved", which is the wrong message when
 the answer is "you wrote a journal row with a bare literal, import the
 constant". Layer 1 in turn catches what layer 2 cannot, and after #336
@@ -52,6 +65,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from kstrl.evolution import JOURNAL_REPAIR_EVENT, SPEC_ISSUES_EVENT
+from tests.helpers import astwalk
 from tests.helpers.astwalk import (
     Sees,
     assert_census,
@@ -63,8 +77,8 @@ from tests.helpers.astwalk import (
 )
 
 #: The journal event names that have been hoisted to a constant, and so
-#: must never be spelled as a literal in ``kstrl/`` again. Five more are
-#: still bare literals (``component_result`` nine times in
+#: must never be spelled as a literal in ``kstrl/`` or ``tests/`` again.
+#: Five more are still bare literals (``component_result`` nine times in
 #: ``evolution.py`` alone, which is exactly what layer 2 counts there,
 #: plus ``role_usage``, ``contract_result``, ``autonomy_transition`` and
 #: ``findings_superseded``); converting them is a follow-up, and
@@ -551,9 +565,19 @@ class TestJournalEventNamesHaveOneHome:
         )
 
     def test_no_module_names_an_enrolled_event_as_a_literal(self) -> None:
-        """Layer 2, the message: name the offending line and its direction."""
+        """Layer 2, the message: name the offending line and its direction.
+
+        Over ``kstrl/`` AND ``tests/`` (#337). Widening the corpus
+        found six sites in the test tree, three writes and three
+        reads, across ``test_decompose.py``, ``test_evolution.py``
+        and ``test_journal_torn_tail.py``. None was deliberate, and
+        a test asserting on production behaviour with its own bare
+        spelling of the event name is asserting partly on its own
+        copy of it. Layer 1 stays on ``kstrl/``; the module
+        docstring carries the measurement for why.
+        """
         found: dict[str, list[str]] = {}
-        for source_file in package_sources():
+        for source_file in package_sources() + astwalk.test_sources():
             tree = parsed(source_file)
             aliases = event_type_aliases(tree)
             hits = [

--- a/tests/test_event_names_have_one_home.py
+++ b/tests/test_event_names_have_one_home.py
@@ -10,16 +10,13 @@ was the literal.
 Split out of ``tests/test_evolution.py`` on #336, and the seam is the one
 ``tests/test_journal_one_writer.py`` already documents about its own
 split: that file is about what the journal DOES, measured against real
-rows in a real file, and this one is a static guard over the whole
-package with no journal in it at all. Different subject, different
+rows in a real file, and this one is a static guard over the source
+trees with no journal in it at all. Different subject, different
 failure message, different reason to fail. The 800-line ratchet could not
 prompt the split, because it reports rather than fails once a file is
 already over, and ``test_evolution.py`` was at 1407 lines.
 
 TWO LAYERS, because one of them is a net and the other is a message.
-They walk different corpora, and the claim each makes is the corpus it
-walks: layer 2 covers ``kstrl/`` and ``tests/``, layer 1 covers
-``kstrl/``.
 
 LAYER 1, :func:`event_name_spellings`, counts every expression in
 ``kstrl/`` whose folded value IS an enrolled event name, per module. It
@@ -40,16 +37,15 @@ an architect payload, which is the guard that gets silenced
 LAYER 2, :func:`literal_event_names`, enumerates shapes and names the
 offending line and its direction. It walks ``kstrl/`` AND ``tests/``
 (#337): a test that spells the name for itself while asserting on
-production behaviour is asserting partly on its own copy of it, and the
-six sites the widened corpus found were all of that kind. It is not
-redundant. Layer 1 can only
-say "this module's spelling count moved", which is the wrong message when
-the answer is "you wrote a journal row with a bare literal, import the
-constant". Layer 1 in turn catches what layer 2 cannot, and after #336
-that is a longer list than layer 2's residual disclosure: a dispatch
-table keyed by the name, a read behind a function boundary, a parameter
-default, ``setattr``, a tuple-unpacked assignment, a function returning
-the bare name. All measured.
+production behaviour is asserting partly on its own copy of it. It is
+not redundant. Layer 1 can only say "this module's spelling count
+moved", which is the wrong message when the answer is "you wrote a
+journal row with a bare literal, import the constant". Layer 1 in turn
+catches what layer 2 cannot, and after #336 that is a longer list than
+layer 2's residual disclosure: a dispatch table keyed by the name, a
+read behind a function boundary, a parameter default, ``setattr``, a
+tuple-unpacked assignment, a function returning the bare name. All
+measured.
 
 What NEITHER layer sees is one thing, and it is disclosed on
 ``folded_str`` next door and pinned in
@@ -65,9 +61,13 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from kstrl.evolution import JOURNAL_REPAIR_EVENT, SPEC_ISSUES_EVENT
+
+# Reached through the module: a from-import of ``test_sources`` would be
+# collected here as a third test. Its docstring carries the measurement.
 from tests.helpers import astwalk
 from tests.helpers.astwalk import (
     Sees,
+    all_nodes,
     assert_census,
     bound_names,
     folded_str,
@@ -195,14 +195,17 @@ def literal_event_names(
 
     ``aliases`` is a loop invariant the caller may hoist. It depends on
     the tree alone, so recomputing it per event name is pure waste:
-    measured at 254 calls over 127 modules for two names, of which 127
-    were duplicates, and the guard test goes 0.61 s to 0.46 s with this
-    and the node walk hoisted. It is O(names x modules) on a computation
-    that does not depend on names, and this file commits to five more
-    names.
+    measured over ``kstrl/`` at 254 calls over 127 modules for two names,
+    of which 127 were duplicates, and the guard test went 0.61 s to
+    0.46 s with this and the node walk hoisted. It is O(names x modules)
+    on a computation that does not depend on names, and this file commits
+    to five more names. The traversal is still per name, but it goes
+    through ``all_nodes``, which memoises it, so the second name reuses
+    the first name's walk instead of repeating it: measured over the
+    333-module corpus, the guard test went 1.53 s to 1.1 s.
     """
     resolved = event_type_aliases(tree) if aliases is None else aliases
-    return [hit for node in ast.walk(tree) for hit in _hits_at(node, event_name, resolved)]
+    return [hit for node in all_nodes(tree) for hit in _hits_at(node, event_name, resolved)]
 
 
 def _hits_at(node: ast.AST, event_name: str, aliases: frozenset[str]) -> list[str]:
@@ -492,7 +495,7 @@ def event_type_aliases(tree: ast.Module) -> frozenset[str]:
     to be wrong in. Measured: 1 of 127 modules in ``kstrl/`` binds any
     alias at all.
     """
-    nodes = list(ast.walk(tree))
+    nodes = list(all_nodes(tree))
     names: frozenset[str] = frozenset()
     while True:
         found = _alias_sweep(nodes, names)
@@ -567,14 +570,11 @@ class TestJournalEventNamesHaveOneHome:
     def test_no_module_names_an_enrolled_event_as_a_literal(self) -> None:
         """Layer 2, the message: name the offending line and its direction.
 
-        Over ``kstrl/`` AND ``tests/`` (#337). Widening the corpus
-        found six sites in the test tree, three writes and three
-        reads, across ``test_decompose.py``, ``test_evolution.py``
-        and ``test_journal_torn_tail.py``. None was deliberate, and
-        a test asserting on production behaviour with its own bare
-        spelling of the event name is asserting partly on its own
-        copy of it. Layer 1 stays on ``kstrl/``; the module
-        docstring carries the measurement for why.
+        Over ``kstrl/`` AND ``tests/`` (#337); the module docstring
+        carries why. Widening the corpus found six sites in the test
+        tree, three writes and three reads, across ``test_decompose.py``,
+        ``test_evolution.py`` and ``test_journal_torn_tail.py``. None was
+        deliberate, so this layer needs no allowlist.
         """
         found: dict[str, list[str]] = {}
         for source_file in package_sources() + astwalk.test_sources():

--- a/tests/test_event_names_have_one_home.py
+++ b/tests/test_event_names_have_one_home.py
@@ -1,4 +1,10 @@
-"""An enrolled journal event name is spelled once, in ``kstrl/evolution.py``.
+"""An enrolled event name is spelled once where a journal row is written or selected.
+
+That one place is ``kstrl/evolution.py``. The scope of the claim is the
+row, not the word: ``tests/`` holds 46 spellings of ``spec_issues`` that
+are the architect's own JSON key, and both layers deliberately leave
+them alone. Which corpus each layer walks is stated under TWO LAYERS
+below, and each layer's claim is exactly the corpus it walks (#337).
 
 ``spec_issues`` used to be spelled twice: a constant in ``decompose``,
 which writes the row, and a literal in ``evolution``, which selects on
@@ -18,8 +24,12 @@ already over, and ``test_evolution.py`` was at 1407 lines.
 
 TWO LAYERS, because one of them is a net and the other is a message.
 
-LAYER 1, :func:`event_name_spellings`, counts every expression in
-``kstrl/`` whose folded value IS an enrolled event name, per module. It
+LAYER 1, the predicate :func:`spells_an_enrolled_event` run through
+``astwalk.census``, counts every expression in ``kstrl/`` whose folded
+value IS an enrolled event name, per module. (:func:`event_name_spellings`
+is one row of that same census, and exists so the shape controls next
+door can ask about a single file; round 1 of review on #337 found it as
+a third raw ``ast.walk``, certifying a copy of the executed path.) It
 is the net: a row cannot be written or selected by a name the module
 never spells, so a second spelling in any shape has to appear here
 first, whatever it does with the string afterwards. It resolves nothing
@@ -57,28 +67,42 @@ run-time lookup. Constant folding answers ``None`` for all of them.
 from __future__ import annotations
 
 import ast
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 
 from kstrl.evolution import JOURNAL_REPAIR_EVENT, SPEC_ISSUES_EVENT
 
-# Reached through the module: a from-import of ``test_sources`` would be
-# collected here as a third test. Its docstring carries the measurement.
+# Reached through the module for readability rather than for safety:
+# ``test_sources`` carries ``__test__ = False``, so a from-import of it
+# would not be collected here either. Its docstring carries both
+# measurements.
 from tests.helpers import astwalk
 from tests.helpers.astwalk import (
+    REPO_ROOT,
+    TESTS_DIR,
     Sees,
     all_nodes,
     assert_census,
     bound_names,
+    census,
     folded_str,
     label,
     package_sources,
     parsed,
 )
 
-#: The journal event names that have been hoisted to a constant, and so
-#: must never be spelled as a literal in ``kstrl/`` or ``tests/`` again.
-#: Five more are still bare literals (``component_result`` nine times in
+#: The journal event names that have been hoisted to a constant. What
+#: the two layers below actually enforce about them, said as narrowly as
+#: they enforce it, because a claim wider than its walk is #337 itself:
+#: in ``kstrl/`` the name must not be spelled at all, in any shape, and
+#: layer 1's census is what says so; in ``tests/`` only the shape
+#: ATTACHED TO THE ``event_type`` COLUMN is forbidden, which is layer 2,
+#: and the 46 spellings layer 1 counts over ``tests/`` are unenforced by
+#: design. One exception, in ``tests/`` and deliberate: a pin on the
+#: WIRE value, where the literal is the assertion rather than a second
+#: spelling of it. There is exactly one, in ``test_decompose.py``, and
+#: it is written against the bytes on disk so that layer 2 does not see
+#: it. Five more names are still bare literals (``component_result`` nine times in
 #: ``evolution.py`` alone, which is exactly what layer 2 counts there,
 #: plus ``role_usage``, ``contract_result``, ``autonomy_transition`` and
 #: ``findings_superseded``); converting them is a follow-up, and
@@ -125,9 +149,18 @@ def event_name_spellings(source_file: Path) -> int:
     the bare string.
 
     Counted per module so an unrelated edit does not fail it.
+
+    ONE ROW OF ``census``, not a second implementation of it. Layer 1's
+    assertion runs ``assert_census``, which counts through
+    ``astwalk.census``; this function's only callers are the shape
+    controls in ``tests/test_event_name_shapes.py``. Round 1 of review
+    on #337 found it here as a third raw ``ast.walk``, so the controls
+    were certifying a copy of the code the guard executes rather than
+    the code itself. That is the same defect as the test-side copy of
+    the selection rule this PR deletes, one file over.
     """
-    sees = spells_an_enrolled_event()
-    return sum(1 for node in ast.walk(parsed(source_file)) if sees(node))
+    key = label(source_file)
+    return census([source_file], spells_an_enrolled_event()).get(key, 0)
 
 
 #: Every place in ``kstrl/`` that spells an enrolled event name outright,
@@ -201,8 +234,14 @@ def literal_event_names(
     on a computation that does not depend on names, and this file commits
     to five more names. The traversal is still per name, but it goes
     through ``all_nodes``, which memoises it, so the second name reuses
-    the first name's walk instead of repeating it: measured over the
-    333-module corpus, the guard test went 1.53 s to 1.1 s.
+    the first name's walk instead of repeating it.
+
+    Measured as process CPU time over the 332-module corpus this layer
+    walks, three sweeps each, parse cache warmed first so the number is
+    about the walk: 1.26-1.27 s a sweep with a raw ``ast.walk``,
+    0.75-0.76 s with the memo warm. The earlier wall-clock version of
+    this number could not be reproduced without knowing what else the
+    machine was running, which is why it is stated as CPU here.
     """
     resolved = event_type_aliases(tree) if aliases is None else aliases
     return [hit for node in all_nodes(tree) for hit in _hits_at(node, event_name, resolved)]
@@ -492,10 +531,21 @@ def event_type_aliases(tree: ast.Module) -> frozenset[str]:
     that function makes too: a name bound to a read anywhere means "the
     event type" everywhere in the file. That over-reports rather than
     under-reports, and over-reporting is the direction a guard is allowed
-    to be wrong in. Measured: 1 of 127 modules in ``kstrl/`` binds any
-    alias at all.
+    to be wrong in.
+
+    Measured over the corpus this function now runs on, by running it
+    (#337 round 1: the earlier sentence gave the ``kstrl/`` number only,
+    which was two thirds short of the walk). ``kstrl/``: 1 of 129
+    modules binds any alias, 6 names, all in ``evolution.py``.
+    ``tests/``: 4 of 204 modules, 10 names, in ``test_factory.py``,
+    ``test_journal_torn_tail.py``, ``test_resume_ergonomics.py`` and
+    ``test_usage_meter.py``. Three of those names are generic
+    (``entry``, ``rows``, ``results``), so an unrelated ``entry ==
+    "<an enrolled name>"`` later in ``test_factory.py`` would read here
+    as an event-type comparison. That is the over-report direction, so
+    it costs a false positive somebody reads rather than a miss.
     """
-    nodes = list(all_nodes(tree))
+    nodes = all_nodes(tree)
     names: frozenset[str] = frozenset()
     while True:
         found = _alias_sweep(nodes, names)
@@ -504,7 +554,7 @@ def event_type_aliases(tree: ast.Module) -> frozenset[str]:
         names |= found
 
 
-def _alias_sweep(nodes: list[ast.AST], names: frozenset[str]) -> frozenset[str]:
+def _alias_sweep(nodes: Sequence[ast.AST], names: frozenset[str]) -> frozenset[str]:
     """The names ONE pass binds to a read, given what is known so far."""
     found: set[str] = set()
     for node in nodes:
@@ -528,12 +578,17 @@ def _read_hit(operand: ast.expr) -> str:
 class TestJournalEventNamesHaveOneHome:
     """#314 item 3, and #336 round 1 for the shape of the mechanism.
 
-    Two assertions, one per layer. Both are pinned inventories rather
-    than "this list is empty" alone, because an empty list is also what a
-    switched-off detector returns. The shape controls in
-    ``tests/test_event_name_shapes.py`` are what make layer 2's assertion
-    mean something: measured, every one of the twenty matcher functions
-    can be stubbed to a constant, and each stub is noticed there.
+    Two assertions, one per layer, and neither is "this list is empty"
+    alone, because an empty list is also what a switched-off detector
+    returns. They reach that differently and the difference is worth
+    stating, because round 1 of review on #337 found this docstring
+    claiming both were pinned inventories when only one is. Layer 1 IS
+    a pinned inventory, plus ``assert_census``'s own control. Layer 2 is
+    an emptiness assertion, held up by two other things: the shape
+    controls in ``tests/test_event_name_shapes.py``, where every one of
+    the twenty matcher functions was stubbed to a constant and each stub
+    noticed, and the corpus control on the assertion itself, which fails
+    if the ``tests/`` half of the walk goes missing.
     """
 
     def test_nobody_spells_an_enrolled_event_name_for_themselves(self) -> None:
@@ -574,10 +629,47 @@ class TestJournalEventNamesHaveOneHome:
         carries why. Widening the corpus found six sites in the test
         tree, three writes and three reads, across ``test_decompose.py``,
         ``test_evolution.py`` and ``test_journal_torn_tail.py``. None was
-        deliberate, so this layer needs no allowlist.
+        deliberate, so this layer needs no allowlist today.
+
+        THE CORPUS IS THE CONTROL, and it needs one because ``found ==
+        {}`` does not distinguish a clean tree from a walk that was
+        narrowed back. Measured in round 1 of review on #337: deleting
+        ``astwalk.test_sources(...)`` from the line below left this file
+        at 2 passed and the full suite at 5564 passed, byte-identical
+        counts, so the subject of this whole change was revertible with
+        the suite green. ``ruff`` does report the unused import that
+        revert leaves, but ``ruff check --fix`` is what the repo's own
+        pre-commit hook runs, and it deletes the import and hands back a
+        clean tree with the mechanism gone. So the assertion below
+        counts what it was HANDED, from the same list it iterates, which
+        is closed by construction rather than a threshold to maintain.
+
+        ``exclude=Path(__file__)`` for the reason the two peers pass it
+        (``tests/test_procgroup.py`` and ``tests/test_process_scoping.py``):
+        a guard that names the shapes it forbids should not scan itself.
+        DISCLOSED, because ``exclude`` takes one path and the exposure
+        is a sibling: ``tests/test_event_name_shapes.py`` is in this
+        corpus and its whole subject is the shapes this layer forbids.
+        It is clean today only because every control there is a source
+        STRING that ``folded_str`` folds whole. The first control
+        somebody writes as real code instead of a snippet makes this
+        assertion fail on its own positive-control file, and the only
+        green route would be to weaken the control. That is the point at
+        which this layer needs a named allowlist, and the same is true
+        from the other direction the day ``component_result`` is
+        enrolled: ``tests/test_decompose.py`` writes a deliberate legacy
+        on-disk row with it.
         """
+        sources = package_sources() + astwalk.test_sources(exclude=Path(__file__))
+        walked_tests = [path for path in sources if path.is_relative_to(TESTS_DIR)]
+        assert walked_tests, (
+            f"layer 2 was handed {len(sources)} modules and none of them is under "
+            f"{TESTS_DIR}, so this assertion covers kstrl/ only and the corpus #337 "
+            "added is gone. Nothing else in the suite fails when that happens."
+        )
+
         found: dict[str, list[str]] = {}
-        for source_file in package_sources() + astwalk.test_sources():
+        for source_file in sources:
             tree = parsed(source_file)
             aliases = event_type_aliases(tree)
             hits = [
@@ -586,7 +678,7 @@ class TestJournalEventNamesHaveOneHome:
                 for hit in literal_event_names(tree, event_name, aliases)
             ]
             if hits:
-                found[label(source_file)] = hits
+                found[label(source_file, REPO_ROOT)] = hits
 
         assert found == {}, (
             "A journal row is written or selected by a bare literal instead of the "

--- a/tests/test_event_names_have_one_home.py
+++ b/tests/test_event_names_have_one_home.py
@@ -1,9 +1,11 @@
 """An enrolled event name is spelled once where a journal row is written or selected.
 
 That one place is ``kstrl/evolution.py``. The scope of the claim is the
-row, not the word: ``tests/`` holds 46 spellings of ``spec_issues`` that
-are the architect's own JSON key, and both layers deliberately leave
-them alone. Which corpus each layer walks is stated under TWO LAYERS
+row, not the word: ``tests/`` holds 46 spellings both layers
+deliberately leave alone, 44 of ``spec_issues`` and 2 of
+``journal_repair``: mostly the architect's own JSON key, and in five
+places the TUI's artifact label or a guard's own fixture argument.
+Which corpus each layer walks is stated under TWO LAYERS
 below, and each layer's claim is exactly the corpus it walks (#337).
 
 ``spec_issues`` used to be spelled twice: a constant in ``decompose``,
@@ -537,10 +539,11 @@ def event_type_aliases(tree: ast.Module) -> frozenset[str]:
     (#337 round 1: the earlier sentence gave the ``kstrl/`` number only,
     which was two thirds short of the walk). ``kstrl/``: 1 of 129
     modules binds any alias, 6 names, all in ``evolution.py``.
-    ``tests/``: 4 of 206 modules, 10 names, in ``test_factory.py``,
-    ``test_journal_torn_tail.py``, ``test_resume_ergonomics.py`` and
-    ``test_usage_meter.py``. Three of those names are generic
-    (``entry``, ``rows``, ``results``), so an unrelated ``entry ==
+    ``tests/``: 5 of 206 modules, 11 names, in ``test_factory.py``,
+    ``test_journal_torn_tail.py``, ``test_resume_ergonomics.py``,
+    ``test_review_gates.py`` and ``test_usage_meter.py``. Four of those
+    names are generic (``entry``, ``matches``, ``rows``, ``results``), so
+    an unrelated ``entry ==
     "<an enrolled name>"`` later in ``test_factory.py`` would read here
     as an event-type comparison. That is the over-report direction, so
     it costs a false positive somebody reads rather than a miss.
@@ -640,9 +643,14 @@ class TestJournalEventNamesHaveOneHome:
         the suite green. ``ruff`` does report the unused import that
         revert leaves, but ``ruff check --fix`` is what the repo's own
         pre-commit hook runs, and it deletes the import and hands back a
-        clean tree with the mechanism gone. So the assertion below
-        counts what it was HANDED, from the same list it iterates, which
-        is closed by construction rather than a threshold to maintain.
+        clean tree with the mechanism gone. So the loop below COUNTS
+        the ``tests/`` modules it opens and the assertion after it
+        compares that count with the corpus size derived independently:
+        a deleted, sliced or repointed corpus all leave the counter
+        short, with no threshold to maintain. Round 2 measured the
+        earlier form, a truthiness check on the binding, clearing a
+        corpus sliced to one module and a loop repointed at
+        ``package_sources()``.
 
         ``exclude=Path(__file__)`` for the reason the two peers pass it
         (``tests/test_procgroup.py`` and ``tests/test_process_scoping.py``):
@@ -661,15 +669,12 @@ class TestJournalEventNamesHaveOneHome:
         on-disk row with it.
         """
         sources = package_sources() + astwalk.test_sources(exclude=Path(__file__))
-        walked_tests = [path for path in sources if path.is_relative_to(TESTS_DIR)]
-        assert walked_tests, (
-            f"layer 2 was handed {len(sources)} modules and none of them is under "
-            f"{TESTS_DIR}, so this assertion covers kstrl/ only and the corpus #337 "
-            "added is gone. Nothing else in the suite fails when that happens."
-        )
+        expected_tests = len(astwalk.test_sources(exclude=Path(__file__)))
+        walked_tests = 0
 
         found: dict[str, list[str]] = {}
         for source_file in sources:
+            walked_tests += source_file.is_relative_to(TESTS_DIR)
             tree = parsed(source_file)
             aliases = event_type_aliases(tree)
             hits = [
@@ -680,6 +685,11 @@ class TestJournalEventNamesHaveOneHome:
             if hits:
                 found[label(source_file, REPO_ROOT)] = hits
 
+        assert walked_tests == expected_tests, (
+            f"layer 2 opened {walked_tests} modules under {TESTS_DIR} and the corpus "
+            f"holds {expected_tests}, so the walk is narrower than the corpus #337 "
+            "added. Nothing else in the suite fails when that happens."
+        )
         assert found == {}, (
             "A journal row is written or selected by a bare literal instead of the "
             f"constant evolution.py declares for it. Import the constant. Sites: {found}"

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -1044,7 +1044,7 @@ class TestSpecIssueRuns:
             {
                 "timestamp": "2026-08-29T00:00:00Z",
                 "project": project,
-                "event_type": "spec_issues",
+                "event_type": SPEC_ISSUES_EVENT,
                 "spec_file": "spec.md",
                 "halted": blockers > 0,
                 "counts": {"blocker": blockers, "major": 0, "minor": 0},

--- a/tests/test_journal_torn_tail.py
+++ b/tests/test_journal_torn_tail.py
@@ -162,7 +162,7 @@ class TestWhatIsNotATear:
         after = path.read_bytes()
         assert after.startswith(before)
         assert after == before + json.dumps(audit("beta"), separators=(",", ":")).encode() + b"\n"
-        assert repair_rows_in(path) == []
+        assert repair_rows_in(journal) == []
 
     def test_an_empty_journal_file_is_not_a_tear(self, tmp_path: Path) -> None:
         """Zero bytes has no unterminated line in it."""
@@ -173,7 +173,7 @@ class TestWhatIsNotATear:
         journal.append_entries([audit("alpha")])
 
         assert audits_in(journal) == ["alpha"]
-        assert repair_rows_in(journal.config.journal_path) == []
+        assert repair_rows_in(journal) == []
 
     def test_a_terminated_but_malformed_tail_is_not_a_tear(self, tmp_path: Path) -> None:
         """Residual 4 of ``append_entries``, pinned rather than implied.
@@ -210,7 +210,7 @@ class TestWhatIsNotATear:
         journal.append_entries([audit("alpha")])
 
         assert audits_in(journal) == ["alpha"]
-        assert repair_rows_in(journal.config.journal_path) == []
+        assert repair_rows_in(journal) == []
 
     def test_an_empty_append_repairs_nothing(self, tmp_path: Path) -> None:
         """Nothing to protect, so nothing is written.
@@ -468,7 +468,7 @@ class TestTheTearIsVisible:
 
         journal.append_entries([audit("beta")])
 
-        rows = repair_rows_in(journal.config.journal_path)
+        rows = repair_rows_in(journal)
         assert len(rows) == 1
         assert rows[0]["timestamp"]
         assert "not newline-terminated" in rows[0]["detail"]
@@ -505,7 +505,7 @@ class TestTheTearIsVisible:
         tear(journal.config.journal_path)
         journal.append_entries([audit("beta")])
 
-        detail = str(repair_rows_in(journal.config.journal_path)[0]["detail"])
+        detail = str(repair_rows_in(journal)[0]["detail"])
         assert "torn fragment that was never readable" in detail
         assert "lost only its newline" in detail
 
@@ -520,7 +520,7 @@ class TestTheTearIsVisible:
         journal.append_entries([audit("beta")])
         journal.append_entries([audit("gamma")])
 
-        assert len(repair_rows_in(journal.config.journal_path)) == 1
+        assert len(repair_rows_in(journal)) == 1
 
     def test_the_repair_row_counts_towards_no_aggregate(self, tmp_path: Path) -> None:
         """A repair row must not move a number anyone reads.
@@ -540,7 +540,7 @@ class TestTheTearIsVisible:
         torn.append_entries(records[:1])
         tear(torn.config.journal_path)
         torn.append_entries(records[1:])
-        assert len(repair_rows_in(torn.config.journal_path)) == 1
+        assert len(repair_rows_in(torn)) == 1
 
         assert clean.get_concern_hit_rate()["components"] == 2
         assert torn.get_concern_hit_rate() == clean.get_concern_hit_rate()

--- a/tests/test_journal_torn_tail.py
+++ b/tests/test_journal_torn_tail.py
@@ -66,7 +66,7 @@ class TestTheEntryAfterATear:
 
         journal.append_entries([audit("beta")])
 
-        assert audits_in(journal.config.journal_path) == ["alpha", "beta"]
+        assert audits_in(journal) == ["alpha", "beta"]
 
     def test_the_torn_fragment_is_not_resurrected(self, tmp_path: Path) -> None:
         """The repair isolates the fragment, it does not repair it.
@@ -102,11 +102,11 @@ class TestTheEntryAfterATear:
         journal.append_entries([audit("a1"), audit("a2"), audit("a3")])
         path = journal.config.journal_path
         lose_the_newline(path)
-        assert audits_in(path) == ["a1", "a2", "a3"]
+        assert audits_in(journal) == ["a1", "a2", "a3"]
 
         journal.append_entries([audit("a4")])
 
-        assert audits_in(path) == ["a1", "a2", "a3", "a4"]
+        assert audits_in(journal) == ["a1", "a2", "a3", "a4"]
 
     def test_an_autonomy_transition_after_a_tear_survives(self, tmp_path: Path) -> None:
         """The second writer, which the fix to the first would not reach.
@@ -172,7 +172,7 @@ class TestWhatIsNotATear:
 
         journal.append_entries([audit("alpha")])
 
-        assert audits_in(journal.config.journal_path) == ["alpha"]
+        assert audits_in(journal) == ["alpha"]
         assert repair_rows_in(journal.config.journal_path) == []
 
     def test_a_terminated_but_malformed_tail_is_not_a_tear(self, tmp_path: Path) -> None:
@@ -197,7 +197,7 @@ class TestWhatIsNotATear:
 
         journal.append_entries([audit("beta")])
 
-        assert audits_in(path) == ["alpha", "beta"]
+        assert audits_in(journal) == ["alpha", "beta"]
         assert journal.get_repair_count() == 0
 
     def test_a_missing_journal_file_is_not_a_tear(self, tmp_path: Path) -> None:
@@ -209,7 +209,7 @@ class TestWhatIsNotATear:
 
         journal.append_entries([audit("alpha")])
 
-        assert audits_in(journal.config.journal_path) == ["alpha"]
+        assert audits_in(journal) == ["alpha"]
         assert repair_rows_in(journal.config.journal_path) == []
 
     def test_an_empty_append_repairs_nothing(self, tmp_path: Path) -> None:
@@ -326,7 +326,7 @@ class TestTheRepairIsReportable:
         path = journal.config.journal_path
         lose_the_newline(path)
         journal.append_entries([audit("beta")])
-        assert audits_in(path) == ["alpha", "beta"]
+        assert audits_in(journal) == ["alpha", "beta"]
 
         output = self.status_output(tmp_path)
 
@@ -647,4 +647,4 @@ class TestTheUndecodableTail:
 
         journal.append_entries([audit("beta")])
 
-        assert audits_in(path) == ["alpha", "beta"]
+        assert audits_in(journal) == ["alpha", "beta"]

--- a/tests/test_journal_torn_tail.py
+++ b/tests/test_journal_torn_tail.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 import pytest
 
-from kstrl.evolution import EXPERIMENTS_HEADER, JOURNAL_REPAIR_EVENT
+from kstrl.evolution import EXPERIMENTS_HEADER, JOURNAL_REPAIR_EVENT, SPEC_ISSUES_EVENT
 from kstrl.observability import handle_ends_without_newline, read_progress_events
 from tests.helpers.journal import (
     DANGLING_UTF8,
@@ -85,7 +85,7 @@ class TestTheEntryAfterATear:
         path = journal.config.journal_path
         assert TORN_FRAGMENT in path.read_text(encoding="utf-8")
         parsed_types = [e.get("event_type") for e in read_progress_events(path)]
-        assert parsed_types == ["spec_issues", JOURNAL_REPAIR_EVENT, "spec_issues"]
+        assert parsed_types == [SPEC_ISSUES_EVENT, JOURNAL_REPAIR_EVENT, SPEC_ISSUES_EVENT]
 
     def test_a_tail_that_lost_only_its_newline_keeps_its_record(self, tmp_path: Path) -> None:
         """The tear that costs TWO records, not one.
@@ -139,7 +139,7 @@ class TestTheEntryAfterATear:
 
         events = read_progress_events(journal.config.journal_path)
         assert [e.get("event_type") for e in events] == [
-            "spec_issues",
+            SPEC_ISSUES_EVENT,
             JOURNAL_REPAIR_EVENT,
             "autonomy_transition",
         ]


### PR DESCRIPTION
## What

The journal event-name guard's layer 2 now walks `tests/` as well as `kstrl/`, the six literal sites the widened corpus found import `SPEC_ISSUES_EVENT`, and the test tree's copy of a production reader's selection rule is gone. Round 1 of review then closed the corpus itself, corrected three claims that were wider than their walk, and put back the two properties the conversions removed.

- `tests/test_event_names_have_one_home.py`: layer 2 loops over `package_sources() + astwalk.test_sources(exclude=Path(__file__))`, having first asserted that a positive number of the modules it was handed are under `tests/`. Layer 1 stays on `kstrl/`, and each layer's prose is now exactly the corpus it walks.
- Six sites import the constant: `test_decompose.py`, `test_evolution.py:1047` and `test_journal_torn_tail.py:88` and `:142`, plus the read inside the helper deleted below.
- `tests/test_decompose.py`: `_read_spec_issue_events` is deleted. It re-implemented `EvolutionJournal.get_spec_audits`, carrying its own copy of the journal path, the JSONL parse and the `event_type == SPEC_ISSUES_EVENT` selection rule. Its callers read through `journal_at(tmp_path).get_spec_audits()`, except the two questions that are about the bytes on disk, which read the bytes.
- `tests/helpers/journal.py`: `audits_in(path)` becomes `audits_in(journal)` and reads through `get_spec_audits`. `repair_rows_in` takes the journal too, for a different reason: there is still no production reader to route it through, but a path parameter made six call sites reach through `journal.config.journal_path`.
- `tests/helpers/astwalk/corpus.py`: `test_sources` carries `__test__ = False`, which deletes the collection hazard instead of documenting it.

## Why

#337. The guard's docstring claimed an enrolled event name is "spelled once, in `kstrl/evolution.py`, and imported everywhere else", and the walk behind that claim covered `package_sources()` only, so a claim about the repository was enforced over a third of it. `Closes #337`.

The sharper half is the second one. A test that spells the event name for itself while asserting on production behaviour is asserting partly on its own copy of that behaviour, and `_read_spec_issue_events` was the worst case: a second implementation of the reader whose consolidation #336 exists to deliver, sitting in the tests that check it.

Layer 1 was deliberately not widened. Measured over `tests/` it counts 46 spellings in 13 modules, 24 of them in `test_decompose.py` where they are the architect's own JSON key inside fixture payloads. A pinned per-module dict over that moves on every fixture that adds an architect payload, which is the guard-that-gets-silenced its own `_assignment_hits` docstring warns about. The enrolment comment now says that, instead of claiming a coverage over `tests/` that neither layer provides.

## What round 1 of review changed

Round 1 found the PR's own subject unprotected and three claims wider than their walk. All seven were measured before and after.

1. **The corpus had no control.** Deleting `astwalk.test_sources()` from layer 2's loop left the guard file at 2 passed and the full suite at 5564 passed, byte-identical. `assert found == {}` reads the same whether the walk is clean or switched off, which is CLAUDE.md's rule (2) and this repo's eleventh instance of the class. Layer 2 now names its corpus, asserts a positive count of `tests/` modules in the list it is about to iterate, then iterates that same list: closed by construction, no threshold to maintain, and a code move elsewhere cannot drift it.
2. **The enrolment comment claimed `tests/`, which neither layer enforces.** Layer 1 is `kstrl/`-only and layer 2 sees only the shape attached to the `event_type` column, so an indirect spelling in a test module is invisible to both. Measured: the plant in `test_evolution.py` gives 2 passed, the byte-identical plant in `kstrl/observability.py` gives 1 failed. The comment now states each layer's actual scope.
3. **`event_name_spellings` was a third raw `ast.walk` that layer 1 never runs.** `assert_census` counts through `astwalk.census`, and this function's only callers are the shape controls next door, so the controls were certifying a copy. It is one row of `census` now. The discriminating mutation is below.
4. **The PR removed the last behavioural pin on the wire value.** Four of the six converted sites used to cross the constant/literal boundary; after the conversion both sides of each are the constant. One test pins the value against the bytes on disk, in a shape layer 2 does not flag.
5. **The tolerant reader replaced a strict one.** `get_spec_audits` reads through `read_progress_events`, which skips a line it cannot parse; the deleted helper raised on one. Two tests whose subject is the writer now pin the row count off the file as well as the parsed count, and the `run_id` test reads the bytes, because a reader that dropped an unknown key could answer its question wrongly.
6. **`repair_rows_in`'s parameter**, and **layer 2's mixed labelling roots** (`label(source_file, REPO_ROOT)`, so `evolution.py` no longer keys as a repo-root file that does not exist).
7. **Two stale measurements**, both re-derived by running: the alias sweep's "1 of 127 modules in `kstrl/`" sized a walk that now covers both corpora, and the memo timing was wall clock on a loaded machine.

## What round 2 of review changed

Round 2 verified all nineteen round-1 items and found four more, all in the guard file and its helpers; the orchestrator applied them directly.

1. **The corpus control was closed over one of three failure shapes.** The round-1 form asserted a positive count over the `sources` binding and then iterated it: it caught the corpus being deleted, but round 2 measured that slicing the corpus to one module (`[:1]`) and repointing the loop at `package_sources()` while the binding stayed whole both left the guard green. The loop now increments a counter for every `tests/` module it opens and the assertion after it compares that counter with the corpus size derived independently; all three shapes are red (deleted: 1 failed; sliced: 1 failed; repointed: 1 failed), and the docstring no longer says "closed by construction" of a check that was coupled by adjacency.
2. **The opening docstring sentence was false in two ways.** The 46 spellings are 44 of `spec_issues` and 2 of `journal_repair`, and five of them are the TUI's artifact label or a guard's own fixture argument rather than the architect's JSON key. Rewritten to the measured breakdown.
3. **`test_sources.__test__ = False` had no control**; deleting the line failed nothing across seven guard files. `tests/test_astwalk_nets.py` now asserts it, next to the exclude test: deleting the line is 1 failed.
4. **`_journal_rows` said "parsed STRICTLY" and accepted a non-object line**, so a planted `[1, 2]` row left the `run_id` test green (`"run_id" not in [1, 2]` is true). The helper now raises on a line that is not an object, and the planted row is red.

Every plant above was run with `__pycache__` deleted and `PYTHONDONTWRITEBYTECODE=1`, and the tree restored from byte copies. Full suite after round 2, on the tree merged with `origin/main` at 50c965e: 5611 passed, 37 skipped, 38 xfailed in 337s, exit 0; mypy strict, ruff, gen_docs and the four precommit ratchets clean.

## Tested vs assumed

Tested. Every number below was produced by running the thing, in this worktree, with `__pycache__` deleted first and `PYTHONDONTWRITEBYTECODE=1`.

Gates on the merged tree (`origin/main` dee0c94 merged in, clean):

- `uv run pytest tests/ -q -p no:cacheprovider`: 5593 passed, 37 skipped, 38 xfailed, exit 0, 325 s. On the branch before the merge: 5565 / 37 / 38, exit 0, 333 s, against the 5564 / 37 / 38 baseline at 568bca4. The delta of one is the wire-value pin, the only test this PR adds.
- `uv run mypy kstrl/ --strict`: success, 129 source files. `uv run ruff check kstrl/ tests/`: clean. `uv run ruff format --check kstrl/ tests/`: 340 files already formatted. `uv run python scripts/gen_docs.py --check`: current.
- `scripts/precommit/`: the full hook set ran on each commit and passed, including the file-length ratchet, the cyclomatic ratchet, complexipy, codespell, vulture and the em-dash check. Zero em dashes added by the diff. The guard file is 686 lines against the 800 ratchet; `test_decompose.py` is 2910.

Guard census, re-derived by executing the detectors in both worktrees, never by diffing a literal:

| corpus | modules | layer 2 sites | layer 1 spellings | modules binding an alias |
|---|---|---|---|---|
| `kstrl/` at 568bca4, at the PR head and merged | 129 | 0 | 6 in 3 | 1, 6 names |
| `tests/` at 568bca4 | 204 | 6 (3 writes, 3 reads) | 53 in 14 | 4, 10 names |
| `tests/` after this PR, before the merge | 204 | 0 | 46 in 13 | 4, 10 names |
| `tests/` after the merge with dee0c94 | 206 | 0 | 46 in 13 | 4, 10 names |
| `tests/` after the merge with 50c965e (#349) | 206 | 0 | 46 in 13 | 5, 11 names |

The first merge added two test modules and neither spells an enrolled name or binds an alias. The second merge (#349) grows `tests/test_review_gates.py`, which now binds `matches` as an event-type alias; the alias sweep's docstring was re-derived on that tree. Layer 1 and layer 2 are unchanged across both. The `component_result` counts in the handoff below come from the guard's own layer-2 detector, not from grep, which gives 5 and 27 for the same population.

Mutations, one per mechanism, each plant asserting its anchor occurred exactly once so a silent no-op would report COULD-NOT-PLANT rather than a pass. None hung, none failed to plant, and each was restored from a byte copy taken before the edit rather than with `git checkout`:

| mutation | layer | outcome |
|---|---|---|
| M0, clean | both | 46 passed |
| M1, `"spec_issues"` back at `test_evolution.py:1047` | 2 | CAUGHT, message names line 1047 and the direction |
| M2, both literals back at `test_journal_torn_tail.py:88` | 2 | CAUGHT, message names line 88 and the list |
| M3, M1 planted AND the corpus narrowed to `package_sources()` | 2, corpus | CAUGHT. Before this round it was STILL GREEN, which is what the corpus control changes |
| M4, the corpus narrowed alone, nothing else | 2, corpus | CAUGHT, 1 failed 45 passed, message reports 129 modules and names the missing directory |
| M5, a row of layer 1's pinned dict changed | 1 | CAUGHT |
| M6, `spells_an_enrolled_event()` stubbed to always-False | 1 and the shape controls | CAUGHT, 9 failed 37 passed |
| M7, `astwalk.census` stubbed to return `{}` | the shape controls, over the executed path | CAUGHT, 8 failed 36 passed |
| M7b, the same census stub with the OLD raw-`ast.walk` `event_name_spellings` restored | same | STILL GREEN, 44 passed. This pair is the finding: the controls used to certify a copy |
| M9, a `from tests.helpers.astwalk import test_sources` | collection | 2 collected with `__test__ = False`, 3 without, and the third PASSES on a warning |
| M11, the writer emits a malformed row after every entry | strict row read | CAUGHT, 2 failed |
| M11b, the same writer mutation with the strictness pin removed | same | STILL GREEN, 2 passed. The tolerant reader skips the row and the count still comes out right |
| M12, the writer emits `run_id` and the reader strips it | byte read | CAUGHT, 1 failed |
| M12b, the same with the test reading through `get_spec_audits` | same | STILL GREEN, 1 passed |
| M13, `SPEC_ISSUES_EVENT` renamed to `spec_audit_row` | wire-value pin | CAUGHT, 1 failed |
| M14, the production tear repair deleted | torn-tail behaviour | CAUGHT, 15 failed 14 passed 1 xfailed, the same count and the same names as before the reroute |
| M15, `get_spec_audits` returns every entry unfiltered | the `audits_in` reroute | CAUGHT, 3 failed, which is coverage this PR gains |

M1, M4, M7 and M13 were re-run on the merged tree and all four stay CAUGHT.

Assumed, not tested: nothing. No claim in this body is relayed from the plan or from review without being re-run here.

## Disclosed, measured, not fixed here

Layer 2's corpus contains `tests/test_event_name_shapes.py`, whose whole subject is the shapes this layer forbids. `exclude=` takes one path and the exposure is a sibling, so it is disclosed in the test's docstring instead: those controls are clean today only because each is a source string that `folded_str` folds whole, and the first control written as real code makes this guard fail on its own positive-control file. That is the point at which layer 2 needs a named allowlist, and the same is true from the other direction the day `component_result` is enrolled, because `tests/test_decompose.py:2460` writes a deliberate legacy on-disk row with it. Enrolling the five names this file commits to is a 43-site job by the guard's own detector: `component_result` alone is 9 in `kstrl/` and 23 across 8 test modules. Two fixtures in `tests/test_evolve_screen_encoding.py` also spell event names inside bytes literals, which `folded_str` folds to `None`, so neither layer sees them; there are zero such fixtures in `kstrl/`.

The 46 layer-1 spellings in 13 test modules are unenforced in every shape but the column-attached one. Widening layer 1 to `tests/` would mean a 46-entry per-module dict that moves on every new architect fixture, so the claim was narrowed instead of the walk widened.

Drive-by, stated rather than implied: the three `read_text(encoding="utf-8")` edits in `tests/test_decompose.py` are the issue's own text, not a sweep of #320's class. The issue names that reader specifically, which is why they are here; they are not an attempt to take the class. 172 bare `read_text()` calls remain in `tests/`, and `tests/helpers/encodingwalk.py` still scans `package_sources()` only, so none of them is a site any guard can report. The issue also asked for `ValueError` beside `OSError`: none of the three sites has an `except` clause at all, so there is nothing for a `UnicodeDecodeError` to escape and that half of the contract does not apply.

## Behaviour changes

None in `kstrl/`. Production code is untouched; this is test infrastructure and test helpers only. Three test-facing signature changes: `audits_in` and `repair_rows_in` take an `EvolutionJournal` rather than a `Path`, and `_read_spec_issue_events` no longer exists. One failure message is worse: a missing journal used to fail as `assert journal.exists(), "journal event was not written"`. The two tests where that mattered now read the file first, so a missing journal fails on the read.

No CHANGELOG line: a test guard's corpus and two test helpers are not user-visible. Same precedent as #324, #336, #341, #342 and #344.

AI code review will be run on this PR as an assist at the owner's request; the owner remains the gating reviewer (H1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtNQsD9BMWmd5razgnKbre

